### PR TITLE
0D, 1D and zero volume support for normalization ops

### DIFF
--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -176,6 +176,9 @@ on:
           - normalization.softmax.softmax
           - normalization.softmax.softmax_sharded
           - normalization.batch_norm.batch_norm
+          - normalization.generality.layernorm
+          - normalization.generality.softmax
+          - normalization.generality.softmax_fused
           - eltwise.unary.identity.identity
           - eltwise.unary.identity.identity_sharded
           - eltwise.unary.neg.neg

--- a/tests/sweep_framework/sweeps/normalization/generality/layernorm.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/layernorm.py
@@ -33,7 +33,7 @@ parameters = {
 }
 
 
-def run_normalization(device, tensor_shape, op) -> list:
+def run_normalization(device, tensor_shape, op) -> tuple:
     """
     Test the compatibility of the torch and ttnn output for the given operation and different
     tensor shapes. Checks for the exactness of shape, values, and dtype of the output tensors.
@@ -93,29 +93,29 @@ def run_normalization(device, tensor_shape, op) -> list:
         ttnn_error_msg = str(e)
 
     if torch_errored != ttnn_errored:
-        return [
+        return (
             False,
             f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
-        ]
+        )
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         logger.warning(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
-        return [True, ""]
+        return (True, "")
 
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
 
     pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
 
     if not pcc_result:
-        return [False, msg]
+        return (False, msg)
 
     atol = rtol = 0.1
 
-    return [
+    return (
         torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
         f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
-    ]
+    )
 
 
 @pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))
@@ -137,7 +137,7 @@ def run(
     op,
     *,
     device,
-) -> list:
+) -> tuple:
     return run_normalization(
         device,
         tensor_shape,

--- a/tests/sweep_framework/sweeps/normalization/generality/layernorm.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/layernorm.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+import pytest
+import random
+import torch
+import ttnn
+
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 30
+
+random.seed(0)
+
+DIM_SIZES = [0, 32]
+"""Possible tensor dimensions are picked from this list"""
+
+parameters = {
+    f"rank_{rank}": {
+        "tensor_shape": list(itertools.product(DIM_SIZES, repeat=rank)),
+        # normalization operations to test
+        "op": [
+            "rms_norm",
+            "layer_norm",
+        ],
+    }
+    for rank in range(5)
+}
+
+
+def run_normalization(device, tensor_shape, op) -> list:
+    """
+    Test the compatibility of the torch and ttnn output for the given operation and different
+    tensor shapes. Checks for the exactness of shape, values, and dtype of the output tensors.
+    Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
+    Note: We do not enforce the same exception type or message.
+    """
+    rank = len(tensor_shape)
+
+    torch_tensor = (
+        torch.randn(*tensor_shape, dtype=torch.bfloat16) if rank > 0 else torch.randn((), dtype=torch.bfloat16)
+    )
+    ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Generate additional inputs
+    epsilon = random.uniform(1e-5, 1e-2)  # Small constant for numerical stability
+    weight = torch.randn(tensor_shape[-1:], dtype=torch.bfloat16) if rank > 0 else None
+    bias = torch.randn(tensor_shape[-1:], dtype=torch.bfloat16) if rank > 0 else None
+
+    ttnn_weight = ttnn.from_torch(weight, layout=ttnn.TILE_LAYOUT, device=device) if weight is not None else None
+    ttnn_bias = ttnn.from_torch(bias, layout=ttnn.TILE_LAYOUT, device=device) if bias is not None else None
+
+    # Run on both and flag exceptions
+    torch_errored = False
+    torch_error_msg = ""
+    try:
+        if op == "rms_norm":
+            # Note: torch's RMSNorm is not available in the current version, so we use a manual implementation
+            torch_result = torch_tensor / torch.sqrt(torch.mean(torch_tensor**2, dim=-1, keepdim=True) + epsilon)
+            if weight is not None:
+                torch_result *= weight
+            if bias is not None:
+                torch_result += bias
+        elif op == "layer_norm":
+            torch_result = torch.nn.functional.layer_norm(
+                torch_tensor, tensor_shape[-1:], weight=weight, bias=bias, eps=epsilon
+            )
+        else:
+            raise ValueError(f"Unsupported operation: {op}")
+    except RuntimeError as e:
+        torch_errored = True
+        torch_error_msg = str(e)
+
+    ttnn_errored = False
+    ttnn_error_msg = ""
+    try:
+        if op == "rms_norm":
+            ttnn_result = ttnn.rms_norm(ttnn_tensor, epsilon=epsilon, weight=ttnn_weight, bias=ttnn_bias)
+        elif op == "layer_norm":
+            ttnn_result = ttnn.layer_norm(ttnn_tensor, epsilon=epsilon, weight=ttnn_weight, bias=ttnn_bias)
+        else:
+            raise ValueError(f"Unsupported operation: {op}")
+
+    # Note: The exception type may differ from torch, so we only check if an exception was raised
+    # and not the specific type or message.
+    except RuntimeError as e:
+        ttnn_errored = True
+        ttnn_error_msg = str(e)
+
+    if torch_errored != ttnn_errored:
+        return [
+            False,
+            f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
+        ]
+
+    # Skip the rest of the test if an exception was raised in both
+    if torch_errored:
+        print(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
+        return [True, ""]
+
+    ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
+
+    pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
+
+    if not pcc_result:
+        return [False, msg]
+
+    atol = rtol = 0.1
+
+    return [
+        torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
+        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
+    ]
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))
+def test_normalization(
+    device,
+    tensor_shape,
+    op,
+):
+    result, error_msg = run_normalization(
+        device,
+        tensor_shape,
+        op,
+    )
+    assert result, error_msg
+
+
+def run(
+    tensor_shape,
+    op,
+    *,
+    device,
+) -> list:
+    return run_normalization(
+        device,
+        tensor_shape,
+        op,
+    )

--- a/tests/sweep_framework/sweeps/normalization/generality/layernorm.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/layernorm.py
@@ -7,6 +7,7 @@ import pytest
 import random
 import torch
 import ttnn
+from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc
@@ -99,7 +100,7 @@ def run_normalization(device, tensor_shape, op) -> list:
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
-        print(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
+        logger.warning(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
         return [True, ""]
 
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))

--- a/tests/sweep_framework/sweeps/normalization/generality/softmax.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/softmax.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+import pytest
+import random
+import torch
+import ttnn
+
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 30
+
+random.seed(0)
+
+DIM_SIZES = [0, 32]
+"""Possible tensor dimensions are picked from this list"""
+
+parameters = {
+    f"rank_{rank}": {
+        "tensor_shape": list(itertools.product(DIM_SIZES, repeat=rank)),
+        "dim": list(range(-rank, rank)) if rank > 0 else [0, -1],  # Rank 0 has no dimensions
+        # normalization operations to test
+        "op": [
+            "softmax",
+        ],
+    }
+    for rank in range(5)
+}
+
+
+def run_softmax(device, tensor_shape, dim, op) -> list:
+    """
+    Test the compatibility of the torch and ttnn output for the given operation and different
+    tensor shapes, and dim values.
+    Checks for the exactness of shape, values, and dtype of the output tensors.
+    Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
+    Note: We do not enforce the same exception type or message.
+    """
+    rank = len(tensor_shape)
+
+    torch_tensor = (
+        torch.randn(*tensor_shape, dtype=torch.bfloat16) if rank > 0 else torch.randn((), dtype=torch.bfloat16)
+    )
+    ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    scale = random.uniform(0.1, 10.0)
+    is_scale_op = op in ("scale_mask_softmax", "scale_mask_softmax_in_place")
+    torch_op, ttnn_op = torch.softmax, getattr(ttnn, op)
+
+    # Run on both and flag exceptions
+    torch_errored = False
+    torch_error_msg = ""
+    try:
+        torch_result = torch_op(torch_tensor, dim=dim)  # if dim is not None else torch_op(torch_tensor)
+    except IndexError as e:
+        torch_errored = True
+        torch_error_msg = str(e)
+
+    ttnn_errored = False
+    ttnn_error_msg = ""
+    try:
+        ttnn_result = ttnn_op(ttnn_tensor, scale=scale, dim=dim) if is_scale_op else ttnn_op(ttnn_tensor, dim=dim)
+    except RuntimeError as e:
+        ttnn_errored = True
+        ttnn_error_msg = str(e)
+
+    if torch_errored != ttnn_errored:
+        return [
+            False,
+            f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
+        ]
+
+    # Skip the rest of the test if an exception was raised in both
+    if torch_errored:
+        print(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
+        return [True, ""]
+
+    ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
+
+    # Add scaling to the torch result to match the ttnn result
+    if is_scale_op:
+        torch_result *= scale
+
+    pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
+
+    if not pcc_result:
+        return [False, msg]
+
+    atol = rtol = 0.1
+
+    # print(
+    #     f"torch: {torch_result.shape}, {torch_result.dtype}, {torch_result.device}, {torch_result} \n"
+    #     f"ttnn: {ttnn_result.shape}, {ttnn_result.dtype}, {ttnn_result.device}, {ttnn_result} \n"
+    # )
+    return [
+        torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
+        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
+    ]
+
+    # TODO: Verify that the sum of the output tensor is equal to 1.0 over the specified dimension
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))
+def test_normalization(
+    device,
+    tensor_shape,
+    dim,
+    op,
+):
+    result, error_msg = run_softmax(
+        device,
+        tensor_shape,
+        dim,
+        op,
+    )
+    assert result, error_msg
+
+
+def run(
+    tensor_shape,
+    dim,
+    op,
+    *,
+    device,
+) -> list:
+    return run_softmax(
+        device,
+        tensor_shape,
+        dim,
+        op,
+    )

--- a/tests/sweep_framework/sweeps/normalization/generality/softmax.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/softmax.py
@@ -7,6 +7,7 @@ import pytest
 import random
 import torch
 import ttnn
+from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc
@@ -75,7 +76,7 @@ def run_softmax(device, tensor_shape, dim, op) -> list:
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
-        print(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
+        logger.warning(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
         return [True, ""]
 
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
@@ -91,10 +92,6 @@ def run_softmax(device, tensor_shape, dim, op) -> list:
 
     atol = rtol = 0.1
 
-    # print(
-    #     f"torch: {torch_result.shape}, {torch_result.dtype}, {torch_result.device}, {torch_result} \n"
-    #     f"ttnn: {ttnn_result.shape}, {ttnn_result.dtype}, {ttnn_result.device}, {ttnn_result} \n"
-    # )
     return [
         torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
         f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",

--- a/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import itertools
+import pytest
+import random
+import torch
+import ttnn
+
+from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+# Override the default timeout in seconds for hang detection.
+TIMEOUT = 30
+
+random.seed(0)
+
+DIM_SIZES = [0, 32]
+"""Possible tensor dimensions are picked from this list"""
+
+
+parameters = {
+    f"rank_{rank}": {
+        "tensor_shape": list(itertools.product(DIM_SIZES, repeat=rank)),
+        # normalization operations to test
+        "op": [
+            "scale_mask_softmax",
+            "softmax_in_place",
+            "scale_mask_softmax_in_place",
+            "scale_causal_mask_hw_dims_softmax_in_place",
+        ],
+    }
+    for rank in range(5)
+}
+
+
+def run_softmax(device, tensor_shape, op) -> list:
+    """
+    Test the compatibility of the torch and ttnn output for the given operation and different
+    tensor and shapes values.
+    Checks for the exactness of shape, values, and dtype of the output tensors.
+    Some operations raise exceptions in torch, we check if the same behavior is observed in ttnn.
+    Note: We do not enforce the same exception type or message.
+    """
+    rank = len(tensor_shape)
+
+    torch_tensor = (
+        torch.randn(*tensor_shape, dtype=torch.bfloat16) if rank > 0 else torch.randn((), dtype=torch.bfloat16)
+    )
+
+    ttnn_tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+
+    torch_mask = torch_tensor.clone() < 0
+    ttnn_mask = ttnn.from_torch(torch_mask.to(torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
+
+    scale = random.uniform(0.1, 10.0)
+    has_scale_mask = ("scale" in op) and ("mask" in op)
+    torch_op, ttnn_op = torch.softmax, getattr(ttnn, op)
+
+    # Print tensor and scale
+    print(
+        f"torch: {torch_tensor.shape}, {torch_tensor.dtype}, {torch_tensor.device}, {torch_tensor} \n"
+        f"scale: {scale} \n"
+        f"torch_mask: {torch_mask.shape}, {torch_mask.dtype}, {torch_mask.device}, {torch_mask} \n"
+    )
+    # Run on both and flag exceptions
+    torch_errored = False
+    torch_error_msg = ""
+    try:
+        if has_scale_mask:
+            torch_result = torch_op(torch_tensor.masked_fill(torch_mask, float("-inf")), dim=-1) * scale
+        else:
+            torch_result = torch_op(torch_tensor, dim=-1)
+    except IndexError as e:
+        torch_errored = True
+        torch_error_msg = str(e)
+
+    ttnn_errored = False
+    ttnn_error_msg = ""
+    try:
+        ttnn_result = ttnn_op(ttnn_tensor, scale, ttnn_mask) if has_scale_mask else ttnn_op(ttnn_tensor)
+    except RuntimeError as e:
+        ttnn_errored = True
+        ttnn_error_msg = str(e)
+
+    if torch_errored != ttnn_errored:
+        return [
+            False,
+            f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
+        ]
+
+    # Skip the rest of the test if an exception was raised in both
+    if torch_errored:
+        print(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
+        return [True, ""]
+
+    ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
+
+    pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
+
+    if not pcc_result:
+        return [False, msg]
+
+    atol = rtol = 0.1
+
+    # print(
+    #     f"torch: {torch_result.shape}, {torch_result.dtype}, {torch_result.device}, {torch_result} \n"
+    #     f"ttnn: {ttnn_result.shape}, {ttnn_result.dtype}, {ttnn_result.device}, {ttnn_result} \n"
+    # )
+    return [
+        torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
+        f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
+    ]
+
+    # TODO: Verify that the sum of the output tensor is equal to 1.0 over the specified dimension
+
+
+@pytest.mark.parametrize(**gen_pytest_parametrize_args(parameters))
+def test_normalization(
+    device,
+    tensor_shape,
+    op,
+):
+    result, error_msg = run_softmax(
+        device,
+        tensor_shape,
+        op,
+    )
+    assert result, error_msg
+
+
+def run(
+    tensor_shape,
+    op,
+    *,
+    device,
+) -> list:
+    return run_softmax(
+        device,
+        tensor_shape,
+        op,
+    )

--- a/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
@@ -87,29 +87,29 @@ def run_softmax(device, tensor_shape, op) -> list:
         ttnn_error_msg = str(e)
 
     if torch_errored != ttnn_errored:
-        return [
+        return (
             False,
             f"mismatch in errors raised: torch: {torch_errored} ({torch_error_msg}), ttnn: {ttnn_errored} ({ttnn_error_msg})",
-        ]
+        )
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
         logger.info(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
-        return [True, ""]
+        return (True, "")
 
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
 
     pcc_result, msg = check_with_pcc(torch_result, ttnn_result, 0.99)
 
     if not pcc_result:
-        return [False, msg]
+        return (False, msg)
 
     atol = rtol = 0.1
 
-    return [
+    return (
         torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
         f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",
-    ]
+    )
 
     # TODO: Verify that the sum of the output tensor is equal to 1.0 over the specified dimension
 

--- a/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
+++ b/tests/sweep_framework/sweeps/normalization/generality/softmax_fused.py
@@ -7,6 +7,7 @@ import pytest
 import random
 import torch
 import ttnn
+from loguru import logger
 
 from tests.sweep_framework.sweep_utils.utils import gen_pytest_parametrize_args
 from tests.ttnn.utils_for_testing import check_with_pcc
@@ -58,12 +59,13 @@ def run_softmax(device, tensor_shape, op) -> list:
     has_scale_mask = ("scale" in op) and ("mask" in op)
     torch_op, ttnn_op = torch.softmax, getattr(ttnn, op)
 
-    # Print tensor and scale
-    print(
+    # Log tensor and scale
+    logger.debug(
         f"torch: {torch_tensor.shape}, {torch_tensor.dtype}, {torch_tensor.device}, {torch_tensor} \n"
         f"scale: {scale} \n"
         f"torch_mask: {torch_mask.shape}, {torch_mask.dtype}, {torch_mask.device}, {torch_mask} \n"
     )
+
     # Run on both and flag exceptions
     torch_errored = False
     torch_error_msg = ""
@@ -92,7 +94,7 @@ def run_softmax(device, tensor_shape, op) -> list:
 
     # Skip the rest of the test if an exception was raised in both
     if torch_errored:
-        print(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
+        logger.info(f"both torch and ttnn raised errors: torch: {torch_error_msg}, ttnn: {ttnn_error_msg}")
         return [True, ""]
 
     ttnn_result = ttnn.to_torch(ttnn.from_device(ttnn_result))
@@ -104,10 +106,6 @@ def run_softmax(device, tensor_shape, op) -> list:
 
     atol = rtol = 0.1
 
-    # print(
-    #     f"torch: {torch_result.shape}, {torch_result.dtype}, {torch_result.device}, {torch_result} \n"
-    #     f"ttnn: {ttnn_result.shape}, {ttnn_result.dtype}, {ttnn_result.device}, {ttnn_result} \n"
-    # )
     return [
         torch.allclose(torch_result, ttnn_result, atol=atol, rtol=rtol, equal_nan=True),
         f"mismatch in allclose: torch: {torch_result}, ttnn: {ttnn_result}",

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -6,6 +6,7 @@
 #include "device/groupnorm_op.hpp"
 
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/clone/clone.hpp"
 
 namespace ttnn::operations::normalization {
 
@@ -67,6 +68,11 @@ ttnn::Tensor ExecuteGroupNorm::invoke(
         "Invalid tensor dimensions: The product of NHW dimensions ({}) must be divisible by the tile size ({}).",
         nhw,
         ttnn::types::TILE_SIZE);
+
+    // For 0V tensors
+    if (input_tensor.get_logical_volume() == 0) [[unlikely]] {
+        return ttnn::clone(input_tensor, /*dtype=*/std::nullopt, memory_config, /*compute_kernel_config=*/std::nullopt);
+    }
 
     const auto output_dtype = dtype.value_or(input_tensor.get_dtype());
 

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
@@ -31,8 +31,6 @@ ttnn::Tensor ExecuteRMSNorm::invoke(
 
     // For 0D tensors
     if (rank == 0) [[unlikely]] {
-        float fill_val = 1.0f;
-        // TODO: fill_val needs to be -1.0f when the 0D value is negative
         auto result = ttnn::divide(
             input_tensor, ttnn::abs(input_tensor, output_memory_config), /*alpha=*/std::nullopt, output_memory_config);
 

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.cpp
@@ -4,6 +4,10 @@
 
 #include "rmsnorm.hpp"
 
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/data_movement/clone/clone.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/eltwise/unary/unary.hpp"
 #include "ttnn/operations/normalization/layernorm/device/layernorm_op.hpp"
 
 namespace ttnn::operations::normalization {
@@ -17,6 +21,30 @@ ttnn::Tensor ExecuteRMSNorm::invoke(
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<const LayerNormProgramConfig>& program_config,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
+    auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
+    auto rank = input_tensor.get_logical_shape().size();
+
+    // For 0V tensors
+    if (input_tensor.get_logical_volume() == 0) [[unlikely]] {
+        return ttnn::clone(input_tensor, /*dtype=*/std::nullopt, output_memory_config, compute_kernel_config);
+    }
+
+    // For 0D tensors
+    if (rank == 0) [[unlikely]] {
+        float fill_val = 1.0f;
+        // TODO: fill_val needs to be -1.0f when the 0D value is negative
+        auto result = ttnn::divide(
+            input_tensor, ttnn::abs(input_tensor, output_memory_config), /*alpha=*/std::nullopt, output_memory_config);
+
+        if (weight.has_value()) {
+            result = ttnn::multiply(result, weight.value(), /*alpha=*/std::nullopt, output_memory_config);
+        }
+        if (bias.has_value()) {
+            result = ttnn::add(result, bias.value(), /*alpha=*/std::nullopt, output_memory_config);
+        }
+        return result;
+    }
+
     auto arch = input_tensor.storage_type() == StorageType::DEVICE
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
@@ -26,7 +54,7 @@ ttnn::Tensor ExecuteRMSNorm::invoke(
                LayerNorm{
                    .norm_type = LayerNormType::RMSNORM,
                    .eps = epsilon,
-                   .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
+                   .output_mem_config = output_memory_config,
                    .program_config = program_config.value_or(LayerNormDefaultProgramConfig{}),
                    .compute_kernel_config = kernel_config_val},
                {input_tensor},

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -698,7 +698,7 @@ tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_sharded_multi_c
         bool mask_stick_size_is_power_of_two = tt::tt_metal::is_power_of_two_at_least_32(mask_stick_size);
         reader_compile_time_args.push_back((std::uint32_t)mask_stick_size_is_power_of_two);
         if (mask_stick_size_is_power_of_two) {
-            uint32_t mask_log2_stick_size = (std::uint32_t)log2(mask_stick_size);
+            uint32_t mask_log2_stick_size = (std::uint32_t)std::log2(mask_stick_size);
             reader_compile_time_args.push_back((std::uint32_t)mask_log2_stick_size);
         } else {
             reader_compile_time_args.push_back(mask_stick_size);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.cpp
@@ -7,6 +7,7 @@
 #include "cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.hpp"
 #include "device/softmax_op.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation.hpp"
 
 namespace ttnn::operations::normalization {
 
@@ -15,15 +16,28 @@ using namespace moreh::moreh_softmax;
 ttnn::Tensor ExecuteSoftmax::invoke(
     const ttnn::Tensor& input_tensor,
     const int dim_arg,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::MemoryConfig>& memory_config_arg,
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
+    auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
     const auto& input_shape = input_tensor.get_logical_shape();
     auto rank = input_shape.size();
     auto dim = dim_arg;
     if (dim < 0) {
         dim = rank + dim;
     }
+
+    // For 0D or 0V tensors
+    if ((rank == 0) || (input_tensor.get_logical_volume() == 0)) {
+        return ttnn::full(
+            input_shape,
+            1.0f,
+            input_tensor.get_dtype(),
+            input_tensor.get_layout(),
+            std::optional<std::reference_wrapper<tt::tt_metal::IDevice>>(*input_tensor.device()),
+            memory_config);
+    }
+
     if (rank > 4) {
         auto output_tensor = ttnn::prim::moreh_softmax(
             input_tensor,
@@ -31,7 +45,7 @@ ttnn::Tensor ExecuteSoftmax::invoke(
             std::nullopt,
             MorehSoftmaxOp::SOFTMAX,
             MorehSoftmaxOpParallelizationStrategy::NONE,
-            memory_config.value_or(input_tensor.memory_config()),
+            memory_config,
             compute_kernel_config);
         return ttnn::reshape(output_tensor, input_shape);
     }
@@ -39,10 +53,7 @@ ttnn::Tensor ExecuteSoftmax::invoke(
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     if (dim == rank - 1) {
         auto output_tensor = ttnn::operations::normalization::softmax(
-            input_tensor_4D,
-            memory_config.value_or(input_tensor.memory_config()),
-            compute_kernel_config,
-            numeric_stable);
+            input_tensor_4D, memory_config, compute_kernel_config, numeric_stable);
         return ttnn::reshape(output_tensor, input_shape);
     } else {
         auto dim_4D = dim + 4 - rank;
@@ -52,7 +63,7 @@ ttnn::Tensor ExecuteSoftmax::invoke(
             std::nullopt,
             MorehSoftmaxOp::SOFTMAX,
             MorehSoftmaxOpParallelizationStrategy::NONE,
-            memory_config.value_or(input_tensor.memory_config()),
+            memory_config,
             compute_kernel_config);
         return ttnn::reshape(output_tensor, input_shape);
     }
@@ -67,6 +78,18 @@ ttnn::Tensor ExecuteScaleMaskSoftmax::invoke(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
     const auto& input_shape = input_tensor.get_logical_shape();
+    const auto rank = input_shape.size();
+
+    // For 0D or 0V tensors
+    if ((rank == 0) || (input_tensor.get_logical_volume() == 0)) {
+        return ttnn::full(
+            input_shape,
+            scale.value_or(1.0f),
+            input_tensor.get_dtype(),
+            input_tensor.get_layout(),
+            std::optional<std::reference_wrapper<tt::tt_metal::IDevice>>(*input_tensor.device()),
+            memory_config);
+    }
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor = ttnn::operations::normalization::scale_mask_softmax(
@@ -86,6 +109,13 @@ ttnn::Tensor ExecuteSoftmaxInPlace::invoke(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
     const auto& input_shape = input_tensor.get_logical_shape();
+    const auto rank = input_shape.size();
+
+    // For 0D or 0V tensors
+    if ((rank == 0) || (input_tensor.get_logical_volume() == 0)) {
+        // Fill the tensor with 1.0f
+        return ttnn::fill(input_tensor, 1.0f);
+    }
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor = ttnn::operations::normalization::softmax_in_place(
@@ -102,6 +132,13 @@ ttnn::Tensor ExecuteScaleMaskSoftmaxInPlace::invoke(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
     const auto& input_shape = input_tensor.get_logical_shape();
+    auto rank = input_shape.size();
+
+    // For 0D or 0V tensors
+    if ((rank == 0) || (input_tensor.get_logical_volume() == 0)) {
+        // Fill the tensor with 1.0f
+        return ttnn::fill(input_tensor, scale.value_or(1.0f));
+    }
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor = ttnn::operations::normalization::scale_mask_softmax_in_place(
@@ -117,6 +154,13 @@ ttnn::Tensor ExecuteScaleCausalMaskHWSoftmaxInPlace::invoke(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
     const auto& input_shape = input_tensor.get_logical_shape();
+    auto rank = input_shape.size();
+
+    // For 0D or 0V tensors
+    if ((rank == 0) || (input_tensor.get_logical_volume() == 0)) {
+        // Fill the tensor with 1.0f
+        return ttnn::fill(input_tensor, scale.value_or(1.0f));
+    }
 
     auto input_tensor_4D = ttnn::unsqueeze_to_4D(input_tensor);
     auto output_tensor = ttnn::operations::normalization::scale_causal_mask_hw_dims_softmax_in_place(


### PR DESCRIPTION
### Ticket
[Addresses Issue 18362](https://github.com/tenstorrent/tt-metal/issues/18362)

### Problem description
Currently, normalization operations only support non-zero volume tensors and tensors with rank >=2.

### What's changed
This PR adds the following:

1. Support 0D and 1D tensors for softmax, layer_norm and rms_norm
2. Support zero volume tensors of any rank (0-4).
3. Support 0V tensors for fused softmax ops.
4. Add sweeps to compare ttnn behavior w.r.t torch for all the flavors above.

| Reduce Op | All ranks supported  | Zero volume supported? | Matches Torch?  | 
|-----------|----------------------|------------------------|-----------------|
| `softmax`     |          Y           |            Y           |        Y        |
| `rms_norm`    |          Y           |            Y           |        Y        |
| `layer_norm`     |          Y           |            Y           |        Y        |
| `softmax in-place`     |          Y           |            N           |        Y        |
| `softmax fused`     |          N           |            Y           |        Y        |
| `batch_norm`*     |          N           |            Y           |        Y        |
| `group_norm`*     |          N           |            Y           |        Y        |

*Batch Norm and Group Norm apply for tensors with rank >= 2. Thus, 0D/1D support does not arise.

### Checklist
- [x] [All post commit #28933](https://github.com/tenstorrent/tt-metal/actions/runs/14207527446) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

#### Runs of new sweeps
[2471](https://github.com/tenstorrent/tt-metal/actions/runs/14207279598)
[2472](https://github.com/tenstorrent/tt-metal/actions/runs/14207279598)
[2473](https://github.com/tenstorrent/tt-metal/actions/runs/14207283992)