### PR TITLE
Revert "Reduce global cb size (#19483)"

### DIFF
--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -75,7 +75,8 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             # This ensures that back to back matmuls (for eg. in MLP) can run
             # without stalling on the weight prefetch
             # calculated by fitting two largest tensor with extra room, ff2 has 391680B per global CB bank, ff1 has 207360B, plus 16320B gap (one block)
-            self.global_cb_size = 620000
+            # TODO: Above calculation is not accurate, need to find a better lower bound
+            self.global_cb_size = 600 * 1088
             self.sender_receiver_mapping = list(zip(self.all_sender_cores, self.all_receiver_cores))
             self.global_circular_buffer = ttnn.create_global_circular_buffer(
                 self.mesh_device, self.sender_receiver_mapping, self.global_cb_size

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -309,8 +309,7 @@ def run_prefetcher_mm(
     # Total: 1470
 
     # global_cb_size = 1000 * max_tile_size # works without profiler, fails with profiler, 900 doesn't provide tracy info
-    # calculated by fitting two largest tensor with extra room, ff2 has 391680B per global CB bank, ff1 has 207360B, plus 16320B gap (one block)
-    global_cb_size = 620000
+    global_cb_size = 600 * max_tile_size
     sender_receiver_mapping = list(zip(all_sender_cores, all_receiver_cores))
     global_circular_buffer = ttnn.create_global_circular_buffer(device, sender_receiver_mapping, global_cb_size)
     logger.info(f"global cb size {global_cb_size}")


### PR DESCRIPTION
This reverts commit a73506053c01dddfe94b9a86eb98f79fb47bb62c.

### Problem description
The previous. commit reduced the global CB size, however, this led to a slowdown in FF2 Matmul in Llama TG (28 us vs 15 us.)

### What's changed
- Revert GloblaCB to a size that is known to not cause regressions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14109197380) CI passes