### PR TITLE
[skip ci] Bump all Galaxy workflows to 22.04

### DIFF
--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -47,6 +47,7 @@ jobs:
       build-type: ${{ inputs.build-type }}
       tracy: ${{ inputs.build-with-tracy }}
       build-wheel: true
+      version: 22.04
     secrets: inherit
   tg-quick:
     if: ${{ inputs.tg-quick }}

--- a/.github/workflows/tg-frequent-tests.yaml
+++ b/.github/workflows/tg-frequent-tests.yaml
@@ -11,6 +11,7 @@ jobs:
     secrets: inherit
     with:
       build-wheel: true
+      version: 22.04
   tg-frequent-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/tg-model-perf-tests.yaml
+++ b/.github/workflows/tg-model-perf-tests.yaml
@@ -11,6 +11,7 @@ jobs:
     with:
       tracy: true
       build-wheel: true
+      version: 22.04
     secrets: inherit
   tg-model-perf-tests:
     needs: build-artifact-profiler

--- a/.github/workflows/tg-unit-tests.yaml
+++ b/.github/workflows/tg-unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     with:
       build-wheel: true
-      version: 20.04
+      version: 22.04
   TG-Unit-tests:
     needs: build-artifact
     secrets: inherit


### PR DESCRIPTION
### Ticket
#12490

### Problem description
20.04 is dead.  Long live 22.04.

### What's changed
20.04 -> 22.04

### Checklist
- [x] TG Freq [runs](https://github.com/tenstorrent/tt-metal/actions/runs/14052208036)
- [x] TG Model perf [runs](https://github.com/tenstorrent/tt-metal/actions/runs/14052215457)
- [x] Unit [runs](https://github.com/tenstorrent/tt-metal/actions/runs/14052220422)
- [x] CYO TG [runs](https://github.com/tenstorrent/tt-metal/actions/runs/14052234325)