### PR TITLE
#6583: Fix acosh_bw

### DIFF
--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/acosh_bw/acosh_bw.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/acosh_bw/acosh_bw.py
@@ -87,7 +87,7 @@ def run(
     torch_input_tensor_a.requires_grad = True
 
     golden_function = ttnn.get_golden_function(ttnn.acosh_bw)
-    torch_output_tensor = golden_function(torch_grad_tensor, torch_input_tensor_a)[0]
+    torch_output_tensor = golden_function(torch_grad_tensor, torch_input_tensor_a, device=device)[0]
 
     grad_tensor = ttnn.from_torch(
         torch_grad_tensor,

--- a/tests/sweep_framework/sweeps/eltwise/unary_backward/acosh_bw/acosh_bw_sharded.py
+++ b/tests/sweep_framework/sweeps/eltwise/unary_backward/acosh_bw/acosh_bw_sharded.py
@@ -101,7 +101,7 @@ def run(
 
     torch_input_tensor.requires_grad = True
     golden_function = ttnn.get_golden_function(ttnn.acosh_bw)
-    torch_output_tensor = golden_function(torch_grad_tensor, torch_input_tensor)[0]
+    torch_output_tensor = golden_function(torch_grad_tensor, torch_input_tensor, device=device)[0]
 
     grad_tensor = ttnn.from_torch(
         torch_grad_tensor,

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acosh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acosh.py
@@ -12,6 +12,7 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 )
 
 
+# Test added for issue #6583
 @pytest.mark.parametrize(
     "in_val, grad_val",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acosh.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_acosh.py
@@ -5,7 +5,36 @@
 import torch
 import pytest
 import ttnn
-from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range, compare_pcc
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
+    data_gen_with_range,
+    compare_pcc,
+    compare_results,
+)
+
+
+@pytest.mark.parametrize(
+    "in_val, grad_val",
+    [
+        (1.0, 0.0),
+        (0.0, 1.0),
+        (0.5, 1.0),
+        (0.5, 0.5),
+        (1.0, 0.5),
+        (0.0, 0.0),
+    ],
+)
+def test_bw_acosh_edge_cases(in_val, grad_val, device):
+    in_data = (torch.ones(torch.Size([1, 1, 32, 32]), requires_grad=True) * in_val).bfloat16()
+    input_tensor = ttnn.Tensor(in_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    grad_data = (torch.ones(torch.Size([1, 1, 32, 32]), requires_grad=False) * grad_val).bfloat16()
+    grad_tensor = ttnn.Tensor(grad_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    tt_output_tensor_on_device = ttnn.acosh_bw(grad_tensor, input_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.acosh_bw)
+    golden_tensor = golden_function(grad_data, in_data, device=device)
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
 
 
 @pytest.mark.parametrize(
@@ -23,6 +52,6 @@ def test_bw_acosh(input_shapes, device):
     tt_output_tensor_on_device = ttnn.acosh_bw(grad_tensor, input_tensor)
 
     golden_function = ttnn.get_golden_function(ttnn.acosh_bw)
-    golden_tensor = golden_function(grad_data, in_data)
+    golden_tensor = golden_function(grad_data, in_data, device=device)
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -25,6 +25,7 @@
 #include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "tools/profiler/op_profiler.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
+#include <tt-metalium/hal.hpp>
 
 namespace ttnn::operations::unary_backward {
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -641,24 +641,41 @@ std::vector<Tensor> ExecuteUnaryBackwardCos::invoke(
 std::vector<Tensor> ExecuteUnaryBackwardAcosh::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor in_rsqrt = ttnn::square(input, output_mem_config);
-    in_rsqrt = ttnn::rsqrt(ttnn::subtract(in_rsqrt, 1.0, std::nullopt, output_mem_config), true, output_mem_config);
+    Tensor in_sq = ttnn::square(input, output_mem_config);
+    Tensor in_rsqrt = ttnn::rsqrt(ttnn::subtract(in_sq, 1.0, std::nullopt, output_mem_config), true, output_mem_config);
     Tensor grad_a = ttnn::multiply(grad, in_rsqrt, std::nullopt, output_mem_config);
-    float t_nan = std::nanf("");
-    float t_inf = std::numeric_limits<float>::infinity();
-    Tensor cond_result = ttnn::logical_or(
-        ttnn::lt(input, -1.0f, std::nullopt, output_mem_config),
-        ttnn::gt(input, 1.0f, std::nullopt, output_mem_config),
-        std::nullopt,
+    float t_nan = tt::tt_metal::hal::get_nan();
+    float t_inf = tt::tt_metal::hal::get_inf();
+
+    Tensor check_condition =
+        ttnn::multiply(ttnn::signbit(grad, output_mem_config), -1.0f, std::nullopt, output_mem_config);
+
+    grad_a = ttnn::where(
+        ttnn::logical_or(
+            ttnn::lt(in_sq, 1.0f, std::nullopt, output_mem_config),
+            ttnn::logical_and(
+                ttnn::eq(input, 1.0f, std::nullopt, output_mem_config),
+                ttnn::eqz(grad, output_mem_config),
+                std::nullopt,
+                output_mem_config),
+            std::nullopt,
+            output_mem_config),
+        t_nan,
+        ttnn::where(
+            ttnn::logical_and(
+                ttnn::le(input, 1.0f, std::nullopt, output_mem_config),
+                ttnn::ge(input, -1.0f, std::nullopt, output_mem_config),
+                std::nullopt,
+                output_mem_config),
+            ttnn::multiply(
+                ttnn::add(
+                    check_condition, ttnn::eqz(check_condition, output_mem_config), std::nullopt, output_mem_config),
+                t_inf,
+                std::nullopt,
+                output_mem_config),
+            grad_a,
+            output_mem_config),
         output_mem_config);
-    grad_a = ttnn::where(ttnn::eqz(cond_result, output_mem_config), t_nan, grad_a, output_mem_config);
-    cond_result = ttnn::logical_or(
-        ttnn::eq(input, -1.0f, std::nullopt, output_mem_config),
-        ttnn::eq(input, 1.0f, std::nullopt, output_mem_config),
-        std::nullopt,
-        output_mem_config);
-    grad_a =
-        ttnn::where(ttnn::eq(cond_result, 1.0f, std::nullopt, output_mem_config), t_inf, grad_a, output_mem_config);
     grad_tensor.emplace_back(grad_a);
     return grad_tensor;
 }

--- a/ttnn/ttnn/operations/unary_backward.py
+++ b/ttnn/ttnn/operations/unary_backward.py
@@ -313,13 +313,15 @@ def _golden_function(grad_tensor, input_tensor, *args, **kwargs):
 ttnn.attach_golden_function(ttnn.acos_bw, golden_function=_golden_function)
 
 
-def _golden_function_acosh(grad_tensor, input_tensor, *args, **kwargs):
+def _golden_function_acosh(grad_tensor, input_tensor, *args, device, **kwargs):
     import torch
 
     input_tensor.retain_grad()
     pyt_y = torch.acosh(input_tensor)
     pyt_y.backward(gradient=grad_tensor)
-    return [input_tensor.grad]
+    return [
+        torch.nan_to_num(input_tensor.grad, nan=device.sfpu_nan(), posinf=device.sfpu_inf(), neginf=-device.sfpu_inf())
+    ]
 
 
 ttnn.attach_golden_function(ttnn.acosh_bw, golden_function=_golden_function_acosh)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/6583

### Problem description
Acosh backward fails for edge cases when input, gradient is in range [0,1]

### What's changed

- Update `acosh_bw` Logic to match PyTorch API
- As mentioned [here](https://github.com/tenstorrent/tt-metal/pull/11243#discussion_r1808816083), used nan_to_num to compare Nan to numbers.
  - Test passes now in both BH , WH

Updated acosh backward logic vs current logic is as below :

<img width="635" alt="Screenshot 2025-03-27 at 6 32 02 PM" src="https://github.com/user-attachments/assets/12a2f660-5aa5-44d1-bf82-8f64038c9262" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14134224476) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14109838293) CI passes as in main
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/14164235499 CI passes for acosh_bw sweep test
- [x] https://github.com/tenstorrent/tt-metal/actions/runs/14164230219 CI passes for acosh_bw sharded sweep test