### PR TITLE
[skip ci] Update Falcon7b TG demo perf targets after cpu performance governor was enabled on TG runners

### DIFF
--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 17921, "decode_t/s": 4873, "decode_t/s/u": 4.76}, False, None),
-        (True, 1024, {"prefill_t/s": 20143, "decode_t/s": 4504, "decode_t/s/u": 4.40}, False, None),
-        (True, 2048, {"prefill_t/s": 14136, "decode_t/s": 4290, "decode_t/s/u": 4.19}, False, None),
+        (True, 128, {"prefill_t/s": 16685, "decode_t/s": 4771, "decode_t/s/u": 4.66}, False, None),
+        (True, 1024, {"prefill_t/s": 20488, "decode_t/s": 4576, "decode_t/s/u": 4.47}, False, None),
+        (True, 2048, {"prefill_t/s": 14972, "decode_t/s": 4567, "decode_t/s/u": 4.46}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- CPU performance governor was enabled on CI TG runners but Falcon7b perf targets were not updated
- seq 128 perf target did not have a sufficient margin

### What's changed
- Updated Falcon7b TG demo perf targets

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes