### PR TITLE
Add ttnn.cumprod scaffold

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -399,6 +399,7 @@ Reduction
    :nosignatures:
    :template: function.rst
 
+   ttnn.experimental.cumprod
    ttnn.max
    ttnn.mean
    ttnn.min

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import torch
+
+import ttnn
+
+
+@pytest.mark.parametrize("dim", [-10, -1, 0, 3, 10])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [],
+        [0],
+        [1],
+        [3, 3],
+        [16, 16],
+        [32, 32, 32],
+        [1, 0, 32, 32],
+        [1000, 32, 32],
+    ],
+)
+def test_cumprod_with_uint8(dim, shape, device):
+    torch.manual_seed(22041997)
+
+    input_tensor = torch.randint(0, 100, shape, dtype=torch.uint8)
+    result_tensor_torch = torch.cumprod(input_tensor, 0)
+    ttnn_tensor = ttnn.from_torch(input_tensor, ttnn.uint8, layout=ttnn.Layout.TILE, device=device)
+    result_tensor = ttnn.experimental.cumprod(ttnn_tensor, dim)
+
+    assert ttnn_tensor.shape == result_tensor.shape
+    assert ttnn_tensor.dtype == result_tensor.dtype
+    assert input_tensor.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == result_tensor.shape
+
+
+@pytest.mark.parametrize("dim", [-10, -1, 0, 3, 10])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [],
+        [0],
+        [1],
+        [3, 3],
+        [16, 16],
+        [32, 32, 32],
+        [1, 0, 32, 32],
+        [1000, 32, 32],
+    ],
+)
+def test_cumprod_with_bfloat16(dim, shape, device):
+    torch.manual_seed(22041997)
+
+    input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    result_tensor_torch = torch.cumprod(input_tensor, 0)
+    ttnn_tensor = ttnn.from_torch(input_tensor, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    result_tensor = ttnn.experimental.cumprod(ttnn_tensor, dim)
+
+    assert ttnn_tensor.shape == result_tensor.shape
+    assert ttnn_tensor.dtype == result_tensor.dtype
+    assert input_tensor.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == result_tensor.shape
+
+
+@pytest.mark.parametrize("dim", [-10, -1, 0, 3, 10])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [],
+        [0],
+        [1],
+        [3, 3],
+        [16, 16],
+        [32, 32, 32],
+        [1, 0, 32, 32],
+        [1000, 32, 32],
+    ],
+)
+def test_cumprod_with_bfloat16_and_preallocation(dim, shape, device):
+    torch.manual_seed(22041997)
+
+    input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    result_tensor_torch = torch.cumprod(input_tensor, 0)
+    ttnn_tensor = ttnn.from_torch(input_tensor, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    preallocated_tensor = ttnn.zeros_like(ttnn_tensor)
+    result_tensor = ttnn.experimental.cumprod(ttnn_tensor, dim, out=preallocated_tensor)
+
+    assert ttnn_tensor.shape == result_tensor.shape
+    assert ttnn_tensor.dtype == result_tensor.dtype
+    assert preallocated_tensor.shape == result_tensor.shape
+    assert preallocated_tensor.dtype == result_tensor.dtype
+    assert input_tensor.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == result_tensor.shape
+
+
+@pytest.mark.parametrize("dim", [-10, -1, 0, 3, 10])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        [],
+        [0],
+        [1],
+        [3, 3],
+        [16, 16],
+        [32, 32, 32],
+        [1, 0, 32, 32],
+        [1000, 32, 32],
+    ],
+)
+def test_cumprod_with_uint8_and_preallocation(dim, shape, device):
+    torch.manual_seed(22041997)
+
+    input_tensor = torch.randint(0, 100, shape, dtype=torch.uint8)
+    result_tensor_torch = torch.cumprod(input_tensor, 0)
+    ttnn_tensor = ttnn.from_torch(input_tensor, ttnn.uint8, layout=ttnn.Layout.TILE, device=device)
+    preallocated_tensor = ttnn.zeros_like(ttnn_tensor)
+    result_tensor = ttnn.experimental.cumprod(ttnn_tensor, dim, out=preallocated_tensor)
+
+    assert ttnn_tensor.shape == result_tensor.shape
+    assert ttnn_tensor.dtype == result_tensor.dtype
+    assert preallocated_tensor.shape == result_tensor.shape
+    assert preallocated_tensor.dtype == result_tensor.dtype
+    assert input_tensor.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == ttnn_tensor.shape
+    assert result_tensor_torch.shape == result_tensor.shape

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -428,6 +428,9 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
@@ -883,6 +886,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/paged_cache/paged_cache_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/plusone/plusone_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reshape/view_pybind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.hpp"
 #include "ttnn/operations/experimental/conv3d/conv3d_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/argmax/argmax_pybind.hpp"
+#include "ttnn/operations/experimental/reduction/cumprod/cumprod_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc_pybind.hpp"
 #include "ttnn/operations/experimental/slice_write/slice_write_pybind.hpp"
 #include "ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce_pybind.hpp"
@@ -76,6 +77,7 @@ void py_module(py::module& module) {
     cnn::detail::bind_convert_to_chw(module);
 
     ttnn::operations::experimental::conv3d::detail::py_bind_conv3d(module);
+    ttnn::operations::experimental::reduction::cumprod::detail::bind_cumprod_operation(module);
 
     copy::detail::py_bind_typecast(module);
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device/cumprod_device_operation.hpp"
+#include "cumprod.hpp"
+
+namespace ttnn::operations::experimental::reduction {
+
+Tensor CumprodOperation::invoke(
+    const Tensor& input_tensor,
+    const int32_t dim,
+    std::optional<Tensor> optional_out,
+    const std::optional<MemoryConfig>& memory_config,
+    const QueueId& queue_id) {
+    auto output_memory_config = optional_out.has_value() ? optional_out.value().memory_config()
+                                                         : memory_config.value_or(input_tensor.memory_config());
+    return ttnn::prim::cumprod(input_tensor, dim, optional_out, output_memory_config, queue_id);
+}
+
+}  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+namespace operations::experimental::reduction {
+
+struct CumprodOperation {
+    static Tensor invoke(
+        const Tensor& input_tensor,
+        const int32_t dim,
+        std::optional<Tensor> optional_out = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const QueueId& queue_id = DefaultQueueId);
+};
+
+}  // namespace operations::experimental::reduction
+
+namespace experimental {
+constexpr auto cumprod = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::experimental::cumprod",
+    ttnn::operations::experimental::reduction::CumprodOperation>();
+
+}  // namespace experimental
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod_pybind.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "cumprod_pybind.hpp"
+#include "ttnn/common/queue_id.hpp"
+
+namespace ttnn::operations::experimental::reduction::cumprod::detail {
+void bind_cumprod_operation(py::module& module) {
+    auto doc =
+        R"doc(
+
+            cumprod(input_tensor: ttnn.Tensor, dim: int) -> ttnn.Tensor
+
+            Returns a tensor witth cumulative product calculated along a given axis (`dim`).
+
+            Args:
+                input_tensor (ttnn.Tensor): the input tensor to calculate cumulative product of.
+                dim (int): axis of product cumulation.
+
+            Keyword Args:
+                queue_id (int, optional): command queue's ID, defaults to 0.
+                memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
+
+            Returns:
+                ttnn.Tensor: the output tensor (for now, it is a copy of input_tensor, because only scaffold is implemented).
+
+            Example:
+                >>> # return a ref
+
+                >>> tensor = ttnn.from_torch(torch.tensor((1, 2, 3), dtype=torch.bfloat16), device=device)
+                >>> # Note that the call below will output the same tensor it was fed for the time being,
+                >>> # until the actual implementation is provided.
+                >>> output = ttnn.experimental.cumprod(tensor, 1)
+                >>> assert tensor.shape == output.shape
+                >>> assert tensor.dtype == output.dtyoe
+
+                >>> # preallocation and return another ref
+
+                >>> tensor = ttnn.from_torch(torch.tensor((1, 2, 3), dtype=torch.uint8), device=device)
+                >>> # Note that the call below will output the same tensor it was fed for the time being,
+                >>> # until the actual implementation is provided.
+                >>> tensor_copy = ttnn.zeros_like(tensor)
+                >>> output = ttnn.experimental.cumprod(tensor, 1, out=tensor_copy)
+                >>> assert tensor.shape == output.shape
+                >>> assert tensor.dtype == output.dtype
+                >>> assert tensor.shape == output.shape
+                >>> assert tensor.dtype == output.dtyoe
+            )doc";
+
+    using OperationType = decltype(ttnn::experimental::cumprod);
+    bind_registered_operation(
+        module,
+        ttnn::experimental::cumprod,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const OperationType& self,
+               const ttnn::Tensor& input_tensor,
+               const int32_t dim,
+               std::optional<Tensor> optional_out,
+               const std::optional<MemoryConfig>& memory_config,
+               const QueueId& queue_id = DefaultQueueId) {
+                return self(input_tensor, dim, optional_out, memory_config, queue_id);
+            },
+            py::arg("input_tensor").noconvert(),
+            py::arg("dim"),
+            py::kw_only(),
+            py::arg("out") = std::nullopt,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("queue_id") = DefaultQueueId});
+}
+
+}  // namespace ttnn::operations::experimental::reduction::cumprod::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod_pybind.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "cpp/pybind11/decorators.hpp"
+
+#include "ttnn/operations/experimental/reduction/cumprod/cumprod.hpp"
+#include "ttnn/types.hpp"
+namespace ttnn::operations::experimental::reduction::cumprod::detail {
+
+void bind_cumprod_operation(py::module& module);
+
+}  // namespace ttnn::operations::experimental::reduction::cumprod::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_device_operation.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "cumprod_device_operation.hpp"
+#include "ttnn/common/queue_id.hpp"
+
+namespace ttnn::operations::experimental::reduction {
+
+// the result depends on tensor_args!
+CumprodDeviceOperation::program_factory_t CumprodDeviceOperation::select_program_factory(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return CumprodProgramFactory{};
+}
+
+void CumprodDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+
+void CumprodDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {}
+
+CumprodDeviceOperation::spec_return_value_t CumprodDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_out.has_value()) {
+        return tensor_args.optional_out->get_tensor_spec();
+    }
+
+    auto output_layout = Layout::TILE;
+    if (attributes.output_memory_config.is_sharded()) {
+        output_layout = tensor_args.input_tensor.get_layout();
+    }
+
+    const auto output_shape = tensor_args.input_tensor.logical_shape();
+    return TensorSpec(
+        output_shape,
+        TensorLayout(tensor_args.input_tensor.get_dtype(), output_layout, attributes.output_memory_config));
+}
+
+CumprodDeviceOperation::tensor_return_value_t CumprodDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.optional_out.has_value()) {
+        return *tensor_args.optional_out;  // a new Python reference to the same tensor is returned here
+    }
+    return create_device_tensor(
+        compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor.device());
+}
+
+CumprodDeviceOperation::invocation_result_t CumprodDeviceOperation::invoke(
+    const Tensor& input_tensor,
+    const int32_t dim,
+    std::optional<Tensor> optional_out,
+    const MemoryConfig& memory_config,
+    const QueueId& queue_id) {
+    return {operation_attributes_t{dim, memory_config}, tensor_args_t{input_tensor, std::move(optional_out)}};
+}
+
+}  // namespace ttnn::operations::experimental::reduction

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_device_operation.hpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/core.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn/decorators.hpp"
+
+namespace ttnn::operations::experimental::reduction {
+
+using tt::tt_metal::MemoryConfig;
+using tt::tt_metal::Tensor;
+using tt::tt_metal::TensorLayout;
+using tt::tt_metal::TensorSpec;
+
+struct CumprodDeviceOperation {
+    struct operation_attributes_t {
+        const int32_t dim;
+        const tt::tt_metal::MemoryConfig output_memory_config;
+    };
+
+    struct tensor_args_t {
+        const Tensor& input_tensor;
+        std::optional<Tensor> optional_out{std::nullopt};
+    };
+
+    using spec_return_value_t = ttnn::TensorSpec;
+
+    using tensor_return_value_t = Tensor;
+    struct CumprodProgramFactory {
+        struct shared_variables_t {
+            tt::tt_metal::KernelHandle unary_reader_kernel_id;
+            tt::tt_metal::KernelHandle unary_writer_kernel_id;
+            std::size_t num_cores;
+            std::size_t num_cores_y;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<CumprodProgramFactory>;
+
+    using invocation_result_t = std::tuple<operation_attributes_t, tensor_args_t>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    // Validate the operation when it creates a program. Usually will have more checks
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    // Validate the operation when it reuses a program. Usually will have less checks
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+
+    // Compute the output specs based on the operation attributes and tensor args
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    // Create the output tensors based on the operation attributes and tensor args
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static invocation_result_t invoke(
+        const Tensor& input_tensor,
+        const int32_t dim,
+        std::optional<Tensor> optional_out,
+        const MemoryConfig& memory_confi,
+        const QueueId& queue_id = DefaultQueueId);
+};
+
+}  // namespace ttnn::operations::experimental::reduction
+
+// Register the operation with the ttnn::register_operation API to make it available to the user as ttnn::prim::cumprod
+namespace ttnn::prim {
+constexpr auto cumprod = ttnn::
+    register_operation<"ttnn::prim::cumprod", ttnn::operations::experimental::reduction::CumprodDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/device/cumprod_program_factory.cpp
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "cumprod_device_operation.hpp"
+#include <tt-metalium/work_split.hpp>
+
+namespace ttnn::operations::experimental::reduction {
+CumprodDeviceOperation::CumprodProgramFactory::cached_program_t CumprodDeviceOperation::CumprodProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto& output_tensor = tensor_return_value;
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensor.buffer();
+
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
+    uint32_t single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
+    tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    uint32_t single_tile_size_output = tt::tt_metal::detail::TileSize(cb_data_format_output);
+
+    uint32_t num_tiles = input_tensor.volume() / tt::constants::TILE_HW;
+
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
+
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t num_input_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    uint32_t output_cb_index = tt::CBIndex::c_2;
+    uint32_t num_output_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * single_tile_size_output, {{output_cb_index, cb_data_format_output}})
+            .set_page_size(output_cb_index, single_tile_size_output);
+    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram};
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM ? 1 : 0;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
+        num_tiles_per_core_group_1,  // per_core_block_cnt
+        1                            // per_core_block_size
+    };
+
+    bool math_approx_mode = false;
+    auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp",
+        core_group_1,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args_group_1});
+
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = {
+            num_tiles_per_core_group_2,  // per_core_block_cnt
+            1                            // per_core_block_size
+        };
+
+        auto eltwise_unary_kernel_group_2_id = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/eltwise_sfpu.cpp",
+            core_group_2,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = compute_kernel_args_group_2});
+    }
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_tiles_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_reader_kernel_id, core, {src_buffer->address(), num_tiles_per_core, num_tiles_written});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    return {
+        std::move(program),
+        {.unary_reader_kernel_id = unary_reader_kernel_id,
+         .unary_writer_kernel_id = unary_writer_kernel_id,
+         .num_cores = num_cores,
+         .num_cores_y = num_cores_y}};
+}
+
+// TODO(jbbieniek): inspect (and refine?)
+void CumprodDeviceOperation::CumprodProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& program = cached_program.program;
+    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    auto& num_cores = cached_program.shared_variables.num_cores;
+    auto& num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    const auto& input_tensor = tensor_args.input_tensor;
+    auto& output_tensor = tensor_return_value;
+
+    auto src_buffer = input_tensor.buffer();
+    auto dst_buffer = output_tensor.buffer();
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    }
+}
+}  // namespace ttnn::operations::experimental::reduction


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19549

### Problem description
Implement scaffold in terms of `ttnn.cumprod` device operation. It returns the same tensor it was supplied with the same size and dtype. The full implementation will be provided later. 

### What's changed
- The approach used to add `ttnn.cumprod` is derived from https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/adding_new_ttnn_operation.html.
- There is a `test_cumprod.py` Pytest UT added.

(links to pipelines incoming)
### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [X] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [X] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [X] New/Existing tests provide coverage for changes