### PR TITLE
#0: [skip ci] Fix cpp-post-commit workflow inputs for blackhole post-commit after #19657

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -104,7 +104,7 @@ jobs:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       timeout: 20
-      os: "ubuntu-22.04"
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
   models-unit-tests:
     needs: build-artifact
     secrets: inherit


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
#19657 changes the expected inputs for cpp-post-commit
https://github.com/tenstorrent/tt-metal/actions/runs/14072740787
As a result, the blackhole post commit yaml is invalid
```
[Invalid workflow file: .github/workflows/blackhole-post-commit.yaml#L102](https://github.com/tenstorrent/tt-metal/actions/runs/14072740787/workflow)
The workflow is not valid. .github/workflows/blackhole-post-commit.yaml (Line: 102, Col: 11): Input docker-image is required, but not provided while calling. .github/workflows/blackhole-post-commit.yaml (Line: 107, Col: 11): Invalid input, os is not defined in the referenced workflow.
```

### What's changed
Update the inputs for the workflows to include `docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}` and remove `os`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes