### PR TITLE
[tt-train] Remove bias for linear layers in Llama

### DIFF
--- a/tt-train/sources/ttml/modules/grouped_query_attention.cpp
+++ b/tt-train/sources/ttml/modules/grouped_query_attention.cpp
@@ -15,11 +15,11 @@ namespace ttml::modules {
 GroupedQueryAttention::GroupedQueryAttention(const GQAConfig& config) :
     m_embedding_dim(config.embedding_dim), m_num_heads(config.num_heads), m_num_groups(config.num_groups) {
     // create layers
-    m_q_linear = std::make_shared<ttml::modules::LinearLayer>(m_embedding_dim, m_embedding_dim);
+    m_q_linear = std::make_shared<ttml::modules::LinearLayer>(m_embedding_dim, m_embedding_dim, config.bias_linears);
     auto concat_kv_dim = 2U * m_num_groups * (m_embedding_dim / m_num_heads);
-    m_kv_linear = std::make_shared<ttml::modules::LinearLayer>(m_embedding_dim, concat_kv_dim);
+    m_kv_linear = std::make_shared<ttml::modules::LinearLayer>(m_embedding_dim, concat_kv_dim, config.bias_linears);
     m_dropout = std::make_shared<ttml::modules::DropoutLayer>(config.dropout_prob);
-    m_out_linear = std::make_shared<ttml::modules::LinearLayer>(m_embedding_dim, m_embedding_dim);
+    m_out_linear = std::make_shared<ttml::modules::LinearLayer>(m_embedding_dim, m_embedding_dim, config.bias_linears);
     m_embedding = std::make_shared<ttml::modules::RotaryEmbedding>(config.rope_params);
 
     // register modules

--- a/tt-train/sources/ttml/modules/grouped_query_attention.hpp
+++ b/tt-train/sources/ttml/modules/grouped_query_attention.hpp
@@ -16,6 +16,7 @@ struct GQAConfig {
     uint32_t num_groups{};
     float dropout_prob{};
     std::reference_wrapper<const ops::RotaryEmbeddingParams> rope_params;
+    bool bias_linears{false};
 };
 
 class GroupedQueryAttention : public ttml::autograd::ModuleBase {

--- a/tt-train/sources/ttml/modules/llama_block.cpp
+++ b/tt-train/sources/ttml/modules/llama_block.cpp
@@ -15,9 +15,9 @@ LlamaMLP::LlamaMLP(uint32_t embedding_size, float dropout_prob) {
     uint32_t multiple_of = 256;
     const uint32_t unrounded_size = static_cast<uint32_t>(static_cast<float>(4 * embedding_size) * (2.0F / 3.0F));
     const uint32_t hidden_size = ((unrounded_size + multiple_of - 1) / multiple_of) * multiple_of;
-    m_w1 = std::make_shared<LinearLayer>(embedding_size, hidden_size);
-    m_w3 = std::make_shared<LinearLayer>(embedding_size, hidden_size);
-    m_w2 = std::make_shared<LinearLayer>(hidden_size, embedding_size);
+    m_w1 = std::make_shared<LinearLayer>(embedding_size, hidden_size, /*has_bias=*/false);
+    m_w3 = std::make_shared<LinearLayer>(embedding_size, hidden_size, /*has_bias=*/false);
+    m_w2 = std::make_shared<LinearLayer>(hidden_size, embedding_size, /*has_bias=*/false);
     m_dropout = std::make_shared<DropoutLayer>(dropout_prob);
 
     create_name("llama_mlp");
@@ -51,6 +51,7 @@ LlamaBlock::LlamaBlock(
         .num_groups = num_groups,
         .dropout_prob = dropout_prob,
         .rope_params = rope_params,
+        .bias_linears = false,
     });
 
     create_name("llama_block");


### PR DESCRIPTION
### Problem description
Llama 3 does not use biased linear layers, but my implementation for tt-train currently includes biases.

### What's changed
- Set bias to false in all linear layers in the Llama module hierarchy.
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/703e988b-0104-443b-b54e-c362413aaee9" />
We observe a slight improvement in convergence speed with this change.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes