### PR TITLE
Add implicit padding to softmax when tensor is in tile layout

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -328,3 +328,43 @@ def test_5d_softmax(device, input_shape, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.999)
+
+
+@pytest.mark.parametrize("input_shape", [(16, 7, 7)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("dlayout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("dim", [-1])
+@pytest.mark.parametrize("numeric_stable", [True])
+@pytest.mark.parametrize(
+    "fill_value",
+    [
+        -338953138925153547590470800371487866880.00000,  # 7E,7M
+        -337623910929368631717566993311207522304.00000,  # 7E,6M
+        -329648542954659136480144150949525454848.00000,  # 7E,4M
+        -297747071055821155530452781502797185024.00000,  # 7E,2M
+        -255211775190703847597530955573826158592.00000,  # 7E,1M
+        -170141183460469231731687303715884105728.00000,  # 7E,0M
+        -84738284731288386897617700092871966720.00000,  # 6E,7M
+        -42535295865117307932921825928971026432.00000,  # 6E,0M
+    ],
+)
+def test_large_fill_softmax(device, input_shape, dtype, dlayout, dim, numeric_stable, fill_value):
+    """
+    Test softmax with specific fill values.
+    This test is designed to check the stability of the softmax operation
+    when using specific fill values that may cause overflow or underflow.
+    Addresses bug #19781.
+    """
+    torch_input_tensor = torch.full(
+        size=input_shape, fill_value=fill_value, dtype=torch.float32 if dtype == ttnn.float32 else torch.bfloat16
+    )
+    torch_output_tensor = torch.softmax(torch_input_tensor, dim)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=dlayout, device=device)
+    output_tensor = ttnn.softmax(input_tensor, dim, numeric_stable=numeric_stable)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert len(output_tensor.shape) == len(torch_output_tensor.shape)
+    assert output_tensor.shape == torch_output_tensor.shape
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
@@ -7,8 +7,10 @@
 // #include "debug/dprint.h"
 
 // H-bcast mask
-FORCE_INLINE void generate_bcast_row_mask(const uint32_t cb_id, const uint32_t num_datum_padded, const uint32_t val) {
-    const uint32_t mask_val = val >> 16;
+FORCE_INLINE void generate_bcast_row_mask(const uint32_t cb_id, const uint32_t num_datum_padded) {
+    // Adds -inf padding. Note: the value is the uint representation of -inf
+    const uint16_t mask_val = 0xFF80;
+
     cb_reserve_back(cb_id, 1);
     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
 
@@ -61,9 +63,8 @@ void kernel_main() {
     constexpr uint32_t cb_id_mask = tt::CBIndex::c_5;
     const uint32_t mask_padded_data = get_arg_val<uint32_t>(4);
     const uint32_t num_datum_padded = get_arg_val<uint32_t>(5);
-    const uint32_t val_to_pad = get_arg_val<uint32_t>(6);
     if (mask_padded_data) {
-        generate_bcast_row_mask(cb_id_mask, num_datum_padded, val_to_pad);
+        generate_bcast_row_mask(cb_id_mask, num_datum_padded);
     }
 
     const InterleavedAddrGenFast<dst_is_dram> s = {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
@@ -7,10 +7,8 @@
 // #include "debug/dprint.h"
 
 // H-bcast mask
-FORCE_INLINE void generate_bcast_row_mask(const uint32_t cb_id, const uint32_t num_datum_padded) {
-    // Adds -inf padding. Note: the value is the uint representation of -inf
-    const uint16_t mask_val = 0xFF80;
-
+FORCE_INLINE void generate_bcast_row_mask(
+    const uint32_t cb_id, const uint32_t num_datum_padded, const uint16_t mask_val) {
     cb_reserve_back(cb_id, 1);
     volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
 
@@ -63,8 +61,11 @@ void kernel_main() {
     constexpr uint32_t cb_id_mask = tt::CBIndex::c_5;
     const uint32_t mask_padded_data = get_arg_val<uint32_t>(4);
     const uint32_t num_datum_padded = get_arg_val<uint32_t>(5);
+
+    // Adds -inf padding. Note: the value is the uint16 representation of bfloat16's -inf
+    constexpr uint16_t mask_val = 0xFF80;
     if (mask_padded_data) {
-        generate_bcast_row_mask(cb_id_mask, num_datum_padded);
+        generate_bcast_row_mask(cb_id_mask, num_datum_padded, mask_val);
     }
 
     const InterleavedAddrGenFast<dst_is_dram> s = {


### PR DESCRIPTION
### Ticket
[Addresses 19781](https://github.com/tenstorrent/tt-metal/issues/19781) 

### Problem description
When last dimension is not a multiple of 32 and input tensor is tiled, softmax operates on the padded data. This padded data should be set to -inf for it to not impact softmax values.

### What's changed
1. Adds -inf padding for padded areas before running softmax
2. Adds unit test for coverage.

### Performance Analysis

We consider two options to implement this fix:

1. Add an `implicit_fill` op before calling softmax
2. Use writer kernel to stream _-infinity_ values to the padded areas.

I ran all the softmax unit tests to get some statistics via tracy. Each OP was run twice and data collected from the second run to negate any impact of stale program cache.

From the 330 softmax operations that were run, approach (2) outperformed approach (1) 65% of the time. In the rest off the 35% traces, approach (1) did better marginally. This is evident by looking at relative runtime between (2) to (1). i.e. when we look at how big (or small) Approach (2) is in runtime as compared to Approach(1), we see this:

| Statistic | (Runtime (1) / Runtime (2) (%)     |
|-----------|-----------|
| MIN       | 92.48%    |
| MAX       | 389.99%   |
| MEDIAN    | 100.41%   |
| AVERAGE   | 110.52%   
| TOTAL COUNT of Softmax ops executed | 330 |
| (2) better in | 213 |
| (2) better (%) | 65% |


i.e. even when approach (1) does better, it is only 8% better than approach (2). However, when approach (2) does better, it delivers a huge speed up. In the worst case scenario, the execution time is cut to 1/4th.

To conclude, we go with approach (2) and [create a new work item](https://github.com/tenstorrent/tt-metal/issues/20171) to explore similar approach for other reductions like min/max etc where padding is necessary.

Raw data is [here](https://docs.google.com/spreadsheets/d/18JBgL99okOoqJx3DTg1G5FECPojHaWeE4rtT53Nx35Q/edit?usp=sharing)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14236083253) CI passing
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes: Added new unit tests