### PR TITLE
[BugFix][tt-train] Add missing value to config that was introduced in previous PR 

### DIFF
--- a/tt-train/configs/training_shakespear_gpt2l.yaml
+++ b/tt-train/configs/training_shakespear_gpt2l.yaml
@@ -1,5 +1,6 @@
 training_config:
   project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
   seed: 5489
   model_save_interval: 500
   batch_size: 2

--- a/tt-train/configs/training_shakespear_gpt2m.yaml
+++ b/tt-train/configs/training_shakespear_gpt2m.yaml
@@ -1,5 +1,6 @@
 training_config:
   project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
   seed: 5489
   model_save_interval: 500
   batch_size: 4

--- a/tt-train/configs/training_shakespear_gpt2s.yaml
+++ b/tt-train/configs/training_shakespear_gpt2s.yaml
@@ -1,5 +1,6 @@
 training_config:
   project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
   seed: 5489
   model_save_interval: 500
   batch_size: 4

--- a/tt-train/configs/training_shakespear_gpt2xl.yaml
+++ b/tt-train/configs/training_shakespear_gpt2xl.yaml
@@ -1,5 +1,6 @@
 training_config:
   project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
   seed: 5489
   model_save_interval: 500
   batch_size: 1

--- a/tt-train/configs/training_shakespear_nanogpt.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt.yaml
@@ -1,5 +1,6 @@
 training_config:
   project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
   seed: 5489
   model_save_interval: 500
   batch_size: 64

--- a/tt-train/configs/training_shakespear_nanogpt_bpe.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt_bpe.yaml
@@ -1,5 +1,6 @@
 training_config:
   project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
   seed: 5489
   model_save_interval: 500
   batch_size: 2

--- a/tt-train/configs/training_shakespear_nanogpt_memory_eff.yaml
+++ b/tt-train/configs/training_shakespear_nanogpt_memory_eff.yaml
@@ -1,5 +1,6 @@
 training_config:
   project_name: "tt_train_nano_gpt"
+  model_type: "gpt2"
   seed: 5489
   model_save_interval: 500
   batch_size: 64


### PR DESCRIPTION
### Problem description
LLaMa integration added dependency on `model_type` config key. Unfortunately, none of the gpt2 configs have this parameter set. 

### What's changed
Add `model_type` to configs.

### Checklist
- [x] New/Existing tests provide coverage for changes