### PR TITLE
Add bfp8 support for ttnn.zeros

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -414,6 +414,6 @@ def test_empty_like_multi_device(mesh_device, input_shapes):
 
 
 @pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
-def test_zeros(device, input_shape, dtype):
+def test_zeros_bfp8(device, input_shape, dtype):
     tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -411,3 +411,9 @@ def test_empty_like_multi_device(mesh_device, input_shapes):
     output_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(output_tensor.cpu())]
     for output_tensor in output_tensors:
         assert list(torch_input_tensor.shape) == list(output_tensor.shape)
+
+
+@pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
+def test_zeros(device, input_shape, dtype):
+    tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+    assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -421,6 +421,6 @@ def test_zeros_bfp8(device, input_shape, dtype):
 
 @pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
 def test_zeros_bfp8(device, input_shape, dtype):
-    tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+    tensor = ttnn.zeros(input_shape, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
     assert tensor.storage_type() == ttnn.StorageType.DEVICE

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -415,12 +415,13 @@ def test_empty_like_multi_device(mesh_device, input_shapes):
 
 @pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
 def test_zeros_bfp8(device, input_shape, dtype):
-    tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+    tensor = ttnn.zeros(input_shape, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
+    assert tensor.storage_type() == ttnn.StorageType.DEVICE
 
 
-@pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
-def test_zeros_bfp8(device, input_shape, dtype):
+@pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat4_b), ((5, 96, 64), ttnn.bfloat4_b)])
+def test_zeros_bfp4(device, input_shape, dtype):
     tensor = ttnn.zeros(input_shape, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
     assert tensor.storage_type() == ttnn.StorageType.DEVICE

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -423,5 +423,5 @@ def test_zeros_bfp8(device, input_shape, dtype):
 @pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat4_b), ((5, 96, 64), ttnn.bfloat4_b)])
 def test_zeros_bfp4(device, input_shape, dtype):
     tensor = ttnn.zeros(input_shape, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT)
-    assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
+    assert tensor.dtype == ttnn.bfloat4_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
     assert tensor.storage_type() == ttnn.StorageType.DEVICE

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -414,6 +414,12 @@ def test_empty_like_multi_device(mesh_device, input_shapes):
 
 
 @pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
+def test_zeros(device, input_shape, dtype):
+    tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
+    assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
+
+
+@pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
 def test_zeros_bfp8(device, input_shape, dtype):
     tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -414,7 +414,7 @@ def test_empty_like_multi_device(mesh_device, input_shapes):
 
 
 @pytest.mark.parametrize("input_shape, dtype", [([32, 32], ttnn.bfloat8_b), ((5, 96, 64), ttnn.bfloat8_b)])
-def test_zeros(device, input_shape, dtype):
+def test_zeros_bfp8(device, input_shape, dtype):
     tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
 

--- a/tests/ttnn/unit_tests/operations/test_creation.py
+++ b/tests/ttnn/unit_tests/operations/test_creation.py
@@ -423,3 +423,4 @@ def test_zeros_bfp8(device, input_shape, dtype):
 def test_zeros_bfp8(device, input_shape, dtype):
     tensor = ttnn.zeros(input_shape, dtype=dtype, layout=ttnn.TILE_LAYOUT)
     assert tensor.dtype == ttnn.bfloat8_b, f"Expected dtype {dtype}, but got {tensor.dtype}"
+    assert tensor.storage_type() == ttnn.StorageType.DEVICE

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -122,11 +122,7 @@ static Tensor full_impl(
     std::fill(std::begin(owned_buffer), std::end(owned_buffer), value);
 
     if (!optional_output_tensor.has_value()) {
-        auto output = Tensor(
-            OwnedStorage{owned_buffer}, shape, data_type, layout);  // Issue lies in Converting the Buffer to Tensor
-
-        // Either the issue is with the OwnedStorage conversion??  or the Tensor doesn't handle the Bfloat8_b support??
-
+        auto output = Tensor(OwnedStorage{owned_buffer}, shape, data_type, layout);
         if (!devices.empty()) {
             output = output.to_device(devices, output_mem_config);
         }

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -122,7 +122,11 @@ static Tensor full_impl(
     std::fill(std::begin(owned_buffer), std::end(owned_buffer), value);
 
     if (!optional_output_tensor.has_value()) {
-        auto output = Tensor(OwnedStorage{owned_buffer}, shape, data_type, layout);
+        auto output = Tensor(
+            OwnedStorage{owned_buffer}, shape, data_type, layout);  // Issue lies in Converting the Buffer to Tensor
+
+        // Either the issue is with the OwnedStorage conversion??  or the Tensor doesn't handle the Bfloat8_b support??
+
         if (!devices.empty()) {
             output = output.to_device(devices, output_mem_config);
         }

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -159,10 +159,15 @@ inline ttnn::Tensor full_impl(
     const std::vector<IDevice*>& workers_to_use =
         optional_output_tensor.has_value() ? optional_output_tensor->get_workers(/*blocking=*/true) : workers;
 
-    Layout layout_value = optional_output_tensor.has_value() ? optional_output_tensor.value().get_layout()
-                                                             : layout.value_or(ttnn::ROW_MAJOR_LAYOUT);
     DataType dtype_value = optional_output_tensor.has_value() ? optional_output_tensor.value().get_dtype()
                                                               : dtype.value_or(DataType::BFLOAT16);
+    auto get_default_layout = [dtype_value]() {
+        return (dtype_value == DataType::BFLOAT4_B || dtype_value == DataType::BFLOAT8_B) ? ttnn::TILE_LAYOUT
+                                                                                          : ttnn::ROW_MAJOR_LAYOUT;
+    };
+
+    Layout layout_value = optional_output_tensor.has_value() ? optional_output_tensor.value().get_layout()
+                                                             : layout.value_or(get_default_layout());
     ttnn::Shape shape_value =
         optional_output_tensor.has_value() ? optional_output_tensor.value().get_logical_shape() : shape;
     MemoryConfig mem_cfg = optional_output_tensor.has_value() ? optional_output_tensor.value().memory_config()
@@ -179,10 +184,9 @@ inline ttnn::Tensor full_impl(
         case DataType::UINT32: return concrete_full.template operator()<uint32_t>(fill_value);
         case DataType::FLOAT32: return concrete_full.template operator()<float>(fill_value);
         case DataType::BFLOAT16: return concrete_full.template operator()<::bfloat16>(static_cast<float>(fill_value));
-
+        case DataType::BFLOAT4_B:
         case DataType::BFLOAT8_B: {
-             TensorSpec tensor_spec(
-                shape_value, TensorLayout(DataType::BFLOAT8_B, PageConfig(layout_value), mem_cfg));
+            TensorSpec tensor_spec(shape_value, TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg));
             std::vector<float> fill_value_vec(shape_value.volume(), static_cast<float>(fill_value));
             auto output = tt::tt_metal::Tensor::from_vector(std::move(fill_value_vec), tensor_spec);
             if (!workers_to_use.empty()) {


### PR DESCRIPTION
### 6185
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/6185

### Problem description
ttnn.zeros doesn't support for bfloat8 dtype

### What's changed
Added bfloat8 support for ttnn.zeros op

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes