### PR TITLE
Add TG llama stress test

### DIFF
--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -14,7 +14,7 @@ on:
         type: string
 
 jobs:
-  tg-quick:
+  tg-stress:
     runs-on:
       - in-service
       - config-tg

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -19,6 +19,7 @@ jobs:
       - in-service
       - config-tg
       - arch-wormhole_b0
+      - pipeline-functional
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:
@@ -58,8 +59,8 @@ jobs:
         run: |
           WHEEL_FILENAME=$(ls -1 *.whl)
           pip3 install $WHEEL_FILENAME
-      - name: Run quick tests
-        timeout-minutes: 20
+      - name: Run stress tests
+        timeout-minutes: 360
         run: |
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full and batch-32-stress-test"
       - uses: ./.github/actions/slack-report

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Run quick tests
         timeout-minutes: 20
         run: |
-          pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full and batch-32-long-context"
+          pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full and batch-32-stress-test"
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -26,6 +26,7 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
+        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /work

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run quick tests
         timeout-minutes: 20
         run: |
-          # Insert tests here
+          pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full and batch-32-long-context"
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -102,7 +102,7 @@ def run_llama3_demo(
     print_to_file,
     weights,
     layers,
-    assert_tsu,
+    stress_test,
 ):
     # Creat batch output file
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -300,10 +300,11 @@ def run_llama3_demo(
         )
         logger.info(f"sampling done")
 
-    ttnn.plus_one(
-        current_pos_tensor,
-        sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
-    )
+    if not stress_test:
+        ttnn.plus_one(
+            current_pos_tensor,
+            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+        )
     # profiler.end(f"plus one position done")
 
     # Capture Trace
@@ -334,10 +335,11 @@ def run_llama3_demo(
         tt_out_rm, dim=3, use_multicore=True, output_tensor=tt_out_tok, sub_core_grids=sub_core_grids
     )
 
-    ttnn.plus_one(
-        current_pos_tensor,
-        sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
-    )
+    if not stress_test:
+        ttnn.plus_one(
+            current_pos_tensor,
+            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+        )
     # ttnn.plus_one(rot_mat_idxs)  # FIXME <- This won't work since embedding requires uint32 and plus_one only works for int32
 
     ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
@@ -395,7 +397,8 @@ def run_llama3_demo(
         # Update current pos and mat idxs on host and send to device
         # TODO This is required for now since we cannot ttnn.plus_one(rot_mat_idxs) while it being uint32.
         # If this tensor is int32, it won't be supported by ttnn.embedding
-        current_pos += 1
+        if not stress_test:
+            current_pos += 1
         rot_mat_idxs_updated = tt_model.rope_setup.get_rot_idxs(current_pos, on_host=True)
         ttnn.copy_host_to_device_tensor(rot_mat_idxs_updated, rot_mat_idxs)
         # ttnn.synchronize_device(mesh_device)
@@ -448,7 +451,7 @@ def run_llama3_demo(
             f"Iteration {iteration}: {1000*iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
         )
         tsu_threshold = 128 if layers == 1 else 28
-        if assert_tsu:
+        if not stress_test:
             assert tokens_per_second_per_user > tsu_threshold, "Throughput is less than 28 tokens per second per user"
         profiler.end(f"log_printing_iter_{iteration}", iteration=iteration)
 
@@ -483,7 +486,7 @@ def run_llama3_demo(
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 # FAKE_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export FAKE_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, assert_tsu",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test",
     [
         # (  # Batch-1 run (Latency) - single user, small prompt
         #     "models/demos/llama3/demo/input_data_questions_prefill_128.json",  # input_prompts
@@ -506,19 +509,19 @@ def run_llama3_demo(
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
-            True,  # assert_tsu
+            False,  # stress_test
         ),
-        (  # Batch-32 Long-context: stress test
+        (  # Stress test: batch-32 very long generations but at same token index
             "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
             1024,  # max_seq_len
             32,  # batch_size
-            128*1024,  # max_generated_tokens
+            4*128*1024,  # max_generated_tokens (same index for stress test)
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
-            False,  # assert_tsu
+            True,  # stress_test
         ),
     ],
     ids=[
@@ -569,7 +572,7 @@ def test_llama_demo(
     use_program_cache,
     is_ci_env,
     reset_seeds,
-    assert_tsu,
+    stress_test,
 ):
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
@@ -604,5 +607,5 @@ def test_llama_demo(
         print_to_file=False,
         weights=weights,
         layers=layers,
-        assert_tsu=assert_tsu,
+        stress_test=stress_test,
     )

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -512,9 +512,9 @@ def run_llama3_demo(
             "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
-            128*1024,  # max_seq_len
+            64*1024,  # max_seq_len
             32,  # batch_size
-            128*1024,  # max_generated_tokens
+            64*1024,  # max_generated_tokens
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -526,8 +526,8 @@ def run_llama3_demo(
     ],
     ids=[
         # "batch-1",  # latency
-        "batch-32",  # throughput
-        "batch-32-long-context",  # stress test with long context
+        "batch-32-demo",  # throughput
+        "batch-32-stress-test",  # stress test with long context
     ],
 )
 @pytest.mark.parametrize(

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -102,6 +102,7 @@ def run_llama3_demo(
     print_to_file,
     weights,
     layers,
+    assert_tsu,
 ):
     # Creat batch output file
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -447,7 +448,8 @@ def run_llama3_demo(
             f"Iteration {iteration}: {1000*iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
         )
         tsu_threshold = 128 if layers == 1 else 28
-        assert tokens_per_second_per_user > tsu_threshold, "Throughput is less than 28 tokens per second per user"
+        if assert_tsu:
+            assert tokens_per_second_per_user > tsu_threshold, "Throughput is less than 28 tokens per second per user"
         profiler.end(f"log_printing_iter_{iteration}", iteration=iteration)
 
         if iteration == 0:  # First iteration also accounts for compile time
@@ -481,7 +483,7 @@ def run_llama3_demo(
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 # FAKE_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export FAKE_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params",
+    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, assert_tsu",
     [
         # (  # Batch-1 run (Latency) - single user, small prompt
         #     "models/demos/llama3/demo/input_data_questions_prefill_128.json",  # input_prompts
@@ -504,6 +506,7 @@ def run_llama3_demo(
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
+            True,  # assert_tsu
         ),
         (  # Batch-32 Long-context: stress test
             "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
@@ -515,6 +518,7 @@ def run_llama3_demo(
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
+            False,  # assert_tsu
         ),
     ],
     ids=[
@@ -565,6 +569,7 @@ def test_llama_demo(
     use_program_cache,
     is_ci_env,
     reset_seeds,
+    assert_tsu,
 ):
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
@@ -599,4 +604,5 @@ def test_llama_demo(
         print_to_file=False,
         weights=weights,
         layers=layers,
+        assert_tsu=assert_tsu,
     )

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -423,7 +423,7 @@ def run_llama3_demo(
             ttnn.copy_host_to_device_tensor(tt_out_tok_reset, tt_out_tok)
         else:
             all_outputs.append(tt_output_torch.tolist()[0])  # Update generated token to list of TT outputs
-            if all_outputs[-1] in [128001, 128009]:  # EoT tokens
+            if all_outputs[-1] in [128001, 128009] and not stress_test:  # EoT tokens
                 users_decoding = False
 
         # Ignore the first iteration for average speed calculation

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -512,9 +512,9 @@ def run_llama3_demo(
             "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
-            64*1024,  # max_seq_len
+            1024,  # max_seq_len
             32,  # batch_size
-            64*1024,  # max_generated_tokens
+            128*1024,  # max_generated_tokens
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -505,22 +505,22 @@ def run_llama3_demo(
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
         ),
-        # (  # Long-context run - Single user, long prompt (adapted to the model being used and architecture)
-        #     "models/demos/llama3/demo/input_data_long_64k.json",  # input_prompts
-        #     True,  # instruct mode
-        #     1,  # repeat_batches
-        #     64 * 1024,  # max_seq_len
-        #     1,  # batch_size
-        #     200,  # max_generated_tokens
-        #     False,  # paged_attention
-        #     {"page_block_size": 64, "page_max_num_blocks": 2048},  # page_params  # TODO This will be serviced by vLLM
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
-        # ),
+        (  # Batch-32 Long-context: stress test
+            "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            128*1024,  # max_seq_len
+            32,  # batch_size
+            128*1024,  # max_generated_tokens
+            False,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
+            {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
+        ),
     ],
     ids=[
         # "batch-1",  # latency
         "batch-32",  # throughput
-        # "long-context",  # max-length
+        "batch-32-long-context",  # stress test with long context
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -13,7 +13,7 @@ run_tg_llama3_tests() {
   # Run all Llama3 tests for 1B, 3B, 8B, 11B and 70B weights
   # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py --timeout 5000; fail+=$?
+    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "batch-32-demo" --timeout 5000; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 


### PR DESCRIPTION
### Problem description
We didn't have a stress test to test for hangs before this.

### What's changed
Added an option to the demo to run the same token index 4 x 128 x 1024 times.

Note: I ran the CI pipeline, the test runs fine but I cancelled before it was finished since it takes a long time; it will only run on weekends (Saturday morning).

Demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/14079310782/job/39428781422

### Checklist
- [x] [New pipeline](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-stress-trigger.yaml) CI runs
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes