### PR TITLE
#0: Fix in calculating ptr in eth_send_packet_byte_addr

### DIFF
--- a/tt_metal/hw/inc/ethernet/tunneling.h
+++ b/tt_metal/hw/inc/ethernet/tunneling.h
@@ -83,7 +83,7 @@ FORCE_INLINE void eth_send_packet(uint32_t q_num, uint32_t src_word_addr, uint32
 FORCE_INLINE
 void eth_send_packet_byte_addr(uint32_t q_num, uint32_t src_addr, uint32_t dest_addr, uint32_t num_words) {
     while (eth_txq_is_busy(q_num));
-    volatile uint32_t* ptr = (volatile uint32_t*)ETH_TXQ0_REGS_START;
+    volatile uint32_t* ptr = (volatile uint32_t*)(ETH_TXQ0_REGS_START + (q_num * ETH_TXQ_REGS_SIZE));
     ptr[ETH_TXQ_TRANSFER_START_ADDR >> 2] = src_addr;
     ptr[ETH_TXQ_DEST_ADDR >> 2] = dest_addr;
     ptr[ETH_TXQ_TRANSFER_SIZE_BYTES >> 2] = num_words << 4;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
ptr offset calculation does not take into account q_num.

### What's changed
Add offset based on q_num to ptr addr.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14139035129
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes