### PR TITLE
#0: Add more data to dispatch profiles

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -214,7 +214,7 @@ def test_dispatch_cores():
     RISC_COUNT = 1
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
-        "Tensix CQ Dispatch": [16, 1501],
+        "Tensix CQ Dispatch": [16, 1404],
         "Tensix CQ Prefetch": [25, 1990],
     }
 
@@ -267,7 +267,7 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [17, 1567],
+        "Ethernet CQ Dispatch": [17, 1480],
         "Ethernet CQ Prefetch": [18, 1951],
     }
     devicesData = run_device_profiler_test(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_device_command.cpp
@@ -193,7 +193,7 @@ TYPED_TEST(WritePackedCommandTest, AddDispatchWritePacked) {
         std::vector<TypeParam> sub_cmds(2);
         uint32_t data[1] = {};
         std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}, {data, 4}};
-        command.add_dispatch_write_packed<TypeParam>(2, 0, 5, 0, sub_cmds, data_collection, 100, 0, false);
+        command.add_dispatch_write_packed<TypeParam>(0, 2, 0, 5, 0, sub_cmds, data_collection, 100, 0, false);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
@@ -204,7 +204,7 @@ TYPED_TEST(WritePackedCommandTest, AddDispatchWritePacked) {
         std::vector<TypeParam> sub_cmds(2);
         uint32_t data[1] = {};
         std::vector<std::pair<const void*, uint32_t>> data_collection{{data, 4}};
-        command.add_dispatch_write_packed<TypeParam>(2, 0, 5, 0, sub_cmds, data_collection, 100, 0, true);
+        command.add_dispatch_write_packed<TypeParam>(0, 2, 0, 5, 0, sub_cmds, data_collection, 100, 0, true);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
 }
@@ -216,7 +216,7 @@ TEST(DeviceCommandTest, AddDispatchWritePackedLarge) {
 
         HostMemDeviceCommand command(calculator.write_offset_bytes());
         std::vector<CQDispatchWritePackedLargeSubCmd> sub_cmds(1);
-        command.add_dispatch_write_packed_large(0, 1, sub_cmds);
+        command.add_dispatch_write_packed_large(CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_UNKNOWN, 0, 1, sub_cmds);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
     {
@@ -228,7 +228,8 @@ TEST(DeviceCommandTest, AddDispatchWritePackedLarge) {
 
         uint8_t data[4] = {};
         std::vector<tt::stl::Span<const uint8_t>> data_collection{{data, 4}};
-        command.add_dispatch_write_packed_large(0, 1, sub_cmds, data_collection, nullptr);
+        command.add_dispatch_write_packed_large(
+            CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_UNKNOWN, 0, 1, sub_cmds, data_collection, nullptr);
         EXPECT_EQ(command.size_bytes(), command.write_offset_bytes());
     }
 }
@@ -264,6 +265,7 @@ TYPED_TEST(WritePackedCommandTest, RandomAddDispatchWritePacked) {
         for (const auto& [sub_cmd_ct, payload_size] : packed_cmd_payloads) {
             std::vector<TypeParam> sub_cmds(sub_cmd_ct);
             command.add_dispatch_write_packed<TypeParam>(
+                0,
                 sub_cmd_ct,
                 0,
                 sub_cmd_sizeB,

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -597,6 +597,7 @@ void DeviceCommand<hugepage_write>::add_data(
 template <bool hugepage_write>
 template <typename PackedSubCmd>
 void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
+    uint8_t type,
     uint16_t num_sub_cmds,
     uint32_t common_addr,
     uint16_t packed_data_sizeB,
@@ -623,13 +624,15 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
         max_num_packed_sub_cmds,
         num_sub_cmds);
 
+    TT_ASSERT((type & ~CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_MASK) == 0, "Invalid type {}", type);
+
     constexpr bool flush_prefetch = true;
     this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
 
     auto initialize_write_packed_cmd = [&](CQDispatchCmd* write_packed_cmd) {
         write_packed_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_PACKED;
         write_packed_cmd->write_packed.flags =
-            (multicast ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE) |
+            type | (multicast ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE) |
             (no_stride ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE);
         write_packed_cmd->write_packed.count = num_sub_cmds;
         write_packed_cmd->write_packed.write_offset_index = write_offset_index;
@@ -671,6 +674,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
 template <bool hugepage_write>
 template <typename PackedSubCmd>
 void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
+    uint8_t type,
     uint16_t num_sub_cmds,
     uint32_t common_addr,
     uint16_t packed_data_sizeB,
@@ -696,6 +700,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
         "Max number of packed sub commands are {} but requesting {}",
         max_num_packed_sub_cmds,
         num_sub_cmds);
+    TT_ASSERT((type & ~CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_MASK) == 0, "Invalid type {}", type);
 
     constexpr bool flush_prefetch = true;
     this->add_prefetch_relay_inline(flush_prefetch, payload_sizeB);
@@ -703,7 +708,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
     auto initialize_write_packed_cmd = [&](CQDispatchCmd* write_packed_cmd) {
         write_packed_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_PACKED;
         write_packed_cmd->write_packed.flags =
-            (multicast ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE) |
+            type | (multicast ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE) |
             (no_stride ? CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE : CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE);
         write_packed_cmd->write_packed.count = num_sub_cmds;
         write_packed_cmd->write_packed.write_offset_index = write_offset_index;
@@ -747,6 +752,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed(
 // Add write packed large, with no data.
 template <bool hugepage_write>
 void DeviceCommand<hugepage_write>::add_dispatch_write_packed_large(
+    uint8_t type,
     uint16_t alignment,
     uint16_t num_sub_cmds,
     const std::vector<CQDispatchWritePackedLargeSubCmd>& sub_cmds,
@@ -756,13 +762,14 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed_large(
     uint32_t sub_cmds_sizeB = num_sub_cmds * sizeof(CQDispatchWritePackedLargeSubCmd);
     uint32_t payload_size = tt::align(sizeof(CQDispatchCmd) + sub_cmds_sizeB, this->l1_alignment);
     this->add_dispatch_write_packed_large_internal(
-        flush_prefetch, alignment, payload_size, num_sub_cmds, sub_cmds, offset_idx, write_offset_index);
+        type, flush_prefetch, alignment, payload_size, num_sub_cmds, sub_cmds, offset_idx, write_offset_index);
     this->cmd_write_offsetB = tt::align(this->cmd_write_offsetB, this->pcie_alignment);
 }
 
 // Add write packed large, with data inlined.
 template <bool hugepage_write>
 void DeviceCommand<hugepage_write>::add_dispatch_write_packed_large(
+    uint8_t type,
     uint16_t alignment,
     uint16_t num_sub_cmds,
     const std::vector<CQDispatchWritePackedLargeSubCmd>& sub_cmds,
@@ -781,7 +788,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed_large(
         tt::align(sizeof(CQDispatchCmd) + sub_cmds_sizeB, this->l1_alignment) + data_collection_size,
         this->l1_alignment);
     this->add_dispatch_write_packed_large_internal(
-        flush_prefetch, alignment, payload_size, num_sub_cmds, sub_cmds, offset_idx, write_offset_index);
+        type, flush_prefetch, alignment, payload_size, num_sub_cmds, sub_cmds, offset_idx, write_offset_index);
 
     if (data_collection_buffer_ptr != nullptr) {
         data_collection_buffer_ptr->resize(data_collection.size());
@@ -829,6 +836,7 @@ void DeviceCommand<hugepage_write>::add_prefetch_relay_inline(
 // Write packed large cmd and subcmds, but not data.
 template <bool hugepage_write>
 void DeviceCommand<hugepage_write>::add_dispatch_write_packed_large_internal(
+    uint8_t type,
     bool flush_prefetch,
     uint16_t alignment,
     uint32_t payload_sizeB,
@@ -846,6 +854,7 @@ void DeviceCommand<hugepage_write>::add_dispatch_write_packed_large_internal(
 
     auto initialize_write_packed_large_cmd = [&](CQDispatchCmd* write_packed_large_cmd) {
         write_packed_large_cmd->base.cmd_id = CQ_DISPATCH_CMD_WRITE_PACKED_LARGE;
+        write_packed_large_cmd->write_packed_large.type = type;
         write_packed_large_cmd->write_packed_large.count = num_sub_cmds;
         write_packed_large_cmd->write_packed_large.alignment = alignment;
         write_packed_large_cmd->write_packed_large.write_offset_index = write_offset_index;
@@ -901,15 +910,15 @@ template class DeviceCommand<false>;
 
 template DeviceCommand<false>::DeviceCommand(uint32_t);
 
-template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
-template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::pair<const void*, uint32_t>>&, uint32_t, const uint32_t, const bool, uint32_t);
 
-template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
-template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
-template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<true>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedUnicastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
+template void DeviceCommand<false>::add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(uint8_t, uint16_t, uint32_t, uint16_t, uint32_t, const std::vector<CQDispatchWritePackedMulticastSubCmd>&, const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>&, uint32_t, const uint32_t, const bool, uint32_t);
 
 template void DeviceCommand<true>::add_dispatch_write_host<false>(bool, uint32_t, bool, const void*);
 template void DeviceCommand<true>::add_dispatch_write_host<true>(bool, uint32_t, bool, const void*);

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -120,6 +120,7 @@ public:
 
     template <typename PackedSubCmd>
     void add_dispatch_write_packed(
+        uint8_t type,
         uint16_t num_sub_cmds,
         uint32_t common_addr,
         uint16_t packed_data_sizeB,
@@ -135,6 +136,7 @@ public:
     //  0:address, 1:size, 2:stride
     template <typename PackedSubCmd>
     void add_dispatch_write_packed(
+        uint8_t type,
         uint16_t num_sub_cmds,
         uint32_t common_addr,
         uint16_t packed_data_sizeB,
@@ -148,6 +150,7 @@ public:
 
     // Add write packed large, with no data.
     void add_dispatch_write_packed_large(
+        uint8_t type,
         uint16_t alignment,
         uint16_t num_sub_cmds,
         const std::vector<CQDispatchWritePackedLargeSubCmd>& sub_cmds,
@@ -156,6 +159,7 @@ public:
 
     // Add write packed large, with data inlined.
     void add_dispatch_write_packed_large(
+        uint8_t type,
         uint16_t alignment,
         uint16_t num_sub_cmds,
         const std::vector<CQDispatchWritePackedLargeSubCmd>& sub_cmds,
@@ -187,6 +191,7 @@ private:
 
     // Write packed large cmd and subcmds, but not data.
     void add_dispatch_write_packed_large_internal(
+        uint8_t type,
         bool flush_prefetch,
         uint16_t alignment,
         uint32_t payload_sizeB,

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -184,6 +184,15 @@ constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NONE = 0x00;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST = 0x01;
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_NO_STRIDE = 0x02;
 
+constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT = 4;
+enum CQDispatchCmdPackedWriteType {
+    CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_MASK = 0xf << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
+    CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_RTA = 0x1 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
+    CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_LAUNCH = 0x2 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
+    CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_SEMS = 0x3 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
+    CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_EVENT = 0x4 << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT,
+};
+
 struct CQDispatchWritePackedCmd {
     uint8_t flags;   // see above
     uint16_t count;  // number of sub-cmds (max 1020 unicast, 510 mcast). Max num sub-cmds =
@@ -224,11 +233,17 @@ get_packed_write_max_multicast_sub_cmds(uint32_t packed_write_max_unicast_sub_cm
 // Current implementation limit is based on size of the l1_cache which stores the sub_cmds
 constexpr uint32_t CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_MAX_SUB_CMDS = 35;
 
+enum CQDispatchCmdPackedWriteLargeType {
+    CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_UNKNOWN = 0,
+    CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS = 1,
+    CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_PROGRAM_BINARIES = 2,
+};
+
 // More flexible/slower than WritePacked
 // Removes size constraints
 // Implicitly mcast
 struct CQDispatchWritePackedLargeCmd {
-    uint8_t pad1;
+    uint8_t type;
     uint16_t count;  // number of sub-cmds
     uint16_t alignment;
     uint16_t write_offset_index;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -614,6 +614,9 @@ void process_write_packed(
         mcasts = 0;
         // Workaround mcast path reservation hangs by always waiting for a write
         // barrier before doing an mcast that isn't linked to a previous mcast.
+#ifdef TRACE_WRITE_BARRIERS
+        DeviceZoneScopedN("noc_async_write_barrier");
+#endif
         noc_async_write_barrier();
     };
     WritePackedSubCmd* sub_cmd_ptr = (WritePackedSubCmd*)l1_cache;
@@ -748,6 +751,9 @@ void process_write_packed_large(
             writes = 0;
             // Workaround mcast path reservation hangs by always waiting for a write
             // barrier before doing an mcast that isn't linked to a previous mcast.
+#ifdef TRACE_WRITE_BARRIERS
+            DeviceZoneScopedN("noc_async_write_barrier");
+#endif
             noc_async_write_barrier();
         };
 
@@ -909,6 +915,9 @@ static void process_wait() {
 
     if (barrier) {
         // DPRINT << " DISPATCH BARRIER\n";
+#ifdef TRACE_WRITE_BARRIERS
+        DeviceZoneScopedN("noc_async_write_barrier");
+#endif
         noc_async_write_barrier();
     }
 
@@ -1012,6 +1021,9 @@ void process_notify_dispatch_s_go_signal_cmd() {
     // write barrier to wait before sending the go signal
     if (wait) {
         DPRINT << " DISPATCH_S_NOTIFY BARRIER\n";
+#ifdef TRACE_WRITE_BARRIERS
+        DeviceZoneScopedN("noc_async_write_barrier");
+#endif
         noc_async_write_barrier();
     }
     uint16_t index_bitmask = cmd->notify_dispatch_s_go_signal.index_bitmask;
@@ -1091,7 +1103,11 @@ re_run_command:
         case CQ_DISPATCH_CMD_WRITE_PACKED: {
             // DPRINT << "cmd_write_packed" << ENDL();
             uint32_t flags = cmd->write_packed.flags;
-            DeviceTimestampedData("subtype_data_dispatch", flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST);
+            // Must match unpacking code in tt_metal/impl/profiler/profiler.cpp.
+            uint32_t data = ((flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_MASK) >>
+                             (CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT - 1)) |
+                            bool(flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST);
+            DeviceTimestampedData("packed_data_dispatch", data);
             if (flags & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST) {
                 process_write_packed<true, CQDispatchWritePackedMulticastSubCmd>(
                     flags, l1_cache, block_noc_writes_to_clear, block_next_start_addr);
@@ -1108,6 +1124,8 @@ re_run_command:
 
         case CQ_DISPATCH_CMD_WRITE_PACKED_LARGE:
             // DPRINT << "cmd_write_packed_large" << ENDL();
+            // Must match unpacking code in tt_metal/impl/profiler/profiler.cpp.
+            DeviceTimestampedData("packed_large_data_dispatch", cmd->write_packed_large.type);
             process_write_packed_large(l1_cache, block_noc_writes_to_clear, block_next_start_addr);
             break;
 
@@ -1278,7 +1296,6 @@ void kernel_main() {
     bool done = false;
     uint32_t heartbeat = 0;
     while (!done) {
-        DeviceZoneScopedN("CQ-DISPATCH");
         if (cmd_ptr == cb_fence) {
             get_cb_page_and_release_pages<
                 dispatch_cb_base,
@@ -1297,6 +1314,7 @@ void kernel_main() {
                 upstream_total_acquired_page_count);
         }
 
+        DeviceZoneScopedN("CQ-DISPATCH");
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
 
         done = is_d_variant ? process_cmd_d(cmd_ptr, l1_cache, block_noc_writes_to_clear, block_next_start_addr)

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -98,6 +98,7 @@ void issue_record_event_commands(
     uint32_t address = cq_id == 0 ? completion_q0_last_event_addr : completion_q1_last_event_addr;
     const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
     command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+        CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_EVENT,
         num_command_queues,
         address,
         DispatchSettings::EVENT_PADDED_SIZE,

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -328,6 +328,8 @@ void DeviceProfiler::logPacketData(
         if (!ret.second) {
             return;
         }
+        // Reset the command subtype, in case it isn't set during the command.
+        this->current_dispatch_meta_data.cmd_subtype = "";
     }
 
     if (packet_type == kernel_profiler::TS_DATA) {
@@ -344,7 +346,21 @@ void DeviceProfiler::logPacketData(
                 } else if (zone_name.find("runtime_host_id_dispatch") != std::string::npos) {
                     this->current_dispatch_meta_data.worker_runtime_id = (uint32_t)data;
                     metaData["workers_runtime_id"] = this->current_dispatch_meta_data.worker_runtime_id;
+                } else if (zone_name.find("packed_data_dispatch") != std::string::npos) {
+                    this->current_dispatch_meta_data.cmd_subtype = fmt::format(
+                        "{}{}",
+                        data & CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_MCAST ? "MCAST," : "",
+                        magic_enum::enum_name(static_cast<CQDispatchCmdPackedWriteType>(
+                            (data >> 1) << CQ_DISPATCH_CMD_PACKED_WRITE_TYPE_SHIFT)));
+                    metaData["dispatch_command_subtype"] = this->current_dispatch_meta_data.cmd_subtype;
+                } else if (zone_name.find("packed_large_data_dispatch") != std::string::npos) {
+                    this->current_dispatch_meta_data.cmd_subtype =
+                        fmt::format("{}", magic_enum::enum_name(static_cast<CQDispatchCmdPackedWriteLargeType>(data)));
+                    metaData["dispatch_command_subtype"] = this->current_dispatch_meta_data.cmd_subtype;
                 }
+                std::string cmd_name = this->current_dispatch_meta_data.cmd_subtype != ""
+                                           ? this->current_dispatch_meta_data.cmd_subtype
+                                           : this->current_dispatch_meta_data.cmd_type;
                 tracy::TTDeviceEvent event = tracy::TTDeviceEvent(
                     this->current_dispatch_meta_data.worker_runtime_id,
                     this->current_zone_it->chip_id,
@@ -355,10 +371,7 @@ void DeviceProfiler::logPacketData(
                     this->current_zone_it->timestamp,
                     this->current_zone_it->line,
                     this->current_zone_it->file,
-                    fmt::format(
-                        "{}:{}",
-                        this->current_dispatch_meta_data.worker_runtime_id,
-                        this->current_dispatch_meta_data.cmd_type),
+                    fmt::format("{}:{}", this->current_dispatch_meta_data.worker_runtime_id, cmd_name),
                     this->current_zone_it->zone_phase);
                 device_events.erase(this->current_zone_it);
                 auto ret = device_events.insert(event);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -36,6 +36,9 @@ struct DisptachMetaData {
 
     // Worker's runtime id
     uint32_t worker_runtime_id = 0;
+
+    // dispatch command subtype.
+    std::string cmd_subtype = "";
 };
 
 class DeviceProfiler {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -516,6 +516,7 @@ void generate_runtime_args_cmds(
             num_packed_cmds, max_runtime_args_len * sizeof(uint32_t), packed_write_max_unicast_sub_cmds, no_stride);
         runtime_args_command_sequences.emplace_back(calculator.write_offset_bytes());
         runtime_args_command_sequences.back().add_dispatch_write_packed<PackedSubCmd>(
+            CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_RTA,
             num_packed_cmds,
             l1_arg_base_addr,
             max_runtime_args_len * sizeof(uint32_t),
@@ -1380,6 +1381,7 @@ void assemble_device_commands(
         }
         std::vector<uint8_t*> data_collection_location;
         device_command_sequence.add_dispatch_write_packed_large(
+            CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_CBS_SEMS_CRTAS,
             l1_alignment,
             batched_dispatch_subcmds[i].size(),
             batched_dispatch_subcmds[i],
@@ -1421,6 +1423,7 @@ void assemble_device_commands(
         uint32_t curr_sub_cmd_idx = 0;
         for (const auto& [num_sub_cmds_in_cmd, unicast_sem_payload_sizeB] : unicast_sem_payload[i]) {
             device_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+                CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_SEMS,
                 num_sub_cmds_in_cmd,
                 unicast_sem_dst_size[i].first + program.get_program_config(index).sem_offset,
                 unicast_sem_dst_size[i].second,
@@ -1449,6 +1452,7 @@ void assemble_device_commands(
     uint32_t dram_alignment = hal_ref.get_alignment(HalMemType::DRAM);
     for (uint32_t i = 0; i < kernel_bins_dispatch_subcmds.size(); ++i) {
         device_command_sequence.add_dispatch_write_packed_large(
+            CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_PROGRAM_BINARIES,
             dram_alignment,
             kernel_bins_dispatch_subcmds[i].size(),
             kernel_bins_dispatch_subcmds[i],
@@ -1472,6 +1476,7 @@ void assemble_device_commands(
         for (const auto& [num_sub_cmds_in_cmd, multicast_go_signal_payload_sizeB] : multicast_go_signals_payload) {
             uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
             device_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
+                CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_LAUNCH,
                 num_sub_cmds_in_cmd,
                 multicast_launch_msg_addr,
                 go_signal_sizeB,
@@ -1504,6 +1509,7 @@ void assemble_device_commands(
         for (const auto& [num_sub_cmds_in_cmd, unicast_go_signal_payload_sizeB] : unicast_go_signals_payload) {
             uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
             device_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
+                CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_LAUNCH,
                 num_sub_cmds_in_cmd,
                 unicast_launch_msg_addr,
                 go_signal_sizeB,


### PR DESCRIPTION

### Problem description
Currently dispatch profiles include information about each command, but not sub-command types (e.g. is a packed write large writing out launch messages or RTAs).

### What's changed
Add information about what sort of data is being sent packed in each packed write or packed write large command.

Don't include the toplevel wait for more pages in the CQ-DISPATCH zone

Add an ifdef to add zones around noc_async_write_barrier. These zones aren't emitted by default to save space in the trace buffer.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes