### PR TITLE
#0: Add dispatch optimizations for llama RotaryEmbedding and UpdateCache

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -16,8 +16,8 @@ from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
         ("ScaledDotProductAttentionDecode", 20, 0.03),
         ("NLPCreateHeadsDecodeDeviceOperation", 8.32, 0.05),
         ("NLPConcatHeadsDecodeDeviceOperation", 6.07, 0.05),
-        ("PagedUpdateCacheDeviceOperation", 5, 0.03),
-        ("RotaryEmbeddingLlamaFusedQK", 4.8, 0.03),
+        ("PagedUpdateCacheDeviceOperation", 4.88, 0.03),
+        ("RotaryEmbeddingLlamaFusedQK", 4.34, 0.03),
     ],
 )
 def test_llama_tg_ops_perf_device(op_name, expected_kernel_duration_us, perf_margin):

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/compute/paged_fused_update_cache.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/pack_untilize.h"
+#include "compute_kernel_api/tilize.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t rt_args_idx = 0;
+    const bool has_work = get_arg_val<uint32_t>(rt_args_idx++);
+    if (!has_work) {
+        return;
+    }
+    const bool is_input1 = get_arg_val<uint32_t>(rt_args_idx++);
+
+    constexpr uint32_t in1_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t in2_cb = get_compile_time_arg_val(1);
+    uint32_t in_cb = in1_cb;
+    if (!is_input1) {
+        in_cb = in2_cb;
+    }
+
+    constexpr uint32_t cache_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t untilized_cache_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t untilized_cache2_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t untilized_in_cb = get_compile_time_arg_val(5);
+    constexpr uint32_t out_cb = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt = get_compile_time_arg_val(7);
+    constexpr uint32_t num_heads = get_compile_time_arg_val(8);
+
+    pack_untilize_init<Wt>(in_cb, untilized_in_cb);
+
+    cb_wait_front(in_cb, Wt);
+    cb_reserve_back(untilized_in_cb, Wt);
+    pack_untilize_block<Wt>(in_cb, 1, untilized_in_cb);
+    cb_push_back(untilized_in_cb, Wt);
+    cb_pop_front(in_cb, Wt);
+
+    reconfig_data_format_srca(in_cb, cache_cb);
+    pack_reconfig_data_format(untilized_in_cb, untilized_cache_cb);
+    for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
+        pack_untilize_init_short<Wt>(cache_cb, untilized_cache_cb);
+
+        // Untilize a block from the cache
+        cb_wait_front(cache_cb, Wt);
+        cb_reserve_back(untilized_cache_cb, Wt);
+
+        pack_untilize_block<Wt>(cache_cb, 1, untilized_cache_cb);
+
+        cb_push_back(untilized_cache_cb, Wt);
+        cb_pop_front(cache_cb, Wt);
+
+        pack_untilize_uninit(untilized_cache_cb);
+
+        reconfig_data_format_srca(cache_cb, untilized_cache2_cb);
+        pack_reconfig_data_format(untilized_cache_cb, out_cb);
+
+        tilize_init_short(untilized_cache2_cb, Wt, out_cb);
+
+        // Wait on writer to update block. Tilize.
+        cb_wait_front(untilized_cache2_cb, Wt);
+
+        cb_reserve_back(out_cb, Wt);
+
+        tilize_block(untilized_cache2_cb, Wt, out_cb);
+
+        cb_push_back(out_cb, Wt);
+        cb_pop_front(untilized_cache2_cb, Wt);
+        tilize_uninit_with_dt(untilized_cache2_cb, cache_cb, out_cb);
+        pack_reconfig_data_format(out_cb, untilized_cache_cb);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/reader_paged_fused_update_cache_interleaved_start_id.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t rt_args_idx = 0;
+    const bool has_work = get_arg_val<uint32_t>(rt_args_idx++);
+    if (!has_work) {
+        return;
+    }
+    const bool is_input1 = get_arg_val<uint32_t>(rt_args_idx++);
+
+    const uint32_t cache_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t cache_start_id = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t index_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t my_batch_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t page_table_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const bool wait_to_start_signal = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+
+    constexpr uint32_t input1_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t input2_cb_id = get_compile_time_arg_val(1);
+    uint32_t input_cb_id = input1_cb_id;
+    if (!is_input1) {
+        input_cb_id = input2_cb_id;
+    }
+
+    constexpr bool cache_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(3);
+    constexpr bool use_index_tensor = get_compile_time_arg_val(4) == 1;
+    constexpr bool index_is_dram = get_compile_time_arg_val(5) == 1;
+    constexpr uint32_t cb_index_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t Wt = get_compile_time_arg_val(8);
+    const uint32_t log_base_2_of_page_size = get_compile_time_arg_val(9);
+    const uint32_t index_stick_size_B = get_compile_time_arg_val(10);
+
+    // paged_cache args
+    constexpr bool is_paged_cache = get_compile_time_arg_val(11) == 1;
+    constexpr uint32_t num_heads = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size = get_compile_time_arg_val(13);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(14);
+    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(15);
+    constexpr uint32_t log2_page_table_stick_size = get_compile_time_arg_val(16);
+    constexpr uint32_t page_table_stick_size = get_compile_time_arg_val(17);
+    constexpr uint32_t page_table_is_dram = get_compile_time_arg_val(18) == 1;
+    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(19);
+
+    const uint32_t St = get_compile_time_arg_val(20);
+    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(21));  // semaphore for receiver
+
+    constexpr uint32_t head_offset_t = Wt * St;
+
+    // Kick off compute
+    cb_reserve_back(input_cb_id, Wt);
+    cb_push_back(input_cb_id, Wt);
+
+    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
+
+    constexpr uint32_t TILE_HEIGHT = 32;
+
+    uint32_t cache_id = cache_start_id;
+
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
+
+    bool skip_update = false;
+
+    if constexpr (use_index_tensor) {
+        const InterleavedAddrGen<index_is_dram> addrg = {
+            .bank_base_address = index_tensor_addr, .page_size = index_stick_size_B};
+
+        cb_reserve_back(cb_index_id, 1);
+        uint32_t index_cb_wr_ptr = get_write_ptr(cb_index_id);
+        // index_tensor has one page to read
+        uint64_t tensor_index_noc_addr = get_noc_addr(0, addrg);
+        noc_async_read(tensor_index_noc_addr, index_cb_wr_ptr, index_stick_size_B);
+        noc_async_read_barrier();
+        cb_push_back(cb_index_id, 1);
+        volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_wr_ptr);
+
+        const uint32_t update_idx = index_ptr[my_batch_idx];
+        if (update_idx == (uint32_t)-1) {
+            // Passing update_idx = -1 tells us to skip update for this user
+            skip_update = true;
+        } else {
+            if constexpr (is_paged_cache) {
+                const InterleavedAddrGen<page_table_is_dram> page_table_gen = {
+                    .bank_base_address = page_table_tensor_addr, .page_size = page_table_stick_size};
+                cb_reserve_back(page_table_cb_id, 1);
+                uint32_t page_table_cb_wr_ptr = get_write_ptr(page_table_cb_id);
+                uint64_t page_table_noc_addr = get_noc_addr(my_batch_idx, page_table_gen);
+                noc_async_read(page_table_noc_addr, page_table_cb_wr_ptr, page_table_stick_size);
+                noc_async_read_barrier();
+                cb_push_back(page_table_cb_id, 1);
+                volatile tt_l1_ptr uint32_t* page_table_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_wr_ptr);
+
+                const uint32_t virtual_block_id = update_idx / block_size;
+                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
+                const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
+                const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
+                const uint32_t block_offset = block_row_tile * Wt;
+                cache_id = block_start_id + block_offset;
+
+            } else {
+                const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;
+                const uint32_t cache_start_id = cache_batch_tile_offset + (update_idx / TILE_HEIGHT) * Wt;
+                cache_id = cache_start_id;
+            }
+        }
+    }
+
+    if (wait_to_start_signal) {
+        // wait for signal to start pushing tensor
+        volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr);
+        noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, 1);
+        noc_semaphore_set(in0_receiver_semaphore_addr_ptr, 0);
+    }
+
+    for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
+        cb_reserve_back(cache_cb_id, Wt);
+        if (!skip_update) {
+            uint32_t cache_l1_write_addr = get_write_ptr(cache_cb_id);
+            for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
+                noc_async_read_tile(curr_cache_id, s0, cache_l1_write_addr);
+                cache_l1_write_addr += cache_tile_bytes;
+            }
+
+            noc_async_read_barrier();
+        }
+        cb_push_back(cache_cb_id, Wt);
+
+        cache_id += head_offset_t;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+void kernel_main() {
+    uint32_t rt_args_idx = 0;
+    const bool has_work = get_arg_val<uint32_t>(rt_args_idx++);
+    if (!has_work) {
+        return;
+    }
+
+    const uint32_t cache_addr = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t cache_start_id = get_arg_val<uint32_t>(rt_args_idx++);
+    uint32_t cache_tile_offset_B = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t my_batch_idx = get_arg_val<uint32_t>(rt_args_idx++);
+    const bool send_signal = get_arg_val<uint32_t>(rt_args_idx++) == 1;
+    const uint32_t send_core_x = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t send_core_y = get_arg_val<uint32_t>(rt_args_idx++);
+
+    constexpr bool cache_is_dram = get_compile_time_arg_val(0) == 1;
+    constexpr uint32_t cache_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t untilized_cache_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t untilized_cache2_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t untilized_input_cb_id = get_compile_time_arg_val(4);
+    constexpr bool use_index_tensor = get_compile_time_arg_val(5) == 1;
+    constexpr uint32_t cb_index_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cache_batch_num_tiles = get_compile_time_arg_val(7);
+    constexpr uint32_t Wt = get_compile_time_arg_val(8);
+    constexpr uint32_t Wbytes = get_compile_time_arg_val(9);
+
+    // paged_cache args
+    constexpr bool is_paged_cache = get_compile_time_arg_val(10) == 1;
+    constexpr uint32_t num_heads = get_compile_time_arg_val(11);
+    constexpr uint32_t block_size = get_compile_time_arg_val(12);
+    constexpr uint32_t block_size_t = get_compile_time_arg_val(13);
+    constexpr uint32_t max_blocks_per_seq = get_compile_time_arg_val(14);
+    constexpr uint32_t page_table_cb_id = get_compile_time_arg_val(15);
+
+    constexpr uint32_t St = get_compile_time_arg_val(16);
+    uint32_t semaphore_addr = get_semaphore(get_compile_time_arg_val(17));  // semaphore for receiver
+    constexpr uint32_t head_offset_t = Wt * St;
+
+    const uint32_t cache_tile_bytes = get_tile_size(cache_cb_id);
+    const DataFormat cache_data_format = get_dataformat(cache_cb_id);
+
+    constexpr uint32_t TILE_HEIGHT = 32;
+
+    const InterleavedAddrGenFast<cache_is_dram> s0 = {
+        .bank_base_address = cache_addr, .page_size = cache_tile_bytes, .data_format = cache_data_format};
+
+    uint32_t cache_id = cache_start_id;
+    uint32_t update_idx = 0;
+
+    bool skip_update = false;
+
+    if constexpr (use_index_tensor) {
+        cb_wait_front(cb_index_id, 1);
+        uint32_t index_cb_ptr = get_read_ptr(cb_index_id);
+        volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
+        const uint32_t update_idx = index_ptr[my_batch_idx];
+
+        if (update_idx == (uint32_t)-1) {
+            // Passing update_idx = -1 tells us to skip update for this user
+            skip_update = true;
+        } else {
+            if constexpr (is_paged_cache) {
+                cb_wait_front(page_table_cb_id, 1);
+                uint32_t page_table_cb_rd_ptr = get_read_ptr(page_table_cb_id);
+                volatile tt_l1_ptr uint32_t* page_table_ptr =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(page_table_cb_rd_ptr);
+
+                const uint32_t virtual_block_id = update_idx / block_size;
+                const uint32_t physical_block_id = page_table_ptr[virtual_block_id];
+                const uint32_t block_start_id = physical_block_id * num_heads * block_size_t * Wt;
+                const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
+                const uint32_t block_offset = block_row_tile * Wt;
+                cache_id = block_start_id + block_offset;
+
+            } else {
+                const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;
+                const uint32_t cache_start_id = cache_batch_tile_offset + (update_idx / TILE_HEIGHT) * Wt;
+                cache_id = cache_start_id;
+            }
+            cache_tile_offset_B = update_idx % TILE_HEIGHT * Wbytes;
+        }
+    }
+
+    cb_wait_front(untilized_input_cb_id, Wt);  // input tensor
+    uint64_t input_l1_read_addr = get_noc_addr(get_read_ptr(untilized_input_cb_id));
+
+    for (uint32_t cur_head = 0; cur_head < num_heads; ++cur_head) {
+        // Wait on compute to untilize a block. Update that block in L1.
+        cb_wait_front(untilized_cache_cb_id, Wt);
+        cb_reserve_back(untilized_cache2_cb_id, Wt);
+
+        uint32_t cache_l1_write_addr = get_read_ptr(untilized_cache_cb_id) + cache_tile_offset_B;
+        noc_async_read(input_l1_read_addr, cache_l1_write_addr, Wbytes);
+        noc_async_read_barrier();
+        cb_push_back(untilized_cache2_cb_id, Wt);
+        cb_pop_front(untilized_cache_cb_id, Wt);  // NEW
+
+        // Wait on compute to tilize an updated block. Write that block to DRAM
+        cb_wait_front(cache_cb_id, Wt);
+        if (!skip_update) {
+            uint32_t out_l1_read_addr = get_read_ptr(cache_cb_id);
+            for (uint32_t curr_cache_id = cache_id; curr_cache_id < cache_id + Wt; ++curr_cache_id) {
+                noc_async_write_tile(curr_cache_id, s0, out_l1_read_addr);
+                out_l1_read_addr += cache_tile_bytes;
+            }
+
+            noc_async_writes_flushed();
+        }
+        cb_pop_front(cache_cb_id, Wt);
+
+        if (!skip_update) {
+            // Delay syncing the writes to maximize perf.
+            noc_async_write_barrier();
+        }
+
+        // read from next head
+        input_l1_read_addr += Wbytes;
+        cache_id += head_offset_t;
+    }
+
+    cb_pop_front(untilized_input_cb_id, Wt);
+
+    if (send_signal) {
+        // send signal to start compute
+        const uint64_t in0_sender_semaphore_noc_addr = get_noc_addr(send_core_x, send_core_y, semaphore_addr);
+        noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -174,8 +174,16 @@ void PagedUpdateCacheDeviceOperation::validate(
     };
 
     const auto validateFusedUpdateTensors = [](const Tensor& input_tensor1, const Tensor& input_tensor2) {
-        bool is_overlap = input_tensor1.shard_spec()->grid.intersects(input_tensor2.shard_spec()->grid);
-        TT_FATAL(!is_overlap, "input_tensor1 and input_tensor2 must not overlap");
+        CoreRangeSet input1_cores = input_tensor1.shard_spec().value().grid;
+        CoreRangeSet input2_cores = input_tensor2.shard_spec().value().grid;
+
+        bool is_overlap = input1_cores.intersects(input2_cores);
+        TT_FATAL(!is_overlap, "input_tensor1 ({}) and input_tensor2 ({}) must not overlap", input1_cores, input2_cores);
+        TT_FATAL(
+            input1_cores.num_cores() == input2_cores.num_cores(),
+            "input_tensor1 ({}) and input_tensor2 ({}) must have same number of cores",
+            input1_cores,
+            input2_cores);
     };
 
     // Validate number of input tensors based on operation type

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/bcast.h"
+#include "compute_kernel_api/matmul.h"
+
+ALWI void ACQ() { acquire_dst(); }
+ALWI void REL() { release_dst(); }
+
+namespace NAMESPACE {
+void MAIN {
+    // TODO: Add back early return? Currently, running out of code size in TRISC2 by 4B
+    // const bool has_work = get_arg_val<uint32_t>(0);
+    // if (!has_work) {
+    //     return;
+    // }
+    const bool is_q = get_arg_val<uint32_t>(0);
+
+    // First 6 args for q and k heads
+    // - First 3 are for q
+    // - Next 3 are for k
+    constexpr uint32_t q_in_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t q_out_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t q_Ht = get_compile_time_arg_val(2);
+    constexpr uint32_t k_in_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t k_out_cb = get_compile_time_arg_val(4);
+    constexpr uint32_t k_Ht = get_compile_time_arg_val(5);
+    uint32_t in_cb = q_in_cb;
+    uint32_t out_cb = q_out_cb;
+    uint32_t Ht = q_Ht;
+    if (!is_q) {
+        in_cb = k_in_cb;
+        out_cb = k_out_cb;
+        Ht = k_Ht;
+    }
+
+    constexpr uint32_t Wt = get_compile_time_arg_val(6);  // How many rows (tiles) in n_heads dimension
+
+    constexpr uint32_t cos_cb = get_compile_time_arg_val(7);
+    constexpr uint32_t sin_cb = get_compile_time_arg_val(8);
+    constexpr uint32_t trans_mat_cb = get_compile_time_arg_val(9);
+
+    constexpr uint32_t rotated_in_interm_cb = get_compile_time_arg_val(10);
+    constexpr uint32_t cos_interm_cb = get_compile_time_arg_val(11);
+    constexpr uint32_t sin_interm_cb = get_compile_time_arg_val(12);
+
+    mm_init(in_cb, trans_mat_cb, out_cb);
+    binary_op_init_common(rotated_in_interm_cb, sin_cb, sin_interm_cb);  // General Init for all binary ops
+
+    /* Unnecessary CB APIs (comment out for code size)
+    // Get the trans_mat
+    constexpr uint32_t onetile = 1;
+    cb_reserve_back(trans_mat_cb, onetile);
+    cb_push_back(trans_mat_cb, onetile);
+    cb_wait_front(trans_mat_cb, onetile);
+
+    // Get the sin/cos matrices
+    // TODO: To parallelize across multiple batch, this should be in a batch loop
+    cb_reserve_back(sin_cb, Wt);
+    cb_reserve_back(cos_cb, Wt);
+
+    cb_push_back(sin_cb, Wt);
+    cb_push_back(cos_cb, Wt);
+    */
+
+    for (uint32_t ht = 0; ht < Ht; ht++) {  // Over n_heads_t dimension
+        cb_reserve_back(rotated_in_interm_cb, Wt);
+        cb_reserve_back(sin_interm_cb, Wt);
+        cb_reserve_back(cos_interm_cb, Wt);
+        cb_reserve_back(out_cb, Wt);
+
+        // Get the input
+        cb_reserve_back(in_cb, Wt);
+        cb_push_back(in_cb, Wt);
+        cb_wait_front(in_cb, Wt);
+
+        // Do the computation
+
+        // rotated = x @ trans_mat
+        mm_init_short(in_cb, trans_mat_cb);
+        ACQ();
+        for (uint32_t j = 0; j < Wt; ++j) {
+            matmul_tiles(in_cb, trans_mat_cb, j, 0, j, false);
+            pack_tile(j, rotated_in_interm_cb, j);
+        }
+        REL();
+        cb_push_back(rotated_in_interm_cb, Wt);
+        cb_wait_front(rotated_in_interm_cb, Wt);
+
+        mul_bcast_rows_init_short(rotated_in_interm_cb, sin_cb);
+        ACQ();
+        for (uint32_t j = 0; j < Wt; ++j) {
+            // sin_interim = rotated * sin
+            mul_tiles_bcast<BroadcastType::ROW>(rotated_in_interm_cb, sin_cb, j, j, j);
+            pack_tile(j, sin_interm_cb, j);
+        }
+        REL();
+        cb_push_back(sin_interm_cb, Wt);
+        cb_pop_front(rotated_in_interm_cb, Wt);
+
+        ACQ();
+        for (uint32_t j = 0; j < Wt; ++j) {
+            // cos_interim = x * cos
+            mul_tiles_bcast<BroadcastType::ROW>(in_cb, cos_cb, j, j, j);
+            pack_tile(j, cos_interm_cb, j);
+        }
+        REL();
+        cb_push_back(cos_interm_cb, Wt);
+        cb_pop_front(in_cb, Wt);  // Done with input
+
+        cb_wait_front(sin_interm_cb, Wt);
+        cb_wait_front(cos_interm_cb, Wt);
+        add_tiles_init(cos_interm_cb, sin_interm_cb);
+        ACQ();
+        for (uint32_t j = 0; j < Wt; ++j) {
+            // out = cos_interim + sin_interim
+            add_tiles(cos_interm_cb, sin_interm_cb, j, j, j);
+            pack_tile(j, out_cb, j);
+        }
+        REL();
+        cb_push_back(out_cb, Wt);
+        cb_pop_front(sin_interm_cb, Wt);
+        cb_pop_front(cos_interm_cb, Wt);
+    }
+
+    /* Unnecessary CB APIs (comment out for code size)
+    // Done with the sin/cos matrices, so remove from CB
+    cb_pop_front(sin_cb, Wt);
+    cb_pop_front(cos_cb, Wt);
+
+    // Done with the transformation matrix, so remove from CB
+    cb_pop_front(trans_mat_cb, onetile);
+    */
+}
+}  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
None

### Problem description
Merge core ranges will improve dispatch times for ops

### What's changed
- Merge core ranges for llama RotaryEmbedding
  - Use bounding box of CoreRangeSets for CB configs and kernel groups
  - Fork rotary embedding compute kernel for llama fused qk 
- Merge core ranges for paged fused UpdateCache
  - Use bounding box of CoreRangeSets for CB configs and kernel groups
  - Fork reader, writer, and compute kernels for paged fused version
  - Unroll handling of K and V heads and remove params structs
  - Add assert for same number of cores for K and V


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14072526659
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable):
  - [x] TG nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14072555187
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes