### PR TITLE
[skip ci] Remove dead code in add_2_integers_in_compute example.

### DIFF
--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -19,8 +19,6 @@ void MAIN {
     cb_wait_front(cb_in0, 1);
     cb_wait_front(cb_in1, 1);
 
-    // cb_reserve_back(cb_out0, 1);
-
     tile_regs_acquire();  // acquire 8 tile registers
 
     add_tiles(cb_in0, cb_in1, 0, 0, 0);
@@ -35,23 +33,5 @@ void MAIN {
     cb_pop_front(cb_in1, 1);
 
     cb_push_back(cb_out0, 1);
-
-    /*
-    acquire_dst();
-
-    cb_wait_front(tt::CBIndex::c_0, 1);
-    cb_wait_front(tt::CBIndex::c_1, 1);
-
-    add_tiles(tt::CBIndex::c_0, tt::CBIndex::c_1, 0, 0, 0);
-
-    cb_pop_front(tt::CBIndex::c_0, 1);
-    cb_pop_front(tt::CBIndex::c_1, 1);
-
-    cb_reserve_back(tt::CBIndex::c_16, 1);
-    pack_tile(0, tt::CBIndex::c_16);
-    cb_push_back(tt::CBIndex::c_16, 1);
-
-    release_dst();
-    */
 }
 }  // namespace NAMESPACE


### PR DESCRIPTION
Unclear why this dead code is here.

### Ticket

Closes #19521

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes