### PR TITLE
#19548: Add ttnn.sort scaffold

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -408,6 +408,7 @@ Reduction
    ttnn.argmax
    ttnn.prod
    ttnn.topk
+   ttnn.experimental.sort
 
 Data Movement
 =============

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from models.utility_functions import skip_for_grayskull
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "shape, dim, descending",
+    [
+        ([16, 1], -1, False),
+        ([1, 16], -1, False),
+        ([3, 3], -1, False),
+        ([16, 16, 16], -1, True),
+        ([3, 3], 1, False),
+        ([3, 16], 0, True),
+        ([32, 32], 0, False),
+        ([64, 64], 1, False),
+        ([128, 32], 1, True),
+        ([87, 87], 0, True),
+        ([1], 0, True),
+        ([], -1, True),
+        ([1, 0, 32, 32], 2, False),
+    ],
+)
+def test_sort_output_shape(shape, dim, descending, device):
+    torch.manual_seed(0)
+
+    torch_dtype = torch.bfloat16
+    input = torch.randn(shape, dtype=torch_dtype)
+
+    ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    torch_sort_values, torch_sort_indeces = torch.sort(input, dim=dim, descending=descending)
+    ttnn_sort_values, ttnn_sort_indices = ttnn.experimental.sort(ttnn_input, dim=dim, descending=descending)
+
+    assert torch_sort_values.shape == ttnn_sort_values.shape
+    assert torch_sort_indeces.shape == ttnn_sort_indices.shape
+
+    assert list(ttnn_sort_values.shape) == shape
+    assert list(ttnn_sort_indices.shape) == shape
+
+
+@skip_for_grayskull()
+@pytest.mark.parametrize(
+    "shape, dim, descending",
+    [
+        ([16, 1], -1, False),
+        ([1, 16], -1, False),
+        ([3, 3], -1, True),
+        ([3, 3], 1, False),
+        ([16, 16, 16], 0, True),
+        ([64, 64], 1, False),
+        ([128, 32], 1, True),
+        ([87, 87], 0, True),
+        ([1], 0, True),
+        ([], -1, True),
+        ([1, 0, 32, 32], 2, False),
+    ],
+)
+def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
+    torch.manual_seed(0)
+
+    torch_dtype = torch.bfloat16
+    input = torch.randn(shape, dtype=torch_dtype)
+    ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+
+    torch_sort_values, torch_sort_indeces = torch.sort(input, dim=dim, descending=descending)
+
+    ttnn_sort_values = ttnn.zeros_like(ttnn_input)
+    ttnn_sort_indices = ttnn.zeros_like(ttnn_input)
+    ttnn.experimental.sort(ttnn_input, dim=dim, descending=descending, out=(ttnn_sort_values, ttnn_sort_indices))
+
+    assert torch_sort_values.shape == ttnn_sort_values.shape
+    assert torch_sort_indeces.shape == ttnn_sort_indices.shape
+
+    assert list(ttnn_sort_values.shape) == shape
+    assert list(ttnn_sort_indices.shape) == shape

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -431,6 +431,8 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/device/nlp_create_qkv_heads_falcon7b_program_factory.cpp
@@ -977,6 +979,7 @@ set(CCL_EXPERIMENTAL_TTNN_SRCS_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/ccl_experimental_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/reduce_scatter_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
 )
 
 set(CCL_TTNN_SRCS_PYBIND

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -40,6 +40,7 @@
 #include "ttnn/operations/experimental/dropout/dropout_pybind.hpp"
 #include "ttnn/operations/experimental/reshape/view_pybind.hpp"
 #include "ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward_pybind.hpp"
+#include "ttnn/operations/experimental/reduction/sort/sort_pybind.hpp"
 
 namespace ttnn::operations::experimental {
 
@@ -88,6 +89,8 @@ void py_module(py::module& module) {
     reshape::detail::py_bind_view(module);
 
     gelu_backward::detail::bind_experimental_gelu_backward_operation(module);
+
+    reduction::detail::bind_reduction_sort_operation(module);
 
     // CCL ops
     auto m_experimental_ccl =

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sort_device_operation.hpp"
+#include "sort_program_factory.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::reduction {
+
+void SortDeviceOperation::validate_with_output_tensors(
+    const std::vector<Tensor>& input_tensor, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    // Validate shapes of input and output tensors
+    const auto input_tensor_shape = input_tensor.at(0).get_padded_shape();
+    if (output_tensors.size() == 2) {
+        if (output_tensors.at(0).has_value() && output_tensors.at(1).has_value()) {
+            const auto output_tensor_shape = output_tensors.at(0)->get_padded_shape();
+            TT_FATAL(
+                output_tensor_shape == input_tensor_shape,
+                "Output tensor shape must be the same as input tensor shape. Got output tensor shape: {} and input "
+                "tensor shape: {}",
+                output_tensor_shape,
+                input_tensor_shape);
+            const auto output_indices_shape = output_tensors.at(1)->get_padded_shape();
+            TT_FATAL(
+                output_indices_shape == input_tensor_shape,
+                "Output tensor indices shape must be the same as input tensor shape. Got output indices tensor shape: "
+                "{} and "
+                "input tensor shape: {}",
+                output_indices_shape,
+                input_tensor_shape);
+        }
+    }
+}
+
+std::vector<TensorSpec> SortDeviceOperation::compute_output_specs(
+    const std::vector<Tensor>& input_tensor, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (output_tensors.size() == 2) {
+        if (output_tensors.at(0).has_value() && output_tensors.at(1).has_value()) {
+            return {output_tensors[0]->get_tensor_spec(), output_tensors[1]->get_tensor_spec()};
+        }
+    }
+    // Create output tensors specs
+    auto output_shape = input_tensor.at(0).get_logical_shape();
+    auto values_spec = TensorSpec(
+        output_shape, TensorLayout(input_tensor.at(0).get_dtype(), PageConfig(Layout::TILE), output_mem_config));
+    auto index_spec =
+        TensorSpec(output_shape, TensorLayout(DataType::UINT16, PageConfig(Layout::TILE), output_mem_config));
+
+    return {values_spec, index_spec};
+}
+
+std::vector<Tensor> SortDeviceOperation::create_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
+    if (output_tensors.size() == 2) {
+        if (output_tensors.at(0).has_value() && output_tensors.at(1).has_value()) {
+            return {output_tensors[0].value(), output_tensors[1].value()};
+        }
+    }
+    auto output_specs = compute_output_specs(input_tensors, output_tensors);
+    return {
+        create_device_tensor(output_specs[0], input_tensors.at(0).device()),
+        create_device_tensor(output_specs[1], input_tensors.at(0).device()),
+    };
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks SortDeviceOperation::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    return detail::sort_program_interleaved(
+        input_tensors.at(0), this->dim, this->descending, this->stable, output_tensors.at(0), output_tensors.at(1));
+}
+}  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/run_operation.hpp"
+
+namespace ttnn::operations::experimental::reduction {
+
+struct SortDeviceOperation {
+    const int8_t dim;
+    const bool descending;
+    const bool stable;
+    const tt::tt_metal::MemoryConfig output_mem_config;
+
+    void validate_with_output_tensors(
+        const std::vector<Tensor>& input_tensor, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<TensorSpec> compute_output_specs(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    std::vector<Tensor> create_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+}  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sort_device_operation.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::experimental::reduction::detail {
+
+operation::ProgramWithCallbacks sort_program_interleaved(
+    const Tensor& input_tensor,
+    const int8_t dim,
+    const bool descending,
+    const bool stable,
+    Tensor& value_tensor,
+    Tensor& index_tensor) {
+    tt::tt_metal::Program program{};
+
+    // TODO: Implementation in next PR
+    tt::log_warning("sort_program_interleaved not implemented yet!");
+
+    return {std::move(program), {}};
+}
+
+}  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sort.hpp"
+#include "device/sort_device_operation.hpp"
+
+#include "ttnn/common/queue_id.hpp"
+#include "ttnn/run_operation.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::reduction {
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+template <class Tuple, class T = std::decay_t<std::tuple_element_t<0, std::decay_t<Tuple>>>>
+std::vector<std::optional<T>> tuple_to_vector_optional(Tuple&& tuple) {
+    return std::apply(
+        [](auto&&... elems) { return std::vector<std::optional<T>>{std::forward<decltype(elems)>(elems)...}; },
+        std::forward<Tuple>(tuple));
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+std::vector<Tensor> ExecuteSort::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const int8_t dim,
+    const bool descending,
+    const bool stable,
+    const std::optional<MemoryConfig>& memory_config,
+    std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
+    auto output_vectors = tt::tt_metal::operation::run(
+        SortDeviceOperation{dim, descending, stable, memory_config.value_or(input_tensor.memory_config())},
+        {input_tensor},
+        {},
+        optional_output_tensors.has_value()
+            ? CMAKE_UNIQUE_NAMESPACE::tuple_to_vector_optional(optional_output_tensors.value())
+            : std::vector<std::optional<Tensor>>{},
+        queue_id);
+
+    return output_vectors;
+}
+
+std::vector<Tensor> ExecuteSort::create_async_output_tensors(
+    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
+    const auto& input_tensor = input_tensors.at(0);
+    return {
+        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor})),
+        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
+}
+
+}  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::experimental::reduction {
+
+struct ExecuteSort {
+    static std::vector<Tensor> invoke(
+        QueueId queue_id,
+        const Tensor& input_tensor,
+        const int8_t dim,
+        const bool descending,
+        const bool stable,
+        const std::optional<MemoryConfig>& memory_config,
+        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
+
+    static std::vector<Tensor> create_async_output_tensors(
+        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
+};
+
+}  // namespace ttnn::operations::experimental::reduction
+
+namespace ttnn::experimental {
+
+constexpr auto sort = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::sort",
+    ttnn::operations::experimental::reduction::ExecuteSort>();
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "sort_pybind.hpp"
+
+#include "pybind11/decorators.hpp"
+
+#include "sort.hpp"
+#include "device/sort_device_operation.hpp"
+
+namespace ttnn::operations::experimental::reduction::detail {
+namespace py = pybind11;
+
+void bind_reduction_sort_operation(py::module& module) {
+    auto doc =
+        R"doc(
+            Sorts the elements of the input tensor along the specified dimension in ascending order by default.
+            If no dimension is specified, the last dimension of the input tensor is used.
+
+            This operation is functionally equivalent to the following PyTorch code:
+
+            .. code-block:: python
+
+                return torch.sort(input_tensor, dim=-1)
+
+            Parameters:
+                * `input_tensor` (Tensor): The input tensor to be sorted.
+
+            Keyword Arguments:
+                * `dim` (int, optional): The dimension along which to sort. Defaults to -1 (last dimension).
+                * `descending` (bool, optional): If `True`, sorts in descending order. Defaults to `False`.
+                * `stable` (bool, optional): If `True`, ensures the original order of equal elements is preserved. Defaults to `False`.
+                * `memory_config` (MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
+                * `out` (tuple of Tensors, optional): Preallocated output tensors for the sorted values and indices. Defaults to `None`.
+
+            Example:
+
+            .. code-block:: python
+
+                import ttnn
+
+                # Create a tensor
+                input_tensor = ttnn.Tensor([3, 1, 2])
+
+                # Sort the tensor in ascending order
+                sorted_tensor, indices = ttnn.experimental.sort(input_tensor)
+
+                # Sort the tensor in descending order
+                sorted_tensor_desc, indices_desc = ttnn.experimental.sort(input_tensor, descending=True)
+
+                # Sort along a specific dimension
+                input_tensor_2d = ttnn.Tensor([[3, 1, 2], [6, 5, 4]])
+                sorted_tensor_dim, indices_dim = ttnn.experimental.sort(input_tensor_2d, dim=1)
+        )doc";
+
+    using OperationType = decltype(ttnn::experimental::sort);
+    bind_registered_operation(
+        module,
+        ttnn::experimental::sort,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               const int8_t dim,
+               const bool descending,
+               const bool stable,
+               std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
+               const std::optional<ttnn::MemoryConfig>& memory_config,
+               QueueId queue_id) {
+                return self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
+            },
+            py::arg("input_tensor").noconvert(),
+            py::arg("dim") = -1,
+            py::arg("descending") = false,
+            py::arg("stable") = false,
+            py::kw_only(),
+            py::arg("out") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+}  // namespace ttnn::operations::experimental::reduction::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::reduction::detail {
+namespace py = pybind11;
+
+void bind_reduction_sort_operation(py::module& module);
+
+}  // namespace ttnn::operations::experimental::reduction::detail


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19548

### Problem description
Creating scaffold for the future implementation of the `sort` method for tensors. This PR introduces experimental functionality that correctly returns the output tensor with the shape based on input arguments.

### What's changed
-	Added program structure for `sort` op implementation,
-	Added tests for checking output shape from `sort` function.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes