### PR TITLE
#19974: Implement max unary

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
@@ -67,6 +67,7 @@ Compute APIs
   unary_ne_tile
   unary_gt_tile
   unary_lt_tile
+  unary_max_tile
 
   cb_wait_front
   cb_pop_front

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/unary_max_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/unary_max_tile.rst
@@ -1,0 +1,5 @@
+unary_max_tile
+--------------
+
+.. doxygenfunction:: unary_max_tile_init()
+.. doxygenfunction:: unary_max_tile(uint32_t idst, uint32_t param0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -174,29 +174,6 @@ def test_binary_maximum_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {-82.5, -45.7, 0.0, 12.5, 66.4, 96, 8},
-)
-def test_binary_maximum_scalar_ttnn(input_shapes, scalar, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-
-    output_tensor = ttnn.maximum(input_tensor1, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.maximum)
-    golden_tensor = golden_function(in_data1, torch.full(input_shapes, scalar))
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 def test_binary_atan2_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_val, scalar",
+    [
+        (0.36719, 0.5),
+        (0, 0.06719),
+        (0, 0.002),
+        (3.4 * 10**38, 1),
+        (-1, -3.4 * 10**38),
+        (3.4 * 10**38, -3.4 * 10**38),
+        (float("inf"), 1),
+        (1, -float("inf")),
+        (3.4 * 10**38, float("inf")),
+        (-3.4 * 10**38, -float("inf")),
+        (11, 1),
+    ],
+)
+def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
+    torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.maximum(tt_in, scalar)
+    result = ttnn.to_torch(tt_result)
+
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_val, scalar",
+    [
+        (0.36719, 0.5),
+        (0.0034, 0.0023),
+        (0, 0.06719),
+        (0, 0.002),
+        (3.4 * 10**38, 1),
+        (-1, -3.4 * 10**38),
+        (3.4 * 10**38, -3.4 * 10**38),
+        (float("inf"), 1),
+        (1, -float("inf")),
+        (3.4 * 10**38, float("inf")),
+        (-3.4 * 10**38, -float("inf")),
+        (11, 1),
+    ],
+)
+def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
+    torch_input = torch.ones(input_shapes, dtype=torch.bfloat16) * input_val
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.maximum(tt_in, scalar)
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-100.0, 100.0),
+        (-3.3 * 10**38, 3.3 * 10**38),
+    ],
+)
+@pytest.mark.parametrize("scalar", [0.5, 0, 20, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
+def test_unary_max_bf16(input_shapes, low, high, scalar, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.maximum(tt_in, scalar)
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-100, 100),
+        (-1.7 * 10**38, 1.7 * 10**38),
+    ],
+)
+@pytest.mark.parametrize("scalar", [0.5, 0.1, 0, 1, 10, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
+def test_unary_max_fp32(input_shapes, low, high, scalar, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.maximum(tt_in, scalar)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -6,6 +6,7 @@
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_unary_sfpu_abs.h"
 #include "llk_math_eltwise_unary_sfpu_comp.h"
+#include "llk_math_eltwise_unary_sfpu_unary_max.h"
 #include "llk_math_eltwise_unary_sfpu_exp2.h"
 #include "llk_math_eltwise_unary_sfpu_expm1.h"
 #include "llk_math_eltwise_unary_sfpu_heaviside.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max(uint value) {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Load value param to lreg1
+        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
+        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
+
+        // Load input to lreg0
+        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+
+        // Maximum value stored in lreg1
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPNOP;
+
+        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_unary_max.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+// Unary maximum
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_max<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -93,4 +93,5 @@ enum SfpuType {
     prelu,
     round,
     cpy_values,
+    unary_max,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -7,6 +7,7 @@
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_abs.h"
 #include "llk_math_eltwise_unary_sfpu_comp.h"
+#include "llk_math_eltwise_unary_sfpu_unary_max.h"
 #include "llk_math_eltwise_unary_sfpu_exp2.h"
 #include "llk_math_eltwise_unary_sfpu_expm1.h"
 #include "llk_math_eltwise_unary_sfpu_heaviside.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "noc_nonblocking_api.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max(uint value) {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Load value param to lreg1
+        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
+        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
+
+        // Load input to lreg0
+        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+
+        // Maximum value stored in lreg1
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPNOP;
+
+        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "ckernel_sfpu_unary_max.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+// Unary maximum
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_max, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_max<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -76,6 +76,7 @@ enum SfpuType {
     unary_ne,
     unary_gt,
     unary_lt,
+    unary_max,
     softplus,
     tiled_prod,
     bitwise_xor,

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -818,6 +818,31 @@ ALWI void dbg_read_dest_acc_row(int row_addr, uint32_t* rd_data) {
     MATH((dbg_get_array_row(dbg_array_id::DEST, row_addr, rd_data)));
 }
 
+// unary_max : if x > value --> x, else value
+// clang-format off
+/**
+ * Performs element-wise computation of:  result = x if x > value , where x is each element of a tile
+ * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
+ */
+// clang-format on
+ALWI void unary_max_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_max<APPROX>(idst, param0)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void unary_max_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_max_init<APPROX>())); }
+
 // unary gt : if x > value --> 1.0, else 0.0
 // clang-format off
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -132,9 +132,8 @@ Tensor ExecuteMaximum::invoke(
 
 Tensor ExecuteMaximum::invoke(
     const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor t_diff = ttnn::rsub(input_a, value, output_mem_config);
-    Tensor result = ttnn::where(t_diff, value, input_a);
-    return result;
+    return ttnn::operations::unary::ExecuteUnaryWithFloatParameter<
+        ttnn::operations::unary::UnaryOpType::MAXIMUM>::invoke(ttnn::DefaultQueueId, input_a, value, output_mem_config);
 }
 
 Tensor _atan2(const Tensor& input_b, const Tensor& input_a, const std::optional<MemoryConfig>& output_mem_config) {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -93,6 +93,7 @@ enum class UnaryOpType {
     PRELU_SFPU,
     ZERO_POINT,
     MISH,
+    MAXIMUM,
 };
 
 struct UnaryWithParam {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -253,6 +253,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                     (uint32_t)datatype_to_dataformat_converter((DataType)params[0]),
                     (uint32_t)datatype_to_dataformat_converter((DataType)params[1]))};
             break;
+        case UnaryOpType::MAXIMUM:
+            op_init_and_name = {
+                "unary_max_tile_init();",
+                fmt::format("unary_max_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            break;
         default: TT_THROW("unexpected parameterized op type {}", op_type);
     };
     return op_init_and_name;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -66,7 +66,8 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::FILL:
         case UnaryOpType::ROUND:
         case UnaryOpType::PRELU_SFPU:
-        case UnaryOpType::FMOD: return true;
+        case UnaryOpType::FMOD:
+        case UnaryOpType::MAXIMUM: return true;
         default: return false;
     }
     return false;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -24,6 +24,7 @@ void validate_supported_arch_dtype(
         case UnaryOpType::ROUND:
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::RIGHT_SHIFT:
+        case UnaryOpType::MAXIMUM:
             TT_FATAL(
                 arch != tt::ARCH::GRAYSKULL,
                 "UnaryOpType '{}' is not supported on Grayskull architecture.",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -164,6 +164,7 @@ template struct ExecuteUnaryWithFloatParameter<UnaryOpType::FILL>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_GT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_LT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_NE>;
+template struct ExecuteUnaryWithFloatParameter<UnaryOpType::MAXIMUM>;
 
 Tensor Sigmoid_accurate::invoke(
     QueueId queue_id,

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -228,6 +228,9 @@ ttnn.attach_golden_function(ttnn.hypot, golden_function=_golden_function_hypot)
 def _golden_function_maximum(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
+    if not torch.is_tensor(input_tensor_b):
+        input_tensor_b = torch.full(input_tensor_a.shape, input_tensor_b)
+
     return torch.maximum(input_tensor_a, input_tensor_b)
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19974

### Problem description
Implement Tensor-scalar version is maximum as SFPU Op

### What's changed
Implemented Tensor-scalar version is maximum as SFPU Op 

- Used TTI_ instructions
- Removed old test and created a new test file which inclused testing the failing case mentioned in #18556
- Tested in WH, BH
- Removed existing GS support
- Performance improvement on moving from composite 
   - Current implementation is about **86.3%** faster than the older implementation.
---> Composite Op : [main.csv](https://github.com/user-attachments/files/19592313/main.csv)
 
<img width="370" alt="Screenshot 2025-04-03 at 11 31 01 PM" src="https://github.com/user-attachments/assets/956482dd-5646-42b5-8d07-b749e00bc577" />

---> SFPU Op : [branch.csv](https://github.com/user-attachments/files/19592314/branch.csv)
<img width="372" alt="Screenshot 2025-04-03 at 11 30 42 PM" src="https://github.com/user-attachments/assets/39bb8a6d-921b-4012-929f-f61a98bc101a" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14276624051) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14255726455) CI passes
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14248565952) CI passes 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14248605406) CI passes
- [x] [new models tests](https://github.com/tenstorrent/tt-metal/actions/runs/14255724868) CI passes as in main