### PR TITLE
Remove fabric redundant ptr

### DIFF
--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -832,8 +832,8 @@ void run_receiver_channel_step(
     WriteTridTracker& receiver_channel_trid_tracker) {
     auto& ack_ptr = receiver_channel_pointers.ack_ptr;
     auto pkts_received_since_last_check = get_ptr_val<to_receiver_pkts_sent_id>();
-    bool pkts_received = pkts_received_since_last_check > 0;
     if constexpr (enable_first_level_ack) {
+        bool pkts_received = pkts_received_since_last_check > 0;
         bool can_send_over_eth = !internal_::eth_txq_is_busy(DEFAULT_ETH_TXQ);
         ASSERT(receiver_channel_pointers.completion_ptr.distance_behind(ack_ptr) < RECEIVER_NUM_BUFFERS);
         if (pkts_received && can_send_over_eth) {


### PR DESCRIPTION
![Screenshot 2025-03-24 at 3 49 35 PM](https://github.com/user-attachments/assets/7ab35c54-af9e-41bb-892c-2e6b44050625)

Remove redundant ptr update.

fabric 1d has previously one code path for writing to both local and downstream, meaning when one of the path is congested, both pass need waiting. Change to separate checks for two paths.

### Checklist
- [x] [All post commit]  https://github.com/tenstorrent/tt-metal/actions/runs/14061370505
- [x] T3K demo https://github.com/tenstorrent/tt-metal/actions/runs/14044788465
- [x] T3k Nightly https://github.com/tenstorrent/tt-metal/actions/runs/14044832161
- [x] TG demo https://github.com/tenstorrent/tt-metal/actions/runs/14061378167
- [x] TG nightly https://github.com/tenstorrent/tt-metal/actions/runs/14044849843
- [x] ubench https://github.com/tenstorrent/tt-metal/actions/runs/14061250770
- [ ] T3K unit https://github.com/tenstorrent/tt-metal/actions/runs/14061356376 - hang not related to this PR