### PR TITLE
[skip ci] Migrate Single-card Device-perf to Ubuntu 22.04

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -6,7 +6,7 @@ on:
       os:
         required: false
         type: string
-        default: "ubuntu-20.04"
+        default: "ubuntu-22.04"
       docker-image:
         required: true
         type: string

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -12,6 +12,7 @@ jobs:
     with:
       tracy: true
       build-wheel: true
+      version: 22.04
     secrets: inherit
   device-perf:
     needs: build-artifact-profiler


### PR DESCRIPTION
### Problem description
Ubuntu 20.04 will not be supported in a few days.

### What's changed
Single-card Device-perf workflow updated to build on Ubuntu 22.04

### Checklist
- [Y] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14085942082) CI passes (if applicable)
- [Y] New/Existing tests provide coverage for changes