### PR TITLE
#19358: Delay deasserting NCRISC reset

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -359,6 +359,10 @@ inline void start_ncrisc_kernel_run(dispatch_core_processor_masks enables) {
         volatile tt_reg_ptr uint32_t* cfg_regs = core.cfg_regs_base(0);
         cfg_regs[NCRISC_RESET_PC_PC_ADDR32] = mailboxes->ncrisc_halt.resume_addr;
         assert_just_ncrisc_reset();
+        // Wait a bit to ensure NCRISC has time to actually reset (otherwise it
+        // may just continue where it left off). This wait value was chosen
+        // empirically.
+        riscv_wait(5);
         deassert_all_reset();
     }
 #endif


### PR DESCRIPTION
### Ticket
#19358 

### Problem description
If reset is deasserted immediately after being asserted, in some very rare circumstances NCRISC may not actually be reset, and will be stuck in a loop inside notify_brisc_and_halt_to_iram. We've seen this happen in one tt-torch unit test

### What's changed
Add a slight delay to ensure NCRISC is really reset and prevent the hang.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes