### PR TITLE
Expose approx mode on sigmoid.

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -41,6 +41,7 @@ def get_torch_act_func_from_string(act_string):
         "silu": torch.nn.functional.silu,
         "mish": torch.nn.functional.mish,
         "sigmoid": torch.nn.functional.sigmoid,
+        "sigmoid_approx": torch.nn.functional.sigmoid,
         "tanh": torch.nn.functional.tanh,
         "log": torch.log,
         "softplus": torch.nn.functional.softplus,
@@ -555,7 +556,7 @@ def test_conv_features_multi_device(
     ],
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.HiFi4])
-@pytest.mark.parametrize("activation", ["", "relu", "silu", "sigmoid", "tanh", "sqrt", "gelu"])
+@pytest.mark.parametrize("activation", ["", "relu", "silu", "sigmoid", "sigmoid_approx", "tanh", "sqrt", "gelu"])
 def test_conv_activation(
     device,
     torch_tensor_map,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -29,6 +29,22 @@ def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
+def run_unary_with_approx_mode_test(device, h, w, ttnn_function, approx_mode, pcc=0.9999):
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.rand((h, w), dtype=torch.bfloat16)
+    golden_function = ttnn.get_golden_function(ttnn_function)
+    torch_output_tensor = golden_function(torch_input_tensor, device=device)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn_function(input_tensor, fast_and_approximate_mode=approx_mode)
+    output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+
+
 def run_unary_test_fixed(device, h, w, fill_value, ttnn_function, pcc=0.9999):
     torch.manual_seed(0)
 
@@ -234,6 +250,13 @@ def test_atan(device, h, w):
 @pytest.mark.parametrize("w", [128])
 def test_sinh(device, h, w):
     run_unary_test(device, h, w, ttnn.sinh)
+
+
+@pytest.mark.parametrize("h", [2048 * 128])
+@pytest.mark.parametrize("w", [32])
+@pytest.mark.parametrize("approx_mode", [True, False])
+def test_sigmoid(device, h, w, approx_mode):
+    run_unary_with_approx_mode_test(device, h, w, ttnn.sigmoid, approx_mode=approx_mode, pcc=0.999)
 
 
 @pytest.mark.parametrize("h", [64])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_ops_ttnn.py
@@ -843,12 +843,16 @@ def test_unary_rsqrt_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_unary_sigmoid_ttnn(input_shapes, device):
+@pytest.mark.parametrize(
+    "approx_mode",
+    (False, True),
+)
+def test_unary_sigmoid_ttnn(input_shapes, device, approx_mode):
     in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
     cq_id = 0
-    ttnn.sigmoid(input_tensor, output_tensor=output_tensor, queue_id=cq_id)
+    ttnn.sigmoid(input_tensor, fast_and_approximate_mode=approx_mode, output_tensor=output_tensor, queue_id=cq_id)
     golden_tensor = torch.sigmoid(in_data)
 
     comp_pass = compare_pcc([output_tensor], [golden_tensor])

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -6,6 +6,7 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_sigmoid_appx.h"
 
 using namespace sfpi;
 
@@ -32,56 +33,62 @@ inline vFloat sigmoid_piecewise_linear_positive(vFloat val) {
 // sigmoid[-x] = 1 - sigmoid[x]
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_sigmoid() {
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-        vFloat result = 0.0f;
+    if constexpr (APPROXIMATION_MODE == false) {
+        for (int d = 0; d < ITERATIONS; d++) {
+            vFloat val = dst_reg[0];
+            vFloat result = 0.0f;
 
-        v_if(val < 0.0f) { val = -val; }
-        v_endif;
+            v_if(val < 0.0f) { val = -val; }
+            v_endif;
 
-        result = sigmoid_piecewise_linear_positive(val);
+            result = sigmoid_piecewise_linear_positive(val);
 
-        val = dst_reg[0];
-        v_if(val < 0.0f) { result = 1.0f - result; }
-        v_endif;
+            val = dst_reg[0];
+            v_if(val < 0.0f) { result = 1.0f - result; }
+            v_endif;
 
-        dst_reg[0] = result;
-        dst_reg++;
+            dst_reg[0] = result;
+            dst_reg++;
+        }
+    } else {
+        calculate_sigmoid_appx<ITERATIONS>();
     }
-
-    return;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
-    // imm0 = 0x3DFF;
-    // imm1 = 0x21D8;
-    // imm2 = 0xFF10;
-    // TTI_SFPLOADI(0, 2, imm0);
-    // TTI_SFPLOADI(1, 2, imm1);
-    // TTI_SFPLOADI(2, 2, imm2);
-    // Using a 6 piece LUT to calculate and model sigmoid  directly
-    // x <= 0.5 --> 0.2452x + (-0.0004997)
-    // x <= 1.0 --> 0.2173x + 0.0152
-    // x <= 1.5 --> 0.1731x + 0.05988
-    // x <= 2.0 --> 0.1262x + 0.1298
-    // x <= 4.0 --> 0.0485x + 0.2998
-    // x >  4.0 --> 0.4998
+    if constexpr (APPROXIMATION_MODE == false) {
+        // imm0 = 0x3DFF;
+        // imm1 = 0x21D8;
+        // imm2 = 0xFF10;
+        // TTI_SFPLOADI(0, 2, imm0);
+        // TTI_SFPLOADI(1, 2, imm1);
+        // TTI_SFPLOADI(2, 2, imm2);
+        // Using a 6 piece LUT to calculate and model sigmoid  directly
+        // x <= 0.5 --> 0.2452x + (-0.0004997)
+        // x <= 1.0 --> 0.2173x + 0.0152
+        // x <= 1.5 --> 0.1731x + 0.05988
+        // x <= 2.0 --> 0.1262x + 0.1298
+        // x <= 4.0 --> 0.0485x + 0.2998
+        // x >  4.0 --> 0.4998
 
-    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-    _sfpu_load_imm32_(0, 0x32F433D9);
-    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-    _sfpu_load_imm32_(4, 0x23C89018);
+        // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
+        _sfpu_load_imm32_(0, 0x32F433D9);
+        // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
+        _sfpu_load_imm32_(4, 0x23C89018);
 
-    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-    _sfpu_load_imm32_(1, 0x300A318A);
-    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-    _sfpu_load_imm32_(5, 0x30272BAA);
+        // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
+        _sfpu_load_imm32_(1, 0x300A318A);
+        // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
+        _sfpu_load_imm32_(5, 0x30272BAA);
 
-    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-    _sfpu_load_imm32_(2, 0x7C002A35);
-    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-    _sfpu_load_imm32_(6, 0x37ff34CC);
+        // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
+        _sfpu_load_imm32_(2, 0x7C002A35);
+        // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
+        _sfpu_load_imm32_(6, 0x37ff34CC);
+    } else {
+        sigmoid_appx_init();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -12,7 +12,7 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <int ITERATIONS = 8>
 inline void calculate_sigmoid_appx() {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
@@ -32,7 +32,6 @@ inline void calculate_sigmoid_appx() {
     l_reg[LRegs::LReg2] = l2;
 }
 
-template <bool APPROXIMATION_MODE>
 inline void sigmoid_appx_init() {
     uint imm0;
     uint imm1;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -14,13 +14,12 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx, APPROXIMATE>(sfpu::sigmoid_appx_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx, APPROXIMATE>(sfpu::sigmoid_appx_init);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_sigmoid_appx<APPROXIMATE>, dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid.h
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "noc_nonblocking_api.h"
+#include "ckernel_sfpu_sigmoid_appx.h"
 
 using namespace sfpi;
 
@@ -33,56 +34,62 @@ inline vFloat sigmoid_piecewise_linear_positive(vFloat val) {
 // sigmoid[-x] = 1 - sigmoid[x]
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_sigmoid() {
-    for (int d = 0; d < ITERATIONS; d++) {
-        vFloat val = dst_reg[0];
-        vFloat result = 0.0f;
+    if constexpr (APPROXIMATION_MODE == false) {
+        for (int d = 0; d < ITERATIONS; d++) {
+            vFloat val = dst_reg[0];
+            vFloat result = 0.0f;
 
-        v_if(val < 0.0f) { val = -val; }
-        v_endif;
+            v_if(val < 0.0f) { val = -val; }
+            v_endif;
 
-        result = sigmoid_piecewise_linear_positive(val);
+            result = sigmoid_piecewise_linear_positive(val);
 
-        val = dst_reg[0];
-        v_if(val < 0.0f) { result = 1.0f - result; }
-        v_endif;
+            val = dst_reg[0];
+            v_if(val < 0.0f) { result = 1.0f - result; }
+            v_endif;
 
-        dst_reg[0] = result;
-        dst_reg++;
+            dst_reg[0] = result;
+            dst_reg++;
+        }
+    } else {
+        calculate_sigmoid_appx<ITERATIONS>();
     }
-
-    return;
 }
 
 template <bool APPROXIMATION_MODE>
 inline void sigmoid_init() {
-    // imm0 = 0x3DFF;
-    // imm1 = 0x21D8;
-    // imm2 = 0xFF10;
-    // TTI_SFPLOADI(0, 2, imm0);
-    // TTI_SFPLOADI(1, 2, imm1);
-    // TTI_SFPLOADI(2, 2, imm2);
-    // Using a 6 piece LUT to calculate and model sigmoid  directly
-    // x <= 0.5 --> 0.2452x + (-0.0004997)
-    // x <= 1.0 --> 0.2173x + 0.0152
-    // x <= 1.5 --> 0.1731x + 0.05988
-    // x <= 2.0 --> 0.1262x + 0.1298
-    // x <= 4.0 --> 0.0485x + 0.2998
-    // x >  4.0 --> 0.4998
+    if constexpr (APPROXIMATION_MODE == false) {
+        // imm0 = 0x3DFF;
+        // imm1 = 0x21D8;
+        // imm2 = 0xFF10;
+        // TTI_SFPLOADI(0, 2, imm0);
+        // TTI_SFPLOADI(1, 2, imm1);
+        // TTI_SFPLOADI(2, 2, imm2);
+        // Using a 6 piece LUT to calculate and model sigmoid  directly
+        // x <= 0.5 --> 0.2452x + (-0.0004997)
+        // x <= 1.0 --> 0.2173x + 0.0152
+        // x <= 1.5 --> 0.1731x + 0.05988
+        // x <= 2.0 --> 0.1262x + 0.1298
+        // x <= 4.0 --> 0.0485x + 0.2998
+        // x >  4.0 --> 0.4998
 
-    // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
-    _sfpu_load_imm32_(0, 0x32F433D9);
-    // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
-    _sfpu_load_imm32_(4, 0x23C89018);
+        // imm0[15:0] = A0=0.2452 = 0x33D9 -- imm0[31:16] = A1=0.2173 = 0x32F4
+        _sfpu_load_imm32_(0, 0x32F433D9);
+        // imm4[15:0] = B0= -0.0004997  = 0x9018 -- imm4[31:16] = B1= 0.0152 = 0x23c8
+        _sfpu_load_imm32_(4, 0x23C89018);
 
-    // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
-    _sfpu_load_imm32_(1, 0x300A318A);
-    // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
-    _sfpu_load_imm32_(5, 0x30272BAA);
+        // imm1[15:0] = A2=0.1731 = 0x318a -- imm1[31:16] = A3=0.1262 = 0x300a
+        _sfpu_load_imm32_(1, 0x300A318A);
+        // imm5[15:0] = B2=0.05988 = 0x2BAA -- imm5[31:16] = B3=0.1298 = 0x3027
+        _sfpu_load_imm32_(5, 0x30272BAA);
 
-    // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
-    _sfpu_load_imm32_(2, 0x7C002A35);
-    // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
-    _sfpu_load_imm32_(6, 0x37ff34CC);
+        // imm2[15:0] = A4=0.0485 = 0x2A35 -- imm2[31:16] = A5=0.0 = 0x7C00
+        _sfpu_load_imm32_(2, 0x7C002A35);
+        // imm6[15:0] = B4=0.2998 = 0x34CC -- imm6[31:16] = B5=0.4998 = 0x37ff
+        _sfpu_load_imm32_(6, 0x37ff34CC);
+    } else {
+        sigmoid_appx_init();
+    }
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_sigmoid_appx.h
@@ -13,7 +13,7 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <int ITERATIONS = 8>
 inline void calculate_sigmoid_appx() {
     vUInt l0 = l_reg[LRegs::LReg0];
     vUInt l1 = l_reg[LRegs::LReg1];
@@ -33,7 +33,6 @@ inline void calculate_sigmoid_appx() {
     l_reg[LRegs::LReg2] = l2;
 }
 
-template <bool APPROXIMATION_MODE>
 inline void sigmoid_appx_init() {
     uint imm0;
     uint imm1;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_sigmoid_appx.h
@@ -14,13 +14,12 @@ namespace ckernel {
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx_init() {
-    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx, APPROXIMATE>(sfpu::sigmoid_appx_init<APPROXIMATE>);
+    llk_math_eltwise_unary_sfpu_init<SfpuType::sigmoid_appx, APPROXIMATE>(sfpu::sigmoid_appx_init);
 }
 
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_sigmoid_appx(uint dst_index, int vector_mode = (int)VectorMode::RC) {
-    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_sigmoid_appx<APPROXIMATE>, dst_index, vector_mode);
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(ckernel::sfpu::calculate_sigmoid_appx, dst_index, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -72,10 +72,10 @@ ALWI void rsqrt_tile_init() {
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | fast_and_approx | Computation to be done faster and approximate                              | bool     |                                                       | False    |
  */
- // clang-format on
+// clang-format on
 template <bool fast_and_approx = true>
 ALWI void rsqrt_tile(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_rsqrt<fast_and_approx>(idst)));
@@ -84,8 +84,9 @@ ALWI void rsqrt_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
+template <bool fast_and_approx = false>
 ALWI void sigmoid_tile_init() {
-    MATH((llk_math_eltwise_unary_sfpu_sigmoid_init<APPROX>()));  // TODO(AP): move out init
+    MATH((llk_math_eltwise_unary_sfpu_sigmoid_init<fast_and_approx>()));
 }
 
 // clang-format off
@@ -101,8 +102,11 @@ ALWI void sigmoid_tile_init() {
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
  * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
- // clang-format on
-ALWI void sigmoid_tile(uint32_t idst) { MATH((llk_math_eltwise_unary_sfpu_sigmoid<APPROX>(idst))); }
+// clang-format on
+template <bool fast_and_approx = false>
+ALWI void sigmoid_tile(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_sigmoid<fast_and_approx>(idst)));
+}
 
 /**
  * Please refer to documentation for any_init.
@@ -145,10 +149,10 @@ ALWI void log_with_base_tile_init() {
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | base_scale      | The log base                                                               | uint32_t | Postive integers                                      | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void log_with_base_tile(uint32_t idst, uint32_t base_scale) {
     MATH((llk_math_eltwise_unary_sfpu_log_with_base<APPROX>(idst, base_scale)));
 }
@@ -444,10 +448,10 @@ ALWI void gez_tile_init() { MATH((llk_math_eltwise_unary_sfpu_gez_init<APPROX>()
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0          | The value of the exponent in the power operation                           | uint32_t |                                                       | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void power_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_power<APPROX>(idst, param0)));
 }
@@ -473,10 +477,10 @@ ALWI void power_tile_init() { MATH((llk_math_eltwise_unary_sfpu_power_init<APPRO
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst0           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst0           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idst1           | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void max_tile(uint32_t idst0, uint32_t idst1) { MATH((llk_math_eltwise_unary_sfpu_max<APPROX>(idst0))); }
 
 /**
@@ -518,10 +522,10 @@ ALWI void exp2_tile_init() { MATH((llk_math_eltwise_unary_sfpu_exp2_init<true>()
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0          | The value the output is if the input is greater than 0                     | uint32_t |                                                       | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void heaviside_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_heaviside<APPROX>(idst, param0)));
 }
@@ -543,10 +547,10 @@ ALWI void heaviside_tile_init() { MATH((llk_math_eltwise_unary_sfpu_heaviside_in
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void unary_ne_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_ne<APPROX>(idst, param0)));
 }
@@ -686,14 +690,14 @@ ALWI void silu_tile_init() { MATH((llk_math_eltwise_unary_sfpu_silu_init<APPROX>
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idir            | The sorting direction of the local sort (0 == decreasing, 1 == increasing) | int32    | 0 to 1                                                | True     |
- * | i_end_phase     | The end phase of the local sort (should be set to log(K)-1)                | int32    | 1 to 5                                                | True     | 
- * | i_start_phase   | The start phase of the local sort (should be set to 0)                     | int32    | 0 to 5                                                | False    | 
- * | i_end_step      | The end step to perform if i_start_phase == i_end_phase                    | int32    | 4 to 6                                                | False    | 
+ * | i_end_phase     | The end phase of the local sort (should be set to log(K)-1)                | int32    | 1 to 5                                                | True     |
+ * | i_start_phase   | The start phase of the local sort (should be set to 0)                     | int32    | 0 to 5                                                | False    |
+ * | i_end_step      | The end step to perform if i_start_phase == i_end_phase                    | int32    | 4 to 6                                                | False    |
  * | i_start_step    | The start step to perform if i_start_phase == i_end_phase                  | int32    | 4 to 6                                                | False    |
  */
- // clang-format on
+// clang-format on
 ALWI void topk_local_sort(
     uint32_t idst, int idir, int i_end_phase, int i_start_phase = 0, int i_end_step = 0, int i_start_step = 0) {
     MATH((llk_math_eltwise_unary_sfpu_topk_local_sort<true>(
@@ -725,11 +729,11 @@ ALWI void topk_local_sort(
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | m_iter          | The index of the merge & rebuild iteration of the algorithm                | int32    | 0 to 9                                                | True     |
  * | k               | The number of sorted values to return                                      | int32    | {4, 8, 16, 32, 64}                                    | True     |
  */
- // clang-format on
+// clang-format on
 template <bool idir = false>
 ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
     MATH((llk_math_eltwise_unary_sfpu_topk_merge<true, idir>(idst, m_iter, k)));
@@ -759,14 +763,14 @@ ALWI void topk_merge(uint32_t idst, int m_iter, int k) {
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | idir            | The sorting direction of the local sort (0 == decreasing, 1 == increasing) | bool     | 0 to 1                                                | True     |
- * | m_iter          | The index of the merge & rebuild iteration of the algorithm                | int32    | 0 to 9                                                | True     | 
- * | k               | The number of sorted values to return                                      | int32    | {4, 8, 16, 32, 64}                                    | True     | 
- * | logk            | The log of K                                                               | int32    | 2 to 6                                                | True     | 
+ * | m_iter          | The index of the merge & rebuild iteration of the algorithm                | int32    | 0 to 9                                                | True     |
+ * | k               | The number of sorted values to return                                      | int32    | {4, 8, 16, 32, 64}                                    | True     |
+ * | logk            | The log of K                                                               | int32    | 2 to 6                                                | True     |
  * | skip_second     | Whether or not to skip second tile                                         | int32    | 0 to 1                                                | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void topk_rebuild(uint32_t idst, bool idir, int m_iter, int k, int logk, int skip_second) {
     MATH((llk_math_eltwise_unary_sfpu_topk_rebuild<true>(idst, idir, m_iter, k, logk, skip_second)));
 }
@@ -826,10 +830,10 @@ ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void unary_gt_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_gt<APPROX>(idst, param0)));
 }
@@ -851,10 +855,10 @@ ALWI void unary_gt_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_gt_init
  *
  * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
  * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
- * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | 
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
  */
- // clang-format on
+// clang-format on
 ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
     MATH((llk_math_eltwise_unary_sfpu_unary_lt<APPROX>(idst, param0)));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -217,6 +217,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 "unary_lt_tile_init();",
                 fmt::format("unary_lt_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
             break;
+        case UnaryOpType::SIGMOID:
+            op_init_and_name = {
+                fmt::format("sigmoid_tile_init<{}u>();", (uint32_t)param0),
+                fmt::format("sigmoid_tile<{1}u>({0});", idst, (uint32_t)param0)};
+            break;
         case UnaryOpType::SOFTPLUS: {
             TT_ASSERT(params.size() == 2, "Expected softplus to take 2 parameters");
             float param1 = params[1];
@@ -261,9 +266,6 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, std:
         case UnaryOpType::RSQRT: op_init_and_name = {"rsqrt_tile_init();", fmt::format("rsqrt_tile({});", idst)}; break;
         case UnaryOpType::RELU: op_init_and_name = {"relu_tile_init();", fmt::format("relu_tile({});", idst)}; break;
         case UnaryOpType::SQRT: op_init_and_name = {"sqrt_tile_init();", fmt::format("sqrt_tile({});", idst)}; break;
-        case UnaryOpType::SIGMOID:
-            op_init_and_name = {"sigmoid_tile_init();", fmt::format("sigmoid_tile({});", idst)};
-            break;
         case UnaryOpType::LOG: op_init_and_name = {"log_tile_init();", fmt::format("log_tile({});", idst)}; break;
         case UnaryOpType::TANH: op_init_and_name = {"tanh_tile_init();", fmt::format("tanh_tile({});", idst)}; break;
         case UnaryOpType::SIGNBIT:
@@ -288,6 +290,9 @@ std::pair<string, string> get_op_init_and_func_default(UnaryOpType op_type, std:
         case UnaryOpType::I0: op_init_and_name = {"i0_tile_init();", fmt::format("i0_tile({});", idst)}; break;
         case UnaryOpType::I1: op_init_and_name = {"i1_tile_init();", fmt::format("i1_tile({});", idst)}; break;
         case UnaryOpType::EXP: op_init_and_name = {"exp_tile_init();", fmt::format("exp_tile({});", idst)}; break;
+        case UnaryOpType::SIGMOID:
+            op_init_and_name = {"sigmoid_tile_init();", fmt::format("sigmoid_tile({});", idst)};
+            break;
         case UnaryOpType::ERF: op_init_and_name = {"erf_tile_init();", fmt::format("erf_tile({0});", idst)}; break;
         case UnaryOpType::ERFC: op_init_and_name = {"erfc_tile_init();", fmt::format("erfc_tile({});", idst)}; break;
         case UnaryOpType::ERFINV:
@@ -377,7 +382,9 @@ UnaryWithParam string_to_unary_with_param(const std::string& name) {
     } else if (name == "silu") {
         return UnaryWithParam(UnaryOpType::SILU);
     } else if (name == "sigmoid") {
-        return UnaryWithParam(UnaryOpType::SIGMOID);
+        return UnaryWithParam(UnaryOpType::SIGMOID, static_cast<float>(false));
+    } else if (name == "sigmoid_approx") {
+        return UnaryWithParam(UnaryOpType::SIGMOID, static_cast<float>(true));
     } else if (name == "sqrt") {
         return UnaryWithParam(UnaryOpType::SQRT);
     } else if (name == "exp") {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -48,6 +48,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::RDIV:
         case UnaryOpType::EXP:
         case UnaryOpType::SOFTPLUS:
+        case UnaryOpType::SIGMOID:
         case UnaryOpType::ADD_UNARY_SFPU:
         case UnaryOpType::SUB_UNARY_SFPU:
         case UnaryOpType::MUL_UNARY_SFPU:

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -611,7 +611,7 @@ Tensor _glu(const Tensor& input_a, int32_t dim, const std::optional<MemoryConfig
         dim = 3;
     }
     std::vector<Tensor> ab = split_tensor_for_glu(input_a, dim, output_mem_config);
-    Tensor sigmoid_b = ttnn::sigmoid(ab[1], output_mem_config);
+    Tensor sigmoid_b = ttnn::sigmoid(ab[1], false, output_mem_config);
     Tensor glu_result = ttnn::multiply(ab[0], sigmoid_b, std::nullopt, output_mem_config);
     return glu_result;
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -104,7 +104,6 @@ template struct ExecuteUnary<UnaryOpType::NEZ>;
 template struct ExecuteUnary<UnaryOpType::RECIP>;
 template struct ExecuteUnary<UnaryOpType::RELU>;
 template struct ExecuteUnary<UnaryOpType::RELU6>;
-template struct ExecuteUnary<UnaryOpType::SIGMOID>;
 template struct ExecuteUnary<UnaryOpType::SIGN>;
 template struct ExecuteUnary<UnaryOpType::SIGNBIT>;
 template struct ExecuteUnary<UnaryOpType::SILU>;
@@ -112,7 +111,7 @@ template struct ExecuteUnary<UnaryOpType::SIN>;
 template struct ExecuteUnary<UnaryOpType::SQRT>;
 template struct ExecuteUnary<UnaryOpType::SQUARE>;
 template struct ExecuteUnary<UnaryOpType::TAN>;
-template struct ExecuteUnary<UnaryOpType::SIGMOID, UnaryOpType::LOG>;
+template struct ExecuteUnary<UnaryOpType::TANH>;
 template struct ExecuteUnary<UnaryOpType::TILED_PROD>;
 template struct ExecuteUnary<UnaryOpType::BITWISE_NOT>;
 
@@ -136,6 +135,7 @@ template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::ERF>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::ERFC>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::GELU>;
 template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::RSQRT>;
+template struct ExecuteUnaryWithFastAndApproximateMode<UnaryOpType::SIGMOID>;
 
 template <UnaryOpType unary_op_type>
 Tensor ExecuteUnaryWithFloatParameter<unary_op_type>::invoke(
@@ -177,6 +177,20 @@ Tensor Sigmoid_accurate::invoke(
          UnaryWithParam(UnaryOpType::EXP, 1.0f),
          UnaryWithParam(UnaryOpType::ADD_UNARY_SFPU, 1.0f),
          UnaryWithParam(UnaryOpType::RECIP)},
+        memory_config,
+        optional_output_tensor);
+}
+
+template struct ExecuteUnary<UnaryOpType::SIGMOID, UnaryOpType::LOG>;
+Tensor LogSigmoid::invoke(
+    QueueId queue_id,
+    const Tensor& input,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    return detail::unary_impl(
+        queue_id,
+        input,
+        {UnaryWithParam(UnaryOpType::SIGMOID, 0), UnaryWithParam(UnaryOpType::LOG)},
         memory_config,
         optional_output_tensor);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -53,6 +53,14 @@ struct ExecuteUnaryWithFloatParameter {
         const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
+struct LogSigmoid {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
 struct Sigmoid_accurate {
     static Tensor invoke(
         QueueId queue_id,
@@ -247,7 +255,6 @@ REGISTER_UNARY_OPERATION(nez, NEZ);
 REGISTER_UNARY_OPERATION(reciprocal, RECIP);
 REGISTER_UNARY_OPERATION(relu, RELU);
 REGISTER_UNARY_OPERATION(relu6, RELU6);
-REGISTER_UNARY_OPERATION(sigmoid, SIGMOID);
 REGISTER_UNARY_OPERATION(sign, SIGN);
 REGISTER_UNARY_OPERATION(signbit, SIGNBIT);
 REGISTER_UNARY_OPERATION(silu, SILU);
@@ -258,17 +265,13 @@ REGISTER_UNARY_OPERATION(tan, TAN);
 REGISTER_UNARY_OPERATION(tiled_prod, TILED_PROD);
 REGISTER_UNARY_OPERATION(bitwise_not, BITWISE_NOT);
 
-constexpr auto log_sigmoid = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::log_sigmoid",
-    ttnn::operations::unary::
-        ExecuteUnary<ttnn::operations::unary::UnaryOpType::SIGMOID, ttnn::operations::unary::UnaryOpType::LOG>>();
-
 // Unaries with fast_and_approximate_mode
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(exp, EXP);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(erf, ERF);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(erfc, ERFC);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(gelu, GELU);
 REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(rsqrt, RSQRT);
+REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(sigmoid, SIGMOID);
 
 // Unaries with float parameter
 REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(elu, ELU);
@@ -303,6 +306,8 @@ constexpr auto prelu_sfpu =
 
 constexpr auto sigmoid_accurate =
     ttnn::register_operation_with_auto_launch_op<"ttnn::sigmoid_accurate", ttnn::operations::unary::Sigmoid_accurate>();
+constexpr auto log_sigmoid =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::log_sigmoid", ttnn::operations::unary::LogSigmoid>();
 constexpr auto unary_chain =
     ttnn::register_operation_with_auto_launch_op<"ttnn::unary_chain", ttnn::operations::unary::Unary_chain>();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1702,7 +1702,6 @@ void py_module(py::module& module) {
     detail::bind_unary_operation_overload_complex_return_complex(module, ttnn::reciprocal, R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(BFLOAT8_B is supported only for non-zero inputs. Inputs containing zero may produce inaccurate results due to the characteristics of the block-FP format.)doc");
     detail::bind_unary_operation(module, ttnn::relu, R"doc(\mathrm{{output\_tensor}}_i = \verb|relu|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::relu6, R"doc(\mathrm{{output\_tensor}}_i = \verb|relu6|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
-    detail::bind_unary_operation(module, ttnn::sigmoid, R"doc(\mathrm{{output\_tensor}}_i = \verb|sigmoid|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::sign, R"doc(\mathrm{{output\_tensor}}_i = \verb|sign|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::signbit, R"doc(\mathrm{{output\_tensor}}_i = \verb|signbit|(\mathrm{{input\_tensor}}_i))doc");
     detail::bind_unary_operation(module, ttnn::silu, R"doc(\mathrm{{output\_tensor}}_i = \verb|silu|(\mathrm{{input\_tensor}}_i))doc", R"doc(BFLOAT16, BFLOAT8_B)doc");
@@ -1721,6 +1720,7 @@ void py_module(py::module& module) {
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::erfc, R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::gelu, R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::rsqrt, R"doc(BFLOAT16, BFLOAT8_B)doc");
+    detail::bind_unary_operation_with_fast_and_approximate_mode(module, ttnn::sigmoid, R"doc(BFLOAT16, BFLOAT8_B)doc");
 
     // Unaries with float parameter
     detail::bind_unary_operation_with_float_parameter(module, ttnn::elu, "alpha", "The alpha parameter for the ELU function","",R"doc(BFLOAT16, BFLOAT8_B)doc");

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -510,7 +510,7 @@ std::vector<Tensor> ExecuteUnaryBackwardTan::invoke(
 std::vector<Tensor> ExecuteUnaryBackwardSigmoid::invoke(
     const Tensor& grad, const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
-    Tensor sig_result = ttnn::sigmoid(input, output_mem_config);
+    Tensor sig_result = ttnn::sigmoid(input, false, output_mem_config);
     Tensor rsub_term = ttnn::rsub(sig_result, 1.0f, output_mem_config);
     Tensor prod_term_1 = ttnn::multiply(sig_result, rsub_term, std::nullopt, output_mem_config);
     Tensor prod_term_2 = ttnn::multiply(prod_term_1, grad, std::nullopt, output_mem_config);
@@ -953,7 +953,7 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardSilu::invoke(
     std::vector<std::optional<Tensor>> result = {std::nullopt};
 
     input_grad = input_grad.value_or(ttnn::empty_like(input));
-    Tensor sigmoid_res = ttnn::sigmoid(input, output_mem_config);
+    Tensor sigmoid_res = ttnn::sigmoid(input, false, output_mem_config);
     Tensor grad_sigmoid = ttnn::multiply(queue_id, grad, sigmoid_res, std::nullopt, output_mem_config);
     Tensor add_sub = ttnn::add(
         queue_id,


### PR DESCRIPTION
### Ticket
#19477 

### Problem description
Sigmoid didn't have approx mode option.

### What's changed
Sigmoid has an approx mode option.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes