### PR TITLE
Add support for in-place halo

### DIFF
--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -10,6 +10,7 @@ from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 UNET_FULL_MODEL_PCC = 0.99999
+UNET_TRACE_REGION_SIZE = 462848
 
 
 @dataclass

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -12,6 +12,8 @@ from models.utility_functions import (
     skip_for_grayskull,
 )
 
+from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_SIZE
+
 
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_device_performance_bare_metal
@@ -45,11 +47,13 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 424960, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 2, 128, 25.0, 830.0),),
+    ((1, 2, 128, 25.0, 825.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -87,13 +91,15 @@ def test_unet_trace_perf(
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 424960, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput, use_async_mode",
     (
         (1, 2, 128, 25.0, 1450.0, True),
-        (1, 2, 128, 25.0, 1650.0, False),
+        (1, 2, 128, 25.0, 1630.0, False),
     ),
 )
 def test_unet_trace_perf_multi_device(

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -19,6 +19,7 @@ from models.experimental.functional_unet.tests.common import (
     is_n300_with_eth_dispatch_cores,
     is_t3k_with_eth_dispatch_cores,
     UNET_FULL_MODEL_PCC,
+    UNET_TRACE_REGION_SIZE,
     UNetPerformanceStatistics,
 )
 
@@ -26,7 +27,9 @@ from models.utility_functions import skip_for_grayskull, divup
 
 
 @skip_for_grayskull("UNet not currently supported on GS")
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 68864, "trace_region_size": 444416}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE}], indirect=True
+)
 @pytest.mark.parametrize(
     "batch, groups, iterations",
     ((1, 2, 32),),
@@ -107,7 +110,9 @@ def test_unet_trace(
 
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 442368, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
@@ -218,7 +223,9 @@ def buffer_address(tensor):
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 442368, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
@@ -336,7 +343,9 @@ def test_unet_trace_2cq_multi_device(
 
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 424960, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",
@@ -470,7 +479,9 @@ def test_unet_trace_2cq_same_io(
 @skip_for_grayskull("UNet not currently supported on GS")
 @pytest.mark.parametrize("enable_async_mode", (True, False), indirect=True)
 @pytest.mark.parametrize(
-    "device_params", [{"l1_small_size": 68864, "trace_region_size": 424960, "num_command_queues": 2}], indirect=True
+    "device_params",
+    [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
+    indirect=True,
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations",

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -139,6 +139,7 @@ def create_unet_model_parameters(
     parameters.c8["use_activation_double_buffer"] = True
     parameters.c8["use_split_reader"] = True
     parameters.c8["input_channels_alignment"] = 16
+    parameters.c8["in_place"] = True
     parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
     parameters.c8_2["use_split_reader"] = True

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -148,6 +148,7 @@ class UNetConv2D:
             output_layout=output_layout,
             input_channels_alignment=conv.input_channels_alignment if "input_channels_alignment" in conv else 32,
             reshard_if_not_optimal=reshard_if_not_optimal,
+            in_place=conv.in_place if "in_place" in conv else False,
         )
         self.compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),

--- a/tests/sweep_framework/sweep_utils/max_pool2d_common.py
+++ b/tests/sweep_framework/sweep_utils/max_pool2d_common.py
@@ -58,6 +58,7 @@ def run_max_pool2d(
     sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     ceil_mode=False,
     memory_config=None,
+    in_place=False,
 ):
     kernel_size = [kernel_h, kernel_w]
     stride = [stride_h, stride_h]
@@ -101,6 +102,7 @@ def run_max_pool2d(
         dilation=[dilation_h, dilation_w],
         memory_config=memory_config,
         applied_shard_scheme=sharding,
+        in_place_halo=in_place,
     )
 
     output_host = output.cpu()

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -1711,6 +1711,8 @@ def test_unet_conv_groups_4_6_wh(
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
+    if input_channels == 32 and input_height == 1056 and groups == 6:
+        pytest.skip("OOM - enable when support for full in-place conv2d")
     run_conv(
         device,
         torch_tensor_map,

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -89,6 +89,7 @@ def run_conv(
     output_mesh_composer=None,
     enable_split_reader=False,
     activation="",
+    in_place=False,
     preprocess_weights_on_device=True,
     run_twice=False,
 ):
@@ -196,6 +197,7 @@ def run_conv(
         transpose_shards=transpose_shards,
         preprocess_weights_on_device=preprocess_weights_on_device,
         always_preprocess_weights=True,
+        in_place=in_place,
     )
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -1648,24 +1650,24 @@ def test_unet_conv_groups_2_wh(
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
-    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant",
+    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant, in_place",
     (
-        (16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        (16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        (32, 16, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (64, 32, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (64, 64, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 96, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 64, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
-        # (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True), # OOM - need inplace convolution
-        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
-        # (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True), # OOM - need inplace convolution
-        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 2 * 32}, False),
+        (16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (32, 16, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (64, 32, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (64, 64, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 96, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 64, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
+        (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
+        (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, True),
+        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 2 * 32}, False, False),
     ),
 )
 @pytest.mark.parametrize(
@@ -1701,6 +1703,7 @@ def test_unet_conv_groups_4_6_wh(
     use_shallow_conv_variant,
     output_layout,
     groups,
+    in_place,
 ):
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         pytest.skip("Test is not supported on n300 (8,7) grid")
@@ -1730,6 +1733,7 @@ def test_unet_conv_groups_4_6_wh(
         transpose_shards=True,  ## use RM (transpose_mcast=False) with 2D on WH
         output_layout=output_layout,
         groups=groups,
+        in_place=in_place,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -78,6 +78,7 @@ parameters = {
     },
     "test_run_max_pool_width_shard": {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "in_place": [True, False],
         "input_specs": [
             # Contains following parameters
             # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, strid_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
@@ -102,6 +103,7 @@ parameters = {
     },
     "test_run_max_pool_height_shard": {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "in_place": [True, False],
         "input_specs": [
             # Contains following parameters
             # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, strid_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
@@ -118,6 +120,7 @@ parameters = {
     },
     "test_run_max_pool_block_shard": {
         "dtype": [ttnn.bfloat16, ttnn.bfloat8_b],
+        "in_place": [True, False],
         "input_specs": [
             # Contains following parameters
             # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, strid_w, pad_h, pad_w, dilation_h, dilation_w, ceil_mode]
@@ -243,8 +246,11 @@ def test_max_pool2d_localrun(device, dtype, input_spec):
 
 @pytest.mark.parametrize("input_spec", parameters["test_run_max_pool_height_shard"]["input_specs"])
 @pytest.mark.parametrize("dtype", parameters["test_run_max_pool_height_shard"]["dtype"])
+@pytest.mark.parametrize("in_place", parameters["test_run_max_pool_height_shard"]["in_place"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_max_pool2d_localrun(device, dtype, input_spec):
+def test_max_pool2d_localrun(device, dtype, in_place, input_spec):
+    if dtype == ttnn.bfloat8_b and in_place:
+        pytest.xfail("BFloat8 is not currently supported when using in-place halo")
     (
         batch_size,
         input_channels,
@@ -277,6 +283,7 @@ def test_max_pool2d_localrun(device, dtype, input_spec):
         device,
         sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ceil_mode=ceil_mode,
+        in_place=in_place,
     )
 
 
@@ -321,8 +328,11 @@ def test_run_max_pool(device, dtype, input_spec):
 
 @pytest.mark.parametrize("input_spec", parameters["test_run_max_pool_width_shard"]["input_specs"])
 @pytest.mark.parametrize("dtype", parameters["test_run_max_pool_width_shard"]["dtype"])
+@pytest.mark.parametrize("in_place", parameters["test_run_max_pool_width_shard"]["in_place"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_run_max_pool_width_shard(device, dtype, input_spec):
+def test_run_max_pool_width_shard(device, dtype, in_place, input_spec):
+    if dtype == ttnn.bfloat8_b and in_place:
+        pytest.xfail("BFloat8 is not currently supported when using in-place halo")
     (
         batch_size,
         input_channels,
@@ -355,13 +365,17 @@ def test_run_max_pool_width_shard(device, dtype, input_spec):
         device,
         sharding=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ceil_mode=ceil_mode,
+        in_place=in_place,
     )
 
 
 @pytest.mark.parametrize("input_spec", parameters["test_run_max_pool_block_shard"]["input_specs"])
 @pytest.mark.parametrize("dtype", parameters["test_run_max_pool_block_shard"]["dtype"])
+@pytest.mark.parametrize("in_place", parameters["test_run_max_pool_block_shard"]["in_place"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_run_max_pool_block_shard(device, dtype, input_spec):
+def test_run_max_pool_block_shard(device, dtype, in_place, input_spec):
+    if dtype == ttnn.bfloat8_b and in_place:
+        pytest.xfail("BFloat8 is not currently supported when using in-place halo")
     (
         batch_size,
         input_channels,
@@ -394,6 +408,7 @@ def test_run_max_pool_block_shard(device, dtype, input_spec):
         device,
         sharding=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
         ceil_mode=ceil_mode,
+        in_place=in_place,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -203,7 +203,8 @@ Result conv2d(
                 parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
                 0,
                 input_tensor_post_tm.memory_config(),
-                true);
+                true,
+                conv_config.in_place);
 
             if (conv_config.deallocate_activation) {
                 input_tensor_post_tm.deallocate(/*force*/ true);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -340,6 +340,7 @@ void py_bind_conv2d(py::module& module) {
             bool,
             bool,
             bool,
+            bool,
             bool>(),
         py::kw_only(),
         py::arg("dtype") = DataType::BFLOAT16,
@@ -361,7 +362,8 @@ void py_bind_conv2d(py::module& module) {
         py::arg("enable_act_double_buffer") = false,
         py::arg("enable_weights_double_buffer") = false,
         py::arg("enable_split_reader") = false,
-        py::arg("enable_subblock_padding") = false);
+        py::arg("enable_subblock_padding") = false,
+        py::arg("in_place") = false);
     py_conv_config.def_readwrite("dtype", &Conv2dConfig::dtype);
     py_conv_config.def_readwrite("weights_dtype", &Conv2dConfig::weights_dtype);
     py_conv_config.def_readwrite("activation", &Conv2dConfig::activation);
@@ -382,6 +384,7 @@ void py_bind_conv2d(py::module& module) {
     py_conv_config.def_readwrite("enable_weights_double_buffer", &Conv2dConfig::enable_weights_double_buffer);
     py_conv_config.def_readwrite("enable_split_reader", &Conv2dConfig::enable_split_reader);
     py_conv_config.def_readwrite("enable_subblock_padding", &Conv2dConfig::enable_subblock_padding);
+    py_conv_config.def_readwrite("in_place", &Conv2dConfig::in_place);
 
     py_conv_config.def("__repr__", [](const Conv2dConfig& config) { return fmt::format("{}", config); });
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -83,6 +83,9 @@ struct Conv2dConfig {
 
     bool enable_subblock_padding = false;
 
+    // Re-use input tensor storage when creating output tensor
+    bool in_place = false;
+
     static constexpr auto attribute_names = std::make_tuple(
         "dtype",
         "weights_dtype",
@@ -102,7 +105,8 @@ struct Conv2dConfig {
         "enable_act_double_buffer",
         "enable_weights_double_buffer",
         "enable_split_reader",
-        "enable_subblock_padding");
+        "enable_subblock_padding",
+        "in_place");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(this->dtype),
@@ -123,7 +127,8 @@ struct Conv2dConfig {
             std::cref(this->enable_act_double_buffer),
             std::cref(this->enable_weights_double_buffer),
             std::cref(this->enable_split_reader),
-            std::cref(this->enable_subblock_padding));
+            std::cref(this->enable_subblock_padding),
+            std::cref(this->in_place));
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -44,7 +44,8 @@ Tensor Pool2DOp<pool_type>::invoke(
     std::array<uint32_t, 2> dilation,
     const std::optional<const MemoryConfig>& memory_config,
     const std::optional<const TensorMemoryLayout> applied_shard_scheme,
-    bool ceil_mode) {
+    bool ceil_mode,
+    bool in_place_halo) {
     sliding_window::SlidingWindowConfig sliding_window_config{
             .batch_size = batch_size,
             .input_hw = {input_h, input_w},
@@ -140,7 +141,8 @@ Tensor Pool2DOp<pool_type>::invoke(
         parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
         0,
         input_tensor_sharded.memory_config(),
-        is_out_tiled);
+        is_out_tiled,
+        in_place_halo);
 
     auto output_tensor = ttnn::prim::pool2d(
         queue_id,

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -30,7 +30,8 @@ struct Pool2DOp {
         std::array<uint32_t, 2> dilation,
         const std::optional<const MemoryConfig>& memory_config = std::nullopt,
         const std::optional<const TensorMemoryLayout> applied_shard_scheme = std::nullopt,
-        bool ceil_mode = false);
+        bool ceil_mode = false,
+        bool in_place_halo = false);
 };
 
 }  // namespace operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -37,6 +37,7 @@ void bind_max_pool2d_operation(py::module& module) {
             memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. Defaults to `None`.
             applied_shard_scheme (ttnn.TensorMemoryLayout, optional): the sharding scheme to apply to a non-pre-sharded input tensor. Defaults to `None`, which should be used with pre-sharded input tensors.
             ceil_mode (bool, optional): whether to use ceil mode for the output shape. Defaults to `False`.
+            in_place (bool, optional): whether to perform the halo operation in place. Defaults to `False`.
             queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
 
         Returns:
@@ -71,6 +72,7 @@ void bind_max_pool2d_operation(py::module& module) {
                                 memory_config=None,
                                 applied_shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
                                 ceil_mode=False,
+                                in_place_halo=False,
                             )
 
         )doc",
@@ -88,6 +90,7 @@ void bind_max_pool2d_operation(py::module& module) {
                const std::optional<const MemoryConfig>& memory_config,
                const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
                bool ceil_mode,
+               bool in_place_halo,
                QueueId queue_id) -> ttnn::Tensor {
                 return self(
                     queue_id,
@@ -102,7 +105,8 @@ void bind_max_pool2d_operation(py::module& module) {
                     dilation,
                     memory_config,
                     applied_shard_scheme,
-                    ceil_mode);
+                    ceil_mode,
+                    in_place_halo);
             },
             py::arg("input_tensor"),
             py::arg("batch_size"),
@@ -117,6 +121,7 @@ void bind_max_pool2d_operation(py::module& module) {
             py::arg("memory_config") = std::nullopt,
             py::arg("applied_shard_scheme") = std::nullopt,
             py::arg("ceil_mode") = false,
+            py::arg("in_place_halo") = false,
             py::arg("queue_id") = DefaultQueueId});
 }
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp"
 #include <array>
@@ -69,6 +70,11 @@ std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vec
         TT_FATAL(input_core_w == output_core_w, "Error");
     }
 
+    if (this->in_place_) {
+        tt::log_info(tt::LogAlways, "halo_device_operation - Using in-place mode so deallocating input buffer");
+        DeallocateBuffer(*input_tensor.buffer());
+    }
+
     auto out_mem_config = output_memory_config_;
     std::array<uint32_t, 2> shard_shape = {
         tt::div_up(output_shape[0] * output_shape[2], config_.num_cores_nhw),
@@ -89,6 +95,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
 
     bool is_in_tiled = input_tensor.get_layout() == Layout::TILE;
     bool is_block_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
+    TT_FATAL(!(is_in_tiled && this->in_place_), "In-place halo does not support tiled input tensors");
 
     auto pad_metadata = sliding_window::generate_pad_metadata(config_);
     auto op_trace_metadata = sliding_window::generate_op_trace_metadata(config_);
@@ -96,14 +103,23 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
     auto tensor_metadata = sliding_window::generate_tensor_metadata(
         pad_metadata, config_, reshard_num_cores_nhw_, is_in_tiled || is_out_tiled_);
     auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
-        tensor_metadata, shard_boundaries, is_block_sharded, transpose_mcast_, remote_read_, device);
+        tensor_metadata,
+        shard_boundaries,
+        is_block_sharded,
+        transpose_mcast_,
+        remote_read_,
+        device,
+        max_out_nsticks_per_core_,
+        in_nsticks_per_core_,
+        this->in_place_);
 
-    const auto& pad_config1 = kernel_config[0];
-    const auto& pad_config2 = kernel_config[1];
-    const auto& local_config1 = kernel_config[2];
-    const auto& local_config2 = kernel_config[3];
-    const auto& remote_config1 = kernel_config[4];
-    const auto& remote_config2 = kernel_config[5];
+    const auto& pad_config1 = std::get<0>(kernel_config)[0];
+    const auto& pad_config2 = std::get<0>(kernel_config)[1];
+    const auto& local_config1 = std::get<0>(kernel_config)[2];
+    const auto& local_config2 = std::get<0>(kernel_config)[3];
+    const auto& remote_config1 = std::get<0>(kernel_config)[4];
+    const auto& remote_config2 = std::get<0>(kernel_config)[5];
+    const auto& max_ref_size = std::get<1>(kernel_config);
 
     auto pad_config_tensor1 =
         sliding_window::construct_on_host_config_tensor(pad_config1, this->config_, this->parallel_config_);
@@ -131,6 +147,11 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
     auto remote_config_device_tensor2 =
         sliding_window::move_config_tensor_to_device(remote_config_tensor2, parallel_config_, is_block_sharded, device);
 
+    DataType type = input_tensor.get_dtype();
+    int num_cores = this->parallel_config_.grid.num_cores();
+    int num_cores_c = conv::get_num_cores_channels_from_parallel_config(this->parallel_config_);
+    int stick_size = input_tensor.get_padded_shape()[3] / num_cores_c;
+
     Program program = CreateProgram();
 
     return {data_movement::detail::untilize_with_halo_multi_core_v2(
@@ -138,7 +159,9 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         input_tensor,
         pad_val_,
         config_.num_cores_nhw,
+        config_.num_cores_c,
         max_out_nsticks_per_core_,
+        max_ref_size,
         pad_config_device_tensor1,
         pad_config_device_tensor2,
         local_config_device_tensor1,
@@ -148,7 +171,8 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         remote_read_,
         transpose_mcast_,
         output_tensor,
-        /*capture_buffers=*/true)};
+        /*capture_buffers=*/true,
+        this->in_place_)};
 }
 
 Tensor halo_op(
@@ -159,7 +183,8 @@ Tensor halo_op(
     bool transpose_mcast,
     uint32_t reshard_num_cores_nhw,
     const MemoryConfig& output_memory_config,
-    bool is_out_tiled) {
+    bool is_out_tiled,
+    bool in_place) {
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Halo expects sharded input tensor");
     TT_FATAL(
         input_tensor.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED ||
@@ -177,7 +202,8 @@ Tensor halo_op(
          transpose_mcast,
          reshard_num_cores_nhw,
          output_memory_config,
-         is_out_tiled](
+         is_out_tiled,
+         in_place](
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
@@ -195,10 +221,19 @@ Tensor halo_op(
 
         uint32_t max_out_nsticks_per_core =
             HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.at(sliding_window_hash);
+        uint32_t in_nsticks_per_core = input_tensor.memory_config().shard_spec->shape[0];
         ParallelConfig p_config;
         p_config.grid = input_tensor.shard_spec().value().grid;
         p_config.shard_scheme = input_tensor.memory_config().memory_layout;
         p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
+
+        if (in_place && in_nsticks_per_core > max_out_nsticks_per_core) {
+            tt::log_info(
+                tt::LogAlways,
+                "halo_device_operation - in place operation is not supported for parameterizations with "
+                "input shard size larger than output shard size, falling back to normal operation");
+            in_place = false;
+        }
 
         return operation::run(
             HaloDeviceOperation{
@@ -209,8 +244,10 @@ Tensor halo_op(
                 .transpose_mcast_ = transpose_mcast,
                 .reshard_num_cores_nhw_ = reshard_num_cores_nhw,
                 .max_out_nsticks_per_core_ = max_out_nsticks_per_core,
+                .in_nsticks_per_core_ = in_nsticks_per_core,
                 .output_memory_config_ = output_memory_config,
-                .is_out_tiled_ = is_out_tiled},
+                .is_out_tiled_ = is_out_tiled,
+                .in_place_ = in_place},
             {input_tensor});
     };
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -23,8 +23,10 @@ struct HaloDeviceOperation {
     bool transpose_mcast_;
     uint32_t reshard_num_cores_nhw_;
     uint32_t max_out_nsticks_per_core_;
+    uint32_t in_nsticks_per_core_;
     tt::tt_metal::MemoryConfig output_memory_config_;
     bool is_out_tiled_;
+    bool in_place_;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
@@ -41,7 +43,8 @@ struct HaloDeviceOperation {
         "reshard_num_cores_nhw_",
         "max_out_nsticks_per_core_",
         "output_memory_config_",
-        "is_out_tiled_");
+        "is_out_tiled_",
+        "in_place_");
     const auto attribute_values() const {
         return std::make_tuple(
             std::cref(config_),
@@ -52,7 +55,8 @@ struct HaloDeviceOperation {
             std::cref(reshard_num_cores_nhw_),
             std::cref(max_out_nsticks_per_core_),
             std::cref(output_memory_config_),
-            std::cref(is_out_tiled_));
+            std::cref(is_out_tiled_),
+            std::cref(in_place_));
     }
 };
 
@@ -64,7 +68,8 @@ Tensor halo_op(
     bool transpose_mcast = true,
     uint32_t reshard_num_cores_nhw = 0,
     const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-    bool is_out_tiled = true);
+    bool is_out_tiled = true,
+    bool in_place = false);
 
 }  // namespace halo
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -89,19 +89,19 @@ void kernel_main() {
     constexpr uint32_t padding_config_cb_id = get_compile_time_arg_val(0);  // has untilized input shard
     constexpr uint32_t local_config_cb_id = get_compile_time_arg_val(1);    // has untilized input shard
     constexpr uint32_t remote_config_cb_id = get_compile_time_arg_val(2);   // has untilized input shard
-    constexpr uint32_t src_cb_id = get_compile_time_arg_val(3);             // has untilized input shard
-    constexpr uint32_t in_cb_id = get_compile_time_arg_val(4);              // has untilized input shard
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(5);     // output shard with padding and halo goes here
-    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(6);     // cb for const pad val buffer
-    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(7);   // pad value to fill pad buffer with
-    constexpr uint32_t in_nsticks = get_compile_time_arg_val(8);    // number of sticks
-    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(9);  // stick size in bytes (post untilize)
-    constexpr uint32_t is_block_sharded = get_compile_time_arg_val(10);
-    constexpr uint32_t remote_read = get_compile_time_arg_val(11);
-    constexpr bool is_col_major = get_compile_time_arg_val(12) == 1;
-    constexpr uint32_t is_width_sharded = get_compile_time_arg_val(13);
-    constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(14);
-    constexpr bool is_reader = get_compile_time_arg_val(15);  // reader core fills the pad buffer and writer core waits
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(4);             // has untilized input shard
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(5);              // has untilized input shard
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(6);     // output shard with padding and halo goes here
+    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(7);     // cb for const pad val buffer
+    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(8);   // pad value to fill pad buffer with
+    constexpr uint32_t in_nsticks = get_compile_time_arg_val(9);    // number of sticks
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(10);  // stick size in bytes (post untilize)
+    constexpr uint32_t is_block_sharded = get_compile_time_arg_val(11);
+    constexpr uint32_t remote_read = get_compile_time_arg_val(12);
+    constexpr bool is_col_major = get_compile_time_arg_val(13) == 1;
+    constexpr uint32_t is_width_sharded = get_compile_time_arg_val(14);
+    constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(15);
+    constexpr bool is_reader = get_compile_time_arg_val(16);  // reader core fills the pad buffer and writer core waits
                                                               // for that buffer to be filled before copying data.
 
     constexpr uint32_t elem_nbytes = sizeof(uint16_t);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
@@ -1,0 +1,306 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <cstdint>
+
+#include "dataflow_api.h"
+
+#define ENABLE_DEBUG 1
+
+#if ENABLE_DEBUG
+#include "debug/dprint_pages.h"
+#endif
+
+// Fill an L1 buffer with the given val
+inline bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
+    // simplest impl:
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(begin_addr);
+    for (uint32_t i = 0; i < n; ++i) {
+        ptr[i] = val;
+    }
+    return true;
+}
+
+template <uint32_t stick_nbytes, uint32_t input_aligned_page_size>
+void copy_sticks_async_to_temp(
+    const tt_l1_ptr uint16_t* config_data,
+    const uint16_t my_noc_x,
+    const uint16_t my_noc_y,
+    const uint32_t in_base_l1_addr,
+    const uint32_t out_base_l1_addr) {
+    int i = 0;
+    int length = config_data[i + 2];
+
+    const uint64_t base_addr = get_noc_addr(my_noc_x, my_noc_y, out_base_l1_addr);
+    uint64_t dst_addr = base_addr;
+
+    while (length) {
+        length = config_data[i + 2];
+        i += 3;
+        for (uint16_t j = 0; j < length; j += 3) {
+            uint16_t src_local_idx = config_data[i + j + 0];
+            uint16_t nsticks = config_data[i + j + 2];
+            uint32_t size = nsticks * stick_nbytes;
+            uint32_t src_offset = src_local_idx * input_aligned_page_size;
+
+            uint32_t src_addr = in_base_l1_addr + src_offset;
+            if constexpr (stick_nbytes == input_aligned_page_size) {
+                noc_async_write(src_addr, dst_addr, size);
+                dst_addr += size;  // remote sticks from each config entry are written contiguously into the temp buffer
+            } else {
+                for (uint16_t k = 0; k < nsticks; k++) {
+                    noc_async_write(src_addr, dst_addr, stick_nbytes);
+                    dst_addr += stick_nbytes;
+                    src_addr += input_aligned_page_size;
+                }
+            }
+        }
+
+        i += length;
+    }
+}
+
+template <
+    uint32_t stick_nbytes,
+    uint32_t input_aligned_page_size,
+    bool is_block_sharded,
+    bool is_width_sharded,
+    bool is_col_major>
+void copy_sticks_async_from_temp(
+    const tt_l1_ptr uint16_t* config_data,
+    const uint16_t my_noc_x,
+    const uint16_t my_noc_y,
+    const uint32_t in_base_l1_addr,
+    const uint32_t out_base_l1_addr) {
+    int i = 0;
+    int length = config_data[i + 2];
+
+    uint64_t src_addr = in_base_l1_addr;
+
+    while (length) {
+        uint16_t noc_x = ((is_block_sharded && !is_col_major) || is_width_sharded) ? my_noc_x : config_data[i + 0];
+        uint16_t noc_y = ((is_block_sharded && is_col_major) || is_width_sharded) ? my_noc_y : config_data[i + 1];
+        length = config_data[i + 2];
+        i += 3;
+        const uint64_t base_addr = get_noc_addr(noc_x, noc_y, out_base_l1_addr);
+        for (uint16_t j = 0; j < length; j += 3) {
+            uint16_t dst_local_idx = config_data[i + j + 1];
+            uint16_t nsticks = config_data[i + j + 2];
+            uint32_t size = nsticks * stick_nbytes;
+            uint32_t dst_offset = dst_local_idx * stick_nbytes;
+
+            uint64_t dst_addr = base_addr + dst_offset;
+            if constexpr (stick_nbytes == input_aligned_page_size) {
+                noc_async_write(src_addr, dst_addr, size);
+                src_addr += size;  // remote sticks from each config entry are read contiguously from the temp buffer
+            } else {
+                for (uint16_t k = 0; k < nsticks; k++) {
+                    noc_async_write(src_addr, dst_addr, stick_nbytes);
+                    dst_addr += stick_nbytes;
+                    src_addr += stick_nbytes;
+                }
+            }
+        }
+
+        i += length;
+    }
+}
+
+template <uint32_t stick_nbytes, uint32_t input_aligned_page_size>
+void copy_sticks_async(
+    const tt_l1_ptr uint16_t* config_data,
+    const uint16_t my_noc_x,
+    const uint16_t my_noc_y,
+    const uint32_t in_base_l1_addr,
+    const uint32_t out_base_l1_addr,
+    const uint32_t in_out_buffer_start_delta) {
+    int i = 0;
+    int length = config_data[i + 2];
+
+    while (length) {
+        length = config_data[i + 2];
+        i += 3;
+        const uint64_t base_addr = get_noc_addr(my_noc_x, my_noc_y, out_base_l1_addr);
+        const uint64_t base_addr_src = get_noc_addr(my_noc_x, my_noc_y, in_base_l1_addr);
+        for (uint16_t j = 0; j < length; j += 3) {
+            uint16_t src_local_idx = config_data[i + j + 0];
+            uint16_t dst_local_idx = config_data[i + j + 1];
+            uint16_t nsticks = config_data[i + j + 2];
+            uint32_t size = nsticks * stick_nbytes;
+            uint32_t dst_offset = dst_local_idx * stick_nbytes;
+            uint32_t src_offset = src_local_idx * input_aligned_page_size;
+
+            uint64_t dst_addr = base_addr + dst_offset;
+            uint32_t src_addr = in_base_l1_addr + src_offset;
+
+            bool is_forward_copy = dst_local_idx > src_local_idx + in_out_buffer_start_delta &&
+                                   dst_local_idx <= src_local_idx + in_out_buffer_start_delta + nsticks;
+            bool is_overlap_copy = (dst_local_idx > src_local_idx + in_out_buffer_start_delta &&
+                                    dst_local_idx <= src_local_idx + in_out_buffer_start_delta + nsticks) ||
+                                   (dst_local_idx + nsticks >= src_local_idx + in_out_buffer_start_delta &&
+                                    dst_local_idx + nsticks < src_local_idx + in_out_buffer_start_delta + nsticks);
+            if (is_overlap_copy) {      // dst and src data overlaps, stick by stick copy is necessary
+                if (is_forward_copy) {  // dst data is being moved "in front" of the source data, reverse
+                                        // ordering of stick by stick copy is necessary
+                    for (int16_t k = nsticks - 1; k >= 0; k--) {
+                        noc_async_write(src_addr + k * stick_nbytes, dst_addr + k * stick_nbytes, stick_nbytes);
+                    }
+                } else {
+                    for (uint16_t k = 0; k < nsticks; k++) {
+                        noc_async_write(src_addr + k * stick_nbytes, dst_addr + k * stick_nbytes, stick_nbytes);
+                    }
+                }
+            } else {
+                noc_async_write(src_addr, dst_addr, size);
+            }
+        }
+
+        i += length;
+    }
+}
+
+/*
+In Place Halo Kernel Details:
+For the in place version of halo the input and output buffers overlap,
+thus it is necessary to order the local, remote and padding data
+movement operations such that the local data originating in each shard
+is not overwritten before being copied to all it's final destinations,
+which may span several output shards. This is done with the following
+steps:
+
+1. (BR) copy the remote sticks from "my" shard to temp buffer
+2. (BR) copy the local sticks from "my" shard to their destinations
+3. (NC,BR) wait on semaphores for all cores to finish 1. and 2.
+4. (NC) write the padding sticks to their destinations
+4. (BR) copy the remote sticks from temp buffer to their destinations
+*/
+
+void kernel_main() {
+    constexpr uint32_t padding_config_cb_id = get_compile_time_arg_val(0);  // has untilized input shard
+    constexpr uint32_t local_config_cb_id = get_compile_time_arg_val(1);    // has untilized input shard
+    constexpr uint32_t remote_config_cb_id = get_compile_time_arg_val(2);   // has untilized input shard
+    constexpr uint32_t remote_temp_cb_id = get_compile_time_arg_val(3);     // has untilized input shard
+    constexpr uint32_t src_cb_id = get_compile_time_arg_val(4);             // has untilized input shard
+    constexpr uint32_t in_cb_id = get_compile_time_arg_val(5);              // has untilized input shard
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(6);      // output shard with padding and halo goes here
+    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(7);      // cb for const pad val buffer
+    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(8);    // pad value to fill pad buffer with
+    constexpr uint32_t in_nsticks = get_compile_time_arg_val(9);     // number of sticks
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(10);  // stick size in bytes (post untilize)
+    constexpr uint32_t is_block_sharded = get_compile_time_arg_val(11);
+    constexpr bool is_col_major = get_compile_time_arg_val(13) == 1;
+    constexpr uint32_t is_width_sharded = get_compile_time_arg_val(14);
+    constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(15);
+    constexpr uint32_t remote_read = get_compile_time_arg_val(16);  // Unused parameter
+    constexpr uint32_t num_cores_nhw = get_compile_time_arg_val(17);
+    constexpr uint32_t num_cores_c = get_compile_time_arg_val(18);
+    constexpr uint32_t num_cores_x = get_compile_time_arg_val(19);
+    constexpr uint32_t semaphore_id = get_compile_time_arg_val(20);
+    constexpr uint32_t max_out_nsticks_per_core = get_compile_time_arg_val(21);
+
+    constexpr uint32_t num_cores = num_cores_nhw * num_cores_c;
+
+    uint32_t arg_idx = 0;
+    tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+    tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += num_cores;
+
+    constexpr uint32_t elem_nbytes = sizeof(uint16_t);
+    constexpr uint16_t pad_core_id = 0xFFFF;
+
+    const uint16_t my_noc_x = NOC_X(my_x[noc_index]);
+    const uint16_t my_noc_y = NOC_Y(my_y[noc_index]);
+    const uint32_t in_base_l1_addr = get_read_ptr(in_cb_id);
+    const uint32_t out_base_l1_addr = get_write_ptr(out_cb_id);
+
+    // input shards
+    if constexpr (local_config_cb_id) {
+        cb_reserve_back(src_cb_id, in_nsticks);
+        cb_push_back(src_cb_id, in_nsticks);
+    }
+
+    uint32_t semaphore_addr = 0;
+    semaphore_addr = get_semaphore(semaphore_id);
+
+    cb_wait_front(in_cb_id, in_nsticks);  // make sure untilized data is available
+    if constexpr (remote_config_cb_id && remote_temp_cb_id) {
+        const uint32_t temp_base_l1_addr = get_write_ptr(remote_temp_cb_id);
+        uint32_t config_data_l1_addr = get_read_ptr(remote_config_cb_id);
+        const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+        copy_sticks_async_to_temp<stick_nbytes, input_aligned_page_size>(
+            config_data, my_noc_x, my_noc_y, in_base_l1_addr, temp_base_l1_addr);
+    }
+
+    noc_async_read_barrier();
+    noc_async_write_barrier();
+
+    if constexpr (local_config_cb_id) {
+        const int32_t in_out_buffer_start_delta = max_out_nsticks_per_core - in_nsticks;
+        uint32_t config_data_l1_addr = get_read_ptr(local_config_cb_id);
+        const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+        copy_sticks_async<stick_nbytes, input_aligned_page_size>(
+            config_data, my_noc_x, my_noc_y, in_base_l1_addr, out_base_l1_addr, in_out_buffer_start_delta);
+    }
+
+    noc_async_read_barrier();
+    noc_async_write_barrier();
+
+    for (uint16_t noc = 0; noc < num_cores; ++noc) {
+        DPRINT << "id=" << noc << " x=" << core_noc_x[noc] << " y=" << core_noc_y[noc] << ENDL();
+        const uint64_t ref_semaphore_noc_addr = get_noc_addr(core_noc_x[noc], core_noc_y[noc], semaphore_addr);
+        noc_semaphore_inc(ref_semaphore_noc_addr, 1);
+    }
+
+    if constexpr (padding_config_cb_id) {
+        const uint64_t my_semaphore_noc_addr = get_noc_addr(my_noc_x, my_noc_y, semaphore_addr);
+        volatile tt_l1_ptr uint32_t* my_semaphore_noc_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(my_semaphore_noc_addr);
+        noc_semaphore_wait(my_semaphore_noc_addr_ptr, 2 * num_cores);
+
+        // construct the pad stick in its buffer
+        cb_reserve_back(pad_cb_id, 1);
+        const uint16_t pad_val = pad_val_u32;
+        fill_with_val(get_write_ptr(pad_cb_id), stick_nbytes / elem_nbytes, pad_val);
+        cb_push_back(pad_cb_id, 1);
+
+        uint32_t padding_config_l1_addr = get_read_ptr(padding_config_cb_id);
+        volatile tt_l1_ptr uint16_t* config_data =
+            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(padding_config_l1_addr);
+        const uint64_t padding_l1_addr = get_noc_addr(my_noc_x, my_noc_y, get_read_ptr(pad_cb_id));
+        const uint32_t dst_base_addr = out_base_l1_addr;
+        uint16_t nsticks = 1;
+        for (uint16_t j = 0; nsticks; j += 2) {
+            uint16_t dst_local_idx = config_data[j + 0];
+            nsticks = config_data[j + 1];
+
+            uint64_t dst_addr = dst_base_addr + dst_local_idx * stick_nbytes;
+            for (uint16_t k = 0; k < nsticks; ++k) {
+                noc_async_read(padding_l1_addr, dst_addr, stick_nbytes);
+                dst_addr += stick_nbytes;
+            }
+        }
+    }
+
+    if constexpr (remote_config_cb_id && remote_temp_cb_id) {
+        const uint64_t my_semaphore_noc_addr = get_noc_addr(my_noc_x, my_noc_y, semaphore_addr);
+        volatile tt_l1_ptr uint32_t* my_semaphore_noc_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(my_semaphore_noc_addr);
+        noc_semaphore_wait(my_semaphore_noc_addr_ptr, 2 * num_cores);
+
+        const uint32_t temp_base_l1_addr = get_read_ptr(remote_temp_cb_id);
+        uint32_t config_data_l1_addr = get_read_ptr(remote_config_cb_id);
+        const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);
+        copy_sticks_async_from_temp<
+            stick_nbytes,
+            input_aligned_page_size,
+            is_block_sharded,
+            is_width_sharded,
+            is_col_major>(config_data, my_noc_x, my_noc_y, temp_base_l1_addr, out_base_l1_addr);
+    }
+
+    noc_async_read_barrier();
+    noc_async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.hpp
@@ -13,7 +13,9 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     const Tensor& input_tensor,
     const uint32_t pad_val,
     const uint32_t ncores_nhw,
+    const uint32_t ncores_c,
     const uint32_t max_out_nsticks_per_core,
+    const uint32_t max_ref_size,
     const Tensor& padding_config1,
     const Tensor& padding_config2,
     const Tensor& local_config1,
@@ -23,6 +25,7 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     const bool remote_read,
     const bool transpose_mcast,
     Tensor& output_tensor,
-    const bool capture_buffers);  // Used by halo op to cache internally created config buffers with the program
-                                  // Untilize with Halo V2 op takes them as inputs from the user, so doesn't capture
+    const bool capture_buffers,
+    bool in_place = false);  // Used by halo op to cache internally created config buffers with the program
+                             // Untilize with Halo V2 op takes them as inputs from the user, so doesn't capture
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
@@ -16,7 +16,8 @@ Tensor HaloOperation::invoke(
     bool transpose_mcast,
     uint32_t reshard_num_cores_nhw,
     const MemoryConfig& output_memory_config,
-    bool is_out_tiled) {
+    bool is_out_tiled,
+    bool in_place) {
     return halo_op(
         input_tensor,
         config,
@@ -25,6 +26,7 @@ Tensor HaloOperation::invoke(
         transpose_mcast,
         reshard_num_cores_nhw,
         std::move(output_memory_config),
-        is_out_tiled);
+        is_out_tiled,
+        in_place);
 }
 };  // namespace ttnn::operations::sliding_window::halo

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
@@ -19,8 +19,9 @@ struct HaloOperation {
         bool remote_read = false,
         bool transpose_mcast = true,
         uint32_t reshard_num_cores_nhw = 0,
-        const MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
-        bool is_out_tiled = true);
+        const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
+        bool is_out_tiled = true,
+        bool in_place = false);
 
     // invoke can be overloaded as many times as needed to provide all desired APIs
 };

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -379,13 +379,16 @@ uint32_t generate_max_out_nsticks_per_core(const std::vector<ShardBoundary>& sha
     return max_out_nsticks_per_core;
 }
 
-std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tensors(
+std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_halo_kernel_config_tensors(
     const std::vector<PixelMetadata>& tensor_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     bool is_block_sharded,
     bool transpose_mcast,
     bool remote_read,
-    IDevice* device) {
+    IDevice* device,
+    uint32_t max_out_nsticks_per_core,
+    uint32_t in_nsticks_per_core,
+    bool in_place) {
     auto core_id_to_noc_coords = [is_block_sharded, transpose_mcast, device](uint32_t core_id) -> CoreCoord {
         auto num_cores_x = device->compute_with_storage_grid_size().x;
         auto core_coord = is_block_sharded ? (transpose_mcast ? CoreCoord(core_id, 0) : CoreCoord(0, core_id))
@@ -468,15 +471,15 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
     }
 
     // flatten and uniformize the lengths of each config list
-    auto flatten_pad_config = [](auto& config) -> std::vector<std::vector<std::vector<uint16_t>>> {
+    auto flatten_pad_config = [in_place](auto& config) -> std::vector<std::vector<std::vector<uint16_t>>> {
         // Find max length for vector which is going to be processed on each core
         size_t max_len = 0;
         for (const auto& data : config) {
-            max_len = std::max(
-                max_len,
-                data.size() +
-                    4);  // For split reader, each vector size is ((2 * data.size()) / 2 + 2) and 2 for null plug.
+            max_len =
+                in_place ? std::max(max_len, 2 * data.size())
+                         : std::max(max_len, data.size());  // For split reader, each vector size is 2 * data.size() / 2
         }
+        max_len += 2;  // account for the null plug
 
         std::vector<std::vector<std::vector<uint16_t>>> flattened_config(2);
         for (const auto& data : config) {
@@ -484,7 +487,7 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
             uint32_t idx1 = 0, idx2 = 0;
             for (size_t i = 0; i < data.size(); ++i) {
                 auto [dst_start, length] = data[i];
-                if (i % 2 == 0) {
+                if (i % 2 == 0 || in_place) {
                     flat_data[0][idx1++] = dst_start;
                     flat_data[0][idx1++] = length;
                 } else {
@@ -499,16 +502,22 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
         return flattened_config;
     };
 
-    auto flatten_local_config = [](auto& config) -> std::vector<std::vector<std::vector<uint16_t>>> {
-        // Find max length
+    auto flatten_local_config = [in_place, max_out_nsticks_per_core, in_nsticks_per_core](
+                                    auto& config) -> std::vector<std::vector<std::vector<uint16_t>>> {
+        // find max length
         size_t max_len = 0;
         for (const auto& [_, data] : config) {
-            max_len = std::max(max_len, 3 * (data.size() / 2 + 1));  // For split reader, each vector is ( 3 *
-                                                                     // data.size() / 2 + 1).
+            max_len =
+                in_place
+                    ? std::max(max_len, 3 * data.size())
+                    : std::max(
+                          max_len,
+                          3 * (data.size() / 2 + 1));  // For split reader, each vector is (3 * data.size() / 2 + 1).
         }
         max_len += 6;  // account for the key tuple and null plug
 
         std::vector<std::vector<std::vector<uint16_t>>> flattened_config(2);
+        int32_t in_out_shard_size_delta = max_out_nsticks_per_core - in_nsticks_per_core;
         for (const auto& [key, data] : config) {
             auto [nocx, nocy, len] = key;
             std::vector<std::vector<uint16_t>> flat_data(2, std::vector<uint16_t>(max_len, 0));
@@ -518,18 +527,41 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
             flat_data[1][1] = nocy;
 
             uint32_t idx1 = 3, idx2 = 3;
-            for (size_t i = 0; i < data.size(); ++i) {
-                auto [src_start, dst_start, length] = data[i];
-                if (i % 2 != 0) {
+            if (!in_place) {
+                for (size_t i = 0; i < data.size(); ++i) {
+                    auto [src_start, dst_start, length] = data[i];
+                    if (i % 2 != 0) {
+                        flat_data[0][idx1++] = src_start;
+                        flat_data[0][idx1++] = dst_start;
+                        flat_data[0][idx1++] = length;
+                        flat_data[0][2] += 3;
+                    } else {
+                        flat_data[1][idx2++] = src_start;
+                        flat_data[1][idx2++] = dst_start;
+                        flat_data[1][idx2++] = length;
+                        flat_data[1][2] += 3;
+                    }
+                }
+            }
+            else {
+                int32_t rev_i_end = data.size();
+                for (uint32_t i = 0; i < data.size(); ++i) {  // normal forward direction local config in region where input / output shards don't overlap (for in place operation)
+                    auto [src_start, dst_start, length] = data[i];
+                    if (dst_start > src_start + in_out_shard_size_delta) {
+                        rev_i_end = i;
+                        break;
+                    }
                     flat_data[0][idx1++] = src_start;
                     flat_data[0][idx1++] = dst_start;
                     flat_data[0][idx1++] = length;
                     flat_data[0][2] += 3;
-                } else {
-                    flat_data[1][idx2++] = src_start;
-                    flat_data[1][idx2++] = dst_start;
-                    flat_data[1][idx2++] = length;
-                    flat_data[1][2] += 3;
+                }
+                for (int32_t i = data.size() - 1; i >= rev_i_end; --i) { // reverse direction local config in region where input / output shards overlap (for in place operation)
+                    auto [src_start, dst_start, length] = data[i];
+                    flat_data[0][idx1++] = src_start;
+                    flat_data[0][idx1++] = dst_start;
+                    flat_data[0][idx1++] = length;
+                    flat_data[0][2] += 3;
                 }
             }
 
@@ -539,26 +571,36 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
         return flattened_config;
     };
 
-    auto flatten_remote_config = [](auto& config) -> std::vector<std::vector<std::vector<uint16_t>>> {
-        // Find max length
+    auto flatten_remote_config = [in_place, core_id_to_noc_coords, &device](
+                                     auto& config) -> std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> {
+        // find max length
         size_t max_len = 0;
         for (const auto& core_config : config) {
             size_t curr_len = 0;
             for (const auto& [key, subdata] : core_config) {
-                curr_len += 3 + (3 * (subdata.size() / 2 + 1));  // For split reader,  3 for source[nocx, nocy, length]
-                                                                 // and each vector is ( 3 * data.size() / 2 + 1).
+                curr_len +=
+                    in_place
+                        ? 3 + 3 * subdata.size()
+                        : 3 + (3 * (subdata.size() / 2 + 1));  // For split reader, 3 for source[nocx, nocy, length] and
+                                                               // each vector is (3 * data.size() / 2 + 1).
             }
             max_len = std::max(max_len, curr_len);
         }
-        max_len += 3;  // account for null plug
+        max_len += 3;  // account for the null plug
 
         std::vector<std::vector<std::vector<uint16_t>>> flattened_config(2);
+        int num_cores_x = device->compute_with_storage_grid_size().x;
+        int num_cores_y = device->compute_with_storage_grid_size().y;
+        int num_cores = num_cores_x * num_cores_y;
+        CoreCoord noc_00 = core_id_to_noc_coords(0);
+        int max_ref_size = 0;  // track the max remote ref size for sizing the remote temp tensor
+        int core = 0;
         for (const auto& core_config : config) {
             std::vector<std::vector<uint16_t>> flat_data(2, std::vector<uint16_t>(max_len, 0));
             uint32_t idx1 = 0, idx2 = 0;
             uint32_t len_idx1 = 0, len_idx2 = 0;
             uint32_t vector_id = 0;
-
+            int ref_size = 0;
             for (const auto& [key, subdata] : core_config) {
                 auto [nocx, nocy, len] = key;
                 flat_data[0][idx1++] = nocx;
@@ -570,14 +612,15 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
                 flat_data[1][idx2++] = nocy;
                 len_idx2 = idx2;
                 flat_data[1][idx2++] = 0;
-
+                int ref_ind = nocx - noc_00.x + (nocy - noc_00.y) * num_cores_x;
                 for (size_t i = 0; i < subdata.size(); ++i) {
                     auto [src_start, dst_start, length] = subdata[i];
-                    if (vector_id) {
+                    if (vector_id || in_place) {
                         flat_data[0][idx1++] = src_start;
                         flat_data[0][idx1++] = dst_start;
                         flat_data[0][idx1++] = length;
                         flat_data[0][len_idx1] += 3;
+                        ref_size += length;
                     } else {
                         flat_data[1][idx2++] = src_start;
                         flat_data[1][idx2++] = dst_start;
@@ -592,13 +635,16 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
 
             flattened_config[0].emplace_back(std::move(flat_data[0]));
             flattened_config[1].emplace_back(std::move(flat_data[1]));
+            core++;
+            max_ref_size = std::max(max_ref_size, ref_size);
         }
-        return flattened_config;
+
+        return std::make_tuple(flattened_config, max_ref_size);
     };
 
     auto flattened_pad_config = flatten_pad_config(pad_config);
     auto flattened_local_config = flatten_local_config(local_config);
-    auto flattened_remote_config = flatten_remote_config(remote_config);
+    auto [flattened_remote_config, max_ref_size] = flatten_remote_config(remote_config);
 
     auto align_config = [](auto& config, size_t align_granularity = 1, uint16_t align_value = 0) {
         size_t max_len = 0;
@@ -626,13 +672,14 @@ std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tens
     align_config(flattened_remote_config[0], 2);
     align_config(flattened_remote_config[1], 2);
 
-    return {
+    std::vector<std::vector<std::vector<uint16_t>>> config{
         flattened_pad_config[0],
         flattened_pad_config[1],
         flattened_local_config[0],
         flattened_local_config[1],
         flattened_remote_config[0],
         flattened_remote_config[1]};
+    return std::make_tuple(std::move(config), max_ref_size);
 }
 
 std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -114,19 +114,22 @@ std::vector<PixelMetadata> generate_tensor_metadata(
     uint32_t reshard_num_cores_nhw = 0,
     bool is_in_tiled = true);
 uint32_t generate_max_out_nsticks_per_core(const std::vector<ShardBoundary>& shard_boundaries);
-std::vector<std::vector<std::vector<uint16_t>>> generate_halo_kernel_config_tensors(
+std::tuple<std::vector<std::vector<std::vector<uint16_t>>>, int> generate_halo_kernel_config_tensors(
     const std::vector<PixelMetadata>& tensor_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     bool is_block_sharded,
     bool transpose_mcast,
     bool remote_read,
-    tt::tt_metal::IDevice* device);
+    tt::tt_metal::IDevice* device,
+    uint32_t max_out_nsticks_per_core = INT_MAX,
+    uint32_t in_nsticks_per_core = 0,
+    bool in_place = false);
 std::vector<std::vector<uint16_t>> generate_sliding_window_op_config(
     const std::vector<uint32_t>& op_trace_metadata,
     const std::vector<ShardBoundary>& shard_boundaries,
     bool pad_tile = false,
     bool pad_cores = false);
-std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input);
+std::vector<uint16_t> flatten(const std::vector<std::vector<uint16_t>>& input, uint32_t extend_with_zeroes = 0);
 Tensor construct_on_host_config_tensor(
     const std::vector<std::vector<uint16_t>>& config,
     const SlidingWindowConfig& sw_config,


### PR DESCRIPTION
### Ticket
#14450

### Problem description
Currently separate buffers are used for the input and output shards of the Halo Op.  This should be adjusted so the output shard contains the input shard, thereby making Halo an "in-place" operation.

This was originally merged/reviewed in https://github.com/tenstorrent/tt-metal/pull/18329, but the commit was reverted due to regressions on BH and WH tests. These issues have been fixed by correcting the assumptions about the core grid shape and with with the worker NOC coordinates used to specify the destination of the `noc_semaphore_inc` calls. 

### What's changed
- In place flags were added to Conv2D and Maxpool, setting these to true prompts deallocation of the sharded input tensor to prompt re-allocation with output size
- Scratch tensor/CB were created for temporary storage of remote sticks
- New in place version of halo gather kernel was implemented
- New kernel functions were implemented to copy remote sticks to/from scratch buffer
- Gather kernel was updated to perform remote / local data movement on same core to block local copies until after scratch writes with in place operation
- Semaphores are used to block remote / padding writes until after scratch and local writes are complete on all cores
- Existing kernel copy function was updated to perform stick by stick copy when input / output chunks overlap and to perform copy in reverse order when output data is moved “in front” of input data
- Local config was updated to reverse chunk order for “forward” copies where dst is greated than src
- Coverage for this feature is included in MaxPool post-commit test on WH and BH

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14129876766
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14133031994, https://github.com/tenstorrent/tt-metal/actions/runs/14136803225
- [x] [Model performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14132747748
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14129881697
- [x] [Nightly](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14136743836
- [x] [N150 L2 nightly tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14178021568