### PR TITLE
#19790: Add an option to enable watcher in blackhole post-commit 

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -71,3 +71,4 @@ runs:
         echo "TT_METAL_WATCHER=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
+      shell: bash

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -66,8 +66,10 @@ runs:
       shell: bash
 
     - name: Set up env vars for watcher
-      if: inputs.enable-watcher == true
+      if: ${{ inputs.enable-watcher == true }}
+      working-directory: ${{ inputs.path }}
       run: |
+        echo "Enabling TT Metal Watcher"
         echo "TT_METAL_WATCHER=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
         echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
 
     - name: Set up env vars for watcher
-      if: ${{ inputs.enable-watcher == true }}
+      if: ${{ inputs.enable-watcher == 'true' }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "Enabling TT Metal Watcher"

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -13,6 +13,10 @@ inputs:
     required: false
     description: Where to checkout
     default: docker-job
+  enable-watcher:
+    description: 'Enable watcher'
+    default: false
+    type: boolean
 runs:
   using: "composite"
   steps:
@@ -60,3 +64,10 @@ runs:
         echo "📦 Installing $WHEEL_FILENAME"
         pip3 install "$WHEEL_FILENAME"
       shell: bash
+
+    - name: Set up env vars for watcher
+      if: inputs.enable-watcher == true
+      run: |
+        echo "TT_METAL_WATCHER=1" >> $GITHUB_ENV
+        echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
+        echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -8,6 +8,10 @@ on:
           required: false
           type: string
           default: 'BH'
+      enable-watcher:
+          description: 'Enable watcher in BH Post commit'
+          default: false
+          type: boolean
   workflow_dispatch:
     inputs:
       runner-label:
@@ -25,11 +29,17 @@ on:
           - RelWithDebInfo
           - ASan
           - TSan
+      enable-watcher:
+        description: 'Enable watcher in BH Post commit'
+        default: false
+        type: boolean
   schedule:
     - cron: "0 */4 * * *"
   # Pause this since not enough runners to support every commit to main
   # push:
   #  branches: ["main"]
+
+run-name: ${{ inputs.enable-watcher == true && 'Blackhole post-commit tests (watcher enabled) ' || 'Blackhole post-commit tests' }}
 
 permissions:
   actions: read
@@ -66,6 +76,7 @@ jobs:
       docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
   umd-unit-tests:
     needs: build-artifact
     secrets: inherit
@@ -85,6 +96,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
   fd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -95,6 +107,7 @@ jobs:
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
   # FD C++ Unit Tests
   cpp-unit-tests:
     needs: build-artifact
@@ -107,6 +120,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
   models-unit-tests:
     needs: build-artifact
     secrets: inherit
@@ -117,6 +131,7 @@ jobs:
       timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher }}
 
 #   profiler-regression:
 #     needs: build-artifact-profiler

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -22,6 +22,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      enable-watcher:
+        description: 'Enable watcher'
+        default: false
+        type: boolean
 
 jobs:
   cpp-unit-tests-slow-dispatch:
@@ -74,6 +78,12 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           # Unsure why these C++ tests need the wheel...  a cleanup to do separately
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: Set up env vars for watcher
+        if: inputs.enable-watcher == true
+        run: |
+          echo "TT_METAL_WATCHER=1" >> $GITHUB_ENV
+          echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
+          echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -78,12 +78,7 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           # Unsure why these C++ tests need the wheel...  a cleanup to do separately
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Set up env vars for watcher
-        if: inputs.enable-watcher == true
-        run: |
-          echo "TT_METAL_WATCHER=1" >> $GITHUB_ENV
-          echo "TT_METAL_WATCHER_APPEND=1" >> $GITHUB_ENV
-          echo "TT_METAL_WATCHER_NOINLINE=1" >> $GITHUB_ENV
+          enable-watcher: ${{ inputs.enable-watcher }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -78,7 +78,7 @@ jobs:
       }}
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -78,7 +78,7 @@ jobs:
       }}
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -22,6 +22,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      enable-watcher:
+        description: 'Enable watcher'
+        default: false
+        type: boolean
 
 jobs:
   cpp-unit-tests:

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -78,7 +78,7 @@ jobs:
       }}
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -85,6 +85,7 @@ jobs:
           # Unsure why these C++ tests need the wheel...  a cleanup to do separately
           # https://github.com/tenstorrent/tt-metal/issues/20166
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-watcher: ${{ inputs.enable-watcher }}
       - name: ${{ matrix.test-group.name }} tests
         #GH Issue 16167
         if: ${{ !(inputs.runner-label == 'BH' && matrix.test-group.name == 'tools') }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -78,7 +78,7 @@ jobs:
       }}
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -62,7 +62,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -62,7 +62,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -62,7 +62,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -66,6 +66,7 @@ jobs:
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-watcher: ${{ inputs.enable-watcher }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -62,7 +62,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -19,6 +19,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      enable-watcher:
+        description: 'Enable watcher'
+        default: false
+        type: boolean
 
 jobs:
   fd-tests:

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -55,7 +55,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -19,6 +19,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      enable-watcher:
+        description: 'Enable watcher'
+        default: false
+        type: boolean
 
 jobs:
   models:

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -110,6 +110,7 @@ jobs:
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-watcher: ${{ inputs.enable-watcher }}
       - name: ${{ matrix.test-group.name }} slow runtime mode tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -55,7 +55,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -55,7 +55,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -55,7 +55,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -59,6 +59,7 @@ jobs:
         timeout-minutes: 10
         with:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-watcher: ${{ inputs.enable-watcher }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -22,6 +22,10 @@ on:
       docker-image:
         required: true
         type: string
+      enable-watcher:
+        description: 'Enable watcher'
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       arch:
@@ -50,6 +54,10 @@ on:
       docker-image:
         required: true
         type: string
+      enable-watcher:
+        description: 'Enable watcher'
+        default: false
+        type: boolean
 
 jobs:
   profiler-regression:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -96,7 +96,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -101,6 +101,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          enable-watcher: ${{ inputs.enable-watcher }}
       - name: Run profiler regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -96,7 +96,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -96,7 +96,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@70bd289d4bfb2f3d93f57dec4e78f3107baa04f5
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -96,7 +96,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@williamly/19790-enable-watcher-bhpc
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}


### PR DESCRIPTION
### Ticket
Resolves #19790

### Problem description
Currently watcher is not enabled in BH post commit.
We want to enable it on workflow dispatch to debug ND behavior such as hangs.

### What's changed
Add an option `inputs.enable-watcher` to blackhole post commit workflows + impl reusables. This is defaulted to false (watcher not enabled).
Enabling sets the following env vars
```
TT_METAL_WATCHER=1 
TT_METAL_WATCHER_APPEND=1
TT_METAL_WATCHER_NOINLINE=1
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/14175581294
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI 
watcher enabled:  https://github.com/tenstorrent/tt-metal/actions/runs/14384446486