### PR TITLE
#18650 Fix sharded unary op writing out of bounds

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_sharded_program_factory.cpp
@@ -61,8 +61,7 @@ UnaryShardedProgramFactory::cached_program_t UnaryShardedProgramFactory::create(
             "Shard width should be multiple of {} to satisfy L1 alignment",
             hal::get_l1_alignment());
         size_t shard_height = shard_spec.shape[0];
-        size_t shard_width = round_up_to_mul16(
-            shard_spec.shape[1]);  // rounding up is done to aligned with  --> tt-metal/tt_metal/detail/util.hpp:31
+        size_t shard_width = shard_spec.shape[1];
         size_t shard_size_in_bytes = shard_height * shard_width * datum_size(act_df);
         TT_FATAL(shard_size_in_bytes % input_tile_size == 0, "Shard Size must be multiple of input_tile_size");
         num_tile_per_core = (shard_size_in_bytes + input_tile_size - 1) / input_tile_size;  // ceil value


### PR DESCRIPTION
In case unary op has sharded input, in row major
layout, and shard width is not a multiple of 16
op will be writing out of bounds.

Fix this by removing wrong alignment of shard
width to be multiple of 16 in unary_sharded_program_factory.

This issue doesn't get exposed in unit tests since output of the op is fine, it's just writing out of bounds.

This was a root cause of data corruption in SD model on blackhole. Issue is not blackhole specific, it
was just unfortunate layout in memory.

This issue was also visible as a warning that
was emitted by the op that CB size exceeds the
the buffer size.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18650)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14046689500) CI passes
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14054723395) CI passes (if applicable)
- [x] [(Single-card) Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14054711110)