### PR TITLE
Remove Mixtral model perf tests from CI

### DIFF
--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -30,7 +30,6 @@ jobs:
       matrix:
         test-group: [
           { name: "t3k LLM falcon7b model perf tests", model: "falcon7b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon7b_tests, timeout: 75, owner_id: U05RWH3QUPM}, # Salar Hosseini
-          { name: "t3k LLM mixtral model perf tests", model: "mixtral", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 75, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "t3k LLM llama2-70B model perf tests", model: "llama2-70b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 75, owner_id: U03FJB5TM5Y}, # Colman Glagovich
           { name: "t3k LLM falcon40b model perf tests", model: "falcon40b", model-type: "LLM", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 75, owner_id: U053W15B6JF}, # Djordje Ivanovic
           { name: "t3k CNN resnet50 model perf tests", model: "resnet50", model-type: "CNN", arch: wormhole_b0, cmd: run_t3000_resnet50_tests, timeout: 75, owner_id: U0837MYG788}, # Marko Radosavljevic

--- a/tests/scripts/t3000/run_t3000_model_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_model_perf_tests.sh
@@ -19,24 +19,6 @@ run_t3000_falcon7b_tests() {
   fi
 }
 
-run_t3000_mixtral_tests() {
-  # Record the start time
-  fail=0
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_mixtral_tests"
-
-  env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py -m "model_perf_t3000" ; fail+=$?
-
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_mixtral_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
-
 # TODO [Deprecation notice] - Llama2-70B will be deprecated soon for the new Llama3-70B. The CI tests will be deprecated with it.
 run_t3000_llama2_70b_tests() {
   # Record the start time
@@ -133,9 +115,6 @@ run_t3000_ccl_reduce_scatter_perf_tests() {
 run_t3000_llm_tests() {
   # Run falcon7b tests
   run_t3000_falcon7b_tests
-
-  # Run mixtral tests
-  run_t3000_mixtral_tests
 
   # Run llama2-70b tests
   run_t3000_llama2_70b_tests


### PR DESCRIPTION
Mixtral is currently being implemented into the TT-Transformers library: https://github.com/tenstorrent/tt-metal/pull/19398

As soon as this hits main the old Mixtral codebase is going to be removed, and the perf test is going to be made redundant, since we now measure perf in the demo script instead.

- [x] [T3K perf pipeline](https://github.com/tenstorrent/tt-metal/actions/runs/14127207258)