### PR TITLE
Afuller/fix asan diagnostics

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -48,7 +48,7 @@ jobs:
     with:
       version: "22.04"
       toolchain: cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
-      build-type: ${{ inputs.build-type || 'Debug' }}
+      build-type: ${{ inputs.build-type || 'ASan' }}
       publish-artifact: false
 
   find-changed-files:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/build-artifact.yaml
     with:
       version: "22.04"
+      toolchain: cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
       build-type: ${{ inputs.build-type || 'Debug' }}
       publish-artifact: false
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -271,6 +271,8 @@ TYPED_TEST(WritePackedCommandTest, RandomAddDispatchWritePacked) {
                 sub_cmds,
                 data_collection,
                 packed_write_max_unicast_sub_cmds,
+                0,
+                false,
                 curr_sub_cmd_idx);
             curr_sub_cmd_idx += sub_cmd_ct;
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -259,7 +259,7 @@ TYPED_TEST(WritePackedCommandTest, RandomAddDispatchWritePacked) {
         }
 
         HostMemDeviceCommand command(calculator.write_offset_bytes());
-        command.add_data(nullptr, 0, random_start);
+        command.add_data(data, 0, random_start);
         uint32_t curr_sub_cmd_idx = 0;
         for (const auto& [sub_cmd_ct, payload_size] : packed_cmd_payloads) {
             std::vector<TypeParam> sub_cmds(sub_cmd_ct);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -115,7 +115,8 @@ public:
 
     void update_cmd_sequence(uint32_t cmd_offsetB, const void* new_data, uint32_t data_sizeB);
 
-    void add_data(const void* data, uint32_t data_size_to_copyB, uint32_t cmd_write_offset_incrementB);
+    void add_data(const void* data, uint32_t data_size_to_copyB, uint32_t cmd_write_offset_incrementB)
+        __attribute((nonnull(2)));
 
     template <typename PackedSubCmd>
     void add_dispatch_write_packed(
@@ -198,7 +199,7 @@ private:
 
     void deepcopy(const DeviceCommand& other);
 
-    void memcpy(void* __restrict dst, const void* __restrict src, size_t n);
+    void memcpy(void* __restrict dst, const void* __restrict src, size_t n) __attribute__((nonnull(2, 3)));
 
     template <typename Command>
     void zero(Command* cmd) {


### PR DESCRIPTION
### Ticket
None

### Problem description
Smoke tests fail under ASan.

### What's changed
First commit addresses a UBSan diagnostic
* Original diagnostic: https://github.com/tenstorrent/tt-metal/actions/runs/14069115639/job/39399030305#step:5:27
* annotate methods that blindly pass a parameter to memcpy's nonnull argument as also being nonnull
  * This is able to catch the UB at compile time (shifted left) like this: https://github.com/tenstorrent/tt-metal/actions/runs/14069502453/job/39400118979#step:10:731

Second commit addresses an ASan diagnostic (heap buffer overflow)
* Original diagnostic: https://github.com/tenstorrent/tt-metal/actions/runs/14069578798/job/39400572749#step:5:31
  * Looks like this API is pretty easy to call incorrectly 🤪 

Third commit switches to the standard toolchain
* With the old toolchain ASan is reporting an alloc-dealloc mismatch; maybe we're building things wrong somewhere
* We want to move to the system default anyway, so no value digging deeper in the toolchain we're moving away from

Last commit turns on ASan in PR Gate so that we don't regress.