### PR TITLE
Revert "Enable bfp4 kv_cache for tt_transformers"

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention.py
@@ -123,7 +123,7 @@ def test_sdpa_tt_padded(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.skipif(is_watcher_enabled(), reason="Kernel OOM with watcher enabled")
 @skip_for_grayskull("Unsupported in GS since L1 runs OOM with most configs")
-@pytest.mark.parametrize("dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp4", "bfp8", "bf16"])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16], ids=["bfp8", "bf16"])
 @pytest.mark.parametrize("q_chunk_size", [128, 256], ids=["q128", "q256"])
 @pytest.mark.parametrize("k_chunk_size", [128, 256], ids=["k128", "k256"])
 @pytest.mark.parametrize(
@@ -137,10 +137,6 @@ def test_sdpa_tt_padded(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dt
     ),
 )
 def test_sdpa_tt(device, b, nh, nkv, s, d, q_chunk_size, k_chunk_size, dtype):
-    if dtype == ttnn.bfloat4_b and (
-        q_chunk_size > 128 or k_chunk_size > 128 or [b, nh, nkv, s, d] != [1, 8, 1, 2048, 128]
-    ):
-        pytest.skip("just need to single test case for sanity-check bfp4")
     if (s % q_chunk_size != 0) or (s % k_chunk_size != 0):
         pytest.skip("s must be divisible by q_chunk_size and k_chunk_size")
     if nh == 8 and q_chunk_size == 128 and k_chunk_size == 128:

--- a/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
+++ b/tests/ttnn/unit_tests/operations/test_paged_update_cache.py
@@ -113,7 +113,7 @@ def run_test_update_cache_decode(
 @pytest.mark.parametrize("num_heads", [8])
 @pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("cache_idx_tensor", [True, False])
-@pytest.mark.parametrize("cache_dtype", [ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat16])
+@pytest.mark.parametrize("cache_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_update_cache_decode(
     check_memory,
     share_cache,
@@ -127,9 +127,6 @@ def test_update_cache_decode(
     device,
     use_program_cache,
 ):
-    if cache_dtype == ttnn.bfloat4_b and (share_cache or max_seq_len == 2048 or not cache_idx_tensor):
-        pytest.skip("just need to sanity-check a select test case for bfp4")
-
     torch.manual_seed(0)
 
     if check_memory:

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/paged_cache_operation.cpp
@@ -47,9 +47,8 @@ void PagedUpdateCacheDeviceOperation::validate(
             "Inputs to update_cache must be tilized");
         TT_FATAL(
             cache_tensor.get_dtype() == DataType::FLOAT32 || cache_tensor.get_dtype() == DataType::BFLOAT16 ||
-                cache_tensor.get_dtype() == DataType::BFLOAT8_B || cache_tensor.get_dtype() == DataType::BFLOAT4_B,
-            "Data type of cache tensor must be FLOAT32, BFLOAT16, BFLOAT8_B, or BFLOAT4_B and is {}",
-            cache_tensor.get_dtype());
+                cache_tensor.get_dtype() == DataType::BFLOAT8_B,
+            "Data type of cache tensor must be FLOAT32, BFLOAT16 or BFLOAT8_B");
     };
 
     const auto validateTensorShapes = [](const Tensor& cache_tensor, const Tensor& input_tensor) {
@@ -157,7 +156,7 @@ void PagedUpdateCacheDeviceOperation::validate(
                                           uint32_t batch_idx) {
         TT_FATAL(
             input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 ||
-                cache_tensor.get_dtype() == DataType::BFLOAT8_B || cache_tensor.get_dtype() == DataType::BFLOAT4_B,
+                cache_tensor.get_dtype() == DataType::BFLOAT8_B,
             "Data type of input tensor for fill cache must be FLOAT32, BFLOAT16, or BFLOAT8_b");
 
         TT_FATAL(input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED, "Error");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -26,10 +26,7 @@ void ScaledDotProductAttention::validate(
         TT_FATAL(input_tensor.buffer() != nullptr, "Operands to SDPA need to be allocated in buffers on device");
         TT_FATAL((input_tensor.get_layout() == Layout::TILE), "Inputs to SDPA must be tilized");
         TT_FATAL(
-            input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B ||
-                input_tensor.get_dtype() == DataType::BFLOAT4_B,
-            "Data type of input tensor must be BFLOAT16, BFLOAT8_B, or BFLOAT4_B and is {}",
-            input_tensor.get_dtype());
+            input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B, "Error");
         TT_FATAL(
             input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM,
             "Operands to SDPA need to be in DRAM");


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#19493

Failing ttnn group 5 tests
```
FAILED tests/ttnn/unit_tests/operations/test_paged_update_cache.py::test_update_cache_decode[cache_dtype=DataType.BFLOAT4_B-cache_idx_tensor=True-input_dtype=DataType.BFLOAT16-num_heads=8-num_users=4-max_seq_len=32768-head_dim=128-share_cache=False-check_memory=False] - assert (True and False)
```
https://github.com/tenstorrent/tt-metal/actions/runs/14037906686/job/39301246023
https://github.com/tenstorrent/tt-metal/actions/runs/14038071402/job/39301679721
https://github.com/tenstorrent/tt-metal/actions/runs/14038071402/job/39301676362