### PR TITLE
EXTERNAL PR: Set cmake to look for venv first and add option to specify python path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,6 @@ if(WITH_PYTHON_BINDINGS)
             Development
     )
     message(STATUS "Python3 include dirs: ${Python3_INCLUDE_DIRS}")
-    message(STATUS "Python3 executable: ${Python3_EXECUTABLE}")
 endif()
 
 find_library(NUMA_LIBRARY NAMES numa)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,10 +158,6 @@ if(WITH_PYTHON_BINDINGS)
     set(Python3_FIND_STRATEGY LOCATION)
     set(Python3_FIND_VIRTUALENV FIRST)
 
-    if(DEFINED Python_EXECUTABLE)
-        set(Python3_EXECUTABLE ${Python_EXECUTABLE})
-    endif()
-
     find_package(
         Python3
         COMPONENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,12 @@ endif()
 
 if(WITH_PYTHON_BINDINGS)
     set(Python3_FIND_STRATEGY LOCATION)
+    set(Python3_FIND_VIRTUALENV FIRST)
+
+    if(DEFINED Python_EXECUTABLE)
+        set(Python3_EXECUTABLE ${Python_EXECUTABLE})
+    endif()
+
     find_package(
         Python3
         COMPONENTS
@@ -163,6 +169,7 @@ if(WITH_PYTHON_BINDINGS)
             Development
     )
     message(STATUS "Python3 include dirs: ${Python3_INCLUDE_DIRS}")
+    message(STATUS "Python3 executable: ${Python3_EXECUTABLE}")
 endif()
 
 find_library(NUMA_LIBRARY NAMES numa)

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -40,7 +40,6 @@ show_help() {
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --enable-coverage                Instrument the binaries for code coverage."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
-    echo "  --python-executable              Specify the Python3 binary path to use during build."
 }
 
 clean() {
@@ -82,7 +81,6 @@ toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
 configure_only="OFF"
 enable_coverage="OFF"
 with_python_bindings="ON"
-PYTHON3_EXECUTABLE=""
 
 declare -a cmake_args
 
@@ -123,7 +121,6 @@ toolchain-path:
 configure-only
 enable-coverage
 without-python-bindings
-python-executable:
 "
 
 # Flatten LONGOPTIONS into a comma-separated string for getopt
@@ -189,8 +186,6 @@ while true; do
             configure_only="ON";;
         --without-python-bindings)
             with_python_bindings="OFF";;
-        --python-executable)
-            PYTHON3_EXECUTABLE="$2";shift;;
         --disable-unity-builds)
 	    unity_builds="OFF";;
         --disable-light-metal-trace)
@@ -271,7 +266,6 @@ echo "INFO: Enable Unity builds: $unity_builds"
 echo "INFO: TTNN Shared sub libs : $ttnn_shared_sub_libs"
 echo "INFO: Enable Light Metal Trace: $light_metal_trace"
 echo "INFO: With python bindings: $with_python_bindings"
-echo "INFO: Python Executable: $PYTHON_EXECUTABLE"
 
 # Prepare cmake arguments
 cmake_args+=("-B" "$build_dir")
@@ -399,10 +393,6 @@ if [ "$with_python_bindings" = "ON" ]; then
     cmake_args+=("-DWITH_PYTHON_BINDINGS=ON")
 else
     cmake_args+=("-DWITH_PYTHON_BINDINGS=OFF")
-fi
-
-if [ "$PYTHON3_EXECUTABLE" != "" ]; then
-    cmake_args+=("-DPython3_EXECUTABLE=$PYTHON3_EXECUTABLE")
 fi
 
 # toolchain and cxx_compiler settings would conflict with eachother

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -40,6 +40,7 @@ show_help() {
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --enable-coverage                Instrument the binaries for code coverage."
     echo "  --without-python-bindings        Disable Python bindings (ttnncpp will be available as standalone library, otherwise ttnn will include the cpp backend and the python bindings), Enabled by default"
+    echo "  --python-executable              Specify the Python3 binary path to use during build."
 }
 
 clean() {
@@ -81,6 +82,7 @@ toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
 configure_only="OFF"
 enable_coverage="OFF"
 with_python_bindings="ON"
+PYTHON3_EXECUTABLE=""
 
 declare -a cmake_args
 
@@ -121,6 +123,7 @@ toolchain-path:
 configure-only
 enable-coverage
 without-python-bindings
+python-executable:
 "
 
 # Flatten LONGOPTIONS into a comma-separated string for getopt
@@ -186,6 +189,8 @@ while true; do
             configure_only="ON";;
         --without-python-bindings)
             with_python_bindings="OFF";;
+        --python-executable)
+            PYTHON3_EXECUTABLE="$2";shift;;
         --disable-unity-builds)
 	    unity_builds="OFF";;
         --disable-light-metal-trace)
@@ -266,6 +271,7 @@ echo "INFO: Enable Unity builds: $unity_builds"
 echo "INFO: TTNN Shared sub libs : $ttnn_shared_sub_libs"
 echo "INFO: Enable Light Metal Trace: $light_metal_trace"
 echo "INFO: With python bindings: $with_python_bindings"
+echo "INFO: Python Executable: $PYTHON_EXECUTABLE"
 
 # Prepare cmake arguments
 cmake_args+=("-B" "$build_dir")
@@ -393,6 +399,10 @@ if [ "$with_python_bindings" = "ON" ]; then
     cmake_args+=("-DWITH_PYTHON_BINDINGS=ON")
 else
     cmake_args+=("-DWITH_PYTHON_BINDINGS=OFF")
+fi
+
+if [ "$PYTHON3_EXECUTABLE" != "" ]; then
+    cmake_args+=("-DPython3_EXECUTABLE=$PYTHON3_EXECUTABLE")
 fi
 
 # toolchain and cxx_compiler settings would conflict with eachother


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19893

### Problem description
- cmake doesn't look for python in virtual environment by default

### What's changed
- Add option to specify python path
- cmake now looks for virtual environment first if no python exec path is specified

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes