### PR TITLE
Add tests for heterogenous dispatch infra

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_async_runtime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_cq_multi_dev.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_launch_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_capture_arguments_morehdot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_capture_arguments_transpose.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_query_op_constraints.cpp

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
+#include "ttnn/mesh_device_operation_utils.hpp"
+#include "ttnn/old_infra_device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operation.hpp"
+
+#include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+namespace ttnn {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::SizeIs;
+
+struct SharedVariables {};
+struct OperationAttributes {};
+
+// New-infra style program factory that uses the "create" method (non-heterogeneous dispatch)
+struct NewInfraProgramFactoryWithCreate {
+    using shared_variables_t = SharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    using operation_attributes_t = OperationAttributes;
+    using tensor_args_t = Tensor;
+    using tensor_return_value_t = Tensor;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {
+        return cached_program_t(tt::tt_metal::Program(), SharedVariables{});
+    }
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {}
+};
+
+// New-infra style program factory that uses the "create_at" method (heterogeneous dispatch)
+struct NewInfraProgramFactoryWithCreateAt {
+    using shared_variables_t = SharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    using operation_attributes_t = OperationAttributes;
+    using tensor_args_t = Tensor;
+    using tensor_return_value_t = Tensor;
+
+    static cached_program_t create_at(
+        const operation_attributes_t& operation_attributes,
+        const ttnn::MeshCoordinate& mesh_coord,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {
+        return cached_program_t(tt::tt_metal::Program(), SharedVariables{});
+    }
+
+    static void override_runtime_arguments_at(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const ttnn::MeshCoordinate& mesh_coord,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {}
+};
+
+// Old infrastructure device operation that uses the "create_program" method
+struct OldInfraDeviceOpWithCreate {
+    void validate(const std::vector<Tensor>& input_tensors) const {}
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
+
+    auto create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+        return tt::tt_metal::operation::ProgramWithCallbacks();
+    }
+};
+
+// Old infrastructure device operation that uses the "create_program_at" method
+struct OldInfraDeviceOpWithCreateAt {
+    void validate(const std::vector<Tensor>& input_tensors) const {}
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
+
+    auto create_program_at(
+        const ttnn::MeshCoordinate& mesh_coord,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const {
+        return tt::tt_metal::operation::ProgramWithCallbacks();
+    }
+};
+
+TEST(UsesHeterogeneousDispatchTest, OldInfra) {
+    auto old_infra_attributes = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreate{});
+    auto old_infra_attributes_with_at = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateAt{});
+
+    auto old_infra_program_factory = tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>::program_factory_t();
+
+    EXPECT_FALSE(std::visit(
+        [&]<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
+            return ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<ConcreteProgramFactory>(
+                old_infra_attributes);
+        },
+        old_infra_program_factory));
+
+    EXPECT_TRUE(std::visit(
+        [&]<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
+            return ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<ConcreteProgramFactory>(
+                old_infra_attributes_with_at);
+        },
+        old_infra_program_factory));
+}
+
+TEST(UsesHeterogeneousDispatchTest, NewInfra) {
+    EXPECT_FALSE(ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreate>(
+        OperationAttributes{}));
+
+    EXPECT_TRUE(ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreateAt>(
+        OperationAttributes{}));
+}
+
+using TensorCoordinatesT3000Test = tt::tt_metal::T3000MeshDeviceFixture;
+
+TEST_F(TensorCoordinatesT3000Test, UniformTensor) {
+    const TensorSpec tensor_spec = TensorSpec(
+        ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    auto full_tensor = tt::tt_metal::allocate_tensor_on_mesh(tensor_spec, mesh_device_.get());
+    std::vector<Tensor> tensor_args = {full_tensor};
+
+    EXPECT_TRUE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args));
+
+    EXPECT_THAT(
+        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(tensor_args),
+        ElementsAre(
+            ttnn::MeshCoordinate{0, 0},  //
+            ttnn::MeshCoordinate{0, 1},
+            ttnn::MeshCoordinate{0, 2},
+            ttnn::MeshCoordinate{0, 3},
+            ttnn::MeshCoordinate{1, 0},
+            ttnn::MeshCoordinate{1, 1},
+            ttnn::MeshCoordinate{1, 2},
+            ttnn::MeshCoordinate{1, 3}));
+}
+
+TEST_F(TensorCoordinatesT3000Test, IncompleteShards) {
+    const TensorSpec tensor_spec = TensorSpec(
+        ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    // Make a tensor spanning 2 devices using `aggregate_as_tensor` with 2 host (owned) tensors.
+    auto host_tensor = Tensor::from_vector(std::vector<float>(tensor_spec.logical_shape().volume()), tensor_spec);
+    auto device_tensor = distributed::aggregate_as_tensor({host_tensor, host_tensor}, tt::tt_metal::AllGatherTensor{})
+                             .to_device(mesh_device_.get());
+    std::vector<Tensor> tensor_args = {device_tensor};
+
+    EXPECT_THAT(device_tensor.device_storage().specs, SizeIs(2));
+
+    EXPECT_FALSE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args));
+    EXPECT_THAT(
+        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(tensor_args),
+        ElementsAre(
+            ttnn::MeshCoordinate{0, 0},  //
+            ttnn::MeshCoordinate{0, 1}));
+}
+
+TEST_F(TensorCoordinatesT3000Test, MismatchedTensors) {
+    const TensorSpec tensor_spec = TensorSpec(
+        ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
+    auto full_tensor = tt::tt_metal::allocate_tensor_on_mesh(tensor_spec, mesh_device_.get());
+    // Make a tensor spanning 2 devices using `aggregate_as_tensor` with 2 host (owned) tensors.
+    auto host_tensor = Tensor::from_vector(std::vector<float>(tensor_spec.logical_shape().volume()), tensor_spec);
+    auto device_tensor = distributed::aggregate_as_tensor({host_tensor, host_tensor}, tt::tt_metal::AllGatherTensor{})
+                             .to_device(mesh_device_.get());
+    std::vector<Tensor> tensor_args = {full_tensor, device_tensor};
+
+    EXPECT_ANY_THROW(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args));
+    EXPECT_ANY_THROW(ttnn::mesh_device_operation_utils::extract_tensor_coordinates(tensor_args));
+}
+
+}  // namespace
+}  // namespace ttnn

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -202,6 +202,7 @@ set(TTNN_BASE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/global_circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/run_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/old_infra_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/api.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_tensor_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_tensor.cpp

--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -79,8 +79,8 @@ struct MeshDeviceOperationAdapter {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value) {
         return std::visit(
-            [&]<typename ConcreteFactory>(const ConcreteFactory& concrete_factory) {
-                return mesh_device_operation_utils::create_mesh_workload<DeviceOperation, ConcreteFactory>(
+            [&]<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
+                return mesh_device_operation_utils::create_mesh_workload<DeviceOperation, ConcreteProgramFactory>(
                     mesh_device, attrs, tensor_args, tensor_return_value);
             },
             select_program_factory(attrs, tensor_args));
@@ -94,8 +94,8 @@ struct MeshDeviceOperationAdapter {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value) {
         std::visit(
-            [&]<typename ConcreteFactory>(const ConcreteFactory& concrete_factory) {
-                mesh_device_operation_utils::override_mesh_runtime_arguments<ConcreteFactory>(
+            [&]<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
+                mesh_device_operation_utils::override_mesh_runtime_arguments<ConcreteProgramFactory>(
                     cached_workload, mesh_device, attrs, tensor_args, tensor_return_value);
             },
             select_program_factory(attrs, tensor_args));

--- a/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
@@ -21,15 +21,16 @@ using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorklo
 
 // Determines if the device operation and a given program factory use heterogenous dispatch (constructing a single
 // program for the entire mesh workload, or creating a program for each device within the mesh).
-// For the old infra type-erased `DeviceOperation`, this is determined by `uses_heterogenous_dispatch` method.
-// For the new infra, this is determined by the presence of `create_at` method for creating programs at a specific
-// location.
-template <typename device_operation_t, typename program_factory_t>
-auto uses_heterogenous_dispatch() {
-    if constexpr (requires { device_operation_t::uses_heterogenous_dispatch(); }) {
-        return device_operation_t::uses_heterogenous_dispatch();
+// For the old infra type-erased `DeviceOperation`, this is determined by `uses_heterogenous_dispatch` method on the
+// program factory.
+// For the new infra, this is determined by the presence of `create_at` method for creating programs at
+// a specific location.
+template <typename ConcreteProgramFactory, typename OperationAttributes>
+auto uses_heterogenous_dispatch(const OperationAttributes& attrs) {
+    if constexpr (requires { ConcreteProgramFactory::uses_heterogenous_dispatch(attrs); }) {
+        return ConcreteProgramFactory::uses_heterogenous_dispatch(attrs);
     } else {
-        constexpr bool has_create_at = requires { &program_factory_t::create_at; };
+        constexpr bool has_create_at = requires { &ConcreteProgramFactory::create_at; };
         return has_create_at;
     }
 }
@@ -114,19 +115,19 @@ void apply_override_runtime_arguments(
 
 template <
     typename DeviceOperationT,
-    typename ProgramFactoryT,
+    typename ConcreteProgramFactory,
     typename AttributesT,
     typename TensorArgsT,
     typename ReturnValueT>
-CachedMeshWorkload<typename ProgramFactoryT::shared_variables_t> create_mesh_workload(
+CachedMeshWorkload<typename ConcreteProgramFactory::shared_variables_t> create_mesh_workload(
     ttnn::MeshDevice* mesh_device,
     const AttributesT& attrs,
     const TensorArgsT& tensor_args,
     ReturnValueT& tensor_return_value) {
-    using shared_vars_t = typename ProgramFactoryT::shared_variables_t;
+    using shared_vars_t = typename ConcreteProgramFactory::shared_variables_t;
     tt::tt_metal::distributed::MeshWorkload mesh_workload;
-    ProgramFactoryT program_factory;
-    constexpr bool has_create = requires { &ProgramFactoryT::create; };
+    ConcreteProgramFactory program_factory;
+    constexpr bool has_create = requires { &ConcreteProgramFactory::create; };
 
     std::unordered_map<ttnn::MeshCoordinateRange, shared_vars_t> coordinate_range_to_shared_variables;
 
@@ -140,7 +141,7 @@ CachedMeshWorkload<typename ProgramFactoryT::shared_variables_t> create_mesh_wor
 
     // Fast path - create a single program for all devices.
     // No customization and uniform tensor storage spanning all devices.
-    if (!uses_heterogenous_dispatch<DeviceOperationT, ProgramFactoryT>() &&
+    if (!uses_heterogenous_dispatch<ConcreteProgramFactory>(attrs) &&
         mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
         const ttnn::MeshCoordinateRange mesh_coordinate_range(mesh_device->shape());
         auto cached_program = make_program(ttnn::MeshCoordinate(0, 0));

--- a/ttnn/cpp/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.hpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/mesh_execution.hpp"
+
+namespace tt::tt_metal::operation {
+
+template <typename OutputTensors>
+struct OldInfraDeviceOperation {
+    using operation_attributes_t = operation::DeviceOperation<OutputTensors>;
+
+    struct tensor_args_t {
+        const operation::Tensors input_tensors;
+        const operation::OptionalConstTensors optional_input_tensors;
+        const operation::OptionalTensors optional_output_tensors;
+    };
+
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+    using tensor_return_value_t = OutputTensors;
+
+    struct ProgramFactory {
+        struct shared_variables_t {
+            std::optional<operation::OverrideAddressesCallback> override_addresses_callback;
+            std::optional<operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
+                override_runtime_arguments_callback;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create_at(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinate& mesh_coord,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments_at(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinate&,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static bool uses_heterogenous_dispatch(const operation_attributes_t& attributes);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory>;
+
+    // Mandatory methods
+
+    // Select the program factory based on the operation attributes and tensor args
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Validate the operation when it creates a program. Usually will have more checks
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Validate the operation when it reuses a program. Usually will have less checks
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Compute the output specs based on the operation attributes and tensor args
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Create the output tensors based on the operation attributes and tensor args
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    static auto create_op_performance_model(
+        const operation_attributes_t& attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static std::string get_type_name(const operation_attributes_t& attributes);
+
+    static bool uses_heterogenous_dispatch(const operation_attributes_t& attributes);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        operation_attributes_t&& operation_attributes,
+        const operation::Tensors& input_tensors,
+        const operation::OptionalConstTensors& optional_input_tensors,
+        const operation::OptionalTensors& optional_output_tensors);
+};
+
+}  // namespace tt::tt_metal::operation
+
+namespace ttnn::prim {
+
+constexpr auto old_infra_device_operation = ttnn::register_mesh_operation<
+    "ttnn::prim::old_infra_device_operation",
+    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::Tensors>>();
+constexpr auto old_infra_device_operation_with_optional_output_tensors = ttnn::register_mesh_operation<
+    "ttnn::prim::old_infra_device_operation_with_optional_output_tensors",
+    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::OptionalTensors>>();
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -7,6 +7,7 @@
 #include <ttnn/tensor/tensor.hpp>
 #include <ttnn/tensor/tensor_utils.hpp>
 
+#include "ttnn/old_infra_device_operation.hpp"
 #include "ttnn/operations/experimental/auto_format/auto_format.hpp"
 #include "ttnn/operation.hpp"
 #include <tt-metalium/tt_metal.hpp>
@@ -39,49 +40,6 @@ IDevice* get_device(const Tensors& input_tensors, const OptionalConstTensors& op
     TT_ASSERT(device != nullptr, "Requires setting default device if no inputs to operation are on device");
     return device;
 }
-
-template <class OutputTensors>
-void override_addresses(
-    const OverrideAddressesCallback& override_addresses_callback,
-    const Program& program,
-    const Tensors& input_tensors,
-    const OptionalConstTensors& optional_input_tensors,
-    const OutputTensors& output_tensors) {
-    std::vector<tt::tt_metal::Buffer*> input_buffers;
-    for (auto& tensor : input_tensors) {
-        input_buffers.push_back(tensor.buffer());
-    }
-    for (auto& tensor : optional_input_tensors) {
-        auto buffer = tensor.has_value() ? tensor.value().buffer() : nullptr;
-        input_buffers.push_back(buffer);
-    }
-
-    std::vector<tt::tt_metal::Buffer*> output_buffers;
-    for (auto& tensor : output_tensors) {
-        if constexpr (std::is_same_v<OptionalTensors, OutputTensors>) {
-            auto buffer = tensor.has_value() ? tensor.value().buffer() : nullptr;
-            output_buffers.push_back(buffer);
-        } else {
-            output_buffers.push_back(tensor.buffer());
-        }
-    }
-
-    override_addresses_callback(program, input_buffers, output_buffers);
-}
-
-template void override_addresses<Tensors>(
-    const OverrideAddressesCallback& override_addresses_callback,
-    const Program& program,
-    const Tensors& input_tensors,
-    const OptionalConstTensors& optional_input_tensors,
-    const Tensors& output_tensors);
-
-template void override_addresses<OptionalTensors>(
-    const OverrideAddressesCallback& override_addresses_callback,
-    const Program& program,
-    const Tensors& input_tensors,
-    const OptionalConstTensors& optional_input_tensors,
-    const OptionalTensors& output_tensors);
 
 template <typename T>
 struct is_optional : std::false_type {};
@@ -132,146 +90,7 @@ auto& get_workers(auto& output_tensors) {
 }
 
 }  // namespace detail
-
-template <typename OutputTensors>
-struct OldInfraDeviceOperation {
-    using operation_attributes_t = operation::DeviceOperation<OutputTensors>;
-
-    struct tensor_args_t {
-        const operation::Tensors input_tensors;
-        const operation::OptionalConstTensors optional_input_tensors;
-        const operation::OptionalTensors optional_output_tensors;
-    };
-
-    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
-
-    using tensor_return_value_t = OutputTensors;
-
-    struct ProgramFactory {
-        struct shared_variables_t {
-            std::optional<operation::OverrideAddressesCallback> override_addresses_callback;
-            std::optional<operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
-                override_runtime_arguments_callback;
-        };
-        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
-
-        static cached_program_t create_at(
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coord,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value) {
-            auto program_with_callbacks = operation_attributes.create_program_at(
-                mesh_coord, tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
-            return cached_program_t{
-                std::move(program_with_callbacks.program),
-                shared_variables_t{
-                    program_with_callbacks.override_addresses_callback,
-                    program_with_callbacks.override_runtime_arguments_callback}};
-        }
-
-        static void override_runtime_arguments_at(
-            cached_program_t& cached_program,
-            const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate&,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value) {
-            auto& override_addresses_callback = cached_program.shared_variables.override_addresses_callback;
-            auto& override_runtime_arguments_callback =
-                cached_program.shared_variables.override_runtime_arguments_callback;
-            auto& program = cached_program.program;
-
-            if (override_addresses_callback.has_value()) {
-                // Deprecated
-                detail::override_addresses(
-                    override_addresses_callback.value(),
-                    program,
-                    tensor_args.input_tensors,
-                    tensor_args.optional_input_tensors,
-                    tensor_return_value);
-            }
-
-            if (override_runtime_arguments_callback.has_value()) {
-                operation_attributes.override_runtime_arguments(
-                    override_runtime_arguments_callback.value(),
-                    program,
-                    tensor_args.input_tensors,
-                    tensor_args.optional_input_tensors,
-                    tensor_return_value);
-            }
-        }
-    };
-
-    using program_factory_t = std::variant<ProgramFactory>;
-
-    // Mandatory methods
-
-    // Select the program factory based on the operation attributes and tensor args
-    static program_factory_t select_program_factory(
-        const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        return ProgramFactory{};
-    }
-
-    // Validate the operation when it creates a program. Usually will have more checks
-    static void validate_on_program_cache_miss(
-        const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        attributes.validate(
-            tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_args.optional_output_tensors);
-    }
-
-    // Validate the operation when it reuses a program. Usually will have less checks
-    static void validate_on_program_cache_hit(
-        const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        validate_on_program_cache_miss(attributes, tensor_args);
-    }
-
-    // Compute the output specs based on the operation attributes and tensor args
-    static spec_return_value_t compute_output_specs(
-        const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        return attributes.compute_output_specs(tensor_args.input_tensors);
-    }
-
-    // Create the output tensors based on the operation attributes and tensor args
-    static tensor_return_value_t create_output_tensors(
-        const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        return attributes.create_output_tensors(tensor_args.input_tensors, tensor_args.optional_output_tensors);
-    }
-
-    static tt::stl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-        return attributes.compute_program_hash(tensor_args.input_tensors, tensor_args.optional_input_tensors);
-    }
-
-    static auto create_op_performance_model(
-        const operation_attributes_t& attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value) {
-        return attributes.create_op_performance_model(
-            tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
-    }
-
-    static std::string get_type_name(const operation_attributes_t& attributes) { return attributes.get_type_name(); }
-
-    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        operation_attributes_t&& operation_attributes,
-        const operation::Tensors& input_tensors,
-        const operation::OptionalConstTensors& optional_input_tensors,
-        const operation::OptionalTensors& optional_output_tensors) {
-        return std::make_tuple(
-            std::move(operation_attributes),
-            tensor_args_t{input_tensors, optional_input_tensors, optional_output_tensors});
-    }
-};
-
 }  // namespace tt::tt_metal::operation
-
-namespace ttnn::prim {
-constexpr auto old_infra_device_operation = ttnn::register_mesh_operation<
-    "ttnn::prim::old_infra_device_operation",
-    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::Tensors>>();
-constexpr auto old_infra_device_operation_with_optional_output_tensors = ttnn::register_mesh_operation<
-    "ttnn::prim::old_infra_device_operation_with_optional_output_tensors",
-    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::OptionalTensors>>();
-}  // namespace ttnn::prim
 
 namespace tt::tt_metal::operation {
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Dispatching TTNN ops to a subset of devices had a couple of problems - `create_at` was not propagated through the legacy path properly, and the runtime attributes weren't set correctly.

### What's changed
* Fix the 2 problems.
* Add `test_launch_operation.cpp` that tests the mesh workload utils.
* This required separation of `OldInfraDeviceOperation` in a header.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14015732962) 
- [X] New/Existing tests provide coverage for changes
- [X] Ran falcon / resnet50 T3K tests locally