### PR TITLE
general CCL optimizations for some Llama ops

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -8,15 +8,15 @@ from loguru import logger
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf_detailed
 
-THRESHOLD = 1.5
+THRESHOLD = 0.7
 
 
 @pytest.mark.parametrize(
     "ag_type, warmup_iters, perf_target_us",
     [
-        ("sdpa", 15, 12.0),
+        ("sdpa", 15, 8.95),
         ("binary_mult", 15, 12.9),
-        ("layernorm", 15, 8.5),
+        ("layernorm", 15, 6.26),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
@@ -70,10 +70,10 @@ def test_ag_tg_llama_perf(
 @pytest.mark.parametrize(
     "ar_type, warmup_iters, perf_target_us",
     [
-        ("ff2", 15, 21),
-        ("qkv", 15, 13),
-        ("ff1", 15, 22),
-        ("lm_head", 15, 70),
+        ("ff2", 15, 17.6),
+        ("qkv", 15, 11.54),
+        ("ff1", 15, 18.0),
+        ("lm_head", 15, 58.4),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
@@ -119,6 +119,6 @@ def test_ar_tg_llama_perf(
         ml_model_name="llama70b-tg-ccl",
     )
 
-    assert (
-        measured_avg_us < perf_target_us + THRESHOLD
+    assert measured_avg_us < perf_target_us * (
+        1 + (THRESHOLD_PERCENT / 100)
     ), f"Performance target not met: {measured_avg_us} us > {perf_target_us} us"

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -15,7 +15,7 @@ THRESHOLD = 0.7
     "ag_type, warmup_iters, perf_target_us",
     [
         ("sdpa", 15, 8.95),
-        ("binary_mult", 15, 12.9),
+        ("binary_mult", 15, 10.07),
         ("layernorm", 15, 6.26),
     ],
 )

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -119,6 +119,6 @@ def test_ar_tg_llama_perf(
         ml_model_name="llama70b-tg-ccl",
     )
 
-    assert measured_avg_us < perf_target_us * (
-        1 + (THRESHOLD_PERCENT / 100)
+    assert (
+        measured_avg_us < perf_target_us + THRESHOLD
     ), f"Performance target not met: {measured_avg_us} us > {perf_target_us} us"

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -8,15 +8,15 @@ from loguru import logger
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf_detailed
 
-THRESHOLD = 0.7
+THRESHOLD = 0.4
 
 
 @pytest.mark.parametrize(
     "ag_type, warmup_iters, perf_target_us",
     [
-        ("sdpa", 15, 8.95),
-        ("binary_mult", 15, 10.07),
-        ("layernorm", 15, 6.26),
+        ("sdpa", 15, 9.49),
+        ("binary_mult", 15, 10.54),
+        ("layernorm", 15, 6.47),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
@@ -70,10 +70,10 @@ def test_ag_tg_llama_perf(
 @pytest.mark.parametrize(
     "ar_type, warmup_iters, perf_target_us",
     [
-        ("ff2", 15, 17.6),
-        ("qkv", 15, 11.54),
-        ("ff1", 15, 18.0),
-        ("lm_head", 15, 58.4),
+        ("ff2", 15, 18.6),
+        ("qkv", 15, 11.9),
+        ("ff1", 15, 19.2),
+        ("lm_head", 15, 61.8),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp
@@ -44,6 +44,7 @@ public:
         }
     }
 
+    template <bool connect = false, bool wait_for_connection_open_finish = false>
     static FabricConnectionManager build_from_args(std::size_t& arg_idx) {
         FabricConnectionManager connection_manager;
         connection_manager.connection_flags = static_cast<uint8_t>(get_arg_val<uint32_t>(arg_idx++) != 0)
@@ -51,14 +52,38 @@ public:
         if (connection_manager.has_forward_connection()) {
             connection_manager.forward_fabric_sender =
                 tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+            if constexpr (connect) {
+                connection_manager.forward_fabric_sender.open_start();
+            }
         }
         connection_manager.connection_flags |= static_cast<uint8_t>(get_arg_val<uint32_t>(arg_idx++) != 0)
                                                << BACKWARD_CONNECTION_FLAG_OFFSET;
         if (connection_manager.has_backward_connection()) {
             connection_manager.backward_fabric_sender =
                 tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
+            if constexpr (connect) {
+                connection_manager.backward_fabric_sender.open_start();
+            }
+        }
+
+        if constexpr (connect && wait_for_connection_open_finish) {
+            if (connection_manager.has_forward_connection()) {
+                connection_manager.forward_fabric_sender.open_finish();
+            }
+            if (connection_manager.has_backward_connection()) {
+                connection_manager.backward_fabric_sender.open_finish();
+            }
         }
         return connection_manager;
+    }
+
+    inline void open_finish() {
+        if (has_forward_connection()) {
+            forward_fabric_sender.open_finish();
+        }
+        if (has_backward_connection()) {
+            backward_fabric_sender.open_finish();
+        }
     }
 
     tt::tt_fabric::WorkerToFabricEdmSender& get_forward_connection() {

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp
@@ -15,20 +15,32 @@ public:
     // make the connection live
     inline void open() {
         if (has_forward_connection()) {
-            forward_fabric_sender.open();
+            forward_fabric_sender.open_start();
         }
         if (has_backward_connection()) {
-            backward_fabric_sender.open();
+            backward_fabric_sender.open_start();
+        }
+        if (has_forward_connection()) {
+            forward_fabric_sender.open_finish();
+        }
+        if (has_backward_connection()) {
+            backward_fabric_sender.open_finish();
         }
     }
     inline bool has_forward_connection() const { return connection_flags & FORWARD_CONNECTION_FLAG_MASK; }
     inline bool has_backward_connection() const { return connection_flags & BACKWARD_CONNECTION_FLAG_MASK; }
     inline void close() {
         if (has_forward_connection()) {
-            forward_fabric_sender.close();
+            forward_fabric_sender.close_start();
         }
         if (has_backward_connection()) {
-            backward_fabric_sender.close();
+            backward_fabric_sender.close_start();
+        }
+        if (has_forward_connection()) {
+            forward_fabric_sender.close_finish();
+        }
+        if (has_backward_connection()) {
+            backward_fabric_sender.close_finish();
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -52,7 +52,8 @@ void kernel_main() {
     tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
     size_t arg_for_fab = arg_idx;
-    auto fabric_connection = FabricConnectionManager::build_from_args(arg_idx);
+    constexpr bool connect_to_fabric_when_creating = true;
+    auto fabric_connection = FabricConnectionManager::build_from_args<connect_to_fabric_when_creating, false>(arg_idx);
 
     DPRINT << "ct args: \n";
     DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";
@@ -112,7 +113,8 @@ void kernel_main() {
     pkt_hdr_backward->to_chip_multicast(
         tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
 
-    fabric_connection.open();
+    // fabric_connection.open();
+    fabric_connection.open_finish();
 
     // 1. mcast via fabric to remote tensor addresses
     uint32_t tiles_read = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -53,7 +53,9 @@ void kernel_main() {
     arg_idx += num_cores;
     size_t arg_for_fab = arg_idx;
     constexpr bool connect_to_fabric_when_creating = true;
-    auto fabric_connection = FabricConnectionManager::build_from_args<connect_to_fabric_when_creating, false>(arg_idx);
+    auto fabric_connection =
+        FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
+            arg_idx);
 
     DPRINT << "ct args: \n";
     DPRINT << "my_chip_id: " << (uint32_t)my_chip_id << "\n";

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -112,9 +112,7 @@ void kernel_main() {
     pkt_hdr_backward->to_chip_multicast(
         tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
 
-    if (fabric_connection.is_logically_connected()) {
-        fabric_connection.open();
-    }
+    fabric_connection.open();
 
     // 1. mcast via fabric to remote tensor addresses
     uint32_t tiles_read = 0;
@@ -181,6 +179,7 @@ void kernel_main() {
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
+    fabric_connection.close();
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
@@ -198,10 +197,6 @@ void kernel_main() {
         const uint64_t dest_noc_addr = get_noc_addr(my_x[0], my_y[0], out_ready_sem_bank_addr);
         noc_inline_dw_write(dest_noc_addr, 0);
         DPRINT << "reset done\n";
-    }
-
-    if (fabric_connection.is_logically_connected()) {
-        fabric_connection.close();
     }
 
     noc_async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -115,7 +115,6 @@ void kernel_main() {
     pkt_hdr_backward->to_chip_multicast(
         tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
 
-    // fabric_connection.open();
     fabric_connection.open_finish();
 
     // 1. mcast via fabric to remote tensor addresses

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -68,6 +68,9 @@ void kernel_main() {
     arg_idx += num_mcast_ranges;
 
     size_t arg_for_fab = arg_idx;
+    // Open the fabric connection at the same time we build but only start the "open" process and don't
+    // require it to finish before exiting because open_finish requires a barrier which can impact performance
+    // We do open_finish later - deferred as late as possible
     auto fabric_connection =
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
@@ -80,8 +83,6 @@ void kernel_main() {
     auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
     cb_push_back(reserved_packet_header_cb_id, 1);
     cb_reserve_back(reserved_packet_header_cb_id, 1);
-    // auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
-    // cb_push_back(reserved_packet_header_cb_id, 1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =


### PR DESCRIPTION
### What's changed
Applied some minor optimizations in all-gather an all-reduce kernels and updated perf bounds && thresholds for ops.

Deltas over perf thresholds in main are quite substantial but those numbers on main are slightly stale (and conservative). The PR is showing substantial improvement (e.g. >= 4us in some cases), but in reality the improvement was not that substantial due to outdated numbers. In practice, the real improvement is in the 500-1500ns range.


The following table shows the _real_ improvements (you may notice the "time before" here is lower than the targets listed in the tests before this PR.
## (IGNORE -- INVALID) Previous perf before and after 
| Op Instance | Time Before (us) | Time After (us) | ~Savings (us) |
|-|-|-|-|
| All-reduce ff2 | 18.156 | 17.6 | 0.550 |
| All-reduce ff1 | 18.667 | 18.0 | 0.667 |
| All-reduce qkv | 11.65 | 11.5 | 0.15 |
| all-reduce lm_head | 58.4 | 58.4 | No Change|
| all-gather sdpa | 10.1 | 8.95 | 1.105 |
| all-gather binary_mult | 12.9 | 10.07 | 2.2 |
| all-gather layernorm | 7.03 | 6.26 | 0.78 |

## Corrected perf before and after
| Op Instance | Time Before (us) | Time After (us) | ~Savings (us) |
|-|-|-|-|
| all-reduce ff1     | 19.8  | 19.18 | 0.620 |
| all-reduce ff2     | 19.49 | 18.55 | 0.851 |
| all-reduce qkv     | 12.2  | 11.9 | 0.3 |
| all-reduce lm_head | 62.15 | 61.82| 0.33 |
| all-gather binarymult   | 11.85 | 10.54 | 0.81 |
| all-gather layernorm   | 7.40  | 6.47 | 0.93 |
| all-gather sdpa    | 10.78 | 9.49  | 1.29 |


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/14088834759
- [ ] TG Model Perf: https://github.com/tenstorrent/tt-metal/actions/runs/14097133289
- [x] New/Existing tests provide coverage for changes