### PR TITLE
[2D Fabric] Test infra updates

### DIFF
--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -50,9 +50,9 @@ TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} 
 
 # Async Write with Push Router
 TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --push_router
-TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --benchmark --push_router
+TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 8 --num_dest_endpoints 8 --num_links 16 --benchmark --push_router
 TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --metal_fabric_init_level 1 --push_router
-TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --benchmark --metal_fabric_init_level 1 --push_router
+TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 8 --num_dest_endpoints 8 --num_links 16 --benchmark --metal_fabric_init_level 1 --push_router
 # Atomic Inc with Push Router
 TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 64 --board_type n300 --data_kb_per_tx 600 --push_router
 TT_METAL_SLOW_DISPATCH_MODE=1 ${TEST_FOLDER}/test_tt_fabric_sanity_${ARCH_NAME} --fabric_command 64 --board_type n300 --data_kb_per_tx 600 --metal_fabric_init_level 1 --push_router

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
@@ -15,80 +15,118 @@ using namespace tt::tt_fabric;
 #define CONTROLLER_HANDSHAKE_START 0x4
 #define CONTROLLER_HANDSHAKE_END 0x8
 
+template <typename T>
+inline void send_packet(
+    T client_interface,
+    uint32_t routing_plane,
+    uint32_t src_addr,
+    uint16_t dst_mesh_id,
+    uint16_t dst_dev_id,
+    uint64_t dst_addr,
+    uint32_t size) {
+#ifdef FVC_MODE_PULL
+    fabric_async_write<ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL, RoutingType::ROUTING_TABLE>(
+#else
+    fabric_async_write<ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL>(
+#endif
+        client_interface, routing_plane, src_addr, dst_mesh_id, dst_dev_id, dst_addr, size);
+
+#ifdef FVC_MODE_PULL
+    fabric_wait_for_pull_request_flushed(client_interface);
+#else
+    noc_async_writes_flushed();
+#endif
+}
+
 void kernel_main() {
     uint32_t rt_args_idx = 0;
     uint32_t time_seed = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t num_tx_workers = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
-    uint32_t tx_signal_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
+    uint32_t tx_signal_address = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t host_signal_address = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t num_mcast_dests = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t mcast_encoding = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
     uint32_t sync_with_remote = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
 
     // wait for sync from tx kernels
-    while (*(volatile tt_l1_ptr uint32_t*)tx_signal_addr != num_tx_workers);
+    volatile tt_l1_ptr uint32_t* tx_signal_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tx_signal_address);
+    while (*tx_signal_ptr != num_tx_workers);
 
     // wait for signal from host
     // this is needed to know that all the routers are up and running on all the chips
-    while (*(volatile tt_l1_ptr uint32_t*)host_signal_address == 0);
+    volatile tt_l1_ptr uint32_t* host_signal_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(host_signal_address);
+    while (*host_signal_ptr == 0);
 
-    tt_l1_ptr uint32_t* mcast_sem = reinterpret_cast<tt_l1_ptr uint32_t*>(0x100000);
-    *mcast_sem = 1;
-
-#ifdef FVC_MODE_PULL
     if (sync_with_remote) {
         uint32_t dest_device = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
         uint32_t remote_controller_noc_encoding = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
         uint32_t outbound_eth_chan = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
 
-        uint32_t remote_notification_addr = host_signal_address + 16;
-        uint32_t pkt_hdr_address = remote_notification_addr + 16;
+        uint32_t remote_notification_address = host_signal_address + 16;
+        uint32_t pkt_hdr_address = remote_notification_address + 16;
         uint32_t payload_address = pkt_hdr_address + PACKET_HEADER_SIZE_BYTES;
         uint32_t payload_size_bytes = 16;
         uint32_t client_interface_addr = payload_address + payload_size_bytes;
 
-        volatile tt_l1_ptr uint32_t* data_buf = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(payload_address);
-        volatile tt_l1_ptr uint32_t* poll_addr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_notification_addr);
+        uint32_t routing_plane = 0;
+        uint16_t dest_mesh_id = dest_device >> 16;
+        uint16_t dest_dev_id = dest_device & 0xFFFF;
 
+        tt_l1_ptr uint32_t* data_buf = reinterpret_cast<tt_l1_ptr uint32_t*>(payload_address);
+        volatile tt_l1_ptr uint32_t* poll_addr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(remote_notification_address);
+
+#ifdef FVC_MODE_PULL
         volatile tt_l1_ptr fabric_pull_client_interface_t* client_interface =
             reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
+#else
+        fabric_push_client_interface_t* client_interface =
+            reinterpret_cast<fabric_push_client_interface_t*>(client_interface_addr);
+#endif
 
         fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(
             client_interface, outbound_eth_chan);
 
-        uint64_t dst_noc_addr = get_noc_addr_helper(remote_controller_noc_encoding, remote_notification_addr);
+#ifndef FVC_MODE_PULL
+        fabric_client_connect(client_interface, routing_plane, dest_mesh_id, dest_dev_id);
+#endif
+
+        uint64_t dst_noc_addr = get_noc_addr_helper(remote_controller_noc_encoding, remote_notification_address);
 
         data_buf[0] = CONTROLLER_HANDSHAKE_START;
-        fabric_async_write<AsyncWriteMode::ALL, RoutingType::ROUTING_TABLE>(
+        send_packet<decltype(client_interface)>(
             client_interface,
-            0,
+            routing_plane,
             pkt_hdr_address,
-            dest_device >> 16,
-            dest_device & 0xFFFF,
+            dest_mesh_id,
+            dest_dev_id,
             dst_noc_addr,
             payload_size_bytes + PACKET_HEADER_SIZE_BYTES);
-        fabric_wait_for_pull_request_flushed(client_interface);
 
         while (*poll_addr != CONTROLLER_HANDSHAKE_START);
 
         data_buf[0] = CONTROLLER_HANDSHAKE_END;
-        fabric_async_write<AsyncWriteMode::ALL, RoutingType::ROUTING_TABLE>(
+        send_packet<decltype(client_interface)>(
             client_interface,
-            0,
+            routing_plane,
             pkt_hdr_address,
-            dest_device >> 16,
-            dest_device & 0xFFFF,
+            dest_mesh_id,
+            dest_dev_id,
             dst_noc_addr,
             payload_size_bytes + PACKET_HEADER_SIZE_BYTES);
-        fabric_wait_for_pull_request_flushed(client_interface);
 
         while (*poll_addr != CONTROLLER_HANDSHAKE_END);
-    }
+
+#ifndef FVC_MODE_PULL
+        fabric_client_disconnect(client_interface);
 #endif
+    }
+
+    tt_l1_ptr uint32_t* mcast_sem = reinterpret_cast<tt_l1_ptr uint32_t*>(0x100000);
+    *mcast_sem = 1;
 
     // do a noc multicast to tx kernels
-    uint64_t mcast_dest_addr = get_noc_addr_helper(mcast_encoding, tx_signal_addr);
+    uint64_t mcast_dest_addr = get_noc_addr_helper(mcast_encoding, tx_signal_address);
     noc_async_write_multicast_loopback_src((uint32_t)mcast_sem, mcast_dest_addr, sizeof(uint32_t), num_mcast_dests);
     noc_async_writes_flushed();
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
@@ -210,7 +210,7 @@ void kernel_main() {
         }
     }
 #else
-    fabric_client_router_reserve(client_interface, 0, dest_device >> 16, dest_device & 0xFFFF);
+    fabric_client_connect(client_interface, 0, dest_device >> 16, dest_device & 0xFFFF);
     uint64_t start_timestamp = get_timestamp();
     uint32_t* payload = (uint32_t*)data_buffer_start_addr;
     while (true) {
@@ -237,6 +237,10 @@ void kernel_main() {
 #endif
 
     uint64_t cycles_elapsed = get_timestamp() - start_timestamp;
+
+#ifndef FVC_MODE_PULL
+    fabric_client_disconnect(client_interface);
+#endif
 
     uint64_t num_packets = packet_count;
     set_64b_result(test_results, data_words_sent, TT_FABRIC_WORD_CNT_INDEX);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -520,6 +520,11 @@ typedef struct test_device {
             }
         }
 
+        if (router_virtual_cores.empty()) {
+            log_fatal(LogTest, "Couldnt find any ethernet core for device: {}", physical_chip_id);
+            throw std::runtime_error("Need atleast 1 ethernet core to run fabric");
+        }
+
         if (benchmark_mode) {
             _generate_router_worker_map();
         }
@@ -648,6 +653,7 @@ typedef struct test_device {
 
         // throw error if no potential router core found
         if (src_routers.size() == 0) {
+            log_fatal(LogTest, "No router cores found for num hops: {}, on device: {}", num_hops, physical_chip_id);
             throw std::runtime_error("No router cores found for specified num hops");
         }
     }
@@ -782,8 +788,9 @@ typedef struct test_traffic {
     uint32_t num_links_to_use;
     uint32_t link_idx = 0;
     bool sync_with_remote_controller_kernel = false;
-    uint32_t remote_controller_noc_encoding;
-    uint32_t remote_controller_mesh_chip_id;
+    std::optional<chan_id_t> controller_outbound_eth_chan;
+    std::optional<uint32_t> remote_controller_noc_encoding;
+    std::optional<uint32_t> remote_controller_mesh_chip_id;
 
     test_traffic(
         std::shared_ptr<test_device_t>& tx_device_,
@@ -845,6 +852,7 @@ typedef struct test_traffic {
     void set_remote_controller(test_traffic& reverse_traffic) {
         sync_with_remote_controller_kernel = true;
         auto remote_tx_device = reverse_traffic.tx_device;
+        controller_outbound_eth_chan = std::get<0>(tx_workers[0]);
         remote_controller_noc_encoding = remote_tx_device->get_noc_offset(reverse_traffic.controller_logical_core);
         remote_controller_mesh_chip_id = remote_tx_device->mesh_chip_id;
     }
@@ -885,9 +893,9 @@ typedef struct test_traffic {
 
             // if need to sync with remote controller
             if (sync_with_remote_controller_kernel) {
-                runtime_args.push_back(remote_controller_mesh_chip_id);
-                runtime_args.push_back(remote_controller_noc_encoding);
-                runtime_args.push_back(std::get<0>(tx_workers[0]));
+                runtime_args.push_back(remote_controller_mesh_chip_id.value());
+                runtime_args.push_back(remote_controller_noc_encoding.value());
+                runtime_args.push_back(controller_outbound_eth_chan.value());
             }
 
             // zero out the signal address
@@ -1040,13 +1048,25 @@ typedef struct test_traffic {
         }
     }
 
+    void wait_for_tx_workers_to_finish() {
+        for (auto& tx_core : tx_virtual_cores) {
+            while (true) {
+                auto tx_status =
+                    tt::llrt::read_hex_vec_from_core(tx_device->physical_chip_id, tx_core, test_results_address, 4);
+                if ((tx_status[0] & 0xFFFF) != 0) {
+                    break;
+                }
+            }
+        }
+    }
+
     void wait_for_rx_workers_to_finish() {
         for (const auto& rx_device : rx_devices) {
             for (auto& rx_core : rx_virtual_cores) {
                 while (true) {
-                    auto tx_status =
+                    auto rx_status =
                         tt::llrt::read_hex_vec_from_core(rx_device->physical_chip_id, rx_core, test_results_address, 4);
-                    if ((tx_status[0] & 0xFFFF) != 0) {
+                    if ((rx_status[0] & 0xFFFF) != 0) {
                         break;
                     }
                 }
@@ -1109,6 +1129,14 @@ typedef struct test_traffic {
                 pass &= (get_64b_result(rx_results[d][i], TX_TEST_IDX_NPKT) == num_tx_packets);
 
                 if (!pass) {
+                    log_fatal(
+                        LogTest,
+                        "Result validation failed b/w TX [Device: Phys: {}, Logical: {}] and RX [Device: Phys: {}, "
+                        "Logical: {}]",
+                        tx_device->physical_chip_id,
+                        (uint32_t)tx_device->logical_chip_id,
+                        rx_devices[d]->physical_chip_id,
+                        (uint32_t)rx_devices[d]->logical_chip_id);
                     break;
                 }
             }
@@ -1161,7 +1189,14 @@ typedef struct test_traffic {
                         stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             */
         }
-        total_tx_bw_2 = ((double)total_tx_words_sent) * PACKET_WORD_SIZE_BYTES / max_tx_elapsed_cycles;
+
+        if (push_mode) {
+            // for push mode, report average b/w
+            total_tx_bw_2 = total_tx_bw / num_tx_workers;
+        } else {
+            total_tx_bw_2 = ((double)total_tx_words_sent) * PACKET_WORD_SIZE_BYTES / max_tx_elapsed_cycles;
+        }
+
         for (uint32_t d = 0; d < rx_devices.size(); d++) {
             for (uint32_t i = 0; i < num_rx_workers; i++) {
                 uint64_t words_received = get_64b_result(rx_results[d][i], TT_FABRIC_WORD_CNT_INDEX);
@@ -1271,10 +1306,9 @@ int main(int argc, char **argv) {
     constexpr uint32_t default_tunneler_test_results_addr = 0x39000; // 0x8000 * 4 + 0x19000; 0x10000 * 4 + 0x19000 = 0x59000 > 0x40000 (256kB)
     constexpr uint32_t default_tunneler_test_results_size = 0x6000;  // 256kB total L1 in ethernet core - 0x39000
 
-    constexpr uint32_t default_timeout_mcycles = 1000;
+    constexpr uint32_t default_timeout_mcycles = 100000000;
     constexpr uint32_t default_rx_disable_data_check = 0;
     constexpr uint32_t default_rx_disable_header_check = 0;
-    constexpr uint32_t default_check_txrx_timeout = 1;
 
     constexpr uint32_t src_endpoint_start_id = 4;
     constexpr uint32_t dest_endpoint_start_id = 11;
@@ -1338,7 +1372,7 @@ int main(int argc, char **argv) {
         log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
         log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
         log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
+        log_info(LogTest, "  --disable_txrx_timeout: Disable timeout during tx & rx (enabled by default)");
         log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
         log_info(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
         log_info(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", false);
@@ -1382,7 +1416,7 @@ int main(int argc, char **argv) {
     bool tx_skip_pkt_content_gen = test_args::has_command_option(input_args, "--tx_skip_pkt_content_gen");
     uint32_t dump_stat_json = test_args::get_command_option_uint32(input_args, "--dump_stat_json", default_dump_stat_json);
     std::string output_dir = test_args::get_command_option(input_args, "--output_dir", std::string(default_output_dir));
-    uint32_t check_txrx_timeout = test_args::get_command_option_uint32(input_args, "--check_txrx_timeout", default_check_txrx_timeout);
+    bool disable_txrx_timeout = test_args::has_command_option(input_args, "--disable_txrx_timeout");
     uint32_t tx_pkt_dest_size_choice = (uint8_t)test_args::get_command_option_uint32(
         input_args, "--tx_pkt_dest_size_choice", default_tx_pkt_dest_size_choice);
     uint32_t tx_data_sent_per_iter_low = test_args::get_command_option_uint32(input_args, "--tx_data_sent_per_iter_low", default_tx_data_sent_per_iter_low);
@@ -1448,6 +1482,9 @@ int main(int argc, char **argv) {
     uint32_t packet_size_kb =
         test_args::get_command_option_uint32(input_args, "--packet_size_kb", default_packet_size_kb);
     uint32_t max_packet_size_words = packet_size_kb * 1024 / PACKET_WORD_SIZE_BYTES;
+
+    uint32_t timeout_cycles = timeout_mcycles * 1000;
+
     // Only supports line mcast from neighbour
     if (mcast && num_hops != default_num_hops && num_hops != 1) {
         throw std::runtime_error("Only line mcast is supported right now");
@@ -1591,21 +1628,6 @@ int main(int argc, char **argv) {
             num_allocated_devices += 1 + rx_chip_ids.size();
         }
 
-        // TODO: check this in a loop for all the devices involved in the traffic
-        /*
-        auto const& device_active_eth_cores =
-            test_devices[test_device_id_l]->device_handle->get_active_ethernet_cores();
-        if (device_active_eth_cores.size() == 0) {
-            log_info(
-                LogTest,
-                "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
-                test_device_id_l);
-            for (auto& test_device : test_devices) {
-                tt_metal::CloseDevice(test_device.second->device_handle);
-            }
-            throw std::runtime_error("Test cannot run on specified device.");
-        } */
-
         uint32_t worker_unreserved_base_addr =
             hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
 
@@ -1622,7 +1644,7 @@ int main(int argc, char **argv) {
                 test_device->create_router_kernels(router_compile_args, defines);
             }
         }
-        if (check_txrx_timeout) {
+        if (!disable_txrx_timeout) {
             defines["CHECK_TIMEOUT"] = "";
         }
 
@@ -1631,35 +1653,35 @@ int main(int argc, char **argv) {
             client_interface_addr + sizeof(fabric_pull_client_interface_t) + sizeof(fabric_router_l1_config_t) * 4;
 
         std::vector<uint32_t> tx_compile_args = {
-            data_mode,                          // 0: Data mode. 0 - Packetized Data. 1 Raw Data.
-            num_dest_endpoints,                 // 1: num_dest_endpoints
-            dest_endpoint_start_id,             // 2:
-            tx_queue_start_addr,                // 3: queue_start_addr_words
-            (tx_queue_size_bytes >> 4),         // 4: queue_size_words
-            routing_table_start_addr,           // 5: routeing table
-            test_results_addr,                  // 6: test_results_addr
-            test_results_size,                  // 7: test_results_size
-            prng_seed,                          // 8: prng_seed
-            data_kb_per_tx,                     // 9: total_data_kb
-            max_packet_size_words,              // 10: max_packet_size_words
-            timeout_mcycles * 1000 * 1000 * 4,  // 11: timeout_cycles
-            tx_skip_pkt_content_gen,            // 12: skip_pkt_content_gen
-            tx_pkt_dest_size_choice,            // 13: pkt_dest_size_choice
-            tx_data_sent_per_iter_low,          // 14: data_sent_per_iter_low
-            tx_data_sent_per_iter_high,         // 15: data_sent_per_iter_high
-            fabric_command,                     // 16: fabric_command
-            target_address,                     // 17: target_address
-            atomic_increment,                   // 18: atomic_increment
-            tx_signal_address,                  // 19: tx_signal_address
-            client_interface_addr,              // 20:
-            client_pull_req_buf_addr,           // 21:
-            fixed_async_wr_notif_addr,          // 22: use fixed addr for async wr atomic inc
-            mcast,                              // 23: mcast
-            mcast_depth[RoutingDirection::E],   // 24: mcast_e
-            mcast_depth[RoutingDirection::W],   // 25: mcast_w
-            mcast_depth[RoutingDirection::N],   // 26: mcast_n
-            mcast_depth[RoutingDirection::S],   // 27: mcast_s
-            push_mode                           // 28: Router mode. 0 - Pull, 1 - Push
+            data_mode,                         // 0: Data mode. 0 - Packetized Data. 1 Raw Data.
+            num_dest_endpoints,                // 1: num_dest_endpoints
+            dest_endpoint_start_id,            // 2:
+            tx_queue_start_addr,               // 3: queue_start_addr_words
+            (tx_queue_size_bytes >> 4),        // 4: queue_size_words
+            routing_table_start_addr,          // 5: routeing table
+            test_results_addr,                 // 6: test_results_addr
+            test_results_size,                 // 7: test_results_size
+            prng_seed,                         // 8: prng_seed
+            data_kb_per_tx,                    // 9: total_data_kb
+            max_packet_size_words,             // 10: max_packet_size_words
+            timeout_cycles,                    // 11: timeout_cycles
+            tx_skip_pkt_content_gen,           // 12: skip_pkt_content_gen
+            tx_pkt_dest_size_choice,           // 13: pkt_dest_size_choice
+            tx_data_sent_per_iter_low,         // 14: data_sent_per_iter_low
+            tx_data_sent_per_iter_high,        // 15: data_sent_per_iter_high
+            fabric_command,                    // 16: fabric_command
+            target_address,                    // 17: target_address
+            atomic_increment,                  // 18: atomic_increment
+            tx_signal_address,                 // 19: tx_signal_address
+            client_interface_addr,             // 20:
+            client_pull_req_buf_addr,          // 21:
+            fixed_async_wr_notif_addr,         // 22: use fixed addr for async wr atomic inc
+            mcast,                             // 23: mcast
+            mcast_depth[RoutingDirection::E],  // 24: mcast_e
+            mcast_depth[RoutingDirection::W],  // 25: mcast_w
+            mcast_depth[RoutingDirection::N],  // 26: mcast_n
+            mcast_depth[RoutingDirection::S],  // 27: mcast_s
+            push_mode                          // 28: Router mode. 0 - Pull, 1 - Push
         };
 
         std::vector<uint32_t> rx_compile_args = {
@@ -1674,6 +1696,7 @@ int main(int argc, char **argv) {
             tx_pkt_dest_size_choice,    // 8: pkt dest and size choice
             tx_skip_pkt_content_gen,    // 9: skip packet validation
             fixed_async_wr_notif_addr,  // 10: use fixed addr for async wr atomic inc
+            timeout_cycles,             // 11: idle timeout cycles
         };
 
         // TODO: launch traffic kernels
@@ -1681,7 +1704,7 @@ int main(int argc, char **argv) {
             traffic.create_kernels(tx_compile_args, rx_compile_args, defines, fabric_command, test_results_addr);
         }
 
-        if (check_txrx_timeout) {
+        if (!disable_txrx_timeout) {
             defines.erase("CHECK_TIMEOUT");
         }
 
@@ -1692,6 +1715,8 @@ int main(int argc, char **argv) {
             tt_metal::detail::LaunchProgram(test_device->device_handle, test_device->program_handle, false);
         }
 
+        log_info(LogTest, "Programs launched, waiting for router sync");
+
         if (metal_fabric_init_level == 0) {
             // wait for all routers to handshake with master router
             for (auto& [chip_id, test_device] : test_devices) {
@@ -1699,21 +1724,37 @@ int main(int argc, char **argv) {
             }
         }
 
+        log_info(LogTest, "Routers sync done, notifying tx controllers");
+
         // notify tx controller to signal the tx workers
         for (auto& traffic : fabric_traffic) {
             traffic.notify_tx_controller();
         }
 
+        log_info(LogTest, "Notified TX controllers, waiting for TX workers to finish");
+
+        // wait for rx kernels to finish
+        for (auto& traffic : fabric_traffic) {
+            traffic.wait_for_tx_workers_to_finish();
+        }
+
+        log_info(LogTest, "TX workers done, waiting for RX workers to finish");
+
         // wait for rx kernels to finish
         for (auto& traffic : fabric_traffic) {
             traffic.wait_for_rx_workers_to_finish();
         }
+
+        log_info(LogTest, "RX workers done, terminating routers");
+
         // terminate fabric routers if control plane is not managed by DevicePool
         if (metal_fabric_init_level == 0) {
             for (auto& [chip_id, test_device] : test_devices) {
                 test_device->terminate_router_kernels();
             }
         }
+
+        log_info(LogTest, "Terminated routers, waiting for program done");
 
         // wait for programs to exit
         for (auto& [chip_id, test_device] : test_devices) {
@@ -1724,39 +1765,28 @@ int main(int argc, char **argv) {
         std::chrono::duration<double> elapsed_seconds = (end-start);
         log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
+        log_info(LogTest, "Programs done, collecting results");
+
         // collect traffic results
         for (auto& traffic : fabric_traffic) {
             pass &= traffic.collect_results(test_results_addr);
             if (!pass) {
-                log_fatal(LogTest, "Result collection failed\n");
+                log_fatal(LogTest, "Result collection failed, skipping any further collection/validation");
+                break;
             }
         }
-
-        /*      TODO: Need to add these once control plane api is available to
-                          get the first and last hop fabric router core.
-                vector<uint32_t> router_results =
-                    tt::llrt::read_hex_vec_from_core(
-                        device->id(), tunneler_phys_core, tunneler_test_results_addr, 128);
-                log_info(LogTest, "L Router status = {}",
-           tt_fabric_status_to_string(router_results[TT_FABRIC_STATUS_INDEX])); pass &=
-           (router_results[TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
-
-                vector<uint32_t> r_router_results =
-                    tt::llrt::read_hex_vec_from_core(
-                        device_r->id(), r_tunneler_phys_core, tunneler_test_results_addr, 128);
-                log_info(LogTest, "R Router status = {}",
-           tt_fabric_status_to_string(r_router_results[TT_FABRIC_STATUS_INDEX])); pass &=
-           (r_router_results[TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
-        */
 
         // close devices
         test_board.close_devices();
 
         // tally-up the packets and words from tx/rx kernels
-        for (auto& traffic : fabric_traffic) {
-            pass &= traffic.validate_results();
-            if (!pass) {
-                log_fatal(LogTest, "Result validation failed\n");
+        if (pass) {
+            for (auto& traffic : fabric_traffic) {
+                pass &= traffic.validate_results();
+                if (!pass) {
+                    log_fatal(LogTest, "Result validation failed, skipping any further validation");
+                    break;
+                }
             }
         }
 

--- a/tt_metal/api/tt-metalium/fabric_host_interface.h
+++ b/tt_metal/api/tt-metalium/fabric_host_interface.h
@@ -30,7 +30,7 @@ static_assert(
 static constexpr std::uint32_t CLIENT_INTERFACE_SIZE = 3280;
 static constexpr std::uint32_t CLIENT_HEADER_BUFFER_ENTRIES = 4;
 static constexpr std::uint32_t PULL_CLIENT_INTERFACE_SIZE = 304;
-static constexpr std::uint32_t PUSH_CLIENT_INTERFACE_SIZE = 240;
+static constexpr std::uint32_t PUSH_CLIENT_INTERFACE_SIZE = 288;
 static constexpr std::uint32_t PACKET_WORD_SIZE_BYTES = 16;
 static constexpr std::uint32_t PACKET_HEADER_SIZE_BYTES = 48;
 static constexpr std::uint32_t PACKET_HEADER_SIZE_WORDS = PACKET_HEADER_SIZE_BYTES / PACKET_WORD_SIZE_BYTES;

--- a/tt_metal/fabric/hw/inc/tt_fabric_interface.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_interface.h
@@ -363,6 +363,24 @@ static_assert(sizeof(fabric_client_interface_t) == CLIENT_INTERFACE_SIZE);
 static_assert(sizeof(fabric_pull_client_interface_t) % 16 == 0);
 static_assert(sizeof(fabric_pull_client_interface_t) == PULL_CLIENT_INTERFACE_SIZE);
 
+constexpr uint32_t FABRIC_ROUTER_CLIENT_QUEUE_SIZE = 48;
+typedef struct _fabric_push_client_queue {
+    chan_ptr client_idx_counter;
+    chan_ptr curr_client_idx;
+    chan_ptr router_wr_ptr;
+} fabric_push_client_queue_t;
+static_assert(sizeof(fabric_push_client_queue_t) % 16 == 0);
+static_assert(sizeof(fabric_push_client_queue_t) == FABRIC_ROUTER_CLIENT_QUEUE_SIZE);
+
+constexpr uint32_t FABRIC_ROUTER_CLIENT_QUEUE_LOCAL_SIZE = 48;
+typedef struct _fabric_push_client_queue_local {
+    chan_ptr my_client_idx;
+    chan_ptr remote_curr_client_idx;
+    chan_ptr remote_router_wr_ptr;
+} fabric_push_client_queue_local_t;
+static_assert(sizeof(fabric_push_client_queue_local_t) % 16 == 0);
+static_assert(sizeof(fabric_push_client_queue_local_t) == FABRIC_ROUTER_CLIENT_QUEUE_LOCAL_SIZE);
+
 typedef struct _fabric_push_client_interface {
     uint32_t num_routing_planes;
     uint32_t routing_tables_l1_offset;
@@ -374,6 +392,7 @@ typedef struct _fabric_push_client_interface {
     uint32_t router_space;
     uint32_t update_router_space;
     uint32_t reserved[3];
+    fabric_push_client_queue_local_t local_client_req_entry;
     packet_header_t header_buffer[CLIENT_HEADER_BUFFER_ENTRIES];
 } fabric_push_client_interface_t;
 
@@ -395,7 +414,8 @@ constexpr uint32_t FVCC_IN_BUF_START = FVCC_SYNC_BUF_START + FVCC_SYNC_BUF_SIZE;
 constexpr uint32_t FVCC_IN_BUF_SIZE = FVCC_BUF_SIZE_BYTES;
 
 // Fabric Virtual Channel start/size
-constexpr uint32_t FABRIC_ROUTER_REQ_QUEUE_START = FVCC_IN_BUF_START + FVCC_IN_BUF_SIZE;
+constexpr uint32_t FABRIC_ROUTER_CLIENT_QUEUE_START = FVCC_IN_BUF_START + FVCC_IN_BUF_SIZE;
+constexpr uint32_t FABRIC_ROUTER_REQ_QUEUE_START = FABRIC_ROUTER_CLIENT_QUEUE_START + FABRIC_ROUTER_CLIENT_QUEUE_SIZE;
 constexpr uint32_t FABRIC_ROUTER_REQ_QUEUE_SIZE = sizeof(chan_req_buf);
 constexpr uint32_t FABRIC_ROUTER_DATA_BUF_START = FABRIC_ROUTER_REQ_QUEUE_START + FABRIC_ROUTER_REQ_QUEUE_SIZE;
 constexpr uint32_t FABRIC_ROUTER_OUTBOUND_BUF_SIZE = 0x4000;

--- a/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
@@ -50,6 +50,9 @@ void kernel_main() {
 #else
     fvc_inbound_push_state_t fvc_inbound_state;
     fvc_outbound_push_state_t fvc_outbound_state[4];
+    volatile tt_l1_ptr fabric_push_client_queue_t* client_queue =
+        reinterpret_cast<tt_l1_ptr fabric_push_client_queue_t*>(FABRIC_ROUTER_CLIENT_QUEUE_START);
+    zero_l1_buf((tt_l1_ptr uint32_t*)client_queue, sizeof(fabric_push_client_queue_t));
 #endif
     rtos_context_switch_ptr = (void (*)())RtosTable[0];
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17573)

### Problem description
1. Current test infra lacks some logs and timeouts that could be helpful to debug test hangs
2. 2D Fabric push mode doesnt have any client friendly APIs to share router buffers and assumes only one worker per buffer

### What's changed
1. Added timeouts to rx kernel
2. Added helpful test logs to aid in debugging
3. The host now also waits for tx kernels to exit (in addition to waiting for rx kernels) 
4. Added `fabric_client_connect` and `fabric_client_disconnect` APIs to allow workers to easily connect to the routers in the push mode. This does not get around the constraint that only one worker can actively send to the router at a time. The `fabric_client_connect` API blocks until the previous client in the queue calls `fabric_client_disconnect`. Hence, the workers should call `fabric_client_disconnect` once they are done sending packets so that other clients can start their transmission.
5. Updated the controller kernel to sync with the remote for bidirectional benchmarks for push mode


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14115533728)
- [x] (T3K fast)(https://github.com/tenstorrent/tt-metal/actions/runs/14114110032/job/39540322387)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes