### PR TITLE
Parameter to specify a header outside of the client interface (async write)

### DIFF
--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -106,11 +106,12 @@ inline void fabric_send_pull_request(
                        // and the routing plane to use when using ROUTING_TABLE
     uint16_t dst_mesh_id,
     uint16_t dst_dev_id,
-    uint32_t header_id = 0) {
+    volatile tt_l1_ptr packet_header_t* header) {
     uint64_t router_addr;
     if constexpr (routing_type == RoutingType::ROUTING_TABLE) {
-        router_addr = get_noc_addr_helper(get_next_hop_router_noc_xy(client_interface, routing, dst_mesh_id, dst_dev_id),
-                      FABRIC_ROUTER_REQ_QUEUE_START);
+        router_addr = get_noc_addr_helper(
+            get_next_hop_router_noc_xy(client_interface, routing, dst_mesh_id, dst_dev_id),
+            FABRIC_ROUTER_REQ_QUEUE_START);
     } else {
         router_addr = get_noc_addr_helper(routing, FABRIC_ROUTER_REQ_QUEUE_START);
     }
@@ -134,13 +135,29 @@ inline void fabric_send_pull_request(
         tt_fabric_check_pull_request_slot<true>(router_addr, pull_request, header_wrptr);
         uint32_t header_wr_index = header_wrptr & CHAN_REQ_BUF_SIZE_MASK;
         uint64_t noc_addr = router_addr + offsetof(chan_req_buf, chan_req) + header_wr_index * sizeof(pull_request_t);
-        noc_async_write_one_packet(
-            (uint32_t)(&client_interface->header_buffer[header_id]), noc_addr, sizeof(pull_request_t), noc_index);
+        noc_async_write_one_packet((uint32_t)header, noc_addr, sizeof(pull_request_t), noc_index);
     } else {
         tt_fabric_check_pull_request_slot<true>(router_addr, pull_request, wrptr);
     }
 
     tt_fabric_send_pull_request(router_addr, pull_request);
+}
+
+template <ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA, RoutingType routing_type = RoutingType::ROUTER_XY>
+inline void fabric_send_pull_request(
+    volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface,
+    uint32_t routing,  // routing refers to the router noc xy to use when using ROUTER_XY,
+                       // and the routing plane to use when using ROUTING_TABLE
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint32_t header_id = 0) {
+    fabric_send_pull_request<data_mode, routing_type>(
+        client_interface,
+        routing,
+        dst_mesh_id,
+        dst_dev_id,
+        reinterpret_cast<volatile tt_l1_ptr packet_header_t*>(
+            &client_interface->header_buffer[header_id]) /*only used for raw mode*/);
 }
 
 FORCE_INLINE void fabric_wait_for_pull_request_words_flushed(
@@ -164,6 +181,40 @@ inline void fabric_wait_for_pull_request_flushed(volatile tt_l1_ptr fabric_pull_
     fabric_wait_for_pull_request_words_flushed(client_interface, words_written);
 }
 
+template <typename T>
+inline void fabric_async_write_add_header(
+    T client_interface,
+    uint32_t src_addr,  // source address in sender’s memory
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint64_t dst_addr,
+    uint32_t size,  // number of bytes to write to remote destination
+    packet_header_t* packet_header) {
+    packet_header->routing.flags = FORWARD;
+    packet_header->routing.packet_size_bytes = size;
+    packet_header->routing.dst_mesh_id = dst_mesh_id;
+    packet_header->routing.dst_dev_id = dst_dev_id;
+    packet_header->session.command = ASYNC_WR;
+    packet_header->session.target_offset_l = (uint32_t)dst_addr;
+    packet_header->session.target_offset_h = dst_addr >> 32;
+    tt_fabric_add_header_checksum(packet_header);
+}
+
+template <typename T>
+inline void fabric_async_write_add_header(
+    T client_interface,
+    uint32_t src_addr,  // source address in sender’s memory
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint64_t dst_addr,
+    uint32_t size,  // number of bytes to write to remote destination
+    low_latency_packet_header_t* packet_header) {
+    packet_header->routing.packet_size_bytes = size;
+    packet_header->routing.target_offset_l = (uint32_t)dst_addr;
+    packet_header->routing.target_offset_h = dst_addr >> 32;
+    packet_header->routing.command = ASYNC_WR;
+}
+
 template <typename T, ClientDataMode data_mode = ClientDataMode::PACKETIZED_DATA>
 inline void fabric_async_write_add_header(
     T client_interface,
@@ -173,50 +224,26 @@ inline void fabric_async_write_add_header(
     uint64_t dst_addr,
     uint32_t size,  // number of bytes to write to remote destination
     uint32_t header_id = 0) {
-#ifdef FVC_MODE_PULL
+#if defined(FVC_MODE_PULL) || !defined(LOW_LATENCY_ROUTING)
     packet_header_t* packet_header;
-    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
-        packet_header = (packet_header_t*)(src_addr);
-    } else {
-        packet_header = (packet_header_t*)&client_interface->header_buffer[header_id];
-    }
-    packet_header->routing.flags = FORWARD;
-    packet_header->routing.packet_size_bytes = size;
-    packet_header->routing.dst_mesh_id = dst_mesh_id;
-    packet_header->routing.dst_dev_id = dst_dev_id;
-    packet_header->session.command = ASYNC_WR;
-    packet_header->session.target_offset_l = (uint32_t)dst_addr;
-    packet_header->session.target_offset_h = dst_addr >> 32;
-    tt_fabric_add_header_checksum(packet_header);
 #else
-#ifdef LOW_LATENCY_ROUTING
     low_latency_packet_header_t* packet_header;
+#endif
+
     if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
-        packet_header = (low_latency_packet_header_t*)(src_addr);
-    } else {
-        packet_header = (low_latency_packet_header_t*)&client_interface->header_buffer[header_id];
-    }
-    packet_header->routing.packet_size_bytes = size;
-    packet_header->routing.target_offset_l = (uint32_t)dst_addr;
-    packet_header->routing.target_offset_h = dst_addr >> 32;
-    packet_header->routing.command = ASYNC_WR;
-#else
-    packet_header_t* packet_header;
-    if constexpr (data_mode == ClientDataMode::PACKETIZED_DATA) {
+#if defined(FVC_MODE_PULL) || !defined(LOW_LATENCY_ROUTING)
         packet_header = (packet_header_t*)(src_addr);
+#else
+        packet_header = (low_latency_packet_header_t*)(src_addr);
+#endif
     } else {
+#if defined(FVC_MODE_PULL) || !defined(LOW_LATENCY_ROUTING)
         packet_header = (packet_header_t*)&client_interface->header_buffer[header_id];
+#else
+        packet_header = (low_latency_packet_header_t*)&client_interface->header_buffer[header_id];
+#endif
     }
-    packet_header->routing.flags = FORWARD;
-    packet_header->routing.packet_size_bytes = size;
-    packet_header->routing.dst_mesh_id = dst_mesh_id;
-    packet_header->routing.dst_dev_id = dst_dev_id;
-    packet_header->session.command = ASYNC_WR;
-    packet_header->session.target_offset_l = (uint32_t)dst_addr;
-    packet_header->session.target_offset_h = dst_addr >> 32;
-    tt_fabric_add_header_checksum(packet_header);
-#endif
-#endif
+    fabric_async_write_add_header(client_interface, src_addr, dst_mesh_id, dst_dev_id, dst_addr, size, packet_header);
 }
 
 #ifdef FVC_MODE_PULL


### PR DESCRIPTION
### Ticket
#18726

### Problem description
Existing out of band header support has 4 headers (`CLIENT_HEADER_BUFFER_ENTRIES`) inside of the client interface. I want to make a custom ring buffer of these `packet_header_t` objects without impacting the size of the client interface.

### What's changed
Add function overloads which accept a `packet_header_t`

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14071601793
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14071603738
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14071606391