### PR TITLE
[skip ci] Don't supress warnings about unused parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,6 @@ add_compile_options(
     -Wreturn-type
     -Wswitch
     -Wuninitialized
-    -Wno-unused-parameter
     -mavx2
     -fPIC
     -fvisibility-inlines-hidden


### PR DESCRIPTION
### Problem description
We are suppressing many compiler warnings.
Lets start ripping off the bandaids.
If it builds, then its good to go.

### What's changed
Don't supresss unused parameters warnings.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes