### PR TITLE
[tt_transformer] Use HF_MODEL as an ID for HuggingFace, not as folder

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -330,8 +330,8 @@ class ModelArgs:
                 config_path = hf_hub_download(HF_MODEL, "config.json")
                 hf_model_dir = os.path.split(config_path)[0]
             except ImportError as e:
-                logger.warning(f"Failed to use hf_hub_download to find model's cache: {e}")
                 hf_model_dir = os.path.join("model_cache", "--".join(["models"] + HF_MODEL.split("/")))
+                logger.warning(f"Failed to use hf_hub_download to find model's cache. Defaulting to: {hf_model_dir}")
 
             self.CKPT_DIR = hf_model_dir
             self.TOKENIZER_PATH = hf_model_dir


### PR DESCRIPTION
### Ticket
Link to Github Issue - [19989](https://github.com/tenstorrent/tt-metal/issues/19989)

### Problem description
Use HuggingFace cache management when using HF_MODEL env var

### What's changed
When setting the model weights directory, HF_MODEL was used similarly to LLAMA_DIR
Instead, let's used huggingface_hub and let it handle cache, based on HF_MODEL
This is more consistent to how HF recommends using their flow.