### PR TITLE
Make ttnn.squeeze great again: unify behavior with torch

### DIFF
--- a/tests/ttnn/unit_tests/test_print_tensor.py
+++ b/tests/ttnn/unit_tests/test_print_tensor.py
@@ -105,4 +105,4 @@ def test_print(device, dtype, layout, profile, deallocate):
 def test_print_0d(device):
     torch_tensor = torch.ones((), dtype=torch.bfloat16)
     tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
-    assert str(tensor) == "ttnn.Tensor([ 1.00000], shape=Shape([]), dtype=DataType::BFLOAT16, layout=Layout::TILE)"
+    assert str(tensor) == "ttnn.Tensor( 1.00000, shape=Shape([]), dtype=DataType::BFLOAT16, layout=Layout::TILE)"

--- a/tests/ttnn/unit_tests/test_squeeze.py
+++ b/tests/ttnn/unit_tests/test_squeeze.py
@@ -10,80 +10,111 @@ import ttnn
 
 
 @pytest.mark.parametrize(
-    "input_shape, dim",
+    "layout",
     [
-        ((1, 1, 1, 256), 2),
-        ((1, 1, 1, 256), -1),
-        ((1, 1, 1, 30), 2),
-        ((1, 1, 1, 30), -1),
-        ((1, 32, 16), 0),
-        ((1, 1, 24576), 0),
-        ((1, 19), 0),
-        ((19), 0),
-        ((1), 0),
-        ((), 0),
-        ((), -1),
-        ((1, 1, 480, 640), 1),
-        ((3, 1370, 1, 1, 1280), -2),
-        ((3, 197, 1, 1, 1024), -2),
-        ((3, 197, 1, 1, 768), -2),
-        ((3, 50, 1, 1, 1024), -2),
-        ((3, 50, 1, 1, 768), -2),
+        (ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.TILE_LAYOUT),
     ],
 )
-def test_squeeze(device, input_shape, dim):
-    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [
+        ((), 0),
+        ((), -1),
+        ((1), 0),
+        ((19), 0),
+        ((1, 19), 0),
+        ((1, 32, 16), 0),
+        ((1, 1, 24576), 0),
+        ((1, 1, 1, 30), 2),
+        ((1, 1, 1, 256), 2),
+        ((1, 1, 1, 30), -1),
+        ((1, 1, 1, 256), -1),
+        ((1, 1, 480, 640), 1),
+        ((3, 50, 1, 1, 768), -2),
+        ((3, 197, 1, 1, 768), -2),
+        ((3, 50, 1, 1, 1024), -2),
+        ((3, 197, 1, 1, 1024), -2),
+        ((3, 1370, 1, 1, 1280), -2),
+    ],
+)
+def test_squeeze(device, input_shape, dim, layout):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_squeeze_tensor = torch.squeeze(torch_input_tensor, dim)
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-    ttnn_output = ttnn.squeeze(input_tensor, dim)
-    torch_output_tensor = ttnn.to_torch(ttnn_output)
-    assert torch.allclose(torch_output_tensor, torch_squeeze_tensor)
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
+    tt_squeeze_tensor = ttnn.squeeze(tt_input_tensor, dim)
+    ttnn_squeeze_tensor = ttnn.to_torch(tt_squeeze_tensor)
+    assert ttnn_squeeze_tensor.shape == torch_squeeze_tensor.shape
+    assert torch.allclose(ttnn_squeeze_tensor, torch_squeeze_tensor)
 
 
+@pytest.mark.parametrize(
+    "layout",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.TILE_LAYOUT),
+    ],
+)
 @pytest.mark.parametrize(
     "input_shape",
     [
-        (1, 1, 1, 256),
-        (1, 32, 16),
-        (1, 1, 480, 640),
-        (3, 1, 1, 1, 1280),
         (),
         (1,),
         (1, 2),
+        (1, 32, 16),
+        (1, 1, 1, 256),
+        (1, 1, 480, 640),
+        (3, 1, 1, 1, 1280),
     ],
 )
-def test_squeeze_default(device, input_shape):
-    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+def test_squeeze_default(device, input_shape, layout):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_squeeze_tensor = torch.squeeze(torch_input_tensor)
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-    ttnn_output = ttnn.squeeze(input_tensor)
-    torch_output_tensor = ttnn.to_torch(ttnn_output)
-    assert torch.allclose(torch_output_tensor, torch_squeeze_tensor)
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
+    ttnn_squeeze_tensor = ttnn.squeeze(tt_input_tensor)
+    ttnn_squeeze_tensor = ttnn.to_torch(ttnn_squeeze_tensor)
+    assert ttnn_squeeze_tensor.shape == torch_squeeze_tensor.shape
+    assert torch.allclose(ttnn_squeeze_tensor, torch_squeeze_tensor)
 
 
 @pytest.mark.parametrize(
-    "input_shape, dims",
+    "layout",
     [
-        ((1, 1, 1, 256), [0, 1]),
-        ((1, 1, 480, 640), [0, 1]),
-        ((3, 1, 1, 1, 1280), [1, 2, 3]),
-        ((1, 1, 1, 256), [-4, -3]),
-        ((1, 1, 1, 256), []),
-        ((1,), [0]),
-        ((1, 2), [0]),
-        ((), []),
-        ((), [-1]),
+        (ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.TILE_LAYOUT),
     ],
 )
-def test_squeeze_multiple_dims(device, input_shape, dims):
-    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+@pytest.mark.parametrize(
+    "input_shape, dims",
+    [
+        ((), []),
+        ((), [-1]),
+        ((1,), [0]),
+        ((1, 2), [0]),
+        ((1, 1, 1, 256), []),
+        ((1, 1, 1, 256), [0, 1]),
+        ((1, 1, 1, 256), [-4, -3]),
+        ((1, 1, 480, 640), [0, 1]),
+        ((3, 1, 1, 1, 1280), [1, 2, 3]),
+    ],
+)
+def test_squeeze_multiple_dims(device, input_shape, dims, layout):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
     torch_squeeze_tensor = torch.squeeze(torch_input_tensor, list(dims))
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
-    input_tensor = ttnn.squeeze(input_tensor, list(dims))
-    torch_output_tensor = ttnn.to_torch(input_tensor)
-    assert torch.allclose(torch_output_tensor, torch_squeeze_tensor)
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
+    tt_squeeze_tensor = ttnn.squeeze(tt_input_tensor, list(dims))
+    tt_squeeze_tensor = ttnn.to_torch(tt_squeeze_tensor)
+    assert tt_squeeze_tensor.shape == torch_squeeze_tensor.shape
+    assert torch.allclose(tt_squeeze_tensor, torch_squeeze_tensor)
 
 
+@pytest.mark.parametrize(
+    "layout",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.TILE_LAYOUT),
+    ],
+)
 @pytest.mark.parametrize(
     "input_shape, dims, expected_exception",
     [
@@ -93,8 +124,33 @@ def test_squeeze_multiple_dims(device, input_shape, dims):
         ((1, 1, 1, 256), [0, -4], RuntimeError),  # Duplicate indices (positive and negative)
     ],
 )
-def test_squeeze_error_cases(device, input_shape, dims, expected_exception):
-    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
-    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+def test_squeeze_error_cases(device, input_shape, dims, expected_exception, layout):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
     with pytest.raises(expected_exception):
         ttnn.squeeze(input_tensor, dims)
+
+
+# This test verifies that padded_shape of tensor after squeezing is properly updated
+@pytest.mark.parametrize(
+    "layout",
+    [
+        (ttnn.ROW_MAJOR_LAYOUT),
+        (ttnn.TILE_LAYOUT),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_shape, dims",
+    [
+        ((1, 1, 1, 256), [0, 1]),
+        ((1, 1, 480, 640), [0]),
+        ((3, 1, 1, 1, 1280), [1, 2, 3]),
+    ],
+)
+def test_squeeze_padded_shape_integrity(device, input_shape, dims, layout):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    tt_input_tensor = ttnn.from_torch(torch_input_tensor, layout=layout, device=device)
+
+    tt_squeeze_tensor = ttnn.squeeze(tt_input_tensor, dims)
+    new_tensor = ttnn.empty(tt_squeeze_tensor.shape, layout=layout, device=device, dtype=ttnn.bfloat16)
+    assert tt_squeeze_tensor.padded_shape == new_tensor.padded_shape

--- a/tests/ttnn/unit_tests/test_squeeze.py
+++ b/tests/ttnn/unit_tests/test_squeeze.py
@@ -84,9 +84,6 @@ def test_squeeze_multiple_dims(device, input_shape, dims):
     assert torch.allclose(torch_output_tensor, torch_squeeze_tensor)
 
 
-# TODO: need test for error (out of range, duplication)
-
-
 @pytest.mark.parametrize(
     "input_shape, dims, expected_exception",
     [

--- a/tests/ttnn/unit_tests/test_squeeze.py
+++ b/tests/ttnn/unit_tests/test_squeeze.py
@@ -19,6 +19,10 @@ import ttnn
         ((1, 32, 16), 0),
         ((1, 1, 24576), 0),
         ((1, 19), 0),
+        ((19), 0),
+        ((1), 0),
+        ((), 0),
+        ((), -1),
         ((1, 1, 480, 640), 1),
         ((3, 1370, 1, 1, 1280), -2),
         ((3, 197, 1, 1, 1024), -2),
@@ -34,3 +38,66 @@ def test_squeeze(device, input_shape, dim):
     ttnn_output = ttnn.squeeze(input_tensor, dim)
     torch_output_tensor = ttnn.to_torch(ttnn_output)
     assert torch.allclose(torch_output_tensor, torch_squeeze_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 1, 1, 256),
+        (1, 32, 16),
+        (1, 1, 480, 640),
+        (3, 1, 1, 1, 1280),
+        (),
+        (1,),
+        (1, 2),
+    ],
+)
+def test_squeeze_default(device, input_shape):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    torch_squeeze_tensor = torch.squeeze(torch_input_tensor)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    ttnn_output = ttnn.squeeze(input_tensor)
+    torch_output_tensor = ttnn.to_torch(ttnn_output)
+    assert torch.allclose(torch_output_tensor, torch_squeeze_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dims",
+    [
+        ((1, 1, 1, 256), [0, 1]),
+        ((1, 1, 480, 640), [0, 1]),
+        ((3, 1, 1, 1, 1280), [1, 2, 3]),
+        ((1, 1, 1, 256), [-4, -3]),
+        ((1, 1, 1, 256), []),
+        ((1,), [0]),
+        ((1, 2), [0]),
+        ((), []),
+        ((), [-1]),
+    ],
+)
+def test_squeeze_multiple_dims(device, input_shape, dims):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    torch_squeeze_tensor = torch.squeeze(torch_input_tensor, list(dims))
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    input_tensor = ttnn.squeeze(input_tensor, list(dims))
+    torch_output_tensor = ttnn.to_torch(input_tensor)
+    assert torch.allclose(torch_output_tensor, torch_squeeze_tensor)
+
+
+# TODO: need test for error (out of range, duplication)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dims, expected_exception",
+    [
+        ((1, 1, 1, 256), [4], RuntimeError),  # Out of range positive index
+        ((1, 1, 1, 256), [-5], RuntimeError),  # Out of range negative index
+        ((1, 1, 1, 256), [0, 0], RuntimeError),  # Duplicate indices
+        ((1, 1, 1, 256), [0, -4], RuntimeError),  # Duplicate indices (positive and negative)
+    ],
+)
+def test_squeeze_error_cases(device, input_shape, dims, expected_exception):
+    torch_input_tensor = torch.rand(input_shape, dtype=torch.float32)
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    with pytest.raises(expected_exception):
+        ttnn.squeeze(input_tensor, dims)

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -52,7 +52,7 @@ ttnn::Tensor SqueezeOperation::invoke(
         if (dims.empty() || (dims.size() == 1 && (dims[0] == 0 || dims[0] == -1))) {
             return input_tensor;
         }
-        TT_FATAL(false, "Dimension out of range (expected to be of [0, -1], but got {})", dims[0]);
+        TT_THROW("Dimension out of range (expected to be of [-1, 0], but got {})", dims[0]);
     }
 
     for (size_t i = 0; i < dims.size(); ++i) {
@@ -63,7 +63,8 @@ ttnn::Tensor SqueezeOperation::invoke(
         }
         TT_FATAL(
             (dim >= 0) && (dim < input_tensor_rank),
-            "Dimension out of range (expected to be in range of [0,{}], but got {})",
+            "Dimension out of range (expected to be in range of [{},{}], but got {})",
+            -static_cast<std::ptrdiff_t>(input_tensor_rank),
             input_tensor_rank - 1,
             dim);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
@@ -44,7 +44,7 @@ ttnn::Tensor SqueezeOperation::invoke(
 
     std::vector<int> dims = parse_dim_argument(dim, input_tensor_rank);
 
-    // Sort the dimensions in descending order to avoid any issues with removing multiple dimensions
+    // Sort the dimensions in descending order to avoid issues with modifying new_shape in loop
     std::sort(dims.rbegin(), dims.rend());
 
     // Special ugly case for 0-ranked input

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
@@ -5,13 +5,14 @@
 #pragma once
 
 #include "ttnn/decorators.hpp"
+#include "tt-metalium/small_vector.hpp"
 
 namespace ttnn {
 namespace operations::data_movement {
 
 struct SqueezeOperation {
     // Note: dim is passed by non-const reference because it's convenient to modify it for processing
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, std::vector<int>& dim);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const ttnn::SmallVector<int>& dim);
     static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, int dim);
     static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
@@ -10,7 +10,10 @@ namespace ttnn {
 namespace operations::data_movement {
 
 struct SqueezeOperation {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor, const std::optional<std::variant<int, std::vector<int>>>& dim = std::nullopt);
     static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const int dim);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const std::vector<int>& dim);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,10 +10,10 @@ namespace ttnn {
 namespace operations::data_movement {
 
 struct SqueezeOperation {
-    static ttnn::Tensor invoke(
-        const ttnn::Tensor& input_tensor, const std::optional<std::variant<int, std::vector<int>>>& dim = std::nullopt);
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const int dim);
-    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const std::vector<int>& dim);
+    // Note: dim is passed by non-const reference because it's convenient to modify it for processing
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, std::vector<int>& dim);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, int dim);
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor);
 };
 
 }  // namespace operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
@@ -21,7 +21,7 @@ void bind_squeeze(pybind11::module& module, const data_movement_operation_t& ope
         operation,
         doc,
         ttnn::pybind_overload_t{
-            [](const data_movement_operation_t& self, const ttnn::Tensor& input_tensor, pybind11::object dim)
+            [](const data_movement_operation_t& self, const ttnn::Tensor& input_tensor, const pybind11::object& dim)
                 -> ttnn::Tensor {
                 if (dim.is_none()) {  // None
                     return self(input_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
@@ -22,11 +22,25 @@ void bind_squeeze(pybind11::module& module, const data_movement_operation_t& ope
         operation,
         doc,
         ttnn::pybind_overload_t{
-            [](const data_movement_operation_t& self, const ttnn::Tensor& input_tensor, const int dim) -> ttnn::Tensor {
-                return self(input_tensor, dim);
+            [](const data_movement_operation_t& self, const ttnn::Tensor& input_tensor, pybind11::object dim)
+                -> ttnn::Tensor {
+                if (dim.is_none()) {
+                    // Handle the case where dim is None (default behavior)
+                    return self(input_tensor);
+                } else if (pybind11::isinstance<pybind11::int_>(dim)) {
+                    // Handle the case where dim is a single integer
+                    return self(input_tensor, dim.cast<int>());
+                } else if (pybind11::isinstance<pybind11::list>(dim)) {
+                    // Handle the case where dim is a list of integers
+                    std::vector<int> dims = dim.cast<std::vector<int>>();
+                    return self(input_tensor, dims);
+                } else {
+                    throw std::invalid_argument("dim must be an int, a list of ints, or None");
+                }
             },
             py::arg("input_tensor"),
-            py::arg("dim")});
+            py::arg("dim") = pybind11::none()  // Default value is None
+        });
 }
 
 }  // namespace detail
@@ -37,7 +51,9 @@ void py_bind_squeeze(pybind11::module& module) {
         ttnn::squeeze,
         R"doc(squeeze(input_tensor: ttnn.Tensor,  dim: int) -> ttnn.Tensor
 
-        Returns a tensor squeezed at the specified dimension. Pytorch supports a tuple as well as a single scalar value for dim, currently our version only supports scalar values. We will address this in the future. If input_tensor.shape()[dim] is not 1, squeeze will be ignored for that shape.
+        Returns a tensor with the specified dimensions squeezed. If `dim` is not provided, all dimensions of size 1 will be squeezed. If `dim` is an integer, only the specified dimension will be squeezed. If `dim` is a list of integers, all specified dimensions will be squeezed.
+
+        If a specified dimension in `dim` does not have size 1, it will be ignored.
 
         Equivalent pytorch code:
 

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
@@ -28,7 +28,7 @@ void bind_squeeze(pybind11::module& module, const data_movement_operation_t& ope
                 } else if (pybind11::isinstance<pybind11::int_>(dim)) {  // int
                     return self(input_tensor, dim.cast<int>());
                 } else if (pybind11::isinstance<pybind11::list>(dim)) {  // List[int]
-                    auto dims = dim.cast<std::vector<int>>();
+                    auto dims = dim.cast<ttnn::SmallVector<int>>();
                     return self(input_tensor, dims);
                 } else {
                     throw std::invalid_argument("dim must be an int, a list of ints, or None");

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,6 @@
 
 #include "cpp/pybind11/decorators.hpp"
 #include "ttnn/operations/data_movement/squeeze/squeeze.hpp"
-#include "ttnn/types.hpp"
 
 namespace ttnn::operations::data_movement {
 
@@ -24,15 +23,12 @@ void bind_squeeze(pybind11::module& module, const data_movement_operation_t& ope
         ttnn::pybind_overload_t{
             [](const data_movement_operation_t& self, const ttnn::Tensor& input_tensor, pybind11::object dim)
                 -> ttnn::Tensor {
-                if (dim.is_none()) {
-                    // Handle the case where dim is None (default behavior)
+                if (dim.is_none()) {  // None
                     return self(input_tensor);
-                } else if (pybind11::isinstance<pybind11::int_>(dim)) {
-                    // Handle the case where dim is a single integer
+                } else if (pybind11::isinstance<pybind11::int_>(dim)) {  // int
                     return self(input_tensor, dim.cast<int>());
-                } else if (pybind11::isinstance<pybind11::list>(dim)) {
-                    // Handle the case where dim is a list of integers
-                    std::vector<int> dims = dim.cast<std::vector<int>>();
+                } else if (pybind11::isinstance<pybind11::list>(dim)) {  // List[int]
+                    auto dims = dim.cast<std::vector<int>>();
                     return self(input_tensor, dims);
                 } else {
                     throw std::invalid_argument("dim must be an int, a list of ints, or None");

--- a/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/squeeze/squeeze_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -375,7 +375,9 @@ void to_string_row_major(
     if (dim > 0 and outer_index > 0) {
         ss << spaces;
     }
-    ss << "[";
+    if (rank != 0) {
+        ss << "[";
+    }
     auto dimension_shortener = get_dimension_shortener(rank != 0 ? shape[-rank] : 1);
     for (std::size_t index = 0;
          dimension_shortener.print_parenthesis_and_advance_index_if_reached_half_of_max_and_check_if_loop_is_done(
@@ -398,7 +400,9 @@ void to_string_row_major(
         }
         print_trailing_comma(ss, index, rank != 0 ? shape[-rank] : 1, after_comma);
     }
-    ss << "]";
+    if (rank != 0) {
+        ss << "]";
+    }
 }
 
 template <typename BufferType>


### PR DESCRIPTION
### Ticket
Github Issue https://github.com/tenstorrent/tt-metal/issues/19746 

### Problem description
`ttnn.squeeze` doesn't support `dim=None` and `dim=[...]` cases, like [torch.squeeze](https://pytorch.org/docs/stable/generated/torch.squeeze.html) does.

### What's changed
- If `ttnn.squeeze` is not provided with dim (or dim=None explicitly), is squeezes all 1-sized dimensions
- if `ttnn.squeeze` is provided with list of dims, then it tries to squeeze those dimensions
- Added more checks to have similar errors to pytorch
- Added more tests (dim=None, dim=[...], errors) and extend shapes for available tests (0 rank handling)
- As a small bonus I fixed printing 0-ranked tensors

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14145537850)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) (https://github.com/tenstorrent/tt-metal/actions/runs/14145537850)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes