### PR TITLE
#18485: skip failing tests for BH and remove WH arch checks

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_backward_embedding.py
+++ b/tests/ttnn/unit_tests/operations/test_backward_embedding.py
@@ -8,11 +8,11 @@ import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import skip_for_blackhole
 from loguru import logger
 
 
-@skip_for_grayskull()
+@skip_for_blackhole("Fails on BH. Issue #11816")
 @pytest.mark.parametrize(
     "batch_size, seq_len, embedding_dim, num_embeddings",
     [
@@ -68,7 +68,6 @@ def test_embedding_bw(input_dtype, output_dtype, batch_size, seq_len, embedding_
     assert comp_pass
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "batch_size, seq_len, embedding_dim, num_embeddings",
     [

--- a/tests/ttnn/unit_tests/operations/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/test_dropout.py
@@ -8,11 +8,11 @@ import pytest
 import ttnn
 import numpy as np
 from models.utility_functions import (
-    skip_for_grayskull,
+    skip_for_blackhole,
 )
 
 
-@skip_for_grayskull()
+@skip_for_blackhole("Fails on BH. Issue #19638")
 def test_dopout(device):
     t = torch.ones(
         (

--- a/tests/ttnn/unit_tests/operations/test_moreh_linear.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_linear.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc, skip_for_grayskull
+from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
 from loguru import logger
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
@@ -392,7 +392,7 @@ def test_moreh_linear_backward_enable_cache(shapes, device, use_program_cache):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
-@skip_for_grayskull("GS does not support fp32")
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shapes",
     (

--- a/tests/ttnn/unit_tests/operations/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/test_sampling.py
@@ -14,7 +14,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
     get_lib_dtype,
 )
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import skip_for_blackhole
 
 
 def check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, device, sub_core_grids):
@@ -121,7 +121,7 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
     )
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
+@skip_for_blackhole("Requires wormhole_b0 to run. Issue #19640")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -147,7 +147,6 @@ def test_sampling_callback(shape, k, p, seed, device, use_program_cache):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -21,10 +21,6 @@ void EmbeddingBackward::validate(const std::vector<Tensor> &input_tensors) const
     const auto &index_tensor_shape = index_tensor.get_padded_shape();
     const auto &grad_tensor_shape = grad_tensor.get_padded_shape();
 
-    TT_FATAL(
-        index_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0,
-        "Embedding backwards is only implemented for Wormhole!");
-
     TT_FATAL(index_tensor.get_layout() == Layout::ROW_MAJOR, "Error");
     TT_FATAL(
         index_tensor.get_dtype() == DataType::UINT32 or index_tensor.get_dtype() == DataType::BFLOAT16,

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -39,12 +39,6 @@ void DropoutDeviceOperation::validate_on_program_cache_miss(
         static_cast<int>(input_tensor.dtype()),
         static_cast<int>(output_datatype));
 
-    auto arch = input_tensor.device()->arch();
-    TT_FATAL(
-        arch == tt::ARCH::WORMHOLE_B0,
-        "Dropout operation is only supported on Wormhole. Device arch: {}",
-        magic_enum::enum_name(arch));
-
     TT_FATAL(
         input_tensor.storage_type() == StorageType::DEVICE,
         "Dropout operation requires input to be on Device. Input storage type: {}",


### PR DESCRIPTION
### Ticket
Link to Github Issue #18485

### Problem description
We're starting to run ttnn unit tests on BH weekly. Some tests fail. However, we'd like to keep the pipeline green while the tests are fixed.

### What's changed
- two tests have been skipped and will be fixed at a later time (issues have already been created).
- two tests have their arch checks removed since GS no longer exists and hopefully the tests will just work, although if they fail somewhere else that will be useful to know (see discussion in this PR), and now skips are added
- removed un-needed skip_for_grayskull calls

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14111625710
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes

Tested locally that the skips work. Unfortunately could not get a BH machine that was in a good state to test behaviour when arch is removed.