### PR TITLE
Minor all-gather optimization

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -14,9 +14,9 @@ THRESHOLD = 0.4
 @pytest.mark.parametrize(
     "ag_type, warmup_iters, perf_target_us",
     [
-        ("sdpa", 15, 9.49),
-        ("binary_mult", 15, 10.54),
-        ("layernorm", 15, 6.47),
+        ("sdpa", 15, 9.01),
+        ("binary_mult", 15, 10.10),
+        ("layernorm", 15, 6.22),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -8,7 +8,7 @@ from loguru import logger
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from models.perf.device_perf_utils import run_device_perf_detailed
 
-THRESHOLD = 0.4
+THRESHOLD = 0.35
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -182,7 +182,7 @@ void kernel_main() {
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
-    fabric_connection.close();
+    fabric_connection.close_start();
     // increment locally
     uint64_t out_ready_sem_noc_addr =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr);
@@ -202,6 +202,7 @@ void kernel_main() {
         DPRINT << "reset done\n";
     }
 
+    fabric_connection.close_finish();
     noc_async_write_barrier();
     DPRINT << "DONE \n";
 }


### PR DESCRIPTION
Use a more advanced two step fabric connection close in all-gather for some additional minor time savings (couple hundred ns per op).

This was missed in this earlier PR: https://github.com/tenstorrent/tt-metal/pull/19715

Results:
| Op | Before (us) | After (us) | Delta (us) |
|-|-|-|-|
| All-gather binary mult | 10.50  | 10.10 | 0.4 |
| All-gather SDPA | 9.49 | 9.00 | 0.49|
| All-gather layernorm | 6.47 | 6.32 | 0.15 |


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes