### PR TITLE
Fix prepare_conv_weight() assert when number of channel tiles is not evenly divisible

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -58,6 +58,8 @@ import ttnn
         (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, False, None),  # r50 fourth bottleneck downsample shape
         # (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
         # (20, 128, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None),  ## L2M1 DS: doesn't fit
+        # formerly failing test case in segformer when ntiles_channels not evenly divisible with num_cores_c
+        (1, 640, 640, 32, 32, 3, 3, 1, 1, 1, 1, False, None),
     ),
 )
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
@@ -191,6 +193,8 @@ def test_prepare_conv_weights(
         (8, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
         (16, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
         (20, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
+        # formerly failing test case in segformer when ntiles_channels not evenly divisible with num_cores_c
+        (1, 640, 640, 32, 32, 3, 3, 1, 1, 1, 1, False, None),
     ),
 )
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -272,7 +272,7 @@ MemoryConfig create_sharded_memory_config_from_parallel_config(
         nhw_padded = round_up(nhw_shape, num_cores_nhw * tile_size);
     }
     uint32_t nhw_shard = nhw_padded / num_cores_nhw;
-    TT_ASSERT(channels % num_cores_channels == 0, "Channels: {}, num core channels: {}", channels, num_cores_channels);
+    TT_FATAL(channels % num_cores_channels == 0, "Channels: {}, num core channels: {}", channels, num_cores_channels);
     uint32_t channel_shard = channels / num_cores_channels;
     auto shard_spec = tt::tt_metal::ShardSpec{parallel_config.grid, {nhw_shard, channel_shard}, shard_orientation};
     log_debug("Calculated Shard Spec = {}", shard_spec);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -603,7 +603,6 @@ static OptimizedConvBlockConfig get_opt_block_config(
             true,
             conv_config.act_block_h_override);
     }
-
     auto output_parallel_config = parallel_config;
     if (conv_config.shard_layout.value() == ttnn::TensorMemoryLayout::WIDTH_SHARDED && !mm_conv) {
         uint32_t max_num_cores = compute_grid_size.x * compute_grid_size.y;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -603,6 +603,7 @@ static OptimizedConvBlockConfig get_opt_block_config(
             true,
             conv_config.act_block_h_override);
     }
+
     auto output_parallel_config = parallel_config;
     if (conv_config.shard_layout.value() == ttnn::TensorMemoryLayout::WIDTH_SHARDED && !mm_conv) {
         uint32_t max_num_cores = compute_grid_size.x * compute_grid_size.y;
@@ -618,7 +619,12 @@ static OptimizedConvBlockConfig get_opt_block_config(
 
     auto conv_out_memory_config = create_sharded_memory_config_from_parallel_config(
         ttnn::Shape(
-            {1, 1, batch_size * output_height * output_width, tt::round_up(out_channels, tt::constants::TILE_WIDTH)}),
+            {1,
+             1,
+             batch_size * output_height * output_width,
+             tt::round_up(
+                 out_channels,
+                 get_num_cores_channels_from_parallel_config(output_parallel_config) * tt::constants::TILE_WIDTH)}),
         output_parallel_config,
         tt::constants::TILE_HEIGHT);
     auto largest_parallel_config = output_parallel_config.grid.num_cores() > parallel_config.grid.num_cores()


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18942)

### Problem description
`determine_parallel_config `calculates the number of cores to shard the tensor on the channel axis by calling `find_closest_largest_divisor_with_num_padding`If the number of tiles is not evenly divisible to the cores it will round the number up first, but it will not update this information in the calling function `get_opt_block_config`, resulting in an assert when it later calls `create_sharded_memory_config_from_parallel_config` with incorrect parameters (due to number of cores not evenly dividing the number of input channels). `opt_block_config` seems to already account for this padding *after* this call.

### What's changed
- Made sure that the call to `create_sharded_memory_config_from_parallel_config` has properly rounded number of channels to both tile width and number of cores.
- Added test case to unit test

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes
- [x] [Nightly tt-metal L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes
- [x] [Nightly model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes
- [x] New/Existing tests provide coverage for changes