### PR TITLE
fix: llk: also reconfigure unpacker when unpack_dst_format differs

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -20,6 +20,11 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
+inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {
+    return (unpack_src_format[old_operand] != unpack_src_format[new_operand]) ||
+           (unpack_dst_format[old_operand] != unpack_dst_format[new_operand]);
+}
+
 void llk_zero_operand(std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     std::uint32_t fifo_base_addr =
@@ -76,7 +81,7 @@ inline void llk_unpack_reconfig_data_format_srca(
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
-    if ((unpack_src_format[old_srca_operand_id] != unpack_src_format[new_srca_operand_id])) {
+    if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
         llk_unpack_reconfig_data_format_srca<to_from_int8, is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
             srca_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
@@ -91,7 +96,7 @@ inline void llk_unpack_reconfig_data_format_srcb(
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    if ((unpack_src_format[old_srcb_operand_id] != unpack_src_format[new_srcb_operand_id])) {
+    if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
         llk_unpack_reconfig_data_format_srcb<to_from_int8, is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
             srcb_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_common_api.h
@@ -20,6 +20,11 @@
  * LLK UNPACK COMMON
  *************************************************************************/
 
+inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_operand) {
+    return (unpack_src_format[old_operand] != unpack_src_format[new_operand]) ||
+           (unpack_dst_format[old_operand] != unpack_dst_format[new_operand]);
+}
+
 void llk_zero_operand(std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     std::uint32_t fifo_base_addr =
@@ -76,7 +81,7 @@ inline void llk_unpack_reconfig_data_format_srca(
     std::uint32_t old_srca_operand_id = get_operand_id(srca_old_operand);
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
 
-    if ((unpack_src_format[old_srca_operand_id] != unpack_src_format[new_srca_operand_id])) {
+    if (should_reconfigure_cbs(srca_old_operand, srca_new_operand)) {
         llk_unpack_reconfig_data_format_srca<to_from_int8, is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
             srca_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {
@@ -91,7 +96,7 @@ inline void llk_unpack_reconfig_data_format_srcb(
     std::uint32_t old_srcb_operand_id = get_operand_id(srcb_old_operand);
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
 
-    if ((unpack_src_format[old_srcb_operand_id] != unpack_src_format[new_srcb_operand_id])) {
+    if (should_reconfigure_cbs(srcb_old_operand, srcb_new_operand)) {
         llk_unpack_reconfig_data_format_srcb<to_from_int8, is_fp32_dest_acc_en, is_tile_dim_reconfig_en>(
             srcb_new_operand);
     } else if constexpr (is_tile_dim_reconfig_en) {


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19896

### Problem description
While testing usage of `reconfig_data_format_*(old, new)` from `reconfig_data_format_*(new)` for performance reasons, we discover a potential issue regarding reconfiguration where it is not executed if `unpack_dst_format` differs. This is because the comparisons in unpacker llks only checks for `unpack_src_format` differences.

This can cause odd behaviors under certain situations 

### What's changed
Added an additional checks in LLKs for all archs (gs, wh_b0, bh) to check `unpack_dst_format` differences

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14189335362
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14189412920
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes