### PR TITLE
EDM config cleanup and CCL 6u changes

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -92,7 +92,7 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     static constexpr std::size_t edm_buffer_size =
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
         sizeof(tt::tt_fabric::PacketHeader);
-    const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+    const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
 
     tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
         .edm_noc_x = edm_eth_core.x,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -453,7 +453,7 @@ bool RunLoopbackTest(
     const auto& worker_core = worker_cores.at(0);
     log_trace(tt::LogTest, "Worker {}. On Core x={},y={}", 0, worker_core.x, worker_core.y);
 
-    const auto& edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+    const auto& edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
     const std::vector<tt::tt_fabric::edm_termination_info_t>& edm_termination_infos =
         enable_persistent_fabric ? std::vector<tt::tt_fabric::edm_termination_info_t>{}
                                  : std::vector<tt::tt_fabric::edm_termination_info_t>{
@@ -1260,7 +1260,7 @@ int TestLoopbackEntrypoint(
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes + PACKET_HEADER_SIZE_BYTES;
     const chip_id_t local_chip_id = 0;
     const chip_id_t remote_chip_id = 1;
-    const auto& edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+    const auto& edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
     auto chip_0_edm_builder = tt::tt_fabric::FabricEriscDatamoverBuilder::build(
         sender_device,
         fabric_sender_program,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
@@ -271,7 +271,7 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
         wrap_mesh = False
     else:
         all_gather_topology = ttnn.Topology.Ring
-        wrap_mesh = True
+        wrap_mesh = False
 
     ttnn_persistent_output_tensor = None
     if use_persistent_output:

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
@@ -104,7 +104,7 @@ def run_all_reduce_impl(
         wrap_mesh = False
     else:
         all_reduce_topology = ttnn.Topology.Ring
-        wrap_mesh = True
+        wrap_mesh = False
 
     worker_sub_device = ttnn.SubDevice([SUB_DEVICE_CRS])
 

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -24,7 +24,6 @@ namespace tt::tt_fabric {
 struct FabricEriscDatamoverConfig {
     static constexpr std::size_t num_sender_channels = 3;
     static constexpr std::size_t num_receiver_channels = 2;
-    static constexpr bool constrain_to_power_of_2_buffer_slot_counts = true;
 
     static constexpr std::size_t field_size = 16;
     static constexpr std::size_t buffer_alignment = 32;
@@ -88,11 +87,7 @@ struct FabricEriscDatamoverConfig {
     std::size_t buffer_region_start;
     std::size_t available_channel_buffering_space;
 
-    FabricEriscDatamoverConfig(
-        std::size_t channel_buffer_size_bytes,
-        std::size_t sender_ratio_size,
-        std::size_t receiver_ratio_size,
-        Topology topology = Topology::Linear);
+    FabricEriscDatamoverConfig(std::size_t channel_buffer_size_bytes, Topology topology = Topology::Linear);
 
     std::size_t channel_buffer_size_bytes = 0;
     std::size_t channel_buffer_size_bytes_with_channel_sync = 0;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -99,11 +99,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig() {
     this->available_channel_buffering_space = max_l1_loading_size - buffer_region_start;
 }
 
-FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
-    std::size_t channel_buffer_size_bytes,
-    std::size_t sender_ratio_size,
-    std::size_t receiver_ratio_size,
-    Topology topology) :
+FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(std::size_t channel_buffer_size_bytes, Topology topology) :
     FabricEriscDatamoverConfig() {
     this->num_used_sender_channels = FabricEriscDatamoverConfig::num_sender_channels;
     this->num_used_receiver_channels = FabricEriscDatamoverConfig::num_receiver_channels;
@@ -168,67 +164,41 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         min_buffer_size);
 
     // TODO: Review
-    size_t default_pow2_num_sender_buffer_slots = 8;
-    size_t default_pow2_num_receiver_buffer_slots = 16;
+    size_t num_sender_buffer_slots = 8;
+    size_t num_receiver_buffer_slots = 16;
     if (topology == Topology::Ring) {
-        default_pow2_num_sender_buffer_slots /= 2;
-        default_pow2_num_receiver_buffer_slots /= 2;
+        num_sender_buffer_slots = 4;
+        num_receiver_buffer_slots = 8;
     }
 
     const std::size_t channel_buffer_size_with_channel_sync =
         channel_buffer_size_bytes +
         sizeof(tt::tt_fabric::PacketHeader);  // + 16 // sizeof(tt::tt_fabric::PacketHeader);
 
-    const size_t next_lowest_power_of_2_buffer_slot_count = this->channel_buffer_size_bytes = channel_buffer_size_bytes;
+    this->channel_buffer_size_bytes = channel_buffer_size_bytes;
     this->channel_buffer_size_bytes_with_channel_sync = channel_buffer_size_with_channel_sync;
-    const std::size_t total_ratio_count =
-        this->num_used_sender_channels * sender_ratio_size + this->num_used_receiver_channels * receiver_ratio_size;
-
-    auto buffer_initializer = [available_channel_buffering_space = this->available_channel_buffering_space,
-                               total_ratio_count,
-                               default_pow2_num_sender_buffer_slots,
-                               channel_buffer_size_with_channel_sync](
-                                  auto& channel_size_bytes,
-                                  auto& num_buffers,
-                                  const auto ratio_size,
-                                  const auto default_pow2_num_buffer_slots) {
-        channel_size_bytes = tt::round_down(
-            (available_channel_buffering_space / total_ratio_count) * ratio_size,
-            channel_buffer_size_with_channel_sync);
-        if constexpr (FabricEriscDatamoverConfig::constrain_to_power_of_2_buffer_slot_counts) {
-            num_buffers = default_pow2_num_buffer_slots;
-        } else {
-            num_buffers = channel_size_bytes / channel_buffer_size_with_channel_sync;
-        }
-    };
+    const std::size_t total_slot_count = this->num_used_sender_channels * num_sender_buffer_slots +
+                                         this->num_used_receiver_channels * num_receiver_buffer_slots;
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
-        buffer_initializer(
-            this->sender_channels_size_bytes[i],
-            this->sender_channels_num_buffers[i],
-            sender_ratio_size,
-            default_pow2_num_sender_buffer_slots);
+        this->sender_channels_num_buffers[i] = num_sender_buffer_slots;
+        this->sender_channels_size_bytes[i] = channel_buffer_size_with_channel_sync * num_sender_buffer_slots;
         TT_FATAL(
-            channel_buffer_size_with_channel_sync * this->sender_channels_num_buffers[i] <=
-                this->sender_channels_size_bytes[i],
+            this->sender_channels_size_bytes[i] <= available_channel_buffering_space,
             "Sender channel with {} buffer slots of size {} B does not fit in {} B",
             this->sender_channels_num_buffers[i],
             channel_buffer_size_with_channel_sync,
-            this->sender_channels_size_bytes[i]);
+            available_channel_buffering_space);
     }
     for (uint32_t i = 0; i < this->num_used_receiver_channels; i++) {
-        buffer_initializer(
-            this->receiver_channels_size_bytes[i],
-            this->receiver_channels_num_buffers[i],
-            receiver_ratio_size,
-            default_pow2_num_receiver_buffer_slots);
+        this->receiver_channels_num_buffers[i] = num_receiver_buffer_slots;
+        this->receiver_channels_size_bytes[i] = channel_buffer_size_with_channel_sync * num_receiver_buffer_slots;
         TT_FATAL(
-            channel_buffer_size_with_channel_sync * this->receiver_channels_num_buffers[i] <=
-                this->receiver_channels_size_bytes[i],
+            this->receiver_channels_size_bytes[i] <= available_channel_buffering_space,
             "Receiver channel with {} buffer slots of size {} B does not fit in {} B",
             this->receiver_channels_num_buffers[i],
             channel_buffer_size_with_channel_sync,
-            this->receiver_channels_size_bytes[i]);
+            available_channel_buffering_space);
     }
 
     uint32_t buffer_addr = buffer_region_start;

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -18,7 +18,7 @@ tt::tt_fabric::FabricEriscDatamoverConfig get_default_fabric_config() {
     constexpr std::size_t edm_buffer_size =
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
         sizeof(tt::tt_fabric::PacketHeader);
-    return tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+    return tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
 }
 
 }  // namespace

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -448,7 +448,7 @@ void DevicePool::wait_for_fabric_router_sync() const {
         static constexpr std::size_t edm_buffer_size =
             tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
             sizeof(tt::tt_fabric::PacketHeader);
-        const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+        const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
         std::vector<uint32_t> signal(1, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
 
         auto wait_for_handshake = [&](IDevice* dev) {
@@ -712,7 +712,7 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
         static constexpr std::size_t edm_buffer_size =
             tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
             sizeof(tt::tt_fabric::PacketHeader);
-        const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+        const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
 
         auto fabric_router_sync_sem_addr = edm_config.termination_signal_address;
         for (const auto& dev : this->get_all_active_devices()) {

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1000,7 +1000,7 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
     static constexpr std::size_t edm_buffer_size =
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
         sizeof(tt::tt_fabric::PacketHeader);
-    const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+    const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
 
     for (const auto& [direction, remote_chip_id] : chip_neighbors) {
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -58,7 +58,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
     static constexpr std::size_t edm_buffer_size =
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
         sizeof(tt::tt_fabric::PacketHeader);
-    const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2, topology);
+    const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology);
     TT_ASSERT(device_sequence.size() == program_sequence.size());
 
     for (size_t i = 0; i < device_sequence.size(); i++) {
@@ -226,7 +226,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
     static constexpr std::size_t edm_buffer_size =
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
         sizeof(tt::tt_fabric::PacketHeader);
-    const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2, topology);
+    const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology);
 
     log_trace(tt::LogOp, "device id={}", local_device->id());
     log_trace(tt::LogOp, "EDM Fabric Factory ctor on device: {}", local_device->id());
@@ -431,7 +431,7 @@ EdmLineFabricOpInterface::generate_ordered_termination_info_farthest_to_nearest(
     static constexpr std::size_t edm_buffer_size =
         tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
         sizeof(tt::tt_fabric::PacketHeader);
-    static const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, 1, 2);
+    static const auto config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
     TT_ASSERT(device_sequence.size() > 0);
     const size_t num_hops = device_sequence.size() - 1;
     TT_ASSERT(num_hops > 0);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/llama_shapes_sharded_writer.cpp
@@ -24,6 +24,10 @@ constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+constexpr bool dynamic_alternate = get_compile_time_arg_val(8);
+constexpr uint32_t num_max_targets = std::max(num_targets_forward_direction, num_targets_backward_direction);
+constexpr uint32_t num_sync_targets_forward = dynamic_alternate ? num_max_targets : num_targets_forward_direction;
+constexpr uint32_t num_sync_targets_backward = dynamic_alternate ? num_max_targets : num_targets_backward_direction;
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -147,6 +151,11 @@ void kernel_main() {
             fabric_connection,
             l1_read_addr,
             num_tiles_to_read_this_core * tensor0_page_size);
+        if constexpr (dynamic_alternate) {
+            std::swap(
+                pkt_hdr_forward->routing_fields.value,
+                pkt_hdr_backward->routing_fields.value);  // alternate the packet header distance for better balancing
+        }
         noc_async_writes_flushed();
 
         cb_pop_front(cb0_id, num_tiles_to_read_this_core);
@@ -170,14 +179,14 @@ void kernel_main() {
     if (fabric_connection.has_forward_connection()) {
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
         pkt_hdr->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_forward)});
         fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
         pkt_hdr->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_backward)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
             packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/device/kernels/dataflow/worker_writer.cpp
@@ -24,6 +24,10 @@ constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
+constexpr bool dynamic_alternate = get_compile_time_arg_val(8);
+constexpr uint32_t num_max_targets = std::max(num_targets_forward_direction, num_targets_backward_direction);
+constexpr uint32_t num_sync_targets_forward = dynamic_alternate ? num_max_targets : num_targets_forward_direction;
+constexpr uint32_t num_sync_targets_backward = dynamic_alternate ? num_max_targets : num_targets_backward_direction;
 
 void kernel_main() {
     ///////////////////////////////////////////////////
@@ -123,6 +127,11 @@ void kernel_main() {
             fabric_connection,
             l1_read_addr,
             num_tiles_to_read_this_core * tensor0_page_size);
+        if constexpr (dynamic_alternate) {
+            std::swap(
+                pkt_hdr_forward->routing_fields.value,
+                pkt_hdr_backward->routing_fields.value);  // alternate the packet header distance for better balancing
+        }
 
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id += num_tiles_to_read_this_core;
@@ -147,7 +156,7 @@ void kernel_main() {
             32});
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
         pkt_hdr_fwd->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_forward)});
         fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
             reinterpret_cast<uint32_t>(pkt_hdr_fwd), sizeof(PACKET_HEADER_TYPE));
     }
@@ -160,7 +169,7 @@ void kernel_main() {
             static_cast<uint16_t>(1),  // increment 1
             32});
         pkt_hdr_bwd->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_backward)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_flush_non_blocking_from_address(
             reinterpret_cast<uint32_t>(pkt_hdr_bwd), sizeof(PACKET_HEADER_TYPE));


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Ratio sizes as user input unnecessarily complicates the buffer slot setup and doesn't actually work as expected.
Minor modifications needed to enable the galaxy ccl unit tests to use ring on 6u. Previous setup was for folded ring on sub-mesh on TG.

### What's changed
Remove ratio size args from fabric config constructor. If needed, we can expose this as user configurable instead of the ratio sizes.
Enable ccl unit tests to run on 6u.
Add some basic configurable options to the all gather/all reduce for different traffic patterns using ring. Currently default to combined static/dynamic alternating ring pattern, but not this may not be the best option in all cases.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14211213720
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14211210262
TG Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14211208580