### PR TITLE
remove output padding for post mul+silu all gather

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
@@ -398,6 +398,9 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
     # device in the line
     repeat_factor = [1] * len(output_golden.shape)
     repeat_factor[dim] = num_devices_per_line
+    # In case of llama post binary mult+silu case, slice the input tensor to remove the padding
+    if full_input_tensor_unfractured.shape[dim] == 3840:
+        full_input_tensor_unfractured = full_input_tensor_unfractured[..., :3584]
     output_golden[:, :, :, :] = full_input_tensor_unfractured.repeat(repeat_factor)
 
     eq = True

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -165,8 +165,16 @@ static void validate_output_tensor_allocation(const std::vector<Tensor>& output_
 
 std::vector<ttnn::TensorSpec> AllGatherAsync::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors[0];
+    AllGatherAsyncVersion version = select_version(input_tensor);
     auto shape = input_tensor.get_padded_shape();  // TODO: Replace with get_logical_shape()
-    shape[this->dim] *= this->ring_size;
+
+    // Adjust shape for llama post binary mult+silu case to remove padding in the output tensor
+    if (version == AllGatherAsyncVersion::LLAMA_MINIMAL_SHARDED && shape[this->dim] == 960) {
+        shape[this->dim] = 896 * this->ring_size;
+    } else {
+        shape[this->dim] *= this->ring_size;
+    }
+
     return {TensorSpec(
         shape,
         TensorLayout(input_tensor.get_dtype(), input_tensor.get_tensor_spec().page_config(), output_mem_config))};
@@ -264,7 +272,6 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
 tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     tt::log_debug(tt::LogOp, "DEBUG: create_program is called");
-
     AllGatherAsyncVersion version = select_version(input_tensors[0]);
 
     log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -272,6 +272,7 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
 tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     tt::log_debug(tt::LogOp, "DEBUG: create_program is called");
+
     AllGatherAsyncVersion version = select_version(input_tensors[0]);
 
     log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));


### PR DESCRIPTION
### Problem description
For FF1 All Reduce [1, 1, 32, 3584(3840)]
Reduce scatter results into 4 output device tensors of shape [1, 1, 32, 960] out of which last device chunk has the padding values.
[1, 1, 32, 960], [1, 1, 32, 960], [1, 1, 32, 960], [1, 1, 32, 706(960)]
However, AllGather can't interpret that only the last device tensor has padding values. Hence, an explicit reshape has been added in the compute output spec to remove padding.
This padding removal is required for subsequent matmul which operates non-padded shape.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14044487500) CI passes
- [ ] [TG Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-nightly-tests.yaml)