### PR TITLE
[skip ci] Add cstdint header missing in mesh_trace_id.hpp

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_trace_id.hpp
+++ b/tt_metal/api/tt-metalium/mesh_trace_id.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <tt_stl/strong_type.hpp>
+#include <cstdint>
 
 namespace tt::tt_metal::distributed {
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Building tt-metal on Arch gives this error:
https://pastecode.io/s/dqt7vmt4

### What's changed
Add missing include. another one-line change 😔

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes