### PR TITLE
Flush denormal inputs to zero

### DIFF
--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -202,17 +202,16 @@ uint8_t convert_u32_to_bfp(uint32_t input, uint32_t shared_exp, bool is_exp_a) {
     constexpr uint32_t MANTISSA_BFP_SHIFT = 24 - MANTISSA_BFP_WIDTH;
     constexpr uint32_t MANTISSA_BFP_MAX_VAL = (1 << MANTISSA_BFP_WIDTH) - 1;
 
-    // check for both +/- 0.0
-    constexpr uint32_t EXP_MANTISSA_BMSK = ((1U << 31) - 1);
-    bool is_zero = ((input & EXP_MANTISSA_BMSK) == 0);
-
-    if (is_zero) {
-        return 0;
-    }
-
     uint32_t mantissa = input & 0x007fffff;
     uint32_t exp = (input & 0x7f800000) >> 23;
     uint32_t sign = (input & 0x80000000) >> 31;
+
+    // check for both +/- 0.0 or +/- denormal
+    bool is_zero_or_denormal = (exp == 0);
+
+    if (is_zero_or_denormal) {
+        return 0;
+    }
 
     if (is_exp_a) {
         int32_t se = static_cast<int32_t>(exp);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18396

### Problem description
The HW does not expect a denormal input, and is not fully supported in SW as well. Converting a denormal from bfp_8 to float can create errors.

### What's changed
To avoid errors, if a denormal is created, it is flushed to zero.