### PR TITLE
Skip hanging conv2d tests

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -3023,6 +3023,9 @@ def test_conv2d_sdxl(
     enable_split_reader,
     split_factor
 ):
+    if (input_channels == 1920 or input_channels == 2560) and input_height == 32 and input_width == 32 and kernel[0] == 1 and kernel[1] == 1 and is_blackhole():
+        pytest.skip("Temporary skip until #19831 is not closed")
+
     config_override = {}
     config_override["act_block_h"] = act_block_h_override
     config_override["act_block_w_div"] = act_block_w_div


### PR DESCRIPTION
### Ticket
#19831

### Problem description
2 conv2d tests are hanging on blackhole - adding temporary skip until issue above is not closed.