### PR TITLE
#19560: [skip ci] Add ttnn to blackhole nightly (only run 1x a week)

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -2,9 +2,28 @@ name: "(Blackhole) Blackhole nightly tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      runner-label:
+          description: 'Optional: BH'
+          required: true
+          type: string
+          default: 'BH'
+      run-ttnn-tests:
+          description: "Run ttnn test suite"
+          default: false
+          type: boolean
   workflow_call:
+    inputs:
+      runner-label:
+          description: 'Optional: BH'
+          required: false
+          type: string
+          default: 'BH'
   schedule:
     - cron: "0 */12 * * *"  # Every day at 0:00 and 12:00 UTC
+    - cron: "0 8 * * 6"     # Runs at 8am UTC every Saturday
+
+run-name: ${{ (github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)) && '(Blackhole) Blackhole nightly tests (with ttnn)' || '(Blackhole) Blackhole nightly tests' }}  # Dynamically change name based on day
 
 jobs:
   build-artifact:
@@ -13,11 +32,22 @@ jobs:
     with:
       build-wheel: true
       version: 22.04
-  fd-nightly:
+  bh-nightly:
     needs: build-artifact
     uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
     secrets: inherit
     with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  ttnn-unit-tests:
+    needs: build-artifact
+    if: github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)  # Only run ttnn on the weekends or if workflow manually triggered with ttnn enabled
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-post-commit.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/19560

### Problem description
Per #19560 we want to run ttnn tests on blackhole. 
Right now we will start by targeting a 1x a week run on Saturday due to capacity constraints, with the eventual goal of nightly cadence, then as part of blackhole post-commit.

### What's changed
Update blackhole nightly wrapper to run ttnn:

- if its a scheduled run on saturday; OR
- manual workflow dispatch trigger AND run-ttnn-tests is checked

### Checklist
- [x] New/Existing tests provide coverage for changes
No code changes:
Workflow dispatch without ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/14040763650
Workflow dispatch with ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/14040897914