### PR TITLE
Add workaround to get rid of nd segfault in reshard op.

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_decoder.py
+++ b/models/demos/llama3_subdevices/tt/llama_decoder.py
@@ -145,6 +145,7 @@ class TtTransformerBlock(LightweightModule):
         # Attention takes replicated inputs and produces fractured outputs
         # pad attn input
         if mode == "decode":
+            attn_in = ttnn.to_memory_config(attn_in, ttnn.DRAM_MEMORY_CONFIG)
             attn_in_sharded = ttnn.to_memory_config(attn_in, self.model_config["SHARDED_ATTN_INPUT_RING_MEMCFG"])
             attn_in.deallocate(True)
         else:
@@ -173,6 +174,7 @@ class TtTransformerBlock(LightweightModule):
 
         # MLP takes replicated inputs and produces fractured outputs
         if mode == "decode":
+            ff_in = ttnn.to_memory_config(ff_in, ttnn.DRAM_MEMORY_CONFIG)
             ff_in_sharded = ttnn.to_memory_config(ff_in, self.model_config["SHARDED_FF12_RING_MEMCFG"])
             ff_in.deallocate(True)
         else:

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -120,7 +120,7 @@ class TtLlamaMLP(LightweightModule):
             w1_out,
             cluster_axis=1,
             num_links=3,
-            memory_config=self.model_config["MUL_IN_MEMCFG"],
+            memory_config=self.model_config["FF2_IN_RING_MEMCFG"],
         )
 
         w3_out = ttnn.linear(
@@ -141,7 +141,7 @@ class TtLlamaMLP(LightweightModule):
                 w3_out,
                 cluster_axis=1,
                 num_links=3,
-                memory_config=self.model_config["MUL_IN_MEMCFG"],
+                memory_config=self.model_config["FF2_IN_RING_MEMCFG"],
             )
         except Exception as e:
             print(e)
@@ -152,10 +152,10 @@ class TtLlamaMLP(LightweightModule):
             w3_out_reduced,
             input_tensor_a_activation=ttnn.UnaryOpType.SILU,
             dtype=ttnn.bfloat16,
-            memory_config=self.model_config["MUL_IN_MEMCFG"],
+            memory_config=self.model_config["FF2_IN_RING_MEMCFG"],
         )
 
-        w2_in = ttnn.to_memory_config(w2_in, self.model_config["FF2_IN_RING_MEMCFG"])
+        # w2_in = ttnn.to_memory_config(w2_in, self.model_config["FF2_IN_RING_MEMCFG"])
 
         # print("eltwise mul", w2_in)
 


### PR DESCRIPTION
### Ticket
- #19913

### Problem description
There are ND segfaults in the llama TG model, coming from `ttnn.reshard`. Please see issue above for more information.

### What's changed
Add workarounds for the following reshards:
- Reshard after layernorm 1
  - Add S2I and I2S calls
- Reshard after layernorm 2
  - same as above
- Remove reshard after binary mul in MLP
  - Just output All reduce on 24 cores, so no reshard necessary

#### Consequences on Performance per layer

- For each layernorm, and extra S2I call is added
  - **Total: 2 x (3.3us kernel + 2.2 us op2op) = ~11 us** 
  - Better workaround: use the fused layernorm + reshard
- All reduce goes back to 24 cores, so decreases packet efficiency
  - **2 x 3us = 6us** (19 us before -> 22 us after)
  - Better workaround: Start using the Reduce Scatter scheme


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14174617678) CI passes
- [ ] [TG Pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/14174652557) passes