### PR TITLE
Added resnet50 perf tests for bh

### DIFF
--- a/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_device_resnet50.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from models.demos.ttnn_resnet.tests.perf_device_resnet50 import run_perf_device
+from models.utility_functions import run_for_blackhole
+
+
+@run_for_blackhole()
+@pytest.mark.models_device_performance_bare_metal
+@pytest.mark.parametrize(
+    "batch_size, test, expected_perf",
+    [
+        [16, "act_dtype0-weight_dtype0-math_fidelity0-16-device_params0", 10113.0],
+        [32, "act_dtype0-weight_dtype0-math_fidelity0-32-device_params0", 11842.0],
+    ],
+)
+def test_perf_device(batch_size, test, expected_perf):
+    command = (
+        f"pytest models/demos/blackhole/resnet50/tests/test_resnet50_performant.py::test_run_resnet50_inference[{test}]"
+    )
+    run_perf_device(batch_size, test, command, expected_perf)

--- a/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.utility_functions import run_for_blackhole
+from models.demos.ttnn_resnet.tests.perf_e2e_resnet50 import run_perf_resnet
+
+# These perf figures were measured on one of the machines in ird -
+# as e2e perf depends on the performance of the host machine,
+# these figures will be appropriately modified at the time of adding tests to CI
+
+
+@run_for_blackhole()
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, expected_inference_time, expected_compile_time",
+    (
+        (16, 0.006, 30),
+        (32, 0.0062, 30),
+    ),
+)
+def test_perf(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    model_location_generator,
+):
+    run_perf_resnet(
+        batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        device,
+        "resnet50",
+        model_location_generator,
+    )
+
+
+@run_for_blackhole()
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 5554176}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
+    (
+        (16, True, 0.002, 30),
+        (16, False, 0.002, 30),
+        (32, True, 0.0034, 30),
+        (32, False, 0.0034, 30),
+    ),
+    indirect=["enable_async_mode"],
+)
+def test_perf_trace(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    enable_async_mode,
+    model_location_generator,
+):
+    mode = "async" if enable_async_mode else "sync"
+    run_perf_resnet(
+        batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        device,
+        f"resnet50_trace_{mode}",
+        model_location_generator,
+    )
+
+
+@run_for_blackhole()
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, expected_inference_time, expected_compile_time",
+    (
+        (16, 0.06, 30),
+        (32, 0.06, 30),
+    ),
+)
+def test_perf_2cqs(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    model_location_generator,
+):
+    run_perf_resnet(
+        batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        device,
+        "resnet50_2cqs",
+        model_location_generator,
+    )
+
+
+@run_for_blackhole()
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 2777088}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.002, 30), (32, 0.003, 30)),
+)
+def test_perf_trace_2cqs(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    model_location_generator,
+):
+    run_perf_resnet(
+        batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        device,
+        "resnet50_trace_2cqs",
+        model_location_generator,
+    )

--- a/models/demos/blackhole/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/blackhole/resnet50/tests/test_resnet50_performant.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+
+from models.utility_functions import run_for_blackhole
+from models.demos.ttnn_resnet.tests.resnet50_performant import (
+    run_resnet50_inference,
+    run_resnet50_2cqs_inference,
+    run_resnet50_trace_inference,
+    run_resnet50_trace_2cqs_inference,
+)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("batch_size", (16, 32))
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype, math_fidelity",
+    ((ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+def test_run_resnet50_inference(
+    device, use_program_cache, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator
+):
+    run_resnet50_inference(device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 5554176}], indirect=True)
+@pytest.mark.parametrize("batch_size", (16, 32))
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype, math_fidelity",
+    ((ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
+def test_run_resnet50_trace_inference(
+    device,
+    use_program_cache,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    math_fidelity,
+    enable_async_mode,
+    model_location_generator,
+):
+    run_resnet50_trace_inference(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        model_location_generator,
+    )
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("batch_size", (16, 32))
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype, math_fidelity",
+    ((ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+def test_run_resnet50_2cqs_inference(
+    device, use_program_cache, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator
+):
+    run_resnet50_2cqs_inference(device, batch_size, act_dtype, weight_dtype, math_fidelity, model_location_generator)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 5554176, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize("batch_size", (16, 32))
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype, math_fidelity",
+    ((ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
+def test_run_resnet50_trace_2cqs_inference(
+    device,
+    use_program_cache,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    math_fidelity,
+    enable_async_mode,
+    model_location_generator,
+):
+    run_resnet50_trace_2cqs_inference(
+        device,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        model_location_generator,
+    )

--- a/models/demos/blackhole/resnet50/tests/test_resnet50_performant_imagenet.py
+++ b/models/demos/blackhole/resnet50/tests/test_resnet50_performant_imagenet.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+from loguru import logger
+
+from models.utility_functions import run_for_blackhole
+from models.demos.ttnn_resnet.tests.resnet50_performant_imagenet import ResNet50Trace2CQ
+from models.demos.ttnn_resnet.tests.demo_utils import get_data_loader, get_batch
+from transformers import AutoImageProcessor
+from models.utility_functions import (
+    profiler,
+)
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 5554176, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize("batch_size", (16, 32))
+@pytest.mark.parametrize(
+    "act_dtype, weight_dtype",
+    ((ttnn.bfloat8_b, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
+def test_run_resnet50_trace_2cqs_inference(
+    device,
+    use_program_cache,
+    batch_size,
+    imagenet_label_dict,
+    act_dtype,
+    weight_dtype,
+    enable_async_mode,
+    model_location_generator,
+):
+    profiler.clear()
+    with torch.no_grad():
+        resnet50_trace_2cq = ResNet50Trace2CQ()
+
+        profiler.start(f"compile")
+        resnet50_trace_2cq.initialize_resnet50_trace_2cqs_inference(
+            device,
+            batch_size,
+            act_dtype,
+            weight_dtype,
+        )
+        profiler.end(f"compile")
+        model_version = "microsoft/resnet-50"
+        iterations = 100
+        image_processor = AutoImageProcessor.from_pretrained(model_version)
+        input_loc = str(model_location_generator("ImageNet_data"))
+        data_loader = get_data_loader(input_loc, batch_size, iterations)
+
+        input_tensors_all = []
+        input_labels_all = []
+        for iter in range(iterations):
+            inputs, labels = get_batch(data_loader, image_processor)
+            input_tensors_all.append(inputs)
+            input_labels_all.append(labels)
+
+        correct = 0
+        profiler.start(f"run")
+        for iter in range(iterations):
+            predictions = []
+            inputs = input_tensors_all[iter]
+            labels = input_labels_all[iter]
+            ### TODO optimize input streamer for better e2e performance
+            tt_inputs_host = ttnn.from_torch(inputs, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+            output = resnet50_trace_2cq.execute_resnet50_trace_2cqs_inference(tt_inputs_host).to_torch().to(torch.float)
+            prediction = output[:, 0, 0, :].argmax(dim=-1)
+            for i in range(batch_size):
+                predictions.append(imagenet_label_dict[prediction[i].item()])
+                logger.info(
+                    f"Iter: {iter} Sample: {i} - Expected Label: {imagenet_label_dict[labels[i]]} -- Predicted Label: {predictions[-1]}"
+                )
+                if imagenet_label_dict[labels[i]] == predictions[-1]:
+                    correct += 1
+        profiler.end(f"run")
+        resnet50_trace_2cq.release_resnet50_trace_2cqs_inference()
+        accuracy = correct / (batch_size * iterations)
+        logger.info(f"=============")
+        logger.info(f"Accuracy for {batch_size}x{iterations} inputs: {accuracy}")
+
+        first_iter_time = profiler.get(f"compile")
+        # ensuring inference time fluctuations is not noise
+        inference_time_avg = profiler.get("run") / (iterations)
+
+        compile_time = first_iter_time - 2 * inference_time_avg
+    logger.info(
+        f"ttnn_{model_version}_batch_size{batch_size} tests inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
+    )
+    logger.info(f"ttnn_{model_version}_batch_size{batch_size} compile time: {compile_time}")


### PR DESCRIPTION
Added perf tests for resnet50 for bh, same ones as we have for wh_b0, with addition of batch=32 case. Please note that e2e perf figures were measured on one of the machines in ird - as e2e perf depends on the performance of the host machine, these figures will be appropriately modified at the time of adding tests to CI.