### PR TITLE
[skip ci] Make build-artifact workflow default to ubuntu 22.04

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -24,7 +24,7 @@ on:
       version:
         required: false
         type: string
-        default: "20.04"
+        default: "22.04"
       architecture:
         required: false
         type: string


### PR DESCRIPTION
See title