### PR TITLE
Enable upsample and downsample tests for BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_downsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_downsample.py
@@ -7,12 +7,11 @@ import math
 from loguru import logger
 
 import ttnn
-from models.utility_functions import skip_for_blackhole, _nearest_y
+from models.utility_functions import is_blackhole, _nearest_y
 import torch
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, stride_h, stride_w, num_cores, grid_size, height_sharded",
@@ -44,6 +43,8 @@ def test_run_downsample(
     height_sharded,
     dtype,
 ):
+    if dtype == ttnn.bfloat8_b and is_blackhole():
+        pytest.skip("Temporary skip until #18643 is not closed")
     if batch_size > 8 and dtype != ttnn.bfloat8_b:
         pytest.skip("Batch > 8 must be run fully bfp8")
     compute_grid_size = device.compute_with_storage_grid_size()

--- a/tests/ttnn/unit_tests/operations/pool/test_upsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_upsample.py
@@ -10,7 +10,7 @@ from typing import Union, Tuple
 import torch
 import torch.nn as nn
 import ttnn
-from models.utility_functions import skip_for_grayskull, skip_for_blackhole, is_grayskull
+from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
 
 
@@ -127,8 +127,6 @@ def test_upsample_single_core(device, input_shapes, scale_h, scale_w):
 def test_upsample_multi_core(device, input_shape, scale_h, scale_w, shard_strategy, shard_orientation):
     if (shard_strategy == ttnn.ShardStrategy.BLOCK) and (shard_orientation == ttnn.ShardOrientation.COL_MAJOR):
         pytest.skip("Disabled until illegal shard configs are fixed (#17795)")
-    if is_grayskull() and (scale_h > 2 or scale_w > 2):
-        pytest.skip("Skipping test because it won't fit in L1!")
 
     ## input shape is N C H W
     batch_size, num_channels, height, width = input_shape
@@ -238,8 +236,7 @@ def test_upsample_multi_core(device, input_shape, scale_h, scale_w, shard_strate
     assert isequal
 
 
-@skip_for_grayskull()
-@skip_for_blackhole()
+@skip_for_blackhole("Temporary skip until #18200 is not closed")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, num_channels, height, width, scale_h, scale_w",


### PR DESCRIPTION
Enable upsample and downsample UTs for BH by removing `skip_for_blackhole`, and remove grayskull checks as it is deprecated.