### PR TITLE
Adding retry for main workflows triggered over night

### DIFF
--- a/.github/workflows/_auto-retry-nightly-workflows.yaml
+++ b/.github/workflows/_auto-retry-nightly-workflows.yaml
@@ -1,4 +1,4 @@
-name: "[internal] Auto-retry post-commit"
+name: "[internal] Auto-retry nightly workflows"
 
 on:
   workflow_dispatch:
@@ -76,7 +76,7 @@ jobs:
             echo "::notice title=no-continue-did-not-fail::This workflow did not fail. Not re-trying"
             should_continue=false
           elif [[ "$CURRENT_HOUR" -lt 8 || "$CURRENT_HOUR" -ge 20 ]]; then
-            echo "::notice title=no-continue-outside-hours::This workflow is outside of the hours of 8am-8pm. Not re-trying"
+            echo "::notice title=no-continue-outside-hours::This workflow is outside of the hours of 8am-8pm PT. Not re-trying"
             should_continue=false
           else
             should_continue=true

--- a/.github/workflows/_auto-retry-nightly-workflows.yaml
+++ b/.github/workflows/_auto-retry-nightly-workflows.yaml
@@ -1,0 +1,101 @@
+name: "[internal] Auto-retry post-commit"
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_workflow_run_id:
+        description: "Unique GitHub workflow run ID to use for test"
+        default: 12788722730
+        type: number
+      test_workflow_run_attempt:
+        description: "Run attempt of the workflow run"
+        default: 1
+        type: number
+  workflow_run:
+    workflows:
+      - "(T3K) T3000 demo tests"
+      - "(T3K) T3000 frequent tests"
+      - "(T3K) T3000 model perf tests"
+      - "(T3K) T3000 nightly tests"
+      - "(T3K) T3000 perplexity tests"
+      - "(T3K) T3000 profiler tests"
+      - "(T3K) T3000 unit tests"
+      - "(TG) TG demo tests"
+      - "(TG) TG frequent tests"
+      - "(TG) TG model perf tests"
+      - "(TG) TG nightly tests"
+      - "(TG) TG unit tests"
+      - "Package and release"
+    types:
+      - completed
+
+jobs:
+  auto-retry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get workflow run_id attempt number to analyze
+        id: get-run-id-and-attempt
+        shell: bash
+        run: |
+          event_name="${{ github.event_name }}"
+          if [[ "$event_name" == "workflow_dispatch" ]]; then
+            run_id="${{ inputs.test_workflow_run_id }}"
+            attempt_number="${{ inputs.test_workflow_run_attempt }}"
+          elif [[ "$event_name" == "workflow_run" ]]; then
+            run_id="${{ github.event.workflow_run.id }}"
+            attempt_number="${{ github.event.workflow_run.run_attempt }}"
+            [[ -z "$run_id" ]] && { echo "run_id is empty" ; exit 1; }
+            [[ -z "$attempt_number" ]] && { echo "attempt_number is empty" ; exit 1; }
+          else
+            echo "Unknown event name" && exit 1
+          fi
+
+          echo $run_id
+          echo $attempt_number
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "attempt-number=$attempt_number" >> "$GITHUB_OUTPUT"
+
+          echo "::notice title=target-workflow-link::The workflow being analyzed is available at https://github.com/tenstorrent/tt-metal/actions/runs/$run_id/attempts/$attempt_number"
+      - name: Determine if we should continue
+        id: determine-should-continue
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MAX_ATTEMPTS=2
+          CURRENT_HOUR=$(date +"%H")
+          read original_trigger conclusion <<< $(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --jq '.event + " " + .conclusion')
+          if [[ "${{ steps.get-run-id-and-attempt.outputs.attempt-number }}" -ge "$MAX_ATTEMPTS" ]]; then
+            echo "::notice title=no-continue-max-tries::This workflow has exceeded max tries. Not re-trying"
+            should_continue=false
+          elif [[ "$original_trigger" == "workflow_dispatch" ]]; then
+            echo "::notice title=no-continue-is-on-branch::This workflow was a workflow dispatched on a branch, not main. Not re-trying"
+            should_continue=false
+          elif [[ "$conclusion" != "failure" ]]; then
+            echo "::notice title=no-continue-did-not-fail::This workflow did not fail. Not re-trying"
+            should_continue=false
+          elif [[ "$CURRENT_HOUR" -lt 8 || "$CURRENT_HOUR" -ge 20 ]]; then
+            echo "::notice title=no-continue-outside-hours::This workflow is outside of the hours of 8am-8pm. Not re-trying"
+            should_continue=false
+          else
+            should_continue=true
+          fi
+
+          echo "should-continue=$should_continue" >> "$GITHUB_OUTPUT"
+      - name: Re-run failed jobs
+        if: ${{ steps.determine-should-continue.outputs.should-continue == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RETRY_WORKFLOW_TOKEN }}
+        run: |
+          echo "Re-running jobs here"
+          # gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/timing
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/rerun-failed-jobs
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: U08BNDNLUCD # akirby-tt


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Many times, a simply retry resolved failed tests.  This workflow triggers the retry; just a single retry and out of office hours due to the limited hardware availability.

### What's changed
This workflow is to test retries for the T3K, TG and Package and Release workflows and limiting them the ones triggered out of office hours to reduce the potential over usage of the limited resources during business hours, but still perform the retries on these workflows out of office hours.  It's the runs that happen over night and early morning that are used to generate the daily chart and this will save time each morning waiting for a retry to happen when the resources are limited.  Once this is proven, I can look at merging this into the existing retry workflow, but didn't want to mess with it until then due to the potential impact of the APC retries.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes