### PR TITLE
Split fabric test from single script. unit and sanity

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -104,7 +104,7 @@ jobs:
       os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
-  # Fabric Unit Tests
+  # Fabric Tests
   fabric-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -105,7 +105,7 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
   # Fabric Unit Tests
-  fabric-unit-tests:
+  fabric-tests:
     needs: build-artifact
     secrets: inherit
     strategy:
@@ -114,7 +114,7 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: N300 },
         ]
-    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+    uses: ./.github/workflows/ufabric-build-and-tests.yaml
     with:
       os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -114,7 +114,7 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: N300 },
         ]
-    uses: ./.github/workflows/ufabric-build-and-tests.yaml
+    uses: ./.github/workflows/fabric-build-and-tests.yaml
     with:
       os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch }}

--- a/.github/workflows/fabric-build-and-tests-wrapper.yaml
+++ b/.github/workflows/fabric-build-and-tests-wrapper.yaml
@@ -19,7 +19,7 @@ jobs:
         test-group: [
           { arch: wormhole_b0, runner-label: tt-beta-ubuntu-2204-n300-large-stable },
         ]
-    uses: ./.github/workflows/fabric-build-and-unit-tests.yaml
+    uses: ./.github/workflows/fabric-build-and-tests.yaml
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}

--- a/.github/workflows/fabric-build-and-tests.yaml
+++ b/.github/workflows/fabric-build-and-tests.yaml
@@ -47,6 +47,7 @@ jobs:
       matrix:
         test-group: [
           {name: fabric unit tests, cmd: ./tests/scripts/run_cpp_fabric_tests.sh },
+          {name: fabric sanity tests, cmd: ./tests/scripts/run_cpp_fabric_sanity_tests.sh },
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
     runs-on: ${{ startsWith(inputs.runner-label, 'tt-beta-ubuntu') && fromJSON(format('["{0}"]', inputs.runner-label)) || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label)) }}

--- a/tests/scripts/run_cpp_fabric_sanity_tests.sh
+++ b/tests/scripts/run_cpp_fabric_sanity_tests.sh
@@ -17,14 +17,6 @@ export TT_METAL_CLEAR_L1=1
 cd $TT_METAL_HOME
 
 #############################################
-# FABRIC UNIT TESTS                         #
-#############################################
-echo "Running fabric unit tests now...";
-
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DFixture.*"
-./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DFixture.*"
-
-#############################################
 # FABRIC SANITY TESTS                       #
 #############################################
 echo "Running fabric sanity tests now...";

--- a/tests/scripts/run_cpp_fabric_unit_tests.sh
+++ b/tests/scripts/run_cpp_fabric_unit_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "$TT_METAL_HOME" ]]; then
+    echo "Must provide TT_METAL_HOME in environment" 1>&2
+    exit 1
+fi
+
+if [[ -z "$ARCH_NAME" ]]; then
+    echo "Must provide ARCH_NAME in environment" 1>&2
+    exit 1
+fi
+
+export TT_METAL_CLEAR_L1=1
+
+cd $TT_METAL_HOME
+
+#############################################
+# FABRIC UNIT TESTS                         #
+#############################################
+echo "Running fabric unit tests now...";
+
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DFixture.*"
+./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DFixture.*"


### PR DESCRIPTION
### Ticket
?

### Problem description
list tests in single scripts makes some tests to be unreachable when a test hangs.

### What's changed
Split unit tests and sanity tests in each script.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes