### PR TITLE
Update p150 mesh graph desc with valid num eth ports

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -179,6 +179,12 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
 
                     paths.at(connected_chip_id)[paths.at(connected_chip_id).size() - 1].push_back(connected_chip_id);
                 }
+            } else {
+                log_debug(
+                    tt::LogFabric,
+                    "Number of eth ports {} does not match num ports specified in Mesh graph descriptor {}",
+                    eth_ports.size(),
+                    num_ports_per_side);
             }
         }
     }

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
@@ -1,10 +1,10 @@
 ChipSpec: {
   arch: blackhole,
   ethernet_ports: {
-    N: 0,
-    E: 0,
-    S: 0,
-    W: 0,
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
   }
 }
 

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
@@ -1,10 +1,10 @@
 ChipSpec: {
   arch: blackhole,
   ethernet_ports: {
-    N: 0,
-    E: 0,
-    S: 0,
-    W: 0,
+    N: 7,
+    E: 7,
+    S: 7,
+    W: 7,
   }
 }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Multichip Llama was segfaulting in control plane due to mesh graph desc having the incorrect number of eth ports. FYI @mtairum 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14051760329)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14051764354)