### PR TITLE
#19569: `MeshWorkloadFactory` integration

### DIFF
--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -447,12 +447,7 @@ void handle_mesh_adapter_cache_hit(
     tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
 
     TracyOpMeshWorkload(
-        mesh_device,
-        cached_mesh_workload.workload,
-        mesh_device_operation_t{},
-        operation_attributes,
-        tensor_args,
-        tensor_return_value);
+        mesh_device, workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);
 }
 
 // Helper for creating and caching a mesh workload

--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -136,16 +136,14 @@ struct MeshDeviceOperationAdapter {
         for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
             auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
 
-            for (const auto& coord : coordinate_range) {
-                mesh_device_operation_utils::apply_override_runtime_arguments(
-                    program_factory,
-                    program,
-                    shared_variables,
-                    attrs,
-                    *(coordinate_range.begin()),
-                    tensor_args,
-                    tensor_return_value);
-            }
+            mesh_device_operation_utils::apply_override_runtime_arguments(
+                program_factory,
+                program,
+                shared_variables,
+                attrs,
+                *(coordinate_range.begin()),
+                tensor_args,
+                tensor_return_value);
         }
     }
 

--- a/ttnn/cpp/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.hpp
@@ -51,9 +51,9 @@ struct OldInfraDeviceOperation {
 
     struct MeshWorkloadFactory {
         struct shared_variables_t {
-            std::optional<operation::OverrideAddressesCallback> override_addresses_callback;
-            std::optional<operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
-                override_runtime_arguments_callback;
+            std::optional<operation::OverrideRuntimeArgumentsWorkloadCallback<OutputTensors>> workload_callback;
+            std::unordered_map<ttnn::MeshCoordinateRange, operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
+                per_program_callbacks;
         };
         using cached_mesh_workload_t = ttnn::device_operation::CachedMeshWorkload<shared_variables_t>;
 

--- a/ttnn/cpp/ttnn/operation_concepts.hpp
+++ b/ttnn/cpp/ttnn/operation_concepts.hpp
@@ -85,14 +85,11 @@ concept DeviceOperationConcept = requires {
                       decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
                       tensor_return_value_t>);
 
+        // All program factories returned by `select_program_factory` must implement exactly one of
+        // `ProgramFactoryConcept` or `MeshWorkloadFactoryConcept`.
         const auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
         std::visit(
-            []<typename ConcreteProgramFactory>(const ConcreteProgramFactory&) {
-                // Exactly one of the two concepts must be implemented.
-                static_assert(
-                    ProgramFactoryConcept<ConcreteProgramFactory> !=
-                    MeshWorkloadFactoryConcept<ConcreteProgramFactory>);
-            },
+            []<typename T>(const T&) { static_assert(ProgramFactoryConcept<T> != MeshWorkloadFactoryConcept<T>); },
             program_factory);
     };
 } && HasComputeOutputSpecs<device_operation_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
@@ -6,6 +6,7 @@
 
 #include "dropout_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn::operations::experimental::dropout::program {
 
@@ -39,11 +40,12 @@ struct DropoutProgramFactory {
 
 struct DropoutMeshWorkloadFactory {
     using shared_variables_t = DropoutSharedVariables;
-    using cached_mesh_workload_t = ttnn::device_operation::CachedMeshWorkload<shared_variables_t>;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
 
     // Dropout generates N different programs, but they differ only in the per-device seed set as a runtime argument.
     // TODO: when heterogenous runtime arguments are supported, create a single program for all devices, and only
-    // override the runtime arguments for each device.
+    // override the runtime arguments for each device. In addition, use `CachedMeshWorkload` instead of
+    // `AdaptedCachedMeshWorkload`, as only a single `shared_variables_t` is needed.
     static cached_mesh_workload_t create_mesh_workload(
         const operation_attributes_t& operation_attributes,
         const std::vector<ttnn::MeshCoordinate>& mesh_coords,


### PR DESCRIPTION
### Ticket
#19569

### Problem description
Continuing on adding support for Op factories that produce mesh workload directly.

### What's changed
* Separate `AdaptedCachedMeshWorkload` and `CachedMeshWorkload` types used in caching. The former is used by infra to adapt single device program factories + shared vars. The latter caches workload and shared vars directly.
* Create path for `MeshWorkloadFactory` that dispatches workload without the use of the adapter. Use C++ concepts to make code paths explicit. 

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14137126917)
  - Failures are either expected or due to instability.
- [X] [TG regression](https://github.com/tenstorrent/tt-metal/actions/runs/14136469115) - pending
  -  @tt-asaigal confirmed TG is not regressing manually.
- [X] Ran TTNN unit tests + model demos locally.