### PR TITLE
#19836: Add support for reusing programs across different sub-device …

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -191,6 +191,52 @@ TEST_F(MeshSubDeviceTestSuite, SubDeviceSwitching) {
     }
     Finish(mesh_device_->mesh_command_queue());
 }
+
+TEST_F(MeshSubDeviceTestSuite, SubDeviceBasicProgramsReuse) {
+    constexpr uint32_t k_num_iters = 5;
+    constexpr uint32_t k_local_l1_size = 3200;
+
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    // sub-device 3 and 4 are supersets of sub-device 1 and 2 respectively
+    SubDevice sub_device_3(std::array{CoreRangeSet(std::vector{CoreRange({0, 0}, {2, 2}), CoreRange({5, 5}, {5, 5})})});
+    SubDevice sub_device_4(std::array{
+        CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4}), CoreRange({6, 6}, {6, 6})})});
+    auto sub_device_manager_1 = mesh_device_->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
+    auto sub_device_manager_2 = mesh_device_->create_sub_device_manager({sub_device_4, sub_device_3}, k_local_l1_size);
+    mesh_device_->load_sub_device_manager(sub_device_manager_1);
+
+    auto [waiter_program, syncer_program, incrementer_program, global_sem] =
+        create_basic_sync_program(mesh_device_.get(), sub_device_1, sub_device_2);
+    MeshCoordinateRange devices(mesh_device_->shape());
+    auto waiter_mesh_workload = CreateMeshWorkload();
+    auto syncer_mesh_workload = CreateMeshWorkload();
+    auto incrementer_mesh_workload = CreateMeshWorkload();
+    AddProgramToMeshWorkload(waiter_mesh_workload, std::move(waiter_program), devices);
+    AddProgramToMeshWorkload(syncer_mesh_workload, std::move(syncer_program), devices);
+    AddProgramToMeshWorkload(incrementer_mesh_workload, std::move(incrementer_program), devices);
+
+    // Run programs on sub-device manager 1
+    for (uint32_t i = 0; i < k_num_iters; i++) {
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), waiter_mesh_workload, false);
+        mesh_device_->set_sub_device_stall_group({SubDeviceId{0}});
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), syncer_mesh_workload, true);
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), incrementer_mesh_workload, false);
+        mesh_device_->reset_sub_device_stall_group();
+    }
+    Finish(mesh_device_->mesh_command_queue());
+
+    // Rerun programs on sub-device manager 2
+    mesh_device_->load_sub_device_manager(sub_device_manager_2);
+    for (uint32_t i = 0; i < k_num_iters; i++) {
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), waiter_mesh_workload, false);
+        mesh_device_->set_sub_device_stall_group({SubDeviceId{1}});
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), syncer_mesh_workload, true);
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), incrementer_mesh_workload, false);
+        mesh_device_->reset_sub_device_stall_group();
+    }
+    Finish(mesh_device_->mesh_command_queue());
+}
 }
 }  // namespace
 }  // namespace tt::tt_metal::distributed::test

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -130,6 +130,7 @@ target_sources(
             test_kernels/misc/print_tile_trisc.cpp
             test_kernels/misc/print_with_wait.cpp
             test_kernels/misc/runtime_args_kernel.cpp
+            test_kernels/misc/sub_device/add_common_and_unique_rta.cpp
             test_kernels/misc/sub_device/incrementer.cpp
             test_kernels/misc/sub_device/persistent_remote_waiter.cpp
             test_kernels/misc/sub_device/persistent_waiter.cpp

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -189,6 +189,47 @@ TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicPrograms) {
     detail::DumpDeviceProfileResults(device);
 }
 
+TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceBasicProgramsReuse) {
+    constexpr uint32_t k_num_iters = 5;
+    auto* device = devices_[0];
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
+    // sub-device 3 and 4 are supersets of sub-device 1 and 2 respectively
+    SubDevice sub_device_3(std::array{CoreRangeSet(std::vector{CoreRange({0, 0}, {2, 2}), CoreRange({5, 5}, {5, 5})})});
+    SubDevice sub_device_4(std::array{
+        CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4}), CoreRange({6, 6}, {6, 6})})});
+    auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
+    auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_4, sub_device_3}, k_local_l1_size);
+    device->load_sub_device_manager(sub_device_manager_1);
+
+    auto [waiter_program, syncer_program, incrementer_program, global_sem] =
+        create_basic_sync_program(device, sub_device_1, sub_device_2);
+
+    // Run programs on sub-device manager 1
+    for (uint32_t i = 0; i < k_num_iters; i++) {
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        device->set_sub_device_stall_group({SubDeviceId{0}});
+        // Test blocking on one sub-device
+        EnqueueProgram(device->command_queue(), syncer_program, true);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        device->reset_sub_device_stall_group();
+    }
+    Synchronize(device);
+
+    // Rerun programs on sub-device manager 2
+    device->load_sub_device_manager(sub_device_manager_2);
+    for (uint32_t i = 0; i < k_num_iters; i++) {
+        EnqueueProgram(device->command_queue(), waiter_program, false);
+        device->set_sub_device_stall_group({SubDeviceId{1}});
+        // Test blocking on one sub-device
+        EnqueueProgram(device->command_queue(), syncer_program, true);
+        EnqueueProgram(device->command_queue(), incrementer_program, false);
+        device->reset_sub_device_stall_group();
+    }
+    Synchronize(device);
+    detail::DumpDeviceProfileResults(device);
+}
+
 TEST_F(CommandQueueSingleCardFixture, TensixActiveEthTestSubDeviceBasicEthPrograms) {
     auto* device = devices_[0];
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
@@ -374,6 +415,53 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordin
         // Check coordinates
         tt::tt_metal::verify_kernel_coordinates(
             tt::BRISC, sub_device_cores, device, tt::tt_metal::SubDeviceId{i}, cb_addr);
+    }
+}
+
+// Test that RTAs will be correctly updated when using the same program on multiple subdevice managers.
+TEST_F(CommandQueueSingleCardFixture, TensixTestSubDeviceProgramReuseRtas) {
+    constexpr uint32_t k_num_iters = 5;
+    auto* device = devices_[0];
+    SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
+    SubDevice sub_device_2(std::array{CoreRangeSet(CoreRange({3, 3}, {3, 3}))});
+    // Sub device IDs are swapped between the two sub device managers.
+    auto sub_device_manager_1 = device->create_sub_device_manager({sub_device_1, sub_device_2}, k_local_l1_size);
+    auto sub_device_manager_2 = device->create_sub_device_manager({sub_device_2, sub_device_1}, k_local_l1_size);
+
+    uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    tt_metal::Program program = tt_metal::CreateProgram();
+    CoreCoord core = {3, 3};
+    std::array<uint32_t, 1> unique_runtime_args = {101};
+    std::array<uint32_t, 1> common_runtime_args = {201};
+
+    tt_metal::KernelHandle add_two_ints_kernel = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/add_common_and_unique_rta.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = {l1_unreserved_base}});
+
+    tt_metal::SetCommonRuntimeArgs(program, add_two_ints_kernel, common_runtime_args);
+
+    for (size_t i = 0; i < k_num_iters; i++) {
+        for (auto& sub_device_manager : {sub_device_manager_1, sub_device_manager_2}) {
+            device->load_sub_device_manager(sub_device_manager);
+            unique_runtime_args[0] += 1;
+            common_runtime_args[0] += 2;
+            tt_metal::SetRuntimeArgs(program, add_two_ints_kernel, core, unique_runtime_args);
+            tt_metal::GetCommonRuntimeArgs(program, add_two_ints_kernel)[0] = common_runtime_args[0];
+
+            // Enqueue twice to ensure waits are correct.
+            EnqueueProgram(device->command_queue(), program, false);
+            EnqueueProgram(device->command_queue(), program, false);
+            Synchronize(device);
+            std::vector<uint32_t> kernel_result;
+            tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, sizeof(int), kernel_result);
+            EXPECT_EQ(kernel_result[0], unique_runtime_args[0] + common_runtime_args[0]);
+        }
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_sub_device.cpp
@@ -293,10 +293,6 @@ TEST_F(CommandQueueSingleCardTraceFixture, TensixTestSubDeviceIllegalOperations)
     EnqueueProgram(device->command_queue(), incrementer_program_2, false);
     EndTraceCapture(device, device->command_queue().id(), tid_2);
 
-    // Regular program execution
-    // Can not run a program on a different sub-device manager
-    EXPECT_THROW(EnqueueProgram(device->command_queue(), waiter_program_1, false), std::exception);
-
     // Full trace execution
     ReplayTrace(device, device->command_queue().id(), tid_2, false);
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/add_common_and_unique_rta.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/add_common_and_unique_rta.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/dprint.h"
+
+/**
+ * add two ints
+ * args are in L1
+ * result is in L1
+ */
+
+void kernel_main() {
+    tt_l1_ptr std::uint32_t* arg_a = (tt_l1_ptr uint32_t*)get_arg_addr(0);
+    tt_l1_ptr std::uint32_t* arg_b = (tt_l1_ptr uint32_t*)get_common_arg_addr(0);
+    constexpr uint32_t l1_address = get_compile_time_arg_val(0);
+
+    volatile tt_l1_ptr std::uint32_t* result = (tt_l1_ptr uint32_t*)(l1_address);
+
+    // Sample print statement
+    //  DPRINT << 123;
+    result[0] = arg_a[0] + arg_b[0];
+}

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -38,7 +38,7 @@ private:
     ProgramBinaryStatus get_program_binary_status(std::size_t mesh_id) const;
     void set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status);
     ProgramConfig& get_program_config(uint32_t index);
-    ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program);
+    ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program, uint64_t command_hash);
 
     std::unordered_map<std::size_t, ProgramBinaryStatus> program_binary_status_;
     std::shared_ptr<MeshBuffer> kernel_bin_buf_;

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -151,6 +151,7 @@ void MeshCommandQueue::clear_expected_num_workers_completed() {
 
 void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
     in_use_ = true;
+    uint64_t command_hash = *mesh_device_->get_active_sub_device_manager_id();
     std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.determine_sub_device_ids(mesh_device_);
     TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
     SubDeviceId sub_device_id = *(sub_device_ids.begin());
@@ -195,7 +196,7 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
     // current device state. Write the finalized program command sequence to each
     // physical device tied to the program.
     for (auto& [device_range, program] : mesh_workload.get_programs()) {
-        auto& program_cmd_seq = mesh_workload.get_dispatch_cmds_for_program(program);
+        auto& program_cmd_seq = mesh_workload.get_dispatch_cmds_for_program(program, command_hash);
         program_dispatch::update_program_dispatch_commands(
             program,
             program_cmd_seq,

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -246,9 +246,9 @@ std::unordered_set<SubDeviceId> MeshWorkload::determine_sub_device_ids(MeshDevic
     return sub_devices_;
 }
 
-ProgramCommandSequence& MeshWorkload::get_dispatch_cmds_for_program(Program& program) {
+ProgramCommandSequence& MeshWorkload::get_dispatch_cmds_for_program(Program& program, uint64_t command_hash) {
     // Get the dispatch commands associated with this program
-    return program.get_cached_program_command_sequences().begin()->second;
+    return program.get_cached_program_command_sequences().at(command_hash);
 }
 
 // The functions below are for testing purposes only

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -147,7 +147,8 @@ void EnqueueProgramCommand::process() {
     RecordProgramRun(program);
 
     // Access the program dispatch-command cache
-    auto& cached_program_command_sequence = program.get_cached_program_command_sequences().begin()->second;
+    uint64_t command_hash = *device->get_active_sub_device_manager_id();
+    auto& cached_program_command_sequence = program.get_cached_program_command_sequences().at(command_hash);
     // Update the generated dispatch commands based on the state of the CQ and the ring buffer
     program_dispatch::update_program_dispatch_commands(
         program,

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -456,11 +456,14 @@ void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDevi
 template <typename PackedSubCmd>
 void generate_runtime_args_cmds(
     std::vector<HostMemDeviceCommand>& runtime_args_command_sequences,
+    std::vector<ProgramCommandSequence::RtaUpdate>& rta_updates,
     const uint32_t& l1_arg_base_addr,
     const std::vector<PackedSubCmd>& sub_cmds,
     const std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>>& rt_data_and_sizes,
     const uint32_t& max_runtime_args_len,
-    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>>& rt_args_data,
+    std::vector<std::vector<
+        std::pair<std::reference_wrapper<RuntimeArgsData>, std::reference_wrapper<const std::vector<uint32_t>>>>>&
+        rt_args_data,
     const uint32_t max_prefetch_command_size,
     const uint32_t packed_write_max_unicast_sub_cmds,
     bool no_stride,
@@ -530,17 +533,28 @@ void generate_runtime_args_cmds(
             runtime_args_command_sequences.back().size_bytes() ==
             runtime_args_command_sequences.back().write_offset_bytes());
 
-        // Update kernel RTA pointers to point into the generated command
-        // Future RTA updates through the API will update the command sequence directly
         uint32_t data_offset = (uint32_t)get_runtime_args_data_offset(num_packed_cmds, max_runtime_args_len, unicast);
         const uint32_t data_inc = tt::align(max_runtime_args_len * sizeof(uint32_t), l1_alignment);
         uint32_t num_data_copies = no_stride ? 1 : num_packed_cmds;
         for (uint32_t i = offset_idx; i < offset_idx + num_data_copies; ++i) {
             uint32_t offset = 0;
-            for (auto& data : rt_args_data[i]) {
-                data.get().rt_args_data =
+            for (uint32_t j = 0; j < rt_args_data[i].size(); ++j) {
+                auto& data = rt_args_data[i][j];
+                uint32_t* data_in_sequence =
                     (uint32_t*)((char*)runtime_args_command_sequences.back().data() + data_offset + offset);
-                offset += data.get().rt_args_count * sizeof(uint32_t);
+                if (data.first.get().rt_args_data == data.second.get().data()) {
+                    // Update the pointer to point into the command sequence. Future RTA updates will modify the command
+                    // sequence directly.
+                    data.first.get().rt_args_data = data_in_sequence;
+                } else {
+                    TT_ASSERT(data.first.get().rt_args_data == std::get<0>(rt_data_and_sizes[i][j]));
+                    // Pointer already points into another command sequence. Schedule a copy from there.
+                    rta_updates.emplace_back(
+                        data.first.get().rt_args_data,
+                        data_in_sequence,
+                        data.first.get().rt_args_count * sizeof(uint32_t));
+                }
+                offset += data.first.get().rt_args_count * sizeof(uint32_t);
             }
             data_offset += data_inc;
         }
@@ -580,16 +594,17 @@ BatchedTransfers assemble_runtime_args_commands(
     const uint32_t max_prefetch_command_size = DispatchMemMap::get(dispatch_core_type).max_prefetch_command_size();
 
     BatchedTransfers transfers = {};
-
+    using RtaDataPair =
+        std::pair<std::reference_wrapper<RuntimeArgsData>, std::reference_wrapper<const std::vector<uint32_t>>>;
     // Dispatch Commands to Unicast Unique Runtime Args to Workers
     std::vector<CQDispatchWritePackedUnicastSubCmd> unique_sub_cmds;
     std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>> unique_rt_data_and_sizes;
-    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> unique_rt_args_data;
+    std::vector<std::vector<RtaDataPair>> unique_rt_args_data;
     // Dispatch Commands to Multicast Common Runtime Args to Workers
     std::variant<std::vector<CQDispatchWritePackedMulticastSubCmd>, std::vector<CQDispatchWritePackedUnicastSubCmd>>
         common_sub_cmds;
     std::vector<std::vector<std::tuple<const void*, uint32_t, uint32_t>>> common_rt_data_and_sizes;
-    std::vector<std::vector<std::reference_wrapper<RuntimeArgsData>>> common_rt_args_data;  // Data per kernel group
+    std::vector<std::vector<RtaDataPair>> common_rt_args_data;  // Data per kernel group
 
     program_command_sequence.runtime_args_command_sequences = {};
     uint32_t command_count = 0;
@@ -756,12 +771,13 @@ BatchedTransfers assemble_runtime_args_commands(
                                     auto kernel = detail::GetKernel(program, device_local_kernel_handle);
                                     if (!kernel->cores_with_runtime_args().empty()) {
                                         const auto& runtime_args_data = kernel->runtime_args(core_coord);
-                                        unique_rt_args_data.back().emplace_back(kernel->runtime_args_data(core_coord));
+                                        unique_rt_args_data.back().emplace_back(
+                                            RtaDataPair(kernel->runtime_args_data(core_coord), runtime_args_data));
                                         TT_ASSERT(
                                             runtime_args_data.size() * sizeof(uint32_t) <=
                                             kg->rta_sizes[dispatch_class]);
                                         unique_rt_data_and_sizes.back().emplace_back(
-                                            runtime_args_data.data(),
+                                            kernel->runtime_args_data(core_coord).rt_args_data,
                                             runtime_args_data.size() * sizeof(uint32_t),
                                             kg->rta_sizes[dispatch_class]);
                                     }
@@ -776,6 +792,7 @@ BatchedTransfers assemble_runtime_args_commands(
                 uint32_t rta_offset = program.get_program_config(index).rta_offset;
                 generate_runtime_args_cmds(
                     program_command_sequence.runtime_args_command_sequences,
+                    program_command_sequence.rta_updates,
                     rta_offset,
                     unique_sub_cmds,
                     unique_rt_data_and_sizes,
@@ -829,8 +846,11 @@ BatchedTransfers assemble_runtime_args_commands(
                     TT_ASSERT(kernel->common_runtime_args_data().size() * sizeof(uint32_t) == common_size);
                     TT_ASSERT(common_rt_args.size() * sizeof(uint32_t) <= common_size);
                     common_rt_data_and_sizes.back().emplace_back(
-                        common_rt_args.data(), common_rt_args.size() * sizeof(uint32_t), common_size);
-                    common_rt_args_data.back().emplace_back(kernel->common_runtime_args_data());
+                        kernel->common_runtime_args_data().data(),
+                        common_rt_args.size() * sizeof(uint32_t),
+                        common_size);
+                    common_rt_args_data.back().emplace_back(
+                        RtaDataPair(kernel->common_runtime_args_data(), common_rt_args));
 
                     if (core_type == CoreType::ETH) {
                         common_sub_cmds.emplace<std::vector<CQDispatchWritePackedUnicastSubCmd>>(
@@ -868,6 +888,7 @@ BatchedTransfers assemble_runtime_args_commands(
                         [&](auto&& sub_cmds) {
                             generate_runtime_args_cmds(
                                 program_command_sequence.runtime_args_command_sequences,
+                                program_command_sequence.rta_updates,
                                 crta_offset,
                                 sub_cmds,
                                 common_rt_data_and_sizes,


### PR DESCRIPTION
…managers

### Ticket
#19836 

### Problem description
Currently, running the same program under different subdevice managers is disallowed.

### What's changed
We need to cache different program command sequence for each sub-device manager, since the command sequence bakes in information about the subdevice the program is running on.

Using the same program on multiple sub-device managers makes dispatch slightly less efficient, since RTAs may need to be copied from one command sequence into another whenever the program is enqueued.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes