### PR TITLE
#16007: Avoiding hammering L1 when waiting for other RISCS in firmware

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -301,6 +301,12 @@ inline void start_ncrisc_kernel_run(dispatch_core_processor_masks enables) {
 inline void wait_ncrisc_trisc() {
     WAYPOINT("NTW");
     while (mailboxes->slave_sync.all != RUN_SYNC_MSG_ALL_SLAVES_DONE) {
+#if defined(ARCH_WORMHOLE)
+        // Avoid hammering L1 while other cores are trying to work. Seems not to
+        // be needed on Blackhole, probably because invalidate_l1_cache takes
+        // time.
+        asm volatile("nop; nop; nop; nop; nop");
+#endif
         invalidate_l1_cache();
     }
     WAYPOINT("NTD");

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -70,6 +70,12 @@ inline __attribute__((always_inline)) void notify_brisc_and_wait() {
         if (run_value == RUN_SYNC_MSG_GO || run_value == RUN_SYNC_MSG_LOAD) {
             break;
         }
+#if defined(ARCH_WORMHOLE)
+        // Avoid hammering L1 while other cores are trying to work. Seems not to
+        // be needed on Blackhole, probably because invalidate_l1_cache takes
+        // time.
+        asm volatile("nop; nop; nop; nop; nop");
+#endif
         invalidate_l1_cache();
     }
 }

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -122,6 +122,12 @@ int main(int argc, char *argv[]) {
                     *trisc_run = RUN_SYNC_MSG_DONE;
                 }
             }
+#if defined(ARCH_WORMHOLE)
+            // Avoid hammering L1 while other cores are trying to work. Seems not to
+            // be needed on Blackhole, probably because invalidate_l1_cache takes
+            // time.
+            asm volatile("nop; nop; nop; nop; nop");
+#endif
             invalidate_l1_cache();
         }
         DeviceZoneScopedMainN("TRISC-FW");

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -52,7 +52,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 256)
+#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 512)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 2048
 #define MEM_TRISC0_FIRMWARE_SIZE 1536


### PR DESCRIPTION
### Ticket
#16007

### Problem description
The firmware on slave riscs needs to poll L1 when waiting to start, and the firmware on the brisc needs to poll when waiting for the other riscs to finish. This can slow down other memory operations on the core. 

### What's changed
Add 5 nops in each loop to reduce that effect, while not introducing much extra latency.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes