### PR TITLE
Simple fix to test profiler

### DIFF
--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -661,6 +661,8 @@ void handle_mesh_adapter_cache_hit(
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     tt::stl::hash::hash_t program_hash) {
+    // Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed profiler regresion
+    // tests well-formed data.
     ZoneScopedN("TT_DNN_DEVICE_OP");
     mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
 
@@ -711,7 +713,8 @@ void create_and_cache_mesh_workload(
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     tt::stl::hash::hash_t program_hash) {
-
+    // Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed profiler regresion
+    // tests well-formed data.
     ZoneScopedN("TT_DNN_DEVICE_OP");
 
     mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -661,7 +661,7 @@ void handle_mesh_adapter_cache_hit(
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     tt::stl::hash::hash_t program_hash) {
-    ZoneScopedN("MeshDeviceAdapter Cache Hit");
+    ZoneScopedN("TT_DNN_DEVICE_OP");
     mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
 
     auto& cached_program_factory = program_cache.get(program_hash);
@@ -712,7 +712,7 @@ void create_and_cache_mesh_workload(
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
     tt::stl::hash::hash_t program_hash) {
 
-    ZoneScopedN("MeshDeviceAdapter Cache Miss");
+    ZoneScopedN("TT_DNN_DEVICE_OP");
 
     mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Profiler regression tests got broken because zone scoped annotations were not properly named.

### What's changed
Use `TT_DNN_DEVICE_OP` where we have `TracyOpMeshWorkload`.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14042316922)