### PR TITLE
[tt_transformers] Fix reference decoder in tests (#19973)

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1838,7 +1838,7 @@ class ModelArgs:
         else:
             model = self.reference_transformer(wrap=False)
             layer = model.model.layers[0]
-            wrapper = HfDecoderWrapper(layer, self.head_dim)
+            wrapper = HfDecoderWrapper(layer, self.head_dim, model.model.rotary_emb)
             return wrapper
 
     def reference_attention(self):
@@ -1987,25 +1987,29 @@ class HfAttentionWrapper:
 
 
 class HfDecoderWrapper:
-    def __init__(self, decoder, head_dim):
+    def __init__(self, decoder, head_dim, rotary_emb):
         from transformers import DynamicCache
 
         self.decoder = decoder
         self.head_dim = head_dim
+        self.rotary_emb = rotary_emb
         self.past_key_values = DynamicCache()
 
     def forward(self, x, start_pos, freqs_cis_i, mask=None):
         position_ids = torch.tensor([list(range(start_pos, start_pos + x.shape[1]))] * x.shape[0])
+        position_embeddings = self.rotary_emb(x, position_ids)
         if mask is not None:
             while len(mask.shape) < 4:
                 mask = mask.unsqueeze(0)
-        output, self.past_key_values = self.decoder.forward(
+        result = self.decoder.forward(
             x,
+            position_embeddings=position_embeddings,
             past_key_value=self.past_key_values,
             use_cache=True,
             position_ids=position_ids,
             attention_mask=mask,
         )
+        output = result[0]
         return output
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
### Ticket
Link to Github Issue - [19973](https://github.com/tenstorrent/tt-metal/issues/19973)

### Problem description
models/tt_transformers/tests/test_decoder.py fails when executing the reference model
1) Decoder requires position_embeddings argument
2) forward outputs a tuple, not a pair

### What's changed
Aligned decoder's expectations with how it is wrapped in HfDecoderWrapper