### PR TITLE
Include what you use in `tt_metal`

### DIFF
--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -5,9 +5,13 @@
 #pragma once
 
 #include <cstdint>
+#include <fstream>
 #include <functional>
-#include <vector>
+#include <memory>
+#include <optional>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "allocator_types.hpp"
 #include "assert.hpp"
@@ -18,11 +22,10 @@ namespace tt {
 
 namespace tt_metal {
 
+class BankManager;
 class Buffer;
-
 // Fwd declares
 enum class BufferType;
-class BankManager;
 
 class Allocator {
 public:

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include <cstring>
-#include <cstdint>
-#include <vector>
-#include <optional>
-#include <functional>
-
 #include <tt-metalium/tile.hpp>
 #include <tt_stl/span.hpp>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 class bfloat16 {
 private:

--- a/tt_metal/api/tt-metalium/bfloat4.hpp
+++ b/tt_metal/api/tt-metalium/bfloat4.hpp
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <vector>
-#include <optional>
-
+#include <stdint.h>
 #include <tt-metalium/tile.hpp>
 #include <tt_stl/span.hpp>
+#include <optional>
+#include <vector>
 
 // TODO: empty struct to facilitate Tensor template logic. Reconsider how/why templating is supported in Tensor
 struct bfloat4_b {};

--- a/tt_metal/api/tt-metalium/bfloat8.hpp
+++ b/tt_metal/api/tt-metalium/bfloat8.hpp
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <vector>
-#include <optional>
-
+#include <stdint.h>
 #include <tt-metalium/tile.hpp>
 #include <tt_stl/span.hpp>
+#include <optional>
+#include <vector>
 
 // TODO: empty struct to facilitate Tensor template logic. Reconsider how/why templating is supported in Tensor
 struct bfloat8_b {};

--- a/tt_metal/api/tt-metalium/blockfloat_common.hpp
+++ b/tt_metal/api/tt-metalium/blockfloat_common.hpp
@@ -3,13 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <stdint.h>
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/tile.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt_stl/span.hpp>
+#include <cstddef>
+#include <optional>
 #include <vector>
 
-#include <tt-metalium/assert.hpp>
-#include <tt-metalium/tt_backend_api_types.hpp>
-
-#include <tt-metalium/tile.hpp>
-#include <tt_stl/span.hpp>
+namespace tt {
+enum class DataFormat : uint8_t;
+}  // namespace tt
 
 uint8_t get_max_exp(const std::vector<uint32_t>& vec, bool is_exp_a);
 

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -4,36 +4,48 @@
 
 #pragma once
 
+// #include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
+#include <tt_stl/concepts.hpp>
 #include <array>
 #include <atomic>
-#include <cstdint>
 #include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <ostream>
 #include <tuple>
 #include <unordered_map>
 #include <variant>
 #include <vector>
 
+#include "assert.hpp"
 #include "bfloat16.hpp"
-#include "core_coord.hpp"
 #include "buffer_constants.hpp"
+#include "core_coord.hpp"
+#include "hal_types.hpp"
 #include "sub_device_types.hpp"
+#include "umd/device/tt_core_coordinates.h"
 #include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/types/xy_pair.h"
-#include <tt_stl/concepts.hpp>
-#include "assert.hpp"
-#include <nlohmann/json.hpp>
 
-#include "hal_types.hpp"
+namespace tt {
+namespace stl {
+namespace json {
+template <typename T>
+struct from_json_t;
+}  // namespace json
+}  // namespace stl
+}  // namespace tt
 
 namespace tt::tt_metal {
 
-class IDevice;
-
 class Allocator;
+class IDevice;
 
 struct ShardSpec {
     /* The individual cores the shard grid is mapped to */

--- a/tt_metal/api/tt-metalium/circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer.hpp
@@ -4,9 +4,20 @@
 
 #pragma once
 
-#include "core_coord.hpp"
-#include "tt_backend_api_types.hpp"
+#include <stdint.h>
+#include <optional>
+#include <unordered_set>
+
 #include "circular_buffer_types.hpp"
+#include "core_coord.hpp"
+#include "hal_types.hpp"
+#include "tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+struct Tile;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/circular_buffer_types.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_types.hpp
@@ -11,12 +11,18 @@
 #include <optional>
 #include <unordered_set>
 
-#include "logger.hpp"
-#include "tt_backend_api_types.hpp"
 #include "buffer.hpp"
-#include "tile.hpp"
-
 #include "circular_buffer_constants.h"
+#include "logger.hpp"
+#include "tile.hpp"
+#include "tt_backend_api_types.hpp"
+
+namespace tt {
+enum class DataFormat : uint8_t;
+namespace tt_metal {
+class Buffer;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/command_queue_common.hpp
+++ b/tt_metal/api/tt-metalium/command_queue_common.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "umd/device/types/cluster_descriptor_types.h"
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -4,17 +4,33 @@
 
 #pragma once
 
+#include <fmt/base.h>
+#include <nlohmann/json.hpp>
+#include <stdint.h>
+#include <tt_stl/reflection.hpp>
+#include <tt_stl/span.hpp>
 #include <algorithm>
+#include <cstddef>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <set>
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include "umd/device/tt_xy_pair.h"
-#include <tt_stl/reflection.hpp>
-#include <tt_stl/span.hpp>
+#include "umd/device/types/xy_pair.h"
+
+namespace tt {
+namespace stl {
+namespace json {
+template <typename T>
+struct from_json_t;
+template <typename T>
+struct to_json_t;
+}  // namespace json
+}  // namespace stl
+}  // namespace tt
 
 using CoreCoord = tt_xy_pair;
 

--- a/tt_metal/api/tt-metalium/core_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/core_descriptor.hpp
@@ -4,11 +4,18 @@
 
 #pragma once
 
-#include "core_coord.hpp"
-#include "dispatch_core_common.hpp"
-
+#include <stdint.h>
 #include <umd/device/types/arch.h>                      // tt::ARCH
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <map>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "core_coord.hpp"
+#include "dispatch_core_common.hpp"
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -4,20 +4,24 @@
 
 #pragma once
 
+#include <tt_stl/span.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 #include "assert.hpp"
+#include "control_plane.hpp"
 #include "device.hpp"
 #include "dispatch_core_common.hpp"
-#include <tt_stl/span.hpp>
+#include "system_memory_manager.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
-#include "control_plane.hpp"
 
 namespace tt {
 namespace tt_metal::detail {

--- a/tt_metal/api/tt-metalium/dispatch_mem_map.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_mem_map.hpp
@@ -4,10 +4,24 @@
 
 #pragma once
 
-#include <tt-metalium/dispatch_settings.hpp>
+#include <stdint.h>
 #include <tt-metalium/command_queue_common.hpp>
-
+#include <tt-metalium/dispatch_settings.hpp>
 #include <tt_stl/indestructible.hpp>
+#include <utility>
+#include <vector>
+
+#include "umd/device/tt_core_coordinates.h"
+
+namespace tt {
+namespace stl {
+template <typename T>
+class Indestructible;
+}  // namespace stl
+namespace tt_metal {
+enum class CommandQueueDeviceAddrType : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/dispatch_settings.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_settings.hpp
@@ -4,10 +4,15 @@
 
 #pragma once
 
-#include <cstdint>
 #include <magic_enum/magic_enum.hpp>
-#include <unordered_map>
 #include <umd/device/tt_core_coordinates.h>
+#include <array>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+enum class CoreType;
 
 namespace tt {
 class Cluster;

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -4,11 +4,30 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "assert.hpp"
+#include "buffer.hpp"
 #include "mesh_buffer.hpp"
-#include "mesh_trace_id.hpp"
 #include "mesh_command_queue.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_event.hpp"
+#include "mesh_trace_id.hpp"
+#include "mesh_workload.hpp"
+#include "span.hpp"
+#include "sub_device_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Program;
+namespace distributed {
+class MeshDevice;
+}  // namespace distributed
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -4,11 +4,15 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <tuple>
 
-#include "core_coord.hpp"
 #include "buffer_constants.hpp"
+#include "core_coord.hpp"
+#include "hal_types.hpp"
 #include "mesh_buffer.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -4,13 +4,26 @@
 
 #pragma once
 
-#include <string>
+#include <nlohmann/json.hpp>
+#include <stdint.h>
 #include <any>
+#include <array>
+#include <functional>
+#include <memory>
 #include <span>
+#include <string>
 #include <string_view>
+#include <vector>
 
-#include "core_coord.hpp"
 #include "buffer.hpp"
+#include "core_coord.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Buffer;
+class IDevice;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/jit_build_options.hpp
+++ b/tt_metal/api/tt-metalium/jit_build_options.hpp
@@ -4,10 +4,19 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <cstddef>
 #include <map>
+#include <string>
+#include <vector>
 
 #include "hlk_desc.hpp"
 #include "hostdevcommon/kernel_structs.h"
+
+enum class MathFidelity : uint8_t;
+namespace tt {
+enum CBIndex : std::uint8_t;
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -4,27 +4,47 @@
 
 #pragma once
 
-#include <string_view>
-#include <vector>
+#include <magic_enum/magic_enum.hpp>
+#include <stdint.h>
+#include <tt_stl/span.hpp>
+#include <cstddef>
+#include <functional>
 #include <map>
-#include <variant>
-#include <type_traits>
 #include <memory>
+#include <ostream>
+#include <set>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <variant>
+#include <vector>
 
 #include "base_types.hpp"
 #include "core_coord.hpp"
-#include "jit_build_settings.hpp"
+#include "hal_types.hpp"
 #include "jit_build_options.hpp"
+#include "jit_build_settings.hpp"
 #include "kernel_types.hpp"
-#include "tt_memory.h"
-#include <tt_stl/span.hpp>
 #include "runtime_args_data.hpp"
+#include "tt_backend_api_types.hpp"
+#include "tt_memory.h"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
+
+namespace ll_api {
+class memory;
+}  // namespace ll_api
 
 namespace tt {
 
 namespace tt_metal {
 
 class IDevice;
+class JitBuildOptions;
+enum class DataMovementProcessor;
 
 constexpr uint32_t max_runtime_args = 256;
 

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -4,12 +4,14 @@
 
 #pragma once
 
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
 #include "base_types.hpp"
 #include "data_types.hpp"
 #include "util.hpp"
-#include <map>
-#include <vector>
-#include <string>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/lightmetal_capture_utils.hpp
+++ b/tt_metal/api/tt-metalium/lightmetal_capture_utils.hpp
@@ -4,8 +4,19 @@
 
 #pragma once
 
-#include "lightmetal/host_api_capture_helpers.hpp"
 #include <tt-metalium/buffer.hpp>
+#include <functional>
+#include <memory>
+#include <variant>
+
+#include "lightmetal/host_api_capture_helpers.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Buffer;
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/memory_reporter.hpp
+++ b/tt_metal/api/tt-metalium/memory_reporter.hpp
@@ -4,19 +4,28 @@
 
 #pragma once
 
-#include <filesystem>
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "allocator.hpp"
+#include "allocator_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+enum class BufferType;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 
-class Program;
 class IDevice;
+class Program;
 
 namespace detail {
 struct MemoryView;

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -4,8 +4,15 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <variant>
+
 #include "buffer.hpp"
 #include "buffer_constants.hpp"
+#include "hal_types.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_device.hpp"
 #include "mesh_device_view.hpp"

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -4,19 +4,49 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <queue>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <variant>
+#include <vector>
 
 #include "buffer.hpp"
 #include "command_queue.hpp"
 #include "command_queue_interface.hpp"
-#include "multi_producer_single_consumer_queue.hpp"
-
+#include "core_coord.hpp"
+#include "dispatch_settings.hpp"
+#include "launch_message_ring_buffer_state.hpp"
 #include "mesh_buffer.hpp"
+#include "mesh_coord.hpp"
 #include "mesh_device.hpp"
-#include "mesh_workload.hpp"
 #include "mesh_trace.hpp"
 #include "mesh_trace_id.hpp"
+#include "mesh_workload.hpp"
+#include "multi_producer_single_consumer_queue.hpp"
+#include "span.hpp"
+#include "sub_device_types.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "vector_aligned.hpp"
+#include "worker_config_buffer.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class SystemMemoryManager;
+namespace distributed {
+class MeshDevice;
+class MeshWorkload;
+}  // namespace distributed
+struct ProgramCommandSequence;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 
@@ -25,8 +55,8 @@ class ThreadPool;
 namespace distributed {
 
 class MeshEvent;
-struct MeshReadEventDescriptor;
 struct MeshBufferReadDescriptor;
+struct MeshReadEventDescriptor;
 
 using MeshCompletionReaderVariant = std::variant<MeshBufferReadDescriptor, MeshReadEventDescriptor>;
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -4,23 +4,53 @@
 
 #pragma once
 
+#include <tt_stl/span.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <ostream>
+#include <set>
+#include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
+#include "core_coord.hpp"
 #include "device.hpp"
 #include "dispatch_core_common.hpp"
-
+#include "hal_types.hpp"
+#include "hostdevcommon/common_values.hpp"
 #include "mesh_config.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_device_view.hpp"
 #include "mesh_trace_id.hpp"
+#include "program_device_map.hpp"
 #include "small_vector.hpp"
 #include "sub_device_types.hpp"
-#include <tt_stl/span.hpp>
+#include "trace_buffer.hpp"
+#include "umd/device/types/arch.h"
+#include "work_executor_types.hpp"
+
+enum class CoreType;
+namespace tt {
+namespace tt_metal {
+class Allocator;
+class CommandQueue;
+class SubDevice;
+class SystemMemoryManager;
+namespace program_cache {
+namespace detail {
+struct ProgramCache;
+}  // namespace detail
+}  // namespace program_cache
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/mesh_event.hpp
+++ b/tt_metal/api/tt-metalium/mesh_event.hpp
@@ -5,7 +5,18 @@
 #pragma once
 
 #include <cstdint>
+#include <ostream>
+
+#include "mesh_coord.hpp"
 #include "mesh_device.hpp"
+
+namespace tt {
+namespace tt_metal {
+namespace distributed {
+class MeshDevice;
+}  // namespace distributed
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/api/tt-metalium/mesh_graph.hpp
+++ b/tt_metal/api/tt-metalium/mesh_graph.hpp
@@ -4,17 +4,22 @@
 
 #pragma once
 
-#include <cstdint>
-#include <string>
-#include <unordered_map>
-#include <vector>
 #include <magic_enum/magic_enum.hpp>
-
 #include <tt-metalium/assert.hpp>
 #include <tt_stl/reflection.hpp>
-
 #include <umd/device/types/arch.h>                      // tt::ARCH
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::tt_fabric {
 struct ChipSpec {

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -4,10 +4,20 @@
 
 #pragma once
 
-#include "tt_backend_api_types.hpp"
+#include <stdint.h>
+#include <cstddef>
+#include <map>
+#include <vector>
+
 #include "core_coord.hpp"
-#include "umd/device/tt_soc_descriptor.h"
+#include "tt_backend_api_types.hpp"
 #include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_soc_descriptor.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/xy_pair.h"
+
+enum BoardType : uint32_t;
 
 //! tt_SocDescriptor contains information regarding the SOC configuration targetted.
 /*!

--- a/tt_metal/api/tt-metalium/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/routing_table_generator.hpp
@@ -4,7 +4,14 @@
 
 #pragma once
 #include <magic_enum/magic_enum.hpp>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "mesh_graph.hpp"
+#include "umd/device/types/cluster_descriptor_types.h"
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/api/tt-metalium/semaphore.hpp
+++ b/tt_metal/api/tt-metalium/semaphore.hpp
@@ -4,8 +4,12 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "core_coord.hpp"
 #include "umd/device/tt_soc_descriptor.h"
+
+enum class CoreType;
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -4,7 +4,14 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <ostream>
+#include <tuple>
+
 #include "shape_base.hpp"
+#include "small_vector.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/system_memory_manager.hpp
+++ b/tt_metal/api/tt-metalium/system_memory_manager.hpp
@@ -4,20 +4,19 @@
 
 #pragma once
 
-#include <atomic>
-#include <cstdint>
-#include <mutex>
-#include <vector>
-
-#include <tt-metalium/system_memory_cq_interface.hpp>
-
+#include <tt-metalium/dispatch_settings.hpp>
 // needed for private members
 #include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/launch_message_ring_buffer_state.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
-#include <umd/device/tt_xy_pair.h>             // for tt_cxy_pair
+#include <tt-metalium/system_memory_cq_interface.hpp>
 #include <umd/device/tt_device/tlb_manager.h>  // needed because tt_io.hpp requires needs TLBManager
 #include <umd/device/tt_io.hpp>                // for tt::Writer
+#include <umd/device/tt_xy_pair.h>             // for tt_cxy_pair
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <vector>
 
 using chip_id_t = int;
 

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -4,11 +4,19 @@
 
 #pragma once
 
+#include <tt_stl/indestructible.hpp>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "mesh_coord.hpp"
-#include <tt_stl/indestructible.hpp>
+
+namespace tt {
+namespace stl {
+template <typename T>
+class Indestructible;
+}  // namespace stl
+}  // namespace tt
 
 namespace tt::tt_metal::distributed {
 
@@ -18,6 +26,7 @@ namespace tt::tt_metal::distributed {
 class SystemMesh {
 private:
     class Impl;  // Forward declaration only
+
     std::unique_ptr<Impl> pimpl_;
     SystemMesh();
 

--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -4,12 +4,19 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <array>
 #include <optional>
+#include <tuple>
 
 #include "bfloat16.hpp"
-#include "tt_backend_api_types.hpp"
 #include "constants.hpp"
 #include "math.hpp"
+#include "tt_backend_api_types.hpp"
+
+namespace tt {
+enum class DataFormat : uint8_t;
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/tilize_utils.hpp
+++ b/tt_metal/api/tt-metalium/tilize_utils.hpp
@@ -8,18 +8,17 @@
 
 #pragma once
 
-#include <cstdint>
-#include <vector>
-#include <optional>
-#include <concepts>
-#include <type_traits>
-
-#include <tt_stl/span.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/assert.hpp>
-#include <tt-metalium/math.hpp>
-
 #include <tracy/Tracy.hpp>
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt_stl/span.hpp>
+#include <array>
+#include <concepts>
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+#include <vector>
 
 namespace tests::utils {
 enum class TensorLayoutType {

--- a/tt_metal/api/tt-metalium/trace.hpp
+++ b/tt_metal/api/tt-metalium/trace.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -13,6 +15,12 @@
 #include "buffer.hpp"
 #include "command_queue.hpp"
 #include "trace_buffer.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/trace_buffer.hpp
+++ b/tt_metal/api/tt-metalium/trace_buffer.hpp
@@ -4,12 +4,14 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "sub_device_types.hpp"
 

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -5,9 +5,11 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <functional>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -3,23 +3,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <vector>
+#include <stdint.h>
+#include <cstddef>
 #include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
-#include "umd/device/types/cluster_descriptor_types.h"
-#include "umd/device/tt_soc_descriptor.h"
-#include "hostdevcommon/common_values.hpp"
+#include "assert.hpp"
+#include "buffer.hpp"
 #include "core_coord.hpp"
 #include "dispatch_core_common.hpp"
-#include "buffer.hpp"
-#include "profiler_types.hpp"
-#include "profiler_optional_metadata.hpp"
 #include "fabric_types.hpp"
+#include "hostdevcommon/common_values.hpp"
+#include "profiler_optional_metadata.hpp"
+#include "profiler_types.hpp"
+#include "span.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_soc_descriptor.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+
+namespace tt {
+namespace tt_metal {
+enum class FabricConfig : uint32_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
-class Program;
 class Buffer;
 class IDevice;
+class Program;
 
 namespace detail {
 

--- a/tt_metal/api/tt-metalium/utils.hpp
+++ b/tt_metal/api/tt-metalium/utils.hpp
@@ -4,8 +4,11 @@
 
 #pragma once
 
-#include <string>
+#include <cstddef>
+#include <functional>
 #include <map>
+#include <string>
+#include <type_traits>
 
 using std::string;
 

--- a/tt_metal/common/core_assignment.cpp
+++ b/tt_metal/common/core_assignment.cpp
@@ -2,8 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <numeric>
+
 #include "assert.hpp"
 #include "core_assignment.hpp"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/common/core_assignment.hpp
+++ b/tt_metal/common/core_assignment.hpp
@@ -2,11 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
+#include <umd/device/types/arch.h>  // tt::ARCH
+#include <vector>
+
 #include "core_coord.hpp"
 
-#include <umd/device/types/arch.h>  // tt::ARCH
-
 namespace tt {
+enum class ARCH;
+
 namespace tt_metal {
 // Returns an ordered list of DRAM Bank ID to optimally placed worker cores. Placing DRAM reader or writer
 // kernels on these worker cores will minimize NOC congestion and the number of NOC hops required to complete

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -2,22 +2,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <core_coord.hpp>
-
-#include <algorithm>
-#include <cstdint>
-#include <limits>
-#include <mutex>
-#include <optional>
-#include <set>
-#include <string>
-#include <vector>
-
-#include "umd/device/tt_xy_pair.h"
 #include <assert.hpp>
-#include "tracy/Tracy.hpp"
+#include <core_coord.hpp>
+#include <nlohmann/detail/json_ref.hpp>
+#include <nlohmann/json.hpp>
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/span.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tracy/Tracy.hpp"
 
 auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) const
     -> format_context::iterator {

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -2,14 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <cstdint>
-#include <optional>
-
 #include <assert.hpp>
+#include <boost/container/vector.hpp>
+#include <boost/move/utility_core.hpp>
 #include <mesh_coord.hpp>
-#include <tt_stl/reflection.hpp>
 #include <tt_stl/span.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <numeric>
+#include <optional>
+#include <ostream>
+#include <utility>
+#include <vector>
+
+#include "shape_base.hpp"
+#include "small_vector.hpp"
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -4,13 +4,13 @@
 
 #include "metal_soc_descriptor.h"
 
-#include <fstream>
-#include <iostream>
+#include <assert.hpp>
+#include <yaml-cpp/yaml.h>
 #include <string>
 
-#include <assert.hpp>
-#include "umd/device/cluster.h"
-#include "yaml-cpp/yaml.h"
+#include "umd/device/types/arch.h"
+
+enum BoardType : uint32_t;
 
 CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view) const {
     TT_ASSERT(

--- a/tt_metal/common/shape.cpp
+++ b/tt_metal/common/shape.cpp
@@ -4,11 +4,14 @@
 
 #include "shape.hpp"
 
-#include <numeric>
-#include <ostream>
-
+#include <boost/container/vector.hpp>
+#include <boost/move/utility_core.hpp>
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/small_vector.hpp>
+#include <functional>
+#include <numeric>
+#include <ostream>
+#include <utility>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/common/shape2d.cpp
+++ b/tt_metal/common/shape2d.cpp
@@ -2,7 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
+#include <array>
+#include <cstddef>
 #include <ostream>
+#include <utility>
 
 #include "shape2d.hpp"
 

--- a/tt_metal/common/shape_base.cpp
+++ b/tt_metal/common/shape_base.cpp
@@ -2,12 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/container/vector.hpp>
+#include <stdint.h>
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+
 #include "assert.hpp"
 #include "shape_base.hpp"
-#include <iterator>
-#include <stdexcept>
-#include <type_traits>
-#include "fmt/color.h"
+#include "span.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -3,8 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <boost/asio.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/thread_pool.hpp>
+#include <cstddef>
 #include <future>
-#include <iostream>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "tt_metal/common/thread_pool.hpp"
 

--- a/tt_metal/common/thread_pool.hpp
+++ b/tt_metal/common/thread_pool.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <thread>
 
 namespace tt::tt_metal {

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_backend_api_types.hpp"
+
+#include <fmt/base.h>
 #include <magic_enum/magic_enum.hpp>
+#include <string_view>
 
 std::string tt::get_string(tt::ARCH arch) {
     switch (arch) {

--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -6,14 +6,16 @@
 // Contains utility functions for partitioning work between multiple cores.
 //
 
-#include <cstdint>
-#include <tuple>
-#include <vector>
-
 #include <assert.hpp>
 #include <core_coord.hpp>
-#include <math.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <tuple>
+#include <utility>
+#include <vector>
+
 #include "tracy/Tracy.hpp"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/detail/reports/memory_reporter.cpp
+++ b/tt_metal/detail/reports/memory_reporter.cpp
@@ -2,15 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <memory_reporter.hpp>
-#include "tt_metal/detail/reports/report_utils.hpp"
 #include <allocator.hpp>
 #include <device.hpp>
-#include <program_impl.hpp>
-
-#include <algorithm>
+#include <memory_reporter.hpp>
+#include <stdint.h>
 #include <filesystem>
+#include <map>
+#include <memory>
 #include <utility>
+
+#include "buffer_constants.hpp"
+#include "tt_metal/detail/reports/report_utils.hpp"
 
 namespace fs = std::filesystem;
 

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -3,10 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/distributed/coordinate_translation.hpp"
-#include "tt_metal/api/tt-metalium/tt_metal.hpp"
-#include "tt_cluster.hpp"
 
+#include <boost/move/utility_core.hpp>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "assert.hpp"
+#include "control_plane.hpp"
 #include "indestructible.hpp"
+#include "logger.hpp"
+#include "mesh_coord.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/types/cluster_descriptor_types.h"
+
 namespace tt::tt_metal::distributed {
 
 const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map() {

--- a/tt_metal/distributed/coordinate_translation.hpp
+++ b/tt_metal/distributed/coordinate_translation.hpp
@@ -5,6 +5,16 @@
 #pragma once
 
 #include <mesh_coord.hpp>
+#include <stdint.h>
+
+namespace tt {
+namespace tt_metal {
+namespace distributed {
+template <typename T>
+class MeshContainer;
+}  // namespace distributed
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -3,6 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/distributed.hpp>
+#include <utility>
+
+#include "device.hpp"
+#include "mesh_device.hpp"
+#include "mesh_trace.hpp"
+#include "program_impl.hpp"
+#include "system_memory_manager.hpp"
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -3,12 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <host_api.hpp>
 #include <mesh_buffer.hpp>
 #include <mesh_coord.hpp>
-#include <mesh_device_view.hpp>
 #include <tt_stl/overloaded.hpp>
-#include <tt_metal.hpp>
-#include <host_api.hpp>
+#include <vector>
+
+#include "assert.hpp"
+#include "device.hpp"
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -2,21 +2,48 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/move/utility_core.hpp>
 #include <mesh_command_queue.hpp>
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
-#include <optional>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <type_traits>
+#include <utility>
 
+#include "assert.hpp"
 #include "buffer.hpp"
+#include "buffer_constants.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch_core_common.hpp"
+#include "event/dispatch.hpp"
+#include "hal_types.hpp"
+#include "mesh_config.hpp"
 #include "mesh_coord.hpp"
+#include "mesh_workload.hpp"
+#include "program_impl.hpp"
+#include "shape2d.hpp"
+#include "strong_type.hpp"
+#include "system_memory_manager.hpp"
+#include "trace_buffer.hpp"
+#include "tt_cluster.hpp"
+#include "tt_metal/common/thread_pool.hpp"
 #include "tt_metal/distributed/mesh_workload_utils.hpp"
 #include "tt_metal/impl/buffers/dispatch.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-#include "tt_metal/common/thread_pool.hpp"
-#include "tt_cluster.hpp"
+#include "umd/device/types/xy_pair.h"
+
+namespace tt {
+namespace tt_metal {
+struct ProgramCommandSequence;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -2,32 +2,53 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <mesh_device.hpp>
-
-#include <cstddef>
-#include <memory>
-#include <unordered_map>
-#include <utility>
-#include <source_location>
-
-#include <logger.hpp>
-#include <host_api.hpp>
-#include <tt_metal.hpp>
-#include <system_mesh.hpp>
-#include <mesh_device_view.hpp>
-#include <mesh_command_queue.hpp>
+#include <boost/container/vector.hpp>
 #include <device_impl.hpp>
+#include <logger.hpp>
+#include <mesh_command_queue.hpp>
+#include <mesh_coord.hpp>
+#include <mesh_device.hpp>
+#include <mesh_device_view.hpp>
+#include <small_vector.hpp>
 #include <sub_device.hpp>
 #include <sub_device_manager_tracker.hpp>
+#include <system_mesh.hpp>
+#include <tt_metal.hpp>
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <source_location>
+#include <unordered_map>
+#include <utility>
 
-#include "tt_metal/impl/sub_device/sub_device_manager.hpp"
+#include "allocator.hpp"
+#include "assert.hpp"
+#include "dispatch_settings.hpp"
+#include "launch_message_ring_buffer_state.hpp"
+#include "mesh_trace.hpp"
+#include "shape_base.hpp"
+#include "span.hpp"
+#include "strong_type.hpp"
 #include "tt_metal/common/thread_pool.hpp"
-
-#include "llrt/hal.hpp"
-#include <mesh_coord.hpp>
-#include <small_vector.hpp>
-
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
+#include "tt_metal/impl/sub_device/sub_device_manager.hpp"
+#include "umd/device/types/xy_pair.h"
+
+enum class CoreType;
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+class SystemMemoryManager;
+namespace program_cache {
+namespace detail {
+struct ProgramCache;
+}  // namespace detail
+}  // namespace program_cache
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -2,14 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <stdexcept>
-
+#include <boost/move/utility_core.hpp>
 #include <mesh_device.hpp>
 #include <mesh_device_view.hpp>
-#include "buffer.hpp"
+#include <cstddef>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include "assert.hpp"
+#include "device.hpp"
+#include "mesh_config.hpp"
 #include "mesh_coord.hpp"
 #include "shape2d.hpp"
+#include "shape_base.hpp"
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tt_metal/distributed/mesh_event.cpp
+++ b/tt_metal/distributed/mesh_event.cpp
@@ -4,6 +4,8 @@
 
 #include <mesh_event.hpp>
 
+#include "mesh_device.hpp"
+
 namespace tt::tt_metal::distributed {
 
 MeshEvent::MeshEvent(uint32_t id, MeshDevice* device, uint32_t mesh_cq_id, const MeshCoordinateRange& device_range) :

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -3,14 +3,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/move/utility_core.hpp>
 #include <mesh_command_queue.hpp>
 #include <mesh_coord.hpp>
 #include <mesh_trace.hpp>
-
+#include <stdint.h>
 #include <tt-metalium/allocator.hpp>
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "allocator_types.hpp"
+#include "assert.hpp"
+#include "buffer.hpp"
+#include "buffer_constants.hpp"
+#include "device.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "math.hpp"
+#include "mesh_buffer.hpp"
+#include "mesh_device.hpp"
+#include "mesh_trace_id.hpp"
+#include "system_memory_manager.hpp"
+#include "trace_buffer.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
-#include "tt_metal/distributed/mesh_workload_utils.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 
 namespace tt::tt_metal::distributed {

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -5,11 +5,41 @@
 #include <mesh_buffer.hpp>
 #include <mesh_command_queue.hpp>
 #include <mesh_workload.hpp>
-#include <tt_metal.hpp>
-
+#include <stdint.h>
 #include <tt_metal/impl/program/program_command_sequence.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "assert.hpp"
+#include "buffer.hpp"
+#include "buffer_constants.hpp"
+#include "core_coord.hpp"
+#include "hal.hpp"
+#include "kernel_types.hpp"
+#include "mesh_coord.hpp"
+#include "mesh_device.hpp"
+#include "program_device_map.hpp"
+#include "program_impl.hpp"
+#include "semaphore.hpp"
+#include "sub_device_types.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
-#include "tt_metal/distributed/mesh_workload_utils.hpp"
+#include "util.hpp"
+
+enum class CoreType;
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class Kernel;
+enum class HalProgrammableCoreType;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::distributed {
 namespace {

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -2,13 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <host_api.hpp>
-#include <command_queue.hpp>
-
-#include "tt_metal/impl/dispatch/device_command.hpp"
-#include "tt_metal/impl/program/dispatch.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "dev_msgs.h"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "strong_type.hpp"
+#include "system_memory_manager.hpp"
+#include "tt_align.hpp"
 #include "tt_metal/distributed/mesh_workload_utils.hpp"
+#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+
+enum class CoreType;
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/mesh_workload_utils.hpp
+++ b/tt_metal/distributed/mesh_workload_utils.hpp
@@ -3,6 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <host_api.hpp>
+#include <stdint.h>
+
+#include "core_coord.hpp"
+#include "sub_device_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class SystemMemoryManager;
+}  // namespace tt_metal
+}  // namespace tt
 
 // Utility functions for dispatch MeshWorkloads
 // Used by MeshCommandQueue

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -2,16 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/container/vector.hpp>
+#include <stdint.h>
 #include <system_mesh.hpp>
-
-#include "small_vector.hpp"
-#include "tt_metal/distributed/coordinate_translation.hpp"
-#include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
-
+#include <tt-metalium/shape2d.hpp>
 #include <tt_stl/indestructible.hpp>
+#include <algorithm>
+#include <cstddef>
+
+#include "assert.hpp"
+#include "logger.hpp"
+#include "mesh_config.hpp"
 #include "mesh_coord.hpp"
-#include "tt_cluster.hpp"
+#include "shape_base.hpp"
+#include "small_vector.hpp"
+#include "span.hpp"
+#include "tt_metal/distributed/coordinate_translation.hpp"
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2,11 +2,42 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "llrt/hal.hpp"
-#include "control_plane.hpp"
+#include <magic_enum/magic_enum.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <initializer_list>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <memory>
+#include <ostream>
 #include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
+#include "assert.hpp"
+#include "control_plane.hpp"
+#include "core_coord.hpp"
+#include "fabric_host_interface.h"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "logger.hpp"
+#include "mesh_coord.hpp"
+#include "mesh_graph.hpp"
+#include "metal_soc_descriptor.h"
+#include "routing_table_generator.hpp"
 #include "tt_cluster.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -2,21 +2,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/math.hpp>
-#include <tt-metalium/sub_device_types.hpp>
+#include <stdint.h>
 #include <tt-metalium/assert.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/program_impl.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/hal.hpp>
 #include <tt-metalium/erisc_datamover_builder.hpp>
 #include <tt-metalium/fabric_edm_packet_header.hpp>
-
-#include <iterator>
-#include <vector>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
-#include <ranges>
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <numeric>
+#include <optional>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+
+#include "core_coord.hpp"
+#include "fabric_edm_types.hpp"
+#include "logger.hpp"
+#include "system_memory_manager.hpp"
+#include "umd/device/tt_core_coordinates.h"
+
+namespace tt {
+namespace tt_metal {
+class Program;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -2,13 +2,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/erisc_datamover_builder.hpp>
-#include <tt-metalium/mesh_graph.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <array>
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <set>
+#include <unordered_map>
+#include <variant>
 
+#include "assert.hpp"
+#include "control_plane.hpp"
+#include "fabric_edm_packet_header.hpp"
 #include "fabric_host_utils.hpp"
+#include "metal_soc_descriptor.h"
 #include "tt_cluster.hpp"
+#include "umd/device/types/xy_pair.h"
+
+namespace tt {
+namespace tt_metal {
+class Program;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -4,7 +4,19 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <tt-metalium/program_impl.hpp>
+#include <vector>
+
+#include "core_coord.hpp"
+#include "fabric_host_interface.h"
+#include "system_memory_manager.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Program;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -4,10 +4,20 @@
 
 #include "mesh_graph.hpp"
 
+#include <magic_enum/magic_enum.hpp>
+#include <yaml-cpp/yaml.h>
+#include <array>
 #include <fstream>
-#include <iostream>
+#include <iomanip>
+#include <optional>
 
-#include "yaml-cpp/yaml.h"
+#include "assert.hpp"
+#include "logger.hpp"
+#include "umd/device/types/cluster_descriptor_types.h"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::tt_fabric {
 

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -4,8 +4,16 @@
 
 #include "routing_table_generator.hpp"
 
-#include <queue>
+#include <magic_enum/magic_enum.hpp>
+#include <algorithm>
+#include <limits>
 #include <memory>
+#include <ostream>
+#include <queue>
+#include <unordered_map>
+
+#include "assert.hpp"
+#include "logger.hpp"
 
 namespace tt::tt_fabric {
 RoutingTableGenerator::RoutingTableGenerator(const std::string& mesh_graph_desc_yaml_file) {

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -4,6 +4,15 @@
 
 #include <graph_tracking.hpp>
 
+#include "assert.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Buffer;
+class IDevice;
+}  // namespace tt_metal
+}  // namespace tt
+
 namespace tt::tt_metal {
 
 bool GraphTracker::is_enabled() const { return (not processors.empty()); }

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -2,13 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <hal.hpp>
+#include <tt_backend_api_types.hpp>
+#include <umd/device/types/arch.h>
 #include <cstdint>
 #include <string>
 
-#include <hal.hpp>
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
-#include <tt_backend_api_types.hpp>
-#include <umd/device/types/arch.h>
 
 using tt::tt_metal::HalL1MemAddrType;
 using tt::tt_metal::HalMemType;

--- a/tt_metal/impl/allocator/algorithms/free_list.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.cpp
@@ -3,11 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/allocator/algorithms/free_list.hpp"
-#include <assert.hpp>
-#include <boost/smart_ptr/make_local_shared.hpp>
 
+#include <assert.hpp>
+#include <boost/smart_ptr/make_local_shared_object.hpp>
 #include <algorithm>
-#include <cmath>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "allocator/algorithms/allocator_algorithm.hpp"
 
 namespace tt {
 

--- a/tt_metal/impl/allocator/algorithms/free_list.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list.hpp
@@ -2,11 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
-#include <string>
-
-#include "hostdevcommon/common_values.hpp"
-#include "allocator_algorithm.hpp"
 #include <boost/smart_ptr/local_shared_ptr.hpp>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "allocator_algorithm.hpp"
+#include "allocator_types.hpp"
+#include "hal_types.hpp"
+#include "hostdevcommon/common_values.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -3,16 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/allocator/algorithms/free_list_opt.hpp"
+
 #include <assert.hpp>
-#include "llrt/hal.hpp"
-#include "allocator_algorithm.hpp"
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
+#include <functional>
 #include <optional>
+#include <string>
+#include <unordered_map>
 #include <vector>
-#include <array>
+
+#include "allocator_algorithm.hpp"
 
 inline size_t intlg2(size_t n) {
     // std::log2() is slow

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -3,12 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <sys/types.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <vector>
 #include <optional>
+#include <ostream>
+#include <utility>
+#include <vector>
 
 #include "allocator_algorithm.hpp"
+#include "allocator_types.hpp"
+#include "hal_types.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -3,11 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <allocator.hpp>
-
-#include <math.hpp>
 #include <buffer.hpp>
+#include <magic_enum/magic_enum.hpp>
+#include <functional>
+#include <string>
+#include <string_view>
 
+#include "assert.hpp"
+#include "buffer_constants.hpp"
 #include "impl/allocator/bank_manager.hpp"
+#include "logger.hpp"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt {
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -4,10 +4,18 @@
 
 #include "bank_manager.hpp"
 
-#include <util.hpp>
-#include <math.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <util.hpp>
+#include <limits>
+#include <string_view>
+#include <utility>
+
+#include "allocator/algorithms/allocator_algorithm.hpp"
+#include "allocator_types.hpp"
+#include "assert.hpp"
+#include "buffer_constants.hpp"
 #include "llrt/hal.hpp"
+#include "logger.hpp"
 #include "tt_metal/impl/allocator/algorithms/free_list_opt.hpp"
 
 namespace tt {

--- a/tt_metal/impl/allocator/bank_manager.hpp
+++ b/tt_metal/impl/allocator/bank_manager.hpp
@@ -4,18 +4,27 @@
 
 #pragma once
 
+#include <allocator_types.hpp>
+#include <buffer_constants.hpp>
+#include <stdint.h>
+#include <fstream>
+#include <memory>
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-#include <allocator_types.hpp>
 #include "algorithms/allocator_algorithm.hpp"
-#include <buffer_constants.hpp>
+#include "core_coord.hpp"
+#include "hal_types.hpp"
 
 namespace tt {
 
 namespace tt_metal {
+enum class BufferType;
+namespace allocator {
+class Algorithm;
+}  // namespace allocator
 
 class BankManager {
 public:

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -4,25 +4,26 @@
 
 #include "l1_banking_allocator.hpp"
 
+#include <allocator.hpp>
+#include <allocator_types.hpp>
+#include <assert.hpp>
+#include <buffer_constants.hpp>
+#include <core_coord.hpp>
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <random>
 #include <unordered_map>
 #include <vector>
 
-#include <allocator.hpp>
-#include <allocator_types.hpp>
-#include <buffer_constants.hpp>
 #include "bank_manager.hpp"
-#include <assert.hpp>
-#include <core_coord.hpp>
-#include "umd/device/types/xy_pair.h"
-#include <fmt/base.h>
-
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt {
 

--- a/tt_metal/impl/allocator/l1_banking_allocator.hpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <cstdint>
-
 #include <tt-metalium/allocator.hpp>
+#include <cstdint>
 
 namespace tt {
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -2,28 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <buffer.hpp>
-
-#include <assert.hpp>
-#include <math.hpp>
-#include <tt_metal.hpp>
 #include <allocator.hpp>
+#include <assert.hpp>
+#include <buffer.hpp>
+#include <buffer_constants.hpp>
 #include <device.hpp>
 #include <graph_tracking.hpp>
+#include <math.hpp>
+#include <nlohmann/json.hpp>
+#include <tt_stl/reflection.hpp>
 #include <algorithm>
 #include <atomic>
+#include <map>
 #include <mutex>
 #include <utility>
-#include <buffer_constants.hpp>
-#include "llrt/hal.hpp"
-#include "umd/device/tt_soc_descriptor.h"
-#include "fmt/base.h"
-#include <tt_stl/reflection.hpp>
+
 #include "lightmetal/host_api_capture_helpers.hpp"
-
-#include "rtoptions.hpp"
-
-#include "tracy/Tracy.hpp"
+#include "strong_type.hpp"
+#include "tt_align.hpp"
+#include "util.hpp"
 
 namespace tt::tt_metal {
 namespace {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -22,10 +22,23 @@
 #include "tt_align.hpp"
 #include "util.hpp"
 
+// Needed if profiler is enabled
+#include <tt_metal.hpp>
+#include "fmt/base.h"
+#include "llrt/hal.hpp"
+#include "rtoptions.hpp"
+#include "tracy/Tracy.hpp"
+#include "umd/device/tt_soc_descriptor.h"
+
 namespace tt::tt_metal {
 namespace {
 
 #if defined(TRACY_ENABLE)
+
+#include <unordered_map>
+#include <mutex>
+#include <fmt/format.h>
+#include <magic_enum/magic_enum.hpp>
 
 std::unordered_map<int, std::string> global_mempool_names;
 std::mutex global_mempool_names_mutex;

--- a/tt_metal/impl/buffers/circular_buffer.cpp
+++ b/tt_metal/impl/buffers/circular_buffer.cpp
@@ -2,15 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <circular_buffer.hpp>
-
-#include <host_api.hpp>
-#include "llrt.hpp"
 #include <buffer.hpp>
+#include <circular_buffer.hpp>
 #include <global_circular_buffer_impl.hpp>
-#include <tt_metal.hpp>
-#include <device.hpp>
-#include <command_queue.hpp>
+#include <array>
+#include <string>
+#include <unordered_map>
+
+#include "assert.hpp"
+#include "circular_buffer_constants.h"
+#include "tile.hpp"
+#include "utils.hpp"
 
 namespace tt {
 

--- a/tt_metal/impl/buffers/circular_buffer_types.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.cpp
@@ -3,7 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "circular_buffer_types.hpp"
-#include <global_circular_buffer_impl.hpp>
+
+#include <unordered_map>
+
+#include "assert.hpp"
+#include "buffer.hpp"
+#include "logger.hpp"
+
+namespace tt {
+enum class DataFormat : uint8_t;
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -2,20 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/core/span.hpp>
 #include <device.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/dispatch_settings.hpp>
+#include <algorithm>
+#include <array>
+#include <optional>
+#include <stack>
+#include <type_traits>
+#include <utility>
+
 #include "assert.hpp"
+#include "buffer_constants.hpp"
 #include "dispatch.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch_mem_map.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "logger.hpp"
+#include "math.hpp"
+#include "strong_type.hpp"
+#include "sub_device_types.hpp"
+#include "tt_align.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 
-#include <stack>
-#include <tt-metalium/command_queue_interface.hpp>
-#include "tt_metal/impl/dispatch/device_command.hpp"
-#include <tt-metalium/dispatch_settings.hpp>
-#include <tt-metalium/program_impl.hpp>
-#include <tt-metalium/allocator.hpp>
-
-#include "tt_cluster.hpp"
+enum class CoreType;
 
 namespace tt::tt_metal {
 namespace buffer_dispatch {

--- a/tt_metal/impl/buffers/dispatch.hpp
+++ b/tt_metal/impl/buffers/dispatch.hpp
@@ -4,11 +4,28 @@
 
 #pragma once
 
-#include <command_queue_interface.hpp>
-#include <sub_device_types.hpp>
 #include <command_queue.hpp>
+#include <command_queue_interface.hpp>
+#include <stdint.h>
+#include <sub_device_types.hpp>
+#include <atomic>
+#include <memory>
+#include <variant>
+#include <vector>
+
 #include "buffer.hpp"
+#include "core_coord.hpp"
+#include "span.hpp"
+#include "system_memory_manager.hpp"
 #include "tt_metal/impl/event/dispatch.hpp"
+
+enum class CoreType;
+namespace tt {
+namespace tt_metal {
+class IDevice;
+enum class TensorMemoryLayout;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/buffers/distribution_spec.cpp
+++ b/tt_metal/impl/buffers/distribution_spec.cpp
@@ -2,9 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/container/vector.hpp>
+#include <boost/move/utility_core.hpp>
+#include <stdint.h>
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
 #include "assert.hpp"
 #include "distribution_spec.hpp"
 #include "math.hpp"
+#include "shape.hpp"
+#include "shape_base.hpp"
+#include "small_vector.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -2,24 +2,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <global_circular_buffer_impl.hpp>
-
-#include <cstdint>
-#include <memory>
-#include <vector>
-
 #include <assert.hpp>
-#include <core_coord.hpp>
-#include <tt_metal.hpp>
-#include <host_api.hpp>
 #include <buffer.hpp>
 #include <buffer_constants.hpp>
+#include <core_coord.hpp>
 #include <device.hpp>
-#include "llrt/hal.hpp"
+#include <global_circular_buffer_impl.hpp>
+#include <host_api.hpp>
 #include <tt_align.hpp>
+#include <tt_metal.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
 
+#include "distributed.hpp"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "mesh_buffer.hpp"
+#include "mesh_device.hpp"
+#include "reflection.hpp"
+#include "span.hpp"
 #include "tt_cluster.hpp"
-#include <tt_stl/overloaded.hpp>
+#include "umd/device/types/xy_pair.h"
 
 namespace tt::tt_metal {
 namespace experimental {

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -2,22 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <global_semaphore.hpp>
-
-#include <cstdint>
-#include <memory>
-#include <vector>
-
 #include <assert.hpp>
-#include <core_coord.hpp>
-#include <tt_metal.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <host_api.hpp>
 #include <buffer.hpp>
 #include <buffer_constants.hpp>
+#include <core_coord.hpp>
 #include <device.hpp>
-#include "llrt/hal.hpp"
+#include <global_semaphore.hpp>
+#include <host_api.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt_metal.hpp>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
 
+#include "mesh_device.hpp"
+#include "reflection.hpp"
 #include "tt_cluster.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/buffers/semaphore.cpp
+++ b/tt_metal/impl/buffers/semaphore.cpp
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <semaphore.hpp>
+#include <stdint.h>
 
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
+#include "umd/device/tt_core_coordinates.h"
 
 namespace tt {
 

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -3,15 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/bfloat16.hpp>
-
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <iostream>
 #include <random>
 #include <vector>
 
 #include "assert.hpp"
-
 #include "tracy/Tracy.hpp"
 
 std::ostream& operator<<(std::ostream& os, const bfloat16& bfp16) {

--- a/tt_metal/impl/data_format/bfloat4.cpp
+++ b/tt_metal/impl/data_format/bfloat4.cpp
@@ -2,21 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <emmintrin.h>
+#include <immintrin.h>
+#include <math.h>
 #include <tt-metalium/bfloat4.hpp>
-
-#include <algorithm>
-#include <iostream>
+#include <tt_stl/span.hpp>
+#include <array>
+#include <functional>
 #include <random>
 #include <vector>
-#include <immintrin.h>
 
 #include "assert.hpp"
 #include "blockfloat_common.hpp"
-#include "tt_backend_api_types.hpp"
-#include <tt_stl/span.hpp>
-#include "tracy/Tracy.hpp"
-
+#include "constants.hpp"
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
+#include "math.hpp"
+#include "tile.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_backend_api_types.hpp"
 
 std::vector<uint32_t> pack_fp32_vec_as_bfp4_tiles(
     tt::stl::Span<const float> fp32_vec,

--- a/tt_metal/impl/data_format/bfloat8.cpp
+++ b/tt_metal/impl/data_format/bfloat8.cpp
@@ -2,21 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <emmintrin.h>
+#include <immintrin.h>
 #include <tt-metalium/bfloat8.hpp>
-
-#include <algorithm>
-#include <iostream>
+#include <tt_stl/span.hpp>
+#include <array>
+#include <functional>
 #include <random>
 #include <vector>
-#include <immintrin.h>
 
 #include "assert.hpp"
 #include "blockfloat_common.hpp"
-#include "tt_backend_api_types.hpp"
-#include <tt_stl/span.hpp>
-#include "tracy/Tracy.hpp"
-
+#include "constants.hpp"
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
+#include "math.hpp"
+#include "tile.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_backend_api_types.hpp"
 
 std::vector<uint32_t> pack_fp32_vec_as_bfp8_tiles(
     tt::stl::Span<const float> fp32_vec,

--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -2,21 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/core/span.hpp>
 #include <tt-metalium/blockfloat_common.hpp>
-
-#include <algorithm>
-#include <iostream>
-#include <random>
+#include <tt_stl/span.hpp>
+#include <array>
 #include <vector>
-#include <immintrin.h>
 
 #include "assert.hpp"
-#include "tt_backend_api_types.hpp"
-#include "tracy/Tracy.hpp"
-#include "tile.hpp"
-#include <tt_stl/span.hpp>
-
+#include "constants.hpp"
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
+#include "math.hpp"
+#include "tile.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_backend_api_types.hpp"
 
 uint8_t get_max_exp(const std::vector<uint32_t>& vec, bool is_exp_a) {
     TT_ASSERT(vec.size() == 16);

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/tile.hpp>
+#include <algorithm>
+#include <stdexcept>
 
+#include "assert.hpp"
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
+#include "math.hpp"
+#include "tt_backend_api_types.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/data_format/tilize_utils.cpp
+++ b/tt_metal/impl/data_format/tilize_utils.cpp
@@ -2,9 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/tilize_utils.hpp>
-
+#include <boost/core/span.hpp>
+#include <tracy/Tracy.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "assert.hpp"
+#include "constants.hpp"
+#include "span.hpp"
 
 TensAddr::TensAddr(const std::vector<std::uint32_t>& shape) : sh(shape) {}
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -2,33 +2,45 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <logger.hpp>
+#include <math.h>
+#include <pthread.h>
+#include <rtoptions.hpp>
+#include <tt-metalium/blockfloat_common.hpp>
+#include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <ostream>
-#include <sstream>
-#include <string>
-#include <thread>
-#include <future>
-#include <iostream>
-#include <fstream>
-#include <iomanip>
-#include <chrono>
-#include <set>
+#include <cstring>
 #include <filesystem>
+#include <future>
+#include <initializer_list>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <thread>
 #include <tuple>
-#include "llrt.hpp"
-#include <logger.hpp>
+#include <vector>
 
-#include "dprint_server.hpp"
+#include "assert.hpp"
+#include "core_coord.hpp"
 #include "debug_helpers.hpp"
-#include <rtoptions.hpp>
-
-#include <tt-metalium/bfloat8.hpp>
-#include <tt-metalium/blockfloat_common.hpp>
-
+#include "dprint_server.hpp"
+#include "fmt/base.h"
 #include "hostdevcommon/dprint_common.h"
 #include "hostdevcommon/kernel_structs.h"
+#include "llrt.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "tt_backend_api_types.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_soc_descriptor.h"
+#include "umd/device/types/xy_pair.h"
 
 using std::cout;
 using std::endl;

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "umd/device/types/cluster_descriptor_types.h"
+
 namespace tt::tt_metal {
 
 /*

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -4,17 +4,24 @@
 
 #include "noc_logging.hpp"
 
+#include <stdint.h>
+#include <array>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 // #include <iomanip>
 #include <set>
+#include <string>
 
+#include "assert.hpp"
+#include "core_coord.hpp"
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "llrt.hpp"
-#include "rtoptions.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "logger.hpp"
+#include "rtoptions.hpp"
+#include "umd/device/tt_soc_descriptor.h"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/debug/noc_logging.hpp
+++ b/tt_metal/impl/debug/noc_logging.hpp
@@ -5,6 +5,9 @@
 #pragma once
 
 #include <host_api.hpp>
+#include <vector>
+
+#include "system_memory_manager.hpp"
 
 namespace tt {
 void ClearNocData(chip_id_t device_id);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -2,34 +2,38 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <ctype.h>
-#include <iostream>
-#include <vector>
-#include <stdexcept>
-#include <string>
-#include <unordered_set>
 #include <assert.hpp>
+#include <circular_buffer_constants.h>  // For NUM_CIRCULAR_BUFFERS
+#include <core_coord.hpp>
+#include <ctype.h>
+#include <dev_msgs.h>
+#include <fmt/base.h>
 #include <logger.hpp>
 #include <metal_soc_descriptor.h>
-#include <dev_msgs.h>
-
-#include "umd/device/types/arch.h"
-#include "umd/device/types/xy_pair.h"
-#include <fmt/base.h>
-#include "llrt.hpp"
+#include <rtoptions.hpp>
 #include <tt_cluster.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
-#include <core_coord.hpp>
-#include <circular_buffer_constants.h>  // For NUM_CIRCULAR_BUFFERS
+#include "core_descriptor.hpp"
+#include "debug_helpers.hpp"
+#include "dispatch_core_common.hpp"
+#include "hal_types.hpp"
 #include "hw/inc/debug/ring_buffer.h"
 #include "impl/dispatch/dispatch_core_manager.hpp"
-#include <rtoptions.hpp>
-
-#include "watcher_device_reader.hpp"
-#include "debug_helpers.hpp"
-
+#include "llrt.hpp"
 #include "llrt/hal.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/xy_pair.h"
+#include "watcher_device_reader.hpp"
 
 using namespace tt::tt_metal;
 using std::string;

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -4,21 +4,22 @@
 
 #pragma once
 
+#include <core_coord.hpp>
+// FIXME: ARCH_NAME specific, needed for several pointer types here
+#include <dev_msgs.h>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
-#include <string>
 #include <map>
 #include <set>
 #include <string>
+#include <string>
 #include <utility>
 #include <vector>
-#include <core_coord.hpp>
-#include "umd/device/tt_soc_descriptor.h"
-#include "llrt/hal.hpp"
 
-// FIXME: ARCH_NAME specific, needed for several pointer types here
-#include <dev_msgs.h>
+#include "llrt/hal.hpp"
+#include "umd/device/tt_soc_descriptor.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 
 namespace tt::watcher {
 

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -4,21 +4,43 @@
 
 #include "watcher_server.hpp"
 
-#include <unistd.h>
-
-#include <chrono>
-#include <ctime>
-#include <filesystem>
-#include <mutex>
-#include <thread>
-
-#include "llrt/hal.hpp"
 #include <dev_msgs.h>
-#include "llrt.hpp"
 #include <rtoptions.hpp>
+#include <unistd.h>
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <functional>
+#include <initializer_list>
+#include <map>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "assert.hpp"
+#include "core_coord.hpp"
 #include "debug/ring_buffer.h"
-#include "watcher_device_reader.hpp"
 #include "debug_helpers.hpp"
+#include "hal_types.hpp"
+#include "llrt.hpp"
+#include "llrt/hal.hpp"
+#include "logger.hpp"
+#include "metal_soc_descriptor.h"
+#include "span.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
+#include "watcher_device_reader.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <string>
 #include <core_coord.hpp>
+#include <stdint.h>
 #include <system_memory_manager.hpp>  // For chip_id_t
+#include <string>
 
 struct metal_SocDescriptor;
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -2,48 +2,90 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <device_impl.hpp>
-
-#include <string>
-#include <thread>
-#include <tt_align.hpp>
-#include <tt-metalium/dispatch_mem_map.hpp>
-#include <tt-metalium/program_cache.hpp>
-
-#include "common/core_assignment.hpp"
-#include <host_api.hpp>
-#include <trace.hpp>
 #include <core_descriptor.hpp>
-#include <tt_metal.hpp>
-#include <utils.hpp>
 #include <dev_msgs.h>
+#include <device_impl.hpp>
 #include <device_pool.hpp>
+#include <host_api.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <persistent_kernel_cache.hpp>
-
-#include "llrt/hal.hpp"
-#include <hal.hpp>
 #include <sub_device.hpp>
 #include <sub_device_manager_tracker.hpp>
 #include <sub_device_types.hpp>
+#include <trace.hpp>
+#include <tt-metalium/dispatch_mem_map.hpp>
+#include <tt-metalium/program_cache.hpp>
+#include <tt_align.hpp>
+#include <tt_metal.hpp>
 #include <tt_stl/span.hpp>
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
 
-#include "tt_metal/tools/profiler/tt_metal_tracy.hpp"
-
-#include "tt_metal/impl/debug/watcher_server.hpp"
-#include "tt_metal/impl/dispatch/topology.hpp"
-#include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
-#include "tt_metal/impl/sub_device/sub_device_manager.hpp"
-#include "tt_metal/impl/dispatch/topology.hpp"
-#include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
-#include "tt_metal/jit_build/build_env_manager.hpp"
-
-#include "lightmetal/lightmetal_capture.hpp"
-#include "tracy/Tracy.hpp"
+#include "allocator.hpp"
+#include "allocator_types.hpp"
+#include "assert.hpp"
+#include "buffer_constants.hpp"
+#include "command_queue.hpp"
+#include "command_queue_common.hpp"
+#include "common/core_assignment.hpp"
+#include "core_coord.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_settings.hpp"
 #include "dprint_server.hpp"
+#include "hal_types.hpp"
+#include "jit_build/build.hpp"
+#include "launch_message_ring_buffer_state.hpp"
+#include "lightmetal/lightmetal_capture.hpp"
 #include "llrt.hpp"
+#include "llrt/hal.hpp"
+#include "logger.hpp"
+#include "metal_soc_descriptor.h"
+#include "multi_producer_single_consumer_queue.hpp"
+#include "profiler_types.hpp"
+#include "program_device_map.hpp"
+#include "program_impl.hpp"
+#include "rtoptions.hpp"
+#include "strong_type.hpp"
+#include "system_memory_manager.hpp"
+#include "trace_buffer.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_cluster.hpp"
+#include "tt_memory.h"
+#include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
+#include "tt_metal/impl/debug/watcher_server.hpp"
+#include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/sub_device/sub_device_manager.hpp"
+#include "tt_metal/jit_build/build_env_manager.hpp"
+#include "tt_metal/tools/profiler/tt_metal_tracy.hpp"
+#include "umd/device/coordinate_manager.h"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_silicon_driver_common.hpp"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/xy_pair.h"
 #include "work_executor.hpp"
+#include "work_executor_types.hpp"
 
 namespace tt {
+enum class ARCH;
 
 namespace tt_metal {
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -2,33 +2,43 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <device_pool.hpp>
 #include <device_impl.hpp>
-
+#include <device_pool.hpp>
 #include <numa.h>
-
+#include <pthread.h>
+#include <sched.h>
+#include <tracy/Tracy.hpp>
+#include <tt_metal.hpp>
+#include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
 #include <algorithm>
 #include <cstdlib>
 #include <set>
 #include <utility>
 
-#include "env_lib.hpp"
-
+#include "control_plane.hpp"
+#include "core_coord.hpp"
 #include "dispatch_settings.hpp"
 #include "dprint_server.hpp"
-#include "host_api.hpp"
+#include "env_lib.hpp"
 #include "erisc_datamover_builder.hpp"
-#include <tt_metal.hpp>
+#include "fabric_edm_packet_header.hpp"
+#include "fabric_host_interface.h"
+#include "fabric_types.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "host_api.hpp"
+#include "logger.hpp"
+#include "profiler_types.hpp"
+#include "rtoptions.hpp"
+#include "span.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
-#include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-
-#include "tt_cluster.hpp"
-
-#include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
+#include "umd/device/tt_core_coordinates.h"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/command_queue_common.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/dispatch_mem_map.hpp>
-#include "dispatch_core_manager.hpp"
+#include <tt-metalium/dispatch_settings.hpp>
 
+#include "dispatch_core_manager.hpp"
 #include "tt_cluster.hpp"
+
+enum class CoreType;
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -3,11 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "data_collection.hpp"
-#include <rtoptions.hpp>
-#include <kernel.hpp>
-#include <core_coord.hpp>
 
+#include <core_coord.hpp>
+#include <kernel.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <rtoptions.hpp>
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "assert.hpp"
+#include "dev_msgs.h"
+#include "program_impl.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "utils.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -2,11 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <host_api.hpp>
 #include <device.hpp>
+#include <host_api.hpp>
+#include <stdint.h>
+#include <vector>
+
 #include "command_queue_interface.hpp"
+#include "tt_backend_api_types.hpp"
+
+enum class CoreType;
 
 namespace tt {
+namespace tt_metal {
+class Program;
+struct KernelGroup;
+}  // namespace tt_metal
 
 typedef enum e_data_collector_t {
     DISPATCH_DATA_CB_CONFIG,

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -4,8 +4,32 @@
 
 #include "debug_tools.hpp"
 
+#include <stdint.h>
+#include <stdlib.h>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "assert.hpp"
+#include "command_queue_common.hpp"
+#include "dispatch_settings.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "host_api.hpp"
+#include "logger.hpp"
+#include "system_memory_cq_interface.hpp"
+#include "system_memory_manager.hpp"
 #include "tt_cluster.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "utils.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace internal {
 

--- a/tt_metal/impl/dispatch/debug_tools.hpp
+++ b/tt_metal/impl/dispatch/debug_tools.hpp
@@ -2,12 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <string>
-#include <fstream>
-
-#include <host_api.hpp>
 #include <device.hpp>
+#include <host_api.hpp>
+#include <fstream>
+#include <string>
+
 #include "command_queue_interface.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class SystemMemoryManager;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace internal {
 

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -4,6 +4,15 @@
 
 #include "device_command.hpp"
 
+#include <cstring>
+
+#include "aligned_allocator.hpp"
+#include "assert.hpp"
+#include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch/memcpy.hpp"
+#include "dispatch_settings.hpp"
+#include "tt_align.hpp"
+
 namespace tt::tt_metal {
 
 template <bool hugepage_write>

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -4,17 +4,25 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <tt_stl/aligned_allocator.hpp>
+#include <algorithm>
 #include <bit>
 #include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
-#include "env_lib.hpp"
 #include "command_queue_interface.hpp"
-#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-#include "memcpy.hpp"
-#include <tt_stl/aligned_allocator.hpp>
+#include "env_lib.hpp"
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
+#include "memcpy.hpp"
+#include "span.hpp"
 #include "tt_align.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "vector_aligned.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/device_command_calculator.cpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.cpp
@@ -4,6 +4,11 @@
 
 #include "device_command_calculator.hpp"
 
+#include <algorithm>
+
+#include "dispatch/kernels/cq_commands.hpp"
+#include "hal.hpp"
+
 namespace tt::tt_metal {
 
 template <typename PackedSubCmd>

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -2,6 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "assert.hpp"
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include "tt_align.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -2,9 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "dispatch_core_manager.hpp"
 #include "dispatch_core_common.hpp"
+#include "dispatch_core_manager.hpp"
 #include "get_platform_architecture.hpp"
+#include "umd/device/types/arch.h"
+
+enum class CoreType;
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -4,12 +4,18 @@
 
 #include "dispatch_core_manager.hpp"
 
-#include "core_descriptor.hpp"
-#include "core_coord.hpp"
+#include <algorithm>
+#include <functional>
 #include <list>
-#include "dispatch_core_common.hpp"
+#include <unordered_set>
 
+#include "assert.hpp"
+#include "core_coord.hpp"
+#include "core_descriptor.hpp"
+#include "dispatch_core_common.hpp"
+#include "logger.hpp"
 #include "tt_cluster.hpp"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -4,13 +4,19 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <list>
+#include <optional>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
-#include "core_descriptor.hpp"
 #include "core_coord.hpp"
+#include "core_descriptor.hpp"
 #include "dispatch_core_common.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/cluster_descriptor_types.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -2,12 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <magic_enum/magic_enum.hpp>
 #include <tt-metalium/dispatch_mem_map.hpp>
-#include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/fabric_host_interface.h>
+#include <tt-metalium/tt_align.hpp>
+#include <optional>
+
+#include "assert.hpp"
+#include "command_queue_common.hpp"
+#include "dispatch_settings.hpp"
+#include "hal_types.hpp"
 #include "indestructible.hpp"
-#include "rtoptions.hpp"
 #include "llrt/hal.hpp"
+#include "rtoptions.hpp"
+#include "utils.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -4,7 +4,18 @@
 
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 
+#include <initializer_list>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "assert.hpp"
+#include "core_descriptor.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
 #include "tt_cluster.hpp"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/xy_pair.h"
 
 using dispatch_core_mgr = tt::tt_metal::dispatch_core_manager;
 

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -2,9 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include <mutex>
+#include <vector>
 
+#include "core_coord.hpp"
+#include "data_types.hpp"
+#include "dispatch_core_common.hpp"
 #include "dispatch_core_manager.hpp"
+#include "umd/device/tt_xy_pair.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -5,27 +5,47 @@
 #include "hardware_command_queue.hpp"
 
 #include <device.hpp>
-#include "dprint_server.hpp"
 #include <event.hpp>
-#include <tt_stl/overloaded.hpp>
-#include <trace_buffer.hpp>
-#include <tt-metalium/command_queue_interface.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
-
-#include "tt_cluster.hpp"
-
-#include "work_executor.hpp"
-
 // Because we are a Friend of Program, accessing Program::get_program_transfer_info() and Program::get_kernels_buffer()
 // MUST REMOVE
 #include <program_impl.hpp>
+#include <trace_buffer.hpp>
+#include <tracy/Tracy.hpp>
+#include <tt-metalium/dispatch_settings.hpp>
+#include <tt_stl/overloaded.hpp>
+#include <algorithm>
+#include <array>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "assert.hpp"
+#include "buffers/dispatch.hpp"
+#include "dispatch/device_command.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/host_runtime_commands.hpp"
+#include "dprint_server.hpp"
+#include "event/dispatch.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "logger.hpp"
+#include "program_device_map.hpp"
+#include "rtoptions.hpp"
+#include "strong_type.hpp"
+#include "system_memory_manager.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "umd/device/tt_xy_pair.h"
+#include "work_executor.hpp"
 
-#include "rtoptions.hpp"
+namespace tt {
+namespace tt_metal {
+enum NOC : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 namespace {

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -4,20 +4,42 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <thread>
+#include <variant>
 
+#include "buffer.hpp"
 #include "command_queue.hpp"
-#include "host_runtime_commands.hpp"
 #include "command_queue_interface.hpp"
+#include "core_coord.hpp"
+#include "dispatch_settings.hpp"
+#include "event.hpp"
+#include "host_runtime_commands.hpp"
+#include "launch_message_ring_buffer_state.hpp"
 #include "multi_producer_single_consumer_queue.hpp"
-#include "worker_config_buffer.hpp"
 #include "program_impl.hpp"
+#include "span.hpp"
+#include "sub_device_types.hpp"
 #include "trace_buffer.hpp"
-
 #include "tt_metal/impl/buffers/dispatch.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "vector_aligned.hpp"
+#include "worker_config_buffer.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class Program;
+class SystemMemoryManager;
+enum NOC : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -4,49 +4,49 @@
 
 #include "host_runtime_commands.hpp"
 
-#include <array>
-#include <chrono>
-#include <cstddef>
-#include <fstream>
-#include <memory>
-#include <mutex>
-#include <string>
-#include <tuple>
-#include <type_traits>
-#include <utility>
-#include <variant>
-
-#include <buffer.hpp>
-#include <math.hpp>
-#include <dev_msgs.h>
-#include "llrt/hal.hpp"
-#include "tt_metal/impl/program/program_command_sequence.hpp"
 #include <assert.hpp>
+#include <buffer.hpp>
+#include <event.hpp>
+#include <host_api.hpp>
 #include <logger.hpp>
 #include <tt_metal.hpp>
-#include <host_api.hpp>
-#include <circular_buffer_constants.h>
-#include <circular_buffer.hpp>
-#include "dprint_server.hpp"
-#include "tt_metal/impl/debug/watcher_server.hpp"
-#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-#include "tt_metal/impl/dispatch/data_collection.hpp"
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "command_queue.hpp"
+#include "device.hpp"
+#include "dispatch/device_command.hpp"
 #include "dispatch_core_manager.hpp"
-#include <event.hpp>
-#include <kernel.hpp>
-#include "tt_metal/impl/program/dispatch.hpp"
-#include "tt_metal/impl/buffers/dispatch.hpp"
-#include "umd/device/tt_xy_pair.h"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-#include <tt-metalium/command_queue_interface.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
-
-#include "llrt/hal.hpp"
+#include "hal_types.hpp"
 #include "lightmetal/host_api_capture_helpers.hpp"
-
-#include "tracy/Tracy.hpp"
-
+#include "llrt/hal.hpp"
+#include "program_impl.hpp"
 #include "rtoptions.hpp"
+#include "span.hpp"
+#include "system_memory_manager.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_metal/impl/debug/watcher_server.hpp"
+#include "tt_metal/impl/dispatch/data_collection.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "tt_metal/impl/program/dispatch.hpp"
+#include "tt_metal/impl/program/program_command_sequence.hpp"
+
+namespace tt {
+namespace tt_metal {
+class WorkerConfigBufferMgr;
+enum NOC : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <tt-metalium/dispatch_settings.hpp>
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
@@ -14,15 +16,27 @@
 #include <utility>
 #include <vector>
 
-#include "env_lib.hpp"
 #include "command_queue_interface.hpp"
-#include <tt-metalium/dispatch_settings.hpp>
+#include "core_coord.hpp"
 #include "device_command.hpp"
+#include "env_lib.hpp"
 #include "multi_producer_single_consumer_queue.hpp"
+#include "program_impl.hpp"
+#include "sub_device_types.hpp"
+#include "trace_buffer.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "worker_config_buffer.hpp"
-#include "program_impl.hpp"
-#include "trace_buffer.hpp"
+
+enum class CoreType;
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class Program;
+class SystemMemoryManager;
+class WorkerConfigBufferMgr;
+enum NOC : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -2,14 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "demux.hpp"
-#include "dispatch.hpp"
-#include "eth_tunneler.hpp"
 
 #include <host_api.hpp>
-#include <tt_metal.hpp>
-
-#include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "assert.hpp"
+#include "device.hpp"
+#include "dispatch.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "eth_tunneler.hpp"
+#include "hal.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_xy_pair.h"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/demux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.hpp
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+#include <stdint.h>
+#include <array>
+#include <optional>
+
+#include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
+#include "system_memory_manager.hpp"
 
 typedef struct demux_static_config {
     std::optional<uint32_t> endpoint_id_start_index;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -2,20 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "dispatch.hpp"
-#include "assert.hpp"
-#include "llrt/hal.hpp"
-#include "prefetch.hpp"
-#include "dispatch_s.hpp"
-#include "demux.hpp"
-#include "mux.hpp"
 
 #include <host_api.hpp>
-#include <tt_metal.hpp>
-#include "rtoptions.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-
-#include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <tt_metal.hpp>
+#include <array>
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "assert.hpp"
+#include "command_queue_common.hpp"
+#include "demux.hpp"
+#include "device.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch/kernels/packet_queue_ctrl.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "dispatch_s.hpp"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "mux.hpp"
+#include "prefetch.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -4,10 +4,18 @@
 
 #pragma once
 
-#include "fd_kernel.hpp"
-#include "tt_metal/impl/dispatch/topology.hpp"
+#include <stdint.h>
+#include <optional>
+
+#include "assert.hpp"
 #include "core_coord.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
+#include "system_memory_manager.hpp"
+#include "tt_cluster.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
+#include "umd/device/tt_xy_pair.h"
 
 typedef struct dispatch_static_config {
     std::optional<uint32_t> dispatch_cb_base;  // 0

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -2,15 +2,30 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "dispatch_s.hpp"
-#include "dispatch.hpp"
-#include "prefetch.hpp"
 
 #include <host_api.hpp>
-#include <tt_metal.hpp>
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-
-#include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <tt_metal.hpp>
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "assert.hpp"
+#include "command_queue_common.hpp"
+#include "device.hpp"
+#include "dispatch.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "prefetch.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -2,7 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+#include <stdint.h>
+#include <optional>
+
+#include "dispatch/dispatch_core_manager.hpp"
 #include "fd_kernel.hpp"
+#include "system_memory_manager.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_xy_pair.h"
 
 typedef struct dispatch_s_static_config {
     std::optional<uint32_t> cb_base;

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -2,14 +2,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "eth_router.hpp"
-#include "prefetch.hpp"
-#include "eth_tunneler.hpp"
 
 #include <host_api.hpp>
-#include <tt_metal.hpp>
-
-#include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "assert.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "eth_tunneler.hpp"
+#include "hal.hpp"
+#include "prefetch.hpp"
+#include "tt_cluster.hpp"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+#include <stdint.h>
+#include <array>
+#include <optional>
+
+#include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
+#include "system_memory_manager.hpp"
 
 typedef struct eth_router_static_config {
     std::optional<uint32_t> vc_count;                   // Set from arch level

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -2,12 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "eth_tunneler.hpp"
-#include "eth_router.hpp"
-#include "demux.hpp"
-#include "mux.hpp"
 
-#include <host_api.hpp>
-#include <tt_metal.hpp>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "assert.hpp"
+#include "demux.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch_core_common.hpp"
+#include "eth_router.hpp"
+#include "hal.hpp"
+#include "mux.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_xy_pair.h"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
@@ -2,7 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+#include <stdint.h>
+#include <array>
+#include <optional>
+
+#include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
+#include "system_memory_manager.hpp"
+#include "umd/device/tt_core_coordinates.h"
 
 typedef struct eth_tunneler_static_config {
     std::optional<uint32_t> endpoint_id_start_index;

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -2,17 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <host_api.hpp>
-#include <tt_metal.hpp>
+#include <vector>
 
-#include <tt-metalium/command_queue_interface.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
-#include <tt-metalium/device_pool.hpp>
 #include "assert.hpp"
+#include "control_plane.hpp"
 #include "dispatch/kernel_config/dispatch.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/kernel_config/prefetch.hpp"
-
 #include "fabric_router_vc.hpp"
+#include "tt_cluster.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.hpp
@@ -4,8 +4,12 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "core_coord.hpp"
+#include "data_types.hpp"
 #include "fd_kernel.hpp"
+#include "system_memory_manager.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -3,21 +3,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "fd_kernel.hpp"
+
 #include <host_api.hpp>
-#include <tt_metal.hpp>
+#include <utility>
+#include <variant>
+
+#include "data_types.hpp"
+#include "demux.hpp"
+#include "device.hpp"
+#include "dispatch.hpp"
 #include "dispatch/kernel_config/fabric_router_vc.hpp"
 #include "dispatch_core_common.hpp"
-#include "dprint_server.hpp"
-
-#include "kernel_types.hpp"
-#include "prefetch.hpp"
-#include "dispatch.hpp"
 #include "dispatch_s.hpp"
-#include "mux.hpp"
-#include "demux.hpp"
+#include "dprint_server.hpp"
 #include "eth_router.hpp"
 #include "eth_tunneler.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "kernel_types.hpp"
+#include "mux.hpp"
+#include "prefetch.hpp"
 #include "rtoptions.hpp"
+#include "umd/device/tt_core_coordinates.h"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -5,11 +5,30 @@
 
 #include <device_impl.hpp>
 #include <program_impl.hpp>
+#include <stdint.h>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "assert.hpp"
 #include "core_coord.hpp"
 #include "mesh_graph.hpp"
+#include "system_memory_manager.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
-#include "tt_cluster.hpp"
+#include "umd/device/tt_xy_pair.h"
+#include "utils.hpp"
+
+enum class CoreType;
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class Program;
+enum DispatchWorkerType : uint32_t;
+enum NOC : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 #define UNUSED_LOGICAL_CORE tt_cxy_pair(device_->id(), 0, 0)
 #define UNUSED_SEM_ID 0

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -2,15 +2,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "mux.hpp"
-#include "dispatch.hpp"
-#include "eth_router.hpp"
-#include "eth_tunneler.hpp"
 
 #include <host_api.hpp>
-#include <tt_metal.hpp>
-
-#include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "assert.hpp"
+#include "device.hpp"
+#include "dispatch.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "eth_tunneler.hpp"
+#include "hal.hpp"
+#include "tt_cluster.hpp"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.hpp
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
+#include <stdint.h>
+#include <array>
+#include <optional>
+
+#include "dispatch/kernels/packet_queue_ctrl.hpp"
 #include "fd_kernel.hpp"
+#include "system_memory_manager.hpp"
 
 typedef struct mux_static_config {
     std::optional<uint32_t> reserved;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -2,19 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "prefetch.hpp"
-#include "dispatch.hpp"
-#include "dispatch/kernel_config/fd_kernel.hpp"
-#include "dispatch_s.hpp"
-#include "eth_router.hpp"
 
 #include <host_api.hpp>
-#include <tt_metal.hpp>
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-
-#include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <tt_metal.hpp>
+#include <array>
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
+#include "assert.hpp"
+#include "command_queue_common.hpp"
+#include "device.hpp"
+#include "dispatch.hpp"
+#include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "dispatch_s.hpp"
+#include "eth_router.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
 #include "rtoptions.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -4,8 +4,16 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <optional>
+
+#include "core_coord.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
 #include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
+#include "system_memory_manager.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_xy_pair.h"
 #include "umd/device/types/cluster_descriptor_types.h"
 
 typedef struct prefetch_static_config {

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/system_memory_cq_interface.hpp>
 #include <tt-metalium/command_queue_common.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
-#include "llrt/hal.hpp"
+#include <tt-metalium/system_memory_cq_interface.hpp>
+
+#include "assert.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -2,18 +2,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/system_memory_manager.hpp>
-#include <tt-metalium/dispatch_mem_map.hpp>
-#include <tt-metalium/command_queue_common.hpp>
-#include "memcpy.hpp"
-
-#include <tt-metalium/launch_message_ring_buffer_state.hpp>
-#include <tt-metalium/tt_align.hpp>
-
 #include <llrt/tt_cluster.hpp>
-#include "dispatch_core_manager.hpp"
-
+#include <tt-metalium/command_queue_common.hpp>
+#include <tt-metalium/dispatch_mem_map.hpp>
+#include <tt-metalium/system_memory_manager.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <algorithm>
 #include <atomic>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <tuple>
+
+#include "assert.hpp"
+#include "core_coord.hpp"
+#include "dispatch_core_manager.hpp"
+#include "dispatch_settings.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "memcpy.hpp"
+#include "system_memory_cq_interface.hpp"
+// #include "umd/device/driver_atomics.h" Should be included as it is used here, but the file is missing include guards
+#include "umd/device/tt_io.hpp"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
+
+enum class CoreType;
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -3,25 +3,50 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "topology.hpp"
-#include "data_types.hpp"
-#include "dispatch_core_common.hpp"
-#include "kernel_config/fd_kernel.hpp"
+
 #include <device_pool.hpp>
-#include <memory>
-#include <tt_metal.hpp>
 #include <host_api.hpp>
+#include <tt-metalium/erisc_datamover_builder.hpp>
+#include <tt-metalium/mesh_graph.hpp>
+#include <tt_metal.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <string>
 #include <unordered_map>
-#include "kernel_config/fd_kernel.hpp"
+#include <unordered_set>
+#include <utility>
+#include <variant>
+
+#include "assert.hpp"
+#include "command_queue_common.hpp"
+#include "control_plane.hpp"
+#include "core_coord.hpp"
+#include "data_types.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "fabric_edm_packet_header.hpp"
+#include "fabric_host_interface.h"
+#include "fabric_types.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
 #include "kernel_config/demux.hpp"
 #include "kernel_config/eth_router.hpp"
 #include "kernel_config/eth_tunneler.hpp"
-#include "fabric_host_interface.h"
-
+#include "kernel_config/fd_kernel.hpp"
+#include "kernel_types.hpp"
+#include "metal_soc_descriptor.h"
 #include "program_impl.hpp"
 #include "rtoptions.hpp"
+#include "span.hpp"
 #include "tt_cluster.hpp"
-#include <tt-metalium/erisc_datamover_builder.hpp>
-#include <tt-metalium/mesh_graph.hpp>
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_xy_pair.h"
+#include "utils.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -3,7 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 #include <device.hpp>
+#include <stdint.h>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "data_types.hpp"
+#include "program_impl.hpp"
+#include "system_memory_manager.hpp"
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+enum DispatchWorkerType : uint32_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -2,16 +2,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/dispatch_settings.hpp>
-#include <tt-metalium/dev_msgs.h>
-#include <cstdint>
-#include "llrt/hal.hpp"
-#include <tt_cluster.hpp>
-#include "magic_enum/magic_enum.hpp"
-#include "umd/device/tt_core_coordinates.h"
 #include <dispatch_settings.hpp>
+#include <limits.h>
+#include <tt-metalium/dev_msgs.h>
+#include <tt-metalium/dispatch_settings.hpp>
+#include <tt_cluster.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <string_view>
+#include <unordered_map>
+
+#include "assert.hpp"
+#include "fmt/base.h"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "magic_enum/magic_enum.hpp"
 #include "size_literals.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
+#include "umd/device/tt_core_coordinates.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -3,11 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <assert.hpp>
+#include <stdint.h>
+#include <stdio.h>
 #include <worker_config_buffer.hpp>
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "logger.hpp"
 
 namespace tt {
 
 namespace tt_metal {
+enum class HalProgrammableCoreType;
 
 constexpr uint32_t kernel_config_entry_count = 8;
 

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -3,14 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tt_metal/impl/event/dispatch.hpp"
+
+#include <boost/core/span.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
+#include <tt_align.hpp>
+#include <utility>
+#include <vector>
+
+#include "assert.hpp"
+#include "command_queue_common.hpp"
+#include "core_coord.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "logger.hpp"
+#include "strong_type.hpp"
+#include "sub_device_types.hpp"
+#include "tt_cluster.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
-#include <tt-metalium/program_impl.hpp>
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
-#include <tt_align.hpp>
+#include "umd/device/tt_xy_pair.h"
 
-#include "tt_cluster.hpp"
+enum class CoreType;
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/event/dispatch.hpp
+++ b/tt_metal/impl/event/dispatch.hpp
@@ -4,9 +4,19 @@
 
 #pragma once
 
-#include <tt-metalium/device.hpp>
 #include <command_queue_interface.hpp>
+#include <stdint.h>
 #include <sub_device_types.hpp>
+#include <tt-metalium/device.hpp>
+
+#include "span.hpp"
+#include "system_memory_manager.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/event/event.cpp
+++ b/tt_metal/impl/event/event.cpp
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <event.hpp>
-
-#include <thread>
-
 #include <assert.hpp>
+#include <event.hpp>
 #include <logger.hpp>
+#include <chrono>
+#include <thread>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.cpp
@@ -3,7 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "flatbuffer/base_types_from_flatbuffer.hpp"
+
+#include <flatbuffers/array.h>
+#include <stdint.h>
+#include <array>
+
 #include "assert.hpp"
+#include "data_types.hpp"
+#include "tile.hpp"
+#include "tt_backend_api_types.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/base_types_from_flatbuffer.hpp
@@ -4,13 +4,15 @@
 
 #pragma once
 
-#include "base_types_generated.h"
 #include <buffer_constants.hpp>
-#include <kernel_types.hpp>
-#include <data_types.hpp>
-#include <tt_backend_api_types.hpp>
-#include <tile.hpp>
 #include <circular_buffer_constants.h>
+#include <data_types.hpp>
+#include <kernel_types.hpp>
+#include <tile.hpp>
+#include <tt_backend_api_types.hpp>
+
+#include "base_types.hpp"
+#include "base_types_generated.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.cpp
@@ -4,6 +4,15 @@
 
 #include "flatbuffer/base_types_to_flatbuffer.hpp"
 
+#include <flatbuffers/stl_emulation.h>
+#include <stdint.h>
+
+#include "assert.hpp"
+#include "base_types.hpp"
+#include "data_types.hpp"
+#include "tile.hpp"
+#include "tt_backend_api_types.hpp"
+
 namespace tt::tt_metal {
 
 // Original types defined in data_types.hpp

--- a/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/base_types_to_flatbuffer.hpp
@@ -4,13 +4,29 @@
 
 #pragma once
 
-#include "base_types_generated.h"
 #include <buffer_constants.hpp>
-#include <kernel_types.hpp>
-#include <data_types.hpp>
-#include <tt_backend_api_types.hpp>
-#include <tile.hpp>
 #include <circular_buffer_constants.h>
+#include <data_types.hpp>
+#include <flatbuffers/buffer.h>
+#include <flatbuffers/flatbuffer_builder.h>
+#include <flatbuffers/vector.h>
+#include <kernel_types.hpp>
+#include <tile.hpp>
+#include <tt_backend_api_types.hpp>
+#include <array>
+#include <optional>
+
+#include "base_types_generated.h"
+
+enum class MathFidelity : uint8_t;
+namespace tt {
+enum class DataFormat : uint8_t;
+namespace tt_metal {
+enum Eth : uint8_t;
+enum class DataMovementProcessor;
+struct Tile;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/buffer_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/buffer_types_from_flatbuffer.cpp
@@ -3,7 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "flatbuffer/buffer_types_from_flatbuffer.hpp"
+
+#include <flatbuffers/vector.h>
+#include <stdint.h>
+#include <array>
+#include <unordered_set>
+
+#include "assert.hpp"
+#include "base_types_generated.h"
+#include "buffer_types_generated.h"
+#include "circular_buffer_constants.h"
+#include "circular_buffer_types.hpp"
+#include "core_coord.hpp"
+#include "flatbuffer/base_types_from_flatbuffer.hpp"
 #include "flatbuffer/program_types_from_flatbuffer.hpp"
+#include "tile.hpp"
+
+namespace tt {
+enum class DataFormat : uint8_t;
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/buffer_types_from_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/buffer_types_from_flatbuffer.hpp
@@ -4,9 +4,25 @@
 
 #pragma once
 
-#include "buffer_types_generated.h"
 #include <circular_buffer_types.hpp>
+#include <optional>
+
+#include "buffer.hpp"
+#include "buffer_constants.hpp"
+#include "buffer_types_generated.h"
 #include "flatbuffer/base_types_from_flatbuffer.hpp"
+
+namespace tt {
+namespace tt_metal {
+namespace flatbuffer {
+enum class BufferType : uint16_t;
+enum class ShardMode : uint8_t;
+struct CircularBufferConfig;
+struct ShardSpec;
+struct ShardSpecBuffer;
+}  // namespace flatbuffer
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/buffer_types_to_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/buffer_types_to_flatbuffer.cpp
@@ -3,6 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "flatbuffer/buffer_types_to_flatbuffer.hpp"
+
+#include <stdint.h>
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+#include "assert.hpp"
+#include "base_types_generated.h"
+#include "buffer.hpp"
+#include "buffer_constants.hpp"
+#include "circular_buffer_types.hpp"
+#include "flatbuffer/base_types_to_flatbuffer.hpp"
 #include "flatbuffer/program_types_to_flatbuffer.hpp"
 #include "lightmetal/lightmetal_capture.hpp"  // For LightMetalCaptureContext
 

--- a/tt_metal/impl/flatbuffer/buffer_types_to_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/buffer_types_to_flatbuffer.hpp
@@ -4,9 +4,24 @@
 
 #pragma once
 
+#include <circular_buffer_types.hpp>
+#include <flatbuffers/buffer.h>
+#include <flatbuffers/flatbuffer_builder.h>
+#include <optional>
+
 #include "buffer_types_generated.h"
 #include "flatbuffer/base_types_to_flatbuffer.hpp"
-#include <circular_buffer_types.hpp>
+
+namespace tt {
+namespace tt_metal {
+enum class BufferType;
+enum class ShardMode;
+enum class ShardOrientation;
+enum class TensorMemoryLayout;
+struct ShardSpec;
+struct ShardSpecBuffer;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.cpp
@@ -3,7 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "flatbuffer/program_types_from_flatbuffer.hpp"
+
+#include <flatbuffers/string.h>
+#include <cstddef>
+#include <map>
+#include <utility>
+
+#include "base_types_generated.h"
+#include "core_coord.hpp"
 #include "flatbuffer/base_types_from_flatbuffer.hpp"
+#include "kernel_types.hpp"
+#include "span.hpp"
+#include "sub_device_types.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/program_types_from_flatbuffer.hpp
@@ -4,10 +4,17 @@
 
 #pragma once
 
-#include "program_types_generated.h"
 #include <core_coord.hpp>
+#include <flatbuffers/buffer.h>
+#include <flatbuffers/vector.h>
 #include <kernel_types.hpp>
+#include <stdint.h>
 #include <sub_device_types.hpp>
+#include <variant>
+#include <vector>
+
+#include "assert.hpp"
+#include "program_types_generated.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.cpp
+++ b/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.cpp
@@ -2,10 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <boost/core/span.hpp>
+#include <tt_stl/overloaded.hpp>
+#include <cstddef>
+#include <map>
+#include <type_traits>
+
+#include "base_types_generated.h"
+#include "buffer.hpp"
+#include "core_coord.hpp"
 #include "flatbuffer/base_types_to_flatbuffer.hpp"
 #include "flatbuffer/program_types_to_flatbuffer.hpp"
+#include "kernel_types.hpp"
 #include "lightmetal/lightmetal_capture.hpp"  // For LightMetalCaptureContext
-#include <tt_stl/overloaded.hpp>
+#include "strong_type.hpp"
+#include "sub_device_types.hpp"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.hpp
+++ b/tt_metal/impl/flatbuffer/program_types_to_flatbuffer.hpp
@@ -4,13 +4,34 @@
 
 #pragma once
 
+#include <buffer.hpp>
+#include <core_coord.hpp>
+#include <flatbuffers/buffer.h>
+#include <flatbuffers/flatbuffer_builder.h>
+#include <flatbuffers/vector.h>
+#include <kernel_types.hpp>
+#include <stdint.h>
+#include <sub_device_types.hpp>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
 #include "flatbuffer/base_types_to_flatbuffer.hpp"
 #include "lightmetal/host_api_capture_helpers.hpp"
 #include "program_types_generated.h"
-#include <core_coord.hpp>
-#include <kernel_types.hpp>
-#include <sub_device_types.hpp>
-#include <buffer.hpp>
+#include "span.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Buffer;
+struct ComputeConfig;
+struct DataMovementConfig;
+struct EthernetConfig;
+struct ReaderDataMovementConfig;
+struct WriterDataMovementConfig;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -2,25 +2,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <kernel.hpp>
-#include <kernel_types.hpp>
-
-#include <fmt/core.h>
-#include <fmt/ranges.h>
-
-#include <magic_enum/magic_enum.hpp>
-#include <set>
-
-#include "llrt.hpp"
-#include <string_view>
-#include <tt_metal.hpp>
-#include "tt_metal/impl/debug/watcher_server.hpp"
-#include <utils.hpp>
 #include <core_coord.hpp>
 #include <device.hpp>
-#include "tt_metal/jit_build/genfiles.hpp"
+#include <fmt/ranges.h>
+#include <kernel.hpp>
+#include <kernel_types.hpp>
+#include <magic_enum/magic_enum.hpp>
+#include <utils.hpp>
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <set>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include "assert.hpp"
+#include "data_types.hpp"
+#include "hal.hpp"
+#include "jit_build/build.hpp"
+#include "jit_build_options.hpp"
+#include "llrt.hpp"
+#include "logger.hpp"
+#include "rtoptions.hpp"
+#include "span.hpp"
+#include "tt_memory.h"
+#include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-#include "hw/inc/wormhole/eth_l1_address_map.h"
+#include "tt_metal/jit_build/genfiles.hpp"
+#include "umd/device/types/arch.h"
 
 namespace tt {
 

--- a/tt_metal/impl/kernels/kernel_types.cpp
+++ b/tt_metal/impl/kernels/kernel_types.cpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <kernel_types.hpp>
+#include <stdint.h>
 #include <tt_cluster.hpp>
-
 #include <utility>
+
+#include "util.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -2,19 +2,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_stl/overloaded.hpp>
-#include <circular_buffer_types.hpp>
+#include <assert.h>
+#include <flatbuffers/buffer.h>
+#include <flatbuffers/vector.h>
+#include <kernel_types.hpp>
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/program_impl.hpp>
+#include <tt_stl/overloaded.hpp>
+#include <cstddef>
 
-#include <kernel_types.hpp>
-#include "lightmetal/host_api_capture_helpers.hpp"
+#include "assert.hpp"
+#include "base_types_generated.h"
+#include "buffer.hpp"
 #include "command_generated.h"
-#include "lightmetal/lightmetal_capture.hpp"
-#include "flatbuffer/base_types_to_flatbuffer.hpp"
-#include "flatbuffer/program_types_to_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_to_flatbuffer.hpp"
+#include "flatbuffer/program_types_to_flatbuffer.hpp"
+#include "lightmetal/host_api_capture_helpers.hpp"
+#include "lightmetal/lightmetal_capture.hpp"
+#include "logger.hpp"
+#include "span.hpp"
+#include "strong_type.hpp"
+#include "system_memory_manager.hpp"
+
+class bfloat16;
+namespace tt {
+namespace tt_metal {
+class Kernel;
+enum class BufferType;
+enum class TensorMemoryLayout;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -4,24 +4,44 @@
 
 #pragma once
 
-#include "flatbuffers/flatbuffers.h"
-#include "lightmetal/lightmetal_capture.hpp"
+#include <kernel_types.hpp>
+#include <stdint.h>
+#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/logger.hpp>
 #include <tt_stl/span.hpp>
-#include <tt-metalium/buffer.hpp>
-#include <kernel_types.hpp>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "command_queue.hpp"
+#include "core_coord.hpp"
+#include "flatbuffers/flatbuffers.h"
+#include "hal_types.hpp"
+#include "lightmetal/lightmetal_capture.hpp"
+#include "sub_device_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Program;
+enum class BufferType;
+enum class TensorMemoryLayout;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 
 // Many forward decls and aliases to reduce includes.
 class CommandQueue;
-struct DataMovementConfig;
-struct ComputeConfig;
-struct EthernetConfig;
-
 class IDevice;
 struct BufferConfig;
 struct CircularBufferConfig;
+struct ComputeConfig;
+struct DataMovementConfig;
+struct EthernetConfig;
+
 using RuntimeArgs = std::vector<std::variant<Buffer*, uint32_t>>;
 
 //////////////////////////////////////////////////////////////

--- a/tt_metal/impl/lightmetal/lightmetal_capture.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.cpp
@@ -2,16 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/logger.hpp>
-#include <tt-metalium/assert.hpp>
-#include "lightmetal/lightmetal_capture.hpp"
-#include "flatbuffers/flatbuffers.h"
-#include "command_generated.h"
-#include "light_metal_binary_generated.h"
 #include <trace_buffer.hpp>
+#include <tt-metalium/assert.hpp>
 #include <tt-metalium/buffer.hpp>
-#include <tt-metalium/program_impl.hpp>
 #include <tt-metalium/kernel.hpp>
+#include <tt-metalium/logger.hpp>
+#include <tt-metalium/program_impl.hpp>
+#include <cstddef>
+#include <functional>
+#include <utility>
+
+#include "circular_buffer_types.hpp"
+#include "light_metal_binary_generated.h"
+#include "lightmetal/lightmetal_capture.hpp"
+#include "lightmetal_binary.hpp"
+#include "strong_type.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/lightmetal/lightmetal_capture.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.hpp
@@ -4,10 +4,14 @@
 
 #pragma once
 
-#include <vector>
-#include <memory>
+#include <flatbuffers/buffer.h>
+#include <flatbuffers/flatbuffer_builder.h>
 #include <flatbuffers/flatbuffers.h>
 #include <lightmetal_binary.hpp>
+#include <stdint.h>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 // Forward decl for command_generated.h
 namespace tt::tt_metal::flatbuffer {
@@ -28,8 +32,9 @@ class TraceDescriptor;
 namespace tt::tt_metal {
 
 class Buffer;
-class Program;
 class Kernel;
+class Program;
+
 using CBHandle = uintptr_t;
 using TraceDescriptorByTraceIdOffset = flatbuffers::Offset<tt::tt_metal::flatbuffer::TraceDescriptorByTraceId>;
 

--- a/tt_metal/impl/lightmetal/lightmetal_capture_utils.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture_utils.cpp
@@ -3,9 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <lightmetal_capture_utils.hpp>
-#include "lightmetal/host_api_capture_helpers.hpp"
+#include <stdint.h>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <cstddef>
+#include <vector>
+
+#include "lightmetal/host_api_capture_helpers.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/lightmetal/lightmetal_replay.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/lightmetal_replay.hpp>
+#include <utility>
 
+#include "lightmetal_binary.hpp"
 #include "tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -4,21 +4,45 @@
 
 #include "lightmetal_replay_impl.hpp"
 
-#include <iostream>
-#include "light_metal_binary_generated.h"
-#include "command_generated.h"
-#include <trace_buffer.hpp>
-#include <tt-metalium/logger.hpp>
-
+#include <flatbuffers/string.h>
+#include <flatbuffers/verifier.h>
 #include <host_api.hpp>
-#include "env_lib.hpp"
-#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/logger.hpp>
 #include <tt-metalium/trace_buffer.hpp>
-#include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/device_impl.hpp>
-#include "flatbuffer/base_types_from_flatbuffer.hpp"
-#include "flatbuffer/program_types_from_flatbuffer.hpp"
+#include <tt-metalium/tt_metal.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <string>
+#include <utility>
+
+#include "assert.hpp"
+#include "base_types_generated.h"
+#include "buffer_types_generated.h"
+#include "command_generated.h"
+#include "device.hpp"
+#include "dispatch_core_common.hpp"
+#include "env_lib.hpp"
 #include "flatbuffer/buffer_types_from_flatbuffer.hpp"
+#include "flatbuffer/program_types_from_flatbuffer.hpp"
+#include "hostdevcommon/common_values.hpp"
+#include "light_metal_binary_generated.h"
+#include "lightmetal_binary.hpp"
+#include "program_impl.hpp"
+#include "program_types_generated.h"
+#include "span.hpp"
+#include "sub_device_types.hpp"
+#include "system_memory_manager.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+class Kernel;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -4,14 +4,30 @@
 
 #pragma once
 
+#include <flatbuffers/buffer.h>
 #include <flatbuffers/flatbuffers.h>
-#include <string>
-#include <vector>
-#include <optional>
-#include <tt-metalium/lightmetal_binary.hpp>
-
-#include <tt-metalium/program_impl.hpp>
+#include <flatbuffers/vector.h>
+#include <stdint.h>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/lightmetal_binary.hpp>
+#include <tt-metalium/program_impl.hpp>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include "buffer.hpp"
+#include "circular_buffer_types.hpp"
+#include "kernel_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class Kernel;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 class TraceDescriptor;
@@ -19,30 +35,29 @@ class TraceDescriptor;
 
 // Forward decl for command_generated.h / light_metal_binary_generated.h
 namespace tt::tt_metal::flatbuffer {
-struct Command;
-struct ReplayTraceCommand;
-struct EnqueueTraceCommand;
-struct LoadTraceCommand;
-struct ReleaseTraceCommand;
 struct BufferCreateCommand;
 struct BufferDeallocateCommand;
 struct BufferDeleteCommand;
-struct EnqueueWriteBufferCommand;
-struct EnqueueReadBufferCommand;
-struct FinishCommand;
-struct ProgramConstructorCommand;
-struct EnqueueProgramCommand;
+struct Command;
+struct CreateCircularBufferCommand;
 struct CreateKernelCommand;
+struct EnqueueProgramCommand;
+struct EnqueueReadBufferCommand;
+struct EnqueueTraceCommand;
+struct EnqueueWriteBufferCommand;
+struct FinishCommand;
+struct LightMetalBinary;
+struct LightMetalCompareCommand;
+struct LoadTraceCommand;
+struct ProgramConstructorCommand;
+struct ReleaseTraceCommand;
+struct ReplayTraceCommand;
+struct RuntimeArg;
+struct SetRuntimeArgsCommand;
 struct SetRuntimeArgsUint32Command;
 struct SetRuntimeArgsUint32VecPerCoreCommand;
-struct SetRuntimeArgsCommand;
-struct CreateCircularBufferCommand;
-struct LightMetalCompareCommand;
-struct RuntimeArg;
-
 struct TraceDescriptor;
 struct TraceDescriptorByTraceId;
-struct LightMetalBinary;
 }  // namespace tt::tt_metal::flatbuffer
 
 using FlatbufferRuntimeArgVector =

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -17,6 +17,7 @@
 #include "dispatch/kernels/cq_commands.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
+#include "host_api.hpp"
 #include "hostdevcommon/profiler_common.h"
 #include "llrt.hpp"
 #include "logger.hpp"
@@ -28,6 +29,7 @@
 #include "tracy/Tracy.hpp"
 #include "tt_backend_api_types.hpp"
 #include "tt_cluster.hpp"
+#include <tt_metal.hpp>
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -2,27 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <iostream>
-#include <fstream>
-#include <iomanip>
-#include <filesystem>
-
-#include <host_api.hpp>
-#include <tt_metal.hpp>
-#include "profiler.hpp"
-#include "profiler_state.hpp"
-#include "profiler_paths.hpp"
-#include "hostdevcommon/profiler_common.h"
-#include <rtoptions.hpp>
 #include <dev_msgs.h>
 #include <device.hpp>
-#include "tools/profiler/event_metadata.hpp"
+#include <magic_enum/magic_enum.hpp>
+#include <nlohmann/json.hpp>
+#include <rtoptions.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <iostream>
 
+#include "assert.hpp"
+#include "dispatch/kernels/cq_commands.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
 #include "hostdevcommon/profiler_common.h"
-#include "tracy/Tracy.hpp"
-#include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-
 #include "llrt.hpp"
+#include "logger.hpp"
+#include "metal_soc_descriptor.h"
+#include "profiler.hpp"
+#include "profiler_paths.hpp"
+#include "profiler_state.hpp"
+#include "tools/profiler/event_metadata.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_backend_api_types.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/xy_pair.h"
 
 namespace tt {
 

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -4,22 +4,45 @@
 
 #pragma once
 
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
+#include <stdint.h>
 #include <chrono>
-#include <string>
-#include <unordered_map>
-#include <iostream>
+#include <cstddef>
 #include <filesystem>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "buffer.hpp"
-#include "program_impl.hpp"
+#include "common/TracyTTDeviceData.hpp"
+#include "core_coord.hpp"
+#include "hostdevcommon/profiler_common.h"
+#include "profiler_optional_metadata.hpp"
+#include "profiler_paths.hpp"
 #include "profiler_state.hpp"
 #include "profiler_types.hpp"
-#include "profiler_paths.hpp"
-#include "profiler_optional_metadata.hpp"
+#include "program_impl.hpp"
+#include "system_memory_manager.hpp"
 #include "tracy/TracyTTDevice.hpp"
-#include "common/TracyTTDeviceData.hpp"
 
-#include <nlohmann/json.hpp>
+namespace tt {
+enum class ARCH;
+namespace tt_metal {
+class Buffer;
+class IDevice;
+class Program;
+}  // namespace tt_metal
+}  // namespace tt
 
 using std::chrono::duration;
 using std::chrono::duration_cast;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -50,6 +50,12 @@
 #include "umd/device/types/xy_pair.h"
 #include "utils.hpp"
 
+// Needed if profiler is enabled
+#include <core_descriptor.hpp>
+#include <dispatch_core_common.hpp>
+#include "dprint_server.hpp"
+#include "llrt/hal.hpp"
+
 class ProfilerOptionalMetadata;
 
 namespace tt {

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -1,34 +1,62 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <chrono>
-#include <thread>
-#include <cmath>
-
-#include "llrt/hal.hpp"
-#include <host_api.hpp>
-#include <dispatch_core_common.hpp>
-#include <core_descriptor.hpp>
-
-#include <profiler.hpp>
-#include "hostdevcommon/profiler_common.h"
-
-#include <tt_metal.hpp>
-
-#include "tracy/Tracy.hpp"
-#include "tracy/TracyTTDevice.hpp"
 #include <device.hpp>
 #include <device_pool.hpp>
+#include <host_api.hpp>
+#include <profiler.hpp>
 #include <tt_cluster.hpp>
+#include <tt_metal.hpp>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <exception>
+#include <filesystem>
+#include <functional>
+#include <limits>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
 
+#include "assert.hpp"
+#include "core_coord.hpp"
+#include "data_types.hpp"
+#include "dev_msgs.h"
+#include "hal_types.hpp"
+#include "hostdevcommon/profiler_common.h"
+#include "kernel_types.hpp"
 #include "llrt.hpp"
-
-#include "dprint_server.hpp"
+#include "logger.hpp"
+#include "metal_soc_descriptor.h"
+#include "profiler_paths.hpp"
+#include "program_impl.hpp"
 #include "rtoptions.hpp"
+#include "system_memory_manager.hpp"
+#include "tracy/Tracy.hpp"
+#include "tracy/TracyTTDevice.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
+
+class ProfilerOptionalMetadata;
 
 namespace tt {
 
 namespace tt_metal {
+enum class ProfilerDumpState;
+enum class ProfilerSyncState;
 
 void DumpDeviceProfileResults(IDevice* device, const Program& program) {
 #if defined(TRACY_ENABLE)

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -4,24 +4,71 @@
 
 #include "tt_metal/impl/program/dispatch.hpp"
 
-#include <command_queue.hpp>
-#include <tt-metalium/command_queue_interface.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
-#include <tt-metalium/allocator.hpp>
-#include <mesh_command_queue.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <mesh_workload.hpp>
-#include <tt_align.hpp>
+#include <stddef.h>
+#include <string.h>
 #include <sub_device_types.hpp>
+#include <tracy/Tracy.hpp>
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/dispatch_settings.hpp>
+#include <tt-metalium/mesh_command_queue.hpp>
+#include <tt_align.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <map>
+#include <optional>
+#include <set>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <unordered_set>
+#include <variant>
 #include <vector>
 
+#include "assert.hpp"
+#include "buffer.hpp"
+#include "circular_buffer.hpp"
+#include "circular_buffer_constants.h"
 #include "core_coord.hpp"
+#include "device.hpp"
+#include "dispatch/device_command.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "hal_types.hpp"
+#include "kernel.hpp"
 #include "llrt/hal.hpp"
+#include "math.hpp"
+#include "program_device_map.hpp"
+#include "program_impl.hpp"
+#include "runtime_args_data.hpp"
+#include "semaphore.hpp"
+#include "span.hpp"
+#include "strong_type.hpp"
+#include "system_memory_manager.hpp"
+#include "tt_memory.h"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
-#include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/xy_pair.h"
+#include "vector_aligned.hpp"
+#include "worker_config_buffer.hpp"
+
+namespace tt {
+namespace tt_metal {
+enum NOC : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace {
 CoreCoord get_sub_device_worker_origin(

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -8,12 +8,33 @@
 #include <device.hpp>
 #include <kernel.hpp>
 #include <program_impl.hpp>
+#include <stdint.h>
 #include <vector_aligned.hpp>
 #include <worker_config_buffer.hpp>
+#include <array>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "core_coord.hpp"
+#include "dev_msgs.h"
+#include "dispatch_settings.hpp"
+#include "kernel_types.hpp"
+#include "sub_device_types.hpp"
+
+enum class CoreType;
 
 namespace tt {
 
 namespace tt_metal {
+class IDevice;
+class Program;
+class Semaphore;
+class SystemMemoryManager;
+enum class ProgramBinaryStatus : uint8_t;
+struct KernelGroup;
+struct ProgramCommandSequence;
 
 namespace program_dispatch {
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2,35 +2,99 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <range/v3/view/filter.hpp>
-#include <range/v3/view/transform.hpp>
-
-#include <circular_buffer_types.hpp>
-#include "common/executor.hpp"
-#include <profiler.hpp>
-#include "tt_metal/detail/kernel_cache.hpp"
-#include <persistent_kernel_cache.hpp>
-#include <memory_reporter.hpp>
-#include <tt_metal.hpp>
-#include <graph_tracking.hpp>
-#include <host_api.hpp>
 #include <allocator.hpp>
 #include <circular_buffer.hpp>
-#include <semaphore.hpp>
-#include "dprint_server.hpp"
+#include <circular_buffer_types.hpp>
 #include <device.hpp>
-#include <command_queue.hpp>
+#include <graph_tracking.hpp>
+#include <magic_enum/magic_enum.hpp>
+#include <memory_reporter.hpp>
+#include <persistent_kernel_cache.hpp>
+#include <semaphore.hpp>
+#include <tt_align.hpp>
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <bitset>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <future>
+#include <initializer_list>
+#include <limits>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "assert.hpp"
+#include "buffer.hpp"
+#include "buffer_constants.hpp"
+#include "circular_buffer_constants.h"
+#include "core_coord.hpp"
+#include "data_types.hpp"
+#include "dev_msgs.h"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch_core_common.hpp"
+#include "dprint_server.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "jit_build/build.hpp"
+#include "jit_build_options.hpp"
+#include "kernel.hpp"
+#include "kernel_types.hpp"
+#include "lightmetal/host_api_capture_helpers.hpp"
+#include "lightmetal/lightmetal_capture.hpp"
+#include "llrt.hpp"
+#include "logger.hpp"
+#include "profiler_state.hpp"
+#include "program_command_sequence.hpp"
+#include "program_device_map.hpp"
+#include "program_impl.hpp"
+#include "rtoptions.hpp"
+#include "span.hpp"
+#include "strong_type.hpp"
+#include "sub_device_types.hpp"
+#include "system_memory_manager.hpp"
+#include "tile.hpp"
+#include "tt_backend_api_types.hpp"
+#include "tt_memory.h"
+#include "tt_metal/detail/kernel_cache.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
-#include "tt_metal/jit_build/genfiles.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-#include "llrt.hpp"
-#include "program_command_sequence.hpp"
-#include "tracy/Tracy.hpp"
-#include <tt_align.hpp>
-#include <tuple>
-#include "lightmetal/host_api_capture_helpers.hpp"
+#include "tt_metal/jit_build/genfiles.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/xy_pair.h"
+#include "util.hpp"
+#include "utils.hpp"
+
+namespace tt {
+class tt_hlk_desc;
+enum CBIndex : std::uint8_t;
+namespace tt_metal {
+class CommandQueue;
+class EnqueueProgramCommand;
+namespace detail {
+class Internal_;
+}  // namespace detail
+namespace experimental {
+class GlobalCircularBuffer;
+}  // namespace experimental
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/sub_device/sub_device.cpp
+++ b/tt_metal/impl/sub_device/sub_device.cpp
@@ -2,15 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <array>
-#include <cstdint>
-
 #include <assert.hpp>
 #include <core_coord.hpp>
 #include <sub_device.hpp>
-#include "llrt/hal.hpp"
 #include <tt_stl/span.hpp>
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <utility>
+
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -2,27 +2,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <vector>
-
-#include "sub_device_manager.hpp"
-
-#include <assert.hpp>
-#include <host_api.hpp>
 #include <allocator.hpp>
+#include <assert.hpp>
 #include <device.hpp>
-#include <command_queue_interface.hpp>
-#include <data_types.hpp>
+#include <host_api.hpp>
 #include <sub_device.hpp>
 #include <sub_device_types.hpp>
 #include <trace.hpp>
-#include <trace_buffer.hpp>
-#include <tt_stl/span.hpp>
 #include <tt_align.hpp>
+#include <tt_stl/span.hpp>
+#include <functional>
+#include <limits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-#include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
-
+#include "allocator_types.hpp"
+#include "buffer_constants.hpp"
+#include "core_coord.hpp"
+#include "dispatch_settings.hpp"
+#include "hal.hpp"
+#include "strong_type.hpp"
+#include "sub_device_manager.hpp"
 #include "tt_cluster.hpp"
+#include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/xy_pair.h"
+#include "vector_aligned.hpp"
+
+namespace tt {
+namespace tt_metal {
+enum NOC : uint8_t;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/sub_device/sub_device_manager.hpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.hpp
@@ -4,24 +4,26 @@
 
 #pragma once
 
+#include <tt-metalium/vector_aligned.hpp>
+#include <tt_stl/span.hpp>
+#include <array>
+#include <atomic>
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "allocator.hpp"
+#include "hal_types.hpp"
 #include "sub_device.hpp"
 #include "sub_device_types.hpp"
 
-#include <tt_stl/span.hpp>
-
-#include <tt-metalium/vector_aligned.hpp>
-
 namespace tt::tt_metal {
 
-class TraceBuffer;
-
 class IDevice;
+class TraceBuffer;
 
 class SubDeviceManager {
 public:

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -2,24 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <memory>
-#include <unordered_set>
-#include <vector>
-
-#include <sub_device_manager_tracker.hpp>
-
-#include <device.hpp>
 #include <allocator.hpp>
 #include <buffer_constants.hpp>
 #include <command_queue.hpp>
-#include <command_queue.hpp>
-#include <tt-metalium/distributed.hpp>
-#include <data_types.hpp>
+#include <device.hpp>
 #include <sub_device.hpp>
+#include <sub_device_manager_tracker.hpp>
 #include <sub_device_types.hpp>
 #include <tt_stl/span.hpp>
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "assert.hpp"
+#include "core_coord.hpp"
+#include "hal_types.hpp"
+#include "mesh_command_queue.hpp"
+#include "mesh_device.hpp"
+#include "strong_type.hpp"
 #include "tt_metal/impl/sub_device/sub_device_manager.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -3,11 +3,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/dev_msgs.h>
+#include <algorithm>
+#include <functional>
 
+#include "assert.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "launch_message_ring_buffer_state.hpp"
+#include "strong_type.hpp"
+#include "system_memory_manager.hpp"
+#include "trace_buffer.hpp"
+#include "tt_align.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
-#include "tt_metal/impl/trace/dispatch.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-#include "tt_metal/impl/dispatch/device_command.hpp"
+#include "tt_metal/impl/trace/dispatch.hpp"
+#include "worker_config_buffer.hpp"
+
 namespace tt::tt_metal::trace_dispatch {
 
 void reset_host_dispatch_state_for_trace(

--- a/tt_metal/impl/trace/dispatch.hpp
+++ b/tt_metal/impl/trace/dispatch.hpp
@@ -5,8 +5,25 @@
 #pragma once
 
 #include <device.hpp>
-#include <worker_config_buffer.hpp>
+#include <stdint.h>
 #include <trace_buffer.hpp>
+#include <worker_config_buffer.hpp>
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+#include "core_coord.hpp"
+#include "dispatch_settings.hpp"
+#include "sub_device_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class LaunchMessageRingBufferState;
+class SystemMemoryManager;
+class WorkerConfigBufferMgr;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::trace_dispatch {
 

--- a/tt_metal/impl/trace/trace.cpp
+++ b/tt_metal/impl/trace/trace.cpp
@@ -2,17 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <trace.hpp>
-
-#include <memory>
-
-#include <logger.hpp>
-#include <tt_metal.hpp>
-#include <host_api.hpp>
-#include <device.hpp>
 #include <command_queue.hpp>
+#include <device.hpp>
+#include <host_api.hpp>
+#include <logger.hpp>
 #include <trace.hpp>
 #include <tt-metalium/allocator.hpp>
+#include <cstddef>
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include "allocator_types.hpp"
+#include "assert.hpp"
+#include "buffer.hpp"
+#include "buffer_constants.hpp"
+#include "math.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/trace/trace_buffer.cpp
+++ b/tt_metal/impl/trace/trace_buffer.cpp
@@ -4,10 +4,12 @@
 
 #include "trace_buffer.hpp"
 
-#include <utility>
 #include <device.hpp>
 #include <tt_metal.hpp>
+#include <utility>
+
 #include "buffer.hpp"
+#include "logger.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -4,21 +4,33 @@
 
 #include "build.hpp"
 
+#include <taskflow/core/async.hpp>
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <span>
 #include <string>
+#include <string_view>
 
+#include "assert.hpp"
 #include "common/executor.hpp"
-#include "jit_build/genfiles.hpp"
+#include "env_lib.hpp"
+#include "fmt/base.h"
+#include "hal_types.hpp"
 #include "jit_build/kernel_args.hpp"
+#include "jit_build_settings.hpp"
+#include "llrt/hal.hpp"
+#include "logger.hpp"
 #include "profiler_paths.hpp"
 #include "profiler_state.hpp"
-#include <command_queue_interface.hpp>
-#include <kernel.hpp>
+#include "rtoptions.hpp"
+#include "tt_backend_api_types.hpp"
 #include "tt_metal/llrt/tt_elffile.hpp"
-#include "env_lib.hpp"
-#include "llrt/hal.hpp"
+#include "umd/device/types/arch.h"
 
 namespace fs = std::filesystem;
 

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -3,20 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <stdint.h>
+#include <tt_stl/aligned_allocator.hpp>
+#include <functional>
+#include <future>
+#include <map>
+#include <memory>
+#include <string>
 #include <string_view>
 #include <thread>
-#include <string>
-#include <future>
+#include <vector>
 
-#include "tt_backend_api_types.hpp"
-#include "utils.hpp"
 #include "core_coord.hpp"
 #include "data_format.hpp"
-#include "jit_build_options.hpp"
 #include "hostdevcommon/common_values.hpp"
-#include "tracy/Tracy.hpp"
-#include <tt_stl/aligned_allocator.hpp>
+#include "jit_build_options.hpp"
 #include "rtoptions.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_backend_api_types.hpp"
+#include "utils.hpp"
+
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -3,9 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "build_env_manager.hpp"
-#include <command_queue_interface.hpp>
-#include "tt_cluster.hpp"
+
+#include <limits.h>
+#include <magic_enum/magic_enum.hpp>
+#include <math.h>
+#include <tracy/Tracy.hpp>
+#include <bitset>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include "assert.hpp"
+#include "core_coord.hpp"
+#include "core_descriptor.hpp"
+#include "dispatch_core_common.hpp"
+#include "dispatch_mem_map.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
 #include "impl/dispatch/dispatch_core_manager.hpp"
+#include "jit_build/build.hpp"
+#include "metal_soc_descriptor.h"
+#include "system_memory_manager.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_core_coordinates.h"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -4,6 +4,12 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "build.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
 

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -4,16 +4,14 @@
 
 #include "data_format.hpp"
 
-#include <iostream>       // for basic_ostream
-#include <map>            // for operator!=
-#include <set>            // for set
-#include <string>         // for char_traits
-#include <unordered_map>  // for unordered_map
-
-#include "fmt/base.h"                      // for format_string
 #include <assert.hpp>      // for tt_throw, TT_FATAL
 #include <base_types.hpp>  // for UnpackToDestMode
 #include <circular_buffer_constants.h>
+#include <functional>
+#include <iostream>       // for basic_ostream
+#include <set>            // for set
+#include <unordered_map>  // for unordered_map
+#include <utility>
 
 namespace tt {
 

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -4,20 +4,35 @@
 
 #include "jit_build/genfiles.hpp"
 
-#include <bit>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include <utility>
-
-#include <tt_backend_api_types.hpp>
-#include <utils.hpp>
-#include "hostdevcommon/common_values.hpp"
-#include "build.hpp"
+#include <circular_buffer_constants.h>
 #include <data_format.hpp>
 #include <jit_build_options.hpp>
+#include <stdint.h>
+#include <tt_backend_api_types.hpp>
+#include <utils.hpp>
+#include <cstddef>
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <utility>
+#include <vector>
 
-#include <circular_buffer_constants.h>
+#include "assert.hpp"
+#include "build.hpp"
+#include "hlk_desc.hpp"
+#include "jit_build_settings.hpp"
+#include "kernel.hpp"
+#include "logger.hpp"
+#include "rtoptions.hpp"
+
+enum class UnpackToDestMode : uint8_t;
+namespace tt {
+enum class ARCH;
+}  // namespace tt
 
 namespace fs = std::filesystem;
 

--- a/tt_metal/jit_build/genfiles.hpp
+++ b/tt_metal/jit_build/genfiles.hpp
@@ -4,17 +4,22 @@
 
 #pragma once
 
+#include <core_coord.hpp>
+#include <kernel.hpp>
 #include <string>
 #include <vector>
 
-#include <core_coord.hpp>
-#include <kernel.hpp>
+namespace tt {
+namespace tt_metal {
+struct KernelSource;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal {
 
 class JitBuildEnv;
-class JitBuildSettings;
 class JitBuildOptions;
+class JitBuildSettings;
 
 void jit_build_genfiles_kernel_include(
     const JitBuildEnv& env, const JitBuildSettings& settings, const KernelSource& kernel_src);

--- a/tt_metal/jit_build/jit_build_options.cpp
+++ b/tt_metal/jit_build/jit_build_options.cpp
@@ -3,9 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <jit_build_options.hpp>
-#include "build.hpp"
-#include <iostream>
 #include <string>
+
+#include "build.hpp"
+#include "utils.hpp"
+
+enum class MathFidelity : uint8_t;
+namespace tt {
+enum CBIndex : std::uint8_t;
+}  // namespace tt
 
 namespace tt::tt_metal {
 

--- a/tt_metal/jit_build/kernel_args.cpp
+++ b/tt_metal/jit_build/kernel_args.cpp
@@ -2,13 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <regex>
+#include <assert.hpp>
+#include <utils.hpp>
+#include <cstddef>
+#include <fstream>
 #include <map>
 #include <mutex>
-#include <fstream>
-#include <utils.hpp>
+#include <string>
 
-#include <assert.hpp>
+#include "logger.hpp"
 
 using namespace std;
 

--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -2,19 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <dev_msgs.h>
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
+#include <vector>
 
+#include "blackhole/bh_hal.hpp"
 #include "core_config.h"  // ProgrammableCoreType
 #include "dev_mem_map.h"
-#include <dev_msgs.h>
-#include "noc/noc_parameters.h"
-#include "noc/noc_overlay_parameters.h"
-#include "tensix.h"
-
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
-#include "blackhole/bh_hal.hpp"
+#include "noc/noc_overlay_parameters.h"
+#include "noc/noc_parameters.h"
+#include "tensix.h"
 
 // Reserved DRAM addresses
 // Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been

--- a/tt_metal/llrt/blackhole/bh_hal.hpp
+++ b/tt_metal/llrt/blackhole/bh_hal.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "hal.hpp"
+
 namespace tt::tt_metal::blackhole {
 
 // If you are trying to include this file and you aren't hal...you are doing something wrong

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -4,20 +4,19 @@
 
 #define COMPILE_FOR_ERISC
 
-#include <algorithm>
+#include <dev_msgs.h>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
-#include "core_config.h"
-#include <dev_msgs.h>
-#include "eth_l1_address_map.h"
-
-#include "llrt/hal.hpp"
-#include "hal_asserts.hpp"
 #include "blackhole/bh_hal.hpp"
-
-#include "umd/device/tt_soc_descriptor.h"  // CoreType
+#include "core_config.h"
+#include "dev_mem_map.h"
+#include "eth_l1_address_map.h"
+#include "hal_asserts.hpp"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "umd/device/tt_core_coordinates.h"
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((std::uint64_t)&(((mailboxes_t*)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -4,21 +4,21 @@
 
 #define COMPILE_FOR_ERISC
 
+#include <dev_msgs.h>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
 
+#include "assert.hpp"
+#include "blackhole/bh_hal.hpp"
 #include "core_config.h"
 #include "dev_mem_map.h"
-#include <dev_msgs.h>
-#include "noc/noc_parameters.h"
-
-#include "llrt/hal.hpp"
 #include "hal_asserts.hpp"
-#include "blackhole/bh_hal.hpp"
-
-#include "umd/device/tt_soc_descriptor.h"  // CoreType
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "noc/noc_parameters.h"
+#include "umd/device/tt_core_coordinates.h"
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t)&(((mailboxes_t*)MEM_IERISC_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -2,22 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <dev_msgs.h>
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
+#include "assert.hpp"
+#include "blackhole/bh_hal.hpp"
 #include "core_config.h"
 #include "dev_mem_map.h"
-#include <dev_msgs.h>
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
 #include "tensix.h"
-
-#include "llrt/hal.hpp"
-#include "hal_asserts.hpp"
-#include "blackhole/bh_hal.hpp"
-
-#include "umd/device/tt_soc_descriptor.h"  // CoreType
+#include "umd/device/tt_core_coordinates.h"
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t)&(((mailboxes_t*)MEM_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -3,10 +3,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "core_descriptor.hpp"
-#include "rtoptions.hpp"
-#include "tt_cluster.hpp"
 
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/yaml.h>
+#include <algorithm>
+#include <bitset>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <stdexcept>
+#include <unordered_map>
+
+#include "assert.hpp"
+#include "hal.hpp"
+#include "hal_types.hpp"
+#include "metal_soc_descriptor.h"
+#include "rtoptions.hpp"
+#include "tt_backend_api_types.hpp"
+#include "tt_cluster.hpp"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
 
 namespace tt {
 

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -4,10 +4,12 @@
 
 #include "llrt/hal.hpp"
 
-#include <tt_backend_api_types.hpp>
 #include <assert.hpp>
 
 #include "get_platform_architecture.hpp"
+#include "hal_types.hpp"
+#include "umd/device/types/arch.h"
+
 namespace tt {
 
 namespace tt_metal {

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -9,14 +9,15 @@
 // level APIs
 //
 
-#include <cstdint>
-#include <functional>
-#include <variant>
-#include <vector>
-#include <memory>
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/utils.hpp>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <variant>
+#include <vector>
 
 enum class CoreType;
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -2,6 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <assert.hpp>
+#include <dev_msgs.h>
+#include <fmt/base.h>
+#include <fmt/ranges.h>
+#include <logger.hpp>
+#include <rtoptions.hpp>
+#include <unistd.h>
 #include <cassert>
 #include <chrono>
 #include <condition_variable>
@@ -10,27 +17,20 @@
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <thread>
-#include <unistd.h>
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
 
-#include <assert.hpp>
-#include <logger.hpp>
-
+#include "hal_types.hpp"
 #include "llrt.hpp"
-#include <rtoptions.hpp>
 #include "llrt/hal.hpp"
-
-#include <jit_build_options.hpp>
-
-#include <fmt/base.h>
-#include <fmt/ranges.h>
-
-#include <dev_msgs.h>
+#include "metal_soc_descriptor.h"
+// #include "umd/device/driver_atomics.h" - should be included as it is used here, but the file is missing include
+// guards
+#include "umd/device/tt_core_coordinates.h"
 
 namespace tt {
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -11,10 +11,18 @@
 #include <unordered_set>
 #include <vector>
 
+#include "core_coord.hpp"
+#include "span.hpp"
 // clang-format off
 #include "tt_cluster.hpp"
-#include "umd/device/tt_xy_pair.h"
 #include "tt_memory.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
+
+struct go_msg_t;
+struct launch_msg_t;
 // clang-format on
 
 namespace tt {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -4,11 +4,16 @@
 
 #include "rtoptions.hpp"
 
+#include <ctype.h>
 #include <stdio.h>
-#include <stdlib.h>
-
+#include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <stdexcept>
 #include <string>
+
+#include "assert.hpp"
+#include "umd/device/tt_core_coordinates.h"
 
 using std::vector;
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -11,12 +11,18 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
+#include <map>
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
 #include "core_coord.hpp"
 #include "dispatch_core_common.hpp"  // For DispatchCoreConfig
+#include "umd/device/types/xy_pair.h"
+
+enum class CoreType;
 
 namespace tt {
 

--- a/tt_metal/llrt/tlb_config.cpp
+++ b/tt_metal/llrt/tlb_config.cpp
@@ -4,10 +4,24 @@
 
 #include "tlb_config.hpp"
 
-#include "umd/device/blackhole_implementation.h"
-#include "umd/device/grayskull_implementation.h"
-#include "umd/device/wormhole_implementation.h"
 #include <assert.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "core_coord.hpp"
+#include "metal_soc_descriptor.h"
+#include "tt_backend_api_types.hpp"
+#include "umd/device/blackhole_implementation.h"
+#include "umd/device/cluster.h"
+#include "umd/device/grayskull_implementation.h"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/xy_pair.h"
+#include "umd/device/wormhole_implementation.h"
 
 namespace ll_api {
 

--- a/tt_metal/llrt/tlb_config.hpp
+++ b/tt_metal/llrt/tlb_config.hpp
@@ -4,11 +4,18 @@
 
 #pragma once
 
-#include "umd/device/device_api_metal.h"
-#include <tt_backend_api_types.hpp>
 #include <metal_soc_descriptor.h>
-
+#include <tt_backend_api_types.hpp>
 #include <unordered_map>
+
+#include "umd/device/device_api_metal.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+
+class tt_device;
+namespace tt {
+enum class ARCH;
+}  // namespace tt
+struct metal_SocDescriptor;
 
 namespace ll_api {
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -4,10 +4,16 @@
 
 #include "tt_cluster.hpp"
 
+#include <core_coord.hpp>
+#include <dev_msgs.h>
+#include <logger.hpp>
+#include <metal_soc_descriptor.h>
+#include <rtoptions.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <initializer_list>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -20,32 +26,25 @@
 #include <utility>
 #include <vector>
 
+#include "control_plane.hpp"
+#include "fabric_host_interface.h"
+#include "fabric_types.hpp"
 #include "fmt/base.h"
-#include <logger.hpp>
-#include <metal_soc_descriptor.h>
-#include <tt_backend_api_types.hpp>
-#include "umd/device/types/arch.h"
-#include "umd/device/tt_cluster_descriptor.h"
-#include "umd/device/types/cluster_descriptor_types.h"
-#include "umd/device/cluster.h"
-#include "umd/device/tt_soc_descriptor.h"
-#include "umd/device/tt_xy_pair.h"
-#include "umd/device/types/xy_pair.h"
-#include "umd/device/hugepage.h"
-
-#include <dev_msgs.h>
-
-#include "llrt/hal.hpp"
-
-#include "tracy/Tracy.hpp"
-#include "umd/device/tt_simulation_device.h"
-
-#include "sanitize_noc_host.hpp"
-#include <rtoptions.hpp>
-#include "tt_metal/llrt/tlb_config.hpp"
-#include <core_coord.hpp>
-
 #include "get_platform_architecture.hpp"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "sanitize_noc_host.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_metal/llrt/tlb_config.hpp"
+#include "umd/device/cluster.h"
+#include "umd/device/hugepage.h"
+#include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/tt_simulation_device.h"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/arch.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/cluster_types.h"
+#include "umd/device/types/xy_pair.h"
 
 static constexpr uint32_t HOST_MEM_CHANNELS = 4;
 static constexpr uint32_t HOST_MEM_CHANNELS_MASK = HOST_MEM_CHANNELS - 1;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -4,21 +4,46 @@
 
 #pragma once
 
-#include <cstdint>
-#include <functional>
-
+#include <tt-metalium/control_plane.hpp>
+#include <tt-metalium/dev_msgs.h>
+#include <tt-metalium/fabric_host_interface.h>
+#include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include <tt-metalium/fabric_host_interface.h>
-#include <tt-metalium/control_plane.hpp>
-#include <tt-metalium/fabric_types.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "assert.hpp"
+#include "core_coord.hpp"
+#include "llrt/hal.hpp"
+#include "umd/device/cluster.h"
 #include "umd/device/device_api_metal.h"
 #include "umd/device/tt_cluster_descriptor.h"
+#include "umd/device/tt_core_coordinates.h"
+#include "umd/device/tt_io.hpp"
+#include "umd/device/tt_silicon_driver_common.hpp"
+#include "umd/device/tt_soc_descriptor.h"
 #include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/cluster_descriptor_types.h"
+#include "umd/device/types/harvesting.h"
 
-#include <tt-metalium/dev_msgs.h>
-
-#include "llrt/hal.hpp"
+namespace tt {
+enum class ARCH;
+namespace tt_fabric {
+class ControlPlane;
+}  // namespace tt_fabric
+}  // namespace tt
+struct tt_device_params;
 
 static constexpr std::uint32_t SW_VERSION = 0x00020000;
 

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -4,21 +4,20 @@
 
 #include "tt_elffile.hpp"
 
-#include <algorithm>
-#include <array>
-
 #include <assert.hpp>
-// C++
-#include <map>
-// C
-#include <errno.h>
-// OS
 #include <elf.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <algorithm>
+#include <cstring>
+#include <iterator>
+#include <map>
+
+#include "logger.hpp"
 
 // Verify some knowledge of, and compatibilty with, RiscV
 #ifndef EM_RISCV

--- a/tt_metal/llrt/tt_elffile.hpp
+++ b/tt_metal/llrt/tt_elffile.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <span>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -82,6 +83,7 @@ public:
 
 private:
     class Impl;
+
     // We can't use unique_ptr here, because the above move semantics
     // would require Impl be complete at this point, which is what
     // we're trying to avoid.

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -4,12 +4,12 @@
 
 #include "tt_memory.h"
 
-#include <cstddef>
+#include <assert.hpp>
+#include <algorithm>
 #include <cstdint>
-#include <limits>
+#include <span>
 
 #include "tt_elffile.hpp"
-#include <assert.hpp>
 
 namespace ll_api {
 

--- a/tt_metal/llrt/utils.cpp
+++ b/tt_metal/llrt/utils.cpp
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdlib.h>
 #include <utils.hpp>
+#include <filesystem>
+#include <iostream>
 #include <mutex>
-#include "tracy/Tracy.hpp"
+
 #include "rtoptions.hpp"
 
-#include <filesystem>
 namespace fs = std::filesystem;
 
 namespace tt {

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -2,20 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <dev_msgs.h>
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
+#include <vector>
 
 #include "core_config.h"  // ProgrammableCoreType
 #include "dev_mem_map.h"  // MEM_LOCAL_BASE
-#include <dev_msgs.h>
-#include "noc/noc_parameters.h"
-#include "noc/noc_overlay_parameters.h"
-#include "tensix.h"
-
-#include "llrt/hal.hpp"
-#include "wormhole/wh_hal.hpp"
+#include "hal_types.hpp"
 #include "hw/inc/wormhole/eth_l1_address_map.h"
+#include "llrt/hal.hpp"
+#include "noc/noc_overlay_parameters.h"
+#include "noc/noc_parameters.h"
+#include "tensix.h"
+#include "wormhole/wh_hal.hpp"
 
 // Reserved DRAM addresses
 // Host writes (4B value) to and reads from DRAM_BARRIER_BASE across all channels to ensure previous writes have been

--- a/tt_metal/llrt/wormhole/wh_hal.hpp
+++ b/tt_metal/llrt/wormhole/wh_hal.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "hal.hpp"
+
 namespace tt::tt_metal::wormhole {
 
 // If you are trying to include this file and you aren't hal...you are doing something wrong

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -4,17 +4,18 @@
 
 #define COMPILE_FOR_ERISC
 
+#include <dev_msgs.h>
+#include <cstddef>
 #include <cstdint>
+#include <vector>
 
 #include "core_config.h"
-#include <dev_msgs.h>
 #include "eth_l1_address_map.h"
-
-#include "llrt/hal.hpp"
 #include "hal_asserts.hpp"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "umd/device/tt_core_coordinates.h"
 #include "wormhole/wh_hal.hpp"
-
-#include "umd/device/tt_soc_descriptor.h"  // CoreType
 
 #define GET_ETH_MAILBOX_ADDRESS_HOST(x) \
     ((uint64_t)&(((mailboxes_t*)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -4,6 +4,7 @@
 
 #define COMPILE_FOR_IDLE_ERISC
 
+#include <dev_msgs.h>
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -11,14 +12,12 @@
 
 #include "core_config.h"
 #include "dev_mem_map.h"
-#include <dev_msgs.h>
-#include "noc/noc_parameters.h"
-
-#include "llrt/hal.hpp"
 #include "hal_asserts.hpp"
+#include "hal_types.hpp"
+#include "llrt/hal.hpp"
+#include "noc/noc_parameters.h"
+#include "umd/device/tt_core_coordinates.h"
 #include "wormhole/wh_hal.hpp"
-
-#include "umd/device/tt_soc_descriptor.h"  // CoreType
 
 #define GET_IERISC_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t)&(((mailboxes_t*)MEM_IERISC_MAILBOX_BASE)->x))
 

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -2,22 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <dev_msgs.h>
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
-#include <numeric>
+#include <cstdlib>
+#include <string>
 #include <vector>
 
+#include "assert.hpp"
 #include "core_config.h"
 #include "dev_mem_map.h"
-#include <dev_msgs.h>
-#include "noc/noc_parameters.h"
-
+#include "hal_types.hpp"
 #include "llrt/hal.hpp"
-#include "hal_asserts.hpp"
+#include "noc/noc_parameters.h"
+#include "umd/device/tt_core_coordinates.h"
 #include "wormhole/wh_hal.hpp"
-
-#include "umd/device/tt_soc_descriptor.h"  // CoreType
 
 #define GET_MAILBOX_ADDRESS_HOST(x) ((std::uint64_t)&(((mailboxes_t*)MEM_MAILBOX_BASE)->x))
 

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -2,9 +2,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
+#include <stdint.h>
+#include <stdio.h>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -2,8 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
+#include <stdio.h>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device_impl.hpp>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/device.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -2,16 +2,39 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
+#include <stdlib.h>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
+#include <map>
 #include <memory>
 #include <random>
+#include <string>
 #include <string_view>
+#include <utility>
+#include <variant>
 #include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -2,8 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "span.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/mesh_config.hpp"
+#include "tt-metalium/mesh_device.hpp"
 
 // Stand-alone example demonstrating usage of native multi-device TT-Metalium APIs
 // for issuing a program dispatch across a mesh of devices.

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -2,8 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <assert.h>
+#include <stdint.h>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "tt-metalium/bfloat16.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/mesh_config.hpp"
+#include "tt-metalium/mesh_coord.hpp"
+#include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/shape2d.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "tt-metalium/util.hpp"
 
 // Stand-alone example demonstrating usage of native multi-device TT-Metalium APIs
 // for issuing Read and Write commands to a distributed memory buffer spanning

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -2,10 +2,38 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <functional>
-
-#include <tt-metalium/distributed.hpp>
+#include <stdint.h>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/mesh_buffer.hpp"
+#include "tt-metalium/mesh_config.hpp"
+#include "tt-metalium/mesh_coord.hpp"
+#include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/shape2d.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "tt-metalium/util.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -2,10 +2,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/sub_device.hpp>
+#include <array>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/dispatch_core_common.hpp"
+#include "tt-metalium/hal_types.hpp"
+#include "tt-metalium/host_api.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/mesh_buffer.hpp"
+#include "tt-metalium/mesh_config.hpp"
+#include "tt-metalium/mesh_device.hpp"
+#include "tt-metalium/mesh_event.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/shape2d.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "tt-metalium/utils.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -2,16 +2,42 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <algorithm>
-#include <functional>
-#include <random>
-
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
-
-#include <tt-metalium/bfloat16.hpp>
-
 #include <magic_enum/magic_enum.hpp>
+#include <stdint.h>
+#include <stdlib.h>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <array>
+#include <chrono>
+#include <exception>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -2,9 +2,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
+#include <stdint.h>
+#include <stdlib.h>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <chrono>
+#include <cmath>
+#include <exception>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
@@ -2,9 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
+#include <stdint.h>
+#include <stdio.h>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <map>
+#include <variant>
+#include <vector>
+
+#include "span.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/core_coord.hpp"
 #include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -2,8 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
+#include <stdio.h>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <map>
+#include <variant>
+#include <vector>
+
+#include "span.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 int main(int argc, char** argv) {
     using namespace tt;

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -2,8 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
+#include <stdint.h>
+#include <stdio.h>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -2,9 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device.hpp>
+#include <stdint.h>
+#include <stdlib.h>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <chrono>
+#include <exception>
+#include <map>
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 /*
  * 1. Host writes data to buffer in DRAM

--- a/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
@@ -2,15 +2,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/util.hpp>
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/work_split.hpp>
 #include <matmul_common/bmm_op.hpp>
+#include <stdlib.h>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <cstdint>
+#include <exception>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt::constants;
 using namespace std;

--- a/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -2,15 +2,43 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/util.hpp>
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <matmul_common/bmm_op.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/util.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "tt-metalium/work_split.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt::constants;
 using namespace std;

--- a/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -2,16 +2,43 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/util.hpp>
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/device.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <matmul_common/bmm_op.hpp>
-#include <algorithm>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/util.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/common_values.hpp"
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt::constants;
 using namespace std;

--- a/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
@@ -2,14 +2,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/util.hpp>
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/tilize_utils.hpp>
-#include <tt-metalium/command_queue.hpp>
 #include <matmul_common/bmm_op.hpp>
-#include <tt-metalium/device_impl.hpp>
+#include <stdlib.h>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+#include <cstdint>
+#include <exception>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/base_types.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/device.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt::constants;
 using namespace std;

--- a/tt_metal/programming_examples/pad/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad/pad_multi_core.cpp
@@ -2,13 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/util.hpp>
+#include <stdint.h>
+#include <stdio.h>
 #include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -2,14 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <errno.h>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <cstdint>
+#include <cstring>
+#include <exception>
 #include <map>
 #include <string>
+#include <utility>
+#include <variant>
 #include <vector>
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
 
 using namespace tt;
 

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -2,14 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <map>
-#include <string>
-#include <vector>
-
+#include <errno.h>
+#include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <map>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
 
 using namespace tt;
 

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -2,14 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <errno.h>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <cstdint>
+#include <cstring>
+#include <exception>
 #include <map>
 #include <string>
+#include <utility>
+#include <variant>
 #include <vector>
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
 
 using namespace tt;
 

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -2,15 +2,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <map>
-#include <string>
-#include <vector>
-
+#include <errno.h>
+#include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+
 #include "hostdevcommon/profiler_common.h"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "umd/device/types/xy_pair.h"
 
 using namespace tt;
 

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -2,9 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <errno.h>
+#include <stdint.h>
+#include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
+#include <cstring>
+#include <exception>
+#include <map>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/profiler_common.h"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
 
 using namespace tt;
 

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -2,9 +2,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
+#include <stdint.h>
+#include <stdlib.h>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <exception>
+#include <map>
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include "span.hpp"
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt::tt_metal;
 

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -2,15 +2,30 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <map>
-#include <string>
-#include <vector>
-
+#include <errno.h>
+#include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
-#include "hostdevcommon/profiler_common.h"
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "tt-metalium/assert.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/logger.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "umd/device/types/xy_pair.h"
 
 using namespace tt;
 

--- a/tt_metal/programming_examples/sharding/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/sharding/shard_data_rm.cpp
@@ -2,14 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/util.hpp>
-#include <tt-metalium/bfloat16.hpp>
-#include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/device.hpp>
+#include <stdio.h>
 #include <tt-metalium/allocator.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_align.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -2,22 +2,44 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdlib.h>
 // this programing example is based on the vecadd single core example in the
 // contributed folder it illustarted using multiple cores to perform vector
 // addition the program will use 4 cores to perform the vector addition
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device_impl.hpp>
 #include <tt-metalium/work_split.hpp>
-
-#include <cstddef>
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <iostream>
+#include <map>
 #include <memory>
 #include <random>
+#include <string>
 #include <string_view>
+#include <utility>
+#include <variant>
 #include <vector>
-#include <algorithm>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/data_types.hpp"
+#include "tt-metalium/device.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -7,18 +7,43 @@
 // then perform vector addition tile by tile. Because of sharding to L1, DRAM is not involved.
 // Data copy is avoided and reader and writer kernels are not needed.
 
+#include <stdlib.h>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/device_impl.hpp>
 #include <tt-metalium/tt_metal.hpp>
-
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <iostream>
+#include <map>
 #include <memory>
 #include <random>
+#include <set>
+#include <string>
 #include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <variant>
 #include <vector>
+
+#include "hostdevcommon/kernel_structs.h"
+#include "span.hpp"
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/buffer_constants.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/device.hpp"
+#include "tt-metalium/kernel_types.hpp"
+#include "tt-metalium/program_impl.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class CommandQueue;
+}  // namespace tt_metal
+}  // namespace tt
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/tools/lightmetal_runner/lightmetal_runner.cpp
+++ b/tt_metal/tools/lightmetal_runner/lightmetal_runner.cpp
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt-metalium/logger.hpp>
 #include <tt-metalium/assert.hpp>
-#include <tt-metalium/lightmetal_replay.hpp>
 #include <tt-metalium/lightmetal_binary.hpp>
+#include <tt-metalium/lightmetal_replay.hpp>
+#include <tt-metalium/logger.hpp>
+#include <string>
+#include <utility>
 
 using namespace tt;
 

--- a/tt_metal/tools/mem_bench/device_utils.cpp
+++ b/tt_metal/tools/mem_bench/device_utils.cpp
@@ -4,8 +4,23 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include "device_utils.hpp"
+#include <map>
+#include <string>
+#include <string_view>
+#include <variant>
+
 #include "context.hpp"
+#include "core_coord.hpp"
+#include "data_types.hpp"
+#include "device.hpp"
+#include "device_utils.hpp"
+#include "kernel_types.hpp"
+
+namespace tt {
+namespace tt_metal {
+class Program;
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::tools::mem_bench {
 

--- a/tt_metal/tools/mem_bench/device_utils.hpp
+++ b/tt_metal/tools/mem_bench/device_utils.hpp
@@ -4,10 +4,25 @@
 
 #pragma once
 
-#include <vector>
-#include <tt-metalium/device.hpp>
+#include <stdint.h>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <optional>
+#include <vector>
+
 #include "context.hpp"
+
+namespace tt {
+namespace tt_metal {
+class IDevice;
+class Program;
+namespace tools {
+namespace mem_bench {
+struct Context;
+}  // namespace mem_bench
+}  // namespace tools
+}  // namespace tt_metal
+}  // namespace tt
 
 namespace tt::tt_metal::tools::mem_bench {
 

--- a/tt_metal/tools/mem_bench/host_utils.cpp
+++ b/tt_metal/tools/mem_bench/host_utils.cpp
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "host_utils.hpp"
+
+#include <tt_cluster.hpp>
+#include <algorithm>
+#include <chrono>
 #include <limits>
 #include <random>
-#include <chrono>
-#include <algorithm>
-#include <numa.h>
-#include <tt_cluster.hpp>
+#include <unordered_set>
 
 namespace tt::tt_metal::tools::mem_bench {
 

--- a/tt_metal/tools/mem_bench/host_utils.hpp
+++ b/tt_metal/tools/mem_bench/host_utils.hpp
@@ -4,11 +4,14 @@
 
 #pragma once
 
+#include <tt-metalium/tt_align.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <span>
 #include <vector>
+
 #include "dispatch/memcpy.hpp"
-#include <tt-metalium/tt_align.hpp>
+#include "vector_aligned.hpp"
 
 namespace tt::tt_metal::tools::mem_bench {
 

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -2,22 +2,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <numeric>
-
 #include <benchmark/benchmark.h>
-
-#include <tt_cluster.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/hal.hpp>
-#include <tt-metalium/tt_metal.hpp>
+#include <stdint.h>
+#include <stdlib.h>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt_cluster.hpp>
+#include <iostream>
+#include <map>
+#include <numeric>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
 
 #include "assert.hpp"
 #include "context.hpp"
-#include "host_utils.hpp"
+#include "device.hpp"
 #include "device_utils.hpp"
-#include "work_thread.hpp"
+#include "host_utils.hpp"
+#include "program_impl.hpp"
+#include "system_memory_manager.hpp"
 #include "tt_metal/impl/dispatch/util/size_literals.hpp"
+#include "vector_aligned.hpp"
+#include "work_thread.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -2,11 +2,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "llrt.hpp"
+#include <stdint.h>
 #include <tt_cluster.hpp>
 #include <tt_stl/span.hpp>
-
 #include <unistd.h>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "assert.hpp"
+#include "fmt/base.h"
+#include "llrt.hpp"
+#include "logger.hpp"
+#include "metal_soc_descriptor.h"
+#include "umd/device/tt_core_coordinates.h"
+#include "utils.hpp"
 
 void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory vector to L1 for all cores at a specific start address.

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -1,13 +1,20 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include <iostream>
-#include <filesystem>
 #include <host_api.hpp>
-#include "impl/debug/watcher_server.hpp"
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "device.hpp"
+#include "dispatch_core_common.hpp"
 #include "impl/debug/noc_logging.hpp"
+#include "impl/debug/watcher_server.hpp"
 #include "impl/dispatch/debug_tools.hpp"
 #include "rtoptions.hpp"
+#include "system_memory_manager.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -2,39 +2,65 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tt_metal.hpp>
-
-#include <algorithm>
-#include <optional>
-
-#include <dev_msgs.h>
-#include "llrt/hal.hpp"
 #include <allocator.hpp>
-#include "dprint_server.hpp"
-#include <command_queue.hpp>
-#include <profiler.hpp>
-
-#include <host_api.hpp>
+#include <circular_buffer.hpp>
 #include <circular_buffer_constants.h>
-#include <trace.hpp>
+#include <dev_msgs.h>
 #include <device_impl.hpp>
 #include <device_pool.hpp>
-#include <kernel.hpp>
-#include <circular_buffer.hpp>
+#include <global_circular_buffer.hpp>
 #include <global_circular_buffer_impl.hpp>
 #include <global_semaphore.hpp>
+#include <host_api.hpp>
+#include <kernel.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <sub_device_types.hpp>
-#include <global_circular_buffer.hpp>
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-#include "tracy/Tracy.hpp"
+#include <trace.hpp>
+#include <tt_metal.hpp>
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <optional>
+#include <string_view>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
 
-#include <graph_tracking.hpp>
+#include "buffer_constants.hpp"
+#include "circular_buffer_types.hpp"
+#include "data_types.hpp"
+#include "device.hpp"
+#include "dispatch/dispatch_core_manager.hpp"
+#include "dispatch_settings.hpp"
+#include "hal_types.hpp"
+#include "kernel_types.hpp"
 #include "lightmetal/host_api_capture_helpers.hpp"
-
+#include "lightmetal/lightmetal_capture.hpp"
+#include "lightmetal_binary.hpp"
 #include "llrt.hpp"
+#include "llrt/hal.hpp"
+#include "logger.hpp"
+#include "program_impl.hpp"
+#include "semaphore.hpp"
+#include "system_memory_manager.hpp"
+#include "tracy/Tracy.hpp"
+#include "tt_cluster.hpp"
+#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "umd/device/tt_xy_pair.h"
+#include "umd/device/types/xy_pair.h"
+#include "utils.hpp"
+
 namespace tt {
 
 namespace tt_metal {
+enum class FabricConfig : uint32_t;
+struct RuntimeArgsData;
+struct TraceDescriptor;
 
 namespace {
 


### PR DESCRIPTION
### Problem description
Code base heavily relies on transitive includes which makes things brittle, and hard to refactor.

### What's changed
Include what you use.
Header files processed in safe mode, where nothing is removed.
CPP files have unnecessary includes removed, and missing includes added.
The tool was permitted to reorder things in this run. 

### Invocation
```bash
$ iwyu_tool.py -p build -j 96 -- -Xiwyu --mapping_file=$(pwd)/libcxx.imp -Xiwyu --experimental=clang_mappings > iwyu.out 2>&1
$ fix_includes.py --nocomments --reorder < iwyu.out
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14161556522) CI passes
- [x] New/Existing tests provide coverage for changes