### PR TITLE
Fusing All Gather with NLP Concat heads for llama attention

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -124,3 +124,53 @@ def test_ar_tg_llama_perf(
     assert (
         measured_avg_us < perf_target_us + THRESHOLD
     ), f"Performance target not met: {measured_avg_us} us > {perf_target_us} us"
+
+
+@pytest.mark.parametrize(
+    "ar_type, warmup_iters, perf_target_us",
+    [
+        ("concat_heads", 10, 25),
+    ],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_fused_all_gather_concat_perf(
+    ar_type,
+    warmup_iters,
+    perf_target_us,
+):
+    profiler = BenchmarkProfiler()
+    benchmark_data = BenchmarkData()
+    step_name = f"all_gather_{ar_type}"
+
+    subdir = "llama_ccl_perf"
+    command = f"pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py::test_concat_fuse -k {ar_type}"
+    cols = ["DEVICE KERNEL"]
+    op_name = "AllGatherConcat"
+    warmup_iters = warmup_iters * 4  # 5 iterations per device
+
+    profiler.start("run")
+    profiler.start(step_name)
+    results = run_device_perf_detailed(command, subdir, cols, op_name, has_signposts=True, warmup_iters=0)
+    profiler.end(step_name)
+    profiler.end("run")
+
+    # Get the measured performance
+    measured_min_us = results[cols[0]]["MIN"] / 1000
+    measured_max_us = results[cols[0]]["MAX"] / 1000
+    measured_avg_us = results[cols[0]]["AVG"] / 1000
+    measured_std_us = results[cols[0]]["STD"] / 1000
+
+    logger.info(f"Measured performance: {measured_avg_us:.3f} us vs. target: {perf_target_us} us")
+
+    # Save the measurement
+    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ar_type}-min-us", measured_min_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ar_type}-max-us", measured_max_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ar_type}-avg-us", measured_avg_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ar_type}-std-us", measured_std_us)
+    benchmark_data.save_partial_run_json(
+        profiler,
+        run_type=f"all_gather_concat_heads_fused",
+        ml_model_name="llama70b-tg-ccl",
+    )
+
+    assert measured_avg_us < perf_target_us, f"Performance target not met: {measured_avg_us} us > {perf_target_us} us"

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -200,6 +200,24 @@ class TT_CCL:
         # ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.worker_sub_device_id])
         return ttnn_tensor_out
 
+    def all_gather_concat(self, input_tensor_mesh, dim, cluster_axis, memory_config, num_links=1, num_heads=8):
+        ttnn_tensor_out = ttnn.experimental.all_gather_concat(
+            input_tensor_mesh,
+            dim,
+            cluster_axis=cluster_axis,
+            mesh_device=self.mesh_device,
+            topology=ttnn.Topology.Linear,
+            multi_device_global_semaphore=self.gather_semaphore_handles[cluster_axis][self.gather_idx[cluster_axis]],
+            num_links=num_links,
+            num_heads=num_heads,
+            memory_config=memory_config,
+            subdevice_id=self.worker_sub_device_id,
+            enable_persistent_fabric_mode=self.enable_persistent_fabric,
+        )
+        self.gather_idx[cluster_axis] = (self.gather_idx[cluster_axis] + 1) % self.num_cbs
+        # ttnn.synchronize_device(self.mesh_device, sub_device_ids=[self.worker_sub_device_id])
+        return ttnn_tensor_out
+
     def close(self):
         if self.enable_persistent_fabric and self.teardown_persistent_fabric:
             logger.info("Tearing down persistent fabric interface")

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/all_reduce_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/all_reduce_test.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull
+from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
+    create_and_load_sub_device_manager_with_fabric_interface,
+    teardown_fabric_interface,
+    create_global_semaphore_with_same_address,
+)
+
+
+def run_with_trace(
+    mesh_device,
+    all_gather_topology,
+    input_tensor_mesh,
+    dim,
+    num_links,
+    output_mem_config,
+    enable_persistent_fabric,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_gather_async(
+        input_tensor_mesh,
+        dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_gather_topology,
+        subdevice_id=subdevice_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_gather_async(
+            input_tensor_mesh,
+            dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_gather_topology,
+            subdevice_id=subdevice_id,
+            enable_persistent_fabric_mode=enable_persistent_fabric,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return tt_out_tensor
+
+
+def run_all_reduce_impl(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    use_program_cache,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    all_gather_topology,
+    num_iters=1,
+    enable_async=False,
+    trace_mode=False,
+    output_shard_shape=None,
+    output_shard_grid=None,
+    tensor_mem_layout=None,
+):
+    enable_persistent_fabric = True
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+    # Use Async mode based on test input config
+    mesh_device.enable_async(enable_async)
+
+    if enable_async:
+        logger.info(f"Using Async Mode for All Gather Op Dispatch")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+        mesh_device,
+        [worker_sub_device],
+        0,
+        0,
+        enable_persistent_fabric,
+        wrap_fabric_around_mesh=True,
+    )
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### For sharded all gather only
+    if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
+        pytest.fail(
+            "Both input_shard_shape, shard_grid, and tensor_mem_layout must be provided together or all must be None"
+        )
+    if input_shard_shape and input_shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            input_shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        if output_shard_shape is None:
+            assert (
+                output_shard_grid is None
+            ), "output_shard_grid must not be provided if output_shard_shape is not provided"
+            output_shard_shape = list(input_shard_shape)
+            if dim == len(output_shape) - 1:
+                output_shard_shape[1] *= num_devices
+            else:
+                output_shard_shape[0] *= num_devices
+            output_shard_spec = ttnn.ShardSpec(
+                input_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+        else:
+            assert output_shard_grid is not None, "output_shard_grid must be provided if output_shard_shape is provided"
+            output_shard_spec = ttnn.ShardSpec(
+                output_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+    ###
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        output_tensor = torch.rand(output_shape).bfloat16()
+        output_tensor_goldens_list.append(output_tensor)
+        input_tensors = torch.chunk(output_tensor, num_devices, dim)
+        tt_input_tensors = []
+        for i, t in enumerate(input_tensors):
+            tt_input_tensors.append(
+                ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], input_mem_config)
+            )
+            logger.info(f"using device {mesh_device.get_devices()[i].id()}")
+
+        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    if trace_mode:
+        tt_out_tensor = run_with_trace(
+            mesh_device,
+            all_gather_topology,
+            input_tensor_mesh_list[0],
+            dim,
+            num_links,
+            output_mem_config,
+            enable_persistent_fabric,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            tt_out_tensor = ttnn.experimental.all_gather_async(
+                input_tensor_mesh_list[i],
+                dim,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+            tt_out_tensor_list.append(tt_out_tensor)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensor = tt_out_tensor_list[tensor_index]
+        output_tensor = output_tensor_goldens_list[tensor_index]
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
+
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+                passed = False
+
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+
+    if enable_persistent_fabric:
+        mesh_device.reset_sub_device_stall_group()
+        teardown_fabric_interface(mesh_device)
+
+    if not passed:
+        assert eq, f"{i} FAILED: {output}"

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
@@ -1,0 +1,638 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull
+from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
+    create_and_load_sub_device_manager_with_fabric_interface,
+    teardown_fabric_interface,
+    create_global_semaphore_with_same_address,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from tracy import signpost
+
+"""
+def run_with_trace(
+    mesh_device,
+    all_gather_topology,
+    input_tensor_mesh,
+    dim,
+    num_links,
+    output_mem_config,
+    enable_persistent_fabric,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_gather_async(
+        input_tensor_mesh,
+        dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_gather_topology,
+        subdevice_id=subdevice_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+    ttnn.synchronize_device(mesh_device)
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_gather_async(
+            input_tensor_mesh,
+            dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_gather_topology,
+            subdevice_id=subdevice_id,
+            enable_persistent_fabric_mode=enable_persistent_fabric,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+    return tt_out_tensor
+"""
+
+
+def run_with_trace(
+    mesh_device,
+    all_gather_topology,
+    input_tensor_mesh,
+    dim,
+    num_links,
+    output_mem_config,
+    enable_persistent_fabric,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+    profiler=BenchmarkProfiler(),
+    warmup_iters=0,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_gather_concat(
+        input_tensor_mesh,
+        dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        num_heads=8,
+        memory_config=output_mem_config,
+        topology=all_gather_topology,
+        subdevice_id=subdevice_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+
+    print("warmup iteration: ", warmup_iters)
+    if warmup_iters > 0:
+        trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for i in range(warmup_iters):
+            tt_out_tensor = ttnn.experimental.all_gather_concat(
+                input_tensor_mesh,
+                dim,
+                multi_device_global_semaphore=multi_device_global_semaphore,
+                num_links=num_links,
+                num_heads=8,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=subdevice_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+        ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_gather_concat(
+            input_tensor_mesh,
+            dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            num_heads=8,
+            memory_config=output_mem_config,
+            topology=all_gather_topology,
+            subdevice_id=subdevice_id,
+            enable_persistent_fabric_mode=enable_persistent_fabric,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+
+    profiler.start("all-gather-concat-trace-warmup")
+    if warmup_iters > 0:
+        ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+        ttnn.release_trace(mesh_device, trace_id_warmup)
+        ttnn.synchronize_device(mesh_device)
+    profiler.end("all-gather-concat-trace-warmup")
+
+    signpost("start")
+    profiler.start("all-gather-concat-trace")
+
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    profiler.end("all-gather-concat-trace")
+    signpost("stop")
+    time_taken = profiler.get_duration("all-gather-concat-trace") - profiler.get_duration(
+        "all-gather-concat-trace-warmup"
+    )
+    # effective_iter = num_iter - warmup_iters
+    # logger.info(f"Time taken e2e: {time_taken} s")
+    # logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
+    # logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
+
+    return tt_out_tensor
+
+
+def run_with_trace_gather_concat(
+    mesh_device,
+    all_gather_topology,
+    input_tensor_mesh,
+    dim,
+    num_links,
+    output_mem_config,
+    enable_persistent_fabric,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+    profiler=BenchmarkProfiler(),
+    warmup_iters=0,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_gather_async(
+        input_tensor_mesh,
+        dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_gather_topology,
+        subdevice_id=subdevice_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+    ttnn.synchronize_device(mesh_device)
+    tt_out_tensor = ttnn.experimental.nlp_concat_heads_decode(tt_out_tensor, num_heads=8)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    if warmup_iters > 0:
+        trace_id_warmup = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for i in range(num_iter):
+            tt_out_tensor = ttnn.experimental.all_gather_async(
+                input_tensor_mesh,
+                dim,
+                multi_device_global_semaphore=multi_device_global_semaphore,
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=subdevice_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+            tt_out_tensor = ttnn.experimental.nlp_concat_heads_decode(tt_out_tensor, num_heads=8)
+        ttnn.end_trace_capture(mesh_device, trace_id_warmup, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        # trace_id_warmup2 = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        # ttnn.end_trace_capture(mesh_device, trace_id_warmup2, cq_id=0)
+
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_gather_async(
+            input_tensor_mesh,
+            dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_gather_topology,
+            subdevice_id=subdevice_id,
+            enable_persistent_fabric_mode=enable_persistent_fabric,
+        )
+        tt_out_tensor = ttnn.experimental.nlp_concat_heads_decode(tt_out_tensor, num_heads=8)
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+    # trace_id2 = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+
+    # ttnn.end_trace_capture(mesh_device, trace_id2, cq_id=0)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    profiler.start("all-gather-concat-trace-warmup")
+    if warmup_iters > 0:
+        ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+        ttnn.release_trace(mesh_device, trace_id_warmup)
+        ttnn.synchronize_device(mesh_device)
+    profiler.end("all-gather-concat-trace-warmup")
+
+    signpost("start")
+    profiler.start("all-gather-concat-trace")
+
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    profiler.end("all-gather-concat-trace")
+    signpost("stop")
+    time_taken = profiler.get_duration("all-gather-concat-trace") - profiler.get_duration(
+        "all-gather-concat-trace-warmup"
+    )
+    return tt_out_tensor
+
+
+def run_gather_concat_impl(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    use_program_cache,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    all_gather_topology,
+    num_iters=1,
+    enable_async=False,
+    trace_mode=False,
+    output_shard_shape=None,
+    output_shard_grid=None,
+    tensor_mem_layout=None,
+    warmup_iters=0,
+    profiler=BenchmarkProfiler(),
+):
+    enable_persistent_fabric = True
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+    # Use Async mode based on test input config
+    mesh_device.enable_async(enable_async)
+
+    if enable_async:
+        logger.info(f"Using Async Mode for All Gather Op Dispatch")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+        mesh_device,
+        [worker_sub_device],
+        0,
+        0,
+        enable_persistent_fabric,
+        wrap_fabric_around_mesh=True,
+    )
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### For sharded all gather only
+    if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
+        pytest.fail(
+            "Both input_shard_shape, shard_grid, and tensor_mem_layout must be provided together or all must be None"
+        )
+    if input_shard_shape and input_shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            input_shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        if output_shard_shape is None:
+            assert (
+                output_shard_grid is None
+            ), "output_shard_grid must not be provided if output_shard_shape is not provided"
+            output_shard_shape = list(input_shard_shape)
+            if dim == len(output_shape) - 1:
+                output_shard_shape[1] *= num_devices
+            else:
+                output_shard_shape[0] *= num_devices
+            output_shard_spec = ttnn.ShardSpec(
+                input_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+        else:
+            assert output_shard_grid is not None, "output_shard_grid must be provided if output_shard_shape is provided"
+            output_shard_spec = ttnn.ShardSpec(
+                output_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+    ###
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        output_tensor = torch.rand(output_shape).bfloat16()
+        output_tensor_goldens_list.append(output_tensor)
+        input_tensors = torch.chunk(output_tensor, num_devices, dim)
+        tt_input_tensors = []
+        for i, t in enumerate(input_tensors):
+            tt_input_tensors.append(
+                ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], input_mem_config)
+            )
+            logger.info(f"using device {mesh_device.get_devices()[i].id()}")
+
+        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    tt_out_tensor_list_concat = []
+    if trace_mode:
+        tt_out_tensor = run_with_trace_gather_concat(
+            mesh_device,
+            all_gather_topology,
+            input_tensor_mesh_list[0],
+            dim,
+            num_links,
+            output_mem_config,
+            enable_persistent_fabric,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+            profiler=profiler,
+            warmup_iters=warmup_iters,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+        tt_out_tensor_list_concat = tt_out_tensor_list
+    else:
+        for i in range(num_iters):
+            tt_out_tensor = ttnn.experimental.all_gather_async(
+                input_tensor_mesh_list[0],
+                dim,
+                multi_device_global_semaphore=ccl_semaphore_handles[0],
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+            tt_out_tensor_list.append(tt_out_tensor)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        for out_gather_idx in range(len(tt_out_tensor_list)):
+            tt_out_tensor_list_concat.append(
+                ttnn.experimental.nlp_concat_heads_decode(tt_out_tensor_list[out_gather_idx], num_heads=8)
+            )
+        logger.info(f"Done op")
+
+    passed = True
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensor = tt_out_tensor_list_concat[tensor_index]
+        output_tensor = output_tensor_goldens_list[0]
+        output_tensor = output_tensor[:, :, :8, :]
+        output_tensor_concat = output_tensor.reshape(1, 1, 32, 1024)
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
+
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor_concat)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor_concat)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+                passed = False
+            # print(tt_output_tensor)
+            # print(output_tensor_concat)
+    """
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+    """
+    mesh_device.reset_sub_device_stall_group()
+    teardown_fabric_interface(mesh_device)
+
+    if not passed:
+        assert eq, f"{i} FAILED: {output}"
+
+
+def run_concat_fuse_impl(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    use_program_cache,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    all_gather_topology,
+    num_iters=1,
+    enable_async=False,
+    trace_mode=False,
+    output_shard_shape=None,
+    output_shard_grid=None,
+    tensor_mem_layout=None,
+    warmup_iters=0,
+    profiler=BenchmarkProfiler(),
+):
+    enable_persistent_fabric = True
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+    # Use Async mode based on test input config
+    mesh_device.enable_async(enable_async)
+
+    if enable_async:
+        logger.info(f"Using Async Mode for All Gather Op Dispatch")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+        mesh_device,
+        [worker_sub_device],
+        0,
+        0,
+        enable_persistent_fabric,
+        wrap_fabric_around_mesh=True,
+    )
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### For sharded all gather only
+    if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
+        pytest.fail(
+            "Both input_shard_shape, shard_grid, and tensor_mem_layout must be provided together or all must be None"
+        )
+    if input_shard_shape and input_shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            input_shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        if output_shard_shape is None:
+            assert (
+                output_shard_grid is None
+            ), "output_shard_grid must not be provided if output_shard_shape is not provided"
+            output_shard_shape = list(input_shard_shape)
+            if dim == len(output_shape) - 1:
+                output_shard_shape[1] *= num_devices
+            else:
+                output_shard_shape[0] *= num_devices
+            output_shard_spec = ttnn.ShardSpec(
+                input_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+        else:
+            assert output_shard_grid is not None, "output_shard_grid must be provided if output_shard_shape is provided"
+            output_shard_spec = ttnn.ShardSpec(
+                output_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+    ###
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        output_tensor = torch.rand(output_shape).bfloat16()
+        output_tensor_goldens_list.append(output_tensor)
+        input_tensors = torch.chunk(output_tensor, num_devices, dim)
+        tt_input_tensors = []
+        for i, t in enumerate(input_tensors):
+            tt_input_tensors.append(
+                ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], input_mem_config)
+            )
+            logger.info(f"using device {mesh_device.get_devices()[i].id()}")
+
+        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    print("input tensor shape: \n", input_tensor_mesh_list[0].shape)
+    if trace_mode:
+        tt_out_tensor = run_with_trace(
+            mesh_device,
+            all_gather_topology,
+            input_tensor_mesh_list[0],
+            dim,
+            num_links,
+            output_mem_config,
+            enable_persistent_fabric,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+            profiler=profiler,
+            warmup_iters=warmup_iters,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            print("iteration: ", i)
+            tt_out_tensor = ttnn.experimental.all_gather_concat(
+                input_tensor_mesh_list[i],
+                dim,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                num_links=num_links,
+                num_heads=8,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+            tt_out_tensor_list.append(tt_out_tensor)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensor = tt_out_tensor_list[tensor_index]
+        output_tensor = output_tensor_goldens_list[tensor_index]
+        output_tensor = output_tensor[:, :, :8, :]
+        output_tensor_concat = output_tensor.reshape(1, 1, 32, 1024)
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
+
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor_concat)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor_concat)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+                passed = False
+            print(tt_output_tensor)
+            print(output_tensor_concat)
+    """
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+    """
+    mesh_device.reset_sub_device_stall_group()
+    teardown_fabric_interface(mesh_device)
+    print("teardown done\n")
+
+    if not passed:
+        assert eq, f"{i} FAILED: {output}"

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
@@ -456,7 +456,7 @@ def run_concat_fuse_impl(
     num_links,
     input_dtype,
     layout,
-    use_program_cache,
+    # use_program_cache,
     function_level_defaults,
     input_shard_shape,
     input_shard_grid,

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/reduce_scatter_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/reduce_scatter_test.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull
+from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
+    create_and_load_sub_device_manager_with_fabric_interface,
+    teardown_fabric_interface,
+    create_global_semaphore_with_same_address,
+)
+
+
+def run_with_trace(
+    mesh_device,
+    all_gather_topology,
+    input_tensor_mesh,
+    dim,
+    num_links,
+    output_mem_config,
+    enable_persistent_fabric,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_gather_async(
+        input_tensor_mesh,
+        dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_gather_topology,
+        subdevice_id=subdevice_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_gather_async(
+            input_tensor_mesh,
+            dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_gather_topology,
+            subdevice_id=subdevice_id,
+            enable_persistent_fabric_mode=enable_persistent_fabric,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return tt_out_tensor
+
+
+def run_reduce_scatter_impl(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    use_program_cache,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    all_gather_topology,
+    num_iters=1,
+    enable_async=False,
+    trace_mode=False,
+    output_shard_shape=None,
+    output_shard_grid=None,
+    tensor_mem_layout=None,
+):
+    enable_persistent_fabric = True
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+    # Use Async mode based on test input config
+    mesh_device.enable_async(enable_async)
+
+    if enable_async:
+        logger.info(f"Using Async Mode for All Gather Op Dispatch")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+        mesh_device,
+        [worker_sub_device],
+        0,
+        0,
+        enable_persistent_fabric,
+        wrap_fabric_around_mesh=True,
+    )
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### For sharded all gather only
+    if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
+        pytest.fail(
+            "Both input_shard_shape, shard_grid, and tensor_mem_layout must be provided together or all must be None"
+        )
+    if input_shard_shape and input_shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            input_shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        if output_shard_shape is None:
+            assert (
+                output_shard_grid is None
+            ), "output_shard_grid must not be provided if output_shard_shape is not provided"
+            output_shard_shape = list(input_shard_shape)
+            if dim == len(output_shape) - 1:
+                output_shard_shape[1] *= num_devices
+            else:
+                output_shard_shape[0] *= num_devices
+            output_shard_spec = ttnn.ShardSpec(
+                input_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+        else:
+            assert output_shard_grid is not None, "output_shard_grid must be provided if output_shard_shape is provided"
+            output_shard_spec = ttnn.ShardSpec(
+                output_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+    ###
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        output_tensor = torch.rand(output_shape).bfloat16()
+        output_tensor_goldens_list.append(output_tensor)
+        input_tensors = torch.chunk(output_tensor, num_devices, dim)
+        tt_input_tensors = []
+        for i, t in enumerate(input_tensors):
+            tt_input_tensors.append(
+                ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], input_mem_config)
+            )
+            logger.info(f"using device {mesh_device.get_devices()[i].id()}")
+
+        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    if trace_mode:
+        tt_out_tensor = run_with_trace(
+            mesh_device,
+            all_gather_topology,
+            input_tensor_mesh_list[0],
+            dim,
+            num_links,
+            output_mem_config,
+            enable_persistent_fabric,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            tt_out_tensor = ttnn.experimental.all_gather_async(
+                input_tensor_mesh_list[i],
+                dim,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+            tt_out_tensor_list.append(tt_out_tensor)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensor = tt_out_tensor_list[tensor_index]
+        output_tensor = output_tensor_goldens_list[tensor_index]
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
+
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+                passed = False
+
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+
+    if enable_persistent_fabric:
+        mesh_device.reset_sub_device_stall_group()
+        teardown_fabric_interface(mesh_device)
+
+    if not passed:
+        assert eq, f"{i} FAILED: {output}"

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull
+from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
+    create_and_load_sub_device_manager_with_fabric_interface,
+    teardown_fabric_interface,
+    create_global_semaphore_with_same_address,
+)
+
+
+def run_with_trace(
+    mesh_device,
+    all_gather_topology,
+    input_tensor_mesh,
+    dim,
+    num_links,
+    output_mem_config,
+    enable_persistent_fabric,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_gather_async(
+        input_tensor_mesh,
+        dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_gather_topology,
+        subdevice_id=subdevice_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_gather_async(
+            input_tensor_mesh,
+            dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_gather_topology,
+            subdevice_id=subdevice_id,
+            enable_persistent_fabric_mode=enable_persistent_fabric,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return tt_out_tensor
+
+
+def run_rms_fuse_impl(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    use_program_cache,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    all_gather_topology,
+    num_iters=1,
+    enable_async=False,
+    trace_mode=False,
+    output_shard_shape=None,
+    output_shard_grid=None,
+    tensor_mem_layout=None,
+):
+    enable_persistent_fabric = True
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+    # Use Async mode based on test input config
+    mesh_device.enable_async(enable_async)
+
+    if enable_async:
+        logger.info(f"Using Async Mode for All Gather Op Dispatch")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+        mesh_device,
+        [worker_sub_device],
+        0,
+        0,
+        enable_persistent_fabric,
+        wrap_fabric_around_mesh=True,
+    )
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### For sharded all gather only
+    if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
+        pytest.fail(
+            "Both input_shard_shape, shard_grid, and tensor_mem_layout must be provided together or all must be None"
+        )
+    if input_shard_shape and input_shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            input_shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        if output_shard_shape is None:
+            assert (
+                output_shard_grid is None
+            ), "output_shard_grid must not be provided if output_shard_shape is not provided"
+            output_shard_shape = list(input_shard_shape)
+            if dim == len(output_shape) - 1:
+                output_shard_shape[1] *= num_devices
+            else:
+                output_shard_shape[0] *= num_devices
+            output_shard_spec = ttnn.ShardSpec(
+                input_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+        else:
+            assert output_shard_grid is not None, "output_shard_grid must be provided if output_shard_shape is provided"
+            output_shard_spec = ttnn.ShardSpec(
+                output_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+    ###
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        output_tensor = torch.rand(output_shape).bfloat16()
+        output_tensor_goldens_list.append(output_tensor)
+        input_tensors = torch.chunk(output_tensor, num_devices, dim)
+        tt_input_tensors = []
+        for i, t in enumerate(input_tensors):
+            tt_input_tensors.append(
+                ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], input_mem_config)
+            )
+            logger.info(f"using device {mesh_device.get_devices()[i].id()}")
+
+        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    if trace_mode:
+        tt_out_tensor = run_with_trace(
+            mesh_device,
+            all_gather_topology,
+            input_tensor_mesh_list[0],
+            dim,
+            num_links,
+            output_mem_config,
+            enable_persistent_fabric,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            tt_out_tensor = ttnn.experimental.all_gather_async(
+                input_tensor_mesh_list[i],
+                dim,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+            tt_out_tensor_list.append(tt_out_tensor)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensor = tt_out_tensor_list[tensor_index]
+        output_tensor = output_tensor_goldens_list[tensor_index]
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
+
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+                passed = False
+
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+
+    if enable_persistent_fabric:
+        mesh_device.reset_sub_device_stall_group()
+        teardown_fabric_interface(mesh_device)
+
+    if not passed:
+        assert eq, f"{i} FAILED: {output}"

--- a/tests/ttnn/unit_tests/operations/ccl/test_gather_concat_fuse.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_gather_concat_fuse.py
@@ -312,7 +312,7 @@ def run_line_all_gather_concat_on_TG_with_mesh_tensor_along_rows(
     # here
     output_tensor_concat = full_input_tensor_unfractured[:, :, :8, :]
     print("output_tensor_concat1:", output_tensor_concat.shape)
-    output_tensor_concat = output_tensor_concat.reshape(8, 1, 32, 1024)
+    output_tensor_concat = output_tensor_concat.reshape(num_all_gather_instances, 1, 32, 1024)
     print("output_tensor_concat2:", output_tensor_concat.shape)
 
     output_golden[:, :, :, :] = output_tensor_concat.repeat(repeat_factor)

--- a/tests/ttnn/unit_tests/operations/ccl/test_gather_concat_fuse.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_gather_concat_fuse.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from models.utility_functions import skip_for_grayskull
+from tracy import signpost
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+
+from tests.ttnn.unit_tests.operations.ccl.test_all_gather_TG_post_commit import (
+    run_line_all_gather_on_TG_with_mesh_tensor_along_rows,
+)
+from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
+    run_all_reduce_impl,
+)
+from ttnn import ShardTensor2dMesh, ConcatMesh2dToTensor
+from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
+    create_and_load_sub_device_manager_with_fabric_interface,
+    teardown_fabric_interface,
+    create_global_semaphore_with_same_address,
+)
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+
+NUM_ITERATIONS = 10
+NUM_BUFFERS = 8
+
+
+def run_with_trace(
+    mesh_device,
+    all_gather_topology,
+    input_tensor,
+    dim,
+    cluster_axis,
+    num_links,
+    output_mem_config,
+    ccl_semaphore_handles,
+    worker_sub_device_id,
+    enable_persistent_fabric,
+    n_worker=None,
+    n_buffer=None,
+    num_iter=20,
+    warmup_iters=0,
+    use_all_gather_async=False,
+    profiler=BenchmarkProfiler(),
+):
+    # Compile Run
+    logger.info("Compiling model")
+    print("input tensor shape: \n", input_tensor.shape)
+
+    tt_out_tensor = ttnn.experimental.all_gather_concat(
+        input_tensor,
+        dim,
+        cluster_axis=cluster_axis,
+        multi_device_global_semaphore=ccl_semaphore_handles[0],
+        mesh_device=mesh_device,
+        num_links=num_links,
+        num_heads=8,
+        memory_config=output_mem_config,
+        topology=ttnn.Topology.Linear,
+        subdevice_id=worker_sub_device_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+
+    def capture_trace(n_iters):
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        for i in range(n_iters):
+            tt_out_tensor = ttnn.experimental.all_gather_concat(
+                input_tensor,
+                dim,
+                cluster_axis=cluster_axis,
+                mesh_device=mesh_device,
+                multi_device_global_semaphore=ccl_semaphore_handles[i % NUM_BUFFERS],
+                num_links=num_links,
+                num_heads=8,
+                memory_config=output_mem_config,
+                topology=ttnn.Topology.Linear,
+                subdevice_id=worker_sub_device_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        return trace_id
+
+    if warmup_iters > 0:
+        trace_id_warmup = capture_trace(warmup_iters)
+    trace_id = capture_trace(num_iter)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    profiler.start("all-gather-async-trace-warmup")
+    if warmup_iters > 0:
+        ttnn.execute_trace(mesh_device, trace_id_warmup, blocking=False)
+        ttnn.release_trace(mesh_device, trace_id_warmup)
+        ttnn.synchronize_device(mesh_device)
+    profiler.end("all-gather-async-trace-warmup")
+
+    profiler.start("all-gather-async-trace")
+    signpost("start")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+    signpost("stop")
+    profiler.end("all-gather-async-trace")
+    time_taken = profiler.get_duration("all-gather-async-trace") - profiler.get_duration(
+        "all-gather-async-trace-warmup"
+    )
+    effective_iter = num_iter - warmup_iters
+    logger.info(f"Time taken e2e: {time_taken} s")
+    logger.info(f"Time per iter e2e: {time_taken / effective_iter} s")
+    logger.info(f"Time per iter e2e: {time_taken / effective_iter * 1e6} us")
+
+    return tt_out_tensor
+
+
+def run_line_all_gather_concat_on_TG_with_mesh_tensor_along_rows(
+    mesh_device,
+    num_devices_per_line,
+    per_chip_output_shape,
+    tensor_memory_layout,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    buffer_type: ttnn.BufferType,
+    # use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_spec: ttnn.ShardSpec = None,
+    output_shard_spec: ttnn.ShardSpec = None,
+    num_all_gather_instances: int = 1,
+    num_iters: int = 1,
+    warmup_iters: int = 0,
+    cluster_axis: int = 0,
+    tile=(32, 32),
+    trace_mode=False,
+    debug=False,
+    profiler=BenchmarkProfiler(),
+    # New all-gather-async and persistent fabric params
+    use_all_gather_async=False,
+    enable_persistent_fabric=False,
+    create_persistent_fabric=False,
+    teardown_persistent_fabric=False,
+):
+    if create_persistent_fabric:
+        assert use_all_gather_async
+        assert enable_persistent_fabric
+    if teardown_persistent_fabric:
+        assert use_all_gather_async
+        assert enable_persistent_fabric
+    if not use_all_gather_async:
+        assert not create_persistent_fabric
+        assert not teardown_persistent_fabric
+        assert not enable_persistent_fabric
+
+    mesh_device.enable_async(enable_async)
+
+    input_shape_per_chip = list(per_chip_output_shape)
+    input_shape_per_chip[dim] //= num_devices_per_line
+    tensor_height_per_all_gather = per_chip_output_shape[-2]
+
+    full_mesh_input_shape = list(per_chip_output_shape)
+    ## The `all_gather_instances_concat_dim` is the dimension we will split the cluster spanning tensor along in order to split it
+    ## off into per-all-gather tensors
+    all_gather_instances_concat_dim = 1 if dim == 0 else 0
+    print("all_gather_instances_concat_dim:", all_gather_instances_concat_dim)
+    print("per_chip_output_shape: ", full_mesh_input_shape)
+    print("all_gather_instances_concat_dim: ", all_gather_instances_concat_dim)
+    print("num_devices_per_line: ", num_devices_per_line)
+
+    full_mesh_input_shape[all_gather_instances_concat_dim] *= num_all_gather_instances
+    print("full_mesh_input_shape: ", full_mesh_input_shape)
+    logger.info(
+        f"per_chip_output_shape: {full_mesh_input_shape}, dim: {dim}, all_gather_instances_concat_dim: {all_gather_instances_concat_dim}, num_devices_per_line: {num_devices_per_line}"
+    )
+
+    all_gather_instances_goldens = []
+    full_input_tensor_unfractured = torch.rand(full_mesh_input_shape, dtype=torch.bfloat16)
+
+    input_mem_config = ttnn.MemoryConfig(tensor_memory_layout, buffer_type=buffer_type, shard_spec=input_shard_spec)
+    shard_dims = (dim, all_gather_instances_concat_dim) if cluster_axis == 0 else (all_gather_instances_concat_dim, dim)
+    concat_dims = shard_dims
+
+    mesh_shape = (
+        (num_devices_per_line, num_all_gather_instances)
+        if cluster_axis == 0
+        else (num_all_gather_instances, num_devices_per_line)
+    )
+
+    if input_shard_spec is not None and output_shard_spec is None:
+        output_shard_shape = list(input_shard_spec.shape)
+        if dim == len(per_chip_output_shape) - 1:
+            output_shard_shape[1] *= num_devices_per_line
+        else:
+            output_shard_shape[0] *= num_devices_per_line
+        output_shard_spec = ttnn.ShardSpec(
+            input_shard_spec.grid,
+            output_shard_shape,
+            input_shard_spec.orientation,
+        )
+
+    output_mem_config = ttnn.MemoryConfig(tensor_memory_layout, buffer_type=buffer_type, shard_spec=output_shard_spec)
+    logger.info(f"input_shard_shape: {input_shard_spec.shape}, output_shard_shape: {output_shard_spec.shape}")
+    ttnn_tensor = ttnn.from_torch(
+        full_input_tensor_unfractured,
+        tile=ttnn.Tile(tile),
+        dtype=input_dtype,
+        device=mesh_device,
+        layout=layout,
+        memory_config=input_mem_config,
+        mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=shard_dims),
+    )
+    logger.info(f"ttnn_tensor_shape: {ttnn_tensor.shape}, mesh_shape: {mesh_shape}, shard_dims: {shard_dims}")
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
+    ttnn_tensor = ttnn.to_memory_config(ttnn_tensor, input_mem_config)
+
+    sub_device_stall_group = []
+    if use_all_gather_async:
+        compute_grid_size = mesh_device.compute_with_storage_grid_size()
+        ccl_sub_device_crs = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+        )
+        worker_sub_device = ttnn.SubDevice(
+            [
+                ccl_sub_device_crs,
+            ]
+        )
+        worker_sub_device_id = ttnn.SubDeviceId(0)
+        sub_device_stall_group = [worker_sub_device_id]
+        if create_persistent_fabric:
+            logger.info("Create persistent fabric interface")
+            mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+                mesh_device, [worker_sub_device], 0, 0, enable_persistent_fabric
+            )
+            logger.info("Done Create persistent fabric interface")
+            mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+        # create global semaphore handles
+        ccl_semaphore_handles = [
+            create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(NUM_BUFFERS)
+        ]
+    try:
+        # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor)
+        if trace_mode:
+            ttnn_tensor_out = run_with_trace(
+                input_tensor=ttnn_tensor,
+                dim=dim,
+                mesh_device=mesh_device,
+                cluster_axis=cluster_axis,
+                num_links=num_links,
+                output_mem_config=output_mem_config,
+                ccl_semaphore_handles=ccl_semaphore_handles,
+                worker_sub_device_id=worker_sub_device_id,
+                enable_persistent_fabric=enable_persistent_fabric,
+                all_gather_topology=ttnn.Topology.Linear,
+                num_iter=num_iters,
+                warmup_iters=warmup_iters,
+                use_all_gather_async=use_all_gather_async,
+                profiler=profiler,
+            )
+
+        else:
+            signpost("start")
+            for i in range(num_iters):
+                logger.info("Running all-gather async")
+                ttnn_tensor_out = ttnn.experimental.all_gather_concat(
+                    ttnn_tensor,
+                    dim,
+                    cluster_axis=cluster_axis,
+                    multi_device_global_semaphore=ccl_semaphore_handles[i % NUM_BUFFERS],
+                    mesh_device=mesh_device,
+                    num_links=num_links,
+                    num_heads=8,
+                    memory_config=output_mem_config,
+                    topology=ttnn.Topology.Linear,
+                    subdevice_id=worker_sub_device_id,
+                    enable_persistent_fabric_mode=enable_persistent_fabric,
+                )
+
+            ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+            signpost("stop")
+    except Exception as e:
+        logger.error(f"Exception: {e}")
+        raise e
+    finally:
+        if enable_persistent_fabric and teardown_persistent_fabric:
+            logger.info("Tearing down persistent fabric interface")
+            mesh_device.reset_sub_device_stall_group()
+            teardown_fabric_interface(mesh_device)
+            logger.info("Done tearing down persistent fabric interface")
+
+    # ttnn.visualize_mesh_device(mesh_device, tensor=ttnn_tensor_out)
+    tt_output_tensor = ttnn.to_torch(
+        ttnn_tensor_out, mesh_composer=ConcatMesh2dToTensor(mesh_device, mesh_shape=mesh_shape, dims=concat_dims)
+    )
+    output_tensors_list = torch.chunk(tt_output_tensor, num_all_gather_instances, dim=all_gather_instances_concat_dim)
+    output_golden = torch.zeros(tt_output_tensor.shape)
+
+    # Repeat the input tensor to represent the fact that the full concatenated input tensor lives across every
+    # device in the line
+    repeat_factor = [1] * len(output_golden.shape)
+    repeat_factor[dim] = num_devices_per_line
+
+    # here
+    output_tensor_concat = full_input_tensor_unfractured[:, :, :8, :]
+    print("output_tensor_concat1:", output_tensor_concat.shape)
+    output_tensor_concat = output_tensor_concat.reshape(8, 1, 32, 1024)
+    print("output_tensor_concat2:", output_tensor_concat.shape)
+
+    output_golden[:, :, :, :] = output_tensor_concat.repeat(repeat_factor)
+    print("output_golden:", output_golden.shape)
+
+    eq = True
+    if input_dtype == ttnn.bfloat16:
+        eq, output = comp_equal(tt_output_tensor, output_golden)
+        if not eq and debug is True:
+            logger.error(f"found mismatches")
+            report_mismatches(tt_output_tensor, output_golden, 100)
+            print_tile_corners_of_tensor(tt_output_tensor)
+    else:
+        eq, output = comp_pcc(tt_output_tensor, output_golden)
+    if not eq:
+        logger.error(f"output mismatch for tensor: {output}")
+
+    assert eq, f"FAILED: {output}"
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, num_links",
+    [
+        (4, 3),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+    ],
+)
+@pytest.mark.parametrize(
+    "num_iters, warmup_iters",
+    [
+        (NUM_ITERATIONS, 0),
+    ],
+)
+@pytest.mark.parametrize("shard_grid_orientation", [ttnn.ShardOrientation.ROW_MAJOR])
+@pytest.mark.parametrize(
+    "tensor_mem_layout, output_shape, dim, input_shard_shape,input_shard_grid,output_shard_shape, output_shard_grid, layout",
+    (
+        (  # AllGather after SDPA
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            (1, 32, 32, 128),
+            1,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+            ttnn.TILE_LAYOUT,
+        ),
+    ),
+    ids=[
+        "sdpa",
+    ],
+)
+@pytest.mark.parametrize("replication_factor", [8])
+@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 17068032}], indirect=True)
+def test_all_gather_concat_fuse_llama(
+    mesh_device,
+    num_devices,
+    output_shape,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    shard_grid_orientation,
+    tensor_mem_layout,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    # use_program_cache,
+    function_level_defaults,
+    enable_async,
+    replication_factor,
+    num_iters,
+    warmup_iters,
+):
+    if len(mesh_device.get_devices()) != 32:
+        pytest.skip("Not TG!")
+    input_shard_spec = ttnn.ShardSpec(
+        input_shard_grid,
+        input_shard_shape,
+        shard_grid_orientation,
+    )
+
+    if output_shard_grid is not None and output_shard_shape is not None:
+        output_shard_spec = ttnn.ShardSpec(
+            output_shard_grid,
+            output_shard_shape,
+            shard_grid_orientation,
+        )
+    else:
+        output_shard_spec = None
+
+    profiler = BenchmarkProfiler()
+
+    run_line_all_gather_concat_on_TG_with_mesh_tensor_along_rows(
+        mesh_device,
+        num_devices,
+        output_shape,
+        tensor_mem_layout,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        ttnn.BufferType.L1,
+        # use_program_cache,
+        function_level_defaults,
+        enable_async=enable_async,
+        num_iters=num_iters,
+        warmup_iters=warmup_iters,
+        input_shard_spec=input_shard_spec,
+        output_shard_spec=output_shard_spec,
+        num_all_gather_instances=replication_factor,
+        cluster_axis=1,
+        profiler=profiler,
+        trace_mode=False,
+        use_all_gather_async=True,
+        enable_persistent_fabric=True,
+        create_persistent_fabric=True,
+        teardown_persistent_fabric=True,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/test_gather_concat_fuse.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_gather_concat_fuse.py
@@ -131,7 +131,7 @@ def run_line_all_gather_concat_on_TG_with_mesh_tensor_along_rows(
     input_dtype,
     layout,
     buffer_type: ttnn.BufferType,
-    # use_program_cache,
+    use_program_cache,
     function_level_defaults,
     enable_async,
     input_shard_spec: ttnn.ShardSpec = None,
@@ -362,9 +362,19 @@ def run_line_all_gather_concat_on_TG_with_mesh_tensor_along_rows(
             (1, 32, 32, 128),
             1,
             (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                }
+            ),
             (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                }
+            ),
             ttnn.TILE_LAYOUT,
         ),
     ),
@@ -390,7 +400,7 @@ def test_all_gather_concat_fuse_llama(
     num_links,
     input_dtype,
     layout,
-    # use_program_cache,
+    use_program_cache,
     function_level_defaults,
     enable_async,
     replication_factor,
@@ -426,7 +436,7 @@ def test_all_gather_concat_fuse_llama(
         input_dtype,
         layout,
         ttnn.BufferType.L1,
-        # use_program_cache,
+        use_program_cache,
         function_level_defaults,
         enable_async=enable_async,
         num_iters=num_iters,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -1,0 +1,650 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal, comp_pcc
+from models.utility_functions import skip_for_grayskull
+from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
+    create_and_load_sub_device_manager_with_fabric_interface,
+    teardown_fabric_interface,
+    create_global_semaphore_with_same_address,
+)
+
+from tests.ttnn.unit_tests.operations.ccl.fusion_subtests.rms_test import run_rms_fuse_impl
+
+from tests.ttnn.unit_tests.operations.ccl.fusion_subtests.reduce_scatter_test import run_reduce_scatter_impl
+
+from tests.ttnn.unit_tests.operations.ccl.fusion_subtests.concat_fuse_test import (
+    run_concat_fuse_impl,
+    run_gather_concat_impl,
+)
+
+from tests.ttnn.unit_tests.operations.ccl.fusion_subtests.all_reduce_test import run_all_reduce_impl
+from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+
+
+def run_allgather_only_with_trace(
+    mesh_device,
+    all_gather_topology,
+    input_tensor_mesh,
+    dim,
+    num_links,
+    output_mem_config,
+    enable_persistent_fabric,
+    multi_device_global_semaphore,
+    num_iter=20,
+    subdevice_id=None,
+):
+    # Compile Run
+    logger.info("Compiling model")
+    tt_out_tensor = ttnn.experimental.all_gather_async(
+        input_tensor_mesh,
+        dim,
+        multi_device_global_semaphore=multi_device_global_semaphore,
+        num_links=num_links,
+        memory_config=output_mem_config,
+        topology=all_gather_topology,
+        subdevice_id=subdevice_id,
+        enable_persistent_fabric_mode=enable_persistent_fabric,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    # Capture trace
+    logger.info("Capturing trace")
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for i in range(num_iter):
+        tt_out_tensor = ttnn.experimental.all_gather_async(
+            input_tensor_mesh,
+            dim,
+            multi_device_global_semaphore=multi_device_global_semaphore,
+            num_links=num_links,
+            memory_config=output_mem_config,
+            topology=all_gather_topology,
+            subdevice_id=subdevice_id,
+            enable_persistent_fabric_mode=enable_persistent_fabric,
+        )
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # Run the op
+    logger.info("Starting Trace perf test...")
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.release_trace(mesh_device, trace_id)
+    ttnn.synchronize_device(mesh_device)
+
+    return tt_out_tensor
+
+
+def run_all_gather_impl(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    use_program_cache,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    all_gather_topology,
+    num_iters=1,
+    enable_async=False,
+    trace_mode=False,
+    output_shard_shape=None,
+    output_shard_grid=None,
+    tensor_mem_layout=None,
+):
+    enable_persistent_fabric = True
+    if num_iters < 1:
+        pytest.fail("num_iters must be >= 1")
+    # Use Async mode based on test input config
+    mesh_device.enable_async(enable_async)
+
+    if enable_async:
+        logger.info(f"Using Async Mode for All Gather Op Dispatch")
+
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(compute_grid_size.x - 1, compute_grid_size.y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice(
+        [
+            ccl_sub_device_crs,
+        ]
+    )
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_stall_group = [worker_sub_device_id]
+    mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
+        mesh_device,
+        [worker_sub_device],
+        0,
+        0,
+        enable_persistent_fabric,
+        wrap_fabric_around_mesh=True,
+    )
+    mesh_device.set_sub_device_stall_group(sub_device_stall_group)
+
+    # create global semaphore handles
+    ccl_semaphore_handles = [
+        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
+    ]
+
+    ### For sharded all gather only
+    if bool(input_shard_shape) != bool(input_shard_grid) and bool(tensor_mem_layout) != bool(input_shard_grid):
+        pytest.fail(
+            "Both input_shard_shape, shard_grid, and tensor_mem_layout must be provided together or all must be None"
+        )
+    if input_shard_shape and input_shard_grid:
+        input_shard_spec = ttnn.ShardSpec(
+            input_shard_grid,
+            input_shard_shape,
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        input_mem_config = ttnn.MemoryConfig(
+            tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=input_shard_spec
+        )
+        if output_shard_shape is None:
+            assert (
+                output_shard_grid is None
+            ), "output_shard_grid must not be provided if output_shard_shape is not provided"
+            output_shard_shape = list(input_shard_shape)
+            if dim == len(output_shape) - 1:
+                output_shard_shape[1] *= num_devices
+            else:
+                output_shard_shape[0] *= num_devices
+            output_shard_spec = ttnn.ShardSpec(
+                input_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+        else:
+            assert output_shard_grid is not None, "output_shard_grid must be provided if output_shard_shape is provided"
+            output_shard_spec = ttnn.ShardSpec(
+                output_shard_grid,
+                output_shard_shape,
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            output_mem_config = ttnn.MemoryConfig(
+                tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=output_shard_spec
+            )
+    ###
+
+    input_tensor_mesh_list = []
+    output_tensor_goldens_list = []
+
+    for i in range(num_iters):
+        output_tensor = torch.rand(output_shape).bfloat16()
+        output_tensor_goldens_list.append(output_tensor)
+        input_tensors = torch.chunk(output_tensor, num_devices, dim)
+        tt_input_tensors = []
+        for i, t in enumerate(input_tensors):
+            tt_input_tensors.append(
+                ttnn.Tensor(t, input_dtype).to(layout).to(mesh_device.get_devices()[i], input_mem_config)
+            )
+            logger.info(f"using device {mesh_device.get_devices()[i].id()}")
+
+        input_tensor_mesh = ttnn.aggregate_as_tensor(tt_input_tensors)
+
+        input_tensor_mesh_list.append(input_tensor_mesh)
+
+    tt_out_tensor_list = []
+    if trace_mode:
+        tt_out_tensor = run_allgather_only_with_trace(
+            mesh_device,
+            all_gather_topology,
+            input_tensor_mesh_list[0],
+            dim,
+            num_links,
+            output_mem_config,
+            enable_persistent_fabric,
+            multi_device_global_semaphore=ccl_semaphore_handles[0],
+            num_iter=num_iters,
+            subdevice_id=worker_sub_device_id,
+        )
+        tt_out_tensor_list.append(tt_out_tensor)
+    else:
+        for i in range(num_iters):
+            tt_out_tensor = ttnn.experimental.all_gather_async(
+                input_tensor_mesh_list[i],
+                dim,
+                multi_device_global_semaphore=ccl_semaphore_handles[i],
+                num_links=num_links,
+                memory_config=output_mem_config,
+                topology=all_gather_topology,
+                subdevice_id=worker_sub_device_id,
+                enable_persistent_fabric_mode=enable_persistent_fabric,
+            )
+            tt_out_tensor_list.append(tt_out_tensor)
+
+        logger.info(f"Waiting for op")
+        ttnn.synchronize_device(mesh_device, sub_device_ids=sub_device_stall_group)
+        logger.info(f"Done op")
+
+    passed = True
+    for tensor_index in range(len(tt_out_tensor_list)):
+        tt_out_tensor = tt_out_tensor_list[tensor_index]
+        output_tensor = output_tensor_goldens_list[tensor_index]
+        for i, t in enumerate(ttnn.get_device_tensors(tt_out_tensor)):
+            tt_output_tensor = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+            logger.info(f"Checking for device {t.device().id()}")
+
+            if input_dtype == ttnn.bfloat16:
+                eq, output = comp_equal(tt_output_tensor, output_tensor)
+            else:
+                eq, output = comp_pcc(tt_output_tensor, output_tensor)
+            if not eq:
+                logger.error(f"output mismatch for tensor {i}")
+                passed = False
+
+    for i in range(num_devices):
+        assert (
+            mesh_device.get_devices()[i].num_program_cache_entries() == 1
+            or mesh_device.get_devices()[i].num_program_cache_entries() == num_iters
+        ), f"Device {i} has {mesh_device.get_devices()[i].num_program_cache_entries()} program cache entries"
+
+    if enable_persistent_fabric:
+        mesh_device.reset_sub_device_stall_group()
+        teardown_fabric_interface(mesh_device)
+
+    if not passed:
+        assert eq, f"{i} FAILED: {output}"
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        # All Reduce test
+        (
+            8,
+            [1, 1, 32, 10240],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 3))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        # Before Concat Heads
+        (
+            4,
+            [1, 32, 32, 128],
+            1,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 7))}),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 7))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+        # Reduce Scatter
+        (
+            8,
+            [1, 1, 32, 30720],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 160),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 7))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+        # RMS NORM ALL GATHER FUSION
+        (
+            4,
+            [1, 1, 32, 128],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [8])
+@pytest.mark.parametrize("enable_async", [True])
+def test_all_gather_only(
+    t3k_mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    run_all_gather_impl(
+        t3k_mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        input_shard_shape,
+        input_shard_grid,
+        all_gather_topology=ttnn.Topology.Linear,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        # RMS NORM ALL GATHER FUSION
+        (
+            4,
+            [1, 1, 32, 128],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 32),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [8])
+@pytest.mark.parametrize("enable_async", [True])
+def test_rms_fuse(
+    t3k_mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    run_rms_fuse_impl(
+        t3k_mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        input_shard_shape,
+        input_shard_grid,
+        all_gather_topology=ttnn.Topology.Linear,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        # Reduce Scatter
+        (
+            8,
+            [1, 1, 32, 30720],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 160),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(2, 7))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [8])
+@pytest.mark.parametrize("enable_async", [True])
+def test_reduce_scatter(
+    t3k_mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    run_reduce_scatter_impl(
+        t3k_mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        input_shard_shape,
+        input_shard_grid,
+        all_gather_topology=ttnn.Topology.Linear,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        # Before Concat Heads
+        (
+            4,
+            [1, 32, 32, 128],
+            1,
+            ttnn.TILE_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            (32, 128),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+    ids=[
+        "concat_heads",
+    ],
+)
+@pytest.mark.parametrize("num_links", [3])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters, warmup_iters", [[100, 10]])
+@pytest.mark.parametrize("enable_async", [True])
+@pytest.mark.parametrize("trace_mode", [True])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 23887872}],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_concat_fuse(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    warmup_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+    trace_mode,
+):
+    profiler = BenchmarkProfiler()
+    run_concat_fuse_impl(
+        mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        input_shard_shape,
+        input_shard_grid,
+        all_gather_topology=ttnn.Topology.Linear,
+        warmup_iters=warmup_iters,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+        trace_mode=trace_mode,
+        profiler=profiler,
+    )
+
+
+# Enumerate the post-commit cases explicitly
+@skip_for_grayskull("Requires eth connected devices to run")
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        # All Reduce test
+        (
+            8,
+            [1, 1, 32, 10240],
+            3,
+            ttnn.TILE_LAYOUT,
+            (32, 64),
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 3))}),
+            None,
+            None,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters", [8])
+@pytest.mark.parametrize("enable_async", [True])
+def test_all_reduce(
+    t3k_mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    use_program_cache,
+    function_level_defaults,
+    enable_async,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+):
+    run_all_reduce_impl(
+        t3k_mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        input_shard_shape,
+        input_shard_grid,
+        all_gather_topology=ttnn.Topology.Linear,
+        num_iters=num_iters,
+        enable_async=enable_async,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+    )

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -528,9 +528,9 @@ def test_reduce_scatter(
         # ttnn.bfloat8_b,
     ],
 )
-@pytest.mark.parametrize("num_iters, warmup_iters", [[100, 10]])
+@pytest.mark.parametrize("num_iters, warmup_iters", [[3, 0]])
 @pytest.mark.parametrize("enable_async", [True])
-@pytest.mark.parametrize("trace_mode", [True])
+@pytest.mark.parametrize("trace_mode", [False])
 @pytest.mark.parametrize(
     "device_params",
     [{"trace_region_size": 23887872}],
@@ -547,7 +547,7 @@ def test_concat_fuse(
     layout,
     num_iters,
     warmup_iters,
-    use_program_cache,
+    # use_program_cache,
     function_level_defaults,
     enable_async,
     input_shard_shape,
@@ -566,7 +566,7 @@ def test_concat_fuse(
         num_links,
         input_dtype,
         layout,
-        use_program_cache,
+        # use_program_cache,
         function_level_defaults,
         input_shard_shape,
         input_shard_grid,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -510,9 +510,19 @@ def test_reduce_scatter(
             1,
             ttnn.TILE_LAYOUT,
             (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))}),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                }
+            ),
             (32, 128),
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))}),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                }
+            ),
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ),
     ],
@@ -547,7 +557,7 @@ def test_concat_fuse(
     layout,
     num_iters,
     warmup_iters,
-    # use_program_cache,
+    use_program_cache,
     function_level_defaults,
     enable_async,
     input_shard_shape,
@@ -566,7 +576,7 @@ def test_concat_fuse(
         num_links,
         input_dtype,
         layout,
-        # use_program_cache,
+        use_program_cache,
         function_level_defaults,
         input_shard_shape,
         input_shard_grid,

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -276,6 +276,9 @@ set(CCL_SRC_EXPERIMENTAL
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
 )
 
 set(TTNN_OP_SRCS
@@ -970,6 +973,7 @@ set(TTNN_SRC_PYBIND
 
 set(CCL_EXPERIMENTAL_TTNN_SRCS_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/all_gather_matmul_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.cpp
@@ -23,8 +23,11 @@ ttnn::Tensor ExecuteAllGatherConcat::invoke(
     std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
     bool enable_persistent_fabric_mode) {
     const std::array<uint32_t, 2> shard_shape = {32, 128};
+
+    auto core_range_1 = CoreRange(CoreCoord{1, 0}, CoreCoord{3, 9});
+    auto core_range_2 = CoreRange(CoreCoord{5, 0}, CoreCoord{6, 0});
     auto shard_spec =
-        ShardSpec(CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{7, 3})), shard_shape, ShardOrientation::ROW_MAJOR);
+        ShardSpec(CoreRangeSet(std::vector{core_range_1, core_range_2}), shard_shape, ShardOrientation::ROW_MAJOR);
     auto inter_output_mem_config =
         ttnn::MemoryConfig(TensorMemoryLayout::HEIGHT_SHARDED, ttnn::BufferType::L1, shard_spec);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_gather_concat.hpp"
+#include <utility>
+#include "ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "cpp/ttnn/global_semaphore.hpp"
+#include "llrt/tt_cluster.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+ttnn::Tensor ExecuteAllGatherConcat::invoke(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor,
+    const int32_t dim,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    bool enable_persistent_fabric_mode) {
+    const std::array<uint32_t, 2> shard_shape = {32, 128};
+    auto shard_spec =
+        ShardSpec(CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{7, 3})), shard_shape, ShardOrientation::ROW_MAJOR);
+    auto inter_output_mem_config =
+        ttnn::MemoryConfig(TensorMemoryLayout::HEIGHT_SHARDED, ttnn::BufferType::L1, shard_spec);
+
+    auto shape = input_tensor.get_padded_shape();
+    shape[dim] *= 4;
+    auto output_intermediate_tensor_spec = TensorSpec(
+        shape,
+        TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), inter_output_mem_config));
+
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map;
+    auto all_devices = input_tensor.get_workers();
+    for (auto d : tt::Cluster::instance().user_exposed_chip_ids()) {
+        for (auto dev : all_devices) {
+            if (dev->id() == d) {
+                auto input_buffer =
+                    tt::tt_metal::tensor_impl::allocate_buffer_on_device(dev, output_intermediate_tensor_spec);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor temp_tensor = Tensor(input_storage, output_intermediate_tensor_spec);
+                temp_tensor_map[d] = temp_tensor;
+            }
+        }
+    }
+    return ttnn::operations::experimental::ccl::all_gather_concat(
+        input_tensor,
+        dim,
+        temp_tensor_map,
+        multi_device_global_semaphore,
+        num_heads,
+        num_links,
+        memory_config,
+        topology,
+        subdevice_id,
+        enable_persistent_fabric_mode);
+}
+
+ttnn::Tensor ExecuteAllGatherConcat::invoke(
+    const ttnn::Tensor& input_tensor,
+    const int32_t dim,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const uint32_t num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    bool enable_persistent_fabric_mode) {
+    return invoke(
+        ttnn::DefaultQueueId,
+        input_tensor,
+        dim,
+        multi_device_global_semaphore,
+        num_heads,
+        num_links,
+        memory_config,
+        topology,
+        subdevice_id,
+        enable_persistent_fabric_mode);
+}
+
+ttnn::Tensor ExecuteAllGatherConcat::invoke(
+    QueueId queue_id,
+    const ttnn::Tensor& input_tensor,
+    const int32_t dim,
+    const uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const std::optional<uint32_t> num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    bool enable_persistent_fabric_mode) {
+    const std::array<uint32_t, 2> shard_shape = {32, 128};
+    auto shard_spec =
+        ShardSpec(CoreRangeSet(CoreRange(CoreCoord{0, 0}, CoreCoord{7, 3})), shard_shape, ShardOrientation::ROW_MAJOR);
+    auto inter_output_mem_config =
+        ttnn::MemoryConfig(TensorMemoryLayout::HEIGHT_SHARDED, ttnn::BufferType::L1, shard_spec);
+
+    auto shape = input_tensor.get_padded_shape();
+    shape[dim] *= 4;
+    auto output_intermediate_tensor_spec = TensorSpec(
+        shape,
+        TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), inter_output_mem_config));
+
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map;
+    auto all_devices = input_tensor.get_workers();
+    for (auto d : tt::Cluster::instance().user_exposed_chip_ids()) {
+        for (auto dev : all_devices) {
+            if (dev->id() == d) {
+                auto input_buffer =
+                    tt::tt_metal::tensor_impl::allocate_buffer_on_device(dev, output_intermediate_tensor_spec);
+                auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
+                Tensor temp_tensor = Tensor(input_storage, output_intermediate_tensor_spec);
+                temp_tensor_map[d] = temp_tensor;
+            }
+        }
+    }
+    return ttnn::operations::experimental::ccl::all_gather_concat(
+        input_tensor,
+        dim,
+        cluster_axis,
+        mesh_device,
+        temp_tensor_map,
+        multi_device_global_semaphore,
+        num_heads,
+        num_links,
+        memory_config,
+        topology,
+        subdevice_id,
+        enable_persistent_fabric_mode);
+}
+
+ttnn::Tensor ExecuteAllGatherConcat::invoke(
+    const ttnn::Tensor& input_tensor,
+    const int32_t dim,
+    const uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const std::optional<uint32_t> num_links,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+    bool enable_persistent_fabric_mode) {
+    return invoke(
+        ttnn::DefaultQueueId,
+        input_tensor,
+        dim,
+        cluster_axis,
+        mesh_device,
+        multi_device_global_semaphore,
+        num_heads,
+        num_links,
+        memory_config,
+        topology,
+        subdevice_id,
+        enable_persistent_fabric_mode);
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "cpp/ttnn/global_semaphore.hpp"
+
+namespace ttnn {
+namespace operations::experimental::ccl {
+
+struct ExecuteAllGatherConcat {
+    static ttnn::Tensor invoke(
+        QueueId queue_id,
+        const ttnn::Tensor& input_tensor,
+        const int32_t dim,
+        const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+        const uint32_t num_heads,
+        const uint32_t num_links = 1,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        bool enable_persistent_fabric_mode = false);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        const int32_t dim,
+        const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+        const uint32_t num_heads,
+        const uint32_t num_links = 1,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        bool enable_persistent_fabric_mode = false);
+
+    static ttnn::Tensor invoke(
+        QueueId queue_id,
+        const ttnn::Tensor& input_tensor,
+        const int32_t dim,
+        const uint32_t cluster_axis,
+        const MeshDevice& mesh_device,
+        const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+        const uint32_t num_heads,
+        const std::optional<uint32_t> num_links = std::nullopt,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        bool enable_persistent_fabric_mode = false);
+
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        const int32_t dim,
+        const uint32_t cluster_axis,
+        const MeshDevice& mesh_device,
+        const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+        const uint32_t num_heads,
+        const std::optional<uint32_t> num_links = std::nullopt,
+        const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+        const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+        std::optional<tt::tt_metal::SubDeviceId> subdevice_id = std::nullopt,
+        bool enable_persistent_fabric_mode = false);
+};
+
+}  // namespace operations::experimental::ccl
+
+namespace experimental {
+
+constexpr auto all_gather_concat = ttnn::register_operation<
+    "ttnn::experimental::all_gather_concat",
+    ttnn::operations::experimental::ccl::ExecuteAllGatherConcat>();
+
+}  // namespace experimental
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_gather_concat_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "cpp/pybind11/decorators.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "cpp/ttnn/global_semaphore.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+namespace detail {
+
+template <typename ccl_operation_t>
+void bind_all_gather_concat(pybind11::module& module, const ccl_operation_t& operation, const char* doc) {
+    // namespace py = pybind11;
+
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               const int32_t dim,
+               const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+               const uint32_t num_heads,
+               const uint32_t num_links,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const ttnn::ccl::Topology topology,
+               std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+               bool enable_persistent_fabric_mode,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(
+                    queue_id,
+                    input_tensor,
+                    dim,
+                    multi_device_global_semaphore,
+                    num_heads,
+                    num_links,
+                    memory_config,
+                    topology,
+                    subdevice_id,
+                    enable_persistent_fabric_mode);
+            },
+            py::arg("input_tensor"),
+            py::arg("dim"),
+            py::arg("multi_device_global_semaphore"),
+            py::arg("num_heads").noconvert(),
+            py::kw_only(),
+            py::arg("num_links") = 1,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("topology") = ttnn::ccl::Topology::Ring,
+            py::arg("subdevice_id") = std::nullopt,
+            py::arg("enable_persistent_fabric_mode") = false,
+            py::arg("queue_id") = DefaultQueueId},
+
+        ttnn::pybind_overload_t{
+            [](const ccl_operation_t& self,
+               const ttnn::Tensor& input_tensor,
+               const int32_t dim,
+               const uint32_t cluster_axis,
+               const MeshDevice& mesh_device,
+               const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+               const uint32_t num_heads,
+               const std::optional<uint32_t> num_links,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               const ttnn::ccl::Topology topology,
+               std::optional<tt::tt_metal::SubDeviceId> subdevice_id,
+               bool enable_persistent_fabric_mode,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(
+                    queue_id,
+                    input_tensor,
+                    dim,
+                    cluster_axis,
+                    mesh_device,
+                    multi_device_global_semaphore,
+                    num_heads,
+                    num_links,
+                    memory_config,
+                    topology,
+                    subdevice_id,
+                    enable_persistent_fabric_mode);
+            },
+            py::arg("input_tensor"),
+            py::arg("dim"),
+            py::arg("cluster_axis"),
+            py::arg("mesh_device"),
+            py::arg("multi_device_global_semaphore"),
+            py::arg("num_heads").noconvert(),
+            py::kw_only(),
+            py::arg("num_links") = 1,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("topology") = ttnn::ccl::Topology::Ring,
+            py::arg("subdevice_id") = std::nullopt,
+            py::arg("enable_persistent_fabric_mode") = false,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+}  // namespace detail
+
+void py_bind_all_gather_concat(pybind11::module& module) {
+    detail::bind_all_gather_concat(
+        module,
+        ttnn::experimental::all_gather_concat,
+        R"doc(
+        Performs an all-gather operation on multi-device :attr:`input_tensor` across all devices.
+        Args:
+            input_tensor (ttnn.Tensor): multi-device tensor.
+            dim (int): Dimension to perform operation.
+            cluster_axis (int): Provided a MeshTensor, the axis corresponding to MeshDevice to perform the line-all-gather operation on.
+            mesh_device (MeshDevice): Device mesh to perform the line-all-gather operation on.
+        * cluster_axis and mesh_device parameters are applicable only for Linear Topology.
+        Mesh Tensor Programming Guide : https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md
+        Keyword Args:
+            num_links (int, optional): Number of links to use for the all-gather operation. Defaults to `1`.
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
+            topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
+        Returns:
+            ttnn.Tensor: the output tensor.
+        Example:
+            >>> full_tensor = torch.randn([1, 1, 32, 256], dtype=torch.bfloat16)
+            >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
+            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
+            >>> ttnn_tensor = ttnn.from_torch(
+                            full_tensor,
+                            dtype=input_dtype,
+                            device=mesh_device,
+                            layout=layout,
+                            memory_config=mem_config,
+                            mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(1, 8), dims=(-1, -2)))
+            >>> ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
+            >>> output = ttnn.all_gather(ttnn_tensor, dim=0, topology=ttnn.Topology.Ring)
+        )doc");
+}
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.cpp
@@ -111,7 +111,7 @@ void py_bind_all_gather_concat(pybind11::module& module) {
         module,
         ttnn::experimental::all_gather_concat,
         R"doc(
-        Performs an all-gather operation on multi-device :attr:`input_tensor` across all devices.
+        Performs a fused all-gather/concat operation on multi-device (specific to llama model):attr:`input_tensor` across all devices.
         Args:
             input_tensor (ttnn.Tensor): multi-device tensor.
             dim (int): Dimension to perform operation.
@@ -121,23 +121,11 @@ void py_bind_all_gather_concat(pybind11::module& module) {
         Mesh Tensor Programming Guide : https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/Programming%20Mesh%20of%20Devices/Programming%20Mesh%20of%20Devices%20with%20TT-NN.md
         Keyword Args:
             num_links (int, optional): Number of links to use for the all-gather operation. Defaults to `1`.
+            num_heads (int): Number of heads for NLP concat heads
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `input tensor memory config`.
             topology (ttnn.Topology, optional): The topology configuration to run the operation in. Valid options are Ring and Linear. Defaults to `ttnn.Topology.Ring`.
         Returns:
             ttnn.Tensor: the output tensor.
-        Example:
-            >>> full_tensor = torch.randn([1, 1, 32, 256], dtype=torch.bfloat16)
-            >>> physical_device_ids = ttnn.get_t3k_physical_device_ids_ring()
-            >>> mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 8), physical_device_ids=physical_device_ids[:8])
-            >>> ttnn_tensor = ttnn.from_torch(
-                            full_tensor,
-                            dtype=input_dtype,
-                            device=mesh_device,
-                            layout=layout,
-                            memory_config=mem_config,
-                            mesh_mapper=ShardTensor2dMesh(mesh_device, mesh_shape=(1, 8), dims=(-1, -2)))
-            >>> ttnn_tensor = ttnn.to_device(ttnn_tensor, mesh_device)
-            >>> output = ttnn.all_gather(ttnn_tensor, dim=0, topology=ttnn.Topology.Ring)
         )doc");
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::ccl {
+
+void py_bind_all_gather_concat(pybind11::module& module);
+
+}  // namespace ttnn::operations::experimental::ccl

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.cpp
@@ -1,0 +1,489 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "all_gather_concat_op.hpp"
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/math.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "cpp/ttnn/global_semaphore.hpp"
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/tensor/tensor_utils.hpp"
+
+namespace ttnn {
+namespace ccl {
+namespace all_gather_concat_detail {
+
+AllGatherConcat create_all_gather_concat_struct(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map,
+    const uint32_t num_links,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::vector<IDevice*>& devices,
+    const ttnn::ccl::Topology topology,
+    const std::vector<GlobalSemaphore>& semaphores,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool enable_persistent_fabric_mode,
+    const uint32_t num_heads) {
+    uint32_t num_devices = devices.size();
+
+    std::optional<IDevice*> forward_device = std::nullopt;
+    std::optional<IDevice*> backward_device = std::nullopt;
+    std::optional<GlobalSemaphore> semaphore = std::nullopt;
+    uint32_t device_index = 0;  // Initialize device index
+    for (uint32_t i = 0; i < num_devices; ++i) {
+        if (devices.at(i) == input_tensor.device()) {
+            device_index = i;
+            semaphore = semaphores.at(i);  // Get raw pointer
+            if (i != 0) {
+                backward_device = devices.at(i - 1);
+            }
+            if (i != num_devices - 1) {
+                forward_device = devices.at(i + 1);
+            }
+        }
+    }
+    printf("in create all gather concat struct HERE\n");
+    return ttnn::AllGatherConcat{
+        forward_device,
+        backward_device,
+        dim,
+        temp_tensor_map,
+        num_links,
+        num_devices,
+        device_index,
+        memory_config.value_or(input_tensor.memory_config()),
+        topology,
+        semaphore.value(),
+        sub_device_id,
+        enable_persistent_fabric_mode,
+        num_heads};
+}
+
+}  // namespace all_gather_concat_detail
+}  // namespace ccl
+
+void AllGatherConcat::validate(const std::vector<Tensor>& input_tensors) const {
+    TT_FATAL(input_tensors.size() == 1, "Error, Input tensor size should be 1 but has {}", input_tensors.size());
+    const auto& input_tensor = input_tensors[0];
+    const auto& layout = input_tensors[0].get_layout();
+    const auto& dtype = input_tensors[0].get_dtype();
+    const auto& page_size = input_tensors[0].buffer()->page_size();
+    TT_FATAL(page_size % input_tensors[0].buffer()->alignment() == 0, "All Gather currently requires aligned pages");
+
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_gather need to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Operands to all_gather need to be allocated in buffers on device!");
+    TT_FATAL(this->num_links > 0, "Error, num_links should be more than 0 but has {}", this->num_links);
+    TT_FATAL(
+        this->num_links <= input_tensor.device()->compute_with_storage_grid_size().y,
+        "Worker cores used by links are parallelizaed over rows");
+
+    TT_FATAL(
+        input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED ||
+            input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED ||
+            input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED ||
+            input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED,
+        "Unsupported memory layout {}.",
+        input_tensor.memory_config().memory_layout);
+    printf("Iin validate HERE\n");
+}
+
+static void validate_output_tensor_alloc(const std::vector<Tensor>& output_tensors) {
+    for (const auto& output_tensor : output_tensors) {
+        const auto& buffers = output_tensor.buffers();
+        const auto first_address = buffers.front()->address();
+        TT_FATAL(
+            std::all_of(
+                buffers.begin(),
+                buffers.end(),
+                [&first_address](const auto& buffer) {
+                    return buffer != nullptr && buffer->address() == first_address;
+                }),
+            "Output buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+            "different addresses across devices.");
+    }
+}
+
+std::vector<ttnn::TensorSpec> AllGatherConcat::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor = input_tensors[0];
+    auto input_shape = input_tensor.get_padded_shape();  // TODO: Replace with get_logical_shape()
+    auto num_heads = this->num_heads;
+    auto sequence_length = input_shape[0];
+    auto batch = input_shape[1];
+    auto head_dim = input_shape[3];
+    // pad batch to 32 if necessary
+    if (batch < 32) {
+        batch = 32;
+    }
+    auto hidden_dim = num_heads * head_dim;
+    printf("in create output spec HERE\n");
+
+    Shape output_shape({sequence_length, 1, batch, hidden_dim});
+
+    CoreRangeSet output_core_grid;
+    output_core_grid = tt::tt_metal::num_cores_to_corerangeset(
+        num_heads, input_tensor.device()->compute_with_storage_grid_size(), true);
+
+    tt::tt_metal::ShardSpec shard_spec{output_core_grid, {batch, head_dim}};
+    auto mem_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED, tt::tt_metal::BufferType::L1};
+    mem_config.shard_spec = shard_spec;
+
+    return {TensorSpec(
+        output_shape, tt::tt_metal::TensorLayout(input_tensor.get_dtype(), tt::tt_metal::Layout::TILE, mem_config))};
+}
+
+AllGatherConcatVersion AllGatherConcat::select_version(const Tensor& input_tensor) const {
+    return AllGatherConcatVersion::LLAMA_MINIMAL_SHARDED;
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks AllGatherConcat::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    tt::log_debug(tt::LogOp, "DEBUG: create_program is called");
+
+    AllGatherConcatVersion version = select_version(input_tensors[0]);
+
+    log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));
+
+    log_trace(tt::LogOp, "Detected all gather specialized shape. all_gather_concat_llama_sharded is called");
+    CoreCoord compute_with_storage_grid_size = input_tensors[0].device()->compute_with_storage_grid_size();
+    const auto& input_tensor = input_tensors[0];
+    /*
+    for (const auto& output_tensor : output_tensors) {
+        const auto& buffers = output_tensor.buffers();
+        const auto first_address = buffers.front()->address();
+        TT_FATAL(
+            std::all_of(
+                buffers.begin(),
+                buffers.end(),
+                [&first_address](const auto& buffer) {
+                    printf("for this output buffer address should be : %u\n", buffer->address());
+                    return buffer != nullptr && buffer->address() == first_address;
+                }),
+            "Output buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+            "different addresses across devices.");
+    }
+    chip_id_t this_device_id = input_tensor.device()->id();
+    const auto& buffers_temp = temp_tensor_map.at(this_device_id).buffers();
+    const auto temp_first_address = buffers_temp.front()->address();
+    TT_FATAL(
+        std::all_of(
+            buffers_temp.begin(),
+            buffers_temp.end(),
+            [&temp_first_address](const auto& buffer) {
+                printf("for this buffer addrerr should be : %u\n", buffer->address());
+                return buffer != nullptr && buffer->address() == temp_first_address;
+            }),
+        "TEMP buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+        "different addresses across devices.");
+    */
+    chip_id_t this_device_id = input_tensor.device()->id();
+    Tensor temp_tensor = this->temp_tensor_map.at(this_device_id);
+    printf(" Create pragram before program fact HERE\n");
+
+    return all_gather_concat_llama_sharded(
+        input_tensors[0],
+        this->forward_device,
+        this->backward_device,
+        output_tensors[0],
+        this->dim,
+        temp_tensor,
+        this->num_links,
+        this->ring_size,
+        this->ring_index,
+        this->topology,
+        this->semaphore,
+        this->sub_device_id,
+        this->enable_persistent_fabric_mode,
+        this->num_heads);
+}
+
+const tt::tt_metal::operation::Hash AllGatherConcat::compute_program_hash(
+    const std::vector<Tensor>& input_tensors) const {
+    log_trace(tt::LogOp, "compute_program_hash is called");
+    AllGatherConcatVersion version = select_version(input_tensors[0]);
+    log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));
+    auto input_shape = input_tensors[0].get_padded_shape();
+    auto input_memory_layout = input_tensors[0].get_layout();
+    auto input_dtype = input_tensors[0].get_dtype();
+    auto input_memory_config = input_tensors[0].memory_config();
+    printf("in compute program hash HERE for device %u\n", input_tensors[0].device()->id());
+    return tt::tt_metal::operation::hash_operation<AllGatherConcat>(
+        this->dim,
+        this->temp_tensor_map,
+        this->num_links,
+        this->ring_size,
+        this->ring_index,
+        this->output_mem_config,
+        this->topology,
+        input_shape,
+        input_memory_layout,
+        input_dtype,
+        input_memory_config,
+        this->num_heads);
+
+    // for (auto it = this->temp_tensor_map.begin(); it !=this->temp_tensor_map.end(); ++it){
+    //     auto buffer_temp = it->second;
+    //     deallocate(buffer_temp, true);
+    // }
+    // return return_val;
+}
+
+namespace operations {
+namespace experimental {
+namespace ccl {
+
+Tensor all_gather_concat(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const uint32_t num_links,
+    const std::optional<MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool enable_persistent_fabric_mode) {
+    TT_FATAL(
+        std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr,
+        "all_gather_concat op is only supported for Fast Dispatch");
+    auto devices = input_tensor.get_workers();
+    uint32_t num_devices = devices.size();
+    TT_FATAL(num_devices > 1, "all_gather_concat op will only work for num_devices > 1, but has {}", num_devices);
+    ttnn::ccl::Topology ccl_topology = topology;
+
+    if (num_devices == 2) {
+        ccl_topology = ttnn::ccl::Topology::Linear;
+    }
+    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
+
+    tt::log_debug(
+        tt::LogOp, "DEBUG: creating line_fabric with num devices: {}, num links: {}", devices.size(), num_links);
+    tt::log_debug(tt::LogOp, "DEBUG: line_fabric is created");
+
+    // create this semaphore for all cores since we don't know which core will be used for teardown draining
+    CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
+    auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+
+    std::vector<GlobalSemaphore> semaphores = multi_device_global_semaphore.global_semaphores;
+
+    printf("before launch op HERE\n");
+    tt::tt_metal::operation::launch_op(
+        [dim,
+         temp_tensor_map,
+         num_links,
+         num_devices,
+         memory_config,
+         devices,
+         ccl_topology,
+         semaphores,
+         sub_device_id,
+         enable_persistent_fabric_mode,
+         num_heads](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor = input_tensors.at(0);
+
+            return tt::tt_metal::operation::run(
+                ttnn::ccl::all_gather_concat_detail::create_all_gather_concat_struct(
+                    input_tensor,
+                    dim,
+                    temp_tensor_map,
+                    num_links,
+                    memory_config,
+                    devices,
+                    ccl_topology,
+                    semaphores,
+                    sub_device_id,
+                    enable_persistent_fabric_mode,
+                    num_heads),
+                {input_tensor});
+        },
+        {input_tensor},
+        output_tensors);
+    printf("after launch op HERE\n");
+    for (const auto& output_tensor : output_tensors) {
+        const auto& buffers = output_tensor.buffers();
+        const auto first_address = buffers.front()->address();
+        TT_FATAL(
+            std::all_of(
+                buffers.begin(),
+                buffers.end(),
+                [&first_address](const auto& buffer) {
+                    printf("for this output buffer address should be : %u\n", buffer->address());
+                    return buffer != nullptr && buffer->address() == first_address;
+                }),
+            "Output buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+            "different addresses across devices.");
+    }
+
+    const auto& in_buffers = input_tensor.buffers();
+    const auto in_first_address = in_buffers.front()->address();
+    TT_FATAL(
+        std::all_of(
+            in_buffers.begin(),
+            in_buffers.end(),
+            [&in_first_address](const auto& buffer) {
+                printf("for this input buffer address should be : %u\n", buffer->address());
+                return buffer != nullptr && buffer->address() == in_first_address;
+            }),
+        "Output buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+        "different addresses across devices.");
+
+    chip_id_t this_device_id = input_tensor.device()->id();
+
+    for (auto it = temp_tensor_map.begin(); it != temp_tensor_map.end(); ++it) {
+        const auto& buffers_temp = it->second.buffers();
+        const auto temp_first_address = buffers_temp.front()->address();
+        TT_FATAL(
+            std::all_of(
+                buffers_temp.begin(),
+                buffers_temp.end(),
+                [&temp_first_address](const auto& buffer) {
+                    printf("for this TEMP buffer address should be : %u\n", buffer->address());
+                    return buffer != nullptr && buffer->address() == temp_first_address;
+                }),
+            "TEMP buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+            "different addresses across devices.");
+    }
+
+    return output_tensors.at(0);
+}
+
+Tensor all_gather_concat(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    const uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const std::optional<uint32_t> num_links,
+    const std::optional<MemoryConfig>& memory_config,
+    const ttnn::ccl::Topology topology,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool enable_persistent_fabric_mode) {
+    TT_FATAL(
+        topology == ttnn::ccl::Topology::Linear,
+        "This all_gather API with cluster_axis is currently supported only for the Linear topology");
+    const auto mesh_view = mesh_device.get_view();
+    auto devices = input_tensor.get_workers();
+    uint32_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+
+    int32_t rank = input_tensor.get_logical_shape().rank();
+
+    int32_t gather_dim = (dim < 0) ? rank + dim : dim;
+    TT_FATAL(
+        gather_dim >= -rank && gather_dim <= rank - 1,
+        "Dimension input should be in between -{} and {}, but has {}",
+        rank,
+        rank - 1,
+        dim);
+
+    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
+    // create this semaphore for all cores since we don't know which core will be used for teardown draining
+    CoreCoord grid_size = devices[0]->compute_with_storage_grid_size();
+    auto core_grid = CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    std::vector<GlobalSemaphore> semaphores = multi_device_global_semaphore.global_semaphores;
+
+    tt::tt_metal::operation::launch_op(
+        [gather_dim,
+         mesh_view,
+         cluster_axis,
+         temp_tensor_map,
+         num_links,
+         num_devices,
+         memory_config,
+         devices,
+         topology,
+         semaphores,
+         sub_device_id,
+         enable_persistent_fabric_mode,
+         num_heads](
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
+            const auto& input_tensor = input_tensors.at(0);
+
+            TT_FATAL(
+                mesh_view.is_mesh_2d(),
+                "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
+            const auto coordinate = mesh_view.find_device(input_tensor.device()->id());
+            std::vector<IDevice*> devices = (cluster_axis == 0) ? mesh_view.get_devices_on_column(coordinate[1])
+                                                                : mesh_view.get_devices_on_row(coordinate[0]);
+
+            return tt::tt_metal::operation::run(
+                ttnn::ccl::all_gather_concat_detail::create_all_gather_concat_struct(
+                    input_tensor,
+                    gather_dim,
+                    temp_tensor_map,
+                    num_links.has_value() ? num_links.value() : 1,
+                    memory_config,
+                    devices,
+                    topology,
+                    semaphores,
+                    sub_device_id,
+                    enable_persistent_fabric_mode,
+                    num_heads),
+                {input_tensor});
+        },
+        {input_tensor},
+        output_tensors);
+
+    printf("after launch op HERE\n");
+    for (const auto& output_tensor : output_tensors) {
+        const auto& buffers = output_tensor.buffers();
+        const auto first_address = buffers.front()->address();
+        TT_FATAL(
+            std::all_of(
+                buffers.begin(),
+                buffers.end(),
+                [&first_address](const auto& buffer) {
+                    printf("for this output buffer address should be : %u\n", buffer->address());
+                    return buffer != nullptr && buffer->address() == first_address;
+                }),
+            "Output buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+            "different addresses across devices.");
+    }
+
+    const auto& in_buffers = input_tensor.buffers();
+    const auto in_first_address = in_buffers.front()->address();
+    TT_FATAL(
+        std::all_of(
+            in_buffers.begin(),
+            in_buffers.end(),
+            [&in_first_address](const auto& buffer) {
+                printf("for this input buffer address should be : %u\n", buffer->address());
+                return buffer != nullptr && buffer->address() == in_first_address;
+            }),
+        "Output buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+        "different addresses across devices.");
+
+    chip_id_t this_device_id = input_tensor.device()->id();
+
+    for (auto it = temp_tensor_map.begin(); it != temp_tensor_map.end(); ++it) {
+        const auto& buffers_temp = it->second.buffers();
+        const auto temp_first_address = buffers_temp.front()->address();
+        TT_FATAL(
+            std::all_of(
+                buffers_temp.begin(),
+                buffers_temp.end(),
+                [&temp_first_address](const auto& buffer) {
+                    printf("for this TEMP buffer address should be : %u\n", buffer->address());
+                    return buffer != nullptr && buffer->address() == temp_first_address;
+                }),
+            "TEMP buffers for all_gather async must be lock-step allocated but some of the tensors were allocated at "
+            "different addresses across devices.");
+    }
+
+    return output_tensors.at(0);
+}
+
+}  // namespace ccl
+}  // namespace experimental
+}  // namespace operations
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.hpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/buffer.hpp>
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/ccl_op_fusion.hpp"
+#include <tt-metalium/global_semaphore.hpp>
+#include "cpp/ttnn/global_semaphore.hpp"
+
+#include "ttnn/run_operation.hpp"
+
+#include <optional>
+#include <vector>
+
+namespace ttnn {
+
+using ccl::EriscDatamoverBuilder;
+
+enum class AllGatherConcatVersion {
+    LLAMA_MINIMAL_SHARDED = 2,
+};
+
+struct AllGatherConcat {
+    std::optional<IDevice*> forward_device;
+    std::optional<IDevice*> backward_device;
+    const uint32_t dim;
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map;
+    const uint32_t num_links;
+    const uint32_t ring_size;
+    const uint32_t ring_index;
+    const MemoryConfig output_mem_config;
+    const ccl::Topology topology;
+    const GlobalSemaphore semaphore;
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
+    bool enable_persistent_fabric_mode;
+    const uint32_t num_heads;
+
+    AllGatherConcat(
+        std::optional<IDevice*> forward_device,
+        std::optional<IDevice*> backward_device,
+        uint32_t dim,
+        std::unordered_map<chip_id_t, Tensor> temp_tensor_map,
+        uint32_t num_links,
+        uint32_t ring_size,
+        uint32_t ring_index,
+        MemoryConfig output_mem_config,
+        ccl::Topology topology,
+        GlobalSemaphore semaphore,
+        std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+        bool enable_persistent_fabric_mode,
+        uint32_t num_heads) :
+        forward_device(forward_device),
+        backward_device(backward_device),
+        dim(dim),
+        temp_tensor_map(temp_tensor_map),
+        num_links(num_links),
+        ring_size(ring_size),
+        ring_index(ring_index),
+        output_mem_config(output_mem_config),
+        topology(topology),
+        semaphore(semaphore),
+        sub_device_id(sub_device_id),
+        enable_persistent_fabric_mode(enable_persistent_fabric_mode),
+        num_heads(num_heads) {}
+
+    // Add attributes method for reflection
+    auto attributes() const {
+        using tt::stl::reflection::Attribute;
+        std::vector<std::tuple<std::string, Attribute>> attrs;
+
+        attrs.emplace_back("dim", dim);
+        attrs.emplace_back("num_links", num_links);
+        attrs.emplace_back("ring_size", ring_size);
+        attrs.emplace_back("ring_index", ring_index);
+        attrs.emplace_back("output_mem_config", output_mem_config);
+        attrs.emplace_back("topology", topology);
+        attrs.emplace_back("semaphore", semaphore);
+        attrs.emplace_back("num_heads", num_heads);
+
+        return attrs;
+    }
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+    const tt::tt_metal::operation::Hash compute_program_hash(const std::vector<Tensor>& input_tensors) const;
+
+    AllGatherConcatVersion select_version(const Tensor& input_tensor) const;
+};
+
+namespace ccl {
+namespace all_gather_concat_detail {
+AllGatherConcat create_all_gather_concat_struct(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map,
+    const uint32_t num_links,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::vector<IDevice*>& devices,
+    const ccl::Topology topology,
+    const std::vector<GlobalSemaphore>& semaphores,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id,
+    bool enable_persistent_fabric_mode,
+    const uint32_t num_heads);
+}  // namespace all_gather_concat_detail
+}  // namespace ccl
+
+// All Gather Variants
+std::tuple<CoreRangeSet, std::vector<CoreCoord>> choose_worker_cores(
+    size_t num_links,
+    size_t num_workers_per_link,
+    bool persistent_fabric_mode,
+    IDevice* device,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id);
+
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    Tensor& temp_tensor,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore& semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    bool enable_persistent_fabric_mode,
+    const uint32_t num_heads);
+
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded_subgrids(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    Tensor& temp_tensor,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore& semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    bool enable_persistent_fabric_mode,
+    const uint32_t num_heads);
+
+namespace operations {
+namespace experimental {
+namespace ccl {
+
+Tensor all_gather_concat(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const uint32_t num_links = 1,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    bool enable_persistent_fabric_mode = false);
+
+Tensor all_gather_concat(
+    const Tensor& input_tensor,
+    const uint32_t dim,
+    const uint32_t cluster_axis,
+    const MeshDevice& mesh_device,
+    std::unordered_map<chip_id_t, Tensor> temp_tensor_map,
+    const global_semaphore::MultiDeviceGlobalSemaphore& multi_device_global_semaphore,
+    const uint32_t num_heads,
+    const std::optional<uint32_t> num_links = std::nullopt,
+    const std::optional<MemoryConfig>& memory_config = std::nullopt,
+    const ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring,
+    std::optional<tt::tt_metal::SubDeviceId> sub_device_id = std::nullopt,
+    bool enable_persistent_fabric_mode = false);
+
+}  // namespace ccl
+}  // namespace experimental
+}  // namespace operations
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -1,0 +1,603 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+///
+#include <algorithm>
+
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/buffer.hpp>
+#include "ttnn/tensor/tensor_impl.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
+#include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
+#include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/math.hpp"
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/host_api.hpp>
+#include "cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp"
+#include "cpp/ttnn/operations/ccl/common/host/ccl_command_stream_builders.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/uops/command_lowering.hpp"
+
+#include "cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
+#include "cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.hpp"
+#include <sstream>
+#include <type_traits>
+#include <ranges>
+#include <optional>
+
+using namespace tt::constants;
+
+namespace ttnn {
+
+using namespace ccl;
+
+void append_fabric_connection_rt_arguments(
+    const std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>& connection,
+    const CoreCoord& core,
+    tt::tt_metal::Program& program,
+    std::vector<uint32_t>& writer_rt_args) {
+    writer_rt_args.push_back(connection.has_value());
+    if (connection.has_value()) {
+        auto sender_worker_flow_control_semaphore_id = CreateSemaphore(program, {core}, 0);
+        auto sender_worker_teardown_semaphore_id = CreateSemaphore(program, {core}, 0);
+        auto sender_worker_buffer_index_semaphore_id = CreateSemaphore(program, {core}, 0);
+        append_worker_to_fabric_edm_sender_rt_args(
+            connection.value(),
+            sender_worker_flow_control_semaphore_id,
+            sender_worker_teardown_semaphore_id,
+            sender_worker_buffer_index_semaphore_id,
+            writer_rt_args);
+    }
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
+    const Tensor& input_tensor,
+    std::optional<IDevice*> forward_device,
+    std::optional<IDevice*> backward_device,
+    Tensor& output_tensor,
+    const uint32_t dim,
+    Tensor& temp_tensor,
+    const uint32_t num_links,
+    const uint32_t ring_size,
+    const uint32_t ring_index,
+    ccl::Topology topology,
+    const GlobalSemaphore& semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    bool enable_persistent_fabric_mode,
+    const uint32_t num_heads) {
+    tt::tt_metal::Program program{};
+    const bool enable_async_output_tensor = false;
+    TT_FATAL(
+        enable_persistent_fabric_mode,
+        "only persistent fabric mode is supported for all_gather_concat_llama_post_binary_matmul");
+
+    IDevice* device = input_tensor.device();
+    TensorSpec output_intermediate_tensor_spec = temp_tensor.tensor_spec();
+    auto output_interm_padded_shape = output_intermediate_tensor_spec.padded_shape();
+
+    bool is_first_chip = ring_index == 0;
+    bool is_last_chip = ring_index == ring_size - 1;
+    log_trace(
+        tt::LogOp,
+        "DEBUG: device: {}, is_first_chip: {}, is_last_chip: {}",
+        input_tensor.device()->id(),
+        is_first_chip,
+        is_last_chip);
+
+    std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_fabric_handle =
+        ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
+            device,
+            forward_device.value_or(nullptr),
+            backward_device.value_or(nullptr),
+            &program,
+            enable_persistent_fabric_mode,
+            num_links);
+
+    // Get OP Config, topology config
+    std::vector<Tensor> input_tensors = {input_tensor};
+    std::vector<Tensor> output_tensors = {output_tensor};
+    std::vector<Tensor> temp_tensors = {temp_tensor};
+    const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, temp_tensors, topology);
+    LineTopology line_topology(ring_size, ring_index);
+    const size_t num_targets_forward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
+    const size_t num_targets_backward =
+        line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
+
+    // Get worker cores, assuming 1 worker per link
+    uint32_t num_workers_per_link = 1;
+    const auto [sender_worker_core_range, sender_worker_cores] =
+        choose_worker_cores(num_links, num_workers_per_link, enable_persistent_fabric_mode, device, sub_device_id);
+
+    // Tensor Info
+    const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const auto input_tensor_cores = input_tensor.memory_config().shard_spec->grid;
+    const auto input_tensor_shard_shape = input_tensor.memory_config().shard_spec->shape;
+    const auto input_tensor_shard_num_pages = input_tensor_shard_shape[0] * input_tensor_shard_shape[1] / TILE_HW;
+
+    const auto output_interm_tensor_cores = temp_tensor.memory_config().shard_spec->grid;
+    const auto output_interm_tensor_shard_shape = temp_tensor.memory_config().shard_spec->shape;
+    const auto output_interm_tensor_shard_num_pages =
+        output_interm_tensor_shard_shape[0] * output_interm_tensor_shard_shape[1] / TILE_HW;
+
+    tt::log_debug(tt::LogOp, "input_tensor_num_pages: {}", input_tensor_num_pages);
+    tt::log_debug(tt::LogOp, "input_tensor_cores: {}", input_tensor_cores);
+    tt::log_debug(tt::LogOp, "input_tensor_shard_shape: {}", input_tensor_shard_shape);
+    tt::log_debug(tt::LogOp, "input_tensor_shard_num_pages: {}", input_tensor_shard_num_pages);
+
+    // concat info
+    const auto& input_concat_shape = temp_tensor.get_padded_shape();
+    const uint32_t head_dim = input_concat_shape[-1];
+    const uint32_t batch = input_concat_shape[1];
+    uint32_t single_tile_size =
+        tt::tt_metal::detail::TileSize(tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype()));
+
+    auto tile_shape = temp_tensor.get_tensor_spec().tile().get_tile_shape();
+    auto tile_h = tile_shape[0];
+    auto tile_w = tile_shape[1];
+    auto tile_hw = tile_h * tile_w;
+
+    auto face_shape = temp_tensor.get_tensor_spec().tile().get_face_shape();
+    auto face_h = face_shape[0];
+    auto face_w = face_shape[1];
+    auto face_hw = face_h * face_w;
+
+    const uint32_t head_tiles = head_dim / tile_w;
+    const uint32_t head_size = head_tiles * single_tile_size;
+
+    uint32_t element_size = temp_tensor.element_size();
+    uint32_t sub_tile_line_bytes = face_w * element_size;
+    auto q_shard_spec = output_tensor.shard_spec().value();
+    auto q_cores = q_shard_spec.grid;
+    auto q_num_tiles = q_shard_spec.shape[0] * q_shard_spec.shape[1] / TILE_HW;
+    auto in_shard_spec = temp_tensor.shard_spec().value();
+    auto in_cores = in_shard_spec.grid;
+    auto in_num_tiles = in_shard_spec.shape[0] * in_shard_spec.shape[1] / TILE_HW;
+
+    // L1 Scratch CB Creation
+    const size_t packet_size_bytes = local_fabric_handle->get_edm_buffer_size_bytes();
+    uint32_t l1_scratch_cb_page_size_bytes = op_config.get_page_size();
+    uint32_t num_pages_per_packet = packet_size_bytes / l1_scratch_cb_page_size_bytes;
+    uint32_t cb_num_pages =
+        input_tensor_num_pages / num_links +
+        1;  // We are dealing with small shapes, so assuming all pages for a worker can be fit into the CB
+    uint32_t src0_cb_index = tt::CB::c_in0;
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(cb_num_pages * l1_scratch_cb_page_size_bytes, {{src0_cb_index, df}})
+            .set_page_size(src0_cb_index, l1_scratch_cb_page_size_bytes);
+    tt::tt_metal::CBHandle cb_src0_workers = CreateCircularBuffer(program, sender_worker_core_range, cb_src0_config);
+    // Set aside a buffer we can use for storing packet headers in (particularly for atomic incs)
+    const auto reserved_packet_header_CB_index = tt::CB::c_in1;
+    static constexpr auto num_packet_headers_storable = 8;
+    static constexpr auto packet_header_size_bytes = sizeof(tt::tt_fabric::PacketHeader);
+    tt::tt_metal::CircularBufferConfig cb_reserved_packet_header_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_packet_headers_storable * packet_header_size_bytes * 2,
+            {{reserved_packet_header_CB_index, tt::DataFormat::RawUInt32}})
+            .set_page_size(reserved_packet_header_CB_index, packet_header_size_bytes);
+    auto reserved_packet_header_CB_handle =
+        CreateCircularBuffer(program, sender_worker_core_range, cb_reserved_packet_header_config);
+
+    uint32_t q_output_cb_index = tt::CBIndex::c_16;
+    tt::tt_metal::CircularBufferConfig cb_q_output_config =
+        tt::tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, df}})
+            .set_page_size(q_output_cb_index, single_tile_size)
+            .set_globally_allocated_address(*output_tensor.buffer());
+    auto cb_q_output = tt::tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+
+    uint32_t tmp_cb_index = tt::CB::c_in2;
+    tt::tt_metal::CircularBufferConfig tmp_cb_config =
+        tt::tt_metal::CircularBufferConfig(2, {{tmp_cb_index, df}}).set_page_size(tmp_cb_index, 2);
+    auto tmp_cb_handle = CreateCircularBuffer(program, q_cores, tmp_cb_config);
+
+    uint32_t q_base_addr = temp_tensor.buffer()->address();
+    // cores to read and write to output
+    const uint32_t num_cores = q_cores.num_cores();  // number of cores of the output
+    const auto& cores = corerange_to_cores(q_cores, num_cores, true);
+
+    const auto& q_cores_updated = CoreRangeSet(CoreRange({3, 0}, {7, 0}));
+    tt::tt_metal::NOC reader_noc = tt::tt_metal::NOC::NOC_1;
+    tt::tt_metal::NOC writer_noc = tt::tt_metal::NOC::NOC_0;
+
+    // cores for input
+    const uint32_t in_num_cores = in_cores.num_cores();  // number of cores of the input
+    const auto& in_cores_vec = corerange_to_cores(in_cores, in_num_cores, true);
+
+    std::vector<uint32_t> noc_x_coords;
+    noc_x_coords.reserve(in_num_cores);
+    std::vector<uint32_t> noc_y_coords;
+    noc_y_coords.reserve(in_num_cores);
+    for (uint32_t i = 0; i < in_num_cores; ++i) {
+        noc_x_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).x);
+        noc_y_coords.push_back(device->worker_core_from_logical_core(in_cores_vec[i]).y);
+    }
+
+    // create concat semaphore for each link
+    uint32_t concat_semaphore_id = tt::tt_metal::CreateSemaphore(program, q_cores, 0);
+
+    std::vector<uint32_t> concat_reader_ct_args = {
+        (std::uint32_t)element_size,
+        (std::uint32_t)sub_tile_line_bytes,
+        q_output_cb_index,
+        head_size,
+        batch,
+        head_tiles,
+        1,  // read the first phase
+        in_num_cores,
+        face_h,
+        face_hw,
+        tmp_cb_index};
+
+    auto concat_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/"
+        "llama_concat_reader.cpp",
+        q_cores_updated,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = reader_noc,
+            .compile_args = concat_reader_ct_args});
+
+    concat_reader_ct_args[6] = 2;
+    auto concat_reader_2_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/"
+        "llama_concat_reader.cpp",
+        q_cores_updated,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = writer_noc,
+            .compile_args = concat_reader_ct_args});
+
+    // KERNEL CREATION
+    // Reader
+
+    std::vector<uint32_t> all_gather_reader_ct_args = {
+        ring_index,                 // my_chip_id
+        src0_cb_index,              // cb0_id
+        op_config.get_page_size(),  // tensor0_page_size
+        (std::uint32_t)element_size,
+        (std::uint32_t)sub_tile_line_bytes,
+        q_output_cb_index,
+        head_size,
+        batch,
+        head_tiles,
+        1,  // read the first phase
+        in_num_cores,
+        face_h,
+        face_hw,
+        tmp_cb_index};
+
+    auto worker_sender_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/"
+        "llama_all_gather_concat_reader.cpp",
+        sender_worker_core_range,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = reader_noc,
+            .compile_args = all_gather_reader_ct_args});
+
+    // Writer
+    std::vector<uint32_t> all_gather_writer_ct_args = {
+        ring_index,                       // my_chip_id
+        reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
+        num_packet_headers_storable,      // num_packet_headers_storable
+        src0_cb_index,                    // cb0_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_targets_forward_direction
+        num_targets_backward,             // num_targets_backward_direction
+        (std::uint32_t)element_size,
+        (std::uint32_t)sub_tile_line_bytes,
+        q_output_cb_index,
+        head_size,
+        batch,
+        head_tiles,
+        2,  // read the first phase
+        in_num_cores,
+        face_h,
+        face_hw,
+        tmp_cb_index};
+
+    auto worker_sender_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/"
+        "llama_all_gather_concat_writer.cpp",
+        sender_worker_core_range,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = writer_noc,
+            .compile_args = all_gather_writer_ct_args});
+
+    // Kernel Runtime Args
+    CoreCoord drain_sync_core;  // the first worker of each chip is the drain sync core, which contains the output ready
+                                // semaphore
+    auto input_cores_vec = corerange_to_cores(input_tensor_cores, std::nullopt, true);
+    auto output_cores_vec = corerange_to_cores(output_interm_tensor_cores, std::nullopt, true);
+    auto cores_per_device = output_cores_vec.size() + ring_size - 1 / ring_size;
+    uint32_t start_core_index_for_device = output_cores_vec.size() / ring_size * ring_index;
+    uint32_t end_core_index_for_device = start_core_index_for_device + cores_per_device;
+
+    TT_FATAL(
+        output_cores_vec.size() % ring_size == 0 || output_cores_vec.size() == 1,
+        "output sharded cores ( {} ) must be divisible by num_links ( {} ) or 1 for this work distribution scheme",
+        output_cores_vec.size(),
+        ring_size);
+    auto output_cores_this_device = std::vector<CoreCoord>(
+        output_cores_vec.begin() + start_core_index_for_device, output_cores_vec.begin() + end_core_index_for_device);
+
+    log_trace(tt::LogOp, "output_cores_this_device: {}", output_cores_this_device);
+
+    for (uint32_t link = 0; link < num_links; link++) {
+        CoreCoord core = sender_worker_cores[link];
+
+        // construct input and output core x and y
+        uint32_t base_pages_per_worker = input_tensor_num_pages / num_links;
+        uint32_t remainder = input_tensor_num_pages % num_links;
+        uint32_t input_tile_id_start = link * base_pages_per_worker + std::min(link, remainder);
+        uint32_t input_tile_id_end = (link + 1) * base_pages_per_worker + std::min(link + 1, remainder);
+
+        uint32_t worker_num_tiles_to_read = input_tile_id_end - input_tile_id_start;
+        uint32_t input_first_core_tile_start_offset = input_tile_id_start % input_tensor_shard_num_pages;
+        uint32_t output_first_core_tile_start_offset =
+            (input_tensor_num_pages * ring_index + input_tile_id_start) % output_interm_tensor_shard_num_pages;
+
+        std::vector<uint32_t> input_tensor_cores_x;
+        std::vector<uint32_t> input_tensor_cores_y;
+        std::vector<uint32_t> output_tensor_cores_x;
+        std::vector<uint32_t> output_tensor_cores_y;
+        for (uint32_t i = input_tile_id_start / input_tensor_shard_num_pages;
+             i < (input_tile_id_end + input_tensor_shard_num_pages - 1) / input_tensor_shard_num_pages;
+             i++) {
+            auto this_core = device->worker_core_from_logical_core(input_cores_vec[i]);
+            input_tensor_cores_x.push_back(this_core.x);
+            input_tensor_cores_y.push_back(this_core.y);
+        }
+        for (uint32_t i = input_tile_id_start / output_interm_tensor_shard_num_pages;
+             i < (input_tile_id_end + output_interm_tensor_shard_num_pages - 1) / output_interm_tensor_shard_num_pages;
+             i++) {
+            auto this_core = device->worker_core_from_logical_core(output_cores_this_device[i]);
+            output_tensor_cores_x.push_back(this_core.x);
+            output_tensor_cores_y.push_back(this_core.y);
+        }
+
+        tt::log_debug(tt::LogOp, "input_tile_id_start: {}", input_tile_id_start);
+        tt::log_debug(tt::LogOp, "input_tile_id_end: {}", input_tile_id_end);
+        tt::log_debug(tt::LogOp, "worker_num_tiles_to_read: {}", worker_num_tiles_to_read);
+        tt::log_debug(tt::LogOp, "input_first_core_tile_start_offset: {}", input_first_core_tile_start_offset);
+        tt::log_debug(tt::LogOp, "output_first_core_tile_start_offset: {}", output_first_core_tile_start_offset);
+        tt::log_debug(tt::LogOp, "input_tensor_cores_x: {}", input_tensor_cores_x);
+        tt::log_debug(tt::LogOp, "input_tensor_cores_y: {}", input_tensor_cores_y);
+        tt::log_debug(tt::LogOp, "output_tensor_cores_x: {}", output_tensor_cores_x);
+        tt::log_debug(tt::LogOp, "output_tensor_cores_y: {}", output_tensor_cores_y);
+
+        if (link == 0) {
+            // drain sync core is the first worker core
+            drain_sync_core = device->worker_core_from_logical_core(core);
+        }
+        std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> forward_fabric_connection =
+            !forward_device.has_value()
+                ? std::nullopt
+                : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::FORWARD));
+        std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> backward_fabric_connection =
+            !backward_device.has_value()
+                ? std::nullopt
+                : std::optional<tt::tt_fabric::SenderWorkerAdapterSpec>(local_fabric_handle->uniquely_connect_worker(
+                      device, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD));
+
+        // Set reader runtime args
+        std::vector<uint32_t> reader_rt_args = {
+            0,
+            input_tensor.buffer()->address(),    // tensor_address0
+            input_tensor_shard_num_pages,        // num_tiles_per_core
+            worker_num_tiles_to_read,            // num_tiles_to_read
+            input_first_core_tile_start_offset,  // first_core_tile_start_offset
+            input_tensor_cores_x.size(),         // num_cores
+        };
+        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_x.begin(), input_tensor_cores_x.end());
+        reader_rt_args.insert(reader_rt_args.end(), input_tensor_cores_y.begin(), input_tensor_cores_y.end());
+        log_trace(tt::LogOp, "Reader Runtime Args:");
+        for (const auto& arg : reader_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        reader_rt_args[0] = reader_rt_args.size();
+        uint32_t in_tile_offset_by_batch_r =
+            link < face_h ? link * sub_tile_line_bytes : (link + face_h) * sub_tile_line_bytes;
+        reader_rt_args.push_back(in_tile_offset_by_batch_r);
+        reader_rt_args.push_back(temp_tensor.buffer()->address());
+        for (auto nocx : noc_x_coords) {
+            reader_rt_args.push_back(nocx);
+        }
+        for (auto nocy : noc_y_coords) {
+            reader_rt_args.push_back(nocy);
+        }
+        reader_rt_args.push_back(semaphore.address());
+        reader_rt_args.push_back(ring_size * num_links);  // sem target value
+        reader_rt_args.push_back(drain_sync_core.x);
+        reader_rt_args.push_back(drain_sync_core.y);
+        reader_rt_args.push_back(link == 0);
+        reader_rt_args.push_back(concat_semaphore_id);
+
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_reader_kernel_id, {core}, reader_rt_args);
+
+        // Set writer runtime args
+        bool wait_output_semaphore = (link == 0) && !enable_async_output_tensor;
+        bool reset_global_semaphore = (link == 0) && !enable_async_output_tensor;
+        uint32_t out_ready_sem_wait_value = ring_size * num_links;
+        std::vector<uint32_t> writer_rt_args = {
+            0,
+            temp_tensor.buffer()->address(),       // tensor_address0
+            semaphore.address(),                   // out_ready_sem_bank_addr (absolute address)
+            output_interm_tensor_shard_num_pages,  // num_tiles_per_core
+            worker_num_tiles_to_read,              // num_tiles_to_read
+            output_first_core_tile_start_offset,   // first_core_tile_start_offset
+            output_tensor_cores_x.size(),          // num_cores
+            wait_output_semaphore,                 // wait_output_semaphore
+            reset_global_semaphore,                // reset_global_semaphore
+            drain_sync_core.x,                     // out_ready_sem_noc0_x
+            drain_sync_core.y,                     // out_ready_sem_noc0_y
+            out_ready_sem_wait_value,              // out_ready_sem_wait_value
+            concat_semaphore_id,
+        };
+
+        auto start_coord = device->worker_core_from_logical_core({1, 0});
+        auto end_coord = device->worker_core_from_logical_core({7, 0});
+        if (writer_noc == tt::tt_metal::NOC::NOC_1) {
+            std::swap(start_coord, end_coord);
+        }
+        writer_rt_args.push_back(start_coord.x);
+        writer_rt_args.push_back(start_coord.y);
+        writer_rt_args.push_back(end_coord.x);
+        writer_rt_args.push_back(end_coord.y);
+
+        writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_x.begin(), output_tensor_cores_x.end());
+        writer_rt_args.insert(writer_rt_args.end(), output_tensor_cores_y.begin(), output_tensor_cores_y.end());
+
+        log_trace(tt::LogOp, "Writer Runtime Args:");
+        for (const auto& arg : writer_rt_args) {
+            log_trace(tt::LogOp, "\t{}", arg);
+        }
+        append_fabric_connection_rt_arguments(forward_fabric_connection, core, program, writer_rt_args);
+        append_fabric_connection_rt_arguments(backward_fabric_connection, core, program, writer_rt_args);
+        writer_rt_args[0] = writer_rt_args.size();
+        uint32_t in_tile_offset_by_batch =
+            link < face_h ? link * sub_tile_line_bytes : (link + face_h) * sub_tile_line_bytes;
+
+        writer_rt_args.push_back(in_tile_offset_by_batch);
+        writer_rt_args.push_back(temp_tensor.buffer()->address());
+        for (auto nocx : noc_x_coords) {
+            writer_rt_args.push_back(nocx);
+        }
+        for (auto nocy : noc_y_coords) {
+            writer_rt_args.push_back(nocy);
+        }
+
+        tt::tt_metal::SetRuntimeArgs(program, worker_sender_writer_kernel_id, {core}, writer_rt_args);
+    }
+
+    /* rt for concat kernels*/
+    uint32_t q_start_addr = temp_tensor.buffer()->address();
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        // in_tile_offset_by_batch is the start address of each batch in the input tile. The first face_h batches are in
+        // the upper half of the tile and rest are in the lower half of tile.
+        uint32_t in_tile_offset_by_batch = i < face_h ? i * sub_tile_line_bytes : (i + face_h) * sub_tile_line_bytes;
+
+        const auto& core = cores[i];
+        printf("core: %zu, %zu\n", core.x, core.y);
+        if (core.x != 0 && core.x != 1 && core.x != 2) {
+            std::vector<uint32_t> reader_runtime_args;
+            reader_runtime_args.reserve(3 + 2 * in_num_cores);
+            reader_runtime_args = {in_tile_offset_by_batch, q_start_addr, concat_semaphore_id};
+            reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
+            reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
+            reader_runtime_args.push_back(semaphore.address());
+            reader_runtime_args.push_back(ring_size * num_links);  // sem target value
+            reader_runtime_args.push_back(drain_sync_core.x);
+            reader_runtime_args.push_back(drain_sync_core.y);
+            tt::tt_metal::SetRuntimeArgs(program, concat_reader_kernel_id, core, reader_runtime_args);
+            tt::tt_metal::SetRuntimeArgs(program, concat_reader_2_kernel_id, core, reader_runtime_args);
+        }
+    }
+
+    auto override_runtime_arguments_callback =
+        [worker_sender_reader_kernel_id,
+         worker_sender_writer_kernel_id,
+         semaphore,
+         sender_worker_cores,
+         num_cores,
+         cb_q_output,
+         cores,
+         temp_tensor,
+         concat_reader_kernel_id,
+         concat_reader_2_kernel_id,
+         face_h,
+         sub_tile_line_bytes](
+            const void* operation,
+            Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+            const std::vector<Tensor>& output_tensors) {
+            const auto& input = input_tensors[0];
+            const auto& output = output_tensors[0];
+            auto dst_buffer_query = output.buffer();
+
+            UpdateDynamicCircularBufferAddress(program, cb_q_output, *dst_buffer_query);
+
+            auto semaphore = static_cast<const ttnn::AllGatherConcat*>(operation)->semaphore;
+
+            log_trace(tt::LogOp, "DEBUG: semaphore: {}", semaphore.address());
+
+            // update senders
+            auto& worker_reader_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_reader_kernel_id);
+            auto& worker_writer_sender_runtime_args_by_core = GetRuntimeArgs(program, worker_sender_writer_kernel_id);
+
+            uint32_t q_base_addr = temp_tensor.buffer()->address();
+            uint32_t q_start_addr = q_base_addr;
+            printf("q_start_addr: %u\n", q_start_addr);
+            uint32_t idx = 0;
+            for (const auto& core : sender_worker_cores) {
+                auto& worker_reader_sender_runtime_args = worker_reader_sender_runtime_args_by_core[core.x][core.y];
+                worker_reader_sender_runtime_args[1] = input.buffer()->address();
+                uint32_t concat_args_index = worker_reader_sender_runtime_args[0];
+                uint32_t in_tile_offset_by_batch =
+                    idx < face_h ? idx * sub_tile_line_bytes : (idx + face_h) * sub_tile_line_bytes;
+
+                worker_reader_sender_runtime_args[concat_args_index] = in_tile_offset_by_batch;
+                worker_reader_sender_runtime_args[concat_args_index + 1] = q_start_addr;
+                worker_reader_sender_runtime_args[worker_reader_sender_runtime_args.size() - 6] = semaphore.address();
+                printf("worker reader rt overwrite:\n");
+                printf("input.buffer()->address(): %u\n", input.buffer()->address());
+                printf("in_tile_offset_by_batch: %u\n", in_tile_offset_by_batch);
+                printf("semaphore.address(): %lu\n", semaphore.address());
+
+                auto& worker_writer_sender_runtime_args = worker_writer_sender_runtime_args_by_core[core.x][core.y];
+                // worker_writer_sender_runtime_args[1] = q_start_addr;
+                worker_writer_sender_runtime_args[2] = semaphore.address();
+                uint32_t concat_args_index_2 = worker_writer_sender_runtime_args[0];
+
+                printf("worker writer rt overwrite:\n");
+                printf("q_start_addr: %u\n", q_start_addr);
+                printf("semaphore.address(): %lu\n", semaphore.address());
+
+                worker_writer_sender_runtime_args[concat_args_index_2] = in_tile_offset_by_batch;
+                worker_writer_sender_runtime_args[concat_args_index_2 + 1] = q_start_addr;
+                printf("in_tile_offset_by_batch: %u\n", in_tile_offset_by_batch);
+                printf("q_start_addr: %u\n", q_start_addr);
+                idx++;
+            }
+
+            for (uint32_t i = 0; i < num_cores; ++i) {
+                if (cores[i].x != 0 && cores[i].x != 1 && cores[i].x != 2) {
+                    uint32_t in_tile_offset_by_batch =
+                        i < face_h ? i * sub_tile_line_bytes : (i + face_h) * sub_tile_line_bytes;
+                    const auto& core = cores[i];
+                    auto& concat_reader_runtime_args = GetRuntimeArgs(program, concat_reader_kernel_id, core);
+                    concat_reader_runtime_args[0] = in_tile_offset_by_batch;
+                    // concat_reader_runtime_args[1] = q_start_addr;
+                    concat_reader_runtime_args[concat_reader_runtime_args.size() - 4] = semaphore.address();
+                    printf("concat reader rt args\n");
+                    printf("in_tile_offset_by_batch: %u\n", in_tile_offset_by_batch);
+                    printf("q_start_addr: %u\n", q_start_addr);
+                    printf("semaphore.address(): %lu\n", semaphore.address());
+
+                    auto& concat_reader_2_runtime_args = GetRuntimeArgs(program, concat_reader_2_kernel_id, core);
+                    concat_reader_2_runtime_args[0] = in_tile_offset_by_batch;
+                    // concat_reader_2_runtime_args[1] = q_start_addr;
+                    concat_reader_2_runtime_args[concat_reader_2_runtime_args.size() - 4] = semaphore.address();
+                    printf("concat reader2 rt args\n");
+                    printf("in_tile_offset_by_batch: %u\n", in_tile_offset_by_batch);
+                    printf("q_start_addr: %u\n", q_start_addr);
+                    printf("semaphore.address(): %lu\n", semaphore.address());
+                }
+            }
+        };
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
@@ -32,6 +32,7 @@ void kernel_main() {
     size_t arg_idx = 1;
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    uint32_t out_ready_sem_bank_addr_concat = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
@@ -78,7 +79,8 @@ void kernel_main() {
     constexpr uint32_t temp_cb_id = get_compile_time_arg_val(13);
 
     uint32_t arg_sem_idx = 2 + 2 * in_num_cores;
-    uint32_t out_ready_sem_bank_addr_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx);
+    DPRINT << "out_ready_sem_bank_addr_concat is at arg index: " << (uint32_t)(concat_arg_start + arg_sem_idx);
+    // uint32_t out_ready_sem_bank_addr_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx);
     uint32_t out_ready_sem_wait_value_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 1);
     uint32_t out_ready_sem_noc0_x_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 2);
     uint32_t out_ready_sem_noc0_y_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 3);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp"
+#include <cstdint>
+#include <utility>
+
+using address_t = uint32_t;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(1);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(2);
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 1;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
+    tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+    tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+
+    // print every compile and runtime arg in uint32_t
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "num_tiles_per_core: " << (uint32_t)num_tiles_per_core << "\n";
+    DPRINT << "num_tiles_to_read: " << (uint32_t)num_tiles_to_read << "\n";
+    DPRINT << "first_core_tile_start_offset: " << (uint32_t)first_core_tile_start_offset << "\n";
+    DPRINT << "num_cores: " << (uint32_t)num_cores << "\n";
+    for (uint32_t i = 0; i < num_cores; i++) {
+        DPRINT << "core_noc_x[" << i << "]: " << (uint32_t)core_noc_x[i] << "\n";
+        DPRINT << "core_noc_y[" << i << "]: " << (uint32_t)core_noc_y[i] << "\n";
+    }
+
+    uint32_t concat_arg_start = get_arg_val<uint32_t>(0);
+    uint32_t in_tile_offset_by_head = get_arg_val<uint32_t>(concat_arg_start);
+    uint32_t q_start_addr = get_arg_val<uint32_t>(concat_arg_start + 1);
+
+    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(3);
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(5);
+    constexpr uint32_t head_size = get_compile_time_arg_val(6);
+    constexpr uint32_t batch = get_compile_time_arg_val(7);
+    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(8);
+    constexpr uint32_t PHASES_TO_READ =
+        get_compile_time_arg_val(9);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+
+    constexpr uint32_t in_num_cores = get_compile_time_arg_val(10);
+    constexpr uint32_t face_h = get_compile_time_arg_val(11);
+    constexpr uint32_t face_hw = get_compile_time_arg_val(12);
+
+    constexpr uint32_t temp_cb_id = get_compile_time_arg_val(13);
+
+    uint32_t arg_sem_idx = 2 + 2 * in_num_cores;
+    uint32_t out_ready_sem_bank_addr_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx);
+    uint32_t out_ready_sem_wait_value_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 1);
+    uint32_t out_ready_sem_noc0_x_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 2);
+    uint32_t out_ready_sem_noc0_y_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 3);
+    uint32_t is_drain_core = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 4);
+    const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 5));
+
+    DPRINT << "signal semaphore addr: " << (uint32_t)signal_semaphore_addr << ENDL();
+
+    volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
+
+    DPRINT << "temp_cb_id: " << (uint32_t)temp_cb_id << ENDL();
+    DPRINT << "out_ready_sem_bank_addr_concat: " << (uint32_t)out_ready_sem_bank_addr_concat << ENDL();
+    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value_concat << ENDL();
+    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x_concat << ENDL();
+    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y_concat << ENDL();
+    DPRINT << "concat arg start: " << (uint32_t)concat_arg_start << ENDL();
+
+    DPRINT << "tensor -> CB: " << (uint32_t)cb0_id << "\n";
+
+    uint32_t tiles_read = 0;
+    uint32_t shard_tile_id = first_core_tile_start_offset;
+    uint32_t core_id = 0;
+    while (tiles_read < num_tiles_to_read) {
+        DPRINT << "tiles_read: " << tiles_read << "\n";
+        uint32_t num_tiles_to_read_this_core =
+            std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
+        cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
+        DPRINT << "num_tiles_to_read_this_core: " << num_tiles_to_read_this_core << ENDL();
+        const uint32_t l1_write_addr = get_write_ptr(cb0_id);
+        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
+        read_addr += shard_tile_id * tensor0_page_size;
+
+        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
+        noc_async_read_barrier();
+
+        cb_push_back(cb0_id, num_tiles_to_read_this_core);
+        tiles_read += num_tiles_to_read_this_core;
+        shard_tile_id = 0;
+        core_id++;
+    }
+
+    DPRINT << "DONE ALL GATHER READ\n";
+
+    uint64_t out_ready_sem_noc_addr_concat =
+        safe_get_noc_addr(out_ready_sem_noc0_x_concat, out_ready_sem_noc0_y_concat, out_ready_sem_bank_addr_concat);
+
+    DPRINT << "is drain core: " << (uint32_t)is_drain_core << ENDL();
+    if (is_drain_core == 1) {
+        while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr_concat) !=
+               out_ready_sem_wait_value_concat) {
+            DPRINT << "waitval done\n";
+        }
+    } else {
+        noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
+        // noc_semaphore_set(signal_semaphore_addr_ptr, 0);
+    }
+
+    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + concat_arg_start));
+    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + in_num_cores + concat_arg_start));
+
+    // Q
+    uint32_t cur_core_idx = 0;
+    uint32_t total_input_cores = in_num_cores;
+    uint32_t num_tiles_per_core_concat = (head_size_num_tiles * batch) / total_input_cores;
+
+    uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                             in_tile_offset_by_head;
+
+    uint32_t num_tiles_read_cur_core = 0;
+    uint32_t q_write_addr = 0;
+    uint32_t tile_size = head_size / head_size_num_tiles;
+    const uint32_t cb_write_ptr_base = get_write_ptr(cb_id_q_out);
+
+    for (uint32_t q = 0; q < batch; ++q) {
+        uint32_t wptr_offset = q < face_h ? q * SUBTILE_LINE_BYTES : (q + face_h) * SUBTILE_LINE_BYTES;
+        uint32_t q_write_addr = cb_write_ptr_base + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // Read first phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
+            }
+            // Read second phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                noc_async_read(
+                    qkv_read_addr + face_hw * ELEMENT_SIZE, q_write_addr + face_hw * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+            }
+
+            qkv_read_addr += tile_size;
+            q_write_addr += tile_size;
+            num_tiles_read_cur_core++;
+
+            if (num_tiles_read_cur_core == num_tiles_per_core_concat) {
+                cur_core_idx++;
+                qkv_read_addr =
+                    get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                    in_tile_offset_by_head;
+                num_tiles_read_cur_core = 0;
+            }
+        }
+    }
+
+    noc_async_read_barrier();
+
+    DPRINT << "DONE\n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
@@ -80,12 +80,11 @@ void kernel_main() {
 
     uint32_t arg_sem_idx = 2 + 2 * in_num_cores;
     DPRINT << "out_ready_sem_bank_addr_concat is at arg index: " << (uint32_t)(concat_arg_start + arg_sem_idx);
-    // uint32_t out_ready_sem_bank_addr_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx);
-    uint32_t out_ready_sem_wait_value_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 1);
-    uint32_t out_ready_sem_noc0_x_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 2);
-    uint32_t out_ready_sem_noc0_y_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 3);
-    uint32_t is_drain_core = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 4);
-    const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 5));
+    uint32_t out_ready_sem_wait_value_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx);
+    uint32_t out_ready_sem_noc0_x_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 1);
+    uint32_t out_ready_sem_noc0_y_concat = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 2);
+    uint32_t is_drain_core = get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 3);
+    const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(concat_arg_start + arg_sem_idx + 4));
 
     DPRINT << "signal semaphore addr: " << (uint32_t)signal_semaphore_addr << ENDL();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -1,0 +1,315 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp"
+#include <cstdint>
+#include <utility>
+
+using address_t = uint32_t;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(1);
+constexpr uint32_t num_packet_headers_storable = get_compile_time_arg_val(2);
+constexpr uint32_t cb0_id = get_compile_time_arg_val(3);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
+constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
+constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
+constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+
+/*
+ * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
+ * dispatch implementations depending on those invocation parameters.
+ */
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    size_t arg_idx = 1;
+    // Load the input tensor spec
+    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+    const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
+    bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);
+
+    const uint32_t concat_semaphore_send_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+
+    uint32_t mcast_dest_noc_start_x = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mcast_dest_noc_start_y = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mcast_dest_noc_end_x = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t mcast_dest_noc_end_y = get_arg_val<uint32_t>(arg_idx++);
+
+    DPRINT << "mcast_dest_noc_start_x: " << (uint32_t)mcast_dest_noc_start_x << ENDL();
+    DPRINT << "mcast_dest_noc_start_y: " << (uint32_t)mcast_dest_noc_start_y << ENDL();
+    DPRINT << "mcast_dest_noc_end_x: " << (uint32_t)mcast_dest_noc_end_x << ENDL();
+    DPRINT << "mcast_dest_noc_end_y: " << (uint32_t)mcast_dest_noc_end_y << ENDL();
+
+    DPRINT << "concat_semaphore_send_addr: " << (uint32_t)concat_semaphore_send_addr << ENDL();
+
+    tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+    tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+
+    size_t arg_for_fab = arg_idx;
+    auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
+
+    DPRINT << "ct args: \n";
+    DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
+    DPRINT << "reserved_packet_header_cb_id: " << (uint32_t)reserved_packet_header_cb_id << "\n";
+    DPRINT << "num_packet_headers_storable: " << (uint32_t)num_packet_headers_storable << "\n";
+    DPRINT << "cb0_id: " << (uint32_t)cb0_id << "\n";
+    DPRINT << "packet_size_in_pages: " << (uint32_t)packet_size_in_pages << "\n";
+    DPRINT << "tensor0_page_size: " << (uint32_t)tensor0_page_size << "\n";
+    DPRINT << "num_targets_forward_direction: " << (uint32_t)num_targets_forward_direction << "\n";
+    DPRINT << "num_targets_backward_direction: " << (uint32_t)num_targets_backward_direction << "\n";
+
+    DPRINT << "rt args: \n";
+    DPRINT << "tensor_address0: " << (uint32_t)tensor_address0 << "\n";
+    DPRINT << "num_tiles_per_core: " << (uint32_t)num_tiles_per_core << "\n";
+    DPRINT << "num_tiles_to_read: " << (uint32_t)num_tiles_to_read << "\n";
+    DPRINT << "first_core_tile_start_offset: " << (uint32_t)first_core_tile_start_offset << "\n";
+    DPRINT << "num_cores: " << (uint32_t)num_cores << "\n";
+    for (uint32_t i = 0; i < num_cores; i++) {
+        DPRINT << "core_noc_x[" << i << "]: " << (uint32_t)core_noc_x[i] << "\n";
+        DPRINT << "core_noc_y[" << i << "]: " << (uint32_t)core_noc_y[i] << "\n";
+    }
+    DPRINT << "wait_output_semaphore: " << (uint32_t)wait_output_semaphore << "\n";
+    DPRINT << "reset_global_semaphore: " << (uint32_t)reset_global_semaphore << "\n";
+    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << "\n";
+    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << "\n";
+    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << "\n";
+    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << "\n";
+
+    DPRINT << "arg_for_fab: " << (uint32_t)arg_for_fab << "\n";
+    DPRINT << "fabric_connection arg 0" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 1" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 2" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 3" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+    DPRINT << "fabric_connection arg 4" << get_arg_val<uint32_t>(arg_for_fab++) << "\n";
+
+    uint32_t concat_arg_start = get_arg_val<uint32_t>(0);
+    uint32_t in_tile_offset_by_head = get_arg_val<uint32_t>(concat_arg_start);
+    uint32_t q_start_addr = get_arg_val<uint32_t>(concat_arg_start + 1);
+
+    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(8);
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(10);
+    constexpr uint32_t head_size = get_compile_time_arg_val(11);
+    constexpr uint32_t batch = get_compile_time_arg_val(12);
+    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(13);
+    constexpr uint32_t PHASES_TO_READ =
+        get_compile_time_arg_val(14);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+
+    constexpr uint32_t in_num_cores = get_compile_time_arg_val(15);
+    constexpr uint32_t face_h = get_compile_time_arg_val(16);
+    constexpr uint32_t face_hw = get_compile_time_arg_val(17);
+
+    constexpr uint32_t temp_cb_id = get_compile_time_arg_val(18);
+
+    // packet header cb
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_forward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
+    DPRINT << "packet_header_buffer_addr_forward: " << (uint32_t)packet_header_buffer_addr_forward << "\n";
+    DPRINT << "packet_header_buffer_addr_backward: " << (uint32_t)packet_header_buffer_addr_backward << "\n";
+    DPRINT << "packet_header_buffer_seminc: " << (uint32_t)packet_header_buffer_seminc << "\n";
+
+    // pre-populate packet headers
+    volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
+    volatile PACKET_HEADER_TYPE* pkt_hdr_backward =
+        reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
+    pkt_hdr_forward->to_chip_multicast(
+        tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+    pkt_hdr_backward->to_chip_multicast(
+        tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.open();
+    }
+
+    // 1. mcast via fabric to remote tensor addresses
+    uint32_t tiles_read = 0;
+    uint32_t shard_tile_id = first_core_tile_start_offset;
+    uint32_t core_id = 0;
+    while (tiles_read < num_tiles_to_read) {
+        DPRINT << "tiles_read: " << tiles_read << "\n";
+        uint32_t num_tiles_to_read_this_core = std::min(num_tiles_per_core - shard_tile_id, packet_size_in_pages);
+        num_tiles_to_read_this_core = std::min(num_tiles_to_read - tiles_read, num_tiles_to_read_this_core);
+        cb_wait_front(cb0_id, num_tiles_to_read_this_core);
+        size_t l1_read_addr = get_read_ptr(cb0_id);
+
+        uint64_t noc0_dest_noc_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0, 0);
+        noc0_dest_noc_addr += shard_tile_id * tensor0_page_size;
+
+        write_and_advance_local_read_address_for_fabric_write(
+            noc0_dest_noc_addr,
+            pkt_hdr_forward,
+            pkt_hdr_backward,
+            fabric_connection,
+            l1_read_addr,
+            num_tiles_to_read_this_core * tensor0_page_size);
+        noc_async_writes_flushed();
+
+        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
+        tiles_read += num_tiles_to_read_this_core;
+        shard_tile_id += num_tiles_to_read_this_core;
+        if (shard_tile_id >= num_tiles_per_core) {
+            shard_tile_id = 0;
+            core_id++;
+        }
+    }
+
+    // 2. mcast output ready semaphore
+    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
+    uint64_t out_ready_sem_noc_addr_in_pkt =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
+    pkt_hdr->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+        out_ready_sem_noc_addr_in_pkt,
+        static_cast<uint16_t>(1),  // increment 1
+        32});
+    // Write the mcast packet (forward)
+    if (fabric_connection.has_forward_connection()) {
+        fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+        pkt_hdr->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+    }
+    // Write the mcast packet (backward)
+    if (fabric_connection.has_backward_connection()) {
+        pkt_hdr->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+        fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
+    }
+    // increment locally
+    uint64_t out_ready_sem_noc_addr =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+    noc_semaphore_inc(out_ready_sem_noc_addr, 1);
+    DPRINT << "inc done\n";
+
+    // 3. wait for mcast output ready semaphore
+    if (wait_output_semaphore) {
+        while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) < out_ready_sem_wait_value);
+        DPRINT << "waitval done\n";
+    }
+
+    // Set up for mcasting to concat workers
+    if (wait_output_semaphore) {
+        volatile tt_l1_ptr uint32_t* concat_semaphore_send_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_semaphore_send_addr);
+        noc_semaphore_set(concat_semaphore_send_addr_ptr, VALID);
+    }
+
+    if (wait_output_semaphore) {
+        DPRINT << " before get noc multicast addr\n";
+        const uint64_t concat_sem_rcv_addr = get_noc_multicast_addr(
+            mcast_dest_noc_start_x,
+            mcast_dest_noc_start_y,
+            mcast_dest_noc_end_x,
+            mcast_dest_noc_end_y,
+            concat_semaphore_send_addr);
+        DPRINT << "concat_sem_rcv_addr: " << (uint32_t)concat_sem_rcv_addr << ENDL();
+        DPRINT << "before noc semaphore set multicast\n";
+        noc_semaphore_set_multicast(
+            concat_semaphore_send_addr,
+            concat_sem_rcv_addr,
+            7,
+            false,  // linked = false
+            true);  // multicast_path_reserve = true
+        DPRINT << "after noc semaphore set multicast\n";
+    }
+
+    if (fabric_connection.is_logically_connected()) {
+        fabric_connection.close();
+    }
+
+    if (!wait_output_semaphore) {
+        volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(concat_semaphore_send_addr);
+        noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
+        // noc_semaphore_set(signal_semaphore_addr_ptr, 0);
+    }
+    DPRINT << "DONE ALL GATHER\n";
+    DPRINT << "START CONCAT HEADS\n";
+
+    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + concat_arg_start));
+    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2 + in_num_cores + concat_arg_start));
+
+    // Q
+    uint32_t cur_core_idx = 0;
+    uint32_t total_input_cores = in_num_cores;
+    uint32_t num_tiles_per_core_concat = (head_size_num_tiles * batch) / total_input_cores;
+
+    uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                             in_tile_offset_by_head;
+
+    uint32_t num_tiles_read_cur_core = 0;
+    uint32_t q_write_addr = 0;
+    uint32_t tile_size = head_size / head_size_num_tiles;
+    const uint32_t cb_write_ptr_base = get_write_ptr(cb_id_q_out);
+
+    for (uint32_t q = 0; q < batch; ++q) {
+        uint32_t wptr_offset = q < face_h ? q * SUBTILE_LINE_BYTES : (q + face_h) * SUBTILE_LINE_BYTES;
+        uint32_t q_write_addr = cb_write_ptr_base + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // Read first phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
+            }
+            // Read second phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                noc_async_read(
+                    qkv_read_addr + face_hw * ELEMENT_SIZE, q_write_addr + face_hw * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+            }
+
+            qkv_read_addr += tile_size;
+            q_write_addr += tile_size;
+            num_tiles_read_cur_core++;
+
+            if (num_tiles_read_cur_core == num_tiles_per_core_concat) {
+                cur_core_idx++;
+                qkv_read_addr =
+                    get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                    in_tile_offset_by_head;
+                num_tiles_read_cur_core = 0;
+            }
+        }
+    }
+
+    if (reset_global_semaphore) {
+        const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr);
+        noc_inline_dw_write(dest_noc_addr, 0);
+        DPRINT << "reset done\n";
+    }
+
+    noc_async_read_barrier();
+    noc_async_write_barrier();
+
+    DPRINT << "DONE\n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include <tt-metalium/buffer_constants.hpp>
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp"
+#include <cstdint>
+#include <utility>
+
+using address_t = uint32_t;
+
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+
+    uint32_t in_tile_offset_by_head = get_arg_val<uint32_t>(0);
+    uint32_t q_start_addr = get_arg_val<uint32_t>(1);
+    const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(2));
+
+    DPRINT << "signal semaphore addr: " << (uint32_t)signal_semaphore_addr << ENDL();
+
+    volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
+
+    constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(0);
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_id_q_out = get_compile_time_arg_val(2);
+    constexpr uint32_t head_size = get_compile_time_arg_val(3);
+    constexpr uint32_t batch = get_compile_time_arg_val(4);
+    constexpr uint32_t head_size_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t PHASES_TO_READ =
+        get_compile_time_arg_val(6);  // 0 to read all phases, 1 to read only first phase, 2 to read only second phase
+
+    constexpr uint32_t in_num_cores = get_compile_time_arg_val(7);
+    constexpr uint32_t face_h = get_compile_time_arg_val(8);
+    constexpr uint32_t face_hw = get_compile_time_arg_val(9);
+
+    constexpr uint32_t temp_cb_id = get_compile_time_arg_val(10);
+
+    uint32_t sem_arg_start = 3 + 2 * in_num_cores;
+    uint32_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(sem_arg_start);
+    uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(sem_arg_start + 1);
+    uint32_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(sem_arg_start + 2);
+    uint32_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(sem_arg_start + 3);
+
+    DPRINT << "this core runs concat\n";
+    DPRINT << "temp_cb_id: " << (uint32_t)temp_cb_id << ENDL();
+    DPRINT << "out_ready_sem_bank_addr: " << (uint32_t)out_ready_sem_bank_addr << ENDL();
+    DPRINT << "out_ready_sem_wait_value: " << (uint32_t)out_ready_sem_wait_value << ENDL();
+    DPRINT << "out_ready_sem_noc0_x: " << (uint32_t)out_ready_sem_noc0_x << ENDL();
+    DPRINT << "out_ready_sem_noc0_y: " << (uint32_t)out_ready_sem_noc0_y << ENDL();
+    uint64_t out_ready_sem_noc_addr =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
+
+    // 1. Wait for signal from All-Gather worker
+    noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
+    noc_semaphore_set(signal_semaphore_addr_ptr, 0);
+
+    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(3));
+    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(3 + in_num_cores));
+
+    // Q
+    uint32_t cur_core_idx = 0;
+    uint32_t total_input_cores = in_num_cores;
+    uint32_t num_tiles_per_core = (head_size_num_tiles * batch) / total_input_cores;
+
+    uint64_t qkv_read_addr = get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                             in_tile_offset_by_head;
+    uint32_t num_tiles_read_cur_core = 0;
+    uint32_t q_write_addr = 0;
+    uint32_t tile_size = head_size / head_size_num_tiles;
+    const uint32_t cb_write_ptr_base = get_write_ptr(cb_id_q_out);
+    for (uint32_t q = 0; q < batch; ++q) {
+        uint32_t wptr_offset = q < face_h ? q * SUBTILE_LINE_BYTES : (q + face_h) * SUBTILE_LINE_BYTES;
+        uint32_t q_write_addr = cb_write_ptr_base + wptr_offset;
+        for (uint32_t i = 0; i < head_size_num_tiles; ++i) {
+            // Read first phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 1) {
+                noc_async_read(qkv_read_addr, q_write_addr, SUBTILE_LINE_BYTES);
+            }
+            // Read second phase
+            if constexpr (PHASES_TO_READ == 0 || PHASES_TO_READ == 2) {
+                noc_async_read(
+                    qkv_read_addr + face_hw * ELEMENT_SIZE, q_write_addr + face_hw * ELEMENT_SIZE, SUBTILE_LINE_BYTES);
+            }
+
+            qkv_read_addr += tile_size;
+            q_write_addr += tile_size;
+            num_tiles_read_cur_core++;
+
+            if (num_tiles_read_cur_core == num_tiles_per_core) {
+                cur_core_idx++;
+                qkv_read_addr =
+                    get_noc_addr(in0_mcast_noc_x[cur_core_idx], in0_mcast_noc_y[cur_core_idx], q_start_addr) +
+                    in_tile_offset_by_head;
+                num_tiles_read_cur_core = 0;
+            }
+        }
+    }
+
+    noc_async_read_barrier();
+
+    DPRINT << "DONE\n";
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ccl_experimental_pybind.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/operations/experimental/ccl/all_gather_matmul/all_gather_matmul_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/all_reduce/all_reduce_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/all_gather_async/all_gather_async_pybind.hpp"
+#include "ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/all_gather_concat_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.hpp"
 #include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.hpp"
 
@@ -17,6 +18,7 @@ void py_module(py::module& module) {
     ccl::py_bind_all_gather_matmul(module);
     ccl::py_bind_all_reduce(module);
     ccl::py_bind_all_gather_async(module);
+    ccl::py_bind_all_gather_concat(module);
     ccl::py_bind_reduce_scatter_async(module);
     ccl::py_bind_all_reduce_async(module);
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/18480

### Problem description
In the current implementation of llama attention, all_gather and NLP concat run as separate ops, leading to a higher op-to-op latency compared to a fused all_gather_concat op 

### What's changed
Fusing All_Gather and NLP_concat_heads:
- The all_gather_concat implementation works with 3 links for the llama attention spec 
- The worker cores are either executing all_gather + concat or just NLP concat 
- NLP concat worker cores are waiting for the all_gather to finish to start the execution
- We add a signal semaphore that is mcasted by the all gather drain core to the other worker cores to signal the end of the all gather op
- The intermediate data is stored in an intermediate tensor. All gather op is writing to that tensor, and NLP concat heads op is reading from it

Adding Unit tests for T3k/TG for all_gather_concat op

Integrating the fused op into llama attention and testing it


The current fusion saves half the op-to-op latency. More optimizations will be implemented for the fused op to improve the kernel latency as well. We will overlap the execution of NLP concat heads for the local data with the all gather execution. For the total kernel time, we expect a reduction of 1/4 of the NLP concat heads kernel time

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes