### PR TITLE
[skip ci] Change name of pipeline to reflect frequency

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -24,7 +24,7 @@ on:
       - "(Single-card) Demo tests"
       - "(Single-card) Tests for new models"
       - "(Single-card) Fast dispatch frequent tests"
-      - "(Single-card) Nightly model and ttnn tests"
+      - "(Single-card) Frequent model and ttnn tests"
       - "(T3K) T3000 demo tests"
       - "(T3K) T3000 frequent tests"
       - "(T3K) T3000 model perf tests"

--- a/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models.yaml
@@ -1,4 +1,4 @@
-name: "(Single-card) Nightly model and ttnn tests"
+name: "(Single-card) Frequent model and ttnn tests"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Ticket

### Problem description
The (Single-card) Nightly model and ttnn tests pipeline (https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) does not run nightly. It runs every 2 hours. Changing name to "Frequent" instead of "Nightly".

### What's changed


### Checklist