### PR TITLE
Fix hash collision for InterleavedToSharded op

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
@@ -21,7 +21,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
 )
 @pytest.mark.parametrize("input_in_l1", [True, False])
-def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in_l1):
+@pytest.mark.parametrize("keep_l1_aligned", [True, False])
+def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in_l1, keep_l1_aligned):
     ttnn.enable_program_cache(device)
 
     # Sample tensor size and shard config
@@ -53,8 +54,12 @@ def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in
 
     # Do interleaved to sharded op on device several times to load the program from cache
     for iter in range(0, 5):
-        output_tensor = ttnn.interleaved_to_sharded(input_tensor_device, sharded_mem_config, first_dtype)
+        output_tensor = ttnn.interleaved_to_sharded(
+            input_tensor_device, sharded_mem_config, first_dtype, keep_l1_aligned=keep_l1_aligned
+        )
         pcc_passed_a, pcc_message_a = assert_with_pcc(input_tensor_torch, ttnn.to_torch(output_tensor), pcc=0.9999)
 
-        output_tensor = ttnn.interleaved_to_sharded(input_tensor_device, sharded_mem_config, second_dtype)
+        output_tensor = ttnn.interleaved_to_sharded(
+            input_tensor_device, sharded_mem_config, second_dtype, keep_l1_aligned=keep_l1_aligned
+        )
         pcc_passed_b, pcc_message_b = assert_with_pcc(input_tensor_torch, ttnn.to_torch(output_tensor), pcc=0.9999)

--- a/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
+++ b/tests/ttnn/unit_tests/operations/test_interleaved_to_sharded.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "first_dtype, second_dtype",
+    [
+        (ttnn.bfloat8_b, ttnn.bfloat16),
+        (ttnn.bfloat8_b, ttnn.float32),
+        (ttnn.bfloat16, ttnn.bfloat8_b),
+        (ttnn.bfloat16, ttnn.float32),
+        (ttnn.float32, ttnn.bfloat8_b),
+        (ttnn.float32, ttnn.bfloat16),
+    ],
+)
+@pytest.mark.parametrize("input_in_l1", [True, False])
+def test_interleaved_to_sharded_hash(device, first_dtype, second_dtype, input_in_l1):
+    ttnn.enable_program_cache(device)
+
+    # Sample tensor size and shard config
+    input_tensor_shape = (1, 1, 512, 512)
+    input_memory_config = ttnn.L1_MEMORY_CONFIG if input_in_l1 else ttnn.DRAM_MEMORY_CONFIG
+
+    # L1 grid and calculations
+    l1_core_grid_x = 4
+    l1_core_grid_y = 4
+    l1_shard_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(l1_core_grid_x - 1, l1_core_grid_y - 1))}
+    )
+    l1_h, l1_w = input_tensor_shape[2] // l1_core_grid_x, input_tensor_shape[3] // l1_core_grid_y
+
+    # Shard spec and mem config
+    shard_spec = ttnn.ShardSpec(l1_shard_grid, [l1_h, l1_w], ttnn.ShardOrientation.ROW_MAJOR)
+
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+
+    # Create input tensors and send to device
+    input_tensor_torch = torch.randn(input_tensor_shape)
+    input_tensor = ttnn.from_torch(input_tensor_torch, first_dtype, layout=ttnn.TILE_LAYOUT)
+    input_tensor_device = ttnn.allocate_tensor_on_device(
+        input_tensor.shape, input_tensor.dtype, input_tensor.layout, device, input_memory_config
+    )
+    ttnn.copy_host_to_device_tensor(input_tensor, input_tensor_device)
+
+    # Do interleaved to sharded op on device several times to load the program from cache
+    for iter in range(0, 5):
+        output_tensor = ttnn.interleaved_to_sharded(input_tensor_device, sharded_mem_config, first_dtype)
+        pcc_passed_a, pcc_message_a = assert_with_pcc(input_tensor_torch, ttnn.to_torch(output_tensor), pcc=0.9999)
+
+        output_tensor = ttnn.interleaved_to_sharded(input_tensor_device, sharded_mem_config, second_dtype)
+        pcc_passed_b, pcc_message_b = assert_with_pcc(input_tensor_torch, ttnn.to_torch(output_tensor), pcc=0.9999)

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -20,9 +20,10 @@ struct InterleavedToShardedDeviceOperation {
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 
-    static constexpr auto attribute_names = std::make_tuple("output_mem_config", "output_dtype");
+    static constexpr auto attribute_names = std::make_tuple("output_mem_config", "output_dtype", "keep_l1_aligned");
     const auto attribute_values() const {
-        return std::make_tuple(std::cref(this->output_mem_config), std::cref(this->output_dtype));
+        return std::make_tuple(
+            std::cref(this->output_mem_config), std::cref(this->output_dtype), std::cref(this->keep_l1_aligned));
     }
 };
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.hpp
@@ -20,7 +20,9 @@ struct InterleavedToShardedDeviceOperation {
     tt::tt_metal::operation::ProgramWithCallbacks create_program(
         const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
 
-    static constexpr auto attribute_names = std::make_tuple("output_mem_config");
-    const auto attribute_values() const { return std::make_tuple(std::cref(this->output_mem_config)); }
+    static constexpr auto attribute_names = std::make_tuple("output_mem_config", "output_dtype");
+    const auto attribute_values() const {
+        return std::make_tuple(std::cref(this->output_mem_config), std::cref(this->output_dtype));
+    }
 };
 }  // namespace ttnn::operations::data_movement


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19756)

### Problem description
InterleavedToSharded has a hash collision when operating on the same input tensor and memory config but different output dtype.

### What's changed
- Added output dtype to op attributes for hashing
- Added test

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes