### PR TITLE
Improve backward eltwise unit test datagen

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_abs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_abs.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_abs(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.abs_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acos.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acos.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_acos(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -2, 2, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -2, 2, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.acos_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acosh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acosh.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_acosh(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.acosh_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_add.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_add.py
@@ -21,8 +21,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_add(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 
     tt_output_tensor_on_device = ttnn.add_bw(grad_tensor, input_tensor, other_tensor)
@@ -43,9 +43,15 @@ def test_bw_add(input_shapes, device):
     ),
 )
 def test_bw_add_bf8b(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    other_data, other_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, False, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    other_data, other_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=1
+    )
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, False, False, ttnn.bfloat8_b, seed=2
+    )
 
     tt_output_tensor_on_device = ttnn.add_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -66,9 +72,9 @@ def test_bw_add_bf8b(input_shapes, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_add_with_opt_output(input_shapes, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device, seed=2)
     input_grad = None
     other_grad = None
 
@@ -112,8 +118,8 @@ def test_bw_add_with_opt_output(input_shapes, device, are_required_outputs):
 )
 @pytest.mark.parametrize("scalar", [1.0, 0.5, 0.035])
 def test_bw_add_scalar(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.add_bw(grad_tensor, input_tensor, scalar)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_addalpha.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_addalpha.py
@@ -18,9 +18,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("alpha", [0.05, 2.0, 1.5, 0.12])
 def test_bw_addalpha(input_shapes, alpha, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.addalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
 
@@ -40,9 +40,9 @@ def test_bw_addalpha(input_shapes, alpha, device):
     ),
 )
 def test_bw_addalpha_wo_alpha(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.addalpha_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -64,9 +64,9 @@ def test_bw_addalpha_wo_alpha(input_shapes, device):
 @pytest.mark.parametrize("alpha", [0.05, 2.0, 1.5, 0.12])
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device, seed=2)
     input_grad = None
     other_grad = None
 
@@ -112,9 +112,9 @@ def test_bw_addalpha_with_opt_output(input_shapes, alpha, device, are_required_o
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_addalpha_with_opt_output_wo_alpha(input_shapes, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -90, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -70, 90, device, seed=2)
     input_grad = None
     other_grad = None
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_addcdiv.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_addcdiv.py
@@ -18,11 +18,11 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 5.0])
 def test_bw_addcdiv(input_shapes, value, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=2)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, False)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, False, seed=4)
 
     tt_output_tensor_on_device = ttnn.addcdiv_bw(grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_addcmul.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_addcmul.py
@@ -18,10 +18,10 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("value", [0.05, 1.0, 0.5, 0.12])
 def test_bw_addcmul(input_shapes, value, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    tensor1_data, tensor1_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    tensor2_data, tensor2_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=2)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=3)
 
     tt_output_tensor_on_device = ttnn.addcmul_bw(grad_tensor, input_tensor, tensor1_tensor, tensor2_tensor, value)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_asin.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_asin.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_asin(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.asin_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_asinh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_asinh.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_asinh(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.asinh_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_assign.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_assign.py
@@ -21,8 +21,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_unary_assign(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.assign_bw(grad_tensor, input_tensor)
 
@@ -42,10 +42,10 @@ def test_bw_unary_assign(input_shapes, device):
     ),
 )
 def test_bw_binary_assign(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.assign_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -64,9 +64,15 @@ def test_bw_binary_assign(input_shapes, device):
     ),
 )
 def test_bw_binary_assign_bf8b(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    other_data, other_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, False, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    other_data, other_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=1
+    )
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, False, False, ttnn.bfloat8_b, seed=2
+    )
 
     tt_output_tensor_on_device = ttnn.assign_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -85,8 +91,8 @@ def test_bw_binary_assign_bf8b(input_shapes, device):
     ),
 )
 def test_bw_unary_assign_opt_output(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
     opt_tensor = torch.zeros(input_shapes, dtype=torch.bfloat16)
     input_grad = ttnn.from_torch(
         opt_tensor, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -112,8 +118,8 @@ def test_bw_unary_assign_opt_output(input_shapes, device):
     ),
 )
 def test_bw_unary_assign_opt_output_rm(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, False, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, False, True, seed=1)
     opt_tensor = torch.zeros(input_shapes, dtype=torch.bfloat16)
     input_grad = ttnn.from_torch(
         opt_tensor, ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -140,8 +146,8 @@ def test_bw_unary_assign_opt_output_rm(input_shapes, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_binary_assign_opt_output(input_shapes, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_atan.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_atan.py
@@ -20,8 +20,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_atan(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.atan_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_atan2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_atan2.py
@@ -20,9 +20,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_atan2(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True, seed=1)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True, seed=2)
 
     pyt_y = torch.atan2(in_data, other_data)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_atanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_atanh.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_atanh(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, required_grad=True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.atanh_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_bias_gelu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_bias_gelu.py
@@ -24,9 +24,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_binary_bias_gelu(input_shapes, approximate, device):
-    in_data_a, input_tensor_a = data_gen_with_range(input_shapes, -100, 100, device, True)
-    in_data_b, input_tensor_b = data_gen_with_range(input_shapes, -10, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data_a, input_tensor_a = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    in_data_b, input_tensor_b = data_gen_with_range(input_shapes, -10, 10, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=2)
     tt_output_tensor_on_device = ttnn.bias_gelu_bw(grad_tensor, input_tensor_a, input_tensor_b, approximate=approximate)
     golden_function = ttnn.get_golden_function(ttnn.bias_gelu_bw)
     golden_tensor = golden_function(grad_data, in_data_a, in_data_b, approximate)
@@ -57,8 +57,8 @@ def test_bw_binary_bias_gelu(input_shapes, approximate, device):
     ),
 )
 def test_bw_bias_gelu_unary(input_shapes, approximate, bias, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.bias_gelu_bw(grad_tensor, input_tensor, bias, approximate=approximate)
 
@@ -84,8 +84,8 @@ def test_bw_bias_gelu_unary(input_shapes, approximate, bias, device):
     ),
 )
 def test_bw_bias_gelu_unary_default(input_shapes, bias, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.bias_gelu_bw(grad_tensor, input_tensor, bias)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_ceil.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_ceil.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_ceil(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.ceil_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_celu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_celu.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_celu(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True, seed=1)
 
     alpha = 1
 
@@ -40,8 +40,8 @@ def test_bw_celu(input_shapes, device):
     ),
 )
 def test_bw_celu_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.celu_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_clamp.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_clamp.py
@@ -36,8 +36,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ],
 )
 def test_unary_bw_clamp_ttnn(input_shapes, min_val, max_val, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, seed=1)
     if min_val == "tensor":
         min, min_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     elif min_val is None:

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_clip.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_clip.py
@@ -36,8 +36,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ],
 )
 def test_unary_bw_clip_ttnn(input_shapes, min_val, max_val, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, seed=1)
     if min_val == "tensor":
         min, min_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     elif min_val is None:

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_concat.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_concat.py
@@ -27,13 +27,13 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_concat(input_shapes, input_shapes_2, dimension, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True, seed=0)
 
-    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True, seed=1)
 
     pyt_y = torch.concat((in_data, other_data), dim=dimension)
 
-    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
+    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.concat_bw(grad_tensor, input_tensor, other_tensor, dimension)
 
@@ -52,13 +52,13 @@ def test_bw_concat(input_shapes, input_shapes_2, dimension, device):
     ),
 )
 def test_bw_concat_Default(input_shapes, input_shapes_2, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True, seed=0)
 
-    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True, seed=1)
 
     pyt_y = torch.concat((in_data, other_data))
 
-    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
+    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.concat_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -96,13 +96,13 @@ def test_bw_concat_default_example(device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_concat_Default_with_output(input_shapes, input_shapes_2, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True, seed=0)
 
-    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True, seed=1)
 
     pyt_y = torch.concat((in_data, other_data))
 
-    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
+    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True, seed=2)
 
     input_grad = None
     other_grad = None
@@ -164,13 +164,13 @@ def test_bw_concat_Default_with_output(input_shapes, input_shapes_2, device, are
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_concat_with_output(input_shapes, input_shapes_2, dimension, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, True, seed=0)
 
-    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True)
+    other_data, other_tensor = data_gen_with_range(input_shapes_2, -100, 100, device, True, True, seed=1)
 
     pyt_y = torch.concat((in_data, other_data), dim=dimension)
 
-    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True)
+    grad_data, grad_tensor = data_gen_with_range(pyt_y.shape, -100, 100, device, True, True, seed=2)
 
     input_grad = None
     other_grad = None

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_cos.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_cos.py
@@ -18,8 +18,8 @@ from math import pi
     ),
 )
 def test_bw_cos(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 0, (2 * pi), device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, False)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0, (2 * pi), device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, False, seed=1)
 
     tt_output_tensor_on_device = ttnn.cos_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_cosh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_cosh.py
@@ -24,8 +24,8 @@ from models.utility_functions import (
     ),
 )
 def test_bw_cosh(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
@@ -45,8 +45,8 @@ def test_bw_cosh(input_shapes, device):
     ),
 )
 def test_bw_cosh_inf(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 90, 95, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 90, 95, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
@@ -66,8 +66,8 @@ def test_bw_cosh_inf(input_shapes, device):
     ),
 )
 def test_bw_cosh_neg_inf(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -95, -89, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -95, -89, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -7, 7, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
@@ -84,8 +84,8 @@ def test_bw_cosh_neg_inf(input_shapes, device):
 )
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_cosh_nan_test1(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 
@@ -102,8 +102,8 @@ def test_bw_cosh_nan_test1(input_shapes, device):
 )
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_cosh_nan_test2(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.cosh_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_deg2rad.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_deg2rad.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_deg2rad(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.deg2rad_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_digamma.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_digamma.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_digamma(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.digamma_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
@@ -34,9 +34,9 @@ from models.utility_functions import (
     ),
 )
 def test_bw_div_binary(input_shapes, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=2)
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)
@@ -56,9 +56,9 @@ def test_bw_div_binary(input_shapes, round_mode, device):
     ),
 )
 def test_bw_div_binary_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=2)
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data)
@@ -87,7 +87,7 @@ def test_bw_div_binary_default(input_shapes, device):
 @pytest.mark.parametrize("scalar", [0.0])
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
@@ -116,8 +116,8 @@ def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_unary_div(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
@@ -138,7 +138,7 @@ def test_bw_unary_div(input_shapes, scalar, round_mode, device):
 @pytest.mark.parametrize("scalar", [0.0])
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_unary_div_0_default(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar)
@@ -160,8 +160,8 @@ def test_bw_unary_div_0_default(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_unary_div_default(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar)
 
@@ -182,8 +182,12 @@ def test_bw_unary_div_default(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_unary_div_bf8b(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -1, 1, device, False, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -1, 1, device, False, False, ttnn.bfloat8_b, seed=1
+    )
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar)
 
@@ -212,8 +216,8 @@ def test_bw_unary_div_bf8b(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -247,18 +251,18 @@ def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_div_opt(input_shapes, round_mode, are_required_outputs, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     input_grad = None
     other_grad = None
     tt_output_tensor_on_device = None
 
     if are_required_outputs[0]:
-        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device, seed=3)
     if are_required_outputs[1]:
-        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
+        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device, seed=4)
 
     cq_id = 0
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div_no_nan.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div_no_nan.py
@@ -18,8 +18,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
 )
 @pytest.mark.parametrize("scalar", [0.05, 0.0, -0.5, 5.12])
 def test_bw_unary_div_no_nan(input_shapes, scalar, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.div_no_nan_bw(grad_tensor, input_tensor, scalar)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_elu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_elu.py
@@ -27,8 +27,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_elu(input_shapes, alpha, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.elu_bw(grad_tensor, input_tensor, alpha=alpha)
 
@@ -47,8 +47,8 @@ def test_bw_elu(input_shapes, alpha, device):
     ),
 )
 def test_bw_elu_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.elu_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_erf.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_erf.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_erf(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 110, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 199, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 110, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 199, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.erf_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_erfc.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_erfc.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_erfc(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 110, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 199, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 110, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 199, device, required_grad=True, seed=1)
     pyt_y = torch.erfc(in_data)
 
     tt_output_tensor_on_device = ttnn.erfc_bw(grad_tensor, input_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_erfinv.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_erfinv.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_erfinv(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -110, 110, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -110, 110, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.erfinv_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_exp.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_exp.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_exp(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -199, 200, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -199, 200, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.exp_bw(grad_tensor, input_tensor)
 
@@ -38,8 +38,8 @@ def test_bw_exp(input_shapes, device):
     ),
 )
 def test_bw_exp_output(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -199, 200, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -199, 200, device, True, seed=1)
     input_grad = None
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_exp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_exp2.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_exp2(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.exp2_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_expm1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_expm1.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_expm1(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.expm1_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fill.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fill.py
@@ -25,8 +25,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 #   self: zeros_like(grad)
 #   result: at::fill(self_t, 0)
 def test_bw_fill(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.fill_bw(grad_tensor, input_tensor)
 
@@ -46,8 +46,8 @@ def test_bw_fill(input_shapes, device):
     ),
 )
 def test_bw_fill_opt_tensor(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=1)
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
     input_grad = ttnn.to_memory_config(input_grad, ttnn.L1_MEMORY_CONFIG)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fill_zero.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fill_zero.py
@@ -21,8 +21,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 #   self: zeros_like(grad)
 #   result: at::fill(self_t, 0)
 def test_bw_fill_zero(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=1)
     tt_output_tensor_on_device = ttnn.fill_zero_bw(grad_tensor, input_tensor)
     golden_function = ttnn.get_golden_function(ttnn.fill_zero_bw)
     golden_tensor = golden_function(grad_data, in_data)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_floor.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_floor.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_floor(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.floor_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fmod.py
@@ -26,8 +26,8 @@ from models.utility_functions import skip_for_grayskull
     ),
 )
 def test_bw_unary_fmod(input_shapes, scalar, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.fmod_bw(grad_tensor, input_tensor, scalar)
 
@@ -47,9 +47,9 @@ def test_bw_unary_fmod(input_shapes, scalar, device):
 )
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for binary fmod backward")
 def test_bw_binary_fmod(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -50, 50, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -50, 50, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.fmod_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_frac.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_frac.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_frac(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.frac_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_gelu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_gelu.py
@@ -24,8 +24,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_gelu(input_shapes, approximate, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.gelu_bw(grad_tensor, input_tensor, approximate=approximate)
 
@@ -45,8 +45,8 @@ def test_bw_gelu(input_shapes, approximate, device):
     ),
 )
 def test_bw_gelu_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.gelu_bw(grad_tensor, input_tensor)
 
@@ -73,8 +73,8 @@ def test_bw_gelu_default(input_shapes, device):
     ),
 )
 def test_bw_gelu_opt_output(input_shapes, approximate, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
     input_grad = torch.zeros(input_shapes, dtype=torch.bfloat16)
     input_grad = ttnn.from_torch(
         input_grad, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -103,8 +103,8 @@ def test_bw_gelu_opt_output(input_shapes, approximate, device):
     ),
 )
 def test_bw_gelu_default_opt_output(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
     input_grad = torch.zeros(input_shapes, dtype=torch.bfloat16)
     input_grad = ttnn.from_torch(
         input_grad, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_gelu_fused.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_gelu_fused.py
@@ -23,11 +23,10 @@ def gen_data(input_shapes, low, high, device, required_grad=False, is_row_major=
     assert high > low, "Incorrect range provided"
     torch.manual_seed(seed)
     pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
+    tt_tensor = ttnn.Tensor(pt_tensor, ttnn.bfloat16)
     if is_row_major:
-        tt_tensor = ttnn.Tensor(pt_tensor, ttnn.bfloat16)
         tt_tensor = ttnn.to_layout(tt_tensor, layout=ttnn.ROW_MAJOR_LAYOUT).to(device)
     else:
-        tt_tensor = ttnn.Tensor(pt_tensor, ttnn.bfloat16)
         tt_tensor = ttnn.to_layout(tt_tensor, layout=ttnn.TILE_LAYOUT).to(device)
 
     return pt_tensor, tt_tensor
@@ -45,8 +44,8 @@ def gen_data(input_shapes, low, high, device, required_grad=False, is_row_major=
     ),
 )
 def test_bw_gelu(input_shapes, approximate, device):
-    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device)
+    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.experimental.gelu_bw(grad_tensor, input_tensor, approximate=approximate)
 
@@ -62,8 +61,8 @@ def test_bw_gelu(input_shapes, approximate, device):
     INPUT_SHAPES,
 )
 def test_bw_gelu_default(input_shapes, device):
-    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device)
+    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.experimental.gelu_bw(grad_tensor, input_tensor)
 
@@ -86,8 +85,8 @@ def test_bw_gelu_default(input_shapes, device):
     ),
 )
 def test_bw_gelu_opt_output(input_shapes, approximate, device):
-    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device)
+    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device, seed=1)
     input_grad = torch.zeros(input_shapes, dtype=torch.bfloat16)
     input_grad = ttnn.from_torch(
         input_grad, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG
@@ -112,8 +111,8 @@ def test_bw_gelu_opt_output(input_shapes, approximate, device):
     INPUT_SHAPES,
 )
 def test_bw_gelu_default_opt_output(input_shapes, device):
-    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device)
+    in_data, input_tensor = gen_data(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = gen_data(input_shapes, -5, 5, device, seed=1)
     input_grad = torch.zeros(input_shapes, dtype=torch.bfloat16)
     input_grad = ttnn.from_torch(
         input_grad, ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.L1_MEMORY_CONFIG

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hardshrink.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hardshrink.py
@@ -18,8 +18,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("lambd", [2.2, 0.5, 1.0, 5.5, 9.9])
 def test_bw_hardshrink(input_shapes, lambd, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.hardshrink_bw(grad_tensor, input_tensor, lambd=lambd)
 
@@ -39,8 +39,8 @@ def test_bw_hardshrink(input_shapes, lambd, device):
     ),
 )
 def test_bw_hardshrink_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.hardshrink_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hardswish.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hardswish.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_hardswish(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.hardswish_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hardtanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hardtanh.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_hardtanh(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
     min_val = -1
     max_val = 1
 
@@ -40,8 +40,8 @@ def test_bw_hardtanh(input_shapes, device):
     ),
 )
 def test_bw_default_hardtanh(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.hardtanh_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hypot.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_hypot.py
@@ -17,9 +17,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_hypot(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -101, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -52, 51, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -101, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -52, 51, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.hypot_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_i0.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_i0.py
@@ -18,8 +18,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ),
 )
 def test_bw_i0(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, required_grad=True, seed=1)
     in_data = in_data.float()
 
     tt_output_tensor_on_device = ttnn.i0_bw(grad_tensor, input_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_ldexp.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_ldexp.py
@@ -21,10 +21,10 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_ldexp(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.ldexp_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -43,10 +43,16 @@ def test_bw_ldexp(input_shapes, device):
     ),
 )
 def test_bw_ldexp_bf8b(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -10, 10, device, True, False, ttnn.bfloat8_b)
-    other_data, other_tensor = data_gen_with_range_dtype(input_shapes, -20, 20, device, True, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -10, 10, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    other_data, other_tensor = data_gen_with_range_dtype(
+        input_shapes, -20, 20, device, True, False, ttnn.bfloat8_b, seed=1
+    )
 
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -5, 5, device, False, False, ttnn.bfloat8_b)
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -5, 5, device, False, False, ttnn.bfloat8_b, seed=2
+    )
 
     tt_output_tensor_on_device = ttnn.ldexp_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_leaky_relu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_leaky_relu.py
@@ -18,8 +18,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("negative_slope", [-0.25, -0.5, 0.01, 0.5, 5.0])
 def test_bw_leaky_relu(input_shapes, negative_slope, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.leaky_relu_bw(grad_tensor, input_tensor, negative_slope=negative_slope)
 
@@ -38,8 +38,8 @@ def test_bw_leaky_relu(input_shapes, negative_slope, device):
     ),
 )
 def test_bw_leaky_relu_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.leaky_relu_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_lerp.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_lerp.py
@@ -18,10 +18,10 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_lerp(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, True)
-    end_data, end_tensor = data_gen_with_range(input_shapes, -199, 199, device, True)
-    weight_data, weight_tensor = data_gen_with_range(input_shapes, -201, 201, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, True, seed=1)
+    end_data, end_tensor = data_gen_with_range(input_shapes, -199, 199, device, True, seed=2)
+    weight_data, weight_tensor = data_gen_with_range(input_shapes, -201, 201, device, True, seed=3)
 
     tt_output_tensor_on_device = ttnn.lerp_bw(grad_tensor, input_tensor, end_tensor, weight_tensor)
 
@@ -41,9 +41,9 @@ def test_bw_lerp(input_shapes, device):
 )
 @pytest.mark.parametrize("weight", [-0.25, -25.0, 0.05, 1.0, 25.0])
 def test_bw_lerp_weight_scalar(input_shapes, weight, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, True)
-    end_data, end_tensor = data_gen_with_range(input_shapes, -199, 199, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, True, seed=1)
+    end_data, end_tensor = data_gen_with_range(input_shapes, -199, 199, device, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.lerp_bw(grad_tensor, input_tensor, end_tensor, weight)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_lgamma.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_lgamma.py
@@ -20,8 +20,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_lgamma(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 199, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 199, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.lgamma_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log.py
@@ -22,7 +22,7 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 )
 def test_bw_log_0(input_shapes, device):
     in_data, input_tensor = data_gen_with_val(input_shapes, device, True, val=0)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=1)
     tt_output_tensor_on_device = ttnn.log_bw(grad_tensor, input_tensor)
 
     golden_function = ttnn.get_golden_function(ttnn.log_bw)
@@ -41,8 +41,8 @@ def test_bw_log_0(input_shapes, device):
     ),
 )
 def test_bw_log(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
     tt_output_tensor_on_device = ttnn.log_bw(grad_tensor, input_tensor)
 
     golden_function = ttnn.get_golden_function(ttnn.log_bw)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log10.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log10.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_log10(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.log10_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log1p.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log1p.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_log1p(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.log1p_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log2.py
@@ -20,8 +20,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_log2(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.log2_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log_sigmoid.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_log_sigmoid.py
@@ -21,8 +21,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_log_sigmoid(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -120, 120, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -120, 120, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 20, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.log_sigmoid_bw(grad_tensor, input_tensor)
 
@@ -42,8 +42,8 @@ def test_bw_log_sigmoid(input_shapes, device):
     ),
 )
 def test_bw_log_sigmoid_neg_inp(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -120, -1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 50, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -120, -1, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 50, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.log_sigmoid_bw(grad_tensor, input_tensor)
 
@@ -63,8 +63,8 @@ def test_bw_log_sigmoid_neg_inp(input_shapes, device):
     ),
 )
 def test_bw_log_sigmoid_pos_inp(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 50, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 50, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.log_sigmoid_bw(grad_tensor, input_tensor)
 
@@ -85,7 +85,7 @@ def test_bw_log_sigmoid_pos_inp(input_shapes, device):
 )
 def test_bw_log_sigmoid_zero_inp(input_shapes, device):
     in_data, input_tensor = data_gen_with_val(input_shapes, device, True, 0)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, 50, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.log_sigmoid_bw(grad_tensor, input_tensor)
 
@@ -105,7 +105,7 @@ def test_bw_log_sigmoid_zero_inp(input_shapes, device):
     ),
 )
 def test_bw_log_sigmoid_zero_grad(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -50, 50, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -50, 50, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, True, 0)
 
     tt_output_tensor_on_device = ttnn.log_sigmoid_bw(grad_tensor, input_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logaddexp.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logaddexp.py
@@ -17,10 +17,10 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_logaddexp(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.logaddexp_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logaddexp2.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logaddexp2.py
@@ -20,10 +20,10 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_logaddexp2(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.logaddexp2_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logit.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logit.py
@@ -21,8 +21,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_logit(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
     tt_output_tensor_on_device = ttnn.logit_bw(grad_tensor, input_tensor)
 
     golden_function = ttnn.get_golden_function(ttnn.logit_bw)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logiteps.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_logiteps.py
@@ -25,8 +25,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     (2, -0.001, 0.4, 0.5, 1.0),
 )
 def test_bw_logiteps(input_shapes, eps, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
     tt_output_tensor_on_device = ttnn.logiteps_bw(grad_tensor, input_tensor, eps=eps)
     golden_function = ttnn.get_golden_function(ttnn.logiteps_bw)
     golden_tensor = golden_function(grad_data, in_data, eps)
@@ -43,8 +43,8 @@ def test_bw_logiteps(input_shapes, eps, device):
     ),
 )
 def test_bw_logiteps_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -2, 2, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
     tt_output_tensor_on_device = ttnn.logiteps_bw(grad_tensor, input_tensor)
     golden_function = ttnn.get_golden_function(ttnn.logiteps_bw)
     golden_tensor = golden_function(grad_data, in_data)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_max.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_max.py
@@ -17,9 +17,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_max(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.max_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_min.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_min.py
@@ -17,9 +17,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_min(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, -1, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, 1, 2, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, -1, device, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.min_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_mul.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_mul.py
@@ -21,9 +21,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_mul(input_shapes, device):
-    in_data_a, input_tensor_a = data_gen_with_range(input_shapes, -1, 1, device, True)
-    in_data_b, input_tensor_b = data_gen_with_range(input_shapes, -5, 5, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data_a, input_tensor_a = data_gen_with_range(input_shapes, -1, 1, device, True, seed=0)
+    in_data_b, input_tensor_b = data_gen_with_range(input_shapes, -5, 5, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.mul_bw(grad_tensor, input_tensor_a, input_tensor_b)
 
@@ -44,9 +44,9 @@ def test_bw_mul(input_shapes, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_mul_opt(input_shapes, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     input_grad = None
     other_grad = None
@@ -92,8 +92,8 @@ def test_bw_mul_opt(input_shapes, device, are_required_outputs):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_mul_scalar(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.mul_bw(grad_tensor, input_tensor, scalar)
 
@@ -114,8 +114,12 @@ def test_bw_mul_scalar(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_mul_scalar_bf8b(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -5, 5, device, False, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -5, 5, device, False, False, ttnn.bfloat8_b, seed=1
+    )
 
     tt_output_tensor_on_device = ttnn.mul_bw(grad_tensor, input_tensor, scalar)
 
@@ -136,8 +140,8 @@ def test_bw_mul_scalar_bf8b(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_mul_scalar_opt_output(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_mvlgamma.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_mvlgamma.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_multigammaln(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 2.5, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 2.5, 10, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.multigammaln_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_neg.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_neg.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_neg(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.neg_bw(grad_tensor, input_tensor)
 
@@ -38,8 +38,8 @@ def test_bw_neg(input_shapes, device):
     ),
 )
 def test_bw_neg_opt(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
     input_grad = ttnn.to_memory_config(input_grad, ttnn.L1_MEMORY_CONFIG)
 
@@ -65,8 +65,8 @@ def test_bw_neg_opt(input_shapes, device):
     ),
 )
 def test_bw_neg_opt_id(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
     input_grad = ttnn.to_memory_config(input_grad, ttnn.L1_MEMORY_CONFIG)
     cq_id = 0

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_polygamma.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_polygamma.py
@@ -29,8 +29,8 @@ from models.utility_functions import (
     [1, 2, 3, 6, 7, 10],
 )
 def test_bw_polygamma(input_shapes, order, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 10, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
     n = order
 
     tt_output_tensor_on_device = ttnn.polygamma_bw(grad_tensor, input_tensor, n)
@@ -51,8 +51,8 @@ def test_bw_polygamma(input_shapes, order, device):
     [1, 4, 7, 10],
 )
 def test_bw_polygamma_range_pos(input_shapes, order, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, seed=1)
     n = order
 
     tt_output_tensor_on_device = ttnn.polygamma_bw(grad_tensor, input_tensor, n)
@@ -98,7 +98,7 @@ def test_bw_polygamma_zero(input_shapes, order, device):
     [2, 5],
 )
 def test_bw_polygamma_grad_zero(input_shapes, order, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, True, 0)
     n = order
 
@@ -121,7 +121,7 @@ def test_bw_polygamma_grad_zero(input_shapes, order, device):
     [1, 2, 5],
 )
 def test_bw_polygamma_input_zero(input_shapes, order, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
     in_data, input_tensor = data_gen_with_val(input_shapes, device, True, 0)
     n = order
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_pow.py
@@ -23,8 +23,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ],
 )
 def test_negative_exponent(input_shapes, exponent, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     with pytest.raises(RuntimeError) as _e:
         tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
@@ -42,8 +42,8 @@ def test_negative_exponent(input_shapes, exponent, device):
     ],
 )
 def test_fw_exponent(input_shapes, exponent, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -90, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     golden_tensor = [
         torch.pow(grad_data, exponent),
@@ -77,8 +77,8 @@ def test_fw_exponent(input_shapes, exponent, device):
 )
 def test_bw_unary_pow(input_shapes, exponent_and_pcc, device):
     exponent, pcc = exponent_and_pcc
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
 
@@ -95,8 +95,8 @@ def test_bw_unary_pow(input_shapes, exponent_and_pcc, device):
 )
 def test_bw_unary_pow_test_inf(input_shapes, device):
     exponent = 2
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 9, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 9, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
     golden_function = ttnn.get_golden_function(ttnn.pow_bw)
@@ -112,8 +112,8 @@ def test_bw_unary_pow_test_inf(input_shapes, device):
 )
 def test_bw_unary_pow_test_neg_inf(input_shapes, device):
     exponent = 2
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, -1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, -1, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
 
@@ -146,8 +146,8 @@ def test_bw_unary_pow_test_neg_inf(input_shapes, device):
 )
 def test_bw_unary_pow_output(input_shapes, exponent_and_pcc, device):
     exponent, pcc = exponent_and_pcc
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
     input_grad = None
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_prod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_prod.py
@@ -47,8 +47,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 )
 @pytest.mark.parametrize("all_dimensions", [True, False])
 def test_bw_prod(input_shapes, all_dimensions, dim, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device, all_dimensions, dim)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device, all_dimensions, dim, seed=1)
     if all_dimensions == False:
         pyt_y = torch.prod(in_data, dim=dim, keepdim=True)
     else:
@@ -73,8 +73,8 @@ def test_bw_prod(input_shapes, all_dimensions, dim, device):
     ),
 )
 def test_bw_prod_default_both(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device, seed=1)
     pyt_y = torch.prod(in_data).view(1, 1, 1, 1)
     tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor)
     in_data.retain_grad()
@@ -97,8 +97,8 @@ def test_bw_prod_default_both(input_shapes, device):
 )
 @pytest.mark.parametrize("all_dimensions", [True, False])
 def test_bw_prod_default_dim(input_shapes, all_dimensions, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device, all_dimensions)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device, all_dimensions, seed=1)
     if all_dimensions == False:
         pyt_y = torch.prod(in_data, dim=0, keepdim=True)
     else:

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rad2deg.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rad2deg.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_rad2deg(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.rad2deg_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rdiv.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rdiv.py
@@ -26,8 +26,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_rdiv(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.rdiv_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
 
@@ -48,8 +48,8 @@ def test_bw_rdiv(input_shapes, scalar, round_mode, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_rdiv_default(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.rdiv_bw(grad_tensor, input_tensor, scalar)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_reciprocal.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_reciprocal.py
@@ -21,7 +21,7 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_reciprocal_0(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=0)
     in_data, input_tensor = data_gen_with_val(input_shapes, device, True, val=0)
 
     tt_output_tensor_on_device = ttnn.reciprocal_bw(grad_tensor, input_tensor)
@@ -42,8 +42,8 @@ def test_bw_reciprocal_0(input_shapes, device):
     ),
 )
 def test_bw_reciprocal(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.reciprocal_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_relu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_relu.py
@@ -18,8 +18,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
 )
 # @pytest.mark.parametrize("threshold",[0.0])
 def test_bw_relu(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.relu_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_relu6.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_relu6.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_relu6(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 110, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 199, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 110, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 199, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.relu6_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_remainder.py
@@ -27,8 +27,8 @@ from models.utility_functions import skip_for_grayskull
     ),
 )
 def test_bw_unary_remainder(input_shapes, scalar, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.remainder_bw(grad_tensor, input_tensor, scalar)
 
@@ -48,9 +48,9 @@ def test_bw_unary_remainder(input_shapes, scalar, device):
 )
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for binary remainder backward")
 def test_bw_binary_remainder(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -50, 50, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -50, 50, device, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.remainder_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_repeat.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_repeat.py
@@ -17,9 +17,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("sizes", [[12, 1, 1, 1], [6, 1, 1, 1], [1, 24, 1, 1], [1, 3, 1, 1]])
 def test_bw_repeat(input_shapes, sizes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True, seed=0)
     pyt_y = in_data.repeat(sizes)
-    grad_data, grad_tensor = data_gen_pt_tt(pyt_y.shape, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(pyt_y.shape, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.repeat_bw(grad_tensor, input_tensor, sizes)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_round.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_round.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_round(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 199, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -200, 201, device, required_grad=True, seed=1)
 
     tt_output_tensor_on_device = ttnn.round_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rpow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rpow.py
@@ -29,8 +29,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_rpow(input_shapes, exponent, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.rpow_bw(grad_tensor, input_tensor, exponent)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rsqrt.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rsqrt.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_rsqrt(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.rsqrt_bw(grad_tensor, input_tensor)
 
@@ -38,8 +38,8 @@ def test_bw_rsqrt(input_shapes, device):
     ),
 )
 def test_bw_rsqrt_opt_output(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 101, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -201, 199, device, True, seed=1)
 
     input_grad = torch.zeros(input_shapes, dtype=torch.bfloat16)
     input_grad = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rsub.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_rsub.py
@@ -17,10 +17,10 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_rsub(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -5, 5, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -5, 5, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 5, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 5, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.rsub_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -41,19 +41,19 @@ def test_bw_rsub(input_shapes, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_rsub_opt(input_shapes, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -5, 5, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -5, 5, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 5, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 5, device, seed=2)
 
     input_grad = None
     other_grad = None
     tt_output_tensor_on_device = None
 
     if are_required_outputs[0]:
-        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device, seed=3)
     if are_required_outputs[1]:
-        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
+        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device, seed=4)
 
     cq_id = 0
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_selu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_selu.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_selu(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.selu_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sigmoid.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sigmoid.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_sigmoid(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.sigmoid_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sign.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sign.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_sign(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.sign_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_silu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_silu.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_silu(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.silu_bw(grad_tensor, input_tensor)
 
@@ -39,8 +39,8 @@ def test_bw_silu(input_shapes, device):
     ),
 )
 def test_bw_silu_opt_tensor(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sin.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sin.py
@@ -18,8 +18,8 @@ from math import pi
     ),
 )
 def test_bw_sin(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 0, 2 * pi, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, False)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0, 2 * pi, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, False, seed=1)
 
     tt_output_tensor_on_device = ttnn.sin_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sinh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sinh.py
@@ -22,8 +22,8 @@ from models.utility_functions import (
     ),
 )
 def test_bw_sinh(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -9, 9, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
@@ -43,8 +43,8 @@ def test_bw_sinh(input_shapes, device):
     ),
 )
 def test_bw_sinh_inf(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 89, 96, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 89, 96, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
@@ -64,8 +64,8 @@ def test_bw_sinh_inf(input_shapes, device):
     ),
 )
 def test_bw_sinh_neg_inf(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -97, -89, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -97, -89, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
@@ -82,8 +82,8 @@ def test_bw_sinh_neg_inf(input_shapes, device):
 )
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_sinh_nan_test1(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 35, 50, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 
@@ -100,8 +100,8 @@ def test_bw_sinh_nan_test1(input_shapes, device):
 )
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_sinh_nan_test2(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 86, 89, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -50, -35, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.sinh_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_softplus.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_softplus.py
@@ -25,8 +25,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     [-20, -10, 10, 20, 5, 0],
 )
 def test_bw_softplus(input_shapes, beta, threshold, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.softplus_bw(grad_tensor, input_tensor, beta=beta, threshold=threshold)
 
@@ -46,8 +46,8 @@ def test_bw_softplus(input_shapes, beta, threshold, device):
     ),
 )
 def test_bw_default_softplus(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.softplus_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_softshrink.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_softshrink.py
@@ -22,8 +22,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 )
 @pytest.mark.parametrize("lambd", [0.5, 1.0, 2.5, 5.5, 9.9])
 def test_bw_softshrink(input_shapes, lambd, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.softshrink_bw(grad_tensor, input_tensor, lambd=lambd)
 
@@ -44,8 +44,12 @@ def test_bw_softshrink(input_shapes, lambd, device):
 )
 @pytest.mark.parametrize("lambd", [0.5, 1.0, 2.5, 5.5, 9.9])
 def test_bw_softshrink_bf8b(input_shapes, lambd, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -20, 20, device, False, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -20, 20, device, False, False, ttnn.bfloat8_b, seed=1
+    )
 
     tt_output_tensor_on_device = ttnn.softshrink_bw(grad_tensor, input_tensor, lambd=lambd)
 
@@ -65,8 +69,8 @@ def test_bw_softshrink_bf8b(input_shapes, lambd, device):
     ],
 )
 def test_bw_softshrink_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.softshrink_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_softsign.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_softsign.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_softsign(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.softsign_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sqrt.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sqrt.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_sqrt(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.sqrt_bw(grad_tensor, input_tensor)
 
@@ -37,8 +37,8 @@ def test_bw_sqrt(input_shapes, device):
     ),
 )
 def test_bw_sqrt_output(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
     input_grad = None
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_square.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_square.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_square(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.square_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_squared_difference.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_squared_difference.py
@@ -17,9 +17,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_squared_difference(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=2)
 
     tt_output_tensor_on_device = ttnn.squared_difference_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sub.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_sub.py
@@ -21,9 +21,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ),
 )
 def test_bw_sub(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.sub_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -43,9 +43,15 @@ def test_bw_sub(input_shapes, device):
     ),
 )
 def test_bw_sub_bf8b(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    other_data, other_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, False, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    other_data, other_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=1
+    )
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, False, False, ttnn.bfloat8_b, seed=2
+    )
 
     tt_output_tensor_on_device = ttnn.sub_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -66,8 +72,8 @@ def test_bw_sub_bf8b(input_shapes, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12])
 def test_bw_unary_sub(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.sub_bw(grad_tensor, input_tensor, scalar)
 
@@ -88,9 +94,9 @@ def test_bw_unary_sub(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_sub_opt(input_shapes, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     input_grad = None
     other_grad = None
@@ -136,8 +142,8 @@ def test_bw_sub_opt(input_shapes, device, are_required_outputs):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_sub_scalar_opt_output(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_subalpha.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_subalpha.py
@@ -18,9 +18,9 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 @pytest.mark.parametrize("alpha", [0.05])
 def test_bw_subalpha(input_shapes, alpha, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.subalpha_bw(grad_tensor, input_tensor, other_tensor, alpha)
 
@@ -40,9 +40,9 @@ def test_bw_subalpha(input_shapes, alpha, device):
     ),
 )
 def test_bw_subalpha_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.subalpha_bw(grad_tensor, input_tensor, other_tensor)
 
@@ -63,9 +63,9 @@ def test_bw_subalpha_default(input_shapes, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_subalpha_opt_output(input_shapes, device, are_required_outputs):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=2)
 
     input_grad = None
     other_grad = None

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_tan.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_tan.py
@@ -21,8 +21,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 )
 def test_bw_tan(input_shapes, device):
     # tt tan supports input range [-1.45, 1.45]
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.tan_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_tanh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_tanh.py
@@ -18,8 +18,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
 )
 def test_bw_tanh(input_shapes, device):
     # tt tan supports input range [-1.45, 1.45]
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.tanh_bw(grad_tensor, input_tensor)
 
@@ -40,8 +40,8 @@ def test_bw_tanh(input_shapes, device):
 )
 def test_bw_tanh_with_output(input_shapes, device):
     # tt tan supports input range [-1.45, 1.45]
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
     input_grad = None
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_tanhshrink.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_tanhshrink.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_tanhshrink(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.tanhshrink_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_threshold.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_threshold.py
@@ -22,8 +22,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
 )
 @pytest.mark.parametrize("value", [1.0])
 def test_bw_threshold(input_shapes, threshold, value, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.threshold_bw(grad_tensor, input_tensor, threshold, value)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_trunc.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_trunc.py
@@ -17,8 +17,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_trunc(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.trunc_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_where.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_where.py
@@ -23,9 +23,9 @@ def test_bw_where(input_shapes, device):
 
     condition_tensor = ttnn.Tensor(condition_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
 
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -4, 4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -1, 1, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -4, 4, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.where_bw(grad_tensor, condition_tensor, input_tensor, other_tensor)
 
@@ -51,16 +51,16 @@ def test_bw_where_output(input_shapes, are_required_outputs, device):
 
     condition_tensor = ttnn.Tensor(condition_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
 
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -4, 4, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -1, 1, device, True, seed=1)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -4, 4, device, seed=2)
     input_grad = None
     other_grad = None
 
     if are_required_outputs[0]:
-        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+        _, input_grad = data_gen_with_range(input_shapes, -1, 1, device, seed=3)
     if are_required_outputs[1]:
-        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device)
+        _, other_grad = data_gen_with_range(input_shapes, -1, 1, device, seed=4)
 
     cq_id = 0
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_xlogy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_xlogy.py
@@ -17,10 +17,10 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_xlogy(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -2, 5, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, -2, 5, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=2)
 
     tt_output_tensor_on_device = ttnn.xlogy_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -10,6 +10,8 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
 
+DEFAULT_SEED = 213919
+
 
 def data_gen_with_range_batch_norm(
     input_shapes,
@@ -20,9 +22,10 @@ def data_gen_with_range_batch_norm(
     required_grad=False,
     testing_dtype="bfloat16",
     memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    seed=DEFAULT_SEED,
 ):
     assert high > low, "Incorrect range provided"
-    torch.manual_seed(213919)
+    torch.manual_seed(seed)
     channels = input_shapes[1]
     size = input_shapes if is_input else channels
     torch_dtype = getattr(torch, testing_dtype)
@@ -41,16 +44,16 @@ def data_gen_with_range_batch_norm(
     return pt_tensor, tt_tensor
 
 
-def data_gen_pt_tt(input_shapes, device, required_grad=False):
-    torch.manual_seed(213919)
+def data_gen_pt_tt(input_shapes, device, required_grad=False, seed=DEFAULT_SEED):
+    torch.manual_seed(seed)
     pt_tensor = torch.randn(input_shapes, requires_grad=required_grad).bfloat16()
     tt_tensor = ttnn.Tensor(pt_tensor, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
     return pt_tensor, tt_tensor
 
 
-def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is_row_major=False):
+def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is_row_major=False, seed=DEFAULT_SEED):
     assert high > low, "Incorrect range provided"
-    torch.manual_seed(213919)
+    torch.manual_seed(seed)
     pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
     if is_row_major:
         tt_tensor = ttnn.Tensor(pt_tensor, ttnn.bfloat16).to(ttnn.ROW_MAJOR_LAYOUT).to(device)
@@ -60,10 +63,17 @@ def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is
 
 
 def data_gen_with_range_dtype(
-    input_shapes, low, high, device, required_grad=False, is_row_major=False, ttnn_dtype=ttnn.bfloat16
+    input_shapes,
+    low,
+    high,
+    device,
+    required_grad=False,
+    is_row_major=False,
+    ttnn_dtype=ttnn.bfloat16,
+    seed=DEFAULT_SEED,
 ):
     assert high > low, "Incorrect range provided"
-    torch.manual_seed(213919)
+    torch.manual_seed(seed)
     pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
     if is_row_major:
         tt_tensor = ttnn.Tensor(pt_tensor, ttnn_dtype).to(ttnn.ROW_MAJOR_LAYOUT).to(device)
@@ -72,9 +82,11 @@ def data_gen_with_range_dtype(
     return pt_tensor, tt_tensor
 
 
-def data_gen_with_range_int(input_shapes, low, high, device, required_grad=False, is_row_major=False):
+def data_gen_with_range_int(
+    input_shapes, low, high, device, required_grad=False, is_row_major=False, seed=DEFAULT_SEED
+):
     assert high > low, "Incorrect range provided"
-    torch.manual_seed(213919)
+    torch.manual_seed(seed)
     pt_tensor = torch.randint(low, high, input_shapes, dtype=torch.int32, requires_grad=required_grad)
 
     if is_row_major:
@@ -94,8 +106,8 @@ def data_gen_with_val(input_shapes, device, required_grad=False, val=1, is_row_m
     return pt_tensor, tt_tensor
 
 
-def data_gen_pt_tt_prod(input_shapes, device, all_dimensions=True, dim=0, required_grad=False):
-    torch.manual_seed(213919)
+def data_gen_pt_tt_prod(input_shapes, device, all_dimensions=True, dim=0, required_grad=False, seed=DEFAULT_SEED):
+    torch.manual_seed(seed)
     pt_tensor_temp = torch.zeros(input_shapes, requires_grad=required_grad).bfloat16()
     shape_Required = torch.Size(
         [


### PR DESCRIPTION
### Ticket
Github Issue https://github.com/tenstorrent/tt-metal/issues/19550

### Problem description
As described in the https://github.com/tenstorrent/tt-metal/issues/19550 seed for data generation is hardcoded, meaning that all of the data is the same for all the arguments (maybe scaled), and since we're using correlation to verify data, it's unsafe to test some operations like that. 

### What's changed
All [functions](https://github.com/tenstorrent/tt-metal/blob/philei/backward_unittest_datagen_improve/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py) that generate random data now get an additional argument for seed. 

All [backward unary tests](https://github.com/tenstorrent/tt-metal/tree/philei/backward_unittest_datagen_improve/tests/ttnn/unit_tests/operations/eltwise/backward) when generate data pass different seed for different arguments.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes