### PR TITLE
[Llama3-8B Blackhole] Change SDPA decode chunk size to 128 to avoid hang in BH and add demo to CI

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -25,6 +25,13 @@ jobs:
             runs-on: ["BH", "pipeline-perf", "in-service"],
             cmd: pytest models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation",
             owner_id: U05RWH3QUPM #Salar Hosseini
+          },
+          {
+            name: "Llama3-8B_performance",
+            arch: blackhole,
+            runs-on: ["BH", "pipeline-perf", "in-service"],
+            cmd: LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1,
+            owner_id: U03PUAKE719 # Miguel Tairum
           }
         ]
     name: ${{ matrix.test-group.name }}

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -712,8 +712,8 @@ class ModelArgs:
             self.model_config["SDPA_DECODE_PROGCFG"] = ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=(8, 8),
                 exp_approx_mode=False,
-                q_chunk_size=256,
-                k_chunk_size=256,
+                q_chunk_size=128 if self.arch_name == "blackhole" else 256,
+                k_chunk_size=128 if self.arch_name == "blackhole" else 256,
             )
 
             self.model_config["SDPA_DECODE_COMPUTE_PROGCFG"] = ttnn.WormholeComputeKernelConfig(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18135

### What's changed
Updated Llama3 config to avoid demo hangs on 1xP150

### Checklist
- [x] [BH Demo pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/14113251816)
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14113269369)
- [x] [BH Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14113281560)