### PR TITLE
Merge AllReduce Worker and Reducer Kernels

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -228,12 +228,12 @@ jobs:
       matrix:
         config:
           - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Debug"
             publish-artifact: false
             skip-tt-train: false
           - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"
             publish-artifact: false
             skip-tt-train: true

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -32,7 +32,7 @@ on:
       toolchain:
         required: false
         type: string
-        default: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+        default: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
         description: "Toolchain file to use for build"
       publish-artifact:
         required: false
@@ -103,7 +103,7 @@ on:
       toolchain:
         required: false
         type: string
-        default: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+        default: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
         description: "Toolchain file to use for build"
       profile:
         required: false

--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -30,7 +30,7 @@ jobs:
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"
           - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+            toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
             build-type: "Release"
           - version: "22.04"
             toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"

--- a/.github/workflows/cpp-ttnn-project.yaml
+++ b/.github/workflows/cpp-ttnn-project.yaml
@@ -86,5 +86,5 @@ jobs:
           run: |
             set -eu # basic shell hygiene
             mkdir -p build && cd build
-            cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake ..
+            cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake ..
             ninja

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build UMD device and tests
         run: |
-          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake
           cmake --build build --target umd_tests
 
       - name: Run UMD unit regression tests

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -66,7 +66,7 @@ jobs:
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
       - name: Build UMD device and tests
         run: |
-          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
+          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake
           cmake --build build --target umd_tests
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,7 @@
           "ENABLE_CCACHE": {"value": "TRUE"},
           "TT_UNITY_BUILDS": {"value": "FALSE"}
         },
-        "toolchainFile": "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+        "toolchainFile": "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
       },
       {
         "name": "clang-tidy",

--- a/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/common_tensor_test_utils.cpp
@@ -35,15 +35,12 @@ void test_tensor_on_device(
     const auto host_buffer_datum_size_bytes = sizeof(uint32_t);
     const auto input_buf_size = input_buf_size_bytes / host_buffer_datum_size_bytes;
 
-    auto host_data = std::shared_ptr<void>(new uint32_t[input_buf_size], std::default_delete<uint32_t[]>());
-    auto* host_data_ptr = static_cast<uint32_t*>(host_data.get());
-
-    auto readback_data = std::shared_ptr<void>(new uint32_t[input_buf_size], std::default_delete<uint32_t[]>());
-    auto* readback_data_ptr = static_cast<uint32_t*>(readback_data.get());
+    auto host_data = std::make_shared<uint32_t[]>(input_buf_size);
+    auto readback_data = std::make_shared<uint32_t[]>(input_buf_size);
 
     const auto random_prime_number = 4051;
     for (int i = 0; i < input_buf_size; i++) {
-        host_data_ptr[i] = i % random_prime_number;
+        host_data[i] = i % random_prime_number;
     }
 
     auto tensor = tt::tt_metal::create_device_tensor(TensorSpec(input_shape, layout), device);
@@ -56,8 +53,8 @@ void test_tensor_on_device(
     ttnn::queue_synchronize(device->command_queue(*io_cq));
 
     for (int i = 0; i < input_buf_size; i++) {
-        EXPECT_EQ(host_data_ptr[i], readback_data_ptr[i]);
-        if (host_data_ptr[i] != readback_data_ptr[i]) {
+        EXPECT_EQ(host_data[i], readback_data[i]);
+        if (host_data[i] != readback_data[i]) {
             break;
         }
     }

--- a/tests/ttnn/unit_tests/operations/test_moreh_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_group_norm.py
@@ -202,8 +202,6 @@ def make_input_tensors(input_shape, affine, do_backward=False):
 
 
 def run_test_moreh_group_norm(N, C_num_groups, HW, eps, affine, compute_mean_rstd, device):
-    pytest.skip("Skipping test_moreh_group_norm for now - libstdc++ issue")
-
     H, W = HW
     C, num_groups = C_num_groups
     input_shape = (N, C, H, W)

--- a/tt-train/CMakeLists.txt
+++ b/tt-train/CMakeLists.txt
@@ -28,9 +28,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 
-option(ENABLE_LIBCXX "Enable using libc++" OFF)
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND ENABLE_LIBCXX)
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     find_library(LIBC++ c++)
     find_library(LIBC++ABI c++abi)
     if(NOT LIBC++ OR NOT LIBC++ABI)

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -161,23 +161,21 @@ target_include_directories(ttml PUBLIC ${CLI11_SOURCE_DIR}/include)
 
 target_include_directories(ttml PUBLIC ${TOKENZIER_CPP_PATH}/include)
 
-if(ENABLE_LIBCXX)
-    target_link_libraries(
-        tokenizers_cpp
-        PUBLIC
-            ${LIBC++}
-            ${LIBC++ABI}
-    )
-    target_compile_options(tokenizers_cpp PUBLIC -stdlib=libc++)
+target_link_libraries(
+    tokenizers_cpp
+    PUBLIC
+        ${LIBC++}
+        ${LIBC++ABI}
+)
+target_compile_options(tokenizers_cpp PUBLIC -stdlib=libc++)
 
-    target_link_libraries(
-        wandbcpp
-        PUBLIC
-            ${LIBC++}
-            ${LIBC++ABI}
-    )
-    target_compile_options(wandbcpp PUBLIC -stdlib=libc++)
-endif()
+target_link_libraries(
+    wandbcpp
+    PUBLIC
+        ${LIBC++}
+        ${LIBC++ABI}
+)
+target_compile_options(wandbcpp PUBLIC -stdlib=libc++)
 
 add_definitions(-DTOKENIZERS_DATA_PATH="${CMAKE_SOURCE_DIR}/data")
 

--- a/tt-train/sources/ttml/autograd/graph.cpp
+++ b/tt-train/sources/ttml/autograd/graph.cpp
@@ -6,14 +6,6 @@
 
 #include <fmt/core.h>
 
-#include <chrono>
-#include <cstddef>
-#include <functional>
-#include <memory>
-#include <span>
-#include <typeinfo>
-#include <vector>
-
 #include "core/debug.hpp"
 #include "core/system_utils.hpp"
 

--- a/tt-train/sources/ttml/core/system_utils.cpp
+++ b/tt-train/sources/ttml/core/system_utils.cpp
@@ -6,9 +6,6 @@
 
 #include <cxxabi.h>
 
-#include <memory>
-#include <string>
-
 namespace ttml::core {
 std::string demangle(const char* name) {
     int status = -4;

--- a/tt-train/sources/ttml/datasets/in_memory_token_dataset.hpp
+++ b/tt-train/sources/ttml/datasets/in_memory_token_dataset.hpp
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include <cstdint>
 #include <span>
-#include <stdexcept>
-#include <vector>
 
 #include "dataset_base.hpp"
 

--- a/tt-train/sources/ttml/init/cpu_initializers.cpp
+++ b/tt-train/sources/ttml/init/cpu_initializers.cpp
@@ -4,7 +4,6 @@
 
 #include "cpu_initializers.hpp"
 
-#include <cmath>
 #include <random>
 
 #include "autograd/auto_context.hpp"
@@ -63,7 +62,7 @@ void xavier_uniform_init(std::vector<float>& vec, FanParams params) {
 
 void xavier_normal_init(std::vector<float>& vec, FanParams params) {
     auto& [fan_in, fan_out] = params;
-    float stddev = std::sqrt(2.0F / (float)(fan_in + fan_out));
+    float stddev = std::sqrtf(2.0F / (float)(fan_in + fan_out));
 
     // Random number generator with a seed
     // Mersenne Twister generator

--- a/tt-train/sources/ttml/modules/distributed/linear.cpp
+++ b/tt-train/sources/ttml/modules/distributed/linear.cpp
@@ -4,8 +4,6 @@
 
 #include "linear.hpp"
 
-#include <cmath>
-
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
@@ -57,7 +55,7 @@ void RowParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out_fe
 
     uint32_t rank = 4U;
     auto mesh_shape = device->shape();
-    const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
+    const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
 
     ttml::core::XTensorToMeshVariant<float> shard_composer =
         ttml::core::ShardXTensorToMesh<float>(mesh_shape, rank - 1U);
@@ -108,7 +106,7 @@ void ColumnParallelLinear::initialize_tensors(uint32_t in_features, uint32_t out
 
     uint32_t rank = 4U;
     auto mesh_shape = device->shape();
-    const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
+    const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
 
     ttml::core::XTensorToMeshVariant<float> shard_composer =
         ttml::core::ShardXTensorToMesh<float>(mesh_shape, rank - 2U);

--- a/tt-train/sources/ttml/modules/linear_module.cpp
+++ b/tt-train/sources/ttml/modules/linear_module.cpp
@@ -4,7 +4,6 @@
 
 #include "linear_module.hpp"
 
-#include <cmath>
 #include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
@@ -21,12 +20,12 @@ ttml::autograd::TensorPtr create_weight(uint32_t in_features, uint32_t out_featu
     auto* device = &autograd::ctx().get_device();
     auto weight_shape = core::create_shape({1, 1, out_features, in_features});
     auto weight = ttml::autograd::create_tensor();
-    const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
+    const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
     init::uniform_init(weight, weight_shape, init::UniformRange{-init_k, init_k});
     return weight;
 }
 ttml::autograd::TensorPtr create_bias(uint32_t in_features, uint32_t out_features) {
-    const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
+    const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
     auto* device = &ttml::autograd::ctx().get_device();
     auto bias_shape = ttml::core::create_shape({1, 1, 1, out_features});
     auto bias = ttml::autograd::create_tensor();

--- a/tt-train/sources/ttml/modules/lora_linear_module.cpp
+++ b/tt-train/sources/ttml/modules/lora_linear_module.cpp
@@ -4,7 +4,6 @@
 
 #include "lora_linear_module.hpp"
 
-#include <cmath>
 #include <core/ttnn_all_includes.hpp>
 
 #include "autograd/auto_context.hpp"
@@ -23,7 +22,7 @@ ttml::autograd::TensorPtr create_weight(uint32_t in_features, uint32_t out_featu
     auto* device = &autograd::ctx().get_device();
     auto weight_shape = core::create_shape({1, 1, out_features, in_features});
     auto weight = ttml::autograd::create_tensor();
-    const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
+    const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
     init::uniform_init(weight, weight_shape, init::UniformRange{-init_k, init_k});
     return weight;
 }
@@ -40,13 +39,13 @@ ttml::autograd::TensorPtr create_lora_b(uint32_t in_features, uint32_t rank) {
     auto* device = &autograd::ctx().get_device();
     auto weight_shape = core::create_shape({1, 1, rank, in_features});
     auto weight = ttml::autograd::create_tensor();
-    const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
+    const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
     init::uniform_init(weight, weight_shape, init::UniformRange{-init_k, init_k});
     return weight;
 }
 
 ttml::autograd::TensorPtr create_bias(uint32_t in_features, uint32_t out_features) {
-    const float init_k = std::sqrt(1.F / static_cast<float>(in_features));
+    const float init_k = std::sqrtf(1.F / static_cast<float>(in_features));
     auto* device = &ttml::autograd::ctx().get_device();
     auto bias_shape = ttml::core::create_shape({1, 1, 1, out_features});
     auto bias = ttml::autograd::create_tensor();

--- a/tt-train/sources/ttml/modules/positional_embeddings.cpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.cpp
@@ -4,8 +4,6 @@
 
 #include "modules/positional_embeddings.hpp"
 
-#include <cmath>
-
 #include "autograd/autocast_tensor.hpp"
 #include "core/tt_tensor_utils.hpp"
 #include "init/tensor_initializers.hpp"
@@ -24,8 +22,8 @@ autograd::AutocastTensor create_positional_embedding_tensor(uint32_t sequence_le
     for (uint32_t pos = 0; pos < sequence_length; ++pos) {
         for (uint32_t emb_idx = 0; emb_idx < embedding_dim; ++emb_idx) {
             float value = (emb_idx & 1)
-                              ? std::cos(pos / std::pow(div_const, static_cast<float>(emb_idx - 1) / embedding_dim))
-                              : std::sin(pos / std::pow(div_const, static_cast<float>(emb_idx) / embedding_dim));
+                              ? std::cosf(pos / std::powf(div_const, static_cast<float>(emb_idx - 1) / embedding_dim))
+                              : std::sinf(pos / std::powf(div_const, static_cast<float>(emb_idx) / embedding_dim));
             positional_embedding_data.push_back(value);
         }
     }

--- a/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
+++ b/tt-train/sources/ttml/ops/scaled_dot_product_attention.cpp
@@ -4,7 +4,6 @@
 
 #include "scaled_dot_product_attention.hpp"
 
-#include <cmath>
 #include <stdexcept>
 
 #include "autograd/auto_context.hpp"
@@ -148,7 +147,7 @@ autograd::TensorPtr scaled_dot_product_attention(
     auto [batch_num, heads, seq_len, embedding_dim] = query->get_value().get_logical_shape().to_array_4D();
     auto groups = value->get_value().get_logical_shape().to_array_4D()[1];
 
-    const float scale = 1.0F / std::sqrt(static_cast<float>(embedding_dim));
+    const float scale = 1.0F / std::sqrtf(static_cast<float>(embedding_dim));
     auto q_scaled = ttnn::experimental::mul(query->get_value(), scale);
     auto key_tensor = key->get_value();
 
@@ -237,7 +236,7 @@ autograd::TensorPtr scaled_sigmoid_dot_product_attention(
     const autograd::TensorPtr& key,
     const autograd::TensorPtr& value,
     const std::optional<autograd::TensorPtr>& mask) {
-    const float scale = 1.0F / std::sqrt(static_cast<float>(query->get_value().get_logical_shape()[-1]));
+    const float scale = 1.0F / std::sqrtf(static_cast<float>(query->get_value().get_logical_shape()[-1]));
     // (B, H, S, E) x (B, H, E, S) -> (B, H, S, S)
     auto qk_t =
         ttnn_fixed::matmul(query->get_value(), key->get_value(), /* transpose_a */ false, /* transpose_b */ true);
@@ -249,7 +248,7 @@ autograd::TensorPtr scaled_sigmoid_dot_product_attention(
     // (B, H, S, S)
     // auto attention_weights = ttnn_fixed::softmax(qk_scaled, /* axis */ 3);
     auto attention_weights = ttnn::sigmoid(
-        ttnn::subtract(qk_scaled, std::log(static_cast<float>(query->get_value().get_logical_shape()[-2]))));
+        ttnn::subtract(qk_scaled, std::logf(static_cast<float>(query->get_value().get_logical_shape()[-2]))));
 
     // (B, H, S, S) x (B, H, S, E) -> (B, H, S, E)
     auto attention_qkv =
@@ -267,7 +266,8 @@ autograd::TensorPtr scaled_sigmoid_dot_product_attention(
             auto grad_scaled_dot =
                 ttnn::sigmoid_bw(
                     grad_attention_weights,
-                    ttnn::subtract(qk_scaled, std::log(static_cast<float>(query->get_value().get_logical_shape()[-2]))))
+                    ttnn::subtract(
+                        qk_scaled, std::logf(static_cast<float>(query->get_value().get_logical_shape()[-2]))))
                     .front();
 
             if (mask.has_value()) {

--- a/tt-train/sources/ttml/serialization/msgpack_file.hpp
+++ b/tt-train/sources/ttml/serialization/msgpack_file.hpp
@@ -9,7 +9,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <variant>
 #include <vector>
 
 namespace ttml::serialization {

--- a/tt-train/sources/ttml/tokenizers/bpe_tokenizer.hpp
+++ b/tt-train/sources/ttml/tokenizers/bpe_tokenizer.hpp
@@ -5,9 +5,6 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
-#include <string>
-#include <vector>
 
 #include "tokenizer_base.hpp"
 

--- a/tt-train/sources/ttml/tokenizers/char_tokenizer_trainer.hpp
+++ b/tt-train/sources/ttml/tokenizers/char_tokenizer_trainer.hpp
@@ -3,9 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <memory>
-#include <string>
-
 #include "char_tokenizer.hpp"
 
 namespace ttml::tokenizers {

--- a/tt-train/tests/datasets/dataloader_test.cpp
+++ b/tt-train/tests/datasets/dataloader_test.cpp
@@ -70,7 +70,6 @@ TEST_F(DataLoaderTest, TestLastBatchHandling) {
 
 // Test that shuffling works correctly
 TEST_F(DataLoaderTest, TestShuffling) {
-    ttml::autograd::ctx().set_seed(1337U);
     ttml::datasets::DataLoader<InMemoryDatasetFloatVecInt> dataloader(*dataset, 2, true);
 
     auto first_batch_before_shuffle = *dataloader.begin();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
@@ -253,7 +253,7 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
     size_t num_links, size_t num_workers_per_link, bool persistent_fabric_mode, const CoreRangeSet& available_cores) {
     std::tuple<CoreRangeSet, std::vector<CoreCoord>> result;
     CoreRangeSet sender_worker_core_range;
-    if (persistent_fabric_mode) {
+    if (!persistent_fabric_mode) {
         const size_t num_workers_preferred = num_workers_per_link * num_links;
         if (available_cores.num_cores() < num_workers_preferred) {
             log_warning(
@@ -286,8 +286,10 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
             }
         }
     } else {
-        sender_worker_core_range =
-            CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_workers_per_link - 1, num_links - 1)));
+        sender_worker_core_range = CoreRangeSet(std::vector<CoreRange>{
+            CoreRange(CoreCoord(2, 0), CoreCoord(2, 0)),
+            CoreRange(CoreCoord(3, 0), CoreCoord(3, 0)),
+            CoreRange(CoreCoord(5, 0), CoreCoord(5, 0))});
     }
     return {sender_worker_core_range, corerange_to_cores(sender_worker_core_range, std::nullopt, true)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
@@ -253,7 +253,7 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
     size_t num_links, size_t num_workers_per_link, bool persistent_fabric_mode, const CoreRangeSet& available_cores) {
     std::tuple<CoreRangeSet, std::vector<CoreCoord>> result;
     CoreRangeSet sender_worker_core_range;
-    if (!persistent_fabric_mode) {
+    if (persistent_fabric_mode) {
         const size_t num_workers_preferred = num_workers_per_link * num_links;
         if (available_cores.num_cores() < num_workers_preferred) {
             log_warning(
@@ -286,7 +286,8 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
             }
         }
     } else {
-        sender_worker_core_range = CoreRangeSet(CoreRange(CoreCoord(3, 0), CoreCoord(3, 3)));
+        sender_worker_core_range =
+            CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_workers_per_link - 1, num_links - 1)));
     }
     return {sender_worker_core_range, corerange_to_cores(sender_worker_core_range, std::nullopt, true)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
@@ -253,7 +253,7 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
     size_t num_links, size_t num_workers_per_link, bool persistent_fabric_mode, const CoreRangeSet& available_cores) {
     std::tuple<CoreRangeSet, std::vector<CoreCoord>> result;
     CoreRangeSet sender_worker_core_range;
-    if (persistent_fabric_mode) {
+    if (!persistent_fabric_mode) {
         const size_t num_workers_preferred = num_workers_per_link * num_links;
         if (available_cores.num_cores() < num_workers_preferred) {
             log_warning(
@@ -286,8 +286,7 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
             }
         }
     } else {
-        sender_worker_core_range =
-            CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_workers_per_link - 1, num_links - 1)));
+        sender_worker_core_range = CoreRangeSet(CoreRange(CoreCoord(3, 0), CoreCoord(3, 3)));
     }
     return {sender_worker_core_range, corerange_to_cores(sender_worker_core_range, std::nullopt, true)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
@@ -253,7 +253,7 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
     size_t num_links, size_t num_workers_per_link, bool persistent_fabric_mode, const CoreRangeSet& available_cores) {
     std::tuple<CoreRangeSet, std::vector<CoreCoord>> result;
     CoreRangeSet sender_worker_core_range;
-    if (!persistent_fabric_mode) {
+    if (persistent_fabric_mode) {
         const size_t num_workers_preferred = num_workers_per_link * num_links;
         if (available_cores.num_cores() < num_workers_preferred) {
             log_warning(
@@ -286,10 +286,8 @@ std::tuple<CoreRangeSet, std::vector<CoreCoord>> ar_choose_worker_cores(
             }
         }
     } else {
-        sender_worker_core_range = CoreRangeSet(std::vector<CoreRange>{
-            CoreRange(CoreCoord(2, 0), CoreCoord(2, 0)),
-            CoreRange(CoreCoord(3, 0), CoreCoord(3, 0)),
-            CoreRange(CoreCoord(5, 0), CoreCoord(5, 0))});
+        sender_worker_core_range =
+            CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_workers_per_link - 1, num_links - 1)));
     }
     return {sender_worker_core_range, corerange_to_cores(sender_worker_core_range, std::nullopt, true)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
@@ -254,7 +254,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
             get_optimal_worker_core_placement(ethernet_cores_virtual, sub_device_cores, num_links);
     } else {
         std::tie(sender_worker_core_range, sender_worker_cores) =
-            choose_worker_cores(num_links, num_workers_per_link, enable_persistent_fabric_mode, sub_device_cores);
+            ar_choose_worker_cores(num_links, num_workers_per_link, enable_persistent_fabric_mode, sub_device_cores);
     }
 
     if (device->id() == 4) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
@@ -126,6 +126,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
             output_cores.push_back(intersection.bounding_box());
         }
     }
+
     // output_cores_all is the bounding box of the output_tensor_cores but respecting boundaries of subdevice grids
     CoreRangeSet output_cores_all(output_cores);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
@@ -240,7 +240,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
-    bool optimal_placement = true;
+    bool optimal_placement = false;
     auto sub_device_cores = device->worker_cores(
         tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value_or(device->get_sub_device_ids().at(0)));
 
@@ -429,8 +429,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
         program, output_tensor_cores, out_cb_config);  // TODO: This should be the output cores instead
 
     // KERNEL CREATION
-    tt::tt_metal::NOC reader_noc = tt::tt_metal::NOC::NOC_0;
-    tt::tt_metal::NOC writer_noc = tt::tt_metal::NOC::NOC_1;
+    tt::tt_metal::NOC reader_noc = tt::tt_metal::NOC::NOC_1;
+    tt::tt_metal::NOC writer_noc = tt::tt_metal::NOC::NOC_0;
     // Reader
     std::vector<uint32_t> reader_compile_args = {
         ring_index,                 // my_chip_id
@@ -446,7 +446,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
         "worker_reader.cpp",
         worker_reducer_cores_all,
         tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = reader_noc,
             .compile_args = reader_compile_args});
 
@@ -469,7 +469,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
         "worker_writer.cpp",
         worker_reducer_cores_all,
         tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = writer_noc,
             .compile_args = writer_compile_args});
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_program_minimal_variants.cpp
@@ -240,7 +240,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_reduce_async_minimal_multi_cor
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
-    bool optimal_placement = false;
+    bool optimal_placement = true;
     auto sub_device_cores = device->worker_cores(
         tt::tt_metal::HalProgrammableCoreType::TENSIX, sub_device_id.value_or(device->get_sub_device_ids().at(0)));
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
@@ -11,14 +11,15 @@ void MAIN {
     constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_in1 = cb_in0;
 
-    uint32_t rt_args_idx = 0;
-    const uint32_t has_work = get_arg_val<uint32_t>(rt_args_idx++);
-    if (has_work == 0) {
+    uint32_t arg_idx = 0;
+    const uint32_t is_worker = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t is_reducer = get_arg_val<uint32_t>(arg_idx++);
+    if (is_reducer == 0) {
         return;
     }
 
-    const uint32_t num_blocks = get_arg_val<uint32_t>(rt_args_idx++);
-    const uint32_t block_num_tiles = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t num_blocks = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t block_num_tiles = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t copy_first_block = num_blocks % 2 != 0;
 
     constexpr uint32_t max_dst_tiles = 8;  // TODO: Make general

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "compute_kernel_api/eltwise_binary.h"
+#include "debug/dprint.h"
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/compute/reduction.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include "compute_kernel_api/eltwise_binary.h"
-#include "debug/dprint.h"
 
 namespace NAMESPACE {
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
@@ -25,6 +25,7 @@ void kernel_main() {
 
     // 1. Wait for signal from All-Gather worker
     noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
+    noc_semaphore_set(signal_semaphore_addr_ptr, 0);
 
     // 2. Signal compute kernel to start processing
     cb_push_back(cb_id, total_num_reduction_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/reduction_receiver.cpp
@@ -25,7 +25,6 @@ void kernel_main() {
 
     // 1. Wait for signal from All-Gather worker
     noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
-    noc_semaphore_set(signal_semaphore_addr_ptr, 0);
 
     // 2. Signal compute kernel to start processing
     cb_push_back(cb_id, total_num_reduction_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_reader.cpp
@@ -16,6 +16,9 @@ using address_t = uint32_t;
 constexpr uint32_t my_chip_id = get_compile_time_arg_val(0);
 constexpr uint32_t cb0_id = get_compile_time_arg_val(1);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(2);
+// reduction compile time args
+constexpr uint32_t cb_id = get_compile_time_arg_val(3);
+constexpr uint32_t total_num_reduction_tiles = get_compile_time_arg_val(4);
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -24,34 +27,53 @@ void kernel_main() {
 
     size_t arg_idx = 0;
     // Load the input tensor spec
-    address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
-    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
-    tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
-    arg_idx += num_cores;
-    tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
-    arg_idx += num_cores;
+    const uint32_t is_worker = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t is_reducer = get_arg_val<uint32_t>(arg_idx++);
+    if (is_worker == 0 && is_reducer == 0) {
+        return;
+    }
+    if (is_worker == 1) {
+        address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
+        uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
+        uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
+        tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+        arg_idx += num_cores;
+        tt_l1_ptr uint32_t* core_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+        arg_idx += num_cores;
 
-    // interleaved addrgen
-    uint32_t tiles_read = 0;
-    uint32_t shard_tile_id = first_core_tile_start_offset;
-    uint32_t core_id = 0;
-    while (tiles_read < num_tiles_to_read) {
-        uint32_t num_tiles_to_read_this_core =
-            std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
-        cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
-        const uint32_t l1_write_addr = get_write_ptr(cb0_id);
-        uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
-        read_addr += shard_tile_id * tensor0_page_size;
+        // interleaved addrgen
+        uint32_t tiles_read = 0;
+        uint32_t shard_tile_id = first_core_tile_start_offset;
+        uint32_t core_id = 0;
+        while (tiles_read < num_tiles_to_read) {
+            uint32_t num_tiles_to_read_this_core =
+                std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
+            cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
+            const uint32_t l1_write_addr = get_write_ptr(cb0_id);
+            uint64_t read_addr = get_noc_addr(core_noc_x[core_id], core_noc_y[core_id], tensor_address0);
+            read_addr += shard_tile_id * tensor0_page_size;
 
-        noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
-        noc_async_read_barrier();
+            noc_async_read(read_addr, l1_write_addr, num_tiles_to_read_this_core * tensor0_page_size);
+            noc_async_read_barrier();
 
-        cb_push_back(cb0_id, num_tiles_to_read_this_core);
-        tiles_read += num_tiles_to_read_this_core;
-        shard_tile_id = 0;
-        core_id++;
+            cb_push_back(cb0_id, num_tiles_to_read_this_core);
+            tiles_read += num_tiles_to_read_this_core;
+            shard_tile_id = 0;
+            core_id++;
+        }
+    }
+    if (is_reducer == 1) {
+        const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+        volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
+
+        // 1. Wait for signal from All-Gather worker
+        noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
+        noc_semaphore_set(signal_semaphore_addr_ptr, 0);
+
+        // 2. Signal compute kernel to start processing
+        cb_push_back(cb_id, total_num_reduction_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_reader.cpp
@@ -6,7 +6,6 @@
 #include <tt-metalium/buffer_constants.hpp>
 #include <cstdint>
 #include <utility>
-#include "debug/dprint.h"
 
 using address_t = uint32_t;
 
@@ -31,7 +30,6 @@ void kernel_main() {
     const uint32_t is_worker = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t is_reducer = get_arg_val<uint32_t>(arg_idx++);
     if (is_worker == 0 && is_reducer == 0) {
-        DPRINT << "not worker or reducer" << ENDL();
         return;
     }
     if (is_worker == 1) {
@@ -50,7 +48,6 @@ void kernel_main() {
         uint32_t shard_tile_id = first_core_tile_start_offset;
         uint32_t core_id = 0;
         while (tiles_read < num_tiles_to_read) {
-            DPRINT << "tiles_read: " << tiles_read << ENDL();
             uint32_t num_tiles_to_read_this_core =
                 std::min(num_tiles_per_core - shard_tile_id, num_tiles_to_read - tiles_read);
             cb_reserve_back(cb0_id, num_tiles_to_read_this_core);
@@ -67,23 +64,18 @@ void kernel_main() {
             core_id++;
         }
     }
-    DPRINT << "is_reducer: " << is_reducer << ENDL();
     if (is_reducer == 1) {
         const uint32_t sem_id = get_arg_val<uint32_t>(arg_idx++);
-        DPRINT << "reducer sem_id: " << sem_id << ENDL();
         const uint32_t signal_semaphore_addr = get_semaphore(sem_id);
         volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
             reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
 
         // 1. Wait for signal from All-Gather worker
-        DPRINT << "reducer wait" << ENDL();
         noc_semaphore_wait(signal_semaphore_addr_ptr, VALID);
         if (is_reducer == 1 && is_worker == 0) {
             noc_semaphore_set(signal_semaphore_addr_ptr, 0);
         }
-        DPRINT << "reducer signal recieved" << ENDL();
         // 2. Signal compute kernel to start processing
         cb_push_back(cb_id, total_num_reduction_tiles);
-        DPRINT << "reader completed" << ENDL();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -205,8 +205,8 @@ void kernel_main() {
             reduction_semaphore_send_addr,
             reduction_semaphore_recv_noc_addr,
             i == 0 ? num_mcast_cores : 0,
-            false,   // linked = false
-            false);  // multicast_path_reserve = true
+            false,  // linked = false
+            true);  // multicast_path_reserve = true
     }
 
     if (is_worker == 1 && is_reducer == 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -9,7 +9,6 @@
 #include "cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_ccl_common.hpp"
 #include <cstdint>
 #include <utility>
-#include "debug/dprint.h"
 
 using address_t = uint32_t;
 
@@ -39,7 +38,6 @@ void kernel_main() {
     const uint32_t is_worker = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t is_reducer = get_arg_val<uint32_t>(arg_idx++);
     if (is_worker == 0) {
-        DPRINT << "non worker detected" << ENDL();
         return;
     }
     // Load the input tensor spec
@@ -186,9 +184,7 @@ void kernel_main() {
     }
 
     // 3. wait for mcast output ready semaphore
-    DPRINT << "worker waiting for global sem" << ENDL();
     while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) != out_ready_sem_wait_value);
-    DPRINT << "worker recieved all global sem" << ENDL();
 
     // Set up for mcasting to reduction workers
     volatile tt_l1_ptr uint32_t* reduction_semaphore_send_addr_ptr =
@@ -198,9 +194,6 @@ void kernel_main() {
     // loop over mcast ranges
     for (uint32_t i = 0; i < num_mcast_ranges; i++) {
         // Signal the reduction workers
-        DPRINT << "mcaster sending to " << i << " out of " << num_mcast_ranges << ENDL();
-        DPRINT << "mcast start: " << mcast_dest_noc_start_x[i] << ", " << mcast_dest_noc_start_y[i] << ENDL();
-        DPRINT << "mcast end: " << mcast_dest_noc_end_x[i] << ", " << mcast_dest_noc_end_y[i] << ENDL();
         const uint64_t reduction_semaphore_recv_noc_addr = get_noc_multicast_addr(
             mcast_dest_noc_start_x[i],
             mcast_dest_noc_start_y[i],
@@ -214,7 +207,6 @@ void kernel_main() {
             i == 0 ? num_mcast_cores : 0,
             false,   // linked = false
             false);  // multicast_path_reserve = true
-        DPRINT << "mcasted " << i << " out of " << num_mcast_cores << ENDL();
     }
 
     if (is_worker == 1 && is_reducer == 1) {
@@ -229,6 +221,4 @@ void kernel_main() {
     }
 
     noc_async_write_barrier();
-
-    DPRINT << "writer done" << ENDL();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -35,6 +35,11 @@ void kernel_main() {
     ///////////////////////////////////////////////////
 
     size_t arg_idx = 0;
+    const uint32_t is_worker = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t is_reducer = get_arg_val<uint32_t>(arg_idx++);
+    if (is_worker == 0) {
+        return;
+    }
     // Load the input tensor spec
     uint32_t reduction_input_cb_id = get_arg_val<address_t>(arg_idx++);
     address_t reduction_input_addr = get_write_ptr(reduction_input_cb_id);
@@ -51,11 +56,6 @@ void kernel_main() {
     const uint32_t reduction_semaphore_send_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t num_mcast_ranges = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t link = get_arg_val<uint32_t>(arg_idx++);
-
-    // Set up for mcasting to reduction workers
-    volatile tt_l1_ptr uint32_t* reduction_semaphore_send_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduction_semaphore_send_addr);
-    noc_semaphore_set(reduction_semaphore_send_addr_ptr, VALID);
 
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
     arg_idx += num_cores;
@@ -185,6 +185,11 @@ void kernel_main() {
 
     // 3. wait for mcast output ready semaphore
     while (*reinterpret_cast<volatile uint32_t*>(out_ready_sem_bank_addr) != out_ready_sem_wait_value);
+
+    // Set up for mcasting to reduction workers
+    volatile tt_l1_ptr uint32_t* reduction_semaphore_send_addr_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(reduction_semaphore_send_addr);
+    noc_semaphore_set(reduction_semaphore_send_addr_ptr, VALID);
 
     // loop over mcast ranges
     for (uint32_t i = 0; i < num_mcast_ranges; i++) {


### PR DESCRIPTION
### Problem description
Presently, the AllReduce Async Op has restriction to place CCL workers on cores other than the reducer cores.
This PR aims to merge mainly reader kernels for worker and reducer so that the workers can be placed anywhere in the sub device coregrid.

This kernel merging task handles these cases when a core is
1. CCL worker as well as a reducer.
2. CCL worker but not a reducer.
3. Not a CCL worker but only a reducer.
4. Neither a CCL worker nor a Reducer

### Optimal Worker Placement Heuristic
1. Get top row of ethernet_cores
2. Convert them virtual positions to logical cores.
3. Place worker core just below or as close to ethernet core inside the subdevice boundary
i. Shift ethernet core X inside the subdevice boundary
ii. place first worker just below the adjusted ethernet core.
iii. if there is already a worker placed at that position, shift the worker core one position down.

### Ethernet Cores and Worker Placement
Writer NOC 0
Reader NOC 1
Note: Green circles marks ethernet core, Yellow stars mark workers
### Cluster Axis 0 (4 links)
![image (2)](https://github.com/user-attachments/assets/e455a1b5-2979-473a-a216-80f20f5319b8)
### Cluster Axis 1 (3 links)
![image (3)](https://github.com/user-attachments/assets/e166a74b-bf75-488f-8c3f-a16a36cb951b)


### What's changed
1. Program factory is updated to pass dynamic sized runtime args based on the type of kernel.
3. reduction_reciever kernel is not used anymore and merged with worker_reader kernel.
5. Update local semaphore set and reset condition to avoid race condition when a core can be worker or reducer.

### Perf before and after
| Op Instance | Time Before (us) | Time After (us) | ~Savings (us) |
|-|-|-|-|
| all-reduce ff1     | 19.18  | 19.07 | +0.11 |
| all-reduce ff2     | 18.55 | 20.10 | -1.55 |
| all-reduce qkv     | 11.9  | 12.66 | -0.76 |
| all-reduce lm_head | 61.82 | 60.79| +1.03 |

### Placement Experiment Result
* If we place the workers as originally as in `all-reduce qkv`, the merged kernels arenot able to reproduce the performance as before. In short, worker placement is ineffective in case of QKV.

| QKV Placement (sender cores)                                   | Min (µs) | Max (µs) | Avg (µs) (baseline : 10.77µs)     |
|---------------------------------------------------|----------|----------|--------------|
| {(x=2, y=0), (x=3, y=0), (x=5, y=0)}               | 9.201    | 13.335   | 11.187       |
| {(x=2, y=0), (x=3, y=1), (x=5, y=2)}               | 9.770    | 13.234   | 11.101       |
| {(x=1, y=7), (x=2, y=8), (x=3, y=9)}  | 9.389    | 12.915   | 11.029       |



### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes