### PR TITLE
Implement `get_type_name` on `MeshDeviceOperationAdapter` to support Op names in profiler

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gmock/gmock.h>
+#include <type_traits>
 
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/old_infra_device_operation.hpp"
 #include "ttnn/operation_concepts.hpp"
+#include "ttnn/operations/examples/example/device/example_device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
@@ -170,6 +172,21 @@ TEST(LaunchOperationTest, NewInfraUsesHeterogeneousDispatch) {
     EXPECT_FALSE(uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreate>(OperationAttributes{}));
 
     EXPECT_TRUE(uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreateAt>(OperationAttributes{}));
+}
+
+TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
+    auto old_infra_attrs = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreate{});
+
+    EXPECT_EQ(
+        device_operation::MeshDeviceOperationAdapter<
+            tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>>::get_type_name(old_infra_attrs),
+        "OldInfraDeviceOpWithCreate");
+
+    using ::ttnn::operations::examples::ExampleDeviceOperation;
+    EXPECT_EQ(
+        device_operation::MeshDeviceOperationAdapter<ExampleDeviceOperation>::get_type_name(
+            ExampleDeviceOperation::operation_attributes_t{.attribute = true, .some_other_attribute = 42}),
+        "ExampleDeviceOperation");
 }
 
 using LaunchOperationT3000Test = tt::tt_metal::T3000MeshDeviceFixture;

--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -51,6 +51,15 @@ struct MeshDeviceOperationAdapter {
         return DeviceOperation::invoke(std::forward<Args>(args)...);
     }
 
+    static std::string get_type_name(const operation_attributes_t& attribute) {
+        if constexpr (requires { device_operation_t::get_type_name(attribute); }) {
+            // OldInfraDeviceOperation path.
+            return device_operation_t::get_type_name(attribute);
+        } else {
+            return std::string(tt::stl::get_type_name<device_operation_t>());
+        }
+    }
+
     static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
         DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
     }

--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -51,6 +51,8 @@ struct MeshDeviceOperationAdapter {
         return DeviceOperation::invoke(std::forward<Args>(args)...);
     }
 
+    // Returns type name of the underlying device operation.
+    // Used for logging and debugging; in particular, Tracy profiler uses this to identify operations.
     static std::string get_type_name(const operation_attributes_t& attribute) {
         if constexpr (requires { device_operation_t::get_type_name(attribute); }) {
             // OldInfraDeviceOperation path.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, Op names in profiler data are recorded as `MeshDeviceOperationAdapter<OldInfraDeviceOperation>`.

### What's changed
Add `get_type_name` that either falls back to `get_type_name` of `OldInfraDeviceOperation` (type-erased mechanism for old infra), or `tt::stl::get_type_name<device_operation_t>()` of the underlying `device_operation_t`.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14148971389)
- [X] New/Existing tests provide coverage for changes