### PR TITLE
Fix CCL tests using ttnn.barrier(...)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
@@ -60,6 +60,7 @@ tt::tt_metal::operation::ProgramWithCallbacks Barrier::create_program_at(
         /*is_starting_core*/ (device_index == 0),
         num_devices,
         device_index,
+        target_device->id(),
         receiver_device_id,
         sender_device_id,
         this->topology);

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
@@ -36,6 +36,7 @@ tt::tt_metal::operation::ProgramWithCallbacks barrier_with_workers(
     const bool is_starting_core,
     const uint32_t ring_size,
     const uint32_t ring_index,
+    chip_id_t target_device_id,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
     ttnn::ccl::Topology topology);

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/host/barrier_full_worker_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/host/barrier_full_worker_grid.cpp
@@ -92,6 +92,7 @@ operation::ProgramWithCallbacks barrier_with_workers(
     const bool is_starting_core,
     const uint32_t ring_size,
     const uint32_t ring_index,
+    chip_id_t target_device_id,
     const std::optional<chip_id_t> receiver_device_id,
     const std::optional<chip_id_t> sender_device_id,
     ttnn::ccl::Topology topology) {
@@ -105,7 +106,7 @@ operation::ProgramWithCallbacks barrier_with_workers(
     auto const& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
 
     // Get the device from the tensor
-    const auto& device = input_tensor.device();
+    const auto& device = input_tensor.mesh_device()->get_device(target_device_id);
     // Get a representation of the topology
 
     // Create the program


### PR DESCRIPTION
### Ticket
None

### Problem description
Tests that were using `ttnn.barrier(...)` were failing with the signature: 
`get_ethernet_sockets() is not supported on MeshDevice - use individual devices instead`

### What's changed
The implementation required `get_ethernet_sockets()` to be queried at the device-level, not at the MeshDevice level.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14119258320) CI passes