### PR TITLE
Validate that control plan doesn't map the same chip to several logical coordinates

### DIFF
--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -21,21 +21,25 @@ const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translat
         }
 
         const auto mesh_id = mesh_ids.front();
-        auto mesh_shape = control_plane->get_physical_mesh_shape(mesh_id);
-        MeshContainer<PhysicalMeshCoordinate> physical_coordinates(
-            mesh_shape, PhysicalMeshCoordinate(/*mesh_id=*/mesh_id, /*chip_id=*/0));
+        const auto mesh_shape = control_plane->get_physical_mesh_shape(mesh_id);
 
+        // Validate that the physical chip ids are unique.
+        std::unordered_set<chip_id_t> unique_chip_ids;
+
+        std::vector<PhysicalMeshCoordinate> physical_coordinates;
+        physical_coordinates.reserve(mesh_shape.mesh_size());
         for (int logical_chip_id = 0; logical_chip_id < mesh_shape.mesh_size(); ++logical_chip_id) {
             // Query the control plane to get the physical chip id from logical chip id
-            auto logical_row_idx = logical_chip_id / mesh_shape[1];
-            auto logical_col_idx = logical_chip_id % mesh_shape[1];
-            auto logical_coordinate = MeshCoordinate(logical_row_idx, logical_col_idx);
-            auto physical_chip_id = control_plane->get_physical_chip_id_from_mesh_chip_id({mesh_id, logical_chip_id});
-
-            auto physical_coordinate = PhysicalMeshCoordinate(/*mesh_id=*/mesh_id, /*chip_id=*/physical_chip_id);
-            physical_coordinates.at(logical_coordinate) = physical_coordinate;
+            const auto physical_chip_id =
+                control_plane->get_physical_chip_id_from_mesh_chip_id({mesh_id, logical_chip_id});
+            TT_FATAL(
+                unique_chip_ids.insert(physical_chip_id).second,
+                "Found duplicate physical chip id: {}, mesh id: {}",
+                physical_chip_id,
+                mesh_id);
+            physical_coordinates.push_back(PhysicalMeshCoordinate(/*mesh_id=*/mesh_id, /*chip_id=*/physical_chip_id));
         }
-        return physical_coordinates;
+        return MeshContainer<PhysicalMeshCoordinate>(mesh_shape, std::move(physical_coordinates));
     }());
     return kTranslationMap.get();
 }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -305,11 +305,8 @@ void ControlPlane::initialize_from_mesh_graph_desc_file(const std::string& mesh_
         // Main board
         this->logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back(
             this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id));
-    } else if (mesh_graph_desc_filename == "t3k_mesh_graph_descriptor.yaml") {
-        // TODO: fix routing code for T3K.
-        std::vector<chip_id_t> physical_chip_id_mapping = {4, 0, 3, 7, 5, 1, 2, 6};
-        logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back(physical_chip_id_mapping);
     } else if (
+        mesh_graph_desc_filename == "t3k_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n150_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n300_mesh_graph_descriptor.yaml") {
         nw_chip_physical_id = this->get_physical_chip_id_from_eth_coord({0, 0, 0, 0, 0});

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -305,8 +305,11 @@ void ControlPlane::initialize_from_mesh_graph_desc_file(const std::string& mesh_
         // Main board
         this->logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back(
             this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id));
+    } else if (mesh_graph_desc_filename == "t3k_mesh_graph_descriptor.yaml") {
+        // TODO: fix routing code for T3K.
+        std::vector<chip_id_t> physical_chip_id_mapping = {4, 0, 3, 7, 5, 1, 2, 6};
+        logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back(physical_chip_id_mapping);
     } else if (
-        mesh_graph_desc_filename == "t3k_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n150_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n300_mesh_graph_descriptor.yaml") {
         nw_chip_physical_id = this->get_physical_chip_id_from_eth_coord({0, 0, 0, 0, 0});


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some T3K machines might have problematic connectors, and control plane might returns the same chip mapped to 2 logical coordinates. Observed issue where `{4, 0, 3, 7, 5, 1, 2, 6}` was expected, but we get `{4, 0, 3, 7, 0, 1, 2, 6}`.

### What's changed
Validation in `tt_metal/distributed/coordinate_translation.cpp` to ensure we aren't double-mapping a coordinate to the same chip ID.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14087920829)
- [X] [T3K pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/14087925969)
- [X] New/Existing tests provide coverage for changes