### PR TITLE
#20003 Read output buffer size directly from the buffer instead of parsing graph capture trace

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -85,9 +85,9 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
             auto compute_with_storage_grid_size = device_->compute_with_storage_grid_size();
             size_t interleaved_storage_cores = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
 
-            auto l1_output_per_core =
-                graph::extract_l1_output_buffer_allocation_size_per_core(json_trace, interleaved_storage_cores);
-            EXPECT_EQ(l1_output_per_core, params.expected_l1_output_per_core);
+            // auto l1_output_per_core =
+            //     graph::extract_l1_output_buffer_allocation_size_per_core(json_trace, interleaved_storage_cores);
+            // EXPECT_EQ(l1_output_per_core, params.expected_l1_output_per_core);
             auto l1_peak_per_core =
                 graph::extract_l1_buffer_allocation_peak_size_per_core(json_trace, interleaved_storage_cores);
             EXPECT_EQ(l1_peak_per_core, params.expected_l1_peak_per_core);

--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -85,9 +85,6 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
             auto compute_with_storage_grid_size = device_->compute_with_storage_grid_size();
             size_t interleaved_storage_cores = compute_with_storage_grid_size.x * compute_with_storage_grid_size.y;
 
-            // auto l1_output_per_core =
-            //     graph::extract_l1_output_buffer_allocation_size_per_core(json_trace, interleaved_storage_cores);
-            // EXPECT_EQ(l1_output_per_core, params.expected_l1_output_per_core);
             auto l1_peak_per_core =
                 graph::extract_l1_buffer_allocation_peak_size_per_core(json_trace, interleaved_storage_cores);
             EXPECT_EQ(l1_peak_per_core, params.expected_l1_peak_per_core);

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -597,19 +597,10 @@ INSTANTIATE_TEST_SUITE_P(
                  ttnn::graph::ResourceUsage{
                      .cb_peak_size_per_core = 28736,
                      .l1_buffers_peak_per_core = 59392,
-                     .l1_output_buffer_per_core = 59392}},
-                {BoardType::E150,
-                 ttnn::graph::ResourceUsage{
-                     .cb_peak_size_per_core = 28736,
-                     .l1_buffers_peak_per_core = 26624,
-                     .l1_output_buffer_per_core = 26624}}})));
+                     .l1_output_buffer_per_core = 59392}}})));
 
 class Conv2dOpIfTest : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(Conv2dOpIfTest, Conv2d) {
-    // Todo(arminaleTT): There is a known problem with calculating conv output size. Once fixed, this test will be
-    // enabled.
-    GTEST_SKIP();
-
     const auto input_spec = ttnn::TensorSpec(
         ttnn::Shape{1, 1, 50176, 3},
         tt::tt_metal::TensorLayout(
@@ -642,7 +633,7 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
     const auto expected_resource_usage_map = ResourceUsageMap{
         {BoardType::N300,
          ttnn::graph::ResourceUsage{
-             .cb_peak_size_per_core = 0, .l1_buffers_peak_per_core = 0, .l1_output_buffer_per_core = 0}},
+             .cb_peak_size_per_core = 229440, .l1_buffers_peak_per_core = 190568, .l1_output_buffer_per_core = 0}},
         {BoardType::E150,
          ttnn::graph::ResourceUsage{
              .cb_peak_size_per_core = 0, .l1_buffers_peak_per_core = 0, .l1_output_buffer_per_core = 0}}};
@@ -655,7 +646,6 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
     // Run the test
     {
         tt::tt_metal::IDevice* device = device_;
-        const auto& output_spec = input_spec;
         auto query = ttnn::graph::query_op_constraints(
             ttnn::conv2d,
             device,
@@ -677,9 +667,11 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
             std::nullopt,
             output_spec.tensor_layout().get_memory_config());
 
-        // Todo(arminaleTT): There is a known problem with calculating conv output size. Once fixed, this test will be
-        // expanded
-        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Error);
+        EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+        EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);
+        EXPECT_EQ(query.resource_usage.l1_buffers_peak_per_core, expected_resource_usage.l1_buffers_peak_per_core);
+        EXPECT_EQ(query.resource_usage.l1_output_buffer_per_core, expected_resource_usage.l1_output_buffer_per_core);
+        EXPECT_EQ(query.output_tensor_spec.value(), output_spec);
     }
 }
 

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -208,6 +208,7 @@ TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
         EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);
         EXPECT_EQ(query.resource_usage.l1_buffers_peak_per_core, expected_resource_usage.l1_buffers_peak_per_core);
         EXPECT_EQ(query.resource_usage.l1_output_buffer_per_core, expected_resource_usage.l1_output_buffer_per_core);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
         EXPECT_EQ(query.output_tensor_spec.value(), input_spec);
     }
 }
@@ -528,6 +529,7 @@ TEST_P(MatmulOpIfTest, Matmul) {
         EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);
         EXPECT_EQ(query.resource_usage.l1_buffers_peak_per_core, expected_resource_usage.l1_buffers_peak_per_core);
         EXPECT_EQ(query.resource_usage.l1_output_buffer_per_core, expected_resource_usage.l1_output_buffer_per_core);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
         EXPECT_EQ(query.output_tensor_spec.value(), output_spec);
     }
 }
@@ -673,6 +675,7 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
         EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);
         EXPECT_EQ(query.resource_usage.l1_buffers_peak_per_core, expected_resource_usage.l1_buffers_peak_per_core);
         EXPECT_EQ(query.resource_usage.l1_output_buffer_per_core, expected_resource_usage.l1_output_buffer_per_core);
+        ASSERT_TRUE(query.output_tensor_spec.has_value());
         EXPECT_EQ(query.output_tensor_spec.value(), output_spec);
     }
 }

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -597,7 +597,12 @@ INSTANTIATE_TEST_SUITE_P(
                  ttnn::graph::ResourceUsage{
                      .cb_peak_size_per_core = 28736,
                      .l1_buffers_peak_per_core = 59392,
-                     .l1_output_buffer_per_core = 59392}}})));
+                     .l1_output_buffer_per_core = 59392}},
+                {BoardType::E150,
+                 ttnn::graph::ResourceUsage{
+                     .cb_peak_size_per_core = 28736,
+                     .l1_buffers_peak_per_core = 26624,
+                     .l1_output_buffer_per_core = 26624}}})));
 
 class Conv2dOpIfTest : public ttnn::TTNNFixtureWithDevice {};
 TEST_F(Conv2dOpIfTest, Conv2d) {
@@ -633,10 +638,7 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
     const auto expected_resource_usage_map = ResourceUsageMap{
         {BoardType::N300,
          ttnn::graph::ResourceUsage{
-             .cb_peak_size_per_core = 229440, .l1_buffers_peak_per_core = 190568, .l1_output_buffer_per_core = 0}},
-        {BoardType::E150,
-         ttnn::graph::ResourceUsage{
-             .cb_peak_size_per_core = 0, .l1_buffers_peak_per_core = 0, .l1_output_buffer_per_core = 0}}};
+             .cb_peak_size_per_core = 229440, .l1_buffers_peak_per_core = 190568, .l1_output_buffer_per_core = 0}}};
     const BoardType board_type = tt::Cluster::instance().get_board_type(0);
     if (expected_resource_usage_map.count(board_type) == 0) {
         GTEST_SKIP();

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -62,7 +62,7 @@ struct ConstraintQueryResponse {
 template <typename Op, typename... Args>
 auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
     nlohmann::json op_trace;
-    std::optional<TensorSpec> output_spec = std::nullopt;
+    Tensor output;
     // outer graph capture is to avoid dispatching/allocating dummy input tensors
     {
         auto capture_outer = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
@@ -80,9 +80,7 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
         // inner graph capture is to capture the actual op graph trace
         try {
             auto capture_inner = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
-            Tensor output = detail::extract_output_tensor(std::apply(op, transformed_args));
-            output_spec = output.get_tensor_spec();
-            op_trace = capture_inner.end_graph_capture();
+            output = detail::extract_output_tensor(std::apply(op, transformed_args));
         }  // end of inner graph capture
         catch (const std::exception& e) {
             tt::log_debug(tt::LogOp, "Error during graph capture: {}", e.what());
@@ -98,12 +96,12 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
     size_t l1_buffers_peak_per_core =
         extract_l1_buffer_allocation_peak_size_per_core(op_trace, interleaved_storage_cores);
     size_t l1_output_buffer_per_core =
-        extract_l1_output_buffer_allocation_size_per_core(op_trace, interleaved_storage_cores);
+        extract_l1_output_buffer_allocation_size_per_core(output, interleaved_storage_cores);
 
     return ConstraintQueryResponse{
         ExecutionStatus::Success,
         {cb_peak_size_per_core, l1_buffers_peak_per_core, l1_output_buffer_per_core},
-        output_spec};
+        output.get_tensor_spec()};
 }
 
 }  // namespace ttnn::graph

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -96,8 +96,9 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
     size_t cb_peak_size_per_core = extract_circular_buffers_peak_size_per_core(op_trace);
     size_t l1_buffers_peak_per_core =
         extract_l1_buffer_allocation_peak_size_per_core(op_trace, interleaved_storage_cores);
-    size_t l1_output_buffer_per_core =
-        extract_l1_output_buffer_allocation_size_per_core(output, interleaved_storage_cores);
+    size_t l1_output_buffer_per_core = output.buffer()->is_dram() ? 0
+                                                                  : extract_l1_output_buffer_allocation_size_per_core(
+                                                                        output, interleaved_storage_cores);
 
     return ConstraintQueryResponse{
         ExecutionStatus::Success,

--- a/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_constraints.hpp
@@ -81,6 +81,7 @@ auto query_op_constraints(Op op, IDevice* device, Args&&... args) {
         try {
             auto capture_inner = ScopedGraphCapture(GraphProcessor::RunMode::NO_DISPATCH);
             output = detail::extract_output_tensor(std::apply(op, transformed_args));
+            op_trace = capture_inner.end_graph_capture();
         }  // end of inner graph capture
         catch (const std::exception& e) {
             tt::log_debug(tt::LogOp, "Error during graph capture: {}", e.what());

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
@@ -242,12 +242,12 @@ size_t worst_case_per_core_allocation(size_t total_size, size_t page_size, size_
 }
 }  // namespace detail
 
-// This function returns the worst-case memory allocation per core for the output L1 buffer. 0 for DRAM buffers.
+// This function returns the worst-case memory allocation per core for the output L1 buffer. Throws for DRAM buffers.
 uint32_t extract_l1_output_buffer_allocation_size_per_core(
     const Tensor& output_tensor, size_t interleaved_storage_cores) {
     tt::tt_metal::Buffer* buffer = output_tensor.buffer();
     if (buffer->is_dram()) {
-        return 0;
+        TT_THROW("No L1 allocation. Tensor is in DRAM");
     }
 
     uint32_t output_buffer_allocate_total_size = buffer->size();

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.cpp
@@ -244,77 +244,17 @@ size_t worst_case_per_core_allocation(size_t total_size, size_t page_size, size_
 
 // This function returns the worst-case memory allocation per core for the output L1 buffer. 0 for DRAM buffers.
 uint32_t extract_l1_output_buffer_allocation_size_per_core(
-    const nlohmann::json& trace, size_t interleaved_storage_cores) {
-    // we are lookin for buffer_allocate that is connected to a buffer,
-    // that is connected to a same tensor as the function_end connected to capture_end
-    // buffer_allocate -> buffer -> tensor <- function_end -> capture_end
-
-    // Find the 'capture_end' node
-    const auto& capture_end_node =
-        std::find_if(trace.rbegin(), trace.rend(), [](const auto& v) { return v.at(kNodeType) == kNodeCaptureEnd; });
-
-    if (capture_end_node == trace.rend()) {
-        throw std::runtime_error("No capture_end node found in the trace");
-    }
-
-    // helper function to find a node of a specific type that points to a given node
-    auto find_a_first_node_of_a_type_pointing_to_me([&](const auto& trace, const char* node_type, const auto& my_node) {
-        return std::find_if(trace.begin(), trace.end(), [&](const auto& v) {
-            // check if v.at(kNodeType) starts with node_type because buffers and tensors have suffixes \"(counter)\"
-            std::string v_node_type = v.at(kNodeType).dump();
-            v_node_type.erase(std::remove(v_node_type.begin(), v_node_type.end(), '"'), v_node_type.end());
-
-            return (v_node_type.starts_with(node_type)) &&
-                   (std::find(v.at(kConnections).begin(), v.at(kConnections).end(), my_node.at(kCounter)) !=
-                    v.at(kConnections).end());
-        });
-    });
-
-    // helper function to find a node by counter
-    auto find_node_by_counter([&](const auto& trace, int counter) {
-        return std::find_if(trace.begin(), trace.end(), [&](const auto& v) { return v.at(kCounter) == counter; });
-    });
-
-    const auto& last_function_end_node =
-        find_a_first_node_of_a_type_pointing_to_me(trace, kNodeFunctionEnd, *capture_end_node);
-
-    if (last_function_end_node == trace.end()) {
-        throw std::runtime_error("No function_end node connected to capture_end found in the trace");
-    }
-
-    const auto& output_tensor_node =
-        find_node_by_counter(trace, last_function_end_node->at(kConnections).at(0).get<int>());
-    if (output_tensor_node == trace.end()) {
-        throw std::runtime_error("No tensor node connected to function_end found in the trace");
-    }
-
-    const auto& output_buffer_node =
-        find_a_first_node_of_a_type_pointing_to_me(trace, kNodeBuffer, *output_tensor_node);
-    if (output_buffer_node == trace.end()) {
-        throw std::runtime_error("No buffer node connected to tensor found in the trace");
-    }
-
-    const auto& output_buffer_allocate_node =
-        find_a_first_node_of_a_type_pointing_to_me(trace, kNodeBufferAllocate, *output_buffer_node);
-    if (output_buffer_allocate_node == trace.end()) {
-        throw std::runtime_error("No buffer_allocate node connected to buffer found in the trace");
-    }
-
-    uint32_t output_buffer_allocate_total_size =
-        std::stoi(output_buffer_allocate_node->at(kParams).at(kSize).get<std::string>());
-
-    // skip dram buffer allocation checks
-    if (output_buffer_allocate_node->at(kParams).at(kType) == "DRAM") {
+    const Tensor& output_tensor, size_t interleaved_storage_cores) {
+    tt::tt_metal::Buffer* buffer = output_tensor.buffer();
+    if (buffer->is_dram()) {
         return 0;
     }
 
-    uint32_t page_size = std::stoi(output_buffer_allocate_node->at(kParams).at(kPageSize).get<std::string>());
-    uint32_t num_of_cores = std::stoi(output_buffer_allocate_node->at(kParams).at(kNumCores).get<std::string>());
-    if (num_of_cores == 0) {
-        num_of_cores = interleaved_storage_cores;
-    }
+    uint32_t output_buffer_allocate_total_size = buffer->size();
+    uint32_t page_size = buffer->page_size();
+    uint32_t num_cores = buffer->num_cores().value_or(interleaved_storage_cores);
 
-    return detail::worst_case_per_core_allocation(output_buffer_allocate_total_size, page_size, num_of_cores);
+    return detail::worst_case_per_core_allocation(output_buffer_allocate_total_size, page_size, num_cores);
 }
 
 // This function returns the worst-case memory allocation per core for the peak L1 usage. Ignores DRAM buffers.

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -20,7 +20,7 @@ enum class ExecutionStatus { Success, Error };
 
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
 uint32_t extract_l1_output_buffer_allocation_size_per_core(
-    const nlohmann::json& trace, size_t interleaved_storage_cores);
+    const Tensor& output_tensor, size_t interleaved_storage_cores);
 uint32_t extract_l1_buffer_allocation_peak_size_per_core(const nlohmann::json& trace, size_t interleaved_storage_cores);
 uint32_t extract_circular_buffers_peak_size_per_core(const nlohmann::json& trace);
 

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -20,7 +20,7 @@ enum class ExecutionStatus { Success, Error };
 
 uint32_t extract_peak_L1_memory_usage(const nlohmann::json& trace);
 uint32_t extract_l1_output_buffer_allocation_size_per_core(
-    const Tensor& output_tensor, size_t interleaved_storage_cores);
+    const ttnn::Tensor& output_tensor, size_t interleaved_storage_cores);
 uint32_t extract_l1_buffer_allocation_peak_size_per_core(const nlohmann::json& trace, size_t interleaved_storage_cores);
 uint32_t extract_circular_buffers_peak_size_per_core(const nlohmann::json& trace);
 

--- a/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_trace_utils.hpp
@@ -6,6 +6,7 @@
 
 #include <nlohmann/json.hpp>
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
 
 #include <vector>
 


### PR DESCRIPTION
### Ticket
#20003

### Problem description
Parsing the graph capture trace is much more complex, and it did not work for Conv2d when all tensors were in DRAM. We now have access to the actual output tensor so we can get the information from the buffer itself.

### What's changed
- Closes #20003
- Read the same properties of the buffer that are recorded in graph capture, but now directly from the buffer itself
  - New implementation returns the same numbers for all existing unit tests
- Enable conv2d constraint unit test

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [X] New/Existing tests provide coverage for changes