### PR TITLE
#19569: Account for heterogenous dispatch when caching mesh workloads

### DIFF
--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -4,12 +4,13 @@
 
 #pragma once
 
+#include <tt-metalium/program_cache.hpp>
+
 #include <memory>
 #include <optional>
 #include <functional>
 #include <concepts>
 #include <variant>
-#include <tt-metalium/program_cache.hpp>
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "tools/profiler/op_profiler.hpp"
 
@@ -103,7 +104,12 @@ struct MeshDeviceOperationAdapter {
         tt::tt_metal::distributed::MeshDevice* mesh_device,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
-        return compute_program_hash(attrs, tensor_args);
+        // Hash the program hash and the tensor coordinates the workload is targeting.
+        auto hash = compute_program_hash(attrs, tensor_args);
+        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args)) {
+            tt::utils::hash_combine(hash, coord);
+        }
+        return hash;
     }
 };
 


### PR DESCRIPTION
### Ticket
#19569

### Problem description
Mesh workloads are cached regardless of how they are distributed among devices.

### What's changed
Keep a rolling hash of mesh coordinates.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14090819218)
- [X] New/Existing tests provide coverage for changes
- [X] Ran T3K unit tests + model demos locally