### PR TITLE
[skip ci] Migrate Single-card Demo Tests to Ubuntu 22.04

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -63,8 +63,7 @@ jobs:
           name: ${{ inputs.wheel-artifact-name }}
       - name: Enable Performance mode
         if: ${{ matrix.test-group.name == 'N300_performance' }}
-        run: |
-          sudo cpupower frequency-set -g performance
+        run: sudo cpupower frequency-set -g performance
       - uses: ./.github/actions/ensure-active-weka-mount
       - name: Run demo regression tests
         uses: ./.github/actions/docker-run
@@ -78,8 +77,6 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GITHUB_ACTIONS=true
-            -e CI=true
             -v /mnt/MLPerf:/mnt/MLPerf:ro
           install_wheel: true
           run_args: |
@@ -97,8 +94,6 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
-            -e GITHUB_ACTIONS=true
-            -e CI=true
             -v /mnt/MLPerf:/mnt/MLPerf:ro
           install_wheel: true
           run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
@@ -119,5 +114,4 @@ jobs:
           prefix: "test_reports_"
       - name: Disable Performance mode
         if: ${{ matrix.test-group.name == 'N300_performance' }}
-        run: |
-          sudo cpupower frequency-set -g ondemand
+        run: sudo cpupower frequency-set -g ondemand

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -13,6 +13,7 @@ jobs:
     secrets: inherit
     with:
       build-wheel: true
+      version: 22.04
   single-card-demo-tests:
     needs: build-artifact
     secrets: inherit


### PR DESCRIPTION
### Problem description
Ubuntu 20.04 will not be supported in a few days.

### What's changed
Single-card Demo Test workflow updated to build on Ubuntu 22.04

### Checklist
- [Y] [Single-card Demo Tests](https://github.com/tenstorrent/tt-metal/actions/runs/14070557849) CI passes (if applicable)
- [Y] New/Existing tests provide coverage for changes