### PR TITLE
removed downloading yolov9 weights

### DIFF
--- a/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
+++ b/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
@@ -20,23 +20,13 @@ from models.experimental.functional_yolov9c.tt import ttnn_yolov9c
 from models.experimental.functional_yolov9c.reference import yolov9c
 from models.experimental.functional_yolov9c.demo.demo_utils import attempt_load
 
-try:
-    sys.modules["ultralytics"] = yolov9c
-    sys.modules["ultralytics.nn.tasks"] = yolov9c
-    sys.modules["ultralytics.nn.modules.conv"] = yolov9c
-    sys.modules["ultralytics.nn.modules.block"] = yolov9c
-    sys.modules["ultralytics.nn.modules.head"] = yolov9c
-
-except KeyError:
-    logger.error("models.experimental.functional_yolov9c.reference.yolov9c not found.")
-
 
 @run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "use_pretrained_weight",
     [
-        # False,
-        True
+        False,
+        # True
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)

--- a/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
+++ b/tests/ttnn/integration_tests/yolov9c/test_ttnn_yolov9c.py
@@ -26,7 +26,6 @@ from models.experimental.functional_yolov9c.demo.demo_utils import attempt_load
     "use_pretrained_weight",
     [
         False,
-        # True
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Seeing conflict issue between yolo models when loading model weights. So changing yolov9 to use random weights till we fix the issue to unblock CI

### What's changed
Used random weights.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes