### PR TITLE
Fix conv2d nightly tests

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -8,6 +8,7 @@ import torch
 import pytest
 from models.utility_functions import (
     is_wormhole_b0,
+    is_blackhole,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
 import ttnn
@@ -72,7 +73,8 @@ def run_conv(
     stride_w,
     padding,
     config_override,
-    dilation=1,
+    dilation_h=1,
+    dilation_w=1,
     use_shallow_conv_variant=False,
     transpose_shards=True,  # https://github.com/tenstorrent/tt-metal/issues/17897
     fp32_accum=False,
@@ -90,7 +92,6 @@ def run_conv(
     output_mesh_composer=None,
     enable_split_reader=False,
     activation="",
-    in_place=False,
     preprocess_weights_on_device=True,
     run_twice=False,
 ):
@@ -156,7 +157,7 @@ def run_conv(
         bias=torch_bias_tensor.reshape(-1) if has_bias else None,
         stride=(stride_h, stride_w),
         padding=(0, 0),
-        dilation=(dilation, dilation),
+        dilation=(dilation_h, dilation_w),
         groups=groups,
     )
     act_func = get_torch_act_func_from_string(activation)
@@ -198,7 +199,6 @@ def run_conv(
         transpose_shards=transpose_shards,
         preprocess_weights_on_device=preprocess_weights_on_device,
         always_preprocess_weights=True,
-        in_place=in_place,
     )
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -228,7 +228,7 @@ def run_conv(
         kernel_size=(filter_height, filter_width),
         stride=(stride_h, stride_w),
         padding=(pad_top, pad_bottom, pad_left, pad_right),
-        dilation=(dilation, dilation),
+        dilation=(dilation_h, dilation_w),
         batch_size=batch_size,
         input_height=input_height,
         input_width=input_width,
@@ -252,7 +252,7 @@ def run_conv(
             kernel_size=(filter_height, filter_width),
             stride=(stride_h, stride_w),
             padding=(pad_top, pad_bottom, pad_left, pad_right),
-            dilation=(dilation, dilation),
+            dilation=(dilation_h, dilation_w),
             batch_size=batch_size,
             input_height=input_height,
             input_width=input_width,
@@ -1651,24 +1651,24 @@ def test_unet_conv_groups_2_wh(
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize(
-    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant, in_place",
+    "output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, shard_layout, config_override, use_shallow_conv_variant",
     (
-        (16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
-        (16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
-        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
-        (32, 16, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (64, 32, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (64, 64, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (32, 96, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (32, 64, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False, False),
-        (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
-        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, False),
-        (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True, True),
-        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 2 * 32}, False, False),
+        (16, 4, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
+        (16, 16, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
+        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
+        (32, 16, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (64, 32, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (64, 64, 66, 10, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (32, 96, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (32, 32, 132, 20, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (32, 64, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
+        (32, 32, 264, 40, 3, 3, 1, 1, 1, 1, HS, None, False),
+        # (16, 48, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True), # OOM - need inplace convolution
+        (16, 16, 528, 80, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True),
+        # (16, 32, 1056, 160, 3, 3, 1, 1, 1, 1, HS, {"act_block_h": 2 * 32}, True), # OOM - need inplace convolution
+        (1, 16, 1056, 160, 1, 1, 1, 1, 0, 0, HS, {"act_block_h": 2 * 32}, False),
     ),
 )
 @pytest.mark.parametrize(
@@ -1704,7 +1704,6 @@ def test_unet_conv_groups_4_6_wh(
     use_shallow_conv_variant,
     output_layout,
     groups,
-    in_place,
 ):
     if (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y) == (8, 7):
         pytest.skip("Test is not supported on n300 (8,7) grid")
@@ -1712,8 +1711,6 @@ def test_unet_conv_groups_4_6_wh(
         pytest.skip("Row major layout not compatible with bfloat8_b")
     if output_layout == ttnn.ROW_MAJOR_LAYOUT and input_height >= 1056:
         pytest.skip("OOM")
-    if input_channels == 32 and input_height == 1056 and groups == 6:
-        pytest.skip("OOM - enable when support for full in-place conv2d")
     run_conv(
         device,
         torch_tensor_map,
@@ -1736,7 +1733,6 @@ def test_unet_conv_groups_4_6_wh(
         transpose_shards=True,  ## use RM (transpose_mcast=False) with 2D on WH
         output_layout=output_layout,
         groups=groups,
-        in_place=in_place,
     )
 
 
@@ -1994,10 +1990,12 @@ def test_conv_core_nondivis(
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
 @pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize(
-    "filter, dilation, pad",
+    "filter_hw, dilation_hw, pad_hw",
     [
-        [3, 2, 2],
-        [3, 3, 3],
+        [(3, 3), (2, 2), (2, 2)],
+        [(3, 3), (3, 3), (3, 3)],
+        [(3, 3), (1, 2), (3, 3)],
+        [(3, 3), (2, 1), (3, 3)],
     ],
 )
 def test_conv_dilation(
@@ -2014,11 +2012,11 @@ def test_conv_dilation(
     input_width,
     act_block_w_div,
     shard_layout,
-    filter,
+    filter_hw,
     stride,
-    pad,
+    pad_hw,
     output_layout,
-    dilation,
+    dilation_hw,
 ):
     config_override = {"act_block_w_div": act_block_w_div}
     run_conv(
@@ -2032,15 +2030,16 @@ def test_conv_dilation(
         input_channels,
         input_height,
         input_width,
-        filter,
-        filter,
+        filter_hw[0],
+        filter_hw[1],
         stride,
         stride,
-        pad,
+        pad_hw,
         config_override,
         shard_layout=shard_layout,
         output_layout=output_layout,
-        dilation=dilation,
+        dilation_h=dilation_hw[0],
+        dilation_w=dilation_hw[1],
         has_bias=False,
     )
 
@@ -2392,7 +2391,8 @@ def test_model_k_256x256(
         (pad_h, pad_w),
         None,
         shard_layout=shard_layout,
-        dilation=dilation,
+        dilation_h=dilation,
+        dilation_w=dilation,
         auto_shard=auto_shard,
     )
 
@@ -2838,7 +2838,8 @@ def test_conv2d_model_fruit(
         stride_w=stride[1],
         padding=padding,
         config_override=config_override,
-        dilation=dilation[0],
+        dilation_h=dilation[0],
+        dilation_w=dilation[1],
         use_shallow_conv_variant=use_shallow_conv_variant,
         fp32_accum=fp32_accum,
         packer_l1_acc=packer_l1_acc,
@@ -2928,6 +2929,9 @@ def test_conv2d_sdxl(
     enable_split_reader,
     split_factor
 ):
+    if (input_channels == 1920 or input_channels == 2560) and input_height == 32 and input_width == 32 and kernel[0] == 1 and kernel[1] == 1 and is_blackhole():
+        pytest.skip("Temporary skip until #19831 is not closed")
+
     config_override = {}
     config_override["act_block_h"] = act_block_h_override
     config_override["act_block_w_div"] = act_block_w_div
@@ -2974,7 +2978,8 @@ def test_conv2d_sdxl(
             stride_w=stride[1],
             padding=padding,
             config_override=config_override,
-            dilation=dilation[0],
+            dilation_h=dilation[0],
+            dilation_w=dilation[1],
             use_shallow_conv_variant=use_shallow_conv_variant,
             fp32_accum=fp32_accum,
             packer_l1_acc=packer_l1_acc,


### PR DESCRIPTION
### Problem description
After #19702 was merged, some tests were not up to date. That happened because that PR (which moves tests from one file to another) was opened a few days ago before it was merged, so it didn't pick up newest updates.

### What's changed
Updated `tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py`.

### Checklist
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14195749744) CI passes