### PR TITLE
[skip ci] Add temporary handling for 20.04 in build_metal.sh

### DIFF
--- a/build_metal.sh
+++ b/build_metal.sh
@@ -86,7 +86,7 @@ toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
 
 # Requested handling for 20.04 -> 22.04 migration
 if [[ "$FLAVOR" == "ubuntu" && "$VERSION" == "20.04" ]]; then
-    echo "WARNING: You are using Ubuntu 20.04 which is end of life. Default toolchain is set to libcpp, which is an unsupported configuration."
+    echo "WARNING: You are using Ubuntu 20.04 which is end of life. Default toolchain is set to libcpp, which is an unsupported configuration. This default behavior will be removed by June 2025."
     toolchain_path="cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
 fi
 

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
+VERSION=`grep '^VERSION_ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
+MAJOR=${VERSION%.*}
+ARCH=`uname -m`
+
 # Function to display help
 show_help() {
     echo "Usage: $0 [options]..."
@@ -78,6 +83,13 @@ cpm_use_local_packages="OFF"
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
 toolchain_path="cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
+
+# Requested handling for 20.04 -> 22.04 migration
+if [[ "$FLAVOR" == "ubuntu" && "$VERSION" == "20.04" ]]; then
+    echo "WARNING: You are using Ubuntu 20.04 which is end of life. Default toolchain is set to libcpp, which is an unsupported configuration."
+    toolchain_path="cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake"
+fi
+
 configure_only="OFF"
 enable_coverage="OFF"
 with_python_bindings="ON"


### PR DESCRIPTION
### Problem description
Some people want to keep working on 20.04 machines for a while.

### What's changed
If distro is detected as Ubuntu 20.04, use the old libc++ toolchain.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes