### PR TITLE
Do not leak tt_metal dir to includes

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -17,9 +17,10 @@ target_sources(
 
 # TODO(afuller): this should be self-describing modules.
 #   For now just cherry-pick all the files I discovered empirally by trying to run a test.
+add_library(jitapi INTERFACE)
 target_sources(
-    tt_metal
-    PUBLIC
+    jitapi
+    INTERFACE
         FILE_SET jit_api
         TYPE HEADERS
         BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
@@ -274,6 +275,7 @@ endif()
 install(
     TARGETS
         tt_metal
+        jitapi
     LIBRARY
         COMPONENT metalium-runtime
     FILE_SET


### PR DESCRIPTION
### Ticket
None

### Problem description
tt_metal got leaked as a public include dir because of the way I was exporting the JIT API.
This already resulted in a public API file including a private file. Bad Bad Bad.

### What's changed
We got the horse back in the barn.  Now close the barn door.
* Define a dedicated target that holds the public headers to be installed (private FILE_SETs are not installed)
* Now the target everyone links against does not export any additional inc dir beyond the API that we've defined.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14204050790)