### PR TITLE
#19569: Remove `create_at` in favor of `create_mesh_workload`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -122,7 +122,7 @@ struct OldInfraDeviceOpWithCreateMeshWorkload {
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
 
     auto create_mesh_workload(
-        const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const std::vector<Tensor>& input_tensors,
         std::vector<Tensor>& output_tensors) const {
         return tt::tt_metal::operation::MeshWorkloadWithCallbacks();

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/distributed_tensor_config.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/old_infra_device_operation.hpp"
 #include "ttnn/operation_concepts.hpp"
@@ -26,7 +27,6 @@ using ::testing::SizeIs;
 using ::ttnn::device_operation::mesh_device_operation_utils::all_tensors_have_uniform_storage;
 using ::ttnn::device_operation::mesh_device_operation_utils::extract_tensor_coordinates;
 using ::ttnn::device_operation::mesh_device_operation_utils::filter_tensor_shards;
-using ::ttnn::device_operation::mesh_device_operation_utils::uses_heterogenous_dispatch;
 
 // Returns device tensor with `num_device_shards` populated.
 Tensor make_tensor_with_num_shards(const TensorSpec& tensor_spec, int num_device_shards, MeshDevice* mesh_device) {
@@ -45,7 +45,7 @@ struct SharedVariables {};
 struct OperationAttributes {};
 
 // New-infra style program factory that uses the "create" method (non-heterogeneous dispatch)
-struct NewInfraProgramFactoryWithCreate {
+struct NewInfraProgramFactory {
     using shared_variables_t = SharedVariables;
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
     using operation_attributes_t = OperationAttributes;
@@ -67,50 +67,40 @@ struct NewInfraProgramFactoryWithCreate {
 };
 
 // New-infra style program factory that uses the "create_at" method (heterogeneous dispatch)
-struct NewInfraProgramFactoryWithCreateAt {
+struct NewInfraWorkloadFactory {
     using shared_variables_t = SharedVariables;
-    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
     using operation_attributes_t = OperationAttributes;
     using tensor_args_t = Tensor;
     using tensor_return_value_t = Tensor;
 
-    static cached_program_t create_at(
+    static cached_mesh_workload_t create_mesh_workload(
         const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coord,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value) {
-        return cached_program_t(tt::tt_metal::Program(), SharedVariables{});
+        return cached_mesh_workload_t(
+            tt::tt_metal::distributed::MeshWorkload(),
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t>());
     }
 
-    static void override_runtime_arguments_at(
-        cached_program_t& cached_program,
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_program,
         const operation_attributes_t& operation_attributes,
-        const ttnn::MeshCoordinate& mesh_coord,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value) {}
 };
 
+static_assert(ttnn::device_operation::MeshWorkloadFactoryConcept<NewInfraWorkloadFactory>);
+static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFactory>);
+
 // Old infrastructure device operation that uses the "create_program" method
-struct OldInfraDeviceOpWithCreate {
+struct OldInfraDeviceOpWithCreateProgram {
     void validate(const std::vector<Tensor>& input_tensors) const {}
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
 
     auto create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-        return tt::tt_metal::operation::ProgramWithCallbacks();
-    }
-};
-
-// Old infrastructure device operation that uses the "create_program_at" method
-struct OldInfraDeviceOpWithCreateAt {
-    void validate(const std::vector<Tensor>& input_tensors) const {}
-    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
-    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
-
-    auto create_program_at(
-        const ttnn::MeshCoordinate& mesh_coord,
-        const std::vector<Tensor>& input_tensors,
-        std::vector<Tensor>& output_tensors) const {
         return tt::tt_metal::operation::ProgramWithCallbacks();
     }
 };
@@ -129,33 +119,9 @@ struct OldInfraDeviceOpWithCreateMeshWorkload {
     }
 };
 
-TEST(LaunchOperationTest, OldInfraUsesHeterogeneousDispatch) {
-    auto old_infra_attributes = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreate{});
-    auto old_infra_attributes_with_at = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateAt{});
-
-    auto old_infra_program_factory = tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>::program_factory_t();
-
-    EXPECT_FALSE(std::visit(
-        tt::stl::overloaded{
-            [&]<device_operation::ProgramFactoryConcept T>(const T&) {
-                return uses_heterogenous_dispatch<T>(old_infra_attributes);
-            },
-            [&]<device_operation::MeshWorkloadFactoryConcept T>(const T&) { return false; },
-        },
-        old_infra_program_factory));
-
-    EXPECT_TRUE(std::visit(
-        tt::stl::overloaded{
-            [&]<device_operation::ProgramFactoryConcept T>(const T&) {
-                return uses_heterogenous_dispatch<T>(old_infra_attributes_with_at);
-            },
-            [&]<device_operation::MeshWorkloadFactoryConcept T>(const T&) { return true; },
-        },
-        old_infra_program_factory));
-}
-
 TEST(LaunchOperationTest, OldInfraSelectsMeshWorkloadFactory) {
-    auto old_infra_attributes_create_program = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreate{});
+    auto old_infra_attributes_create_program =
+        tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateProgram{});
     auto old_infra_attributes_create_mesh_workload =
         tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateMeshWorkload{});
 
@@ -168,19 +134,13 @@ TEST(LaunchOperationTest, OldInfraSelectsMeshWorkloadFactory) {
         OldInfraDeviceOperation::select_program_factory(old_infra_attributes_create_mesh_workload, {})));
 }
 
-TEST(LaunchOperationTest, NewInfraUsesHeterogeneousDispatch) {
-    EXPECT_FALSE(uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreate>(OperationAttributes{}));
-
-    EXPECT_TRUE(uses_heterogenous_dispatch<NewInfraProgramFactoryWithCreateAt>(OperationAttributes{}));
-}
-
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
-    auto old_infra_attrs = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreate{});
+    auto old_infra_attrs = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateProgram{});
 
     EXPECT_EQ(
         device_operation::MeshDeviceOperationAdapter<
             tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>>::get_type_name(old_infra_attrs),
-        "OldInfraDeviceOpWithCreate");
+        "OldInfraDeviceOpWithCreateProgram");
 
     using ::ttnn::operations::examples::ExampleDeviceOperation;
     EXPECT_EQ(

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <random>
 #include <tt_stl/overloaded.hpp>
+#include "indestructible.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 #include <tt-metalium/program_cache.hpp>
@@ -53,6 +54,16 @@ template <typename... Ts>
 }
 
 inline const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
+
+// Returns `MeshCoordinateRangeSet` that covers a single coordinate (0,0).
+inline const auto& get_unit_tensor_coords() {
+    static tt::stl::Indestructible<ttnn::MeshCoordinateRangeSet> tensor_coords([]() {
+        ttnn::MeshCoordinateRangeSet res;
+        res.merge(ttnn::MeshCoordinateRange(ttnn::MeshCoordinate(0, 0), ttnn::MeshCoordinate(0, 0)));
+        return res;
+    }());
+    return tensor_coords.get();
+}
 
 template <typename device_operation_t>
 auto compute_program_hash(
@@ -126,10 +137,7 @@ tt::tt_metal::Program& create_or_get_program_from_cache(
                         program_hash,
                         CachedProgramFactory{
                             WorkloadFactory::create_mesh_workload(
-                                operation_attributes,
-                                std::vector<ttnn::MeshCoordinate>{ttnn::MeshCoordinate(0, 0)},
-                                tensor_args,
-                                tensor_return_value),
+                                operation_attributes, get_unit_tensor_coords(), tensor_args, tensor_return_value),
                             program_factory_index});
                     auto& cached_program_factory = program_cache.get(program_hash);
                     auto& cached_workload =
@@ -367,9 +375,8 @@ void launch_on_worker_thread(
                 },
                 [&]<MeshWorkloadFactoryConcept ProgramFactory>(
                     const ProgramFactory&) -> std::shared_ptr<tt::tt_metal::Program> {
-                    std::vector<ttnn::MeshCoordinate> mesh_coords = {ttnn::MeshCoordinate(0, 0)};
                     auto cached_workload = ProgramFactory::create_mesh_workload(
-                        operation_attributes, mesh_coords, tensor_args, tensor_return_value);
+                        operation_attributes, get_unit_tensor_coords(), tensor_args, tensor_return_value);
                     TT_FATAL(cached_workload.workload.get_programs().size() == 1, "Expected 1 program in workload.");
                     return std::make_shared<tt::tt_metal::Program>(
                         std::move(cached_workload.workload.get_programs().begin()->second));
@@ -397,6 +404,46 @@ void launch_on_worker_thread(
 }
 
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
+void enqueue_mesh_workload(
+    QueueId cq_id,
+    const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
+    const typename mesh_device_operation_t::tensor_args_t& tensor_args,
+    typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
+    distributed::MeshDevice* mesh_device,
+    tt::tt_metal::distributed::MeshWorkload& workload) {
+    // Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed profiler
+    // regresion
+    // tests well-formed data.
+    ZoneScopedN("TT_DNN_DEVICE_OP");
+    mesh_device_operation_utils::set_runtime_id(workload, mesh_device);
+    if (mesh_device_operation_utils::track_workload(workload, mesh_device)) {
+        return;
+    }
+
+    tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
+
+    TracyOpMeshWorkload(
+        mesh_device, workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);
+}
+
+// Dispatches `fn` to `program_factory` through either the `MeshWorkloadFactoryConcept` directly, or through the adapted
+// path for `ProgramFactoryConcept` factories.
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t, typename ProgramFactory, typename Fn>
+void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, const Fn& fn) {
+    std::visit(
+        tt::stl::overloaded{
+            [&]<ProgramFactoryConcept T>(const T&) {
+                // Adapt ProgramFactory to MeshWorkloadFactory concept.
+                using AdaptedMeshWorkloadFactory = mesh_device_operation_t::template MeshWorkloadFactoryAdapter<T>;
+                fn.template operator()<AdaptedMeshWorkloadFactory>();
+            },
+            [&]<MeshWorkloadFactoryConcept WorkloadFactory>(const WorkloadFactory&) {
+                fn.template operator()<WorkloadFactory>();
+            }},
+        program_factory);
+}
+
+template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t>
 void handle_mesh_adapter_cache_hit(
     QueueId cq_id,
     const typename mesh_device_operation_t::operation_attributes_t& operation_attributes,
@@ -409,47 +456,25 @@ void handle_mesh_adapter_cache_hit(
 
     auto& cached_program_factory = program_cache.get(program_hash);
     auto program_factory_index = cached_program_factory.program_factory_index;
+    auto program_factory = map_index_to_variant(
+        program_factory_index, mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
 
-    using program_factory_variant_t =
-        decltype(mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
-    auto program_factory = map_index_to_variant(program_factory_index, program_factory_variant_t{});
+    dispatch_to_mesh_workload_factory<mesh_device_operation_t>(
+        program_factory, [&]<MeshWorkloadFactoryConcept WorkloadFactory>() {
+            using cached_mesh_workload_t = typename WorkloadFactory::cached_mesh_workload_t;
+            auto& cached_mesh_workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
 
-    auto& workload = std::visit(
-        tt::stl::overloaded{
-            [&]<ProgramFactoryConcept ProgramFactory>(
-                const ProgramFactory&) -> tt::tt_metal::distributed::MeshWorkload& {
-                using cached_mesh_workload_t = AdaptedCachedMeshWorkload<typename ProgramFactory::shared_variables_t>;
-                auto& cached_mesh_workload =
-                    cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
-                mesh_device_operation_t::template override_mesh_runtime_arguments<ProgramFactory>(
-                    cached_mesh_workload, mesh_device, operation_attributes, tensor_args, tensor_return_value);
-                return cached_mesh_workload.workload;
-            },
-            [&]<MeshWorkloadFactoryConcept WorkloadFactory>(
-                const WorkloadFactory&) -> tt::tt_metal::distributed::MeshWorkload& {
-                using cached_mesh_workload_t = typename WorkloadFactory::cached_mesh_workload_t;
-                auto& cached_mesh_workload =
-                    cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
-                WorkloadFactory::override_runtime_arguments(
-                    cached_mesh_workload, operation_attributes, tensor_args, tensor_return_value);
-                return cached_mesh_workload.workload;
-            }},
-        program_factory);
+            WorkloadFactory::override_runtime_arguments(
+                cached_mesh_workload, operation_attributes, tensor_args, tensor_return_value);
 
-    {  // Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed profiler
-       // regresion
-        // tests well-formed data.
-        ZoneScopedN("TT_DNN_DEVICE_OP");
-        mesh_device_operation_utils::set_runtime_id(workload, mesh_device);
-        if (mesh_device_operation_utils::track_workload(workload, mesh_device)) {
-            return;
-        }
-
-        tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
-
-        TracyOpMeshWorkload(
-            mesh_device, workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);
-    }
+            enqueue_mesh_workload<mesh_device_operation_t>(
+                cq_id,
+                operation_attributes,
+                tensor_args,
+                tensor_return_value,
+                mesh_device,
+                cached_mesh_workload.workload);
+        });
 }
 
 // Helper for creating and caching a mesh workload
@@ -467,56 +492,35 @@ void create_and_cache_mesh_workload(
     auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
     auto program_factory_index = program_factory.index();
 
-    auto enqueue_workload = [&](tt::tt_metal::distributed::MeshWorkload& workload) {
-        // Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed profiler
-        // regresion tests well-formed data.
-        ZoneScopedN("TT_DNN_DEVICE_OP");
-        mesh_device_operation_utils::set_runtime_id(workload, mesh_device);
-        if (mesh_device_operation_utils::track_workload(workload, mesh_device)) {
-            return;
+    dispatch_to_mesh_workload_factory<
+        mesh_device_operation_t>(program_factory, [&]<MeshWorkloadFactoryConcept WorkloadFactory>() {
+        using cached_mesh_workload_t = typename WorkloadFactory::cached_mesh_workload_t;
+
+        ttnn::MeshCoordinateRangeSet tensor_coords;
+        if (mesh_device_operation_utils::all_tensors_have_uniform_storage(tensor_args)) {
+            tensor_coords.merge(ttnn::MeshCoordinateRange(mesh_device->shape()));
+        } else {
+            for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args)) {
+                tensor_coords.merge(ttnn::MeshCoordinateRange(coord, coord));
+            }
         }
+        auto cached_workload = WorkloadFactory::create_mesh_workload(
+            operation_attributes,
+            tensor_coords,
+            tensor_args,
+            tensor_return_value);
 
-        tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
-        TracyOpMeshWorkload(
-            mesh_device, workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);
-    };
-
-    std::visit(
-        tt::stl::overloaded{
-            [&]<ProgramFactoryConcept ProgramFactory>(const ProgramFactory&) {
-                using cached_mesh_workload_t = AdaptedCachedMeshWorkload<typename ProgramFactory::shared_variables_t>;
-                auto cached_workload = mesh_device_operation_t::template create_mesh_workload<ProgramFactory>(
-                    mesh_device, operation_attributes, tensor_args, tensor_return_value);
-
-                if (program_cache.is_enabled()) {
-                    program_cache.insert(
-                        program_hash, CachedProgramFactory{std::move(cached_workload), program_factory_index});
-                    auto& cached_program_factory = program_cache.get(program_hash);
-                    enqueue_workload(
-                        cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload);
-                } else {
-                    enqueue_workload(cached_workload.workload);
-                }
-            },
-            [&]<MeshWorkloadFactoryConcept WorkloadFactory>(const WorkloadFactory&) {
-                using cached_mesh_workload_t = typename WorkloadFactory::cached_mesh_workload_t;
-                auto cached_workload = WorkloadFactory::create_mesh_workload(
-                    operation_attributes,
-                    mesh_device_operation_utils::extract_tensor_coordinates(tensor_args),
-                    tensor_args,
-                    tensor_return_value);
-
-                if (program_cache.is_enabled()) {
-                    program_cache.insert(
-                        program_hash, CachedProgramFactory{std::move(cached_workload), program_factory_index});
-                    auto& cached_program_factory = program_cache.get(program_hash);
-                    enqueue_workload(
-                        cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload);
-                } else {
-                    enqueue_workload(cached_workload.workload);
-                }
-            }},
-        program_factory);
+        if (program_cache.is_enabled()) {
+            program_cache.insert(program_hash, CachedProgramFactory{std::move(cached_workload), program_factory_index});
+            auto& cached_program_factory = program_cache.get(program_hash);
+            auto& workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload;
+            enqueue_mesh_workload<mesh_device_operation_t>(
+                cq_id, operation_attributes, tensor_args, tensor_return_value, mesh_device, workload);
+        } else {
+            enqueue_mesh_workload<mesh_device_operation_t>(
+                cq_id, operation_attributes, tensor_args, tensor_return_value, mesh_device, cached_workload.workload);
+        }
+    });
 }
 
 // Main function to launch operations on mesh devices with special handling for MeshDeviceOperationAdapter

--- a/ttnn/cpp/ttnn/distributed/types.hpp
+++ b/ttnn/cpp/ttnn/distributed/types.hpp
@@ -16,6 +16,7 @@ namespace ttnn::distributed {
 using MeshShape = tt::tt_metal::distributed::MeshShape;
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 using MeshCoordinateRange = tt::tt_metal::distributed::MeshCoordinateRange;
+using MeshCoordinateRangeSet = tt::tt_metal::distributed::MeshCoordinateRangeSet;
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using SystemMesh = tt::tt_metal::distributed::SystemMesh;
 using MeshDeviceView = tt::tt_metal::distributed::MeshDeviceView;
@@ -29,6 +30,7 @@ namespace ttnn {
 // These types are exported to the ttnn namespace for convenience.
 using ttnn::distributed::MeshCoordinate;
 using ttnn::distributed::MeshCoordinateRange;
+using ttnn::distributed::MeshCoordinateRangeSet;
 using ttnn::distributed::MeshDevice;
 using ttnn::distributed::MeshDeviceConfig;
 using ttnn::distributed::MeshDeviceView;

--- a/ttnn/cpp/ttnn/old_infra_device_operation.cpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.cpp
@@ -57,13 +57,12 @@ template void override_addresses<OptionalTensors>(
 
 template <typename OutputTensors>
 typename OldInfraDeviceOperation<OutputTensors>::ProgramFactory::cached_program_t
-OldInfraDeviceOperation<OutputTensors>::ProgramFactory::create_at(
+OldInfraDeviceOperation<OutputTensors>::ProgramFactory::create(
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate& mesh_coord,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
-    auto program_with_callbacks = operation_attributes.create_program_at(
-        mesh_coord, tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
+    auto program_with_callbacks = operation_attributes.create_program(
+        tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
     return cached_program_t{
         std::move(program_with_callbacks.program),
         shared_variables_t{
@@ -72,10 +71,9 @@ OldInfraDeviceOperation<OutputTensors>::ProgramFactory::create_at(
 }
 
 template <typename OutputTensors>
-void OldInfraDeviceOperation<OutputTensors>::ProgramFactory::override_runtime_arguments_at(
+void OldInfraDeviceOperation<OutputTensors>::ProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
     const operation_attributes_t& operation_attributes,
-    const ttnn::MeshCoordinate&,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
     auto& override_addresses_callback = cached_program.shared_variables.override_addresses_callback;
@@ -198,12 +196,6 @@ auto OldInfraDeviceOperation<OutputTensors>::create_op_performance_model(
 template <typename OutputTensors>
 std::string OldInfraDeviceOperation<OutputTensors>::get_type_name(const operation_attributes_t& attributes) {
     return attributes.get_type_name();
-}
-
-template <typename OutputTensors>
-bool OldInfraDeviceOperation<OutputTensors>::ProgramFactory::uses_heterogenous_dispatch(
-    const operation_attributes_t& attributes) {
-    return attributes.uses_heterogenous_dispatch();
 }
 
 template <typename OutputTensors>

--- a/ttnn/cpp/ttnn/old_infra_device_operation.cpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.cpp
@@ -106,11 +106,11 @@ template <typename OutputTensors>
 typename OldInfraDeviceOperation<OutputTensors>::MeshWorkloadFactory::cached_mesh_workload_t
 OldInfraDeviceOperation<OutputTensors>::MeshWorkloadFactory::create_mesh_workload(
     const operation_attributes_t& operation_attributes,
-    const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
     auto workload_with_callbacks = operation_attributes.create_mesh_workload(
-        mesh_coords, tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
+        tensor_coords, tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
 
     TT_FATAL(
         !workload_with_callbacks.workload_callback.has_value() || workload_with_callbacks.per_program_callbacks.empty(),

--- a/ttnn/cpp/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.hpp
@@ -33,20 +33,16 @@ struct OldInfraDeviceOperation {
         };
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-        static cached_program_t create_at(
+        static cached_program_t create(
             const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate& mesh_coord,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
 
-        static void override_runtime_arguments_at(
+        static void override_runtime_arguments(
             cached_program_t& cached_program,
             const operation_attributes_t& operation_attributes,
-            const ttnn::MeshCoordinate&,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
-
-        static bool uses_heterogenous_dispatch(const operation_attributes_t& attributes);
     };
 
     struct MeshWorkloadFactory {
@@ -112,8 +108,6 @@ struct OldInfraDeviceOperation {
         tensor_return_value_t& tensor_return_value);
 
     static std::string get_type_name(const operation_attributes_t& attributes);
-
-    static bool uses_heterogenous_dispatch(const operation_attributes_t& attributes);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         operation_attributes_t&& operation_attributes,

--- a/ttnn/cpp/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.hpp
@@ -59,7 +59,7 @@ struct OldInfraDeviceOperation {
 
         static cached_mesh_workload_t create_mesh_workload(
             const operation_attributes_t& operation_attributes,
-            const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value);
 

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -395,13 +395,13 @@ constexpr bool implements_create_mesh_workload() {
     return std::experimental::is_detected_v<
                has_create_mesh_workload_t,
                T,
-               const std::vector<ttnn::MeshCoordinate>&,
+               const ttnn::MeshCoordinateRangeSet&,
                const Tensors&,
                Tensors&> or
            std::experimental::is_detected_v<
                has_create_mesh_workload_t,
                T,
-               const std::vector<ttnn::MeshCoordinate>&,
+               const ttnn::MeshCoordinateRangeSet&,
                const Tensors&,
                OptionalTensors&>;
 }
@@ -411,14 +411,14 @@ constexpr bool implements_create_mesh_workload_with_optional_input_tensors() {
     return std::experimental::is_detected_v<
                has_create_mesh_workload_t,
                T,
-               const std::vector<ttnn::MeshCoordinate>&,
+               const ttnn::MeshCoordinateRangeSet&,
                const Tensors&,
                const std::vector<std::optional<const Tensor>>&,
                Tensors&> or
            std::experimental::is_detected_v<
                has_create_mesh_workload_t,
                T,
-               const std::vector<ttnn::MeshCoordinate>&,
+               const ttnn::MeshCoordinateRangeSet&,
                const Tensors&,
                const std::vector<std::optional<const Tensor>>&,
                OptionalTensors&>;
@@ -550,12 +550,12 @@ public:
     }
 
     CacheableMeshWorkload<OutputTensors> create_mesh_workload(
-        const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const Tensors& input_tensors,
         const OptionalConstTensors& optional_input_tensors,
         OutputTensors& output_tensors) const {
         return this->create_mesh_workload_impl_(
-            this->type_erased_storage, mesh_coords, input_tensors, optional_input_tensors, output_tensors);
+            this->type_erased_storage, tensor_coords, input_tensors, optional_input_tensors, output_tensors);
     }
 
     bool uses_heterogenous_dispatch() const { return this->uses_heterogenous_dispatch_impl_(); }
@@ -781,7 +781,7 @@ public:
             }},
         create_mesh_workload_impl_{
             [](const storage_t& storage,
-               const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+               const ttnn::MeshCoordinateRangeSet& tensor_coords,
                const Tensors& input_tensors,
                const OptionalConstTensors& optional_input_tensors,
                OutputTensors& output_tensors) -> CacheableMeshWorkload<OutputTensors> {
@@ -791,14 +791,14 @@ public:
                         optional_input_tensors.empty(),
                         "Optional input tensors not supported by {}",
                         tt::stl::get_type_name<T>());
-                    return operation.create_mesh_workload(mesh_coords, input_tensors, output_tensors);
+                    return operation.create_mesh_workload(tensor_coords, input_tensors, output_tensors);
                 } else if constexpr (detail::implements_create_mesh_workload_with_optional_input_tensors<T>()) {
                     TT_FATAL(
                         not optional_input_tensors.empty(),
                         "Non-optional input tensors not supported by {}",
                         tt::stl::get_type_name<T>());
                     return operation.create_mesh_workload(
-                        mesh_coords, input_tensors, optional_input_tensors, output_tensors);
+                        tensor_coords, input_tensors, optional_input_tensors, output_tensors);
                 } else {
                     TT_THROW("Operation doesn't implement create_mesh_workload");
                 }
@@ -1052,7 +1052,7 @@ private:
 
     CacheableMeshWorkload<OutputTensors> (*create_mesh_workload_impl_)(
         const storage_t& value,
-        const std::vector<ttnn::MeshCoordinate>&,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const Tensors&,
         const std::vector<std::optional<const Tensor>>&,
         OutputTensors&);

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -337,23 +337,12 @@ template <class T, class... Args>
 using has_create_program_t = decltype(std::declval<T>().create_program(std::declval<Args>()...));
 
 template <class T, class... Args>
-using has_create_program_at_t = decltype(std::declval<T>().create_program_at(std::declval<Args>()...));
-
-template <class T, class... Args>
 using has_create_mesh_workload_t = decltype(std::declval<T>().create_mesh_workload(std::declval<Args>()...));
 
 template <class T>
 constexpr bool implements_create_program() {
     return std::experimental::is_detected_v<has_create_program_t, T, const Tensors&, Tensors&> or
            std::experimental::is_detected_v<has_create_program_t, T, const Tensors&, OptionalTensors&>;
-}
-
-template <class T>
-constexpr bool implements_create_program_at() {
-    return std::experimental::
-               is_detected_v<has_create_program_at_t, T, const ttnn::MeshCoordinate&, const Tensors&, Tensors&> or
-           std::experimental::
-               is_detected_v<has_create_program_at_t, T, const ttnn::MeshCoordinate&, const Tensors&, OptionalTensors&>;
 }
 
 template <class T>
@@ -367,24 +356,6 @@ constexpr bool implements_create_program_with_optional_input_tensors() {
            std::experimental::is_detected_v<
                has_create_program_t,
                T,
-               const Tensors&,
-               const std::vector<std::optional<const Tensor>>&,
-               OptionalTensors&>;
-}
-
-template <class T>
-constexpr bool implements_create_program_at_with_optional_input_tensors() {
-    return std::experimental::is_detected_v<
-               has_create_program_at_t,
-               T,
-               const ttnn::MeshCoordinate&,
-               const Tensors&,
-               const std::vector<std::optional<const Tensor>>&,
-               Tensors&> or
-           std::experimental::is_detected_v<
-               has_create_program_at_t,
-               T,
-               const ttnn::MeshCoordinate&,
                const Tensors&,
                const std::vector<std::optional<const Tensor>>&,
                OptionalTensors&>;
@@ -461,9 +432,8 @@ constexpr bool implements_compute_program_hash_with_optional_input_tensors() {
 
 template <class T>
 constexpr bool is_device_operation() {
-    return implements_create_program<T>() || implements_create_program_at<T>() ||
-           implements_create_mesh_workload<T>() || implements_create_program_with_optional_input_tensors<T>() ||
-           implements_create_program_at_with_optional_input_tensors<T>() ||
+    return implements_create_program<T>() || implements_create_mesh_workload<T>() ||
+           implements_create_program_with_optional_input_tensors<T>() ||
            implements_create_mesh_workload_with_optional_input_tensors<T>();
 }
 
@@ -532,21 +502,12 @@ public:
         return this->create_output_tensors_impl_(this->type_erased_storage, input_tensors, output_tensors);
     }
 
-    // `create_at` is a method on program factories that indicates the factory potentially parameterizes the
-    // program creation by a mesh coordinate. This leads to creation of distinct programs on each device of the
-    // mesh.
-    //
-    // For old style infra, we choose to supply a factory that implements `create_at` generically, but the decision to
-    // dispatch homogenous mesh workload or create individual programs for all devices is determined by
-    // `uses_heterogenous_dispatch` method below.
-    //
-    CacheableProgram<OutputTensors> create_program_at(
-        const ttnn::MeshCoordinate& mesh_coord,
+    CacheableProgram<OutputTensors> create_program(
         const Tensors& input_tensors,
         const OptionalConstTensors& optional_input_tensors,
         OutputTensors& output_tensors) const {
-        return this->create_program_at_impl_(
-            this->type_erased_storage, mesh_coord, input_tensors, optional_input_tensors, output_tensors);
+        return this->create_program_impl_(
+            this->type_erased_storage, input_tensors, optional_input_tensors, output_tensors);
     }
 
     CacheableMeshWorkload<OutputTensors> create_mesh_workload(
@@ -558,7 +519,6 @@ public:
             this->type_erased_storage, tensor_coords, input_tensors, optional_input_tensors, output_tensors);
     }
 
-    bool uses_heterogenous_dispatch() const { return this->uses_heterogenous_dispatch_impl_(); }
     bool has_create_workload_method() const { return this->has_create_workload_method_impl_(); }
 
     OpPerformanceModelGeneral<OutputTensors> create_op_performance_model(
@@ -667,8 +627,7 @@ public:
                         "You cannot implement both validate and validate_with_output_tensors");
                 } else if constexpr (
                     detail::implements_validate<T>() and
-                    not(detail::implements_create_program<T>() || detail::implements_create_program_at<T>() ||
-                        detail::implements_create_mesh_workload<T>())) {
+                    not(detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>())) {
                     static_assert(
                         tt::stl::concepts::always_false_v<T>,
                         "Operation doesn't implement both the validate and the correct create_program or "
@@ -676,7 +635,6 @@ public:
                 } else if constexpr (
                     detail::implements_validate_with_optional_input_tensors<T>() and
                     not(detail::implements_create_program_with_optional_input_tensors<T>() ||
-                        detail::implements_create_program_at_with_optional_input_tensors<T>() ||
                         detail::implements_create_mesh_workload_with_optional_input_tensors<T>())) {
                     static_assert(
                         tt::stl::concepts::always_false_v<T>,
@@ -743,20 +701,13 @@ public:
                         "Operation must implement either create_output_tensors or compute_output_specs");
                 }
             }},
-        create_program_at_impl_{
+        create_program_impl_{
             [](const storage_t& storage,
-               const ttnn::MeshCoordinate& mesh_coord,
                const Tensors& input_tensors,
                const OptionalConstTensors& optional_input_tensors,
                OutputTensors& output_tensors) -> CacheableProgram<OutputTensors> {
                 const auto& operation = *reinterpret_cast<const std::decay_t<T>*>(&storage);
-                if constexpr (detail::implements_create_program_at<T>()) {
-                    TT_FATAL(
-                        optional_input_tensors.empty(),
-                        "Optional input tensors not supported by {}",
-                        tt::stl::get_type_name<T>());
-                    return operation.create_program_at(mesh_coord, input_tensors, output_tensors);
-                } else if constexpr (detail::implements_create_program<T>()) {
+                if constexpr (detail::implements_create_program<T>()) {
                     TT_FATAL(
                         optional_input_tensors.empty(),
                         "Optional input tensors not supported by {}",
@@ -768,13 +719,6 @@ public:
                         "Non-optional input tensors not supported by {}",
                         tt::stl::get_type_name<T>());
                     return operation.create_program(input_tensors, optional_input_tensors, output_tensors);
-                } else if constexpr (detail::implements_create_program_at_with_optional_input_tensors<T>()) {
-                    TT_FATAL(
-                        not optional_input_tensors.empty(),
-                        "Non-optional input tensors not supported by {}",
-                        tt::stl::get_type_name<T>());
-                    return operation.create_program_at(
-                        mesh_coord, input_tensors, optional_input_tensors, output_tensors);
                 } else {
                     TT_THROW("Operation doesn't implement create_program");
                 }
@@ -844,8 +788,7 @@ public:
 
                 if constexpr (detail::implements_compute_program_hash<T>()) {
                     static_assert(
-                        detail::implements_create_program<T>() || detail::implements_create_program_at<T>() ||
-                        detail::implements_create_mesh_workload<T>());
+                        detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>());
                     TT_FATAL(
                         optional_input_tensors.empty(),
                         "Optional input tensors not supported by {}",
@@ -854,7 +797,6 @@ public:
                 } else if constexpr (detail::implements_compute_program_hash_with_optional_input_tensors<T>()) {
                     static_assert(
                         detail::implements_create_program_with_optional_input_tensors<T>() ||
-                        detail::implements_create_program_at_with_optional_input_tensors<T>() ||
                         detail::implements_create_mesh_workload_with_optional_input_tensors<T>());
                     TT_FATAL(
                         not optional_input_tensors.empty(),
@@ -862,8 +804,7 @@ public:
                         tt::stl::get_type_name<T>());
                     return operation.compute_program_hash(input_tensors, optional_input_tensors);
                 } else if constexpr (
-                    detail::implements_create_program<T>() || detail::implements_create_program_at<T>() ||
-                    detail::implements_create_mesh_workload<T>()) {
+                    detail::implements_create_program<T>() || detail::implements_create_mesh_workload<T>()) {
                     TT_FATAL(
                         optional_input_tensors.empty(),
                         "Optional input tensors not supported by {}",
@@ -871,7 +812,6 @@ public:
                     return hash_operation<T>(operation, input_tensors);
                 } else if constexpr (
                     detail::implements_create_program_with_optional_input_tensors<T>() ||
-                    detail::implements_create_program_at_with_optional_input_tensors<T>() ||
                     detail::implements_create_mesh_workload_with_optional_input_tensors<T>()) {
                     TT_FATAL(
                         not optional_input_tensors.empty(),
@@ -893,19 +833,13 @@ public:
                 return false;
             }
         }},
-        uses_heterogenous_dispatch_impl_{[]() -> bool {
-            return detail::implements_create_program_at<T>() ||
-                   detail::implements_create_program_at_with_optional_input_tensors<T>();
-        }},
         has_create_workload_method_impl_{[]() -> bool {
             // Operation must implement exactly one of the `create_program` or `create_mesh_workload` methods.
             static_assert(
                 (detail::implements_create_mesh_workload<T>() ||
                  detail::implements_create_mesh_workload_with_optional_input_tensors<T>()) !=
                 (detail::implements_create_program<T>() ||  //
-                 detail::implements_create_program_at<T>() ||
-                 detail::implements_create_program_with_optional_input_tensors<T>() ||
-                 detail::implements_create_program_at_with_optional_input_tensors<T>()));
+                 detail::implements_create_program_with_optional_input_tensors<T>()));
             return detail::implements_create_mesh_workload<T>() ||
                    detail::implements_create_mesh_workload_with_optional_input_tensors<T>();
         }},
@@ -935,13 +869,12 @@ public:
         validate_impl_{other.validate_impl_},
         compute_output_specs_impl_{other.compute_output_specs_impl_},
         create_output_tensors_impl_{other.create_output_tensors_impl_},
-        create_program_at_impl_{other.create_program_at_impl_},
+        create_program_impl_{other.create_program_impl_},
         create_mesh_workload_impl_{other.create_mesh_workload_impl_},
         create_op_performance_model_impl_{other.create_op_performance_model_impl_},
         override_runtime_arguments_program_impl_{other.override_runtime_arguments_program_impl_},
         override_runtime_arguments_workload_impl_{other.override_runtime_arguments_workload_impl_},
         uses_custom_program_hash_impl_{other.uses_custom_program_hash_impl_},
-        uses_heterogenous_dispatch_impl_{other.uses_heterogenous_dispatch_impl_},
         has_create_workload_method_impl_{other.has_create_workload_method_impl_},
         compute_program_hash_impl_{other.compute_program_hash_impl_},
         create_profiler_info_impl_{other.create_profiler_info_impl_},
@@ -961,13 +894,12 @@ public:
             this->validate_impl_ = other.validate_impl_;
             this->compute_output_specs_impl_ = other.compute_output_specs_impl_;
             this->create_output_tensors_impl_ = other.create_output_tensors_impl_;
-            this->create_program_at_impl_ = other.create_program_at_impl_;
+            this->create_program_impl_ = other.create_program_impl_;
             this->create_mesh_workload_impl_ = other.create_mesh_workload_impl_;
             this->create_op_performance_model_impl_ = other.create_op_performance_model_impl_;
             this->override_runtime_arguments_program_impl_ = other.override_runtime_arguments_program_impl_;
             this->override_runtime_arguments_workload_impl_ = other.override_runtime_arguments_workload_impl_;
             this->uses_custom_program_hash_impl_ = other.uses_custom_program_hash_impl_;
-            this->uses_heterogenous_dispatch_impl_ = other.uses_heterogenous_dispatch_impl_;
             this->has_create_workload_method_impl_ = other.has_create_workload_method_impl_;
             this->compute_program_hash_impl_ = other.compute_program_hash_impl_;
             this->create_profiler_info_impl_ = other.create_profiler_info_impl_;
@@ -985,13 +917,12 @@ public:
         validate_impl_{other.validate_impl_},
         compute_output_specs_impl_{other.compute_output_specs_impl_},
         create_output_tensors_impl_{other.create_output_tensors_impl_},
-        create_program_at_impl_{other.create_program_at_impl_},
+        create_program_impl_{other.create_program_impl_},
         create_mesh_workload_impl_{other.create_mesh_workload_impl_},
         create_op_performance_model_impl_{other.create_op_performance_model_impl_},
         override_runtime_arguments_program_impl_{other.override_runtime_arguments_program_impl_},
         override_runtime_arguments_workload_impl_{other.override_runtime_arguments_workload_impl_},
         uses_custom_program_hash_impl_{other.uses_custom_program_hash_impl_},
-        uses_heterogenous_dispatch_impl_{other.uses_heterogenous_dispatch_impl_},
         has_create_workload_method_impl_{other.has_create_workload_method_impl_},
         compute_program_hash_impl_{other.compute_program_hash_impl_},
         create_profiler_info_impl_{other.create_profiler_info_impl_},
@@ -1015,7 +946,6 @@ public:
             this->create_op_performance_model_impl_ = other.create_op_performance_model_impl_;
             this->override_runtime_arguments_impl_ = other.override_runtime_arguments_impl_;
             this->uses_custom_program_hash_impl_ = other.uses_custom_program_hash_impl_;
-            this->uses_heterogenous_dispatch_impl_ = other.uses_heterogenous_dispatch_impl_;
             this->has_create_workload_method_impl_ = other.has_create_workload_method_impl_;
             this->compute_program_hash_impl_ = other.compute_program_hash_impl_;
             this->create_profiler_info_impl_ = other.create_profiler_info_impl_;
@@ -1043,12 +973,8 @@ private:
     const ComputedSpecs (*compute_output_specs_impl_)(const storage_t& value, const Tensors&, const OptionalTensors&);
     const OutputTensors (*create_output_tensors_impl_)(const storage_t& value, const Tensors&, const OptionalTensors&);
 
-    CacheableProgram<OutputTensors> (*create_program_at_impl_)(
-        const storage_t& value,
-        const ttnn::MeshCoordinate&,
-        const Tensors&,
-        const std::vector<std::optional<const Tensor>>&,
-        OutputTensors&);
+    CacheableProgram<OutputTensors> (*create_program_impl_)(
+        const storage_t& value, const Tensors&, const std::vector<std::optional<const Tensor>>&, OutputTensors&);
 
     CacheableMeshWorkload<OutputTensors> (*create_mesh_workload_impl_)(
         const storage_t& value,
@@ -1074,7 +1000,6 @@ private:
         const std::vector<std::optional<const Tensor>>&,
         OutputTensors&);
     bool (*uses_custom_program_hash_impl_)();
-    bool (*uses_heterogenous_dispatch_impl_)();
     bool (*has_create_workload_method_impl_)();
     const Hash (*compute_program_hash_impl_)(
         const storage_t& value, const Tensors&, const std::vector<std::optional<const Tensor>>&);

--- a/ttnn/cpp/ttnn/operation_concepts.hpp
+++ b/ttnn/cpp/ttnn/operation_concepts.hpp
@@ -24,30 +24,9 @@ concept ProgramFactoryConcept = requires {
     typename T::cached_program_t;
 
     [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
-        // Check that exactly one of create or create_at is implemented.
-        constexpr bool has_create = requires { T::create(operation_attributes, tensor_args, tensor_return_value); };
-        constexpr bool has_create_at = requires {
-            T::create_at(operation_attributes, std::declval<ttnn::MeshCoordinate>(), tensor_args, tensor_return_value);
-        };
-        static_assert(has_create != has_create_at, "Program factory must implement exactly one of create or create_at");
+        auto cached_program = T::create(operation_attributes, tensor_args, tensor_return_value);
 
-        if constexpr (has_create) {
-            auto cached_program = T::create(operation_attributes, tensor_args, tensor_return_value);
-            T::override_runtime_arguments(cached_program, operation_attributes, tensor_args, tensor_return_value);
-        } else if constexpr (has_create_at) {
-            auto cached_program = T::create_at(
-                operation_attributes, std::declval<ttnn::MeshCoordinate>(), tensor_args, tensor_return_value);
-            T::override_runtime_arguments_at(
-                cached_program,
-                operation_attributes,
-                std::declval<ttnn::MeshCoordinate>(),
-                tensor_args,
-                tensor_return_value);
-        } else {
-            static_assert(
-                tt::stl::concepts::always_false_v<T>,
-                "Program factory must implement exactly one of create or create_at");
-        }
+        T::override_runtime_arguments(cached_program, operation_attributes, tensor_args, tensor_return_value);
     };
 };
 

--- a/ttnn/cpp/ttnn/operation_concepts.hpp
+++ b/ttnn/cpp/ttnn/operation_concepts.hpp
@@ -55,9 +55,12 @@ template <typename T>
 concept MeshWorkloadFactoryConcept = requires {
     typename T::cached_mesh_workload_t;
 
-    [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
-        auto cached_workload = T::create_mesh_workload(
-            operation_attributes, std::vector<ttnn::MeshCoordinate>{}, tensor_args, tensor_return_value);
+    [](const auto& operation_attributes,
+       const ttnn::MeshCoordinateRangeSet& tensor_coords,
+       const auto& tensor_args,
+       auto& tensor_return_value) {
+        auto cached_workload =
+            T::create_mesh_workload(operation_attributes, tensor_coords, tensor_args, tensor_return_value);
 
         T::override_runtime_arguments(cached_workload, operation_attributes, tensor_args, tensor_return_value);
     };

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -173,6 +173,16 @@ std::vector<Tensor> AllGather::create_output_tensors(const std::vector<Tensor>& 
     return tt::tt_metal::operation::default_create_output_tensors(*this, input_tensors, {});
 }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks AllGather::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(coord, input_tensors, output_tensors);
+        });
+}
+
 tt::tt_metal::operation::ProgramWithCallbacks AllGather::create_program_at(
     const ttnn::MeshCoordinate& mesh_coord,
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.hpp
@@ -132,6 +132,10 @@ struct AllGather {
     void validate(const std::vector<Tensor> &input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor> &input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor> &input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& mesh_coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
@@ -28,6 +28,16 @@ std::vector<Tensor> Barrier::create_output_tensors(const std::vector<Tensor>& in
     return input_tensors;
 }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks Barrier::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(coord, input_tensors, output_tensors);
+        });
+}
+
 tt::tt_metal::operation::ProgramWithCallbacks Barrier::create_program_at(
     const ttnn::MeshCoordinate& mesh_coord,
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.hpp
@@ -20,6 +20,10 @@ struct Barrier {
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& mesh_coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -59,6 +59,26 @@ size_t LineTopology::get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInter
 
 ttnn::ccl::Topology LineTopology::topology() const { return ttnn::ccl::Topology::Linear; }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_programs(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors,
+    const std::function<tt::tt_metal::operation::ProgramWithCallbacks(const ttnn::MeshCoordinate&)>& create_program) {
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks workload_with_callbacks;
+    for (const auto& range : tensor_coords.ranges()) {
+        for (const auto& coord : range) {
+            const ttnn::MeshCoordinateRange program_range(coord, coord);
+            auto program_with_callbacks = create_program(coord);
+            workload_with_callbacks.workload.add_program(program_range, std::move(program_with_callbacks.program));
+            if (program_with_callbacks.override_runtime_arguments_callback.has_value()) {
+                workload_with_callbacks.per_program_callbacks.emplace(
+                    program_range, std::move(*program_with_callbacks.override_runtime_arguments_callback));
+            }
+        }
+    }
+    return workload_with_callbacks;
+}
+
 std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> get_device_index_and_sender_receiver_ids(
     const IDevice* target_device, const std::vector<IDevice*>& devices, const ttnn::ccl::Topology& topology) {
     uint32_t num_devices = devices.size();

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -8,6 +8,7 @@
 #include <numeric>
 
 #include <tt-metalium/constants.hpp>
+#include "ttnn/operation.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/common/types/ccl_types.hpp"
 #include "ttnn/operations/ccl/shared_with_host/hetergeneous_data_structs.hpp"
@@ -30,6 +31,13 @@ struct SyncModeSpec {
 };
 
 class EriscDatamoverBuilder;
+
+// Creates a mesh workload by calling the `create_program` function for each coordinate in the `tensor_coords` set.
+tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_programs(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors,
+    const std::function<tt::tt_metal::operation::ProgramWithCallbacks(const ttnn::MeshCoordinate&)>& create_program);
 
 std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> get_device_index_and_sender_receiver_ids(
     const IDevice* target_device, const std::vector<IDevice*>& devices, const ttnn::ccl::Topology& topology);
@@ -459,7 +467,7 @@ class RingReduceScatterWrappedTensorSlicer : public RingReduceScatterBaseTensorS
 class InterleavedRingAllGatherTensorSlicer : public LegacyCclTensorSlicer {
    public:
     InterleavedRingAllGatherTensorSlicer(
-        Tensor const& input_tensor, Tensor const& output_tensor, int slice_dim, uint32_t slice_idx) :
+         const Tensor & input_tensor,  const Tensor & output_tensor, int slice_dim, uint32_t slice_idx) :
         LegacyCclTensorSlicer() {
         this->row_major = input_tensor.get_layout() == tt::tt_metal::Layout::ROW_MAJOR;
         this->slice_dim_is_width = input_tensor.get_padded_shape().rank() - 1 == slice_dim;

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -37,6 +37,16 @@ std::vector<ttnn::TensorSpec> ReduceScatter::compute_output_specs(const std::vec
     return std::vector<ttnn::TensorSpec>(input_tensors.size(), spec);
 }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks ReduceScatter::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(coord, input_tensors, output_tensors);
+        });
+}
+
 tt::tt_metal::operation::ProgramWithCallbacks ReduceScatter::create_program_at(
     const MeshCoordinate& mesh_coord,
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.hpp
@@ -26,6 +26,10 @@ struct ReduceScatter {
     const std::vector<IDevice*> devices;
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const MeshCoordinate& mesh_coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -209,6 +209,16 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
     return AllGatherAsyncVersion::GENERIC;
 }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks AllGatherAsync::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(coord, input_tensors, output_tensors);
+        });
+}
+
 tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program_at(
     const MeshCoordinate& coord, const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     std::vector<IDevice*> devices;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp
@@ -80,6 +80,10 @@ struct AllGatherAsync {
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.hpp
@@ -49,6 +49,11 @@ struct AllGatherMatmul {
         const std::vector<std::optional<Tensor>>& optional_output_tensors = {std::nullopt}) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
     std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        const std::vector<std::optional<const Tensor>>& optional_input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& mesh_coordinate,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -28,6 +28,16 @@ std::vector<ttnn::TensorSpec> AllReduce::compute_output_specs(const std::vector<
     return std::vector<ttnn::TensorSpec>(input_tensors.size(), spec);
 }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks AllReduce::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(coord, input_tensors, output_tensors);
+        });
+};
+
 tt::tt_metal::operation::ProgramWithCallbacks AllReduce::create_program_at(
     const ttnn::MeshCoordinate& coord,
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.hpp
@@ -30,6 +30,10 @@ struct AllReduce {
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.cpp
@@ -73,6 +73,16 @@ std::vector<ttnn::TensorSpec> AllReduceAsync::compute_output_specs(const std::ve
     return {TensorSpec(shape, output_tensor_layout)};
 }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks AllReduceAsync::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(coord, input_tensors, output_tensors);
+        });
+};
+
 tt::tt_metal::operation::ProgramWithCallbacks AllReduceAsync::create_program_at(
     const ttnn::MeshCoordinate& coord,
     const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/all_reduce_async_op.hpp
@@ -69,6 +69,10 @@ struct AllReduceAsync {
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -133,6 +133,16 @@ std::vector<ttnn::TensorSpec> ReduceScatterAsync::compute_output_specs(const std
     return output_tensors;
 }
 
+tt::tt_metal::operation::MeshWorkloadWithCallbacks ReduceScatterAsync::create_mesh_workload(
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const std::vector<Tensor>& input_tensors,
+    std::vector<Tensor>& output_tensors) const {
+    return ccl::create_mesh_workload_from_programs(
+        tensor_coords, input_tensors, output_tensors, [&, this](const ttnn::MeshCoordinate& coord) {
+            return create_program_at(coord, input_tensors, output_tensors);
+        });
+};
+
 operation::ProgramWithCallbacks ReduceScatterAsync::create_program_at(
     const MeshCoordinate& coord, const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     std::vector<IDevice*> devices;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.hpp
@@ -65,6 +65,10 @@ struct ReduceScatterAsync {
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const;
     tt::tt_metal::operation::ProgramWithCallbacks create_program_at(
         const ttnn::MeshCoordinate& coord,
         const std::vector<Tensor>& input_tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.hpp
@@ -48,7 +48,7 @@ struct DropoutMeshWorkloadFactory {
     // `AdaptedCachedMeshWorkload`, as only a single `shared_variables_t` is needed.
     static cached_mesh_workload_t create_mesh_workload(
         const operation_attributes_t& operation_attributes,
-        const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -195,7 +195,7 @@ struct Matmul {
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<Tensor>>& optional_output_tensors = {std::nullopt}) const;
     tt::tt_metal::operation::CacheableMeshWorkload<std::vector<Tensor>> create_mesh_workload(
-        const std::vector<ttnn::MeshCoordinate>& mesh_coords,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
         const std::vector<Tensor>& input_tensors,
         const std::vector<std::optional<const Tensor>>& optional_input_tensors,
         std::vector<Tensor>& output_tensors) const;


### PR DESCRIPTION
### Ticket
#19569

### Problem description
This PR finalizes `create_mesh_workload` interfaces.

### What's changed
* Migrate CCLs and matmul w/ sharded DRAM to `create_mesh_workload` interface.
* Get rid of `create_at` and friends.
* Deduplicate a lot of code by introducing `MeshWorkloadFactoryAdapter`. The pattern is as follows:
  * `select_program_factory` returns a variant of multiple factories, some of which implement `ProgramFactoryConcept`, others implement `MeshWorkloadFactoryConcept` (mutually exclusive)
  * If `T` implements `MeshWorkloadFactoryConcept`, use methods on `T` directly.
  * Otherwise, wrap `T` into `MeshWorkloadFactoryAdapter`, and use `MeshWorkloadFactoryAdapter<T>` instead.
  * See `dispatch_to_mesh_workload_factory` for an example.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14176536957)
- [X] Ran T3K tests locally (TTNN unit tests, resnet and falcon 7b model tests) 
- [X] @tt-asaigal validated TG perf is not affected.
- [X] New/Existing tests provide coverage for changes