### PR TITLE
#19677: Use ttnn.bcast in SD component to avoid ttnn.repeat pcc issue

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -15,9 +15,6 @@ from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_p
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
     UNet2DConditionModel as UNet2D,
 )
-from models.utility_functions import (
-    skip_for_grayskull,
-)
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 scheduler = LMSDiscreteScheduler(
@@ -28,13 +25,6 @@ scheduler = LMSDiscreteScheduler(
 )
 
 scheduler.set_timesteps(1)
-
-
-def ttnn_to_torch(input):
-    input = ttnn.to_layout(input, ttnn.ROW_MAJOR_LAYOUT)
-    input = ttnn.from_device(input)
-    input = ttnn.to_torch(input)
-    return input
 
 
 def constant_prop_time_embeddings(timesteps, batch_size, time_proj):
@@ -57,7 +47,6 @@ def unsqueeze_all_params_to_4d(params):
     return params
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768}], ids=["device_params=l1_small_size_24576"], indirect=True
 )
@@ -170,5 +159,5 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
     second_iter = time.time() - second_iter
     print(f"Second iteration took {second_iter} seconds")
 
-    ttnn_output = ttnn_to_torch(ttnn_output)
+    ttnn_output = ttnn.to_torch(ttnn_output)
     assert_with_pcc(torch_output, ttnn_output, 0.996)

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -171,4 +171,4 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
     print(f"Second iteration took {second_iter} seconds")
 
     ttnn_output = ttnn_to_torch(ttnn_output)
-    assert_with_pcc(torch_output, ttnn_output, 0.99)
+    assert_with_pcc(torch_output, ttnn_output, 0.996)

--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -4,24 +4,21 @@
 
 import os
 import torch
-from diffusers import StableDiffusionPipeline
 import pytest
-from tqdm.auto import tqdm
 import time
+from tqdm.auto import tqdm
+from diffusers import LMSDiscreteScheduler, StableDiffusionPipeline
 
-from models.utility_functions import (
-    skip_for_grayskull,
-    comp_pcc,
-)
-from diffusers import LMSDiscreteScheduler
 import ttnn
 from ttnn.model_preprocessing import preprocess_model_parameters
 from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_preprocessor
-
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
     UNet2DConditionModel as UNet2D,
 )
-from ttnn import unsqueeze_to_4D
+from models.utility_functions import (
+    skip_for_grayskull,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 scheduler = LMSDiscreteScheduler(
     beta_start=0.00085,
@@ -55,7 +52,7 @@ def unsqueeze_all_params_to_4d(params):
         for i in range(len(params)):
             params[i] = unsqueeze_all_params_to_4d(params[i])
     elif isinstance(params, ttnn.Tensor):
-        params = unsqueeze_to_4D(params)
+        params = ttnn.unsqueeze_to_4D(params)
 
     return params
 
@@ -172,35 +169,6 @@ def test_unet_2d_condition_model_512x512(device, batch_size, in_channels, input_
     )
     second_iter = time.time() - second_iter
     print(f"Second iteration took {second_iter} seconds")
+
     ttnn_output = ttnn_to_torch(ttnn_output)
-
-    # times = []
-    # for i in range(50):
-    #     start = time.time()
-    #     ttnn_output = model(
-    #         input,
-    #         timestep=ttnn_timestep,
-    #         encoder_hidden_states=encoder_hidden_states,
-    #         class_labels=class_labels,
-    #         attention_mask=attention_mask,
-    #         cross_attention_kwargs=cross_attention_kwargs,
-    #         return_dict=return_dict,
-    #         config=config,
-    #     )
-    #     ttnn_output = ttnn_to_torch(ttnn_output)
-    #     passing, output = comp_pcc(torch_output, ttnn_output, pcc=0.99)
-    #     print(output)
-    #     end = time.time()
-    #     times.append(end - start)
-    #     print(f"Current iteration took {end - start} seconds")
-    # total_time = 0
-    # for iter in times:
-    #     total_time += iter
-    #     print(iter)
-    # print(f"Time taken for 50 iterations: {total_time}")
-    # print(f"Samples per second: {50 / total_time}")
-    passing, output = comp_pcc(torch_output, ttnn_output, pcc=0.981)
-    print(output)
-    assert passing
-
-    print("EXIT UNET-2D TEST")
+    assert_with_pcc(torch_output, ttnn_output, 0.99)

--- a/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attention.py
+++ b/models/demos/wormhole/stable_diffusion/tt/ttnn_functional_cross_attention.py
@@ -520,14 +520,13 @@ class cross_attention:
                 is_causal_mask=False,
             )
         else:
-            # This needs to be updated when optional output tensors are available
-            attention_scores_temp = attention_scores
-            attention_scores = ttnn.multiply(
-                attention_scores_temp,
+            attention_scores = ttnn.bcast(
+                attention_scores,
                 self.scale,
+                math_op=ttnn.BcastOpMath.MUL,
+                dim=ttnn.BcastOpDim.HW,
                 memory_config=attention_scores.memory_config(),
             )
-            attention_scores_temp.deallocate()
             attention_scores = ttnn.softmax_in_place(
                 attention_scores,
                 program_config=softmax_program_config,


### PR DESCRIPTION
### Ticket
#19677

### Problem description
`ttnn.multiply` calls `ttnn.repeat` under the hood to repeat dimensions higher than 2, however, repeat op returns output with half zeros.

### What's changed
- `ttnn.bcast` doesn't call `ttnn.repeat`, so using it instead.
- unet block 2d test is updated to check for 0.996 pcc, as this is needed for nice image outputs

### Checklist
- [WH] Models perf: https://github.com/tenstorrent/tt-metal/actions/runs/14079164190
- [WH] Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/14079160341
- [WH] Nightly model and ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/14080167237
- [BH] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/14079400383