### PR TITLE
[skip ci] Add default branches for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,20 @@
 [submodule "tt_metal/third_party/tracy"]
 	path = tt_metal/third_party/tracy
 	url = https://github.com/tenstorrent-metal/tracy.git
+	branch = master
 [submodule "tt_metal/third_party/umd"]
 	path = tt_metal/third_party/umd
 	url = https://github.com/tenstorrent/tt-umd.git
+	branch = main
 [submodule "models/demos/t3000/llama2_70b/reference/llama"]
 	path = models/demos/t3000/llama2_70b/reference/llama
 	url = https://github.com/tenstorrent-metal/llama.git
+	branch = main
 [submodule "3rd_party/wandb-cpp"]
 	path = tt-train/3rd_party/wandb-cpp
 	url = https://github.com/yhisaki/wandb-cpp
+	branch = master
 [submodule "tt_metal/third_party/tt_llk"]
 	path = tt_metal/third_party/tt_llk
 	url = https://github.com/tenstorrent/tt-llk.git
+	branch = main


### PR DESCRIPTION
### Ticket
Fixes #19800 

### Problem description
Missing default branches for submodules cause problems with importing the project through `FetchContent` mechanism.

### What's changed
No changes in default behavior.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes