### PR TITLE
Add SD 1.4 perf test using trace and 2 command queues

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_perf.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_perf.py
@@ -11,9 +11,7 @@ from loguru import logger
 from diffusers import (
     StableDiffusionPipeline,
 )
-from models.utility_functions import (
-    skip_for_grayskull,
-)
+
 from ttnn.model_preprocessing import preprocess_model_parameters
 from ttnn import unsqueeze_to_4D
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -25,7 +23,8 @@ from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition
 
 from models.perf.perf_utils import prep_perf_report
 from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
-from models.utility_functions import profiler, is_wormhole_b0
+from models.utility_functions import profiler, is_wormhole_b0, is_blackhole
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 def constant_prop_time_embeddings(timesteps, sample, time_proj):
@@ -46,6 +45,145 @@ def unsqueeze_all_params_to_4d(params):
         params = unsqueeze_to_4D(params)
 
     return params
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "trace_region_size": 15659008, "num_command_queues": 2}], indirect=True
+)
+def test_stable_diffusion_trace_2cq(device, use_program_cache):
+    assert is_wormhole_b0() or is_blackhole(), "SD 1.4 runs on Wormhole B0 or Blackhole"
+
+    profiler.clear()
+    torch.manual_seed(0)
+
+    model_name = "CompVis/stable-diffusion-v1-4"
+    pipe = StableDiffusionPipeline.from_pretrained(model_name, torch_dtype=torch.float32)
+    torch_model = pipe.unet
+    torch_model.eval()
+    config = torch_model.config
+
+    # Setup scheduler
+    ttnn_scheduler = TtPNDMScheduler(
+        beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", num_train_timesteps=1000, device=device
+    )
+    ttnn_scheduler.set_timesteps(4)
+
+    parameters = preprocess_model_parameters(
+        model_name=model_name,
+        initialize_model=lambda: torch_model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    parameters = unsqueeze_all_params_to_4d(parameters)
+
+    batch_size = 2
+    in_channels = 4
+    input_height = 64
+    input_width = 64
+    encoder_hidden_states_shape = [1, 2, 77, 768]
+    hidden_states_shape = [batch_size, in_channels, input_height, input_width]
+    reader_patterns_cache = {}
+    class_labels = None
+    attention_mask = None
+    cross_attention_kwargs = None
+    return_dict = True
+
+    # Run torch model
+    torch_input = torch.randn(hidden_states_shape)
+    torch_encoder_hidden_states = torch.randn(encoder_hidden_states_shape)
+    time_step = ttnn_scheduler.timesteps.tolist()
+    torch_output = torch_model(
+        torch_input, timestep=time_step[0], encoder_hidden_states=torch_encoder_hidden_states.squeeze(0)
+    ).sample
+
+    # Set up ttnn inputs
+    ttnn_input = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    torch_encoder_hidden_states = torch.nn.functional.pad(torch_encoder_hidden_states, (0, 0, 0, 19))
+    encoder_hidden_states = ttnn.from_torch(
+        torch_encoder_hidden_states, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    encoder_hidden_states = ttnn.to_device(encoder_hidden_states, device, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    _tlist = []
+    for t in ttnn_scheduler.timesteps:
+        _t = constant_prop_time_embeddings(t, ttnn_input, torch_model.time_proj)
+        _t = _t.unsqueeze(0).unsqueeze(0)
+        _t = _t.permute(2, 0, 1, 3)  # pre-permute temb
+        _t = ttnn.from_torch(_t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+        _tlist.append(_t)
+
+    ttnn_model = UNet2D(device, parameters, batch_size, input_height, input_width, reader_patterns_cache)
+
+    input_tensor = ttnn.allocate_tensor_on_device(
+        ttnn_input.shape, ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG
+    )
+    op_event = ttnn.record_event(device, 0)
+
+    # COMPILE
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+    write_event = ttnn.record_event(device, 1)
+    ttnn.wait_for_event(0, write_event)
+    output_tensor = ttnn.from_device(
+        ttnn_model(
+            input_tensor,
+            timestep=_tlist[0],
+            encoder_hidden_states=encoder_hidden_states,
+            class_labels=class_labels,
+            attention_mask=attention_mask,
+            cross_attention_kwargs=cross_attention_kwargs,
+            return_dict=return_dict,
+            config=config,
+        ),
+        blocking=True,
+    )
+
+    # CAPTURE
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+    write_event = ttnn.record_event(device, 1)
+    ttnn.wait_for_event(0, write_event)
+    output_tensor.deallocate(True)
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    output_tensor = ttnn_model(
+        input_tensor,
+        timestep=_tlist[0],
+        encoder_hidden_states=encoder_hidden_states,
+        class_labels=class_labels,
+        attention_mask=attention_mask,
+        cross_attention_kwargs=cross_attention_kwargs,
+        return_dict=return_dict,
+        config=config,
+    )
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+
+    # TRACE
+    ttnn.synchronize_device(device)
+    profiler.start(f"model_run_for_inference_{0}")
+
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(ttnn_input, input_tensor, cq_id=1)
+    write_event = ttnn.record_event(device, 1)
+    ttnn.wait_for_event(0, write_event)
+    ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+    host_output_tensor = output_tensor.cpu(blocking=False)
+    ttnn.synchronize_device(device)
+
+    profiler.end(f"model_run_for_inference_{0}")
+    ttnn.release_trace(device, tid)
+
+    assert_with_pcc(torch_output, ttnn.to_torch(host_output_tensor), 0.996)
+
+    inference_time = profiler.get(f"model_run_for_inference_{0}")
+    expected_inference_time = 0.113 if is_wormhole_b0() else 0.072
+
+    assert (
+        inference_time <= expected_inference_time
+    ), f"Inference time with trace and 2 cqs is {inference_time}s, while expected time is {expected_inference_time}s"
+
+    num_model_iterations_per_image = 51
+    fps = 1 / (inference_time * num_model_iterations_per_image)
+    print(f"SD1.4 is running at {fps} FPS")
 
 
 @pytest.mark.models_performance_bare_metal
@@ -176,7 +314,6 @@ def test_stable_diffusion_perf(
     logger.info("Exit SD perf test")
 
 
-@skip_for_grayskull()
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "expected_kernel_samples_per_second",


### PR DESCRIPTION
### Ticket
#17725

### What's changed

- Added a new test to test_perf.py file - it doesn't run on the CI yet, but we need it to obtain perf comparison for WH and BH. No pipelines are affected.
- The test initialization can be refactored to avoid duplication with other tests, but I chose not to deal with it in this PR, but separately.