### PR TITLE
enable iram by default in 1d fabric tests

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -33,7 +33,9 @@ def get_device_freq():
     return freq
 
 
-def profile_results(zone_name, packets_per_src_chip, line_size, packet_size, fabric_mode):
+def profile_results(
+    zone_name, packets_per_src_chip, line_size, packet_size, fabric_mode, disable_sends_for_interior_workers
+):
     freq = get_device_freq() / 1000.0
     setup = device_post_proc_config.default_setup()
     setup.deviceInputLog = profiler_log_path
@@ -60,6 +62,8 @@ def profile_results(zone_name, packets_per_src_chip, line_size, packet_size, fab
         traffic_streams_through_boundary = 3
     else:
         traffic_streams_through_boundary = line_size / 2
+        if disable_sends_for_interior_workers:
+            traffic_streams_through_boundary = 1
     total_byte_sent = packets_per_src_chip * traffic_streams_through_boundary * packet_size
     bandwidth = total_byte_sent / max(main_loop_cycles)
 
@@ -77,11 +81,12 @@ def run_fabric_edm(
     packet_size,
     fabric_mode,
     expected_bw,
+    disable_sends_for_interior_workers,
 ):
     logger.warning("removing file profile_log_device.csv")
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
 
-    cmd = f"TT_METAL_DEVICE_PROFILER=1 \
+    cmd = f"TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_DEVICE_PROFILER=1 \
             {os.environ['TT_METAL_HOME']}/build/test/ttnn/unit_tests_ttnn_fabric_edm \
                 {num_mcasts} \
                 {num_unicasts} \
@@ -90,7 +95,8 @@ def run_fabric_edm(
                 {int(line_sync)} \
                 {line_size} \
                 {packet_size} \
-                {fabric_mode.value}"
+                {fabric_mode.value} \
+                {int(disable_sends_for_interior_workers)}"
     rc = os.system(cmd)
     if rc != 0:
         if os.WEXITSTATUS(rc) == 1:
@@ -103,8 +109,12 @@ def run_fabric_edm(
     zone_name_main = "MAIN-TEST-BODY"
 
     num_messages = num_mcasts + num_unicasts
-    bandwidth_inner_loop = profile_results(zone_name_inner, num_messages, line_size, packet_size, fabric_mode)
-    bandwidth = profile_results(zone_name_main, num_messages, line_size, packet_size, fabric_mode)
+    bandwidth_inner_loop = profile_results(
+        zone_name_inner, num_messages, line_size, packet_size, fabric_mode, disable_sends_for_interior_workers
+    )
+    bandwidth = profile_results(
+        zone_name_main, num_messages, line_size, packet_size, fabric_mode, disable_sends_for_interior_workers
+    )
     logger.info("bandwidth_inner_loop: {} B/c", bandwidth_inner_loop)
     logger.info("bandwidth: {} B/c", bandwidth)
     assert expected_bw - 0.07 <= bandwidth <= expected_bw + 0.07
@@ -115,7 +125,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.35), (4, 2, 7.24)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 8.23), (4, 2, 8.17)])
 def test_fabric_edm_mcast_half_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -137,37 +147,7 @@ def test_fabric_edm_mcast_half_ring_bw(
         packet_size,
         FabricTestMode.HalfRing,
         expected_bw,
-    )
-
-
-@pytest.mark.parametrize("num_mcasts", [200000])
-@pytest.mark.parametrize("num_unicasts", [0])
-@pytest.mark.parametrize("num_op_invocations", [1])
-@pytest.mark.parametrize("line_sync", [True])
-@pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size", [4])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 7.35), (2, 7.24)])
-def test_fabric_edm_mcast_ring_bw(
-    num_mcasts,
-    num_unicasts,
-    num_links,
-    num_op_invocations,
-    line_sync,
-    line_size,
-    packet_size,
-    expected_bw,
-):
-    run_fabric_edm(
         False,
-        num_mcasts,
-        num_unicasts,
-        num_links,
-        num_op_invocations,
-        line_sync,
-        line_size,
-        packet_size,
-        FabricTestMode.HalfRing,
-        expected_bw,
     )
 
 
@@ -176,7 +156,7 @@ def test_fabric_edm_mcast_ring_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.38), (4, 2, 5.31), (8, 1, 4.03)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.81), (4, 2, 5.75), (8, 1, 4.46)])
 def test_fabric_edm_mcast_full_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -198,6 +178,7 @@ def test_fabric_edm_mcast_full_ring_bw(
         packet_size,
         FabricTestMode.FullRing,
         expected_bw,
+        False,
     )
 
 
@@ -206,7 +187,7 @@ def test_fabric_edm_mcast_full_ring_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.04), (4, 2, 5.91)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.72), (4, 2, 6.54)])
 def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -228,6 +209,7 @@ def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
         packet_size,
         FabricTestMode.SaturateChipToChipRing,
         expected_bw,
+        False,
     )
 
 
@@ -236,7 +218,7 @@ def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.37), (4, 2, 7.31)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.75), (4, 2, 7.75)])
 def test_fabric_edm_mcast_bw(
     num_mcasts,
     num_unicasts,
@@ -258,6 +240,7 @@ def test_fabric_edm_mcast_bw(
         packet_size,
         FabricTestMode.Linear,
         expected_bw,
+        False,
     )
 
 
@@ -267,7 +250,7 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 9.22), (2, 7.61)])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 11.03), (2, 11.03)])
 def test_fabric_edm_unicast_bw(
     num_mcasts,
     num_unicasts,
@@ -289,4 +272,69 @@ def test_fabric_edm_unicast_bw(
         packet_size,
         FabricTestMode.Linear,
         expected_bw,
+        False,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [0])
+@pytest.mark.parametrize("num_unicasts", [200000])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize("packet_size", [4096])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 9.74), (2, 9.63)])
+def test_fabric_edm_unicast_multiproducer_multihop_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+):
+    run_fabric_edm(
+        True,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        FabricTestMode.Linear,
+        expected_bw,
+        False,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [0])
+@pytest.mark.parametrize("num_unicasts", [200000])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize("packet_size", [4096])
+@pytest.mark.parametrize("num_links, expected_bw", [(1, 9.35), (2, 9.26)])
+def test_fabric_edm_unicast_single_producer_multihop_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+):
+    run_fabric_edm(
+        True,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        FabricTestMode.Linear,
+        expected_bw,
+        True,
     )

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/edm_fabric_writer.cpp
@@ -191,18 +191,26 @@ void kernel_main() {
 
         {
             DeviceZoneScopedN("MAIN-WRITE-UNICAST-ZONE");
+            auto& fabric_conn = unicast_is_fwd ? fabric_connection.get_forward_connection()
+                                               : fabric_connection.get_backward_connection();
             for (size_t i = 0; i < num_unicasts; i++) {
                 auto noc0_dest_addr = safe_get_noc_addr(
                     static_cast<uint8_t>(dest_noc_x), static_cast<uint8_t>(dest_noc_y), dest_bank_addr, 0);
-                auto& fabric_conn = unicast_is_fwd ? fabric_connection.get_forward_connection()
-                                                   : fabric_connection.get_backward_connection();
                 unicast_packet_header->to_noc_unicast_write(
                     NocUnicastCommandHeader{noc0_dest_addr}, packet_payload_size_bytes);
-                fabric_conn.wait_for_empty_write_slot();
-                fabric_conn.send_payload_without_header_non_blocking_from_address(
-                    source_l1_buffer_address, packet_payload_size_bytes);
-                fabric_conn.send_payload_blocking_from_address(
-                    (uint32_t)unicast_packet_header, sizeof(PACKET_HEADER_TYPE));
+                if (unicast_is_fwd) {
+                    fabric_connection.get_forward_connection().wait_for_empty_write_slot();
+                    fabric_connection.get_forward_connection().send_payload_without_header_non_blocking_from_address(
+                        source_l1_buffer_address, packet_payload_size_bytes);
+                    fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+                        (uint32_t)unicast_packet_header, sizeof(PACKET_HEADER_TYPE));
+                } else {
+                    fabric_connection.get_backward_connection().wait_for_empty_write_slot();
+                    fabric_connection.get_backward_connection().send_payload_without_header_non_blocking_from_address(
+                        source_l1_buffer_address, packet_payload_size_bytes);
+                    fabric_connection.get_backward_connection().send_payload_flush_blocking_from_address(
+                        (uint32_t)unicast_packet_header, sizeof(PACKET_HEADER_TYPE));
+                }
             }
         }
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm.cpp
@@ -14,6 +14,7 @@ int main(int argc, char** argv) {
     std::size_t line_size = std::stoi(argv[arg_idx++]);
     std::size_t packet_payload_size_bytes = std::stoi(argv[arg_idx++]);
     uint32_t fabric_mode = std::stoi(argv[arg_idx++]);
+    bool disable_sends_for_interior_workers = std::stoi(argv[arg_idx++]);
 
     uint32_t min_test_num_devices = 8;
     if (tt::tt_metal::GetNumAvailableDevices() < min_test_num_devices) {
@@ -25,6 +26,7 @@ int main(int argc, char** argv) {
     params.line_sync = line_sync;
     params.line_size = line_size;
     params.fabric_mode = static_cast<FabricTestMode>(fabric_mode);
+    params.disable_sends_for_interior_workers = disable_sends_for_interior_workers;
     RunWriteThroughputStabilityTestWithPersistentFabric(
         num_mcasts, num_unicasts, num_links, num_op_invocations, params, packet_payload_size_bytes);
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2190,6 +2190,9 @@ struct WriteThroughputStabilityTestWithPersistentFabricParams {
     size_t num_devices_with_workers = 0;
     bool line_sync = true;
     FabricTestMode fabric_mode = FabricTestMode::Linear;
+
+    // True if you only want the workers on the end to send
+    bool disable_sends_for_interior_workers = false;
 };
 
 void RunWriteThroughputStabilityTestWithPersistentFabric(
@@ -2201,6 +2204,9 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
     size_t packet_payload_size_bytes = tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes) {
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
+    TT_FATAL(
+        !params.disable_sends_for_interior_workers || params.fabric_mode == FabricTestMode::Linear,
+        "This test can only be run with disable_sends_for_interior_workers set to true or fabric_mode set to Linear");
     bool use_tg = num_devices == 32;
     if (num_devices < 4) {
         log_info("This test can only be run on T3000 devices");
@@ -2480,7 +2486,7 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
             bool end_of_line = line_index == line_size - 1;
             has_forward_connection = !end_of_line;
             has_backward_connection = !start_of_line;
-            unicast_forward = !end_of_line;
+            unicast_forward = line_index < (line_size / 2);
             mcast_fwd_hops = line_size - line_index - 1;
             mcast_bwd_hops = line_index;
             unicast_hops = unicast_forward ? mcast_fwd_hops : mcast_bwd_hops;
@@ -2545,17 +2551,20 @@ void RunWriteThroughputStabilityTestWithPersistentFabric(
                 }
             };
             // RT ARGS
+            bool disable_sends_for_worker =
+                params.disable_sends_for_interior_workers && (i != 0) && (i != line_size - 1);
+
             std::vector<uint32_t> rt_args = {
                 dest_bank_addr,
                 packet_payload_size_bytes,
                 dest_noc_x,
                 dest_noc_y,
 
-                num_mcasts,
+                disable_sends_for_worker ? 0 : num_mcasts,
                 mcast_fwd_hops,
                 mcast_bwd_hops,
 
-                num_unicasts,
+                disable_sends_for_worker ? 0 : num_unicasts,
                 unicast_hops,
                 unicast_forward,
 


### PR DESCRIPTION
update fabric perf tests to use IRAM by defaults and update targets accordingly.

Note this has additional changes which are from this pr: https://github.com/tenstorrent/tt-metal/pull/19440

I have built this branch on top because that will be merged soon and it updates the targets

Additionally, several additional unicast tests were added (and a small performance bug in the test kernel resolved).

New numbers are as follows (for 4k packet size):
| Test Case | Bandwidth GB/s/dir | Comment |
|-|-|-|
| ![image](https://github.com/user-attachments/assets/ed373382-91f5-4748-b9ed-613e96590e6f) | 11.03 | This was the old unicast test but performance has improved due to fix in worker kernel, unicast 1 hop | 
| ![image](https://github.com/user-attachments/assets/16bf7606-62b5-4cf2-bbd6-06c30c8fc272)  | 9.74 | Unicast, multiple producers/dir, multiple hops, bidir |
| ![image](https://github.com/user-attachments/assets/9d65f78c-cdb9-4a87-ad59-abadeecf3cf7) | 9.35 | Currently unclear why this performs worse than above. There should be enough buffering for latency hiding but maybe not |  Unicast, single producer/dir, multiple hops, bidir |


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/14010116751
- [x] New/Existing tests provide coverage for changes