### PR TITLE
#0: [skip ci] Fix L2+ttnn sweep artifact and wheel inputs to setup-job

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -69,8 +69,8 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
-          build-artifact-name: ${{ inputs.build-artifact-name }}
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+          wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ (github.event_name == 'schedule' && 120) || fromJSON(inputs.timeout) }}
         run: ${{ matrix.test-group.cmd }}

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -580,8 +580,8 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
-          build-artifact-name: ${{ inputs.build-artifact-name }}
-          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+          wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       - name: Run ttnn sweeps generation (single sweep)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sweep_name != 'ALL SWEEPS (Nightly)' }}
         run: python3 tests/sweep_framework/sweeps_parameter_generator.py --module-name ${{ github.event.inputs.sweep_name }} --elastic cloud --tag ci-main --explicit
@@ -637,27 +637,12 @@ jobs:
     timeout-minutes: 720
     runs-on: ${{ matrix.test-group.runs-on }}
     steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
         with:
-          submodules: recursive
-          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
-      - name: ⬇️ Download Build
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-          path: docker-job
-      - name: Extract files
-        run: tar -xvf ttm_any.tar
-      - name: ⬇️ Download Wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-          path: docker-job
-      - name: Install Wheel
-        run: |
-          WHEEL_FILENAME=$(ls -1 *.whl)
-          pip3 install $WHEEL_FILENAME
+          build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+          wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       - name: Run ttnn sweeps (single sweep)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sweep_name != 'ALL SWEEPS (Nightly)' }}
         run: python3 tests/sweep_framework/sweeps_runner.py --module-name ${{ github.event.inputs.sweep_name }} --elastic cloud --tag ci-main


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Metal L2 nightly is not a reusable/impl workflow so it doesn't have build and wheel artifact names as inputs. They're passed in directly from the build-artifact job.
Also fixed ttnn - run sweeps which has the same issue.

### What's changed
Change inputs to setup job step to the expected parameters.

### Checklist
- [ ] Metal L2: https://github.com/tenstorrent/tt-metal/actions/runs/14133411682
- [ ] ttnn sweeps (`add` module only): https://github.com/tenstorrent/tt-metal/actions/runs/14133562179