### PR TITLE
Fix bilinear multicore upsampling setting too large buffers on tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -145,12 +145,11 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     using tt::tt_metal::CircularBufferConfig;
 
     uint32_t next_cb_index = CBIndex::c_0;
-    uint32_t buffering_factor = 2;
 
     // input data is in a sharded CB
     uint32_t aligned_input_stick_nbytes = round_up_to_mul32(input_stick_nbytes);
     uint32_t in_cb_pagesize = aligned_input_stick_nbytes;
-    uint32_t in_cb_npages = halo_shard_shape[0] * buffering_factor;
+    uint32_t in_cb_npages = halo_shard_shape[0];
 
     auto [in_cb_id, cb_src0] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, in_cb_pagesize, in_cb_npages, input_cb_data_format, halo_in.buffer());
@@ -162,7 +161,7 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         program,
         all_cores,
         in_cb_pagesize,
-        4 * buffering_factor,
+        4,
         input_cb_data_format);  // since 4 pixels per page are needed for intermediate tensor.
 
     // intermediate tensor CB
@@ -172,12 +171,12 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         program,
         all_cores,
         in_cb_pagesize,
-        4 * buffering_factor,
+        4,
         input_cb_data_format);  // since 4 pixels per page are needed for intermediate tensor.
 
     // scaler CB
     uint32_t in_scalar_cb_pagesize = tile_size(input_cb_data_format);
-    uint32_t in_scalar_cb_npages = 1 * buffering_factor;
+    uint32_t in_scalar_cb_npages = 1;
 
     uint32_t in_scalar_cb_id1 = next_cb_index++;
     tt::tt_metal::create_cb(
@@ -189,7 +188,7 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
 
     // output sharded CB with upsampled data
     uint32_t out_cb_pagesize = round_up_to_mul32(output_stick_nbytes);  // aligned output stick n bytes
-    uint32_t out_cb_npages = output_nsticks_per_core * buffering_factor;
+    uint32_t out_cb_npages = output_nsticks_per_core;
     auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, output_cb_data_format, output.buffer());
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/18949)

### Problem description
Issue is caused by a buffering factor variable that multiplies the number of pages of all input, output and intermediate buffers used in the op. This buffering factor should only be applied to the intermediate buffers which do not have an associated tensor, as setting circular buffers on existing tensor buffers larger than their size is unsupported behaviour.

### What's changed
Stopped applying buffering factor variable that assigned more pages to circular buffers outside of tensor bounds in the upsample op.

Segformer is the only model currently using bilinear upsampling, and keeps the ~5% device perf improvement over no double buffering without throwing the assert after the fix.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] [Nightly tt-metal L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes (if applicable)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes 
- [x] New/Existing tests provide coverage for changes