### PR TITLE
Meshdevice reshape fix

### DIFF
--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -452,10 +452,17 @@ typename device_operation_t::tensor_return_value_t launch_on_multi_device(
     std::vector<tensor_return_value_t> outputs;
     outputs.reserve(num_shards);
 
-    for (auto shard_index = 0; shard_index < num_shards; shard_index++) {
-        auto device = storage.get_buffer_for_device_id(shard_index)->device();
-        auto shard_tensor_args = get_shard_tensor_args<device_operation_t>(shard_index, device, tensor_args);
+    for (int i = 0; i < storage.ordered_device_ids.size(); i++) {
+
+        auto device_id  =  storage.ordered_device_ids[i];
+
+
+        auto device = storage.get_buffer_for_device_id(device_id)->device();
+
+        auto shard_tensor_args = get_shard_tensor_args<device_operation_t>(i, device, tensor_args);
+
         outputs.push_back(launch_on_single_device<device_operation_t>(cq_id, operation_attributes, shard_tensor_args));
+
     }
 
     return make_tensor_return_value_from_shards(storage, outputs);

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -452,8 +452,8 @@ typename device_operation_t::tensor_return_value_t launch_on_multi_device(
     std::vector<tensor_return_value_t> outputs;
     outputs.reserve(num_shards);
 
-    for (const auto &[shard_index, buffer] : storage.buffers ) {
-        auto device = buffer->device();
+    for (auto shard_index = 0; shard_index < num_shards; shard_index++) {
+        auto device = storage.get_buffer_for_device_id(shard_index)->device();
         auto shard_tensor_args = get_shard_tensor_args<device_operation_t>(shard_index, device, tensor_args);
         outputs.push_back(launch_on_single_device<device_operation_t>(cq_id, operation_attributes, shard_tensor_args));
     }


### PR DESCRIPTION
###  #15422
Link to Github Issue : https://github.com/tenstorrent/tt-metal/issues/15422

### Problem description
Reshaping the tensor, which is currently in TILE_LAYOUT, is resulting in a low PCC value of -0.0015. So they cannot able switch the tensor to ROW_MAJOR_LAYOUT format because the subsequent operation is ttnn.linear, which specifically expects the tensor to remain in TILE_LAYOUT.

### What's changed
Iterated the storage.buffers using index from 0 to num_shards. Modified the device retrieval to use num_shards.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes