### PR TITLE
Add ttnn support for adaptiveavgpool1d and adaptiveavgpool2d ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_adaptive_avg_pool.py
+++ b/tests/ttnn/unit_tests/operations/test_adaptive_avg_pool.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+import torch
+import pytest
+import math
+from tests.ttnn.utils_for_testing import assert_with_pcc
+import ttnn
+
+
+shapes_and_output_sizes = [
+    ((1, 3, 8, 8), (4, 4)),
+    ((1, 3, 8, 16), (4, 8)),
+    ((1, 1, 10, 10), (5, 5)),
+    ((1, 3, 8, 8), (2, 2)),
+    ((1, 6, 64, 64), (16, 16)),
+    ((1, 3, 3, 3), (1, 1)),
+    ((1, 3, 7, 13), (3, 5)),
+    ((1, 4, 8, 16), (8, 8)),
+]
+
+
+@pytest.mark.parametrize("input_shape, output_size", shapes_and_output_sizes)
+def test_run_adaptive_avg_pool2d(device, input_shape, output_size):
+    dtype = ttnn.float32
+
+    torch.manual_seed(0)
+    torch_input_tensor = torch.randn(input_shape)
+    torch_output_tensor = torch.nn.functional.adaptive_avg_pool2d(torch_input_tensor, output_size)
+    torch_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, device=device)
+    output_tensor = ttnn.adaptive_avg_pool2d(input_tensor, ttnn.Shape(output_size))
+    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+    assert_with_pcc(torch_output_tensor, output_tensor)
+
+
+shapes_and_output_sizes_1d = [
+    ((1, 3, 8), (4,)),
+    ((1, 1, 10), (5,)),
+    ((2, 4, 16), (8,)),
+    ((3, 2, 12), (6,)),
+    ((1, 5, 20), (10,)),
+    ((4, 3, 15), (3,)),
+]
+
+
+@pytest.mark.parametrize("input_shape, output_size", shapes_and_output_sizes_1d)
+def test_run_adaptive_avg_pool1d(device, input_shape, output_size):
+    dtype = ttnn.float32
+
+    torch.manual_seed(0)
+    torch_input_tensor = torch.randn(input_shape)
+
+    torch_output_tensor = torch.nn.functional.adaptive_avg_pool1d(torch_input_tensor, output_size[0])
+    torch_input_tensor = torch.permute(torch_input_tensor, (0, 2, 1))
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, device=device)
+    output_tensor = ttnn.adaptive_avg_pool1d(input_tensor, ttnn.Shape(output_size))
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    output_tensor = torch.permute(output_tensor, (0, 2, 1))
+
+    assert_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/test_adaptive_avg_pool.py
+++ b/tests/ttnn/unit_tests/operations/test_adaptive_avg_pool.py
@@ -22,12 +22,11 @@ shapes_and_output_sizes = [
 ]
 
 
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize("input_shape, output_size", shapes_and_output_sizes)
-def test_run_adaptive_avg_pool2d(device, input_shape, output_size):
-    dtype = ttnn.float32
-
+def test_run_adaptive_avg_pool2d(device, input_shape, output_size, dtype):
     torch.manual_seed(0)
-    torch_input_tensor = torch.randn(input_shape)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
     torch_output_tensor = torch.nn.functional.adaptive_avg_pool2d(torch_input_tensor, output_size)
     torch_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, device=device)
@@ -47,10 +46,9 @@ shapes_and_output_sizes_1d = [
 ]
 
 
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize("input_shape, output_size", shapes_and_output_sizes_1d)
-def test_run_adaptive_avg_pool1d(device, input_shape, output_size):
-    dtype = ttnn.float32
-
+def test_run_adaptive_avg_pool1d(device, input_shape, output_size, dtype):
     torch.manual_seed(0)
     torch_input_tensor = torch.randn(input_shape)
 

--- a/tests/ttnn/unit_tests/operations/test_adaptive_avg_pool.py
+++ b/tests/ttnn/unit_tests/operations/test_adaptive_avg_pool.py
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
 # SPDX-License-Identifier: Apache-2.0
 
 from loguru import logger

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -48,6 +48,9 @@ public:
     bool operator==(const bfloat16 rhs) const { return uint16_data == rhs.uint16_data; }
     bool operator!=(const bfloat16 rhs) const { return not(*this == rhs); }
     bfloat16 operator*(const bfloat16 rhs) const { return bfloat16(this->to_float() * rhs.to_float()); }
+    bfloat16 operator+(const bfloat16 rhs) const { return bfloat16(this->to_float() + rhs.to_float()); }
+
+    bfloat16 operator/(int64_t rhs) const { return bfloat16(this->to_float() / static_cast<float>(rhs)); }
 };
 
 std::ostream& operator<<(std::ostream& os, const bfloat16& bfp16);

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -539,7 +539,6 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/generic_pools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device//upsample_bilinear_program_factory_multicore.cpp
@@ -952,6 +951,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_distributed_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/normalization/softmax/softmax_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/downsample/downsample_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/upsample_pybind.cpp

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -538,6 +538,8 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/generic_pools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device//upsample_bilinear_program_factory_multicore.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -42,6 +42,7 @@
 #include "ttnn/operations/pool/downsample/downsample_pybind.hpp"
 #include "ttnn/operations/pool/generic/generic_pools_pybind.hpp"
 #include "ttnn/operations/pool/global_avg_pool/global_avg_pool_pybind.hpp"
+#include "ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.hpp"
 #include "ttnn/operations/pool/upsample/upsample_pybind.hpp"
 #include "ttnn/operations/reduction/reduction_pybind.hpp"
 #include "ttnn/operations/sliding_window/sliding_window_pybind.hpp"
@@ -136,6 +137,7 @@ void py_module(py::module& module) {
     avgpool::py_module(m_pool);
     upsample::py_module(m_pool);
     downsample::py_bind_downsample(m_pool);
+    pool::py_bind_adaptive_avg_pool(m_pool);
 
     auto m_normalization = module.def_submodule("normalization", "normalization operations");
     normalization::py_module(m_normalization);

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "adaptive_avg_pool.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp"
+#include "cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
+
+namespace ttnn::operations::pool {
+
+ttnn::Tensor AdaptiveAvgPool2DOperation::invoke(
+    const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config) {
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "Input tensor must be on device");
+
+    auto input_mem_config = input.memory_config();
+    auto input_shape = input.get_logical_shape();
+    auto input_height = input_shape[-3];
+    auto input_width = input_shape[-2];
+    auto input_channels = input_shape[-1];
+
+    auto output_height = output_size[0];
+    auto output_width = output_size[1];
+    auto channels = input_channels;
+
+    auto output_shape = input_shape;
+    output_shape[-3] = output_height;
+    output_shape[-2] = output_width;
+
+    auto output_mem_config = mem_config.value_or(input_mem_config);
+    // create output tensor
+    auto output_tensor =
+        create_device_tensor(output_shape, input.get_dtype(), input.get_layout(), input.device(), output_mem_config);
+
+    std::vector<float> input_buffer(input.volume());
+    tt::tt_metal::tensor_impl::read_data_from_device_buffer<float>(
+        input.device()->command_queue(), input.device_buffer(), input_buffer.data(), true);
+
+    std::vector<float> output_buffer(output_tensor.volume(), 0.0f);
+
+    auto input_strides = input.strides();
+    auto output_strides = output_tensor.strides();
+    for (uint32_t n = 0; n < input_shape[0]; ++n) {
+        for (uint32_t oh = 0; oh < output_height; ++oh) {
+            int64_t ih0 = start_index(oh, output_height, input_height);
+            int64_t ih1 = end_index(oh, output_height, input_height);
+            int64_t kh = ih1 - ih0;
+
+            for (uint32_t ow = 0; ow < output_width; ++ow) {
+                int64_t iw0 = start_index(ow, output_width, input_width);
+                int64_t iw1 = end_index(ow, output_width, input_width);
+                int64_t kw = iw1 - iw0;
+                for (uint32_t c = 0; c < channels; ++c) {
+                    float sum = 0.0f;
+                    for (int64_t ih = ih0; ih < ih1; ++ih) {
+                        for (int64_t iw = iw0; iw < iw1; ++iw) {
+                            size_t input_idx = n * input_strides[0] + ih * input_strides[1] + iw * input_strides[2] + c;
+                            sum += input_buffer[input_idx];
+                        }
+                    }
+
+                    size_t output_idx = n * output_strides[0] + oh * output_strides[1] + ow * output_strides[2] + c;
+                    output_buffer[output_idx] = sum / kh / kw;
+                }
+            }
+        }
+    }
+
+    auto output_tensor_buffer = tt::tt_metal::owned_buffer::create<float>(output_buffer.size());
+    std::copy(output_buffer.begin(), output_buffer.end(), output_tensor_buffer.begin());
+
+    auto output_tensor_with_data =
+        Tensor(OwnedStorage{output_tensor_buffer}, output_shape, input.get_dtype(), input.get_layout());
+    if (input.device() != nullptr) {
+        output_tensor_with_data = output_tensor_with_data.to(input.device(), output_mem_config);
+    }
+
+    return output_tensor_with_data;
+}
+
+ttnn::Tensor AdaptiveAvgPool1DOperation::invoke(
+    const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config) {
+    auto input_tensor = ttnn::unsqueeze(input, 1);
+    ttnn::Shape out_size = {1, output_size[0]};
+    auto output_tensor = ttnn::adaptive_avg_pool2d(input_tensor, out_size, mem_config);
+    output_tensor = ttnn::squeeze(output_tensor, 1);
+    return output_tensor;
+}
+
+}  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
@@ -77,7 +77,7 @@ static ttnn::Tensor compute_adaptive_avg_pool(
 
     auto output = Tensor(OwnedStorage{owned_buffer}, output_shape, input.get_dtype(), input.get_layout());
     if (input.device() != nullptr) {
-        output = output.to(input.device(), output_mem_config);
+        output = output.to_device(input.device(), output_mem_config);
     }
 
     return output;
@@ -102,7 +102,7 @@ ttnn::Tensor AdaptiveAvgPool1DOperation::invoke(
     TT_FATAL(input_dims >= 2 && input_dims < 4, "Input tensor must have dimensions between 2 and 4");
     TT_FATAL(output_size.size() == 1, "Output size must be a 1D dimension");
     auto input_tensor = ttnn::unsqueeze(input, 1);
-    ttnn::Shape out_size = {1, output_size[0]};
+    ttnn::Shape out_size{1, output_size[0]};
     auto output_tensor = ttnn::adaptive_avg_pool2d(input_tensor, out_size, mem_config);
     output_tensor = ttnn::squeeze(output_tensor, 1);
     return output_tensor;

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.cpp
@@ -6,12 +6,19 @@
 #include "ttnn/operations/core/core.hpp"
 #include "cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp"
 #include "cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
-#include <ttnn/tensor/types.hpp>
 
 namespace ttnn::operations::pool {
 
+inline int64_t start_index(int64_t out_idx, int64_t out_size, int64_t in_size) {
+    return (out_idx * in_size) / out_size;
+}
+
+inline int64_t end_index(int64_t out_idx, int64_t out_size, int64_t in_size) {
+    return ((out_idx + 1) * in_size + out_size - 1) / out_size;
+}
+
 template <typename T>
-ttnn::Tensor compute_adaptive_avg_pool(
+static ttnn::Tensor compute_adaptive_avg_pool(
     const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config) {
     auto input_mem_config = input.memory_config();
     auto input_shape = input.get_logical_shape();

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
@@ -8,6 +8,8 @@
 
 namespace ttnn {
 namespace operations::pool {
+ttnn::Tensor compute_adaptive_avg_pool(
+    const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config);
 
 inline int64_t start_index(int64_t out_idx, int64_t out_size, int64_t in_size) {
     return (out_idx * in_size) / out_size;

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
@@ -8,17 +8,6 @@
 
 namespace ttnn {
 namespace operations::pool {
-ttnn::Tensor compute_adaptive_avg_pool(
-    const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config);
-
-inline int64_t start_index(int64_t out_idx, int64_t out_size, int64_t in_size) {
-    return (out_idx * in_size) / out_size;
-}
-
-inline int64_t end_index(int64_t out_idx, int64_t out_size, int64_t in_size) {
-    return ((out_idx + 1) * in_size + out_size - 1) / out_size;
-}
-
 struct AdaptiveAvgPool2DOperation {
     static ttnn::Tensor invoke(
         const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config);

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+namespace operations::pool {
+
+inline int64_t start_index(int64_t out_idx, int64_t out_size, int64_t in_size) {
+    return (out_idx * in_size) / out_size;
+}
+
+inline int64_t end_index(int64_t out_idx, int64_t out_size, int64_t in_size) {
+    return ((out_idx + 1) * in_size + out_size - 1) / out_size;
+}
+
+struct AdaptiveAvgPool2DOperation {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config);
+};
+
+struct AdaptiveAvgPool1DOperation {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input, const ttnn::Shape& output_size, const std::optional<MemoryConfig>& mem_config);
+};
+
+}  // namespace operations::pool
+
+constexpr auto adaptive_avg_pool2d =
+    ttnn::register_operation<"ttnn::adaptive_avg_pool2d", ttnn::operations::pool::AdaptiveAvgPool2DOperation>();
+
+constexpr auto adaptive_avg_pool1d =
+    ttnn::register_operation<"ttnn::adaptive_avg_pool1d", ttnn::operations::pool::AdaptiveAvgPool1DOperation>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "adaptive_avg_pool_pybind.hpp"
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "pybind11/decorators.hpp"
+#include "ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::pool {
+namespace detail {
+template <typename pool_operation_t>
+void bind_adaptive_avg_pool(pybind11::module& module, const pool_operation_t& operation, const char* doc) {
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const decltype(operation)& self,
+               const ttnn::Tensor& input,
+               const ttnn::Shape& output_size,
+               const std::optional<ttnn::MemoryConfig>& memory_config) {
+                return self(input, output_size, memory_config);
+            },
+            pybind11::arg("input").noconvert(),
+            pybind11::arg("output_size"),
+            pybind11::kw_only(),
+            pybind11::arg("memory_config") = std::nullopt});
+}
+}  // namespace detail
+
+void py_bind_adaptive_avg_pool(pybind11::module& module) {
+    detail::bind_adaptive_avg_pool(
+        module,
+        ttnn::adaptive_avg_pool2d,
+        R"doc(adaptive_avg_pool2d(input: ttnn.Tensor, output_size: ttnn.Shape) -> ttnn.Tensor
+        Applies a 2D adaptive average pooling operation on the input tensor.
+        Args:
+            * :attr:`input`: Input tensor.
+            * :attr:`output_size`: Target output size.
+            * :attr:`<optional> mem_config`.
+        )doc");
+
+    detail::bind_adaptive_avg_pool(
+        module,
+        ttnn::adaptive_avg_pool1d,
+        R"doc(adaptive_avg_pool1d(input: ttnn.Tensor, output_size: ttnn.Shape) -> ttnn.Tensor
+        Applies a 1D adaptive average pooling operation on the input tensor.
+        Args:
+            * :attr:`input`: Input tensor.
+            * :attr:`output_size`: Target output size.
+            * :attr:`<optional> mem_config`.
+        )doc");
+}
+}  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::pool {
+void py_bind_adaptive_avg_pool(pybind11::module& module);
+}  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/adaptive_avg_pool/adaptive_avg_pool_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
TTNN doesn't have support for adaptive average pool ops

### What's changed
Added ttnn support for adaptiveavgpool1d and adaptiveavgpool2d ops

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes