### PR TITLE
fix device perf post processing for CCLs

### DIFF
--- a/models/perf/device_perf_utils.py
+++ b/models/perf/device_perf_utils.py
@@ -72,6 +72,17 @@ def post_process_ops_log_detailed(
     if op_name != "":
         df = df[df["OP CODE"] == op_name]
 
+    # group by DEVICE ID
+    df = df.groupby("DEVICE ID")
+    # now sort the list of df by the DEVICE FW START CYCLE
+    df = sorted(df, key=lambda x: x[1]["DEVICE FW START CYCLE"].iloc[0])
+
+    # Convert list of tuples to list of dataframes
+    dfs = [group for _, group in df]
+
+    # concatenate the list of df into a single df by interleaving the rows
+    df = pd.concat([df.iloc[[i]] for i in range(len(dfs[0])) for df in dfs], ignore_index=True)
+
     if warmup_iters > 0:
         df = df.iloc[warmup_iters:]
 


### PR DESCRIPTION
### Problem description
This PR fixes a bug in the post-processing function used for profiling CCLs.

**Bug**: The function incorrectly drops the first n warmup iterations from the top of the dataframe, which does not guarantee removing n iterations per device ID. As a result, some execution trace iterations may remain in the dataset, leading to inflated kernel durations and outliers.

**Fix**: Instead of removing warmup iterations from the top, the function now creates a new dataframe where iterations are ordered sequentially by device ID, ensuring consistent filtering.

### Kernel Profiling Results on 1GHz 4U (glx-15)

| Kernel Name                    | Avg Duration | Min Duration | Max Duration | Std Dev |
|--------------------------------|-------------|-------------|-------------|---------|
| AllGather SDPA                | 8736.49     | 6486.0      | 11079.0     | 896.45  |
| AllGatherAsync binary_mult     | 9576.90     | 7788.0      | 11713.0     | 384.61  |
| AllGatherAsync Layernorm       | 5816.33     | 4231.0      | 7485.0      | 365.89  |
| AllReduceAsync FF2             | 16788.33    | 15896.0     | 17700.0     | 218.08  |
| AllReduceAsync FF1             | 17431.55    | 16330.0     | 18407.0     | 347.05  |
| AllReduceAsync QKV             | 10776.36    | 9803.0      | 11880.0     | 321.01  |
| AllReduceAsync lm_head         | 55098.62    | 53722.0     | 56724.0     | 441.20  |


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14230293024) CI passes
- [ ] [TG Model Perf](https://github.com/tenstorrent/tt-metal/actions/workflows/tg-model-perf-tests.yaml) *This is blocked due to existing hang in CI