### PR TITLE
Introduce simd-everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,10 +196,10 @@ add_compile_options(
     -Wreturn-type
     -Wswitch
     -Wuninitialized
-    -mavx2
     -fPIC
     -fvisibility-inlines-hidden
     -fno-lto # FIXME: This seems to be here for ttnn; it should go to TTNN, then.
+    "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-mavx2>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wsometimes-uninitialized>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-c++11-narrowing>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-error=local-type-template-args>"

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -222,3 +222,14 @@ if(flatbuffers_ADDED)
     target_compile_options(flatc PRIVATE -Wno-restrict)
     target_compile_options(flatbuffers PRIVATE -Wno-restrict)
 endif()
+
+############################################################################################################################
+# simd-everywhere/simde : https://github.com/simd-everywhere/simde
+############################################################################################################################
+
+CPMAddPackage(NAME simd-everywhere GITHUB_REPOSITORY simd-everywhere/simde GIT_TAG v0.8.2)
+if(simd-everywhere_ADDED)
+    add_library(simde INTERFACE)
+    add_library(simde::simde ALIAS simde)
+    target_include_directories(simde SYSTEM INTERFACE ${simd-everywhere_SOURCE_DIR})
+endif()

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -1,8 +1,5 @@
 set(PERF_MICROBENCH_TESTS_SRCS
     dispatch/test_pgm_dispatch.cpp
-    dispatch/test_bw_and_latency.cpp
-    dispatch/test_dispatcher.cpp
-    dispatch/test_prefetcher.cpp
     ethernet/test_ethernet_read_and_send_data.cpp
     ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
     ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -33,7 +30,6 @@ set(PERF_MICROBENCH_TESTS_SRCS
     2_noc_adjacent/test_noc_adjacent.cpp
     2_noc_rtor/test_noc_rtor.cpp
     3_pcie_transfer/test_rw_buffer.cpp
-    3_pcie_transfer/test_pull_from_pcie.cpp
     6_dram_offchip/test_dram_offchip.cpp
     7_kernel_launch/test_kernel_launch.cpp
     8_dram_adjacent_core_read/test_dram_read.cpp
@@ -41,6 +37,19 @@ set(PERF_MICROBENCH_TESTS_SRCS
     10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
     11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
 )
+
+# These tests use SIMD intrinsics and are not portable.
+set(X86_64_ONLY_TESTS
+    dispatch/test_prefetcher.cpp
+    dispatch/test_bw_and_latency.cpp
+    dispatch/test_dispatcher.cpp
+    3_pcie_transfer/test_pull_from_pcie.cpp
+)
+
+# Add x86_64 tests only on appropriate platforms.
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    list(APPEND PERF_MICROBENCH_TESTS_SRCS ${X86_64_ONLY_TESTS})
+endif()
 
 set(ARCHITECTURES
     "wormhole"

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
         TT:STL
         umd::Firmware
         umd::device
+        simde::simde
     PRIVATE
         Tracy::TracyClient
         TT::Metalium::HostDevCommon


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20019

### Problem description
I want to build and run Metal under non-x86 platforms.  This fails today because:
1. Metal contains x86-specific code
2. sfpi compiler binaries are for x86

This PR addresses problem 1.

### What's changed
Changes:
* add [simde](https://github.com/simd-everywhere/simde) as a dependency with CPM
* use simde wrappers in bfloat4.cpp and bfloat8.cpp instead of x86-specific intrinsics
* add a non-x86 memcpy_to_device implementation
* exclude perf microbenchmarks using x86-specific intrinsics from non-x86 builds

Impact: it is possible to build and run Metal for aarch64 and riscv64 (provided appropriate sfpi binaries).  I did a test build under both platforms.  Using these changes I ran the Falcon7B model on N300 with a RISC-V host.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes