### PR TITLE
Add measurement option to decode demo

### DIFF
--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Run stress tests
         timeout-minutes: 360
         run: |
-          pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "full and batch-32-stress-test"
+          pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "stress-test"
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -103,6 +103,7 @@ def run_llama3_demo(
     weights,
     layers,
     stress_test,
+    start_iter,
 ):
     # Creat batch output file
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -272,6 +273,8 @@ def run_llama3_demo(
     logger.info(f"Compiling model trace...")
     if layers == 1:
         num_compile_iters = 10
+    elif layers == 5:
+        num_compile_iters = 2
     else:
         num_compile_iters = 1
     for i in range(num_compile_iters):
@@ -374,7 +377,7 @@ def run_llama3_demo(
     ttnn.synchronize_device(mesh_device)
 
     # Start decoding
-    iteration = 0
+    iteration = start_iter
     users_decoding = True  # reset to handle next batch
     total_decoding_time = 0  # Track total decoding time
     total_tokens_generated = 0  # Track total tokens generated
@@ -486,20 +489,11 @@ def run_llama3_demo(
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
 # FAKE_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export FAKE_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
-    "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test",
+    "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_iter",
     [
-        # (  # Batch-1 run (Latency) - single user, small prompt
-        #     "models/demos/llama3/demo/input_data_questions_prefill_128.json",  # input_prompts
-        #     True,  # instruct mode
-        #     1,  # repeat_batches
-        #     1024,  # max_seq_len
-        #     1,  # batch_size
-        #     200,  # max_generated_tokens
-        #     False,  # True,  # paged_attention
-        #     {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
-        #     {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
-        # ),
-        (  # Batch-32 run (Throughput) - 32 users, small prompt
+        (  # full demo, batch 32
+            "instruct",
+            80,
             "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -510,33 +504,60 @@ def run_llama3_demo(
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
             False,  # stress_test
+            0,  # start_iter
         ),
-        (  # Stress test: batch-32 very long generations but at same token index
+        (  # quick 1L demo
+            "random",
+            1,
             "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
             1024,  # max_seq_len
             32,  # batch_size
-            4*128*1024,  # max_generated_tokens (same index for stress test)
+            200,  # max_generated_tokens
+            False,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
+            {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
+            False,  # stress_test
+            0,  # start_iter
+        ),
+        (  # Stress test: batch-32 very long generations but at same token index
+            "instruct",
+            80,
+            "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            4 * 128 * 1024,  # max_generated_tokens (same index for stress test)
             False,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
             True,  # stress_test
+            0,  # start_iter
+        ),
+        (  # 10 layers for devive perf measurements
+            "random",
+            10,
+            "models/demos/llama3_subdevices/demo/input_data_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            1,  # max_generated_tokens
+            False,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
+            {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
+            False,  # stress_test
+            127,  # start_iter
         ),
     ],
     ids=[
-        # "batch-1",  # latency
-        "batch-32-demo",  # throughput
-        "batch-32-stress-test",  # stress test with long context
+        "full",  # full demo
+        "quick",  # 1L demo
+        "stress-test",  # stress test with many iterations and same token index, full model
+        "measure-device-perf",  # 10L demo for device performance measurements
     ],
-)
-@pytest.mark.parametrize(
-    "weights, layers",
-    [
-        ("random", 1),
-        ("instruct", 80),
-    ],
-    ids=["quick", "full"],
 )
 @pytest.mark.parametrize(
     "optimizations",
@@ -556,6 +577,8 @@ def run_llama3_demo(
     "device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}], indirect=True
 )
 def test_llama_demo(
+    weights,
+    layers,
     input_prompts,
     instruct,
     repeat_batches,
@@ -565,14 +588,13 @@ def test_llama_demo(
     paged_attention,
     page_params,
     sampling_params,
+    stress_test,
+    start_iter,
     optimizations,
-    weights,
-    layers,
     mesh_device,
     use_program_cache,
     is_ci_env,
     reset_seeds,
-    stress_test,
 ):
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
@@ -608,4 +630,5 @@ def test_llama_demo(
         weights=weights,
         layers=layers,
         stress_test=stress_test,
+        start_iter=start_iter,
     )

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -13,7 +13,7 @@ run_tg_llama3_tests() {
   # Run all Llama3 tests for 1B, 3B, 8B, 11B and 70B weights
   # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "batch-32-demo" --timeout 5000; fail+=$?
+    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 5000; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 


### PR DESCRIPTION
### Problem description
No option to run device perf measurements without changes in code.

### What's changed
Added and merged options so that we have options to run: quick, full, stress-test and measure-device-perf runs.

- [x] TG demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/14135281013
- [x] TG stress tests: https://github.com/tenstorrent/tt-metal/actions/runs/14156099074

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes