### PR TITLE
#19569: Extend TTNN Op infra to natively support MeshWorkload

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/old_infra_device_operation.hpp"
+#include "ttnn/operation_concepts.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
@@ -20,6 +21,10 @@ namespace {
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::SizeIs;
+using ::ttnn::device_operation::mesh_device_operation_utils::all_tensors_have_uniform_storage;
+using ::ttnn::device_operation::mesh_device_operation_utils::extract_tensor_coordinates;
+using ::ttnn::device_operation::mesh_device_operation_utils::filter_tensor_shards;
+using ::ttnn::device_operation::mesh_device_operation_utils::uses_heterogenous_dispatch;
 
 // Returns device tensor with `num_device_shards` populated.
 Tensor make_tensor_with_num_shards(const TensorSpec& tensor_spec, int num_device_shards, MeshDevice* mesh_device) {
@@ -108,6 +113,20 @@ struct OldInfraDeviceOpWithCreateAt {
     }
 };
 
+// Old infrastructure device operation that uses the "create_program_at" method
+struct OldInfraDeviceOpWithCreateMeshWorkload {
+    void validate(const std::vector<Tensor>& input_tensors) const {}
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
+
+    auto create_mesh_workload(
+        const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const {
+        return tt::tt_metal::operation::MeshWorkloadWithCallbacks();
+    }
+};
+
 TEST(LaunchOperationTest, OldInfraUsesHeterogeneousDispatch) {
     auto old_infra_attributes = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreate{});
     auto old_infra_attributes_with_at = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateAt{});
@@ -115,26 +134,42 @@ TEST(LaunchOperationTest, OldInfraUsesHeterogeneousDispatch) {
     auto old_infra_program_factory = tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>::program_factory_t();
 
     EXPECT_FALSE(std::visit(
-        [&]<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
-            return ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<ConcreteProgramFactory>(
-                old_infra_attributes);
+        tt::stl::overloaded{
+            [&]<device_operation::ProgramFactoryConcept T>(const T&) {
+                return uses_heterogenous_dispatch<T>(old_infra_attributes);
+            },
+            [&]<device_operation::MeshWorkloadFactoryConcept T>(const T&) { return false; },
         },
         old_infra_program_factory));
 
     EXPECT_TRUE(std::visit(
-        [&]<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
-            return ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<ConcreteProgramFactory>(
-                old_infra_attributes_with_at);
+        tt::stl::overloaded{
+            [&]<device_operation::ProgramFactoryConcept T>(const T&) {
+                return uses_heterogenous_dispatch<T>(old_infra_attributes_with_at);
+            },
+            [&]<device_operation::MeshWorkloadFactoryConcept T>(const T&) { return true; },
         },
         old_infra_program_factory));
 }
 
-TEST(LaunchOperationTest, NewInfraUsesHeterogeneousDispatch) {
-    EXPECT_FALSE(ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreate>(
-        OperationAttributes{}));
+TEST(LaunchOperationTest, OldInfraSelectsMeshWorkloadFactory) {
+    auto old_infra_attributes_create_program = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreate{});
+    auto old_infra_attributes_create_mesh_workload =
+        tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateMeshWorkload{});
 
-    EXPECT_TRUE(ttnn::mesh_device_operation_utils::uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreateAt>(
-        OperationAttributes{}));
+    using OldInfraDeviceOperation = tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>;
+
+    EXPECT_TRUE(std::holds_alternative<OldInfraDeviceOperation::ProgramFactory>(
+        OldInfraDeviceOperation::select_program_factory(old_infra_attributes_create_program, {})));
+
+    EXPECT_TRUE(std::holds_alternative<OldInfraDeviceOperation::MeshWorkloadFactory>(
+        OldInfraDeviceOperation::select_program_factory(old_infra_attributes_create_mesh_workload, {})));
+}
+
+TEST(LaunchOperationTest, NewInfraUsesHeterogeneousDispatch) {
+    EXPECT_FALSE(uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreate>(OperationAttributes{}));
+
+    EXPECT_TRUE(uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreateAt>(OperationAttributes{}));
 }
 
 using LaunchOperationT3000Test = tt::tt_metal::T3000MeshDeviceFixture;
@@ -144,10 +179,10 @@ TEST_F(LaunchOperationT3000Test, UniformTensor) {
         ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
     auto full_tensor = tt::tt_metal::allocate_tensor_on_mesh(tensor_spec, mesh_device_.get());
 
-    EXPECT_TRUE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(full_tensor));
+    EXPECT_TRUE(all_tensors_have_uniform_storage(full_tensor));
 
     EXPECT_THAT(
-        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(full_tensor),
+        extract_tensor_coordinates(full_tensor),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{0, 1},
@@ -166,9 +201,9 @@ TEST_F(LaunchOperationT3000Test, UnevenTensor) {
 
     EXPECT_THAT(uneven_tensor.device_storage().specs, SizeIs(2));
 
-    EXPECT_FALSE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(uneven_tensor));
+    EXPECT_FALSE(all_tensors_have_uniform_storage(uneven_tensor));
     EXPECT_THAT(
-        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(uneven_tensor),
+        extract_tensor_coordinates(uneven_tensor),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{0, 1}));
@@ -182,8 +217,9 @@ TEST_F(LaunchOperationT3000Test, MismatchedTensorsThrow) {
 
     std::vector<Tensor> tensor_args = {full_tensor, uneven_tensor};
 
-    EXPECT_ANY_THROW(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args));
-    EXPECT_ANY_THROW(ttnn::mesh_device_operation_utils::extract_tensor_coordinates(tensor_args));
+    EXPECT_ANY_THROW(
+        ttnn::device_operation::mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args));
+    EXPECT_ANY_THROW(ttnn::device_operation::mesh_device_operation_utils::extract_tensor_coordinates(tensor_args));
 }
 
 TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
@@ -191,9 +227,9 @@ TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
         ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::ROW_MAJOR, MemoryConfig{}));
     auto full_tensor = tt::tt_metal::allocate_tensor_on_mesh(tensor_spec, mesh_device_.get());
 
-    EXPECT_TRUE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(full_tensor));
+    EXPECT_TRUE(all_tensors_have_uniform_storage(full_tensor));
     EXPECT_THAT(
-        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(full_tensor),
+        extract_tensor_coordinates(full_tensor),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{0, 1},
@@ -205,7 +241,7 @@ TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
             ttnn::MeshCoordinate{1, 3}));
 
     // Filter the first 2 shards and the last 3 shards.
-    ttnn::mesh_device_operation_utils::filter_tensor_shards(
+    filter_tensor_shards(
         {ttnn::MeshCoordinate{0, 0},
          ttnn::MeshCoordinate{0, 1},
          ttnn::MeshCoordinate{1, 1},
@@ -213,9 +249,9 @@ TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
          ttnn::MeshCoordinate{1, 3}},
         full_tensor);
 
-    EXPECT_FALSE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(full_tensor));
+    EXPECT_FALSE(all_tensors_have_uniform_storage(full_tensor));
     EXPECT_THAT(
-        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(full_tensor),
+        extract_tensor_coordinates(full_tensor),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{0, 1},
@@ -224,23 +260,23 @@ TEST_F(LaunchOperationT3000Test, FilterTensorShards) {
             ttnn::MeshCoordinate{1, 3}));
 
     // Filter the first and the last shards.
-    ttnn::mesh_device_operation_utils::filter_tensor_shards(
+    filter_tensor_shards(
         {ttnn::MeshCoordinate{0, 0},  //
          ttnn::MeshCoordinate{1, 3}},
         full_tensor);
 
-    EXPECT_FALSE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(full_tensor));
+    EXPECT_FALSE(all_tensors_have_uniform_storage(full_tensor));
     EXPECT_THAT(
-        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(full_tensor),
+        extract_tensor_coordinates(full_tensor),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{1, 3}));
 
     // Filter the rest.
-    ttnn::mesh_device_operation_utils::filter_tensor_shards(/*tensor_coordinates=*/{}, full_tensor);
+    filter_tensor_shards(/*tensor_coordinates=*/{}, full_tensor);
 
-    EXPECT_FALSE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(full_tensor));
-    EXPECT_THAT(ttnn::mesh_device_operation_utils::extract_tensor_coordinates(full_tensor), IsEmpty());
+    EXPECT_FALSE(all_tensors_have_uniform_storage(full_tensor));
+    EXPECT_THAT(extract_tensor_coordinates(full_tensor), IsEmpty());
 }
 
 TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
@@ -249,9 +285,9 @@ TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
     auto full_tensor = make_tensor_with_num_shards(tensor_spec, 8, mesh_device_.get());
     auto sum = ttnn::add(full_tensor, full_tensor);
 
-    EXPECT_TRUE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(sum));
+    EXPECT_TRUE(all_tensors_have_uniform_storage(sum));
     EXPECT_THAT(
-        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(sum),
+        extract_tensor_coordinates(sum),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{0, 1},
@@ -265,9 +301,9 @@ TEST_F(LaunchOperationT3000Test, LaunchOpFilterTensorShards) {
     auto uneven_tensor = make_tensor_with_num_shards(tensor_spec, 2, mesh_device_.get());
     auto sum_uneven = ttnn::add(uneven_tensor, uneven_tensor);
 
-    EXPECT_FALSE(ttnn::mesh_device_operation_utils::all_tensors_have_uniform_storage(sum_uneven));
+    EXPECT_FALSE(all_tensors_have_uniform_storage(sum_uneven));
     EXPECT_THAT(
-        ttnn::mesh_device_operation_utils::extract_tensor_coordinates(sum_uneven),
+        extract_tensor_coordinates(sum_uneven),
         ElementsAre(
             ttnn::MeshCoordinate{0, 0},  //
             ttnn::MeshCoordinate{0, 1}));

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -6,131 +6,51 @@
 
 #include <unordered_map>
 
-#include "program_impl.hpp"
 #include <tt_stl/unique_any.hpp>
-#include "mesh_workload.hpp"
 #include <tt_stl/overloaded.hpp>
 
-namespace tt::tt_metal::program_cache::detail {
-template <typename shared_variables_t>
-struct CachedMeshWorkload {
-    tt::tt_metal::distributed::MeshWorkload workload;
-    // Shared variables between create and override_runtime_arguments functions
-    std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_variables_t>
-        coordinate_range_to_shared_variables;
+#include "program_impl.hpp"
+#include "mesh_workload.hpp"
 
-    CachedMeshWorkload(
-        tt::tt_metal::distributed::MeshWorkload&& workload,
-        std::unordered_map<tt::tt_metal::distributed::MeshCoordinateRange, shared_variables_t>&&
-            coordinate_range_to_shared_variables) :
-        workload{std::move(workload)},
-        coordinate_range_to_shared_variables{std::move(coordinate_range_to_shared_variables)} {}
-};
+namespace tt::tt_metal::program_cache::detail {
 
 template <typename shared_variables_t>
 struct CachedProgram {
-    tt::tt_metal::Program program;
+private:
+    std::optional<tt::tt_metal::Program> owned_program;
+    std::optional<shared_variables_t> owned_shared_variables;
+
+public:
+    tt::tt_metal::Program& program;
+
     // Cached program needs to share shared_variables between create and override_runtime_arguments functions
-    shared_variables_t shared_variables;
+    shared_variables_t& shared_variables;
 
     CachedProgram(tt::tt_metal::Program&& program, shared_variables_t&& shared_variables) :
-        program{std::move(program)}, shared_variables{std::forward<shared_variables_t>(shared_variables)} {}
-};
+        owned_program{std::move(program)},
+        owned_shared_variables{std::move(shared_variables)},
+        program{*owned_program},
+        shared_variables{*owned_shared_variables} {}
 
-template <typename shared_variables_t>
-struct CachedProgramRef {
-    std::reference_wrapper<tt::tt_metal::Program> program;
-    // Cached program needs to share shared_variables between create and override_runtime_arguments functions
-    std::reference_wrapper<shared_variables_t> shared_variables;
-
-    CachedProgramRef(tt::tt_metal::Program& program, shared_variables_t& shared_variables) :
+    // Creates a "proxy" `CachedProgram` that references `program` and `shared_variables`.
+    // Used for adapting `CachedMeshWorkload` to `CachedProgram`, and interfacing with TTNN Ops in
+    // `override_runtime_arguments` methods.
+    CachedProgram(tt::tt_metal::Program& program, shared_variables_t& shared_variables) :
         program{program}, shared_variables{shared_variables} {}
 };
 
-// Adapter that provides a unified interface for both CachedProgram and CachedMeshWorkload
 template <typename shared_variables_t>
-class ProgramAdapter {
-private:
-    using CachedObject = std::variant<
-        CachedMeshWorkload<shared_variables_t>,
-        CachedProgram<shared_variables_t>,
-        CachedProgramRef<shared_variables_t>>;
-    CachedObject cached_object_;
-    // Helper to retrieve the first program from a mesh workload
-    static tt::tt_metal::Program& get_first_program(CachedMeshWorkload<shared_variables_t>& cached_mesh_workload) {
-        // Get the programs map from the workload
-        auto& programs = cached_mesh_workload.workload.get_programs();
+struct CachedMeshWorkload {
+    tt::tt_metal::distributed::MeshWorkload workload;
 
-        // There must be at least one program in the workload
-        TT_FATAL(!programs.empty(), "Mesh workload must have at least one program");
+    // Shared variables between create and override_runtime_arguments functions.
+    // Correspnds to ranges defined in `workload`.
+    std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t> shared_variables;
 
-        // Return the first program in the workload
-        auto& first_program_pair = *programs.begin();
-        return first_program_pair.second;
-    }
-    static shared_variables_t& get_first_shared_variables(
-        CachedMeshWorkload<shared_variables_t>& cached_mesh_workload) {
-        // Get the first shared variables from the map
-        // careful, this is an unordered map so the "first" element is arbitrary
-        auto& map = cached_mesh_workload.coordinate_range_to_shared_variables;
-        TT_FATAL(!map.empty(), "Shared variables map is empty");
-        return map.begin()->second;
-    }
-
-public:
-    // These are references to the original objects
-    tt::tt_metal::Program& program;
-    shared_variables_t& shared_variables;
-
-    // Constructor for CachedProgram
-    ProgramAdapter(CachedProgram<shared_variables_t>&& cached_program) :
-        cached_object_(std::move(cached_program)),
-        program(std::get<CachedProgram<shared_variables_t>>(cached_object_).program),
-        shared_variables(std::get<CachedProgram<shared_variables_t>>(cached_object_).shared_variables) {}
-    ProgramAdapter(CachedProgramRef<shared_variables_t>&& cached_program_ref) :
-        cached_object_(std::move(cached_program_ref)),
-        program(std::get<CachedProgramRef<shared_variables_t>>(cached_object_).program),
-        shared_variables(std::get<CachedProgramRef<shared_variables_t>>(cached_object_).shared_variables) {}
-
-    // Constructor for CachedProgram, CachedProgramRef, and CachedMeshWorkload
-    ProgramAdapter(tt::tt_metal::Program&& program, shared_variables_t&& shared_vars) :
-        ProgramAdapter(CachedProgram<shared_variables_t>{std::move(program), std::move(shared_vars)}) {}
-    ProgramAdapter(tt::tt_metal::Program& program, shared_variables_t& shared_vars) :
-        ProgramAdapter(CachedProgramRef<shared_variables_t>{program, shared_vars}) {}
-    ProgramAdapter(CachedMeshWorkload<shared_variables_t>&& cached_mesh_workload) :
-        cached_object_(std::move(cached_mesh_workload)),
-        program(get_first_program(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_))),
-        shared_variables(get_first_shared_variables(std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_))) {
-    }
-
-    ProgramAdapter(ProgramAdapter&& other) noexcept :
-        cached_object_{std::move(other.cached_object_)},
-        program{std::visit(
-            tt::stl::overloaded{
-                [&](CachedMeshWorkload<shared_variables_t>& obj) -> tt::tt_metal::Program& {
-                    return get_first_program(obj);
-                },
-                [&](CachedProgram<shared_variables_t>& obj) -> tt::tt_metal::Program& { return obj.program; },
-                [&](CachedProgramRef<shared_variables_t>& obj) -> tt::tt_metal::Program& { return obj.program; }},
-            cached_object_)},
-        shared_variables{std::visit(
-            tt::stl::overloaded{
-                [&](CachedMeshWorkload<shared_variables_t>& obj) -> shared_variables_t& {
-                    return get_first_shared_variables(obj);
-                },
-                [&](CachedProgram<shared_variables_t>& obj) -> shared_variables_t& { return obj.shared_variables; },
-                [&](CachedProgramRef<shared_variables_t>& obj) -> shared_variables_t& { return obj.shared_variables; }},
-            cached_object_)} {}
-
-    // Get the CachedMeshWorkload (throws if not a mesh workload)
-    CachedMeshWorkload<shared_variables_t>& get_cached_mesh_workload() {
-        return std::get<CachedMeshWorkload<shared_variables_t>>(cached_object_);
-    }
-
-    // Get the CachedProgram (throws if not a program)
-    CachedProgram<shared_variables_t>& get_cached_program() {
-        return std::get<CachedProgram<shared_variables_t>>(cached_object_);
-    }
+    CachedMeshWorkload(
+        tt::tt_metal::distributed::MeshWorkload&& workload,
+        std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t>&& shared_variables) :
+        workload{std::move(workload)}, shared_variables{std::move(shared_variables)} {}
 };
 
 struct CachedProgramFactory {
@@ -138,11 +58,16 @@ struct CachedProgramFactory {
     static constexpr auto ALIGNMENT = 32;
 
     tt::stl::unique_any<MAX_SIZE, ALIGNMENT> cached_program;
-    // program_factory_index is used to map a runtime value to a program factory type that is being used
-    std::size_t program_factory_index;
+
+    // Used to map a runtime value to a program factory type that is being used
+    std::size_t program_factory_index = 0;
 
     template <typename shared_variables_t>
-    CachedProgramFactory(ProgramAdapter<shared_variables_t>&& cached_program, std::size_t program_factory_index) :
+    CachedProgramFactory(CachedMeshWorkload<shared_variables_t>&& cached_workload, std::size_t program_factory_index) :
+        cached_program{std::move(cached_workload)}, program_factory_index{program_factory_index} {}
+
+    template <typename shared_variables_t>
+    CachedProgramFactory(CachedProgram<shared_variables_t>&& cached_program, std::size_t program_factory_index) :
         cached_program{std::move(cached_program)}, program_factory_index{program_factory_index} {}
 };
 

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -20,6 +20,7 @@
 #include <type_traits>
 #include "tools/profiler/op_profiler.hpp"
 #include "ttnn/mesh_device_operation_adapter.hpp"
+#include "ttnn/operation_concepts.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/distributed/types.hpp"
 
@@ -28,98 +29,10 @@ namespace ttnn {
 namespace device_operation {
 
 template <typename T>
-using CachedProgram = tt::tt_metal::program_cache::detail::ProgramAdapter<T>;
+using CachedProgram = tt::tt_metal::program_cache::detail::CachedProgram<T>;
 
-template <typename program_factory_t>
-concept ProgramFactoryConcept = requires {
-    [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
-        // Check that exactly one of create or create_at is implemented.
-        constexpr bool has_create =
-            requires { program_factory_t::create(operation_attributes, tensor_args, tensor_return_value); };
-        constexpr bool has_create_at = requires {
-            program_factory_t::create_at(
-                operation_attributes, std::declval<ttnn::MeshCoordinate>(), tensor_args, tensor_return_value);
-        };
-        static_assert(has_create != has_create_at, "Program factory must implement exactly one of create or create_at");
-
-        if constexpr (has_create) {
-            auto cached_program = program_factory_t::create(operation_attributes, tensor_args, tensor_return_value);
-            program_factory_t::override_runtime_arguments(
-                cached_program, operation_attributes, tensor_args, tensor_return_value);
-        } else if constexpr (has_create_at) {
-            auto cached_program = program_factory_t::create_at(
-                operation_attributes, std::declval<ttnn::MeshCoordinate>(), tensor_args, tensor_return_value);
-            program_factory_t::override_runtime_arguments_at(
-                cached_program,
-                operation_attributes,
-                std::declval<ttnn::MeshCoordinate>(),
-                tensor_args,
-                tensor_return_value);
-        }
-    };
-};
-
-template <typename device_operation_t>
-concept HasComputeOutputSpecs = requires(device_operation_t op,
-    const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args) {
-    {op.compute_output_specs(operation_attributes, tensor_args)} -> std::same_as<typename device_operation_t::spec_return_value_t>;
-};
-
-template <typename device_operation_t>
-concept DeviceOperationConcept = requires {
-    [](const typename device_operation_t::operation_attributes_t& operation_attributes,
-       const typename device_operation_t::tensor_args_t& tensor_args) {
-        device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
-        device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
-
-        using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;
-        static_assert(std::same_as<
-                      decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
-                      tensor_return_value_t>);
-
-        const auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
-        std::visit(
-            [](auto&& program_factory) {
-                using program_factory_t = std::decay_t<decltype(program_factory)>;
-                static_assert(ProgramFactoryConcept<program_factory_t>);
-            },
-            program_factory);
-    };
-} && HasComputeOutputSpecs<device_operation_t>;
-
-/**
- * @brief Concept that defines a device operation that has a mesh device adapter.
- *
- * This concept requires that the type satisfies both the DeviceOperationConcept
- * and the MeshDeviceOperationAdapterType concept. It represents operations that
- * can be executed across multiple devices in a mesh configuration using the
- * adapter pattern.
- */
-template <typename device_operation_t>
-concept DeviceOperationWithMeshDeviceAdapter =
-    DeviceOperationConcept<device_operation_t> && is_mesh_device_operation_adapter_v<device_operation_t>;
-
-
-template <typename device_operation_t>
-concept DeviceOperationWithCustomProgramCacheConcept =
-    DeviceOperationConcept<device_operation_t> &&
-    requires(
-        const typename device_operation_t::operation_attributes_t& operation_attributes,
-        const typename device_operation_t::tensor_args_t& tensor_args) {
-        { device_operation_t::compute_program_hash(operation_attributes, tensor_args)} -> std::convertible_to<tt::stl::hash::hash_t>;
-    };
-
-template <typename device_operation_t>
-concept HasSkipLaunch = requires(
-    device_operation_t op,
-    const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args,
-    const typename device_operation_t::tensor_return_value_t& tensor_return_value) {
-    {
-        device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)
-    } -> std::convertible_to<bool>;
-};
+template <typename T>
+using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorkload<T>;
 
 namespace detail {
 
@@ -159,37 +72,66 @@ tt::tt_metal::Program& create_or_get_program_from_cache(
         auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
 
         tt::tt_metal::Program& program = std::visit(
-            [&program_cache,
-             &program_hash,
-             &operation_attributes,
-             &tensor_args,
-             &tensor_return_value,
-             program_factory_index = program_factory.index()]<typename ProgramFactory>(const ProgramFactory&) -> tt::tt_metal::Program& {
-                if constexpr (requires { &ProgramFactory::create; }) {
-                    using cached_program_t =
-                        decltype(ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value));
+            tt::stl::overloaded{
+                [&program_cache,
+                 &program_hash,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value,
+                 program_factory_index = program_factory.index()]<ProgramFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> tt::tt_metal::Program& {
+                    if constexpr (requires { &ProgramFactory::create; }) {
+                        using cached_program_t =
+                            decltype(ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value));
+                        program_cache.insert(
+                            program_hash,
+                            tt::tt_metal::program_cache::detail::CachedProgramFactory{
+                                tt::tt_metal::program_cache::detail::CachedProgram(
+                                    ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value)),
+                                program_factory_index});
+                        auto& cached_program_factory = program_cache.get(program_hash);
+                        auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+                        return cached_program.program;
+                    } else {
+                        using cached_program_t = decltype(ProgramFactory::create_at(
+                            operation_attributes, ttnn::MeshCoordinate(0, 0), tensor_args, tensor_return_value));
+                        program_cache.insert(
+                            program_hash,
+                            tt::tt_metal::program_cache::detail::CachedProgramFactory{
+                                tt::tt_metal::program_cache::detail::CachedProgram(ProgramFactory::create_at(
+                                    operation_attributes,
+                                    ttnn::MeshCoordinate(0, 0),
+                                    tensor_args,
+                                    tensor_return_value)),
+                                program_factory_index});
+                        auto& cached_program_factory = program_cache.get(program_hash);
+                        auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+                        return cached_program.program;
+                    }
+                },
+                [&program_cache,
+                 &program_hash,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value,
+                 program_factory_index = program_factory.index()]<MeshWorkloadFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> tt::tt_metal::Program& {
+                    using cached_mesh_workload_t = ProgramFactory::cached_mesh_workload_t;
                     program_cache.insert(
                         program_hash,
                         tt::tt_metal::program_cache::detail::CachedProgramFactory{
-                            tt::tt_metal::program_cache::detail::ProgramAdapter(
-                                ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value)),
+                            tt::tt_metal::program_cache::detail::CachedMeshWorkload(
+                                ProgramFactory::create_mesh_workload(
+                                    operation_attributes,
+                                    std::vector<ttnn::MeshCoordinate>{ttnn::MeshCoordinate(0, 0)},
+                                    tensor_args,
+                                    tensor_return_value)),
                             program_factory_index});
                     auto& cached_program_factory = program_cache.get(program_hash);
-                    auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
-                    return cached_program.program;
-                } else {
-                    using cached_program_t = decltype(ProgramFactory::create_at(
-                        operation_attributes, ttnn::MeshCoordinate(0, 0), tensor_args, tensor_return_value));
-                    program_cache.insert(
-                        program_hash,
-                        tt::tt_metal::program_cache::detail::CachedProgramFactory{
-                            tt::tt_metal::program_cache::detail::ProgramAdapter(ProgramFactory::create_at(
-                                operation_attributes, ttnn::MeshCoordinate(0, 0), tensor_args, tensor_return_value)),
-                            program_factory_index});
-                    auto& cached_program_factory = program_cache.get(program_hash);
-                    auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
-                    return cached_program.program;
-                }
+                    auto& cached_workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
+                    TT_FATAL(cached_workload.workload.get_programs().size() == 1, "Expected 1 program in workload.");
+                    return cached_workload.workload.get_programs().begin()->second;
+                },
             },
             program_factory);
         return program;
@@ -203,29 +145,48 @@ tt::tt_metal::Program& create_or_get_program_from_cache(
         auto program_factory = map_index_to_variant(program_factory_index, program_factory_variant_t{});
 
         tt::tt_metal::Program& program = std::visit(
-            [&cached_program_factory,
-             &operation_attributes,
-             &tensor_args,
-             &tensor_return_value]<typename ProgramFactory>(const ProgramFactory&) -> tt::tt_metal::Program& {
-                if constexpr (requires { &ProgramFactory::create; }) {
-                    using cached_program_t =
-                        decltype(ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value));
-                    auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+            tt::stl::overloaded{
+                [&cached_program_factory,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value]<ProgramFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> tt::tt_metal::Program& {
+                    if constexpr (requires { &ProgramFactory::create; }) {
+                        using cached_program_t =
+                            decltype(ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value));
+                        auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+                        ProgramFactory::override_runtime_arguments(
+                            cached_program, operation_attributes, tensor_args, tensor_return_value);
+                        return cached_program.program;
+                    } else {
+                        using cached_program_t = decltype(ProgramFactory::create_at(
+                            operation_attributes,
+                            std::declval<ttnn::MeshCoordinate>(),
+                            tensor_args,
+                            tensor_return_value));
+                        auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+                        ProgramFactory::override_runtime_arguments_at(
+                            cached_program,
+                            operation_attributes,
+                            ttnn::MeshCoordinate(0, 0),
+                            tensor_args,
+                            tensor_return_value);
+                        return cached_program.program;
+                    }
+                },
+                [&cached_program_factory,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value]<MeshWorkloadFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> tt::tt_metal::Program& {
+                    using cached_mesh_workload_t = ProgramFactory::cached_mesh_workload_t;
+                    auto& cached_workload =
+                        cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
                     ProgramFactory::override_runtime_arguments(
-                        cached_program, operation_attributes, tensor_args, tensor_return_value);
-                    return cached_program.program;
-                } else {
-                    using cached_program_t = decltype(ProgramFactory::create_at(
-                        operation_attributes, std::declval<ttnn::MeshCoordinate>(), tensor_args, tensor_return_value));
-                    auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
-                    ProgramFactory::override_runtime_arguments_at(
-                        cached_program,
-                        operation_attributes,
-                        ttnn::MeshCoordinate(0, 0),
-                        tensor_args,
-                        tensor_return_value);
-                    return cached_program.program;
-                }
+                        cached_workload, operation_attributes, tensor_args, tensor_return_value);
+                    TT_FATAL(cached_workload.workload.get_programs().size() == 1, "Expected 1 program in workload.");
+                    return cached_workload.workload.get_programs().begin()->second;
+                },
             },
             program_factory);
         return program;
@@ -386,17 +347,27 @@ void launch_on_worker_thread(
 
     } else {
         auto program = std::visit(
-            [&]<typename ProgramFactory>(const ProgramFactory&) {
-                if constexpr (requires { &ProgramFactory::create; }) {
-                    auto cached_program =
-                        ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
-                    return std::make_shared<tt::tt_metal::Program>(std::move(cached_program.program));
-                } else {
-                    auto cached_program = ProgramFactory::create_at(
-                        operation_attributes, ttnn::MeshCoordinate(0, 0), tensor_args, tensor_return_value);
-                    return std::make_shared<tt::tt_metal::Program>(std::move(cached_program.program));
-                }
-            },
+            tt::stl::overloaded{
+                [&]<ProgramFactoryConcept ProgramFactory>(const ProgramFactory&) {
+                    if constexpr (requires { &ProgramFactory::create; }) {
+                        auto cached_program =
+                            ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
+                        return std::make_shared<tt::tt_metal::Program>(std::move(cached_program.program));
+                    } else {
+                        auto cached_program = ProgramFactory::create_at(
+                            operation_attributes, ttnn::MeshCoordinate(0, 0), tensor_args, tensor_return_value);
+                        return std::make_shared<tt::tt_metal::Program>(std::move(cached_program.program));
+                    }
+                },
+                [&]<MeshWorkloadFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> std::shared_ptr<tt::tt_metal::Program> {
+                    std::vector<ttnn::MeshCoordinate> mesh_coords = {ttnn::MeshCoordinate(0, 0)};
+                    auto cached_workload = ProgramFactory::create_mesh_workload(
+                        operation_attributes, mesh_coords, tensor_args, tensor_return_value);
+                    TT_FATAL(cached_workload.workload.get_programs().size() == 1, "Expected 1 program in workload.");
+                    return std::make_shared<tt::tt_metal::Program>(
+                        std::move(cached_workload.workload.get_programs().begin()->second));
+                }},
             device_operation_t::select_program_factory(operation_attributes, tensor_args));
 
         program->set_runtime_id(device_operation_id);
@@ -440,35 +411,40 @@ void handle_mesh_adapter_cache_hit(
         decltype(mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
     auto program_factory = map_index_to_variant(program_factory_index, program_factory_variant_t{});
 
-    std::visit([&]<typename ProgramFactory>(const ProgramFactory&) {
-        using shared_variables_t = typename ProgramFactory::shared_variables_t;
+    std::visit(
+        [&]<typename ProgramFactory>(const ProgramFactory&) {
+            using shared_variables_t = typename ProgramFactory::shared_variables_t;
 
-        // Get the adapter from cache with the correct shared variables type
-        auto& adapter = cached_program_factory.cached_program.template get<
-            tt::tt_metal::program_cache::detail::ProgramAdapter<shared_variables_t>>();
+            // Get the adapter from cache with the correct shared variables type
+            auto& cached_mesh_workload =
+                cached_program_factory.cached_program
+                    .template get<tt::tt_metal::program_cache::detail::CachedMeshWorkload<shared_variables_t>>();
 
-        // Override runtime arguments using the MeshDeviceOperationAdapter interface
-        mesh_device_operation_t::template override_mesh_runtime_arguments<ProgramFactory>(
-            adapter.get_cached_mesh_workload(),
-            mesh_device,
-            operation_attributes,
-            tensor_args,
-            tensor_return_value);
+            // Override runtime arguments using the MeshDeviceOperationAdapter interface
+            mesh_device_operation_t::template override_mesh_runtime_arguments<ProgramFactory>(
+                cached_mesh_workload, mesh_device, operation_attributes, tensor_args, tensor_return_value);
 
-        // Set runtime ID for all programs
-        for (auto& [_, program] : adapter.get_cached_mesh_workload().workload.get_programs()) {
-            program.set_runtime_id(ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
-            tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
-            if (tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
-                return;
+            // Set runtime ID for all programs
+            for (auto& [_, program] : cached_mesh_workload.workload.get_programs()) {
+                program.set_runtime_id(ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
+                tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
+                if (tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
+                    return;
+                }
             }
-        }
 
-        tt::tt_metal::distributed::EnqueueMeshWorkload(
-            mesh_device->mesh_command_queue(*cq_id), adapter.get_cached_mesh_workload().workload, false);
+            tt::tt_metal::distributed::EnqueueMeshWorkload(
+                mesh_device->mesh_command_queue(*cq_id), cached_mesh_workload.workload, false);
 
-        TracyOpMeshWorkload(mesh_device, adapter.get_cached_mesh_workload().workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);
-    }, program_factory);
+            TracyOpMeshWorkload(
+                mesh_device,
+                cached_mesh_workload.workload,
+                mesh_device_operation_t{},
+                operation_attributes,
+                tensor_args,
+                tensor_return_value);
+        },
+        program_factory);
 }
 
 // Helper for creating and caching a mesh workload
@@ -487,51 +463,62 @@ void create_and_cache_mesh_workload(
 
     auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
     auto program_factory_index = program_factory.index();
-    std::visit([&]<typename ConcreteFactory>(const ConcreteFactory&) {
-        using concrete_shared_vars_t = typename ConcreteFactory::shared_variables_t;
-        mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
-        tt::tt_metal::program_cache::detail::CachedMeshWorkload<typename ConcreteFactory::shared_variables_t>
-            cached_workload =
-                mesh_device_operation_utils::create_mesh_workload<mesh_device_operation_t, ConcreteFactory>(
+    std::visit(
+        [&]<typename ConcreteFactory>(const ConcreteFactory&) {
+            using concrete_shared_vars_t = typename ConcreteFactory::shared_variables_t;
+            mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+            CachedMeshWorkload<typename ConcreteFactory::shared_variables_t> cached_workload =
+                mesh_device_operation_utils::create_mesh_workload<ConcreteFactory>(
                     mesh_device, operation_attributes, tensor_args, tensor_return_value);
 
-        // Set runtime ID for all programs
-        for (auto& [_, program] : cached_workload.workload.get_programs()) {
-            program.set_runtime_id(ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
-            tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
-            if (tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
-                return;
+            // Set runtime ID for all programs
+            for (auto& [_, program] : cached_workload.workload.get_programs()) {
+                program.set_runtime_id(ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
+                tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
+                if (tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
+                    return;
+                }
             }
-        }
 
-        if (program_cache.is_enabled()) {
-            using namespace tt::tt_metal::program_cache::detail;
-            auto cmw = CachedMeshWorkload<concrete_shared_vars_t>(
-                std::move(cached_workload.workload),
-                std::move(cached_workload.coordinate_range_to_shared_variables));
+            if (program_cache.is_enabled()) {
+                using namespace tt::tt_metal::program_cache::detail;
+                program_cache.insert(
+                    program_hash,
+                    CachedProgramFactory{
+                        CachedMeshWorkload<concrete_shared_vars_t>(
+                            std::move(cached_workload.workload),
+                            std::move(cached_workload.shared_variables)),
+                        program_factory_index});
 
-            ProgramAdapter<concrete_shared_vars_t> adapter(std::move(cmw));
+                auto& cached_program_factory = program_cache.get(program_hash);
+                auto& cached_mesh_workload =
+                    cached_program_factory.cached_program.template get<CachedMeshWorkload<concrete_shared_vars_t>>();
 
-            program_cache.insert(
-                program_hash,
-                CachedProgramFactory{std::move(adapter), program_factory_index});
+                // Enqueue the workload
+                tt::tt_metal::distributed::EnqueueMeshWorkload(
+                    mesh_device->mesh_command_queue(*cq_id), cached_mesh_workload.workload, false);
 
-            auto& cached_program_factory = program_cache.get(program_hash);
-            auto& cached_adapter = cached_program_factory.cached_program.template get<
-                tt::tt_metal::program_cache::detail::ProgramAdapter<concrete_shared_vars_t>>();
-
-            // Enqueue the workload
-            tt::tt_metal::distributed::EnqueueMeshWorkload(
-                mesh_device->mesh_command_queue(*cq_id), cached_adapter.get_cached_mesh_workload().workload, false);
-
-            TracyOpMeshWorkload(mesh_device, cached_adapter.get_cached_mesh_workload().workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);
-        } else {
-            // Enqueue the workload directly (no caching)
-            tt::tt_metal::distributed::EnqueueMeshWorkload(
-                mesh_device->mesh_command_queue(*cq_id), cached_workload.workload, false);
-            TracyOpMeshWorkload(mesh_device, cached_workload.workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);
-        }
-    }, program_factory);
+                TracyOpMeshWorkload(
+                    mesh_device,
+                    cached_mesh_workload.workload,
+                    mesh_device_operation_t{},
+                    operation_attributes,
+                    tensor_args,
+                    tensor_return_value);
+            } else {
+                // Enqueue the workload directly (no caching)
+                tt::tt_metal::distributed::EnqueueMeshWorkload(
+                    mesh_device->mesh_command_queue(*cq_id), cached_workload.workload, false);
+                TracyOpMeshWorkload(
+                    mesh_device,
+                    cached_workload.workload,
+                    mesh_device_operation_t{},
+                    operation_attributes,
+                    tensor_args,
+                    tensor_return_value);
+            }
+        },
+        program_factory);
 }
 
 // Main function to launch operations on mesh devices with special handling for MeshDeviceOperationAdapter

--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -11,9 +11,9 @@
 #include <variant>
 #include <tt-metalium/program_cache.hpp>
 #include "ttnn/mesh_device_operation_utils.hpp"
-#include "tools/profiler/op_profiler.hpp"
+#include "ttnn/operation_concepts.hpp"
 
-namespace ttnn {
+namespace ttnn::device_operation {
 
 /**
  * A generic adapter that adds mesh device capabilities to any existing device operation.
@@ -82,9 +82,8 @@ struct MeshDeviceOperationAdapter {
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value) {
-        return ttnn::mesh_device_operation_utils::
-            template create_mesh_workload<DeviceOperation, ConcreteProgramFactory>(
-                mesh_device, attrs, tensor_args, tensor_return_value);
+        return mesh_device_operation_utils::create_mesh_workload<ConcreteProgramFactory>(
+            mesh_device, attrs, tensor_args, tensor_return_value);
     }
 
     template <typename ConcreteProgramFactory>
@@ -116,4 +115,16 @@ struct is_mesh_device_operation_adapter<MeshDeviceOperationAdapter<DeviceOp>> : 
 template <typename T>
 inline constexpr bool is_mesh_device_operation_adapter_v = is_mesh_device_operation_adapter<T>::value;
 
-}  // namespace ttnn
+/**
+ * @brief Concept that defines a device operation that has a mesh device adapter.
+ *
+ * This concept requires that the type satisfies both the DeviceOperationConcept
+ * and the MeshDeviceOperationAdapterType concept. It represents operations that
+ * can be executed across multiple devices in a mesh configuration using the
+ * adapter pattern.
+ */
+template <typename device_operation_t>
+concept DeviceOperationWithMeshDeviceAdapter =
+    DeviceOperationConcept<device_operation_t> && is_mesh_device_operation_adapter_v<device_operation_t>;
+
+}  // namespace ttnn::device_operation

--- a/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
@@ -134,12 +134,12 @@ void apply_override_runtime_arguments(
                 tensor_args,
                 return_value);
         }) {
-        // Wrap reference to `program` and `shared_vars` in a "cached program" object.
-        typename ConcreteProgramFactory::cached_program_t cached_program(program, shared_vars);
+        // Proxy references to `program` and `shared_vars` as a `CachedProgram` object.
+        auto cached_program_proxy = ConcreteProgramFactory::cached_program_t::proxy(program, shared_vars);
         if constexpr (requires { &ConcreteProgramFactory::override_runtime_arguments_at; }) {
-            factory.override_runtime_arguments_at(cached_program, attrs, coord, tensor_args, return_value);
+            factory.override_runtime_arguments_at(cached_program_proxy, attrs, coord, tensor_args, return_value);
         } else {
-            factory.override_runtime_arguments(cached_program, attrs, tensor_args, return_value);
+            factory.override_runtime_arguments(cached_program_proxy, attrs, tensor_args, return_value);
         }
     } else {
         if constexpr (requires { &ConcreteProgramFactory::override_runtime_arguments_at; }) {

--- a/ttnn/cpp/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/decorators.hpp"
+#include "ttnn/operation_concepts.hpp"
 
 namespace tt::tt_metal::operation {
 
@@ -48,7 +49,37 @@ struct OldInfraDeviceOperation {
         static bool uses_heterogenous_dispatch(const operation_attributes_t& attributes);
     };
 
-    using program_factory_t = std::variant<ProgramFactory>;
+    struct MeshWorkloadFactory {
+        struct shared_variables_t {
+            std::optional<operation::OverrideAddressesCallback> override_addresses_callback;
+            std::optional<operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
+                override_runtime_arguments_callback;
+        };
+        using cached_mesh_workload_t = ttnn::device_operation::CachedMeshWorkload<shared_variables_t>;
+
+        static cached_mesh_workload_t create_mesh_workload(
+            const operation_attributes_t& operation_attributes,
+            const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    // When the wrapped operation has `create_mesh_workload` method, `OldInfraDeviceOperation` adapter will select
+    // `MeshWorkloadFactory` as the program factory.
+    static_assert(
+        !ttnn::device_operation::ProgramFactoryConcept<MeshWorkloadFactory> &&
+        ttnn::device_operation::MeshWorkloadFactoryConcept<MeshWorkloadFactory>);
+    static_assert(
+        ttnn::device_operation::ProgramFactoryConcept<ProgramFactory> &&
+        !ttnn::device_operation::MeshWorkloadFactoryConcept<ProgramFactory>);
+
+    using program_factory_t = std::variant<ProgramFactory, MeshWorkloadFactory>;
 
     // Mandatory methods
 

--- a/ttnn/cpp/ttnn/operation_concepts.hpp
+++ b/ttnn/cpp/ttnn/operation_concepts.hpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <concepts>
+#include <optional>
+#include <random>
+#include <type_traits>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/graph_tracking.hpp>
+#include <tt-metalium/program_cache.hpp>
+
+#include <tt_stl/reflection.hpp>
+
+#include "ttnn/distributed/types.hpp"
+
+namespace ttnn::device_operation {
+
+template <typename T>
+concept ProgramFactoryConcept = requires {
+    typename T::cached_program_t;
+
+    [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
+        // Check that exactly one of create or create_at is implemented.
+        constexpr bool has_create = requires { T::create(operation_attributes, tensor_args, tensor_return_value); };
+        constexpr bool has_create_at = requires {
+            T::create_at(operation_attributes, std::declval<ttnn::MeshCoordinate>(), tensor_args, tensor_return_value);
+        };
+        static_assert(has_create != has_create_at, "Program factory must implement exactly one of create or create_at");
+
+        if constexpr (has_create) {
+            auto cached_program = T::create(operation_attributes, tensor_args, tensor_return_value);
+            T::override_runtime_arguments(cached_program, operation_attributes, tensor_args, tensor_return_value);
+        } else if constexpr (has_create_at) {
+            auto cached_program = T::create_at(
+                operation_attributes, std::declval<ttnn::MeshCoordinate>(), tensor_args, tensor_return_value);
+            T::override_runtime_arguments_at(
+                cached_program,
+                operation_attributes,
+                std::declval<ttnn::MeshCoordinate>(),
+                tensor_args,
+                tensor_return_value);
+        } else {
+            static_assert(
+                tt::stl::concepts::always_false_v<T>,
+                "Program factory must implement exactly one of create or create_at");
+        }
+    };
+};
+
+template <typename T>
+concept MeshWorkloadFactoryConcept = requires {
+    typename T::cached_mesh_workload_t;
+
+    [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
+        auto cached_workload = T::create_mesh_workload(
+            operation_attributes, std::vector<ttnn::MeshCoordinate>{}, tensor_args, tensor_return_value);
+
+        T::override_runtime_arguments(cached_workload, operation_attributes, tensor_args, tensor_return_value);
+    };
+};
+
+template <typename device_operation_t>
+concept HasComputeOutputSpecs = requires(
+    device_operation_t op,
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        op.compute_output_specs(operation_attributes, tensor_args)
+    } -> std::same_as<typename device_operation_t::spec_return_value_t>;
+};
+
+template <typename device_operation_t>
+concept DeviceOperationConcept = requires {
+    [](const typename device_operation_t::operation_attributes_t& operation_attributes,
+       const typename device_operation_t::tensor_args_t& tensor_args) {
+        device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+        device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+
+        using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;
+        static_assert(std::same_as<
+                      decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
+                      tensor_return_value_t>);
+
+        const auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
+        std::visit(
+            []<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
+                // Exactly one of the two concepts must be implemented.
+                static_assert(
+                    ProgramFactoryConcept<ConcreteProgramFactory> !=
+                    MeshWorkloadFactoryConcept<ConcreteProgramFactory>);
+            },
+            program_factory);
+    };
+} && HasComputeOutputSpecs<device_operation_t>;
+
+template <typename device_operation_t>
+concept DeviceOperationWithCustomProgramCacheConcept =
+    DeviceOperationConcept<device_operation_t> &&
+    requires(
+        const typename device_operation_t::operation_attributes_t& operation_attributes,
+        const typename device_operation_t::tensor_args_t& tensor_args) {
+        {
+            device_operation_t::compute_program_hash(operation_attributes, tensor_args)
+        } -> std::convertible_to<tt::stl::hash::hash_t>;
+    };
+
+template <typename device_operation_t>
+concept HasSkipLaunch = requires(
+    device_operation_t op,
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args,
+    const typename device_operation_t::tensor_return_value_t& tensor_return_value) {
+    {
+        device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)
+    } -> std::convertible_to<bool>;
+};
+
+}  // namespace ttnn::device_operation

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -15,7 +15,7 @@ namespace ttnn::operations::experimental::dropout {
 DropoutDeviceOperation::program_factory_t DropoutDeviceOperation::select_program_factory(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (args.use_per_device_seed) {
-        return program::DropoutProgramFactoryPerDeviceSeed{};
+        return program::DropoutMeshWorkloadFactory{};
     } else {
         return program::DropoutProgramFactory{};
     }

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -22,7 +22,7 @@ struct DropoutDeviceOperation {
     using tensor_args_t = dropout::tensor_args_t;
     using spec_return_value_t = dropout::spec_return_value_t;
     using tensor_return_value_t = dropout::tensor_return_value_t;
-    using program_factory_t = std::variant<program::DropoutProgramFactory, program::DropoutProgramFactoryPerDeviceSeed>;
+    using program_factory_t = std::variant<program::DropoutProgramFactory, program::DropoutMeshWorkloadFactory>;
     using shared_variables_t = program::DropoutProgramFactory::shared_variables_t;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
@@ -376,10 +376,10 @@ void DropoutMeshWorkloadFactory::override_runtime_arguments(
     TT_ASSERT(args.use_per_device_seed, "DropoutMeshWorkloadFactory should only be used if per-device seed is used.");
 
     for (auto& [mesh_coord_range, program] : cached_workload.workload.get_programs()) {
-        DropoutProgramFactory::cached_program_t cached_program(
+        auto cached_program_proxy = DropoutProgramFactory::cached_program_t::proxy(
             program, cached_workload.shared_variables.at(mesh_coord_range));
         DropoutProgramFactory::override_runtime_arguments(
-            cached_program,
+            cached_program_proxy,
             override_per_device_seed(args, mesh_coord_range.start_coord(), tensor_args.input),
             tensor_args,
             tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
@@ -37,23 +37,22 @@ struct DropoutProgramFactory {
         tensor_return_value_t& tensor_return_value);
 };
 
-struct DropoutProgramFactoryPerDeviceSeed {
+struct DropoutMeshWorkloadFactory {
     using shared_variables_t = DropoutSharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    using cached_mesh_workload_t = ttnn::device_operation::CachedMeshWorkload<shared_variables_t>;
 
-    // Dropout generates N different but they differ only in seed per device
-    // Hash erases the seed
-    // override_runtime_arguments_at sets the seed to per-device seed.
-    static cached_program_t create_at(
+    // Dropout generates N different programs, but they differ only in the per-device seed set as a runtime argument.
+    // TODO: when heterogenous runtime arguments are supported, create a single program for all devices, and only
+    // override the runtime arguments for each device.
+    static cached_mesh_workload_t create_mesh_workload(
         const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coord,
+        const std::vector<ttnn::MeshCoordinate>& mesh_coords,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
 
-    static void override_runtime_arguments_at(
-        cached_program_t& cached_program,
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
         const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coord,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
 };


### PR DESCRIPTION
### Ticket
#19569

### Problem description
Ops will benefit from having `create_mesh_workload` method.

### What's changed
* For new infra, introduce `MeshWorkloadFactoryConcept`. Factories that implement this, will need to provide `cached_mesh_workload_t`, `create_mesh_workload`, and `override_runtime_arguments` that works with `cached_mesh_workload_t`.
* For old infra, either `ProgramFactory` or `MeshWorkloadFactory` are selected based on whether the underlying Op satisfies `has_create_workload_method`.
* This PR keeps `create_at` infra, but it will be removed subsequently. In that PR, CCLs that rely on `create_at` will be migrated to `create_mesh_workload`.
* Tested `MeshWorkloadFactoryConcept` with making a change to dropout op.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14120345470)
- [X] New/Existing tests provide coverage for changes
- [X] Ran T3K TTNN unit tests and model tests locally.