### PR TITLE
#0: Allow setting worker L1 size at device creation time

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -591,8 +591,10 @@ def run_llama3_demo(
     ],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}], indirect=True
+@pytest.mark.parametrize(  # Worker size is selected to give 120kB ringbuffer size
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872, "worker_l1_size": 1344544}],
+    indirect=True,
 )
 def test_llama_demo(
     weights,
@@ -616,11 +618,6 @@ def test_llama_demo(
 ):
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
-
-    assert_msg = (
-        "Ring buffer size not set. Needs to be set env TT_METAL_WORKER_RINGBUFFER_SIZE=122880 (120KB) for best perf"
-    )
-    assert os.environ.get("TT_METAL_WORKER_RINGBUFFER_SIZE") is not None, assert_msg
 
     # TODO: Remove this once all batch sizes are supported on TG
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -13,7 +13,7 @@ run_tg_llama3_tests() {
   # Run all Llama3 tests for 1B, 3B, 8B, 11B and 70B weights
   # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir TT_METAL_WORKER_RINGBUFFER_SIZE=122880 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 5000; fail+=$?
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 5000; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -13,8 +13,8 @@ run_tg_llama3_tests() {
   # Run all Llama3 tests for 8B, 1B, and 3B weights
   # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir TT_METAL_WORKER_RINGBUFFER_SIZE=122880 FAKE_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model_nd.py --timeout=1800 ; fail+=$?
-    LLAMA_DIR=$llama_dir TT_METAL_WORKER_RINGBUFFER_SIZE=122880 FAKE_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model.py -k full --timeout=1800 ; fail+=$?
+    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model_nd.py --timeout=1800 ; fail+=$?
+    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model.py -k full --timeout=1800 ; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 

--- a/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
@@ -12,6 +12,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include "device_fixture.hpp"
@@ -35,7 +36,7 @@ TEST_F(DeviceFixture, TensixTestTwentyThousandCompileTimeArgs) {
         CoreCoord core = {0, 0};
         Program program;
 
-        const uint32_t write_addr = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+        const uint32_t write_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
 
         const std::map<string, string>& defines = {{"WRITE_ADDRESS", std::to_string(write_addr)}};
 

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -310,11 +310,11 @@ TEST_F(DeviceFixture, TensixIncrementStreamRegWrite) {
 TEST_F(DeviceFixture, TensixInlineWrite4BAlignment) {
     CoreCoord writer_core{0, 0};
     CoreCoord receiver_core(0, 1);
-    uint32_t receiver_addr = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED) + 4;
-    EXPECT_EQ(receiver_addr % 4, 0)
-        << "Expected dest address to be 4B aligned to test noc_inline_dw_write alignment rule";
     uint32_t value_to_write = 39;
     for (tt_metal::IDevice* device : this->devices_) {
+        uint32_t receiver_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1) + 4;
+        EXPECT_EQ(receiver_addr % 4, 0)
+            << "Expected dest address to be 4B aligned to test noc_inline_dw_write alignment rule";
         std::vector<uint32_t> readback(sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, receiver_addr, readback);
 
@@ -345,11 +345,11 @@ TEST_F(DeviceFixture, TensixInlineWrite4BAlignment) {
 TEST_F(DeviceFixture, TensixInlineWriteDedicatedNoc) {
     CoreCoord writer_core{0, 0};
     CoreCoord receiver_core(0, 1);
-    uint32_t first_receiver_addr = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
-    uint32_t second_receiver_addr = first_receiver_addr + hal_ref.get_alignment(HalMemType::L1);
     uint32_t value_to_write = 39;
 
     for (tt_metal::IDevice* device : this->devices_) {
+        uint32_t first_receiver_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+        uint32_t second_receiver_addr = first_receiver_addr + hal_ref.get_alignment(HalMemType::L1);
         std::vector<uint32_t> readback(32 / sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, first_receiver_addr, readback);
 
@@ -393,12 +393,11 @@ TEST_F(DeviceFixture, TensixInlineWriteDedicatedNoc) {
 TEST_F(DeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
     CoreCoord writer_core{0, 0};
     CoreCoord receiver_core(0, 1);
-    uint32_t base_receiver_addr =
-        hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED) + 4;
     uint32_t value_to_write = 39;
     uint32_t num_writes = 8;
 
     for (tt_metal::IDevice* device : this->devices_) {
+        uint32_t base_receiver_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1) + 4;
         std::vector<uint32_t> readback(num_writes * sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, base_receiver_addr, readback);
 
@@ -439,11 +438,11 @@ TEST_F(DeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
 TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
     CoreCoord writer_core{0, 0};
     CoreCoord receiver_core(0, 1);
-    uint32_t receiver_addr0 = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
-    uint32_t receiver_addr2 = receiver_addr0 + (2 * hal_ref.get_alignment(HalMemType::L1));
     uint32_t value_to_write = 39;
 
     for (tt_metal::IDevice* device : this->devices_) {
+        uint32_t receiver_addr0 = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+        uint32_t receiver_addr2 = receiver_addr0 + (2 * hal_ref.get_alignment(HalMemType::L1));
         std::vector<uint32_t> readback(80 / sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, receiver_addr0, readback);
 

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -107,6 +107,7 @@ protected:
         std::unordered_set<MeshDeviceType> mesh_device_types;
         int num_cqs = 1;
         uint32_t trace_region_size = 0;
+        uint32_t worker_l1_size = DEFAULT_WORKER_L1_SIZE;
     };
 
     MeshDeviceFixtureBase(const Config& fixture_config) : config_(fixture_config) {}
@@ -148,7 +149,9 @@ protected:
             0,
             config_.trace_region_size,
             config_.num_cqs,
-            core_type);
+            core_type,
+            {},
+            config_.worker_l1_size);
     }
 
     void TearDown() override {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -73,7 +73,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 50;
     uint32_t l1_buffer_size = single_tile_size * num_tiles;
-    uint32_t l1_buffer_addr = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+    uint32_t l1_buffer_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
 
     // For ethernet core, need to have smaller buffer at a different address
     if (is_eth_core) {

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -51,12 +51,15 @@ TEST(DevicePool, DevicePoolReconfigDevices) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
+    int worker_l1_size = 0;
     const auto& dispatch_core_config = llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
     DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
+        auto& config = dev->allocator()->get_config();
         ASSERT_TRUE((int)(dev->allocator()->get_config().l1_small_size) == l1_small_size);
         ASSERT_TRUE((int)(dev->num_hw_cqs()) == num_hw_cqs);
+        EXPECT_NE(config.l1_unreserved_base, config.worker_l1_size);
         ASSERT_TRUE(dev->is_initialized());
     }
 
@@ -65,10 +68,14 @@ TEST(DevicePool, DevicePoolReconfigDevices) {
         dev->close();
     }
     l1_small_size = 2048;
-    DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
+    worker_l1_size = 4096;
+    DevicePool::initialize(
+        device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config, {}, worker_l1_size);
     devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
-        ASSERT_TRUE((int)(dev->allocator()->get_config().l1_small_size) == l1_small_size);
+        auto& config = dev->allocator()->get_config();
+        ASSERT_TRUE((int)(config.l1_small_size) == l1_small_size);
+        EXPECT_EQ(config.worker_l1_size - config.l1_unreserved_base, worker_l1_size);
         ASSERT_TRUE(dev->is_initialized());
     }
     for (const auto& dev : devices) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -959,8 +959,9 @@ void test_my_coordinates(IDevice* device, tt::RISCV processor_class, size_t cq_i
         cr = CoreRangeSet{std::set<CoreRange>{eth_cores.begin(), eth_cores.end()}};
     }
 
-    uint32_t cb_addr = processor_class == tt::RISCV::ERISC ? hal::get_erisc_l1_unreserved_base()
-                                                           : hal::get_tensix_l1_unreserved_base();
+    uint32_t cb_addr = processor_class == tt::RISCV::ERISC
+                           ? hal::get_erisc_l1_unreserved_base()
+                           : device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
     std::vector<uint32_t> compile_args{
         cb_addr,
     };

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -298,7 +298,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordin
     const auto sub_device_1_cores = device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{0});
     const auto sub_device_2_cores = device->worker_cores(HalProgrammableCoreType::TENSIX, SubDeviceId{1});
 
-    uint32_t cb_addr = hal::get_tensix_l1_unreserved_base();
+    uint32_t cb_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
     std::vector<uint32_t> compile_args{cb_addr};
 
     // Start kernels on each sub device and verify their coordinates
@@ -348,7 +348,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixActiveEthTestSubDeviceMyLogic
     device->load_sub_device_manager(sub_device_manager);
 
     uint32_t cb_addr_eth = hal::get_erisc_l1_unreserved_base();
-    uint32_t cb_addr_worker = hal::get_tensix_l1_unreserved_base();
+    uint32_t cb_addr_worker = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
 
     // Start kernels on each sub device and verify their coordinates
     Program program_1 = tt::tt_metal::CreateProgram();
@@ -412,7 +412,7 @@ TEST_F(CommandQueueSingleCardProgramFixture, TensixTestSubDeviceMyLogicalCoordin
         device->create_sub_device_manager({sub_device_3, sub_device_4}, k_local_l1_size),
     };
 
-    uint32_t cb_addr = hal::get_tensix_l1_unreserved_base();
+    uint32_t cb_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
     std::vector<uint32_t> compile_args{cb_addr};
 
     for (int i = 0; i < sub_device_managers.size(); ++i) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -7,6 +7,7 @@
 #include <fmt/base.h>
 #include <nlohmann/json_fwd.hpp>
 #include <stdint.h>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -331,7 +332,7 @@ int main(int argc, char** argv) {
         CoreCoord router_phys_core;
         CoreCoord gk_phys_core;
         uint32_t routing_table_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+            device_map[test_device_id_l]->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
         uint32_t gk_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
         uint32_t client_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
         uint32_t client_pull_req_buf_addr = client_interface_addr + sizeof(fabric_pull_client_interface_t);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -46,6 +46,7 @@
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
 #include "rtoptions.hpp"
+#include <tt-metalium/allocator.hpp>
 #include "span.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
@@ -1679,7 +1680,7 @@ int main(int argc, char **argv) {
         }
 
         uint32_t worker_unreserved_base_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+            test_devices.begin()->second->device_handle->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
 
         if (metal_fabric_init_level == 0) {
             // manual init fabric

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -23,6 +23,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
@@ -329,7 +330,7 @@ int main(int argc, char** argv) {
         routing_plane_id_t routing_plane;
         CoreCoord gk_phys_core;
         uint32_t routing_table_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
+            device_map[test_device_id_l]->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
         uint32_t gk_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
         uint32_t client_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
         uint32_t client_pull_req_buf_addr = client_interface_addr + sizeof(fabric_pull_client_interface_t);

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -22,6 +22,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
@@ -163,10 +164,10 @@ int main(int argc, char** argv) {
         virtual_offset.y,
         N_RANDS,
         rnd_delay_g,
-        tt::tt_metal::hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED),
-        tt::tt_metal::hal_ref.get_dev_addr(
-            mcast_from_eth_g ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::TENSIX,
-            HalL1MemAddrType::UNRESERVED),
+        device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
+        mcast_from_eth_g
+            ? tt::tt_metal::hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED)
+            : device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
     };
 
     KernelHandle ucast_kernel = tt_metal::CreateKernel(

--- a/tests/ttnn/unit_tests/test_device.py
+++ b/tests/ttnn/unit_tests/test_device.py
@@ -20,6 +20,10 @@ def test_manage_device():
         pass
 
 
+def test_l1_size():
+    assert ttnn.get_max_worker_l1_unreserved_size() > 1024 * 1024
+
+
 @pytest.mark.parametrize(
     "device_params",
     [{"worker_l1_size": 16385}],

--- a/tests/ttnn/unit_tests/test_device.py
+++ b/tests/ttnn/unit_tests/test_device.py
@@ -5,6 +5,7 @@
 import pytest
 
 import ttnn
+import torch
 
 
 def test_open_device():
@@ -17,3 +18,42 @@ def test_manage_device():
     """Simple unit test to test device context manager APIs"""
     with ttnn.manage_device(0) as device:
         pass
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"worker_l1_size": 16385}],
+    indirect=True,
+)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
+def test_worker_l1_size(device, layout, dtype):
+    torch_tensor = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
+
+    core_grid = ttnn.CoreGrid(y=1, x=1)
+    memory_config = ttnn.create_sharded_memory_config(torch_tensor.shape, core_grid, ttnn.ShardStrategy.BLOCK)
+    ttnn_tensor = ttnn.from_torch(torch_tensor, dtype=dtype, layout=layout)
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device, memory_config=memory_config)
+    ttnn_loop_back_tensor = ttnn.from_device(ttnn_tensor)
+    torch_loop_back_tensor = ttnn.to_torch(ttnn_loop_back_tensor)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"worker_l1_size": 16385}],
+    indirect=True,
+)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_worker_l1_fail(device, layout, dtype):
+    torch_tensor = torch.rand((1, 1, 32, 1024), dtype=torch.bfloat16)
+
+    core_grid = ttnn.CoreGrid(y=1, x=1)
+    memory_config = ttnn.create_sharded_memory_config(torch_tensor.shape, core_grid, ttnn.ShardStrategy.BLOCK)
+    ttnn_tensor = ttnn.from_torch(torch_tensor, dtype=dtype, layout=layout)
+    with pytest.raises(RuntimeError, match=".*Out of Memory:.*"):
+        ttnn_tensor = ttnn.to_device(
+            ttnn_tensor,
+            device,
+            memory_config=memory_config,
+        )

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -338,7 +338,8 @@ struct core_info_msg_t {
     volatile uint8_t worker_grid_size_y;
     volatile uint8_t absolute_logical_x;  // Logical X coordinate of this core
     volatile uint8_t absolute_logical_y;  // Logical Y coordinate of this core
-    volatile uint8_t pad[23];
+    volatile uint32_t l1_unreserved_start;
+    volatile uint8_t pad[19];
 };
 
 constexpr uint32_t launch_msg_buffer_num_entries = 8;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -166,6 +166,7 @@ public:
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
         size_t trace_region_size,
+        size_t worker_l1_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) = 0;
     virtual void reset_cores() = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -37,7 +37,8 @@ public:
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false,
         uint32_t worker_thread_core = 0,
-        uint32_t completion_queue_reader_core = 0);
+        uint32_t completion_queue_reader_core = 0,
+        std::size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
     ~Device() override;
 
@@ -140,6 +141,7 @@ public:
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
         size_t trace_region_size,
+        size_t worker_l1_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) override;
     void reset_cores() override;
@@ -201,11 +203,18 @@ private:
 
     void initialize_cluster();
     std::unique_ptr<Allocator> initialize_allocator(
-        size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
+        size_t l1_small_size,
+        size_t trace_region_size,
+        size_t worker_l1_unreserved_start,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
     void initialize_device_bank_to_noc_tables(const HalProgrammableCoreType &core_type, CoreCoord virtual_core);
     void initialize_firmware(const HalProgrammableCoreType &core_type, CoreCoord virtual_core, launch_msg_t *launch_msg, go_msg_t* go_msg);
 
-    void initialize_default_sub_device_state(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap);
+    void initialize_default_sub_device_state(
+        size_t l1_small_size,
+        size_t trace_region_size,
+        size_t worker_l1_unreserved_start,
+        tt::stl::Span<const std::uint32_t> l1_bank_remap);
 
     void compile_command_queue_programs();
     void configure_command_queue_programs();

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -50,7 +50,8 @@ public:
         size_t l1_small_size,
         size_t trace_region_size,
         const tt_metal::DispatchCoreConfig& dispatch_core_config,
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {}) noexcept;
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE) noexcept;
 
     tt_metal::IDevice* get_active_device(chip_id_t device_id) const;
     std::vector<tt_metal::IDevice*> get_all_active_devices() const;
@@ -67,6 +68,7 @@ private:
     uint8_t num_hw_cqs;
     size_t l1_small_size;
     size_t trace_region_size;
+    size_t worker_l1_size;
     std::vector<uint32_t> l1_bank_remap;
     bool using_fast_dispatch;
     std::mutex lock;

--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -69,6 +69,15 @@ uint32_t get_erisc_l1_unreserved_base();
 uint32_t get_erisc_l1_unreserved_size();
 
 /**
+ * @brief Uses the hardware abstraction layer to inform client of architecture specific size.
+ * This size corresponds to the maximum size of the L1 SRAM buffer that can be
+ * used by the application, if the ringbuffer size is set to 0.
+ *
+ * @return size in bytes
+ */
+uint32_t get_max_worker_l1_unreserved_size();
+
+/**
  * @brief Uses the hardware abstraction layer to fetch the representable epsilon value.
  *
  * @return SFPU epsilon value

--- a/tt_metal/api/tt-metalium/hal.hpp
+++ b/tt_metal/api/tt-metalium/hal.hpp
@@ -69,22 +69,6 @@ uint32_t get_erisc_l1_unreserved_base();
 uint32_t get_erisc_l1_unreserved_size();
 
 /**
- * @brief Uses the hardware abstraction layer to inform client of architecture specific address.
- * this address corresponds to the beginning of free space in the TENSIX core's L1 SRAM
- *
- * @return address
- */
-uint32_t get_tensix_l1_unreserved_base();
-
-/**
- * @brief Uses the hardware abstraction layer to inform client of architecture specific size.
- * this size corresponds to the total free space in the TENSIX core's L1 SRAM for host usage
- *
- * @return size in bytes
- */
-uint32_t get_tensix_l1_unreserved_size();
-
-/**
  * @brief Uses the hardware abstraction layer to fetch the representable epsilon value.
  *
  * @return SFPU epsilon value

--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -29,8 +29,9 @@ enum class HalL1MemAddrType : uint8_t {
     WATCHER,
     DPRINT,
     PROFILER,
-    KERNEL_CONFIG,
-    UNRESERVED,
+    KERNEL_CONFIG,  // End is start of unreserved memory
+    UNRESERVED,     // Only for ethernet cores
+    DEFAULT_UNRESERVED,
     CORE_INFO,
     GO_MSG,
     LAUNCH_MSG_BUFFER_RD_PTR,

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -89,7 +89,8 @@ IDevice* CreateDevice(
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
     const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-    const std::vector<uint32_t>& l1_bank_remap = {});
+    const std::vector<uint32_t>& l1_bank_remap = {},
+    const size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
 // clang-format off
 /**

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -80,6 +80,7 @@ private:
             size_t l1_small_size,
             size_t trace_region_size,
             size_t num_command_queues,
+            size_t worker_l1_size,
             const DispatchCoreConfig& dispatch_core_config,
             const MeshDeviceConfig& config);
         ScopedDevices(
@@ -87,6 +88,7 @@ private:
             size_t l1_small_size,
             size_t trace_region_size,
             size_t num_command_queues,
+            size_t worker_l1_size,
             const DispatchCoreConfig& dispatch_core_config);
 
         // Destructor releases physical resources
@@ -217,6 +219,7 @@ public:
         const uint8_t num_hw_cqs,
         size_t l1_small_size,
         size_t trace_region_size,
+        size_t worker_l1_size,
         tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
         bool minimal = false) override;
     void reset_cores() override;
@@ -328,21 +331,24 @@ public:
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
     static std::shared_ptr<MeshDevice> create_unit_mesh(
         int device_id,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
     static std::map<int, std::shared_ptr<MeshDevice>> create_unit_meshes(
         const std::vector<int>& device_ids,
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
         size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
         size_t num_command_queues = 1,
         const DispatchCoreConfig& dispatch_core_config = DispatchCoreConfig{},
-        tt::stl::Span<const std::uint32_t> l1_bank_remap = {});
+        tt::stl::Span<const std::uint32_t> l1_bank_remap = {},
+        size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 };
 
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device);

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -52,7 +52,8 @@ std::map<chip_id_t, IDevice*> CreateDevices(
     const size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
     const tt_metal::DispatchCoreConfig& dispatch_core_config = tt_metal::DispatchCoreConfig{},
-    const std::vector<uint32_t>& l1_bank_remap = {});
+    const std::vector<uint32_t>& l1_bank_remap = {},
+    const size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
 void CloseDevices(const std::map<chip_id_t, IDevice*>& devices);
 

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -6,6 +6,7 @@
 #include <mesh_command_queue.hpp>
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
 #include <algorithm>
 #include <array>
@@ -69,7 +70,10 @@ MeshCommandQueue::MeshCommandQueue(
     mesh_device_ = mesh_device;
     id_ = id;
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
-        config_buffer_mgr_, expected_num_workers_completed_, DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
+        config_buffer_mgr_,
+        expected_num_workers_completed_,
+        DispatchSettings::DISPATCH_MESSAGE_ENTRIES,
+        mesh_device_->allocator()->get_config().l1_unreserved_base);
     this->populate_virtual_program_dispatch_core();
     this->populate_dispatch_core_type();
     this->populate_read_descriptor_queue();
@@ -768,7 +772,10 @@ void MeshCommandQueue::reset_worker_state(
             mesh_device_, go_signal_noc_data, device->sysmem_manager(), id_);
     }
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
-        config_buffer_mgr_, expected_num_workers_completed_, mesh_device_->num_sub_devices());
+        config_buffer_mgr_,
+        expected_num_workers_completed_,
+        mesh_device_->num_sub_devices(),
+        mesh_device_->allocator()->get_config().l1_unreserved_base);
     if (reset_launch_msg_state) {
         std::for_each(
             this->worker_launch_message_buffer_state_->begin(),

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -93,6 +93,7 @@ MeshDevice::ScopedDevices::ScopedDevices(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
+    size_t worker_l1_size,
     const DispatchCoreConfig& dispatch_core_config,
     const MeshDeviceConfig& config) :
     ScopedDevices(
@@ -102,6 +103,7 @@ MeshDevice::ScopedDevices::ScopedDevices(
         l1_small_size,
         trace_region_size,
         num_command_queues,
+        worker_l1_size,
         dispatch_core_config) {}
 
 MeshDevice::ScopedDevices::ScopedDevices(
@@ -109,9 +111,10 @@ MeshDevice::ScopedDevices::ScopedDevices(
     size_t l1_small_size,
     size_t trace_region_size,
     size_t num_command_queues,
+    size_t worker_l1_size,
     const DispatchCoreConfig& dispatch_core_config) {
     opened_devices_ = tt::tt_metal::detail::CreateDevices(
-        device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config);
+        device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config, {}, worker_l1_size);
 
     for (auto device_id : device_ids) {
         devices_.push_back(opened_devices_.at(device_id));
@@ -165,14 +168,15 @@ std::shared_ptr<MeshDevice> MeshDevice::create(
     size_t trace_region_size,
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
-    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
     auto scoped_devices = std::make_shared<ScopedDevices>(
-        l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, config);
+        l1_small_size, trace_region_size, num_command_queues, worker_l1_size, dispatch_core_config, config);
     MeshContainer<IDevice*> devices(config.mesh_shape(), scoped_devices->root_devices());
     auto mesh_device = std::make_shared<MeshDevice>(
         std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::shared_ptr<MeshDevice>());
 
-    mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, l1_bank_remap);
+    mesh_device->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
     return mesh_device;
 }
 
@@ -182,9 +186,10 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
     size_t trace_region_size,
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
-    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
     auto scoped_devices = std::make_shared<ScopedDevices>(
-        device_ids, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config);
+        device_ids, l1_small_size, trace_region_size, num_command_queues, worker_l1_size, dispatch_core_config);
     MeshContainer<IDevice*> devices(MeshShape(1, device_ids.size()), scoped_devices->root_devices());
     auto mesh_device = std::make_shared<MeshDevice>(
         std::move(scoped_devices), std::make_unique<MeshDeviceView>(devices), std::shared_ptr<MeshDevice>());
@@ -197,7 +202,7 @@ std::map<int, std::shared_ptr<MeshDevice>> MeshDevice::create_unit_meshes(
         device_ids.size());
     std::map<int, std::shared_ptr<MeshDevice>> result;
     for (size_t i = 0; i < device_ids.size(); i++) {
-        submeshes[i]->initialize(num_command_queues, l1_small_size, trace_region_size, l1_bank_remap);
+        submeshes[i]->initialize(num_command_queues, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap);
         result[device_ids[i]] = submeshes[i];
     }
 
@@ -210,9 +215,16 @@ std::shared_ptr<MeshDevice> MeshDevice::create_unit_mesh(
     size_t trace_region_size,
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
-    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    size_t worker_l1_size) {
     return create_unit_meshes(
-               {device_id}, l1_small_size, trace_region_size, num_command_queues, dispatch_core_config, l1_bank_remap)
+               {device_id},
+               l1_small_size,
+               trace_region_size,
+               num_command_queues,
+               dispatch_core_config,
+               l1_bank_remap,
+               worker_l1_size)
         .at(device_id);
 }
 
@@ -711,6 +723,7 @@ bool MeshDevice::initialize(
     const uint8_t /*num_hw_cqs*/,
     size_t /*l1_small_size*/,
     size_t /*trace_region_size*/,
+    size_t /*worker_l1_size*/,
     tt::stl::Span<const std::uint32_t> /*l1_bank_remap*/,
     bool /*minimal*/) {
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -51,22 +51,6 @@ uint32_t get_erisc_l1_unreserved_size() {
     return 0;
 }
 
-uint32_t get_tensix_l1_unreserved_base() {
-    auto& hal_ref = HalSingleton::getInstance();
-    if (hal_ref.get_arch() != tt::ARCH::GRAYSKULL) {
-        return hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
-    }
-    return 0;
-}
-
-uint32_t get_tensix_l1_unreserved_size() {
-    auto& hal_ref = HalSingleton::getInstance();
-    if (hal_ref.get_arch() != tt::ARCH::GRAYSKULL) {
-        return hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED);
-    }
-    return 0;
-}
-
 float get_eps() { return HalSingleton::getInstance().get_eps(); }
 
 float get_nan() { return HalSingleton::getInstance().get_nan(); }

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -51,6 +51,13 @@ uint32_t get_erisc_l1_unreserved_size() {
     return 0;
 }
 
+uint32_t get_max_worker_l1_unreserved_size() {
+    auto& hal_ref = HalSingleton::getInstance();
+    size_t l1_end = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
+                    hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
+    return l1_end - hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+}
+
 float get_eps() { return HalSingleton::getInstance().get_eps(); }
 
 float get_nan() { return HalSingleton::getInstance().get_nan(); }

--- a/tt_metal/hostdevcommon/api/hostdevcommon/common_values.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/common_values.hpp
@@ -14,3 +14,4 @@ constexpr static std::uint32_t INVALID = 0;
 constexpr static std::uint32_t VALID = 1;
 constexpr static std::size_t DEFAULT_L1_SMALL_SIZE = 0;  //(1 << 15);  // 32KB
 constexpr static std::size_t DEFAULT_TRACE_REGION_SIZE = 0;
+constexpr static std::size_t DEFAULT_WORKER_L1_SIZE = 0;  // Size is dynamically determined based on the device type.

--- a/tt_metal/hw/inc/debug/dprint_tile.h
+++ b/tt_metal/hw/inc/debug/dprint_tile.h
@@ -217,7 +217,7 @@ struct TileSlice : TileSliceHostDev<MAX_BYTES> {
         this->cb_ptr += tile_idx * tile_info.tile_size;
 
         // Check for unprintable data, and return error as necessary
-        if (this->cb_ptr < L1_UNRESERVED_BASE || this->cb_ptr >= MEM_L1_SIZE) {
+        if (this->cb_ptr < *GET_MAILBOX_ADDRESS_DEV(core_info.l1_unreserved_start) || this->cb_ptr >= MEM_L1_SIZE) {
             this->return_code = DPrintErrorBadPointer;
             return;  // bad tile pointer, return
         }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1143,6 +1143,7 @@ bool Device::initialize(
         "Worker L1 size {} is larger than max size {}",
         worker_l1_size,
         max_worker_l1_size);
+    log_debug(tt::LogMetal, "Worker L1 size: {} Max: {}", worker_l1_size, max_worker_l1_size);
     std::uint32_t max_alignment =
         std::max(hal_ref.get_alignment(HalMemType::DRAM), hal_ref.get_alignment(HalMemType::L1));
     uint32_t worker_l1_unreserved_start = tt::align(

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -104,13 +104,14 @@ Device::Device(
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool minimal,
     uint32_t worker_thread_core,
-    uint32_t completion_queue_reader_core) :
+    uint32_t completion_queue_reader_core,
+    size_t worker_l1_size) :
     id_(device_id),
     worker_thread_core_(worker_thread_core),
     completion_queue_reader_core_(completion_queue_reader_core),
     work_executor_(std::make_unique<WorkExecutor>(worker_thread_core, device_id)) {
     ZoneScoped;
-    this->initialize(num_hw_cqs, l1_small_size, trace_region_size, l1_bank_remap, minimal);
+    this->initialize(num_hw_cqs, l1_small_size, trace_region_size, worker_l1_size, l1_bank_remap, minimal);
 }
 
 std::unordered_set<CoreCoord> Device::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
@@ -330,7 +331,11 @@ void Device::initialize_cluster() {
     log_info(tt::LogMetal, "AI CLK for device {} is:   {} MHz", this->id_, ai_clk);
 }
 
-void Device::initialize_default_sub_device_state(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap) {
+void Device::initialize_default_sub_device_state(
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t worker_l1_unreserved_start,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
     // Create the default sub-device manager representing the entire chip
     const auto& compute_grid_size = this->compute_with_storage_grid_size();
     const auto& active_eth_cores = this->get_active_ethernet_cores(true);
@@ -345,10 +350,16 @@ void Device::initialize_default_sub_device_state(size_t l1_small_size, size_t tr
         CoreRangeSet(std::move(active_eth_core_ranges))})};
 
     sub_device_manager_tracker_ = std::make_unique<SubDeviceManagerTracker>(
-        this, this->initialize_allocator(l1_small_size, trace_region_size, l1_bank_remap), sub_devices);
+        this,
+        this->initialize_allocator(l1_small_size, trace_region_size, worker_l1_unreserved_start, l1_bank_remap),
+        sub_devices);
 }
 
-std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap) {
+std::unique_ptr<Allocator> Device::initialize_allocator(
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t worker_l1_unreserved_start,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap) {
     ZoneScoped;
     const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
     const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
@@ -367,9 +378,7 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
          .dram_unreserved_base = hal_ref.get_dev_addr(HalDramMemAddrType::DRAM_BARRIER) +
                                  hal_ref.get_dev_size(HalDramMemAddrType::DRAM_BARRIER),
          .dram_alignment = hal_ref.get_alignment(HalMemType::DRAM),
-         .l1_unreserved_base = align(
-             hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED),
-             hal_ref.get_alignment(HalMemType::DRAM)),
+         .l1_unreserved_base = align(worker_l1_unreserved_start, hal_ref.get_alignment(HalMemType::DRAM)),
          .worker_grid = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(logical_size.x - 1, logical_size.y - 1))),
          .worker_l1_size = static_cast<size_t>(soc_desc.worker_l1_size),
          .storage_core_bank_size = get_storage_core_bank_size(id_, num_hw_cqs_, dispatch_core_config),
@@ -729,6 +738,7 @@ void Device::initialize_and_launch_firmware() {
     core_info->noc_pcie_addr_end = pcie_chan_end_addr;
     core_info->noc_dram_addr_base = 0;
     core_info->noc_dram_addr_end = soc_d.dram_core_size;
+    core_info->l1_unreserved_start = this->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
 
     const std::vector<tt::umd::CoreCoord>& pcie_cores = soc_d.get_cores(CoreType::PCIE, soc_d.get_umd_coord_system());
     const std::vector<tt::umd::CoreCoord>& dram_cores = soc_d.get_cores(CoreType::DRAM, soc_d.get_umd_coord_system());
@@ -1105,7 +1115,13 @@ void Device::init_fabric() {
     }
 }
 
-bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap, bool minimal) {
+bool Device::initialize(
+    const uint8_t num_hw_cqs,
+    size_t l1_small_size,
+    size_t trace_region_size,
+    size_t worker_l1_size,
+    tt::stl::Span<const std::uint32_t> l1_bank_remap,
+    bool minimal) {
     ZoneScoped;
     log_info(tt::LogMetal, "Initializing device {}. Program cache is {}enabled", this->id_, this->program_cache_.is_enabled() ? "": "NOT ");
     log_debug(tt::LogMetal, "Running with {} cqs ", num_hw_cqs);
@@ -1114,9 +1130,29 @@ bool Device::initialize(const uint8_t num_hw_cqs, size_t l1_small_size, size_t t
     // Trying to preserve logic that was in device_pool.cpp
     // However, I honestly don't understand it
     this->num_hw_cqs_ = num_hw_cqs;
+    if (worker_l1_size == 0) {
+        worker_l1_size = hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    }
+
+    size_t max_worker_l1_size = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
+                                hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) -
+                                hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+
+    TT_FATAL(
+        worker_l1_size <= max_worker_l1_size,
+        "Worker L1 size {} is larger than max size {}",
+        worker_l1_size,
+        max_worker_l1_size);
+    std::uint32_t max_alignment =
+        std::max(hal_ref.get_alignment(HalMemType::DRAM), hal_ref.get_alignment(HalMemType::L1));
+    uint32_t worker_l1_unreserved_start = tt::align(
+        hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
+            hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - worker_l1_size,
+        max_alignment);
     BuildEnvManager::get_instance().add_build_env(this->id(), this->num_hw_cqs());
     this->initialize_cluster();
-    this->initialize_default_sub_device_state(l1_small_size, trace_region_size, l1_bank_remap);
+    this->initialize_default_sub_device_state(
+        l1_small_size, trace_region_size, worker_l1_unreserved_start, l1_bank_remap);
     this->generate_device_bank_to_noc_tables();
 
     // For minimal setup, don't initialize FW, watcher, dprint. They won't work if we're attaching to a hung chip.

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -189,7 +189,7 @@ std::pair<uint32_t, uint32_t> DispatchMemMap::get_device_l1_info(const CoreType&
     uint32_t l1_size;
     if (core_type == CoreType::WORKER) {
         l1_base = hal_ref.get_dev_addr(
-            tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
         l1_size =
             hal_ref.get_dev_size(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE);
     } else if (core_type == CoreType::ETH) {

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/program.hpp>
 #include <trace_buffer.hpp>
 #include <tracy/Tracy.hpp>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
 #include <tt_stl/overloaded.hpp>
 #include <algorithm>
@@ -119,7 +120,10 @@ HWCommandQueue::HWCommandQueue(
     // Set the affinity of the completion queue reader.
     set_device_thread_affinity(this->completion_queue_thread_, this->completion_queue_reader_core_);
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
-        this->config_buffer_mgr_, this->expected_num_workers_completed_, DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
+        this->config_buffer_mgr_,
+        this->expected_num_workers_completed_,
+        DispatchSettings::DISPATCH_MESSAGE_ENTRIES,
+        device_->allocator()->get_config().l1_unreserved_base);
 }
 
 uint32_t HWCommandQueue::id() const { return this->id_; }
@@ -146,7 +150,10 @@ void HWCommandQueue::reset_worker_state(
     // on host, along with the config_buf_manager being reset, since we wait for all programs across SubDevices
     // to complete as part of resetting the worker state
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
-        this->config_buffer_mgr_, this->expected_num_workers_completed_, device_->num_sub_devices());
+        this->config_buffer_mgr_,
+        this->expected_num_workers_completed_,
+        device_->num_sub_devices(),
+        device_->allocator()->get_config().l1_unreserved_base);
     if (reset_launch_msg_state) {
         std::for_each(
             this->worker_launch_message_buffer_state_->begin(),

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -132,7 +132,8 @@ KernelHandle get_device_local_kernel_handle(KernelHandle kernel_handle);
 void reset_config_buf_mgrs_and_expected_workers(
     DispatchArray<WorkerConfigBufferMgr>& config_buffer_mgrs,
     DispatchArray<uint32_t>& expected_num_workers_completed,
-    uint32_t num_entries_to_reset);
+    uint32_t num_entries_to_reset,
+    uint32_t worker_l1_unreserved_start);
 
 void reset_worker_dispatch_state_on_device(
     IDevice* device,

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -198,9 +198,7 @@ void JitBuildEnv::init(
     }
 
     if (tt::llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
-        this->defines_ +=
-            "-DDEBUG_PRINT_ENABLED -DL1_UNRESERVED_BASE=" +
-            to_string(hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::UNRESERVED)) + " ";
+        this->defines_ += "-DDEBUG_PRINT_ENABLED ";
     }
 
     if (tt::llrt::RunTimeOptions::get_instance().get_record_noc_transfers()) {

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -22,19 +22,12 @@
 #define GET_MAILBOX_ADDRESS_HOST(x) ((uint64_t)&(((mailboxes_t*)MEM_MAILBOX_BASE)->x))
 
 namespace tt::tt_metal::blackhole {
-static uint32_t get_l1_kernel_config_size() {
-    const char* worker_ringbuffer_size = std::getenv("TT_METAL_WORKER_RINGBUFFER_SIZE");
-    if (!worker_ringbuffer_size) {
-        return 69 * 1024;
-    }
-    return std::stoul(worker_ringbuffer_size);
-}
 
 HalCoreInfoType create_tensix_mem_map() {
     uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 
     std::vector<DeviceAddr> mem_map_bases;
-    const uint32_t l1_kernel_config_size = get_l1_kernel_config_size();
+    const uint32_t default_l1_kernel_config_size = 69 * 1024;
 
     mem_map_bases.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
      mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BASE)] = MEM_L1_BASE;
@@ -45,14 +38,14 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = GET_MAILBOX_ADDRESS_HOST(dprint_buf);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = GET_MAILBOX_ADDRESS_HOST(profiler);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = MEM_MAP_END;
-    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
-        ((MEM_MAP_END + l1_kernel_config_size - 1) | (max_alignment - 1)) + 1;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORE_INFO)] = GET_MAILBOX_ADDRESS_HOST(core_info);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = GET_MAILBOX_ADDRESS_HOST(go_message);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] =
         GET_MAILBOX_ADDRESS_HOST(launch_msg_rd_ptr);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::LOCAL)] = MEM_LOCAL_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_BANK_TO_NOC_SCRATCH;
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DEFAULT_UNRESERVED)] =
+        ((MEM_MAP_END + default_l1_kernel_config_size - 1) | (max_alignment - 1)) + 1;
 
     std::vector<uint32_t> mem_map_sizes;
     mem_map_sizes.resize(static_cast<std::size_t>(HalL1MemAddrType::COUNT));
@@ -63,13 +56,12 @@ HalCoreInfoType create_tensix_mem_map() {
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::WATCHER)] = sizeof(watcher_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DPRINT)] = sizeof(dprint_buf_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::PROFILER)] = sizeof(profiler_msg_t);
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::KERNEL_CONFIG)] = get_l1_kernel_config_size();
-    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)] =
-        MEM_L1_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNRESERVED)];
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::GO_MSG)] = sizeof(go_msg_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR)] = sizeof(uint32_t);
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::LOCAL)] = MEM_TRISC_LOCAL_SIZE; // TRISC, BRISC, or NCRISC?
     mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::BANK_TO_NOC_SCRATCH)] = MEM_BANK_TO_NOC_SIZE;
+    mem_map_sizes[static_cast<std::size_t>(HalL1MemAddrType::DEFAULT_UNRESERVED)] =
+        MEM_L1_SIZE - mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::DEFAULT_UNRESERVED)];
 
     std::vector<std::vector<HalJitBuildConfig>> processor_classes(NumTensixDispatchClasses);
     std::vector<HalJitBuildConfig> processor_types;

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -289,18 +289,31 @@ template <typename T>
 inline T Hal::get_dev_addr(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const {
     uint32_t index = utils::underlying_type<HalProgrammableCoreType>(programmable_core_type);
     TT_ASSERT(index < this->core_info_.size());
+    TT_FATAL(
+        !(programmable_core_type == HalProgrammableCoreType::TENSIX && addr_type == HalL1MemAddrType::UNRESERVED),
+        "Attempting to read addr of unreserved memory");
     return this->core_info_[index].get_dev_addr<T>(addr_type);
 }
 
 template <typename T>
 inline T Hal::get_dev_addr(uint32_t programmable_core_type_index, HalL1MemAddrType addr_type) const {
     TT_ASSERT(programmable_core_type_index < this->core_info_.size());
+    TT_FATAL(
+        !(get_programmable_core_type(programmable_core_type_index) == HalProgrammableCoreType::TENSIX &&
+          addr_type == HalL1MemAddrType::UNRESERVED),
+        "Attempting to read addr of unreserved memory");
     return this->core_info_[programmable_core_type_index].get_dev_addr<T>(addr_type);
 }
 
 inline uint32_t Hal::get_dev_size(HalProgrammableCoreType programmable_core_type, HalL1MemAddrType addr_type) const {
     uint32_t index = utils::underlying_type<HalProgrammableCoreType>(programmable_core_type);
     TT_ASSERT(index < this->core_info_.size());
+    TT_FATAL(
+        !(programmable_core_type == HalProgrammableCoreType::TENSIX && addr_type == HalL1MemAddrType::UNRESERVED),
+        "Attempting to read size of unreserved memory");
+    TT_FATAL(
+        !(programmable_core_type == HalProgrammableCoreType::TENSIX && addr_type == HalL1MemAddrType::KERNEL_CONFIG),
+        "Attempting to read size of kernel config memory");
     return this->core_info_[index].get_dev_size(addr_type);
 }
 

--- a/tt_metal/tools/mem_bench/context.hpp
+++ b/tt_metal/tools/mem_bench/context.hpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <map>
+#include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_align.hpp>
@@ -59,7 +60,7 @@ struct Context {
         bool enable_host_copy_with_kernels_,
         int iterations_) {
         auto l1_alignment = hal::get_l1_alignment();
-        auto l1_base = hal::get_tensix_l1_unreserved_base();
+        auto l1_base = devices_.begin()->second->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
         device_address.cycles = l1_base;
         device_address.rd_bytes = align(device_address.cycles + sizeof(uint32_t), l1_alignment);
         device_address.wr_bytes = align(device_address.rd_bytes + sizeof(uint32_t), l1_alignment);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -384,10 +384,12 @@ std::map<chip_id_t, IDevice*> CreateDevices(
     const size_t l1_small_size,
     const size_t trace_region_size,
     const DispatchCoreConfig& dispatch_core_config,
-    const std::vector<uint32_t>& /*l1_bank_remap*/) {
+    const std::vector<uint32_t>& /*l1_bank_remap*/,
+    const size_t worker_l1_size) {
     ZoneScoped;
     bool is_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
-    tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_config);
+    tt::DevicePool::initialize(
+        device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_config, {}, worker_l1_size);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     std::map<chip_id_t, IDevice*> ret_devices;
     // Only include the mmio device in the active devices set returned to the caller if we are not running
@@ -939,11 +941,12 @@ IDevice* CreateDevice(
     const size_t l1_small_size,
     const size_t trace_region_size,
     const DispatchCoreConfig& dispatch_core_config,
-    const std::vector<uint32_t>& l1_bank_remap) {
+    const std::vector<uint32_t>& l1_bank_remap,
+    const size_t worker_l1_size) {
     ZoneScoped;
 
     tt::DevicePool::initialize(
-        {device_id}, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_config, l1_bank_remap);
+        {device_id}, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_config, l1_bank_remap, worker_l1_size);
     auto dev = tt::DevicePool::instance().get_active_device(device_id);
     return dev;
 }

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -666,6 +666,11 @@ void device_module(py::module& m_device) {
     m_device.attr("DEFAULT_TRACE_REGION_SIZE") = py::int_(DEFAULT_TRACE_REGION_SIZE);
     m_device.attr("DEFAULT_WORKER_L1_SIZE") = py::int_(DEFAULT_WORKER_L1_SIZE);
 
+    m_device.def(
+        "get_max_worker_l1_unreserved_size",
+        &tt::tt_metal::hal::get_max_worker_l1_unreserved_size,
+        "Return the maximum size of the worker L1 unreserved memory.");
+
     m_device.attr("DefaultQueueId") = ttnn::DefaultQueueId;
 }
 

--- a/ttnn/cpp/ttnn/device.cpp
+++ b/ttnn/cpp/ttnn/device.cpp
@@ -13,8 +13,10 @@ IDevice& open_device(
     int device_id,
     size_t l1_small_size,
     size_t trace_region_size,
-    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
-    tt::DevicePool::initialize({device_id}, 1, l1_small_size, trace_region_size, dispatch_core_config, {});
+    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config,
+    size_t worker_l1_size) {
+    tt::DevicePool::initialize(
+        {device_id}, 1, l1_small_size, trace_region_size, dispatch_core_config, {}, worker_l1_size);
     return *(tt::DevicePool::instance().get_active_device(device_id));
 }
 

--- a/ttnn/cpp/ttnn/device.hpp
+++ b/ttnn/cpp/ttnn/device.hpp
@@ -16,7 +16,8 @@ IDevice& open_device(
     int device_id,
     size_t l1_small_size = DEFAULT_L1_SMALL_SIZE,
     size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE,
-    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = tt::tt_metal::DispatchCoreConfig{});
+    const tt::tt_metal::DispatchCoreConfig& dispatch_core_config = tt::tt_metal::DispatchCoreConfig{},
+    size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 void close_device(IDevice& device);
 void enable_program_cache(IDevice& device);
 void disable_and_clear_program_cache(IDevice& device);

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -28,13 +28,16 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t num_command_queues,
     const DispatchCoreConfig& dispatch_core_config,
     const std::optional<MeshCoordinate>& offset,
-    const std::vector<int>& physical_device_ids) {
+    const std::vector<int>& physical_device_ids,
+    size_t worker_l1_size) {
     return MeshDevice::create(
         MeshDeviceConfig(mesh_shape, offset, physical_device_ids),
         l1_small_size,
         trace_region_size,
         num_command_queues,
-        dispatch_core_config);
+        dispatch_core_config,
+        {},
+        worker_l1_size);
 }
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device) { mesh_device->close(); }

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -19,7 +19,8 @@ std::shared_ptr<MeshDevice> open_mesh_device(
     size_t num_command_queues,
     const tt::tt_metal::DispatchCoreConfig& dispatch_core_config,
     const std::optional<MeshCoordinate>& offset = std::nullopt,
-    const std::vector<int>& physical_device_ids = {});
+    const std::vector<int>& physical_device_ids = {},
+    size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE);
 
 void close_mesh_device(const std::shared_ptr<MeshDevice>& mesh_device);
 

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -144,13 +144,16 @@ void py_module(py::module& module) {
                         size_t num_command_queues,
                         const DispatchCoreConfig& dispatch_core_config,
                         const std::optional<MeshCoordinate>& offset,
-                        const std::vector<chip_id_t>& physical_device_ids) {
+                        const std::vector<chip_id_t>& physical_device_ids,
+                        size_t worker_l1_size) {
                 return MeshDevice::create(
                     MeshDeviceConfig(mesh_shape, offset, physical_device_ids),
                     l1_small_size,
                     trace_region_size,
                     num_command_queues,
-                    dispatch_core_config);
+                    dispatch_core_config,
+                    {},
+                    worker_l1_size);
             }),
             py::kw_only(),
             py::arg("mesh_shape"),
@@ -159,7 +162,8 @@ void py_module(py::module& module) {
             py::arg("num_command_queues"),
             py::arg("dispatch_core_config"),
             py::arg("offset"),
-            py::arg("physical_device_ids"))
+            py::arg("physical_device_ids"),
+            py::arg("worker_l1_size") = DEFAULT_WORKER_L1_SIZE)
         .def("get_num_devices", &MeshDevice::num_devices)
         .def("id", &MeshDevice::id)
         .def("get_device_ids", &MeshDevice::get_device_ids)
@@ -395,7 +399,8 @@ void py_module(py::module& module) {
         py::arg("num_command_queues"),
         py::arg("offset"),
         py::arg("physical_device_ids"),
-        py::arg("dispatch_core_config"));
+        py::arg("dispatch_core_config"),
+        py::arg("worker_l1_size") = DEFAULT_WORKER_L1_SIZE);
     module.def("close_mesh_device", &close_mesh_device, py::arg("mesh_device"), py::kw_only());
     module.def(
         "get_device_tensor",

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -212,6 +212,7 @@ from ttnn.device import (
     synchronize_mesh_device,
     dump_device_memory_state,
     get_memory_view,
+    get_max_worker_l1_unreserved_size,
     GetPCIeDeviceID,
     GetNumPCIeDevices,
     GetNumAvailableDevices,

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -66,9 +66,16 @@ def CreateDevice(
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     dispatch_core_config: DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig(),
+    *,
+    worker_l1_size: int = ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE,
 ):
     return ttnn._ttnn.device.CreateDevice(
-        device_id, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config
+        device_id,
+        num_command_queues,
+        l1_small_size,
+        trace_region_size,
+        dispatch_core_config,
+        worker_l1_size=worker_l1_size,
     )
 
 
@@ -78,9 +85,16 @@ def CreateDevices(
     l1_small_size: int = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE,
     trace_region_size: int = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE,
     dispatch_core_config: DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig(),
+    *,
+    worker_l1_size: int = ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE,
 ):
     return ttnn._ttnn.device.CreateDevices(
-        device_ids, num_command_queues, l1_small_size, trace_region_size, dispatch_core_config
+        device_ids,
+        num_command_queues,
+        l1_small_size,
+        trace_region_size,
+        dispatch_core_config,
+        worker_l1_size=worker_l1_size,
     )
 
 

--- a/ttnn/ttnn/device.py
+++ b/ttnn/ttnn/device.py
@@ -23,6 +23,7 @@ DispatchCoreConfig = ttnn._ttnn.device.DispatchCoreConfig
 Arch = ttnn._ttnn.device.Arch
 DEFAULT_L1_SMALL_SIZE = ttnn._ttnn.device.DEFAULT_L1_SMALL_SIZE
 DEFAULT_TRACE_REGION_SIZE = ttnn._ttnn.device.DEFAULT_TRACE_REGION_SIZE
+get_max_worker_l1_unreserved_size = ttnn._ttnn.device.get_max_worker_l1_unreserved_size
 
 open_device = ttnn._ttnn.device.open_device
 init_device_compute_kernel_config = ttnn._ttnn.operations.core.init_device_compute_kernel_config

--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -140,6 +140,7 @@ def open_mesh_device(
     dispatch_core_config: ttnn.DispatchCoreConfig = ttnn.DispatchCoreConfig(),
     offset: Optional[ttnn.MeshCoordinate] = None,
     physical_device_ids: List[int] = [],
+    worker_l1_size: int = ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE,
 ):
     """
     Open a mesh device with the specified configuration.
@@ -152,6 +153,7 @@ def open_mesh_device(
         dispatch_core_type (int, optional): Type of dispatch core. Defaults to DispatchCoreType.WORKER.
         offset (ttnn.MeshCoordinate, optional): Offset in logical mesh coordinates for the mesh device. Defaults to None.
         physical_device_ids (List[int], optional): List of physical device IDs to use. Defaults to [].
+        worker_l1_size (int, optional): Size of the usable worker L1 memory. Defaults to ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE.
 
     Returns:
         ttnn._ttnn.multi_device.MeshDevice: The opened mesh device.
@@ -165,6 +167,7 @@ def open_mesh_device(
         dispatch_core_config=dispatch_core_config,
         offset=offset,
         physical_device_ids=physical_device_ids,
+        worker_l1_size=worker_l1_size,
     )
 
 


### PR DESCRIPTION
### Problem description
Currently we use a dispatcher ringbuffer that's 69 kB, which always works, but has limited dispatch parallelism when programs have large kernels.

### What's changed
To help improve this, add a flag to the device so users can specify how much worker L1 space they need to store the data. They can reduce this to increase the size of the ringbuffer. If no value is specified, default is used which will set the ringbuffer size to 69 kB.

With this change, the start of unreserved memory isn't a constant that's exposed through hal, but should be retrieved from the allocator.

The ethernet core ringbuffer size stays fixed, since it's often it's used by fabric, which is outside the application's normal control.

To take advantage of this, users should attempt to set a variety of L1 sizes smaller than ttnn.get_max_worker_l1_unreserved_size() to see how performance changes, potentially reducing the size of some CBs/buffers (e.g. a prefetch buffer) if worker_l1_size is too small to fit the program, or reducing worker_l1_size if programs are too large to fit in the ringbuffer. Then pick a value that seems good and hardcode that on device creation. If you want to adjust, experiment again.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes