### PR TITLE
add packets per second metric to 1D fabric

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -11,6 +11,8 @@ import pytest
 import csv
 from tt_metal.tools.profiler.process_device_log import import_log_run_stats
 import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
+from tabulate import tabulate
+import pandas as pd
 
 from tt_metal.tools.profiler.common import PROFILER_LOGS_DIR, PROFILER_DEVICE_SIDE_LOG
 
@@ -33,10 +35,26 @@ def get_device_freq():
     return freq
 
 
+def summarize_to_csv(test_name, packet_size, bandwidth, packets_per_second):
+    """Write test results to a CSV file organized by packet size"""
+    csv_path = os.path.join(os.environ["TT_METAL_HOME"], "generated/profiler/.logs/bandwidth_summary.csv")
+
+    # Create header if file doesn't exist
+    if not os.path.exists(csv_path):
+        with open(csv_path, "w") as f:
+            writer = csv.writer(f)
+            writer.writerow(["Test Name", "Packet Size", "Bandwidth (B/c)", "Packets/Second"])
+
+    # Append results
+    with open(csv_path, "a") as f:
+        writer = csv.writer(f)
+        writer.writerow([test_name, packet_size, bandwidth, packets_per_second])
+
+
 def profile_results(
     zone_name, packets_per_src_chip, line_size, packet_size, fabric_mode, disable_sends_for_interior_workers
 ):
-    freq = get_device_freq() / 1000.0
+    freq_hz = get_device_freq() * 1000.0 * 1000.0
     setup = device_post_proc_config.default_setup()
     setup.deviceInputLog = profiler_log_path
     setup.timerAnalysis = {
@@ -64,10 +82,12 @@ def profile_results(
         traffic_streams_through_boundary = line_size / 2
         if disable_sends_for_interior_workers:
             traffic_streams_through_boundary = 1
-    total_byte_sent = packets_per_src_chip * traffic_streams_through_boundary * packet_size
+    total_packets_sent = packets_per_src_chip * traffic_streams_through_boundary
+    total_byte_sent = total_packets_sent * packet_size
     bandwidth = total_byte_sent / max(main_loop_cycles)
+    packets_per_second = total_packets_sent / max(main_loop_cycles) * freq_hz
 
-    return bandwidth
+    return bandwidth, packets_per_second
 
 
 def run_fabric_edm(
@@ -81,6 +101,7 @@ def run_fabric_edm(
     packet_size,
     fabric_mode,
     expected_bw,
+    expected_Mpps,
     disable_sends_for_interior_workers,
 ):
     logger.warning("removing file profile_log_device.csv")
@@ -109,15 +130,27 @@ def run_fabric_edm(
     zone_name_main = "MAIN-TEST-BODY"
 
     num_messages = num_mcasts + num_unicasts
-    bandwidth_inner_loop = profile_results(
+    bandwidth_inner_loop, packets_per_second_inner_loop = profile_results(
         zone_name_inner, num_messages, line_size, packet_size, fabric_mode, disable_sends_for_interior_workers
     )
-    bandwidth = profile_results(
+    bandwidth, packets_per_second = profile_results(
         zone_name_main, num_messages, line_size, packet_size, fabric_mode, disable_sends_for_interior_workers
     )
     logger.info("bandwidth_inner_loop: {} B/c", bandwidth_inner_loop)
     logger.info("bandwidth: {} B/c", bandwidth)
-    assert expected_bw - 0.07 <= bandwidth <= expected_bw + 0.07
+    logger.info("packets_per_second_inner_loop: {} pps", packets_per_second_inner_loop)
+    logger.info("packets_per_second: {} pps", packets_per_second)
+    mega_packets_per_second = packets_per_second / 1000000
+
+    # Add summary to CSV
+    test_name = f"{'unicast' if is_unicast else 'mcast'}_{fabric_mode.name}"
+    summarize_to_csv(test_name, packet_size, bandwidth, packets_per_second)
+    bw_threshold = 0.07
+    if packet_size <= 2048 and fabric_mode != FabricTestMode.Linear:
+        bw_threshold = 0.12
+    assert expected_bw - bw_threshold <= bandwidth <= expected_bw + bw_threshold
+    if expected_Mpps is not None:
+        assert expected_Mpps - 0.01 <= mega_packets_per_second <= expected_Mpps + 0.01
 
 
 @pytest.mark.parametrize("num_mcasts", [200000])
@@ -125,7 +158,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 8.23), (4, 2, 8.17)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw, expected_Mpps", [(4, 1, 8.23, 2.01), (4, 2, 8.17, 1.99)])
 def test_fabric_edm_mcast_half_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -135,6 +168,7 @@ def test_fabric_edm_mcast_half_ring_bw(
     line_size,
     packet_size,
     expected_bw,
+    expected_Mpps,
 ):
     run_fabric_edm(
         False,
@@ -147,6 +181,7 @@ def test_fabric_edm_mcast_half_ring_bw(
         packet_size,
         FabricTestMode.HalfRing,
         expected_bw,
+        expected_Mpps,
         False,
     )
 
@@ -155,9 +190,12 @@ def test_fabric_edm_mcast_half_ring_bw(
 @pytest.mark.parametrize("num_unicasts", [0])
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
-@pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 5.81), (4, 2, 5.75), (8, 1, 4.46)])
-def test_fabric_edm_mcast_full_ring_bw(
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.029, 1.864), (2048, 3.33, 1.626), (4096, 5.8, 1.419)]
+)
+def test_fabric_4chip_one_link_mcast_full_ring_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -166,6 +204,7 @@ def test_fabric_edm_mcast_full_ring_bw(
     line_size,
     packet_size,
     expected_bw,
+    expected_Mpps,
 ):
     run_fabric_edm(
         False,
@@ -178,6 +217,7 @@ def test_fabric_edm_mcast_full_ring_bw(
         packet_size,
         FabricTestMode.FullRing,
         expected_bw,
+        expected_Mpps,
         False,
     )
 
@@ -186,9 +226,12 @@ def test_fabric_edm_mcast_full_ring_bw(
 @pytest.mark.parametrize("num_unicasts", [0])
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
-@pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 6.72), (4, 2, 6.54)])
-def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
+@pytest.mark.parametrize("line_size", [8])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.025, None), (2048, 2.32, None), (4096, 4.46, 1.09)]
+)  #  _
+def test_fabric_8chip_one_link_edm_mcast_full_ring_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -197,6 +240,43 @@ def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
     line_size,
     packet_size,
     expected_bw,
+    expected_Mpps,
+):
+    run_fabric_edm(
+        False,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        FabricTestMode.FullRing,
+        expected_bw,
+        expected_Mpps,
+        False,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [200000])
+@pytest.mark.parametrize("num_unicasts", [0])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.032, 2.037), (2048, 3.74, 1.825), (4096, 6.72, 1.642)]
+)
+def test_fabric_4_chip_one_link_mcast_saturate_chip_to_chip_ring_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+    expected_Mpps,
 ):
     run_fabric_edm(
         False,
@@ -209,17 +289,22 @@ def test_fabric_edm_mcast_saturate_chip_to_chip_ring_bw(
         packet_size,
         FabricTestMode.SaturateChipToChipRing,
         expected_bw,
+        expected_Mpps,
         False,
     )
 
 
+# expected_Mpps = expected millions of packets per second
 @pytest.mark.parametrize("num_mcasts", [200000])
 @pytest.mark.parametrize("num_unicasts", [0])
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
-@pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw", [(4, 1, 7.75), (4, 2, 7.75)])
-def test_fabric_edm_mcast_bw(
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.034, 2.13), (2048, 4.36, 2.13), (4096, 7.75, 1.89)]
+)
+def test_fabric_4chip_one_link_mcast_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -228,6 +313,7 @@ def test_fabric_edm_mcast_bw(
     line_size,
     packet_size,
     expected_bw,
+    expected_Mpps,
 ):
     run_fabric_edm(
         False,
@@ -240,6 +326,43 @@ def test_fabric_edm_mcast_bw(
         packet_size,
         FabricTestMode.Linear,
         expected_bw,
+        expected_Mpps,
+        False,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [200000])
+@pytest.mark.parametrize("num_unicasts", [0])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize("num_links", [2])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.034, 2.13), (2048, 4.35, 2.13), (4096, 7.75, 1.89)]
+)
+def test_fabric_4chip_two_link_mcast_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+    expected_Mpps,
+):
+    run_fabric_edm(
+        False,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        FabricTestMode.Linear,
+        expected_bw,
+        expected_Mpps,
         False,
     )
 
@@ -249,9 +372,11 @@ def test_fabric_edm_mcast_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [2])
-@pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 11.03), (2, 11.03)])
-def test_fabric_edm_unicast_bw(
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.044, 2.762), (2048, 5.64, 2.757), (4096, 11.03, 2.673)]
+)  # _ _ |
+def test_fabric_one_link_non_forwarding_unicast_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -260,6 +385,7 @@ def test_fabric_edm_unicast_bw(
     line_size,
     packet_size,
     expected_bw,
+    expected_Mpps,
 ):
     run_fabric_edm(
         True,
@@ -272,6 +398,43 @@ def test_fabric_edm_unicast_bw(
         packet_size,
         FabricTestMode.Linear,
         expected_bw,
+        expected_Mpps,
+        False,
+    )
+
+
+@pytest.mark.parametrize("num_mcasts", [0])
+@pytest.mark.parametrize("num_unicasts", [200000])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("line_size", [2])
+@pytest.mark.parametrize("num_links", [2])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.044, 2.755), (2048, 5.64, 2.755), (4096, 11.03, 2.67)]
+)
+def test_fabric_two_link_non_forwarding_unicast_bw(
+    num_mcasts,
+    num_unicasts,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+    expected_bw,
+    expected_Mpps,
+):
+    run_fabric_edm(
+        True,
+        num_mcasts,
+        num_unicasts,
+        num_links,
+        num_op_invocations,
+        line_sync,
+        line_size,
+        packet_size,
+        FabricTestMode.Linear,
+        expected_bw,
+        expected_Mpps,
         False,
     )
 
@@ -281,9 +444,11 @@ def test_fabric_edm_unicast_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [4])
-@pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 9.74), (2, 9.63)])
-def test_fabric_edm_unicast_multiproducer_multihop_bw(
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.038, None), (2048, 4.897, 2.379), (4096, 9.72, 2.373)]
+)  # too unstable
+def test_fabric_one_link_forwarding_unicast_multiproducer_multihop_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -292,6 +457,7 @@ def test_fabric_edm_unicast_multiproducer_multihop_bw(
     line_size,
     packet_size,
     expected_bw,
+    expected_Mpps,
 ):
     run_fabric_edm(
         True,
@@ -304,6 +470,7 @@ def test_fabric_edm_unicast_multiproducer_multihop_bw(
         packet_size,
         FabricTestMode.Linear,
         expected_bw,
+        expected_Mpps,
         False,
     )
 
@@ -313,9 +480,11 @@ def test_fabric_edm_unicast_multiproducer_multihop_bw(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("line_size", [4])
-@pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("num_links, expected_bw", [(1, 9.35), (2, 9.26)])
-def test_fabric_edm_unicast_single_producer_multihop_bw(
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize(
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.037, 2.348), (2048, 4.815, 2.351), (4096, 9.35, 2.2846)]
+)  # _ _
+def test_fabric_one_link_forwarding_unicast_single_producer_multihop_bw(
     num_mcasts,
     num_unicasts,
     num_links,
@@ -324,6 +493,7 @@ def test_fabric_edm_unicast_single_producer_multihop_bw(
     line_size,
     packet_size,
     expected_bw,
+    expected_Mpps,
 ):
     run_fabric_edm(
         True,
@@ -336,5 +506,39 @@ def test_fabric_edm_unicast_single_producer_multihop_bw(
         packet_size,
         FabricTestMode.Linear,
         expected_bw,
+        expected_Mpps,
         True,
     )
+
+
+def print_bandwidth_summary():
+    """Print a summary table of all test results by packet size"""
+    csv_path = os.path.join(os.environ["TT_METAL_HOME"], "generated/profiler/.logs/bandwidth_summary.csv")
+
+    if not os.path.exists(csv_path):
+        logger.warning("No bandwidth summary data found")
+        return
+
+    df = pd.read_csv(csv_path)
+
+    # Sort by test name and packet size
+    df = df.sort_values(["Test Name", "Packet Size"])
+
+    # Format table with raw values
+    table = tabulate(
+        df, headers=["Test Name", "Packet Size", "Bandwidth (B/c)", "Packets/Second"], tablefmt="grid", floatfmt=".2f"
+    )
+    logger.info("\nBandwidth Test Results:\n{}", table)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def print_summary_at_end(request):
+    """Print bandwidth summary at end of session"""
+    # Delete old CSV file at start
+    csv_path = os.path.join(os.environ["TT_METAL_HOME"], "generated/profiler/.logs/bandwidth_summary.csv")
+    if os.path.exists(csv_path):
+        os.remove(csv_path)
+        logger.info("Removed old bandwidth summary file")
+
+    yield
+    print_bandwidth_summary()

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -158,7 +158,7 @@ def run_fabric_edm(
 @pytest.mark.parametrize("num_op_invocations", [1])
 @pytest.mark.parametrize("line_sync", [True])
 @pytest.mark.parametrize("packet_size", [4096])
-@pytest.mark.parametrize("line_size, num_links, expected_bw, expected_Mpps", [(4, 1, 8.23, 2.01), (4, 2, 8.17, 1.99)])
+@pytest.mark.parametrize("line_size, num_links, expected_bw, expected_Mpps", [(4, 1, 8.23, None), (4, 2, 8.17, 1.99)])
 def test_fabric_edm_mcast_half_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -373,7 +373,7 @@ def test_fabric_4chip_two_link_mcast_bw(
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
-    "packet_size, expected_bw, expected_Mpps", [(16, 0.044, 2.762), (2048, 5.64, 2.757), (4096, 11.03, 2.673)]
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.044, 2.762), (2048, 5.64, 2.757), (4096, 11.02, 2.673)]
 )
 def test_fabric_one_link_non_forwarding_unicast_bw(
     num_mcasts,
@@ -409,7 +409,7 @@ def test_fabric_one_link_non_forwarding_unicast_bw(
 @pytest.mark.parametrize("line_size", [2])
 @pytest.mark.parametrize("num_links", [2])
 @pytest.mark.parametrize(
-    "packet_size, expected_bw, expected_Mpps", [(16, 0.044, 2.755), (2048, 5.64, 2.755), (4096, 11.03, 2.67)]
+    "packet_size, expected_bw, expected_Mpps", [(16, 0.044, 2.755), (2048, 5.64, 2.755), (4096, 11.02, 2.67)]
 )
 def test_fabric_two_link_non_forwarding_unicast_bw(
     num_mcasts,

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -101,7 +101,7 @@ def run_fabric_edm(
     packet_size,
     fabric_mode,
     expected_bw,
-    expected_Mpps,
+    expected_Mpps,  # expected_Mpps = expected millions of packets per second
     disable_sends_for_interior_workers,
 ):
     logger.warning("removing file profile_log_device.csv")
@@ -230,7 +230,7 @@ def test_fabric_4chip_one_link_mcast_full_ring_bw(
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "packet_size, expected_bw, expected_Mpps", [(16, 0.025, None), (2048, 2.32, None), (4096, 4.46, 1.09)]
-)  #  _
+)  # Marked None if packets per second varies too much run to run (>= 5%)
 def test_fabric_8chip_one_link_edm_mcast_full_ring_bw(
     num_mcasts,
     num_unicasts,
@@ -294,7 +294,6 @@ def test_fabric_4_chip_one_link_mcast_saturate_chip_to_chip_ring_bw(
     )
 
 
-# expected_Mpps = expected millions of packets per second
 @pytest.mark.parametrize("num_mcasts", [200000])
 @pytest.mark.parametrize("num_unicasts", [0])
 @pytest.mark.parametrize("num_op_invocations", [1])
@@ -375,7 +374,7 @@ def test_fabric_4chip_two_link_mcast_bw(
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "packet_size, expected_bw, expected_Mpps", [(16, 0.044, 2.762), (2048, 5.64, 2.757), (4096, 11.03, 2.673)]
-)  # _ _ |
+)
 def test_fabric_one_link_non_forwarding_unicast_bw(
     num_mcasts,
     num_unicasts,
@@ -447,7 +446,7 @@ def test_fabric_two_link_non_forwarding_unicast_bw(
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "packet_size, expected_bw, expected_Mpps", [(16, 0.038, None), (2048, 4.897, 2.379), (4096, 9.72, 2.373)]
-)  # too unstable
+)  # Marked None if packets per second varies too much run to run (>= 5%)
 def test_fabric_one_link_forwarding_unicast_multiproducer_multihop_bw(
     num_mcasts,
     num_unicasts,
@@ -483,7 +482,7 @@ def test_fabric_one_link_forwarding_unicast_multiproducer_multihop_bw(
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize(
     "packet_size, expected_bw, expected_Mpps", [(16, 0.037, 2.348), (2048, 4.815, 2.351), (4096, 9.35, 2.2846)]
-)  # _ _
+)
 def test_fabric_one_link_forwarding_unicast_single_producer_multihop_bw(
     num_mcasts,
     num_unicasts,


### PR DESCRIPTION
Adding a new metric. As a result was able to observe the following:

Some interesting results (for line fabric). I wanted to add a new metric to start tracking for perf microbenchmarks which is packets/s which should give us a measure of our software performance, somewhat independent of packet size. For two reasons:

1. The number should be relatively consistent for a given command type
2. We can isolate performance overheads of adding additional commands

I went ahead and added this metric to our bandwidth ubench and found some interesting results for mcast. Namely, we are not SW bound for mcast with max packet size.

Here's a plot (red line is packets per second -> around 2.12 Mpackets/s and then dips. Blue is BW (GB/s)). We can see that packets per second is extremely consistent up until around the 7.x GB/s  inbound (to noc) mark. At that point we are pusing 15.x GB/s to noc and our packet throughput efficiency drops; bandwidth basically flatlines. This is the next issue to look at for mcast perf. If we were able to sustain the packet processing rate, our implementation would be at nearly 17 GB/s (bidir) for 4k packet size! I take this to mean we are being limited somewhere in getting data out to noc or ethernet link. However, since unicast tests are able to send at a higher throughput over the link, it is extremely unlikely to be an issue related to the link.

![image](https://github.com/user-attachments/assets/cb99469e-d24f-43b7-943b-d70029055604)



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/14035690896
- [ ] ubench: https://github.com/tenstorrent/tt-metal/actions/runs/14039612544
- [ ] New/Existing tests provide coverage for changes