### PR TITLE
#0: Minor improvements to `MeshCoordinate` infra

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -47,9 +47,8 @@ TEST(MeshShapeTest, Construction) {
 }
 
 TEST(MeshShapeTest, ZeroShape) {
-    MeshShape shape({});
-    EXPECT_EQ(shape.dims(), 0);
-    EXPECT_EQ(shape.mesh_size(), 0);
+    // MeshShapes are not allowed to be empty.
+    EXPECT_ANY_THROW(MeshShape shape({}));
 }
 
 TEST(MeshShapeTest, Strides) {
@@ -313,30 +312,89 @@ TEST(MeshCoordinateRangeSetTest, MergeInvalidDimensions) {
 
 TEST(MeshCoordinateRangeSetTest, Merge1D) {
     MeshCoordinateRangeSet set;
+
     // Merge first range: [0, 3].
-    MeshCoordinateRange r1(MeshCoordinate(0), MeshCoordinate(3));
-    set.merge(r1);
+    set.merge(MeshCoordinateRange(MeshCoordinate(0), MeshCoordinate(3)));
+    EXPECT_THAT(set.ranges(), ElementsAre(MeshCoordinateRange(MeshCoordinate(0), MeshCoordinate(3))));
 
     // Merge an adjacent range: [4, 6] (adjacent to r1, since 3 and 4 touch).
-    MeshCoordinateRange r2(MeshCoordinate(4), MeshCoordinate(6));
-    set.merge(r2);
-    ASSERT_EQ(set.size(), 1);
-    auto merged_range = set.ranges().front();
-    EXPECT_EQ(merged_range.start_coord(), MeshCoordinate(0));
-    EXPECT_EQ(merged_range.end_coord(), MeshCoordinate(6));
+    set.merge(MeshCoordinateRange(MeshCoordinate(4), MeshCoordinate(6)));
+    EXPECT_THAT(set.ranges(), ElementsAre(MeshCoordinateRange(MeshCoordinate(0), MeshCoordinate(6))));
 
     // Merge a separate range: [8, 10].
-    MeshCoordinateRange r3(MeshCoordinate(8), MeshCoordinate(10));
-    set.merge(r3);
+    set.merge(MeshCoordinateRange(MeshCoordinate(8), MeshCoordinate(10)));
     ASSERT_EQ(set.size(), 2);
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0), MeshCoordinate(6))),
+            Eq(MeshCoordinateRange(MeshCoordinate(8), MeshCoordinate(10)))));
 
     // Merge a range bridging the gap: [7, 7] should merge all into one [0, 10].
-    MeshCoordinateRange r4(MeshCoordinate(7), MeshCoordinate(7));
-    set.merge(r4);
-    ASSERT_EQ(set.size(), 1);
-    merged_range = set.ranges().front();
-    EXPECT_EQ(merged_range.start_coord(), MeshCoordinate(0));
-    EXPECT_EQ(merged_range.end_coord(), MeshCoordinate(10));
+    set.merge(MeshCoordinateRange(MeshCoordinate(7), MeshCoordinate(7)));
+
+    EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(0), MeshCoordinate(10)))));
+}
+
+TEST(MeshCoordinateRangeSetTest, MergeOrder) {
+    MeshCoordinateRangeSet set;
+    set.merge(MeshCoordinateRange(MeshCoordinate(5, 5), MeshCoordinate(6, 6)));
+
+    EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(5, 5), MeshCoordinate(6, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1))),
+            Eq(MeshCoordinateRange(MeshCoordinate(5, 5), MeshCoordinate(6, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 2), MeshCoordinate(1, 3)));
+
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 3))),
+            Eq(MeshCoordinateRange(MeshCoordinate(5, 5), MeshCoordinate(6, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(2, 0), MeshCoordinate(3, 1)));
+
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 3))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 0), MeshCoordinate(3, 1))),
+            Eq(MeshCoordinateRange(MeshCoordinate(5, 5), MeshCoordinate(6, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(2, 2), MeshCoordinate(3, 3)));
+
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 3))),
+            Eq(MeshCoordinateRange(MeshCoordinate(5, 5), MeshCoordinate(6, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(4, 0), MeshCoordinate(4, 6)));
+
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 3))),
+            Eq(MeshCoordinateRange(MeshCoordinate(4, 0), MeshCoordinate(4, 6))),
+            Eq(MeshCoordinateRange(MeshCoordinate(5, 5), MeshCoordinate(6, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(5, 0), MeshCoordinate(6, 4)));
+
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 3))),
+            Eq(MeshCoordinateRange(MeshCoordinate(4, 0), MeshCoordinate(6, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 4), MeshCoordinate(3, 6)));
+
+    EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(6, 6)))));
 }
 
 TEST(MeshCoordinateRangeSetTest, SubtractInvalidDimensions) {
@@ -370,17 +428,93 @@ TEST(MeshCoordinateRangeSetTest, Subtract1DAdjacentIntersection) {
 }
 
 TEST(MeshCoordinateRangeSetTest, Subtract2DNonAdjacentIntersection) {
-    // Parent [(0,0) to (2,2)] and intersection [(1,1) to (1,1)].
     MeshCoordinateRange parent(MeshCoordinate(0, 0), MeshCoordinate(2, 2));
     MeshCoordinateRange intersection(MeshCoordinate(1, 1), MeshCoordinate(1, 1));
 
     EXPECT_THAT(
         subtract(parent, intersection).ranges(),
-        UnorderedElementsAre(
+        ElementsAre(
             Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 2))),
             Eq(MeshCoordinateRange(MeshCoordinate(1, 0), MeshCoordinate(2, 0))),
-            Eq(MeshCoordinateRange(MeshCoordinate(2, 1), MeshCoordinate(2, 1))),
-            Eq(MeshCoordinateRange(MeshCoordinate(1, 2), MeshCoordinate(2, 2)))));
+            Eq(MeshCoordinateRange(MeshCoordinate(1, 2), MeshCoordinate(2, 2))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 1), MeshCoordinate(2, 1)))));
+}
+
+TEST(MeshCoordinateRangeSetTest, Equality) {
+    MeshCoordinateRangeSet set1;
+    set1.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+    set1.merge(MeshCoordinateRange(MeshCoordinate(3, 3), MeshCoordinate(4, 4)));
+
+    MeshCoordinateRangeSet set2;
+    // Add in different order, should still be equal due to sorting
+    set2.merge(MeshCoordinateRange(MeshCoordinate(3, 3), MeshCoordinate(4, 4)));
+    set2.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+
+    MeshCoordinateRangeSet set3;
+    set3.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+    set3.merge(MeshCoordinateRange(MeshCoordinate(3, 3), MeshCoordinate(5, 5)));
+
+    MeshCoordinateRangeSet set4;
+    set4.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+
+    EXPECT_EQ(set1, set2);
+    EXPECT_NE(set1, set3);
+    EXPECT_NE(set1, set4);
+    EXPECT_NE(set2, set3);
+    EXPECT_NE(set2, set4);
+    EXPECT_NE(set3, set4);
+}
+
+TEST(MeshCoordinateRangeSetTest, UnorderedSet) {
+    MeshCoordinateRangeSet set1;
+    set1.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+    set1.merge(MeshCoordinateRange(MeshCoordinate(3, 3), MeshCoordinate(4, 4)));
+
+    MeshCoordinateRangeSet set2;  // Same ranges as set1, added in different order
+    set2.merge(MeshCoordinateRange(MeshCoordinate(3, 3), MeshCoordinate(4, 4)));
+    set2.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+
+    MeshCoordinateRangeSet set3;  // Different set
+    set3.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(2, 2)));
+
+    std::unordered_set<MeshCoordinateRangeSet> set;
+    EXPECT_TRUE(set.insert(set1).second);
+    EXPECT_FALSE(set.insert(set2).second);
+    EXPECT_TRUE(set.insert(set3).second);
+
+    EXPECT_THAT(set, UnorderedElementsAre(Eq(set1), Eq(set3)));
+}
+
+TEST(MeshCoordinateRangeSetTest, Coords) {
+    MeshCoordinateRangeSet set;
+
+    EXPECT_THAT(set.coords(), IsEmpty());
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 1)));
+    set.merge(MeshCoordinateRange(MeshCoordinate(1, 1), MeshCoordinate(1, 1)));
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 3), MeshCoordinate(0, 3)));
+
+    EXPECT_THAT(
+        set.coords(),
+        ElementsAre(
+            MeshCoordinate(0, 0),  //
+            MeshCoordinate(0, 1),
+            MeshCoordinate(0, 3),
+            MeshCoordinate(1, 1)));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 2), MeshCoordinate(1, 2)));
+    set.merge(MeshCoordinateRange(MeshCoordinate(1, 3), MeshCoordinate(1, 3)));
+
+    EXPECT_THAT(
+        set.coords(),
+        ElementsAre(
+            MeshCoordinate(0, 0),
+            MeshCoordinate(0, 1),
+            MeshCoordinate(0, 2),
+            MeshCoordinate(0, 3),
+            MeshCoordinate(1, 1),
+            MeshCoordinate(1, 2),
+            MeshCoordinate(1, 3)));
 }
 
 TEST(ToLinearIndexTest, Basic) {

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -90,10 +90,13 @@ private:
 
 bool operator==(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
 bool operator!=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+
+// Compares two coordinates in lexicographical order.
 bool operator<(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
 bool operator>(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
 bool operator<=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
 bool operator>=(const MeshCoordinate& lhs, const MeshCoordinate& rhs);
+
 std::ostream& operator<<(std::ostream& os, const MeshCoordinate& shape);
 
 // Converts a MeshCoordinate to a linear index.
@@ -108,6 +111,9 @@ public:
 
     // Constructs a range that iterates over all coordinates in the mesh.
     explicit MeshCoordinateRange(const MeshShape& shape);
+
+    // Constructs a range that includes a single coordinate.
+    explicit MeshCoordinateRange(const MeshCoordinate& coord);
 
     // Returns the dimensionality of the range.
     size_t dims() const;
@@ -154,31 +160,49 @@ public:
     Iterator begin() const;
     Iterator end() const;
 
-    friend bool operator==(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
-    friend bool operator!=(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
-    friend std::ostream& operator<<(std::ostream& os, const MeshCoordinateRange& range);
-
 private:
     MeshCoordinate start_;
     MeshCoordinate end_;
 };
+
+bool operator==(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
+bool operator!=(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
+std::ostream& operator<<(std::ostream& os, const MeshCoordinateRange& range);
 
 // Represents a set of non-overlapping MeshCoordinateRanges.
 class MeshCoordinateRangeSet {
 public:
     MeshCoordinateRangeSet() = default;
 
+    // Constructs a set with a single range.
+    explicit MeshCoordinateRangeSet(const MeshCoordinateRange&);
+
     // Merges the given range into the set.
     void merge(const MeshCoordinateRange& range);
 
+    // Returns the number of ranges in the set.
     size_t size() const { return ranges_.size(); }
+
+    // Returns true if the set is empty.
     bool empty() const { return ranges_.empty(); }
 
+    // Returns all ranges in the set, sorted in lexicographical order.
     const auto& ranges() const { return ranges_; }
+
+    // Flattens ranges and returns all coordinates that this set covers, sorted in lexicographical order.
+    std::vector<MeshCoordinate> coords() const;
+
+    // Needed for reflect / fmt
+    static constexpr auto attribute_names = std::forward_as_tuple("ranges");
+    auto attribute_values() const { return std::forward_as_tuple(ranges_); }
 
 private:
     std::vector<MeshCoordinateRange> ranges_;
 };
+
+bool operator==(const MeshCoordinateRangeSet& lhs, const MeshCoordinateRangeSet& rhs);
+bool operator!=(const MeshCoordinateRangeSet& lhs, const MeshCoordinateRangeSet& rhs);
+std::ostream& operator<<(std::ostream& os, const MeshCoordinateRangeSet& range_set);
 
 // Returns the set of ranges that result from subtracting the intersection from the parent range.
 MeshCoordinateRangeSet subtract(const MeshCoordinateRange& parent, const MeshCoordinateRange& intersection);
@@ -459,6 +483,17 @@ struct hash<tt::tt_metal::distributed::MeshCoordinateRange> {
         size_t seed = 0;
         tt::utils::hash_combine(seed, range.start_coord());
         tt::utils::hash_combine(seed, range.end_coord());
+        return seed;
+    }
+};
+
+template <>
+struct hash<tt::tt_metal::distributed::MeshCoordinateRangeSet> {
+    size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRangeSet& range_set) const noexcept {
+        size_t seed = 0;
+        for (const auto& range : range_set.ranges()) {
+            tt::utils::hash_combine(seed, range);
+        }
         return seed;
     }
 };

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "assert.hpp"
+#include "reflection.hpp"
 #include "shape_base.hpp"
 #include "utils.hpp"
 
@@ -469,32 +470,21 @@ struct tuple_element<1, tt::tt_metal::distributed::detail::MeshCoordinateValuePr
 template <>
 struct hash<tt::tt_metal::distributed::MeshCoordinate> {
     size_t operator()(const tt::tt_metal::distributed::MeshCoordinate& coord) const noexcept {
-        size_t seed = 0;
-        for (const auto coord_value : coord.coords()) {
-            tt::utils::hash_combine(seed, coord_value);
-        }
-        return seed;
+        return tt::stl::hash::hash_objects_with_default_seed(coord.attribute_values());
     }
 };
 
 template <>
 struct hash<tt::tt_metal::distributed::MeshCoordinateRange> {
     size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRange& range) const noexcept {
-        size_t seed = 0;
-        tt::utils::hash_combine(seed, range.start_coord());
-        tt::utils::hash_combine(seed, range.end_coord());
-        return seed;
+        return tt::stl::hash::hash_objects_with_default_seed(range.attribute_values());
     }
 };
 
 template <>
 struct hash<tt::tt_metal::distributed::MeshCoordinateRangeSet> {
     size_t operator()(const tt::tt_metal::distributed::MeshCoordinateRangeSet& range_set) const noexcept {
-        size_t seed = 0;
-        for (const auto& range : range_set.ranges()) {
-            tt::utils::hash_combine(seed, range);
-        }
-        return seed;
+        return tt::stl::hash::hash_objects_with_default_seed(range_set.attribute_values());
     }
 };
 

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -43,6 +43,7 @@ bool check_mergeable(const MeshCoordinateRange& a, const MeshCoordinateRange& b)
 
     auto diff_dims = find_diff_dimensions(a, b);
     if (diff_dims.empty()) {
+        // Ranges are identical.
         return true;
     } else if (diff_dims.size() == 1) {
         size_t diff_dim = diff_dims[0];
@@ -52,6 +53,13 @@ bool check_mergeable(const MeshCoordinateRange& a, const MeshCoordinateRange& b)
         return false;
     }
 }
+
+// Compares two ranges in lexicographical order.
+struct MeshCoordinateRangeLessThan {
+    bool operator()(const MeshCoordinateRange& a, const MeshCoordinateRange& b) const {
+        return (a.start_coord() != b.start_coord()) ? a.start_coord() < b.start_coord() : a.end_coord() < b.end_coord();
+    }
+};
 
 }  // namespace
 
@@ -162,6 +170,8 @@ MeshCoordinateRange::MeshCoordinateRange(const MeshCoordinate& start, const Mesh
 MeshCoordinateRange::MeshCoordinateRange(const MeshShape& shape) :
     MeshCoordinateRange(MeshCoordinate::zero_coordinate(shape.dims()), shape_back(shape)) {}
 
+MeshCoordinateRange::MeshCoordinateRange(const MeshCoordinate& coord) : start_(coord), end_(coord) {}
+
 size_t MeshCoordinateRange::dims() const { return start_.dims(); }
 const MeshCoordinate& MeshCoordinateRange::start_coord() const { return start_; }
 const MeshCoordinate& MeshCoordinateRange::end_coord() const { return end_; }
@@ -264,6 +274,8 @@ size_t to_linear_index(const MeshShape& shape, const MeshCoordinate& coord) {
     return linear_index;
 }
 
+MeshCoordinateRangeSet::MeshCoordinateRangeSet(const MeshCoordinateRange& range) { ranges_.push_back(range); }
+
 void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
     TT_FATAL(
         ranges_.empty() || ranges_.front().dims() == to_merge.dims(),
@@ -292,6 +304,9 @@ void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
         }
     }
     ranges_.push_back(merged);
+
+    // Sort the ranges to ensure deterministic order.
+    std::sort(ranges_.begin(), ranges_.end(), MeshCoordinateRangeLessThan{});
 }
 
 MeshCoordinateRangeSet subtract(const MeshCoordinateRange& parent, const MeshCoordinateRange& intersection) {
@@ -358,6 +373,35 @@ MeshCoordinateRangeSet subtract(const MeshCoordinateRange& parent, const MeshCoo
         }
         return complement_set;
     }
+}
+
+std::vector<MeshCoordinate> MeshCoordinateRangeSet::coords() const {
+    std::vector<MeshCoordinate> coords;
+    for (const auto& range : ranges_) {
+        for (const auto& coord : range) {
+            coords.push_back(coord);
+        }
+    }
+    std::sort(coords.begin(), coords.end());
+    return coords;
+}
+
+bool operator==(const MeshCoordinateRangeSet& lhs, const MeshCoordinateRangeSet& rhs) {
+    return lhs.ranges() == rhs.ranges();
+}
+
+bool operator!=(const MeshCoordinateRangeSet& lhs, const MeshCoordinateRangeSet& rhs) { return !(lhs == rhs); }
+
+std::ostream& operator<<(std::ostream& os, const MeshCoordinateRangeSet& range_set) {
+    os << "MeshCoordinateRangeSet([";
+    for (size_t i = 0; i < range_set.size(); ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        os << range_set.ranges()[i];
+    }
+    os << "])";
+    return os;
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -30,6 +30,8 @@ void py_module_types(py::module& module) {
     py::class_<MeshShape>(module, "MeshShape", "Shape of a mesh device.");
     py::class_<MeshCoordinate>(module, "MeshCoordinate", "Coordinate within a mesh device.");
     py::class_<MeshCoordinateRange>(module, "MeshCoordinateRange", "Range of coordinates within a mesh device.");
+    py::class_<MeshCoordinateRangeSet>(
+        module, "MeshCoordinateRangeSet", "Set of coordinate ranges within a mesh device.");
 }
 
 void py_module(py::module& module) {
@@ -111,6 +113,21 @@ void py_module(py::module& module) {
             "__iter__",
             [](const MeshCoordinateRange& mcr) { return py::make_iterator(mcr.begin(), mcr.end()); },
             py::keep_alive<0, 1>());
+
+    static_cast<py::class_<MeshCoordinateRangeSet>>(module.attr("MeshCoordinateRangeSet"))
+        .def(
+            py::init([]() { return MeshCoordinateRangeSet(); }),
+            "Default constructor for an empty MeshCoordinateRangeSet.")
+        .def(
+            py::init([](const MeshCoordinateRange& range) { return MeshCoordinateRangeSet(range); }),
+            "Constructor with specified range.",
+            py::arg("range"))
+        .def("merge", &MeshCoordinateRangeSet::merge, py::arg("range"))
+        .def("__repr__", [](const MeshCoordinateRangeSet& mcrs) {
+            std::ostringstream str;
+            str << mcrs;
+            return str.str();
+        });
 
     auto py_mesh_device = static_cast<py::class_<MeshDevice, std::shared_ptr<MeshDevice>>>(module.attr("MeshDevice"));
     py_mesh_device

--- a/ttnn/cpp/ttnn/distributed/types.hpp
+++ b/ttnn/cpp/ttnn/distributed/types.hpp
@@ -16,6 +16,7 @@ namespace ttnn::distributed {
 using MeshShape = tt::tt_metal::distributed::MeshShape;
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 using MeshCoordinateRange = tt::tt_metal::distributed::MeshCoordinateRange;
+using MeshCoordinateRangeSet = tt::tt_metal::distributed::MeshCoordinateRangeSet;
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using SystemMesh = tt::tt_metal::distributed::SystemMesh;
 using MeshDeviceView = tt::tt_metal::distributed::MeshDeviceView;
@@ -29,6 +30,7 @@ namespace ttnn {
 // These types are exported to the ttnn namespace for convenience.
 using ttnn::distributed::MeshCoordinate;
 using ttnn::distributed::MeshCoordinateRange;
+using ttnn::distributed::MeshCoordinateRangeSet;
 using ttnn::distributed::MeshDevice;
 using ttnn::distributed::MeshDeviceConfig;
 using ttnn::distributed::MeshDeviceView;

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -178,6 +178,7 @@ from ttnn.types import (
     MeshShape,
     MeshCoordinate,
     MeshCoordinateRange,
+    MeshCoordinateRangeSet,
     QueueId,
     UnaryWithParam,
     UnaryOpType,

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -67,6 +67,7 @@ class ShardStrategy(Enum):
 MeshShape = ttnn._ttnn.multi_device.MeshShape
 MeshCoordinate = ttnn._ttnn.multi_device.MeshCoordinate
 MeshCoordinateRange = ttnn._ttnn.multi_device.MeshCoordinateRange
+MeshCoordinateRangeSet = ttnn._ttnn.multi_device.MeshCoordinateRangeSet
 ShardOrientation = ttnn._ttnn.tensor.ShardOrientation
 ShardMode = ttnn._ttnn.tensor.ShardMode
 ShardSpec = ttnn._ttnn.tensor.ShardSpec


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Needed for integrating `MeshCoordinateRangeSet` into `MeshWorkload`

### What's changed
* Convenience methods `MeshCoordinateRangeSet::coords`
* `operator<<` / `operator==` / `operator!=`
* Constructors for `MeshCoordinateRange` and `MeshCoordinateRange` that accept 1 coordinate / 1 range
* `std::hash` specialization
* Sort `ranges` in `MeshCoordinateRangeSet` for ease of debugging.
* Plumb `MeshCoordinateRangeSet` into TTNN.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14200503851)
- [X] New/Existing tests provide coverage for changes