### PR TITLE
Remove blackhole condition for asserts on l1 usage

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -331,27 +331,23 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             kernel_dims[1],
             sliding_window_config.get_output_shape()[2]));
 
-    if (device->arch() != tt::ARCH::BLACKHOLE) {
-        // FIXME: This L1 calculation is not accurate for Blackhole due to different alignment.
-        // https://github.com/tenstorrent/tt-metal/issues/17216
-        TT_FATAL(
-            actual_cb_size == l1_usage.CB_allocation_size,
-            "Calculated CB size {} does not match with the actual CB size {}",
-            l1_usage.CB_allocation_size,
-            actual_cb_size);
+    TT_FATAL(
+        actual_cb_size == l1_usage.CB_allocation_size,
+        "Calculated CB size {} does not match with the actual CB size {}",
+        l1_usage.CB_allocation_size,
+        actual_cb_size);
 
-        // For now assume that if post_op_l1_allocation_size == 0 op is being run
-        // in graph capture NO_DISPATCH mode.
-        // ToDo: Device should offer an API to inform the op if it is running in NO_DISPATCH mode.
-        bool is_graph_capture_no_dispathch_mode = post_op_l1_allocation_size == 0;
-        TT_FATAL(
-            post_op_l1_allocation_size == (this->pre_op_l1_allocation_size_bytes + l1_usage.tensor_allocation_size) ||
-                is_graph_capture_no_dispathch_mode,
-            "Mismatch!! L1 Allocation Pre Op =  {}, Post Op = {} Calculated Size = {}",
-            this->pre_op_l1_allocation_size_bytes,
-            post_op_l1_allocation_size,
-            l1_usage.tensor_allocation_size);
-    }
+    // For now assume that if post_op_l1_allocation_size == 0 op is being run
+    // in graph capture NO_DISPATCH mode.
+    // ToDo: Device should offer an API to inform the op if it is running in NO_DISPATCH mode.
+    bool is_graph_capture_no_dispathch_mode = post_op_l1_allocation_size == 0;
+    TT_FATAL(
+        post_op_l1_allocation_size == (this->pre_op_l1_allocation_size_bytes + l1_usage.tensor_allocation_size) ||
+            is_graph_capture_no_dispathch_mode,
+        "Mismatch!! L1 Allocation Pre Op =  {}, Post Op = {} Calculated Size = {}",
+        this->pre_op_l1_allocation_size_bytes,
+        post_op_l1_allocation_size,
+        l1_usage.tensor_allocation_size);
     return program_with_cbs;
 }
 


### PR DESCRIPTION
### Ticket
#17216

### What's changed
Remove blackhole condition for asserts on l1 usage, as asserts are valid for blackhole too. 
Made sure that conv2d UTs and sweeps passed with a change.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14136120226)