### PR TITLE
#19924 Fix yolov4 640x640 conv2d config

### DIFF
--- a/models/demos/yolov4/ttnn/model_preprocessing.py
+++ b/models/demos/yolov4/ttnn/model_preprocessing.py
@@ -3,10 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+from ttnn.model_preprocessing import (
+    fold_batch_norm2d_into_conv2d,
+    infer_ttnn_module_args,
+    preprocess_model_parameters,
+)
+
 import ttnn
-from ttnn.model_preprocessing import infer_ttnn_module_args
 from models.demos.yolov4.reference import yolov4
-from ttnn.model_preprocessing import preprocess_model_parameters, fold_batch_norm2d_into_conv2d
 from models.demos.yolov4.reference.resblock import ResBlock
 
 
@@ -215,7 +219,7 @@ def create_yolov4_model_parameters(model: yolov4.Yolov4, input_tensor: torch.Ten
         parameters.conv_args.downsample1.c5["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
         parameters.conv_args.downsample1.c5["transpose_shards"] = False
 
-        parameters.conv_args.downsample1.c6["act_block_h"] = 240
+        parameters.conv_args.downsample1.c6["act_block_h"] = 256
         parameters.conv_args.downsample1.c6["enable_split_reader"] = False
         parameters.conv_args.downsample1.c6["enable_act_double_buffer"] = False
         parameters.conv_args.downsample1.c6["deallocate_activation"] = True


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
YOLOv4 test failing in debug mode https://github.com/tenstorrent/tt-metal/issues/19924
```
test_yolov4[1-pretrained_weight_false-0]

RuntimeError: TT_ASSERT @ /work/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp:347: act_block_h_override % 32 == 0
info:
Config Error: act_block_h_override must be a multiple of 32 (tile height).
backtrace:
 --- /opt/venv/lib/python3.10/site-packages/ttnn/_ttnn.cpython-310-x86_64-linux-gnu.so(+0xe1a258) [0x7f1500eef258]
 --- ttnn::operations::conv::determine_per_core_conv_block_config(ttnn::operations::sliding_window::ParallelConfig const&, ttnn::operations::conv::conv2d::OptimizedConvParallelizationConfig const&, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, bool, bool)
 --- /opt/venv/lib/python3.10/site-packages/ttnn/_ttnn.cpython-310-x86_64-linux-gnu.so(+0x1a699f4) [0x7f1501b3e9f4]
 --- /opt/venv/lib/python3.10/site-packages/ttnn/_ttnn.cpython-310-x86_64-linux-gnu.so(_ZN4ttnn10operations4conv6conv2d20prepare_conv_weightsIN2tt8tt_metal7IDeviceEEENS5_6TensorERKS7_RKNS5_12MemoryConfigENS5_6LayoutERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEjjjjjSt5arrayIjLm2EESN_St7variantIJSN_SM_IjLm4EEEESN_bjPT_RKSt8optionalIKNS2_12Conv2dConfigEERKST_IKSO_IJNS_28GrayskullComputeKernelConfigENS_27WormholeComputeKernelConfigEEEE+0x3d1) [0x7f1501b3dd71]
```

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes