### PR TITLE
[skip ci] Convert Docker Release Image flow to build 22.04 image and use 22.04 wheel artifact

### DIFF
--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -8,6 +8,7 @@ jobs:
     secrets: inherit
     with:
       build-wheel: true
+      version: "22.04"
   create-image-tag-name:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -22,7 +22,7 @@ jobs:
   create-docker-release-image:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on:
       - ubuntu-latest
     outputs:
@@ -66,7 +66,7 @@ jobs:
     needs: create-docker-release-image
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         test_group:
           [
               {
@@ -113,7 +113,7 @@ jobs:
     needs: [smoke-test-docker-image, create-docker-release-image]
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on:
       - ubuntu-latest
     steps:

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 #############################################################
 
 # Accept an argument to specify the Ubuntu version
-ARG UBUNTU_VERSION=20.04
+ARG UBUNTU_VERSION=22.04
 FROM public.ecr.aws/ubuntu/ubuntu:${UBUNTU_VERSION} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Ticket

#19749

### Problem description

Ubuntun 20.04 is being deprecated and we need to migrate to a more recent version of Ubuntu.

### What's changed

There were already many areas of the workflow that were parametrized so the only differences was adjusting the parameters to the updated version value.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes