### PR TITLE
Update Falcon7b and Whisper perf targets due to recent 22.04/libstdc++ changes, increase TG Falcon CI perf tolerance

### DIFF
--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -556,7 +556,10 @@ def run_falcon_demo_kv(
     # Verify output or perf if expected values are provided
     assert expected_perf_metrics is None or expected_greedy_output_path is None
     if expected_perf_metrics is not None:
-        verify_perf(measurements, expected_perf_metrics)
+        if num_devices == 32:  # set higher margin to 20% for Galaxy due to larger variance on CI
+            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.20)
+        else:
+            verify_perf(measurements, expected_perf_metrics)
     elif expected_greedy_output_path is not None:
         if token_check_does_pass:
             logger.info("Output Check Passed!")

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 10963, "decode_t/s": 3662, "decode_t/s/u": 14.3}, False, None),
-        (True, 1024, {"prefill_t/s": 12938, "decode_t/s": 3390, "decode_t/s/u": 13.3}, False, None),
-        (True, 2048, {"prefill_t/s": 10813, "decode_t/s": 3234, "decode_t/s/u": 12.6}, False, None),
+        (True, 128, {"prefill_t/s": 10500, "decode_t/s": 3710, "decode_t/s/u": 14.5}, False, None),
+        (True, 1024, {"prefill_t/s": 12522, "decode_t/s": 3434, "decode_t/s/u": 13.4}, False, None),
+        (True, 2048, {"prefill_t/s": 10725, "decode_t/s": 3203, "decode_t/s/u": 12.5}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 16685, "decode_t/s": 4771, "decode_t/s/u": 4.66}, False, None),
-        (True, 1024, {"prefill_t/s": 20488, "decode_t/s": 4576, "decode_t/s/u": 4.47}, False, None),
-        (True, 2048, {"prefill_t/s": 14972, "decode_t/s": 4567, "decode_t/s/u": 4.46}, False, None),
+        (True, 128, {"prefill_t/s": 14501, "decode_t/s": 4000, "decode_t/s/u": 3.91}, False, None),
+        (True, 1024, {"prefill_t/s": 18000, "decode_t/s": 3495, "decode_t/s/u": 3.41}, False, None),
+        (True, 2048, {"prefill_t/s": 13200, "decode_t/s": 3448, "decode_t/s/u": 3.37}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -483,7 +483,7 @@ def test_demo_for_conditional_generation(
         if is_blackhole():
             expected_perf_metrics = {"prefill_t/s": 7.31, "decode_t/s/u": 67.8}
         else:  # wormhole_b0
-            expected_perf_metrics = {"prefill_t/s": 3.84, "decode_t/s/u": 36.7}
+            expected_perf_metrics = {"prefill_t/s": 3.64, "decode_t/s/u": 35.1}
         expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"]  # Only supporting batch 1
         measurements = {"prefill_t/s": 1 / ttft, "decode_t/s": decode_throughput, "decode_t/s/u": decode_throughput}
         verify_perf(measurements, expected_perf_metrics)

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 1750, "decode_t/s": 559, "decode_t/s/u": 17.5}, False, None),
-        (True, 1024, {"prefill_t/s": 2250, "decode_t/s": 499, "decode_t/s/u": 15.6}, False, None),
-        (True, 2048, {"prefill_t/s": 1990, "decode_t/s": 462, "decode_t/s/u": 14.4}, False, None),
+        (True, 128, {"prefill_t/s": 1412, "decode_t/s": 516, "decode_t/s/u": 16.11}, False, None),
+        (True, 1024, {"prefill_t/s": 2117, "decode_t/s": 440, "decode_t/s/u": 13.7}, False, None),
+        (True, 2048, {"prefill_t/s": 1967, "decode_t/s": 420, "decode_t/s/u": 13.12}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Falcon7b WH/T3K/TG and Whisper WH perf targets need to be adjusted due to an expected decrease from the recent ubuntu 22.04 (f021518) and libstdc++ changes (6302798)
- Falcon7B TG tolerance was not wide enough to account for TG CI variability (https://github.com/tenstorrent/tt-metal/issues/19745)

### What's changed
- Adjusted perf targets
- Increased higher-than tolerance for Falcon7B TG to 20% instead of 10%

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes