### PR TITLE
Fix tt-forge conv1d cases

### DIFF
--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
@@ -1650,5 +1650,4 @@ def test_conv2d_localrun_conv1d(device, input_spec):
 
 failing_parameters_conv1d = [
     # [batch_size, output_channels, input_channels, input_length, kernel_size, stride, pad, groups, dilation, bias]
-    [1, 768, 768, 3000, 3, 2, 1, 1, 1, True],
 ]

--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_ttforge_sweep.py
@@ -480,6 +480,9 @@ parameters = {
             [1, 64, 64, 112, 112, 3, 3, 16, 16, 0, 0, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
             [1, 16, 3, 640, 640, 6, 6, 2, 2, 2, 2, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
             [1, 32, 3, 1280, 1280, 6, 6, 2, 2, 2, 2, 1, 1, 1, False, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
+            [1, 768, 768, 3000, 1, 3, 1, 2, 1, 1, 0, 1, 1, 1, True, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
+            [1, 3072, 768, 8, 1, 1, 1, 1, 1, 0, 0, 4, 1, 1, True, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
+            [1, 3072, 3072, 6, 1, 4, 1, 1, 1, 3, 0, 3072, 1, 1, True, [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], [int(ttnn.ROW_MAJOR_LAYOUT), "system_memory", int(ttnn.bfloat16)], [int(ttnn.TILE_LAYOUT), "dram", int(ttnn.bfloat16)], ],
         ],
         "is_conv1d": [False], },
     }

--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -6,18 +6,8 @@ from loguru import logger
 
 import torch
 import pytest
-from models.utility_functions import (
-    is_wormhole_b0,
-    skip_for_grayskull,
-    is_grayskull,
-    is_wormhole_b0,
-    is_x2_harvested,
-)
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc, check_with_pcc_without_tensor_printout
 import ttnn
-import math
-import os
-import torch.nn as nn
 
 
 def run_conv(
@@ -152,7 +142,6 @@ def run_conv(
     assert passing
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_length, kernel_size, stride, padding, groups, use_1d_systolic_array, config_override, use_shallow_conv_variant",
@@ -231,7 +220,6 @@ def test_conv1d_mamba(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_length, kernel_size, stride, padding, groups, use_1d_systolic_array, config_override, use_shallow_conv_variant",
@@ -306,7 +294,6 @@ def test_conv1d(
     )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_length, kernel_size, stride, padding, groups, shard_layout, config_override, use_shallow_conv_variant",

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -38,7 +38,13 @@ bool use_matmul_for_1x1_conv(
 bool is_1d_conv(uint32_t kernel_width, uint32_t image_width);
 
 bool is_1d_deptwise_conv(
-    uint32_t groups, uint32_t input_channels, uint32_t output_channels, uint32_t kernel_width, uint32_t image_width);
+    uint32_t groups,
+    uint32_t input_channels,
+    uint32_t output_channels,
+    uint32_t kernel_width,
+    uint32_t image_width,
+    bool has_bias);
+
 sliding_window::ParallelConfig determine_parallel_config(
     const TensorMemoryLayout shard_layout,
     uint32_t batch_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -271,7 +271,7 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
     auto& output_tensor = output_tensors.at(0);
     tt::tt_metal::IDevice* device = input_tensor_a.device();
 
-    const auto has_bias = input_tensor_bias.has_value();
+    const bool has_bias = input_tensor_bias.has_value();
 
     const auto weights_shape = input_tensor_b.get_padded_shape();
 
@@ -329,7 +329,8 @@ operation::ProgramWithCallbacks OptimizedConvNew::create_program(
             input_tensor_shape[3],
             output_channels,
             kernel_dims[1],
-            sliding_window_config.get_output_shape()[2]));
+            sliding_window_config.get_output_shape()[2],
+            has_bias));
 
     TT_FATAL(
         actual_cb_size == l1_usage.CB_allocation_size,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -596,7 +596,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     uint32_t input_channels = ashape[3];
     bool is_conv1d = is_1d_conv(filter_w, input_width);
     bool is_conv_1d_depthwise_conv =
-        is_1d_deptwise_conv(groups, input_channels, output_channels, filter_w, input_width);
+        is_1d_deptwise_conv(groups, input_channels, output_channels, filter_w, input_width, has_bias);
 
     if (has_bias) {
         if (is_conv_1d_depthwise_conv) {
@@ -1217,7 +1217,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_col_major_out_blocks.cpp";
     // Input should always be sharded in this conv; always use reader kernel for input shard with halo and padding
     if (filter_h >= 1 and filter_w >= 1) {
-        if (!is_conv1d and weight_width_sliced) {
+        if (!is_conv_1d_depthwise_conv and weight_width_sliced) {
             // Block sharded conv
             TT_FATAL(read_window_in_inner_loop == true, "read_window_in_inner_loop should be true for this conv");
             reader_kernel =


### PR DESCRIPTION
* Allow conv1d to use width and block sharding
* Add auto-shard support for these cases
* Skip conv1d deptwise code path in case conv has bias, as conv1d deptwise doesn't have bias
support ATM.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14169195836) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14169208808) CI passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14169202954) CI passes
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/14171444944)