### PR TITLE
Fix run_device_perf call from resnet50 device perf test

### DIFF
--- a/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
+++ b/models/demos/ttnn_resnet/tests/perf_device_resnet50.py
@@ -13,7 +13,7 @@ def run_perf_device(batch_size, test, command, expected_perf):
     inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
     expected_perf_cols = {inference_time_key: expected_perf}
 
-    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size, True)
+    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size, has_signposts=True)
     expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols)
     prep_device_perf_report(
         model_name=f"ttnn_resnet50_batch_size{batch_size}",


### PR DESCRIPTION
### Ticket
#19601

### Problem description
When running resnet50 device perf: `models/demos/wormhole/resnet50/tests/test_perf_device_resnet50.py`,
outputs are Infinity values. 
After #19296, new parameter in `models/perf/device_perf_utils.py::run_device_perf` is added, which caused wrong interprettation of parameters in resnet50 device perf test.

### What's changed
Change the input parameter to be explicitly assigned to `has_signposts`, instead of being implicitly assigned to the wrong variable. I have checked all the calls to this function, and this is the only place where it needs to be changed.