### PR TITLE
#16439: Disable instruction coalescing

### DIFF
--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -93,6 +93,8 @@ void init_sync_registers() {
 }
 
 int main(int argc, char *argv[]) {
+    // Workaround for tt-metal#16439, making sure gathering is disabled
+    disable_gathering();
     configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -94,7 +94,9 @@ void init_sync_registers() {
 
 int main(int argc, char *argv[]) {
     // Workaround for tt-metal#16439, making sure gathering is disabled
+#ifdef ARCH_BLACKHOLE
     disable_gathering();
+#endif
     configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
@@ -87,7 +87,11 @@ void MAIN {
                 tilize_uninit(cb_intermed2, out_cb_id);
 
                 pack_reconfig_data_format(out_cb_id, cb_intermed0);
-                mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed2, transpose_hw);
+                // #ifdef ARCH_BLACKHOLE
+                mm_init(cb_in0, cb_in1, cb_intermed0, transpose_hw);
+                // #else
+                //                 mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed2, transpose_hw);
+                // #endif
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/kernels/compute/transformer_attn_matmul.cpp
@@ -87,11 +87,9 @@ void MAIN {
                 tilize_uninit(cb_intermed2, out_cb_id);
 
                 pack_reconfig_data_format(out_cb_id, cb_intermed0);
-                // #ifdef ARCH_BLACKHOLE
+                // Workaround, needs to be reverted to the following when fix is found:
+                // mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed2, transpose_hw);
                 mm_init(cb_in0, cb_in1, cb_intermed0, transpose_hw);
-                // #else
-                //                 mm_init_short_with_dt(cb_in0, cb_in1, cb_intermed2, transpose_hw);
-                // #endif
             }
         }
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16439
https://github.com/tenstorrent/tt-metal/issues/18550

### Problem description
Hangs are present in ResNet 50 and Stable Diffusion 1.4. These issues are blocking further model bringup work. The hangs are reproducible with matmul tests, namely test_benchmark.py and test_benchmark.cpp (if present in main).

### What's changed
We are disabling instruction coalescing in Blackhole inside load_replay_buf calls. This will unblock RN and SD work for now. This is done by calling `disable_gathering` function inside both `load_replay_buf` implementations, but also invoking it at the start of TRISC firmware. The motivation behind these numerous attempts to disable the same feature is an assumption that perhaps this feature either gets enabled by accident somewhere else in the code, or that disabling it by performing a CSR write is not that reliable for some reason.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - [#28259](https://github.com/tenstorrent/tt-metal/actions/runs/14040772111)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) - [#4507](https://github.com/tenstorrent/tt-metal/actions/runs/14040841721) - known failure in main
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) - [#8137](https://github.com/tenstorrent/tt-metal/actions/runs/14040765010)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) - [#5482](https://github.com/tenstorrent/tt-metal/actions/runs/14040753000)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes