### PR TITLE
All includes in public headers should use fully qualified paths

### DIFF
--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -13,10 +13,10 @@
 #include <unordered_set>
 #include <vector>
 
-#include "allocator_types.hpp"
-#include "assert.hpp"
-#include "core_coord.hpp"
-#include "hal_types.hpp"
+#include <tt-metalium/allocator_types.hpp>
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/allocator_types.hpp
+++ b/tt_metal/api/tt-metalium/allocator_types.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 #include <cstdlib>
 #include <functional>
-#include "core_coord.hpp"
+#include <tt-metalium/core_coord.hpp>
 #include "hostdevcommon/common_values.hpp"
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/assert.hpp
+++ b/tt_metal/api/tt-metalium/assert.hpp
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <vector>
 
-#include "logger.hpp"
+#include <tt-metalium/logger.hpp>
 
 namespace tt {
 template <typename A, typename B>

--- a/tt_metal/api/tt-metalium/base_types.hpp
+++ b/tt_metal/api/tt-metalium/base_types.hpp
@@ -6,7 +6,7 @@
 
 #include <ostream>
 
-#include "constants.hpp"
+#include <tt-metalium/constants.hpp>
 
 enum class MathFidelity : uint8_t {
     LoFi = 0,

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -22,12 +22,12 @@
 #include <variant>
 #include <vector>
 
-#include "assert.hpp"
-#include "bfloat16.hpp"
-#include "buffer_constants.hpp"
-#include "core_coord.hpp"
-#include "hal_types.hpp"
-#include "sub_device_types.hpp"
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer_constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/sub_device_types.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/xy_pair.h>

--- a/tt_metal/api/tt-metalium/circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer.hpp
@@ -8,10 +8,10 @@
 #include <optional>
 #include <unordered_set>
 
-#include "circular_buffer_types.hpp"
-#include "core_coord.hpp"
-#include "hal_types.hpp"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/circular_buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/circular_buffer_types.hpp
+++ b/tt_metal/api/tt-metalium/circular_buffer_types.hpp
@@ -11,11 +11,11 @@
 #include <optional>
 #include <unordered_set>
 
-#include "buffer.hpp"
-#include "circular_buffer_constants.h"
-#include "logger.hpp"
-#include "tile.hpp"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
+#include <tt-metalium/logger.hpp>
+#include <tt-metalium/tile.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt {
 enum class DataFormat : uint8_t;

--- a/tt_metal/api/tt-metalium/command_queue.hpp
+++ b/tt_metal/api/tt-metalium/command_queue.hpp
@@ -9,11 +9,11 @@
 #include <memory>
 #include <thread>
 
-#include "worker_config_buffer.hpp"
-#include "trace_buffer.hpp"
-#include "command_queue_interface.hpp"
+#include <tt-metalium/worker_config_buffer.hpp>
+#include <tt-metalium/trace_buffer.hpp>
+#include <tt-metalium/command_queue_interface.hpp>
 
-#include "vector_aligned.hpp"
+#include <tt-metalium/vector_aligned.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/command_queue_interface.hpp
+++ b/tt_metal/api/tt-metalium/command_queue_interface.hpp
@@ -9,12 +9,12 @@
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/fabric_host_interface.h>
 
-#include "launch_message_ring_buffer_state.hpp"
-#include "dispatch_settings.hpp"
-#include "buffer.hpp"
+#include <tt-metalium/launch_message_ring_buffer_state.hpp>
+#include <tt-metalium/dispatch_settings.hpp>
+#include <tt-metalium/buffer.hpp>
 #include <umd/device/tt_core_coordinates.h>
 
-#include "command_queue_common.hpp"
-#include "system_memory_manager.hpp"
-#include "system_memory_cq_interface.hpp"
-#include "dispatch_mem_map.hpp"
+#include <tt-metalium/command_queue_common.hpp>
+#include <tt-metalium/system_memory_manager.hpp>
+#include <tt-metalium/system_memory_cq_interface.hpp>
+#include <tt-metalium/dispatch_mem_map.hpp>

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "routing_table_generator.hpp"
+#include <tt-metalium/routing_table_generator.hpp>
 #include <tt-metalium/fabric_host_interface.h>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_coord.hpp>

--- a/tt_metal/api/tt-metalium/core_descriptor.hpp
+++ b/tt_metal/api/tt-metalium/core_descriptor.hpp
@@ -14,8 +14,8 @@
 #include <utility>
 #include <vector>
 
-#include "core_coord.hpp"
-#include "dispatch_core_common.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/data_format.hpp
+++ b/tt_metal/api/tt-metalium/data_format.hpp
@@ -5,9 +5,9 @@
 #pragma once
 #include <cstdint>
 #include <vector>
-#include "tt_backend_api_types.hpp"              // for DataFormat
+#include <tt-metalium/tt_backend_api_types.hpp>  // for DataFormat
 #include <umd/device/types/arch.h>               // for ARCH
-#include "circular_buffer_constants.h"  // for NUM_CIRCULAR_BUFFERS
+#include <tt-metalium/circular_buffer_constants.h>  // for NUM_CIRCULAR_BUFFERS
 
 enum class UnpackToDestMode : std::uint8_t;
 

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -16,12 +16,12 @@
 
 #include "hostdevcommon/common_values.hpp"
 #include "hostdevcommon/kernel_structs.h"  // Not used here, but leaked to programming examples
-#include "work_executor_types.hpp"
-#include "data_types.hpp"
-#include "program_device_map.hpp"
-#include "hal_types.hpp"
-#include "command_queue_interface.hpp"
-#include "sub_device_types.hpp"
+#include <tt-metalium/work_executor_types.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/program_device_map.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/command_queue_interface.hpp>
+#include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/allocator_types.hpp>
 
 #include <tt_stl/span.hpp>

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -7,20 +7,20 @@
 #include <memory>
 #include <utility>
 
-#include "device.hpp"
+#include <tt-metalium/device.hpp>
 #include "hostdevcommon/common_values.hpp"
 #include "hostdevcommon/kernel_structs.h"  // Leaked up to ttnn level from here
-#include "work_executor_types.hpp"
-#include "data_types.hpp"
-#include "program_device_map.hpp"
-#include "hal_types.hpp"
-#include "command_queue_interface.hpp"
-#include "command_queue.hpp"
-#include "sub_device_manager_tracker.hpp"
-#include "sub_device_types.hpp"
-#include "trace_buffer.hpp"
+#include <tt-metalium/work_executor_types.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/program_device_map.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/command_queue_interface.hpp>
+#include <tt-metalium/command_queue.hpp>
+#include <tt-metalium/sub_device_manager_tracker.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/trace_buffer.hpp>
 #include <tt_stl/span.hpp>
-#include "program_cache.hpp"
+#include <tt-metalium/program_cache.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -16,11 +16,11 @@
 #include <unordered_set>
 #include <vector>
 
-#include "assert.hpp"
-#include "control_plane.hpp"
-#include "device.hpp"
-#include "dispatch_core_common.hpp"
-#include "system_memory_manager.hpp"
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/control_plane.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/system_memory_manager.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 
 namespace tt {

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "assert.hpp"
-#include "core_coord.hpp"
-#include "data_types.hpp"
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
 #include <tt_stl/reflection.hpp>
 
 #include <umd/device/tt_core_coordinates.h>  // CoreType

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -9,16 +9,16 @@
 #include <optional>
 #include <vector>
 
-#include "assert.hpp"
-#include "buffer.hpp"
-#include "mesh_buffer.hpp"
-#include "mesh_command_queue.hpp"
-#include "mesh_coord.hpp"
-#include "mesh_event.hpp"
-#include "mesh_trace_id.hpp"
-#include "mesh_workload.hpp"
-#include "span.hpp"
-#include "sub_device_types.hpp"
+#include <tt_stl/span.hpp>
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_command_queue.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_event.hpp>
+#include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/sub_device_types.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/distribution_spec.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 #include <variant>
 
-#include "shape.hpp"
+#include <tt-metalium/shape.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -10,9 +10,9 @@
 #include <tt-metalium/hal.hpp>
 
 #include <umd/device/types/cluster_descriptor_types.h>
-#include "fabric_edm_types.hpp"
-#include "fabric_edm_packet_header.hpp"
-#include "edm_fabric_counters.hpp"
+#include <tt-metalium/fabric_edm_types.hpp>
+#include <tt-metalium/fabric_edm_packet_header.hpp>
+#include <tt-metalium/edm_fabric_counters.hpp>
 
 #include <unordered_map>
 #include <optional>

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -13,7 +13,7 @@
 #include "ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
 #else
-#include "assert.hpp"
+#include <tt-metalium/assert.hpp>
 #endif
 
 namespace tt::tt_fabric {

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "global_circular_buffer_impl.hpp"
+#include <tt-metalium/global_circular_buffer_impl.hpp>
 //==================================================
 //        GLOBAL CIRCULAR BUFFER FUNCTIONS
 //==================================================

--- a/tt_metal/api/tt-metalium/global_circular_buffer_impl.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer_impl.hpp
@@ -7,9 +7,9 @@
 #include <cstdint>
 #include <memory>
 
-#include "core_coord.hpp"
-#include "buffer_constants.hpp"
-#include "distributed.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/buffer_constants.hpp>
+#include <tt-metalium/distributed.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -10,10 +10,10 @@
 #include <memory>
 #include <tuple>
 
-#include "buffer_constants.hpp"
-#include "core_coord.hpp"
-#include "hal_types.hpp"
-#include "mesh_buffer.hpp"
+#include <tt-metalium/buffer_constants.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -15,8 +15,8 @@
 #include <string_view>
 #include <vector>
 
-#include "buffer.hpp"
-#include "core_coord.hpp"
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/core_coord.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/hlk_desc.hpp
+++ b/tt_metal/api/tt-metalium/hlk_desc.hpp
@@ -7,11 +7,11 @@
 #include <string>
 
 #include "hostdevcommon/kernel_structs.h"
-#include "assert.hpp"
-#include "base_types.hpp"
-#include "tt_backend_api_types.hpp"
-#include "utils.hpp"
-#include "circular_buffer_constants.h"  // for NUM_CIRCULAR_BUFFERS
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/base_types.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/utils.hpp>
+#include <tt-metalium/circular_buffer_constants.h>  // for NUM_CIRCULAR_BUFFERS
 
 namespace tt {
 /**

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -7,13 +7,13 @@
 #include <variant>
 #include <vector>
 
-#include "dispatch_core_common.hpp"
-#include "runtime_args_data.hpp"
-#include "program_impl.hpp"
-#include "device.hpp"
-#include "sub_device_types.hpp"
+#include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/runtime_args_data.hpp>
+#include <tt-metalium/program_impl.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/sub_device_types.hpp>
 #include <tt_stl/span.hpp>
-#include "lightmetal_binary.hpp"
+#include <tt-metalium/lightmetal_binary.hpp>
 
 /** @file */
 

--- a/tt_metal/api/tt-metalium/jit_build_options.hpp
+++ b/tt_metal/api/tt-metalium/jit_build_options.hpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "hlk_desc.hpp"
+#include <tt-metalium/hlk_desc.hpp>
 #include "hostdevcommon/kernel_structs.h"
 
 enum class MathFidelity : uint8_t;

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -20,19 +20,19 @@
 #include <variant>
 #include <vector>
 
-#include "base_types.hpp"
-#include "core_coord.hpp"
-#include "hal_types.hpp"
-#include "jit_build_options.hpp"
-#include "jit_build_settings.hpp"
-#include "kernel_types.hpp"
-#include "runtime_args_data.hpp"
-#include "tt_backend_api_types.hpp"
-#include "tt_memory.h"
+#include <tt-metalium/base_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/jit_build_options.hpp>
+#include <tt-metalium/jit_build_settings.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/runtime_args_data.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tt_memory.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.h>
-#include "utils.hpp"
+#include <tt-metalium/utils.hpp>
 
 namespace ll_api {
 class memory;

--- a/tt_metal/api/tt-metalium/kernel_types.hpp
+++ b/tt_metal/api/tt-metalium/kernel_types.hpp
@@ -9,9 +9,9 @@
 #include <string>
 #include <vector>
 
-#include "base_types.hpp"
-#include "data_types.hpp"
-#include "util.hpp"
+#include <tt-metalium/base_types.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/util.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/memory_reporter.hpp
+++ b/tt_metal/api/tt-metalium/memory_reporter.hpp
@@ -13,8 +13,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "allocator.hpp"
-#include "allocator_types.hpp"
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/allocator_types.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -10,13 +10,13 @@
 #include <utility>
 #include <variant>
 
-#include "buffer.hpp"
-#include "buffer_constants.hpp"
-#include "hal_types.hpp"
-#include "mesh_coord.hpp"
-#include "mesh_device.hpp"
-#include "mesh_device_view.hpp"
-#include "shape2d.hpp"
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_constants.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_device_view.hpp>
+#include <tt-metalium/shape2d.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -17,24 +17,24 @@
 #include <variant>
 #include <vector>
 
-#include "buffer.hpp"
-#include "command_queue.hpp"
-#include "command_queue_interface.hpp"
-#include "core_coord.hpp"
-#include "dispatch_settings.hpp"
-#include "launch_message_ring_buffer_state.hpp"
-#include "mesh_buffer.hpp"
-#include "mesh_coord.hpp"
-#include "mesh_device.hpp"
-#include "mesh_trace.hpp"
-#include "mesh_trace_id.hpp"
-#include "mesh_workload.hpp"
-#include "multi_producer_single_consumer_queue.hpp"
-#include "span.hpp"
-#include "sub_device_types.hpp"
+#include <tt_stl/span.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/command_queue.hpp>
+#include <tt-metalium/command_queue_interface.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/dispatch_settings.hpp>
+#include <tt-metalium/launch_message_ring_buffer_state.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_trace.hpp>
+#include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/multi_producer_single_consumer_queue.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/vector_aligned.hpp>
+#include <tt-metalium/worker_config_buffer.hpp>
 #include <umd/device/tt_core_coordinates.h>
-#include "vector_aligned.hpp"
-#include "worker_config_buffer.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/mesh_config.hpp
+++ b/tt_metal/api/tt-metalium/mesh_config.hpp
@@ -6,7 +6,7 @@
 
 #include <vector>
 
-#include "mesh_coord.hpp"
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -9,10 +9,10 @@
 #include <type_traits>
 #include <vector>
 
-#include "assert.hpp"
-#include "reflection.hpp"
-#include "shape_base.hpp"
-#include "utils.hpp"
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/reflection.hpp>
+#include <tt-metalium/shape_base.hpp>
+#include <tt-metalium/utils.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -9,8 +9,8 @@
 #include <type_traits>
 #include <vector>
 
+#include <tt_stl/reflection.hpp>
 #include <tt-metalium/assert.hpp>
-#include <tt-metalium/reflection.hpp>
 #include <tt-metalium/shape_base.hpp>
 #include <tt-metalium/utils.hpp>
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -21,21 +21,21 @@
 #include <utility>
 #include <vector>
 
-#include "core_coord.hpp"
-#include "device.hpp"
-#include "dispatch_core_common.hpp"
-#include "hal_types.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/hal_types.hpp>
 #include "hostdevcommon/common_values.hpp"
-#include "mesh_config.hpp"
-#include "mesh_coord.hpp"
-#include "mesh_device_view.hpp"
-#include "mesh_trace_id.hpp"
-#include "program_device_map.hpp"
-#include "small_vector.hpp"
-#include "sub_device_types.hpp"
-#include "trace_buffer.hpp"
+#include <tt-metalium/mesh_config.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device_view.hpp>
+#include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/program_device_map.hpp>
+#include <tt-metalium/small_vector.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/trace_buffer.hpp>
 #include <umd/device/types/arch.h>
-#include "work_executor_types.hpp"
+#include <tt-metalium/work_executor_types.hpp>
 
 enum class CoreType;
 namespace tt {

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -11,10 +11,10 @@
 #include <optional>
 #include <functional>
 
-#include "device.hpp"
-#include "mesh_config.hpp"
-#include "mesh_coord.hpp"
-#include "shape2d.hpp"
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_config.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/shape2d.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/api/tt-metalium/mesh_event.hpp
+++ b/tt_metal/api/tt-metalium/mesh_event.hpp
@@ -7,8 +7,8 @@
 #include <cstdint>
 #include <ostream>
 
-#include "mesh_coord.hpp"
-#include "mesh_device.hpp"
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/mesh_trace.hpp
+++ b/tt_metal/api/tt-metalium/mesh_trace.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "mesh_buffer.hpp"
-#include "mesh_trace_id.hpp"
-#include "trace_buffer.hpp"
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_trace_id.hpp>
+#include <tt-metalium/trace_buffer.hpp>
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "host_api.hpp"
-#include "mesh_device.hpp"
-#include "mesh_buffer.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 
 namespace tt::tt_metal::distributed {
 using RuntimeArgsPerCore = std::vector<std::vector<RuntimeArgsData>>;

--- a/tt_metal/api/tt-metalium/metal_soc_descriptor.h
+++ b/tt_metal/api/tt-metalium/metal_soc_descriptor.h
@@ -9,8 +9,8 @@
 #include <map>
 #include <vector>
 
-#include "core_coord.hpp"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/tt_cluster_descriptor.h>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>

--- a/tt_metal/api/tt-metalium/multi_producer_single_consumer_queue.hpp
+++ b/tt_metal/api/tt-metalium/multi_producer_single_consumer_queue.hpp
@@ -7,7 +7,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
-#include "assert.hpp"
+#include <tt-metalium/assert.hpp>
 
 template <typename T>
 class MultiProducerSingleConsumerQueue {

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -6,7 +6,7 @@
 
 #include <unordered_map>
 
-#include "program_impl.hpp"
+#include <tt-metalium/program_impl.hpp>
 #include <tt_stl/unique_any.hpp>
 
 namespace tt::tt_metal::program_cache::detail {

--- a/tt_metal/api/tt-metalium/program_device_map.hpp
+++ b/tt_metal/api/tt-metalium/program_device_map.hpp
@@ -9,8 +9,8 @@
 #include <variant>
 #include <vector>
 
-#include "core_coord.hpp"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/program_impl.hpp
+++ b/tt_metal/api/tt-metalium/program_impl.hpp
@@ -7,12 +7,12 @@
 #include <memory>
 #include <optional>
 
-#include "kernel_types.hpp"
-#include "circular_buffer_types.hpp"
-#include "semaphore.hpp"
-#include "program_device_map.hpp"
-#include "worker_config_buffer.hpp"
-#include "dev_msgs.h"
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/circular_buffer_types.hpp>
+#include <tt-metalium/semaphore.hpp>
+#include <tt-metalium/program_device_map.hpp>
+#include <tt-metalium/worker_config_buffer.hpp>
+#include <tt-metalium/dev_msgs.h>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/routing_table_generator.hpp
+++ b/tt_metal/api/tt-metalium/routing_table_generator.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-#include "mesh_graph.hpp"
+#include <tt-metalium/mesh_graph.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>
 
 namespace tt::tt_fabric {

--- a/tt_metal/api/tt-metalium/semaphore.hpp
+++ b/tt_metal/api/tt-metalium/semaphore.hpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-#include "core_coord.hpp"
+#include <tt-metalium/core_coord.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 
 enum class CoreType;

--- a/tt_metal/api/tt-metalium/shape.hpp
+++ b/tt_metal/api/tt-metalium/shape.hpp
@@ -10,8 +10,8 @@
 #include <ostream>
 #include <tuple>
 
-#include "shape_base.hpp"
-#include "small_vector.hpp"
+#include <tt-metalium/shape_base.hpp>
+#include <tt-metalium/small_vector.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/shape_base.hpp
+++ b/tt_metal/api/tt-metalium/shape_base.hpp
@@ -6,7 +6,7 @@
 
 #include <vector>
 
-#include "small_vector.hpp"
+#include <tt-metalium/small_vector.hpp>
 #include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/sub_device.hpp
+++ b/tt_metal/api/tt-metalium/sub_device.hpp
@@ -7,8 +7,8 @@
 #include <array>
 #include <cstdint>
 
-#include "core_coord.hpp"
-#include "hal_types.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/hal_types.hpp>
 #include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/sub_device_manager_tracker.hpp
+++ b/tt_metal/api/tt-metalium/sub_device_manager_tracker.hpp
@@ -8,8 +8,8 @@
 #include <memory>
 #include <unordered_map>
 
-#include "sub_device.hpp"
-#include "sub_device_types.hpp"
+#include <tt-metalium/sub_device.hpp>
+#include <tt-metalium/sub_device_types.hpp>
 #include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/api/tt-metalium/system_mesh.hpp
+++ b/tt_metal/api/tt-metalium/system_mesh.hpp
@@ -9,7 +9,7 @@
 #include <optional>
 #include <vector>
 
-#include "mesh_coord.hpp"
+#include <tt-metalium/mesh_coord.hpp>
 
 namespace tt {
 namespace stl {

--- a/tt_metal/api/tt-metalium/tile.hpp
+++ b/tt_metal/api/tt-metalium/tile.hpp
@@ -9,10 +9,10 @@
 #include <optional>
 #include <tuple>
 
-#include "bfloat16.hpp"
-#include "constants.hpp"
-#include "math.hpp"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt {
 enum class DataFormat : uint8_t;

--- a/tt_metal/api/tt-metalium/trace.hpp
+++ b/tt_metal/api/tt-metalium/trace.hpp
@@ -12,9 +12,9 @@
 #include <utility>
 #include <variant>
 
-#include "buffer.hpp"
-#include "command_queue.hpp"
-#include "trace_buffer.hpp"
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/command_queue.hpp>
+#include <tt-metalium/trace_buffer.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/trace_buffer.hpp
+++ b/tt_metal/api/tt-metalium/trace_buffer.hpp
@@ -13,7 +13,7 @@
 #include <variant>
 #include <vector>
 
-#include "sub_device_types.hpp"
+#include <tt-metalium/sub_device_types.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -11,13 +11,13 @@
 #include <string>
 #include <vector>
 
+#include <hostdevcommon/common_values.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/fabric_types.hpp>
-#include <tt-metalium/hostdevcommon/common_values.hpp>
 #include <tt-metalium/profiler_optional_metadata.hpp>
 #include <tt-metalium/profiler_types.hpp>
 #include <umd/device/tt_core_coordinates.h>

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -11,15 +11,15 @@
 #include <string>
 #include <vector>
 
-#include "assert.hpp"
-#include "buffer.hpp"
-#include "core_coord.hpp"
-#include "dispatch_core_common.hpp"
-#include "fabric_types.hpp"
-#include "hostdevcommon/common_values.hpp"
-#include "profiler_optional_metadata.hpp"
-#include "profiler_types.hpp"
-#include "span.hpp"
+#include <tt_stl/span.hpp>
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/fabric_types.hpp>
+#include <tt-metalium/hostdevcommon/common_values.hpp>
+#include <tt-metalium/profiler_optional_metadata.hpp>
+#include <tt-metalium/profiler_types.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/cluster_descriptor_types.h>

--- a/tt_metal/api/tt-metalium/util.hpp
+++ b/tt_metal/api/tt-metalium/util.hpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include "assert.hpp"
-#include "math.hpp"
-#include "tt_backend_api_types.hpp"
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
 #include "hostdevcommon/common_values.hpp"
-#include "data_types.hpp"
-#include "hal_types.hpp"
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/hal_types.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 
 namespace tt::tt_metal::detail {

--- a/tt_metal/api/tt-metalium/work_split.hpp
+++ b/tt_metal/api/tt-metalium/work_split.hpp
@@ -12,7 +12,7 @@
 #include <tuple>
 #include <vector>
 
-#include "core_coord.hpp"
+#include <tt-metalium/core_coord.hpp>
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/worker_config_buffer.hpp
+++ b/tt_metal/api/tt-metalium/worker_config_buffer.hpp
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 #include <vector>
-#include "hal_types.hpp"
+#include <tt-metalium/hal_types.hpp>
 
 namespace tt {
 


### PR DESCRIPTION
### Problem description
TT-MLIR Uplift was failing, because our public headers were using internal include paths.

### What's changed
Fully qualify all tenstorrent includes with either `<tt-metalium/` or `<tt_stl/` or `<hostdevcommon/` (crying)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14204251310) CI passes
- [x] New/Existing tests provide coverage for changes