### PR TITLE
#0: Implement merging of overlapping / intersecting ranges

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_coord.cpp
+++ b/tests/tt_metal/distributed/test_mesh_coord.cpp
@@ -397,6 +397,63 @@ TEST(MeshCoordinateRangeSetTest, MergeOrder) {
     EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(6, 6)))));
 }
 
+TEST(MeshCoordinateRangeSetTest, MergeWithOverlaps) {
+    MeshCoordinateRangeSet set;
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)));
+    EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 1)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(1, 1), MeshCoordinate(2, 2)));
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(0, 1))),
+            Eq(MeshCoordinateRange(MeshCoordinate(1, 0), MeshCoordinate(1, 0))),
+            Eq(MeshCoordinateRange(MeshCoordinate(1, 1), MeshCoordinate(2, 2)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 3)));
+    EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 3)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 4), MeshCoordinate(2, 6)));
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(3, 3))),
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 4), MeshCoordinate(2, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(2, 2), MeshCoordinate(4, 4)));
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 6))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 0), MeshCoordinate(3, 1))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 2), MeshCoordinate(4, 4))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 5), MeshCoordinate(2, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 3), MeshCoordinate(1, 3)));
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 6))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 0), MeshCoordinate(3, 1))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 2), MeshCoordinate(4, 4))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 5), MeshCoordinate(2, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(3, 0), MeshCoordinate(4, 2)));
+    EXPECT_THAT(
+        set.ranges(),
+        ElementsAre(
+            Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(1, 6))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 0), MeshCoordinate(4, 2))),
+            Eq(MeshCoordinateRange(MeshCoordinate(2, 3), MeshCoordinate(2, 6))),
+            Eq(MeshCoordinateRange(MeshCoordinate(3, 3), MeshCoordinate(4, 4)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(1, 3), MeshCoordinate(4, 6)));
+    EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(4, 6)))));
+
+    set.merge(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(5, 7)));
+    EXPECT_THAT(set.ranges(), ElementsAre(Eq(MeshCoordinateRange(MeshCoordinate(0, 0), MeshCoordinate(5, 7)))));
+}
+
 TEST(MeshCoordinateRangeSetTest, SubtractInvalidDimensions) {
     EXPECT_ANY_THROW(subtract(
         MeshCoordinateRange(MeshCoordinate(0, 0, 0), MeshCoordinate(1, 1, 1)),

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -171,6 +171,7 @@ bool operator!=(const MeshCoordinateRange& lhs, const MeshCoordinateRange& rhs);
 std::ostream& operator<<(std::ostream& os, const MeshCoordinateRange& range);
 
 // Represents a set of non-overlapping MeshCoordinateRanges.
+// `MeshCoordinateRangeSet` performs a best-effort merge of ranges, but does not guarantee that the set is minimal.
 class MeshCoordinateRangeSet {
 public:
     MeshCoordinateRangeSet() = default;

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -309,13 +309,12 @@ void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
             } else if (merged.intersects(*it) || it->intersects(merged)) {
                 // There is an intersection between `merged` and `it`.
                 // For simplicity, erase the entire `it`, but add back what isn't present in `merged`.
-                const auto removed = *it;
-                ranges_.erase(it);
-                for (const auto& coord : removed) {
+                for (const auto& coord : *it) {
                     if (!merged.contains(coord)) {
                         add_back.push_back(MeshCoordinateRange(coord));
                     }
                 }
+                it = ranges_.erase(it);
             } else {
                 // Cannot merge nor intersect with `it`, proceed to the next element.
                 ++it;

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -46,8 +46,8 @@ std::vector<size_t> find_diff_dimensions(const MeshCoordinateRange& a, const Mes
     return diff_dims;
 }
 
-// Returns true if the two ranges are mergeable: ranges must either be identical, have an intersection, or be adjacent
-// along exactly one dimension.
+// Returns true if the two ranges are mergeable; that is, when 2 ranges can be replaced by one.
+// Ranges must either be identical, be adjacent along exactly one dimension, or contain each other.
 bool check_mergeable(const MeshCoordinateRange& a, const MeshCoordinateRange& b) {
     TT_ASSERT(a.dims() == b.dims(), "Cannot compare ranges with different dimensions: {} != {}", a.dims(), b.dims());
 
@@ -56,11 +56,12 @@ bool check_mergeable(const MeshCoordinateRange& a, const MeshCoordinateRange& b)
         // Ranges are identical.
         return true;
     } else if (diff_dims.size() == 1) {
+        // Ranges are adjacent or overlap along one dimension.
         size_t diff_dim = diff_dims[0];
         return std::max(a.start_coord()[diff_dim], b.start_coord()[diff_dim]) <=
                std::min(a.end_coord()[diff_dim], b.end_coord()[diff_dim]) + 1;
     } else {
-        return false;
+        return a.contains(b) || b.contains(a);
     }
 }
 
@@ -288,12 +289,13 @@ void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
         to_merge.dims());
 
     // Iteratively merge the new range with existing ranges until no more merges are possible.
+    std::vector<MeshCoordinateRange> add_back;
     MeshCoordinateRange merged = to_merge;
-    bool did_merge = true;
-    while (did_merge) {
-        did_merge = false;
-        for (auto it = ranges_.begin(); it != ranges_.end(); ++it) {
+    while (true) {
+        bool did_merge = false;
+        for (auto it = ranges_.begin(); it != ranges_.end();) {
             if (check_mergeable(merged, *it)) {
+                // Can replace `it` + `merged` with a single new range.
                 tt::stl::SmallVector<uint32_t> new_start;
                 tt::stl::SmallVector<uint32_t> new_end;
                 for (size_t i = 0; i < merged.dims(); ++i) {
@@ -304,7 +306,24 @@ void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
                 ranges_.erase(it);
                 did_merge = true;
                 break;
+            } else if (merged.intersects(*it) || it->intersects(merged)) {
+                // There is an intersection between `merged` and `it`.
+                // For simplicity, erase the entire `it`, but add back what isn't present in `merged`.
+                const auto removed = *it;
+                ranges_.erase(it);
+                for (const auto& coord : removed) {
+                    if (!merged.contains(coord)) {
+                        add_back.push_back(MeshCoordinateRange(coord));
+                    }
+                }
+            } else {
+                // Cannot merge nor intersect with `it`, proceed to the next element.
+                ++it;
             }
+        }
+
+        if (!did_merge) {
+            break;
         }
     }
     ranges_.push_back(merged);
@@ -313,6 +332,11 @@ void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
     std::sort(ranges_.begin(), ranges_.end(), [](const auto& a, const auto& b) {
         return (a.start_coord() != b.start_coord()) ? a.start_coord() < b.start_coord() : a.end_coord() < b.end_coord();
     });
+
+    // Merge back the ranges that were removed.
+    for (const auto& range : add_back) {
+        merge(range);
+    }
 }
 
 MeshCoordinateRangeSet subtract(const MeshCoordinateRange& parent, const MeshCoordinateRange& intersection) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`MeshCoordinateRangeSet` currently doesn't support merging of ranges that overlap or contain ranges that already exist in the set.

### What's changed
Implement the functionality and add a test.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14202517160)
- [X] New/Existing tests provide coverage for changes