### PR TITLE
#11973: Properly label the docker image that we're using in CI

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -68,7 +68,7 @@ jobs:
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
 
@@ -134,7 +134,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD Model Tests
@@ -182,7 +182,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
   run-profiler-regression:
     needs: build-artifact-profiler
     strategy:
@@ -197,7 +197,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   build-docs:
@@ -205,7 +205,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   build:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -68,7 +68,7 @@ jobs:
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
 
@@ -134,7 +134,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD Model Tests
@@ -182,7 +182,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
   run-profiler-regression:
     needs: build-artifact-profiler
     strategy:
@@ -197,7 +197,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   build-docs:
@@ -205,7 +205,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   build:

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -68,7 +68,7 @@ jobs:
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
 
@@ -134,7 +134,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD Model Tests
@@ -182,7 +182,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   run-profiler-regression:
     needs: build-artifact-profiler
     strategy:
@@ -197,7 +197,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   build-docs:
@@ -205,7 +205,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   build:

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -66,7 +66,7 @@ jobs:
       arch: "blackhole"
       timeout: 20
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   umd-unit-tests:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -66,7 +66,7 @@ jobs:
       arch: "blackhole"
       timeout: 20
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   umd-unit-tests:

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -66,7 +66,7 @@ jobs:
       arch: "blackhole"
       timeout: 20
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   umd-unit-tests:

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -53,12 +53,15 @@ on:
         default: false
         description: "Profile the compilation"
     outputs:
-      ci-build-docker-image:
-        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
-        value: ${{ jobs.build-docker-image.outputs.ci-build-tag }}
+      #ci-build-docker-image:
+      #  description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
+      #  value: ${{ jobs.build-docker-image.outputs.dev-tag }}
       #ci-test-docker-image:
       #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
       #  value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
+      dev-docker-image:
+        description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
+        value: ${{ jobs.build-docker-image.outputs.dev-tag }}
       packages-artifact-name:
         description: "Name to give download-artifact to get the packages"
         value: ${{ jobs.build-artifact.outputs.packages-artifact-name }}
@@ -130,7 +133,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.dev-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -53,12 +53,12 @@ on:
         default: false
         description: "Profile the compilation"
     outputs:
-      ci-build-docker-image:
-        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
-        value: ${{ jobs.build-docker-image.outputs.ci-build-tag }}
-      #ci-test-docker-image:
-      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
-      #  value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
+      ci-test-docker-image:
+        description: "Docker tag for the CI Build Docker image for testing TT-Metalium et al"
+        value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
+      #dev-docker-image:
+      #  description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
+      #  value: ${{ jobs.build-docker-image.outputs.dev-tag }}
       packages-artifact-name:
         description: "Name to give download-artifact to get the packages"
         value: ${{ jobs.build-artifact.outputs.packages-artifact-name }}
@@ -130,7 +130,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.ci-test-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -53,12 +53,12 @@ on:
         default: false
         description: "Profile the compilation"
     outputs:
-      ci-test-docker-image:
-        description: "Docker tag for the CI Build Docker image for testing TT-Metalium et al"
-        value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
-      #dev-docker-image:
-      #  description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
-      #  value: ${{ jobs.build-docker-image.outputs.dev-tag }}
+      ci-build-docker-image:
+        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
+        value: ${{ jobs.build-docker-image.outputs.ci-build-tag }}
+      #ci-test-docker-image:
+      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
+      #  value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
       packages-artifact-name:
         description: "Name to give download-artifact to get the packages"
         value: ${{ jobs.build-artifact.outputs.packages-artifact-name }}
@@ -130,7 +130,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-test-tag || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -16,9 +16,9 @@ on:
         type: string
         default: "amd64"
     outputs:
-      ci-build-tag:
-        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
-        value: ${{ jobs.check-docker-images.outputs.ci-build-tag }}
+      dev-tag:
+        description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
+        value: ${{ jobs.check-docker-images.outputs.dev-tag }}
       #ci-test-tag:
       #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
       #  value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
@@ -52,10 +52,12 @@ jobs:
   check-docker-images:
     runs-on: ubuntu-latest
     outputs:
-      ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
-      ci-build-tag: ${{ steps.tags.outputs.ci-build-tag }}
+      # ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
+      # ci-build-tag: ${{ steps.tags.outputs.ci-build-tag }}
       # ci-test-exists: ${{ steps.images.outputs.ci-test-exists }}
       # ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
+      dev-exists: ${{ steps.images.outputs.dev-exists }}
+      dev-tag: ${{ steps.tags.outputs.dev-tag }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -65,14 +67,14 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          BUILD_TAG=$(cat \
+          DEV_TAG=$(cat \
             install_dependencies.sh \
             dockerfile/Dockerfile \
             tt_metal/python_env/requirements-dev.txt \
             docs/requirements-docs.txt \
             tests/sweep_framework/requirements-sweeps.txt \
             | sha1sum | cut -d' ' -f1)
-          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${BUILD_TAG}" >> $GITHUB_OUTPUT
+          echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${DEV_TAG}" >> $GITHUB_OUTPUT
 
           # TODO: When we have multiple Docker images, do something like this:
           # TEST_TAG=$(cat tt_metal/python_env/requirements-dev.txt pyproject.toml | sha1sum | cut -d' ' -f1)
@@ -81,19 +83,19 @@ jobs:
       - name: Query images exist
         id: images
         run: |
-          if docker manifest inspect ${{ steps.tags.outputs.ci-build-tag }} > /dev/null 2>&1; then
-            echo "${{ steps.tags.outputs.ci-build-tag }} exists"
-            echo "ci-build-exists=true" >> $GITHUB_OUTPUT
+          if docker manifest inspect ${{ steps.tags.outputs.dev-tag }} > /dev/null 2>&1; then
+            echo "${{ steps.tags.outputs.dev-tag }} exists"
+            echo "dev-exists=true" >> $GITHUB_OUTPUT
           else
-            echo "${{ steps.tags.outputs.ci-build-tag }} does not exist"
-            echo "ci-build-exists=false" >> $GITHUB_OUTPUT
+            echo "${{ steps.tags.outputs.dev-tag }} does not exist"
+            echo "dev-exists=false" >> $GITHUB_OUTPUT
           fi
 
 
   build-docker-image:
     name: "🐳️ Build image"
     needs: check-docker-images
-    if: needs.check-docker-images.outputs.ci-build-exists != 'true'
+    if: needs.check-docker-images.outputs.dev-exists != 'true'
     timeout-minutes: 30
     runs-on:
       - build-docker
@@ -113,7 +115,7 @@ jobs:
           file: dockerfile/Dockerfile
           target: dev
           push: true
-          tags: ${{ needs.check-docker-images.outputs.ci-build-tag }}
+          tags: ${{ needs.check-docker-images.outputs.dev-tag }}
           build-args: UBUNTU_VERSION=${{ inputs.version }}
           cache-to: type=inline
           pull: true
@@ -125,7 +127,7 @@ jobs:
   tag-latest:
     name: "🔄 Update latest tag"
     needs: check-docker-images
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.check-docker-images.outputs.ci-build-exists == 'true'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.check-docker-images.outputs.dev-exists == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Login to GitHub Container Registry
@@ -139,8 +141,8 @@ jobs:
         run: |
           IMAGE_REPO="ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}"
           LATEST_TAG="${IMAGE_REPO}:latest"
-          BUILD_TAG="${{ needs.check-docker-images.outputs.ci-build-tag }}"
-          echo "Tagging ${BUILD_TAG} as ${LATEST_TAG}"
-          docker pull ${BUILD_TAG}
-          docker tag ${BUILD_TAG} ${LATEST_TAG}
+          DEV_TAG="${{ needs.check-docker-images.outputs.dev-tag }}"
+          echo "Tagging ${DEV_TAG} as ${LATEST_TAG}"
+          docker pull ${DEV_TAG}
+          docker tag ${DEV_TAG} ${LATEST_TAG}
           docker push ${LATEST_TAG}

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -46,7 +46,8 @@ on:
             - "amd64"
 
 env:
-  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-dev-${{ inputs.architecture }}
+  # Only build ci-test for now
+  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-ci-test-${{ inputs.architecture }}
 
 jobs:
   check-docker-images:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -16,12 +16,12 @@ on:
         type: string
         default: "amd64"
     outputs:
-      ci-build-tag:
-        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
-        value: ${{ jobs.check-docker-images.outputs.ci-build-tag }}
-      #ci-test-tag:
-      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
-      #  value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
+      ci-test-tag:
+        description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
+        value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
+      #dev-tag:
+      #  description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
+      #  value: ${{ jobs.check-docker-images.outputs.dev-tag }}
   workflow_dispatch:
     inputs:
       distro:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
-      ci-build-tag: ${{ steps.tags.outputs.ci-build-tag }}
+      ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
       # ci-test-exists: ${{ steps.images.outputs.ci-test-exists }}
       # ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
     steps:
@@ -65,27 +65,27 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          BUILD_TAG=$(cat \
+          TEST_TAG=$(cat \
             install_dependencies.sh \
             dockerfile/Dockerfile \
             tt_metal/python_env/requirements-dev.txt \
             docs/requirements-docs.txt \
             tests/sweep_framework/requirements-sweeps.txt \
             | sha1sum | cut -d' ' -f1)
-          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${BUILD_TAG}" >> $GITHUB_OUTPUT
+          echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${TEST_TAG}" >> $GITHUB_OUTPUT
 
           # TODO: When we have multiple Docker images, do something like this:
-          # TEST_TAG=$(cat tt_metal/python_env/requirements-dev.txt pyproject.toml | sha1sum | cut -d' ' -f1)
-          # echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${TEST_TAG}" >> $GITHUB_OUTPUT
+          # DEV_TAG=$(cat tt_metal/python_env/requirements-dev.txt pyproject.toml | sha1sum | cut -d' ' -f1)
+          # echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${DEV_TAG}" >> $GITHUB_OUTPUT
 
       - name: Query images exist
         id: images
         run: |
-          if docker manifest inspect ${{ steps.tags.outputs.ci-build-tag }} > /dev/null 2>&1; then
-            echo "${{ steps.tags.outputs.ci-build-tag }} exists"
+          if docker manifest inspect ${{ steps.tags.outputs.ci-test-tag }} > /dev/null 2>&1; then
+            echo "${{ steps.tags.outputs.ci-test-tag }} exists"
             echo "ci-build-exists=true" >> $GITHUB_OUTPUT
           else
-            echo "${{ steps.tags.outputs.ci-build-tag }} does not exist"
+            echo "${{ steps.tags.outputs.ci-test-tag }} does not exist"
             echo "ci-build-exists=false" >> $GITHUB_OUTPUT
           fi
 
@@ -111,9 +111,9 @@ jobs:
         with:
           context: ${{ github.workspace }}
           file: dockerfile/Dockerfile
-          target: dev
+          target: ci-test
           push: true
-          tags: ${{ needs.check-docker-images.outputs.ci-build-tag }}
+          tags: ${{ needs.check-docker-images.outputs.ci-test-tag }}
           build-args: UBUNTU_VERSION=${{ inputs.version }}
           cache-to: type=inline
           pull: true
@@ -139,8 +139,8 @@ jobs:
         run: |
           IMAGE_REPO="ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}"
           LATEST_TAG="${IMAGE_REPO}:latest"
-          BUILD_TAG="${{ needs.check-docker-images.outputs.ci-build-tag }}"
-          echo "Tagging ${BUILD_TAG} as ${LATEST_TAG}"
-          docker pull ${BUILD_TAG}
-          docker tag ${BUILD_TAG} ${LATEST_TAG}
+          TEST_TAG="${{ needs.check-docker-images.outputs.ci-test-tag }}"
+          echo "Tagging ${TEST_TAG} as ${LATEST_TAG}"
+          docker pull ${TEST_TAG}
+          docker tag ${TEST_TAG} ${LATEST_TAG}
           docker push ${LATEST_TAG}

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -46,8 +46,7 @@ on:
             - "amd64"
 
 env:
-  # Only build ci-test for now
-  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-ci-test-${{ inputs.architecture }}
+  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-dev-${{ inputs.architecture }}
 
 jobs:
   check-docker-images:

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -16,12 +16,12 @@ on:
         type: string
         default: "amd64"
     outputs:
-      ci-test-tag:
-        description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
-        value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
-      #dev-tag:
-      #  description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
-      #  value: ${{ jobs.check-docker-images.outputs.dev-tag }}
+      ci-build-tag:
+        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
+        value: ${{ jobs.check-docker-images.outputs.ci-build-tag }}
+      #ci-test-tag:
+      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
+      #  value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
   workflow_dispatch:
     inputs:
       distro:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
-      ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
+      ci-build-tag: ${{ steps.tags.outputs.ci-build-tag }}
       # ci-test-exists: ${{ steps.images.outputs.ci-test-exists }}
       # ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
     steps:
@@ -65,27 +65,27 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          TEST_TAG=$(cat \
+          BUILD_TAG=$(cat \
             install_dependencies.sh \
             dockerfile/Dockerfile \
             tt_metal/python_env/requirements-dev.txt \
             docs/requirements-docs.txt \
             tests/sweep_framework/requirements-sweeps.txt \
             | sha1sum | cut -d' ' -f1)
-          echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${TEST_TAG}" >> $GITHUB_OUTPUT
+          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${BUILD_TAG}" >> $GITHUB_OUTPUT
 
           # TODO: When we have multiple Docker images, do something like this:
-          # DEV_TAG=$(cat tt_metal/python_env/requirements-dev.txt pyproject.toml | sha1sum | cut -d' ' -f1)
-          # echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${DEV_TAG}" >> $GITHUB_OUTPUT
+          # TEST_TAG=$(cat tt_metal/python_env/requirements-dev.txt pyproject.toml | sha1sum | cut -d' ' -f1)
+          # echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${TEST_TAG}" >> $GITHUB_OUTPUT
 
       - name: Query images exist
         id: images
         run: |
-          if docker manifest inspect ${{ steps.tags.outputs.ci-test-tag }} > /dev/null 2>&1; then
-            echo "${{ steps.tags.outputs.ci-test-tag }} exists"
+          if docker manifest inspect ${{ steps.tags.outputs.ci-build-tag }} > /dev/null 2>&1; then
+            echo "${{ steps.tags.outputs.ci-build-tag }} exists"
             echo "ci-build-exists=true" >> $GITHUB_OUTPUT
           else
-            echo "${{ steps.tags.outputs.ci-test-tag }} does not exist"
+            echo "${{ steps.tags.outputs.ci-build-tag }} does not exist"
             echo "ci-build-exists=false" >> $GITHUB_OUTPUT
           fi
 
@@ -111,9 +111,9 @@ jobs:
         with:
           context: ${{ github.workspace }}
           file: dockerfile/Dockerfile
-          target: ci-test
+          target: dev
           push: true
-          tags: ${{ needs.check-docker-images.outputs.ci-test-tag }}
+          tags: ${{ needs.check-docker-images.outputs.ci-build-tag }}
           build-args: UBUNTU_VERSION=${{ inputs.version }}
           cache-to: type=inline
           pull: true
@@ -139,8 +139,8 @@ jobs:
         run: |
           IMAGE_REPO="ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}"
           LATEST_TAG="${IMAGE_REPO}:latest"
-          TEST_TAG="${{ needs.check-docker-images.outputs.ci-test-tag }}"
-          echo "Tagging ${TEST_TAG} as ${LATEST_TAG}"
-          docker pull ${TEST_TAG}
-          docker tag ${TEST_TAG} ${LATEST_TAG}
+          BUILD_TAG="${{ needs.check-docker-images.outputs.ci-build-tag }}"
+          echo "Tagging ${BUILD_TAG} as ${LATEST_TAG}"
+          docker pull ${BUILD_TAG}
+          docker tag ${BUILD_TAG} ${LATEST_TAG}
           docker push ${LATEST_TAG}

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -68,7 +68,7 @@ jobs:
       - build
       - in-service
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.dev-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -68,7 +68,7 @@ jobs:
       - build
       - in-service
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.ci-test-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -68,7 +68,7 @@ jobs:
       - build
       - in-service
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-test-tag || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo

--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -20,6 +20,6 @@ jobs:
     secrets: inherit
     with:
       version: latest
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -20,6 +20,6 @@ jobs:
     secrets: inherit
     with:
       version: latest
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -20,6 +20,6 @@ jobs:
     secrets: inherit
     with:
       version: latest
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
@@ -39,7 +39,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 

--- a/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
@@ -39,7 +39,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 

--- a/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
@@ -39,7 +39,7 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 

--- a/.github/workflows/fast-dispatch-frequent-tests.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-frequent-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-frequent-tests.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-frequent-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-frequent-tests.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-frequent-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -41,14 +41,14 @@ jobs:
     uses: ./.github/workflows/perf-device-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   e2e-model-perf-single-card:
     needs: build-artifact
     uses: ./.github/workflows/perf-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   demos-single-card:

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -41,14 +41,14 @@ jobs:
     uses: ./.github/workflows/perf-device-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   e2e-model-perf-single-card:
     needs: build-artifact
     uses: ./.github/workflows/perf-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   demos-single-card:

--- a/.github/workflows/full-new-models-suite.yaml
+++ b/.github/workflows/full-new-models-suite.yaml
@@ -41,14 +41,14 @@ jobs:
     uses: ./.github/workflows/perf-device-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
   e2e-model-perf-single-card:
     needs: build-artifact
     uses: ./.github/workflows/perf-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   demos-single-card:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/metal-run-microbenchmarks-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/metal-run-microbenchmarks-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/metal-run-microbenchmarks-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   t3000-model-perf:
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   get-params:
@@ -210,7 +210,7 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      base-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
   release-docs:
@@ -224,7 +224,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     with:
       version: ${{ needs.create-tag.outputs.version }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   t3000-model-perf:
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   get-params:
@@ -210,7 +210,7 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
   release-docs:
@@ -224,7 +224,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     with:
       version: ${{ needs.create-tag.outputs.version }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   t3000-model-perf:
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   get-params:
@@ -210,7 +210,7 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      base-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       version: ${{ needs.create-tag.outputs.version }}
       is_major_version:  ${{ needs.get-params.outputs.is-release-candidate !='true' && needs.get-params.outputs.should-create-release == 'true' }}
   release-docs:
@@ -224,7 +224,7 @@ jobs:
     uses: ./.github/workflows/docs-latest-public.yaml
     with:
       version: ${{ needs.create-tag.outputs.version }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     secrets: inherit

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/perf-device-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/perf-device-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/perf-device-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/perf-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/perf-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/perf-models.yaml
+++ b/.github/workflows/perf-models.yaml
@@ -18,6 +18,6 @@ jobs:
     uses: ./.github/workflows/perf-models-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/tg-quick.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-unit-tests:
@@ -61,7 +61,7 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-frequent-tests:
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-model-perf-tests:
@@ -84,6 +84,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-nightly-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/tg-quick.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-unit-tests:
@@ -61,7 +61,7 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-frequent-tests:
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-model-perf-tests:
@@ -84,6 +84,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-nightly-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/tg-quick.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-unit-tests:
@@ -61,7 +61,7 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-frequent-tests:
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   tg-model-perf-tests:
@@ -84,6 +84,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-nightly-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-unit }}
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-demo }}
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/t3000-frequent-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-frequent }}
@@ -98,7 +98,7 @@ jobs:
     uses: ./.github/workflows/t3000-nightly-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-nightly }}
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
@@ -120,7 +120,7 @@ jobs:
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-profiler }}
@@ -130,7 +130,7 @@ jobs:
     uses: ./.github/workflows/t3000-perplexity-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-perplexity }}

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-unit }}
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-demo }}
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/t3000-frequent-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-frequent }}
@@ -98,7 +98,7 @@ jobs:
     uses: ./.github/workflows/t3000-nightly-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-nightly }}
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
@@ -120,7 +120,7 @@ jobs:
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-profiler }}
@@ -130,7 +130,7 @@ jobs:
     uses: ./.github/workflows/t3000-perplexity-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-perplexity }}

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -68,7 +68,7 @@ jobs:
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-unit }}
@@ -78,7 +78,7 @@ jobs:
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-demo }}
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/t3000-frequent-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-frequent }}
@@ -98,7 +98,7 @@ jobs:
     uses: ./.github/workflows/t3000-nightly-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-nightly }}
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
@@ -120,7 +120,7 @@ jobs:
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-profiler }}
@@ -130,7 +130,7 @@ jobs:
     uses: ./.github/workflows/t3000-perplexity-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.t3000-perplexity }}

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/perf-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.single-card-perf-models }}
@@ -67,7 +67,7 @@ jobs:
     uses: ./.github/workflows/perf-device-models-impl.yaml
     if: ${{ inputs.single-card-perf-device-models }}
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   single-card-nightly:
@@ -75,7 +75,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.single-card-nightly }}

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/perf-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.single-card-perf-models }}
@@ -67,7 +67,7 @@ jobs:
     uses: ./.github/workflows/perf-device-models-impl.yaml
     if: ${{ inputs.single-card-perf-device-models }}
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   single-card-nightly:
@@ -75,7 +75,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.single-card-nightly }}

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/perf-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.single-card-perf-models }}
@@ -67,7 +67,7 @@ jobs:
     uses: ./.github/workflows/perf-device-models-impl.yaml
     if: ${{ inputs.single-card-perf-device-models }}
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   single-card-nightly:
@@ -75,7 +75,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
     if: ${{ inputs.single-card-nightly }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -65,7 +65,7 @@ jobs:
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
-      docker-image: ${{ needs.build.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
 

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -65,7 +65,7 @@ jobs:
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
-      docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build.outputs.ci-build-docker-image }}
       package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
 

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -65,7 +65,7 @@ jobs:
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
-      docker-image: ${{ needs.build.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build.outputs.ci-test-docker-image }}
       package-artifact-name: ${{ needs.build.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
 

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -24,6 +24,6 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      base-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       version: dev-${{ needs.create-image-tag-name.outputs.image-tag-name }}
       is_major_version: false

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -24,6 +24,6 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      base-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       version: dev-${{ needs.create-image-tag-name.outputs.image-tag-name }}
       is_major_version: false

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -24,6 +24,6 @@ jobs:
     uses: ./.github/workflows/publish-release-image.yaml
     secrets: inherit
     with:
-      base-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      base-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       version: dev-${{ needs.create-image-tag-name.outputs.image-tag-name }}
       is_major_version: false

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -25,6 +25,6 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -25,6 +25,6 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/run-profiler-regression-wrapper.yaml
+++ b/.github/workflows/run-profiler-regression-wrapper.yaml
@@ -25,6 +25,6 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       extra-tag: ${{ inputs.extra-tag || 'in-service' }}

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       extra-tag: ${{ inputs.extra-tag || 'in-service' }}

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       extra-tag: ${{ inputs.extra-tag || 'in-service' }}

--- a/.github/workflows/t3000-fast-tests.yaml
+++ b/.github/workflows/t3000-fast-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-fast-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-fast-tests.yaml
+++ b/.github/workflows/t3000-fast-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-fast-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-fast-tests.yaml
+++ b/.github/workflows/t3000-fast-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-fast-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-frequent-tests.yaml
+++ b/.github/workflows/t3000-frequent-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-model-perf-tests.yaml
+++ b/.github/workflows/t3000-model-perf-tests.yaml
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-model-perf-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-profiler-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-nightly-tests.yaml
+++ b/.github/workflows/t3000-nightly-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-nightly-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-nightly-tests.yaml
+++ b/.github/workflows/t3000-nightly-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-nightly-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-nightly-tests.yaml
+++ b/.github/workflows/t3000-nightly-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-nightly-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-perplexity-tests.yaml
+++ b/.github/workflows/t3000-perplexity-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-perplexity-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-perplexity-tests.yaml
+++ b/.github/workflows/t3000-perplexity-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-perplexity-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-perplexity-tests.yaml
+++ b/.github/workflows/t3000-perplexity-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-perplexity-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -19,6 +19,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -19,6 +19,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -19,6 +19,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact-profiler.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tg-demo-tests.yaml
+++ b/.github/workflows/tg-demo-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-demo-tests.yaml
+++ b/.github/workflows/tg-demo-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-demo-tests.yaml
+++ b/.github/workflows/tg-demo-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -16,6 +16,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     uses: ./.github/workflows/tg-nightly-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     uses: ./.github/workflows/tg-nightly-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-nightly-tests.yaml
+++ b/.github/workflows/tg-nightly-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     uses: ./.github/workflows/tg-nightly-tests-impl.yaml
     secrets: inherit
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-quick-trigger.yaml
+++ b/.github/workflows/tg-quick-trigger.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-quick-trigger.yaml
+++ b/.github/workflows/tg-quick-trigger.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-quick-trigger.yaml
+++ b/.github/workflows/tg-quick-trigger.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-stress-trigger.yaml
+++ b/.github/workflows/tg-stress-trigger.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-stress.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-stress-trigger.yaml
+++ b/.github/workflows/tg-stress-trigger.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-stress.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-stress-trigger.yaml
+++ b/.github/workflows/tg-stress-trigger.yaml
@@ -18,6 +18,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-stress.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -17,6 +17,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -46,7 +46,7 @@ jobs:
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
             owner: U052J2QDDKQ # Pavle Josipovic
     container:
-      image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -46,7 +46,7 @@ jobs:
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
             owner: U052J2QDDKQ # Pavle Josipovic
     container:
-      image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       env:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -46,7 +46,7 @@ jobs:
             cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
             owner: U052J2QDDKQ # Pavle Josipovic
     container:
-      image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       env:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib

--- a/.github/workflows/tt-train-post-commit-wrapper.yaml
+++ b/.github/workflows/tt-train-post-commit-wrapper.yaml
@@ -29,4 +29,4 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/tt-train-post-commit-wrapper.yaml
+++ b/.github/workflows/tt-train-post-commit-wrapper.yaml
@@ -29,4 +29,4 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}

--- a/.github/workflows/tt-train-post-commit-wrapper.yaml
+++ b/.github/workflows/tt-train-post-commit-wrapper.yaml
@@ -29,4 +29,4 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}

--- a/.github/workflows/ttnn-post-commit-wrapper.yaml
+++ b/.github/workflows/ttnn-post-commit-wrapper.yaml
@@ -25,6 +25,6 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/ttnn-post-commit-wrapper.yaml
+++ b/.github/workflows/ttnn-post-commit-wrapper.yaml
@@ -25,6 +25,6 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/ttnn-post-commit-wrapper.yaml
+++ b/.github/workflows/ttnn-post-commit-wrapper.yaml
@@ -25,6 +25,6 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-      docker-image: ${{ needs.build-artifact.outputs.ci-build-docker-image }}
+      docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket

#11973 

### Problem description

After discussing with @afuller-TT on https://github.com/tenstorrent/tt-metal/pull/19342, we decided that it would be best to resolve this weird disconnect we have in our Docker-related stuff when we can.

Currently, we create the `dev` target of our Docker image and upload it with the right name. That seems fine, however we call it `ci-build-docker-image` everywhere in our workflows, which is a misnomer.

### What's changed

We renamed `ci-build-docker-image` usage to `dev-docker-image` and made usage of `ci-build` and `dev` consistent in `build-docker-artifact.yaml`.

We can slowly move over to the new `ci-test` image when it comes later. Using a different target now would disrupt devs from getting the latest container images.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- A selection: https://github.com/tenstorrent/tt-metal/actions?query=branch%3Arkim%2F11973-rename-tag