### PR TITLE
#20057: [skip ci] Distinguish between timeouts and hangs in data pipeline for superset

### DIFF
--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -121,7 +121,7 @@ jobs:
           find generated/cicd/ -type f
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'infra/requirements-infra.txt'
       - name: Install infra dependencies

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'infra/requirements-infra.txt'
       - name: Install infra dependencies

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5.0.0
         with:
-          python-version: '3.12'
+          python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'infra/requirements-infra.txt'
       - name: Install infra dependencies

--- a/.github/workflows/_unit-tests-infra.yaml
+++ b/.github/workflows/_unit-tests-infra.yaml
@@ -14,7 +14,7 @@ jobs:
   build-and-test-infra:
     strategy:
       matrix:
-        python-version: [3.12]
+        python-version: [3.8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_unit-tests-infra.yaml
+++ b/.github/workflows/_unit-tests-infra.yaml
@@ -14,7 +14,7 @@ jobs:
   build-and-test-infra:
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.10]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_unit-tests-infra.yaml
+++ b/.github/workflows/_unit-tests-infra.yaml
@@ -14,7 +14,7 @@ jobs:
   build-and-test-infra:
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_unit-tests-infra.yaml
+++ b/.github/workflows/_unit-tests-infra.yaml
@@ -14,7 +14,7 @@ jobs:
   build-and-test-infra:
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -46,7 +46,7 @@ def create_cicd_json_for_data_analysis(
 
     github_job_id_to_annotations = get_github_job_id_to_annotations(workflow_outputs_dir, github_pipeline_id)
 
-    raw_jobs = get_job_rows_from_github_info(github_pipeline_json, github_jobs_json, github_job_id_to_annotations)
+    raw_jobs = get_job_rows_from_github_info(workflow_outputs_dir, github_jobs_json, github_job_id_to_annotations)
 
     github_job_ids = []
     for raw_job in raw_jobs:

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -11,6 +11,7 @@ from typing import Optional, Union
 
 from loguru import logger
 
+from infra.data_collection.github.workflows import is_job_hanging_from_job_log
 from infra.data_collection.models import InfraErrorV1, TestErrorV1
 from infra.data_collection.pydantic_models import CompleteBenchmarkRun
 
@@ -93,9 +94,9 @@ def return_first_string_starts_with(starting_string, strings):
     raise Exception(f"{strings} do not have any that match {starting_string}")
 
 
-def get_job_failure_signature_(github_job, failure_description) -> Optional[Union[InfraErrorV1]]:
+def get_job_failure_signature_(github_job, failure_description, workflow_outputs_dir) -> Optional[Union[InfraErrorV1]]:
     error_snippet_to_signature_mapping = {
-        "timed out": str(InfraErrorV1.JOB_UNIT_TIMEOUT_FAILURE),
+        "has timed out": str(InfraErrorV1.JOB_UNIT_TIMEOUT_FAILURE),
         "exceeded the maximum execution time": str(InfraErrorV1.JOB_CUMULATIVE_TIMEOUT_FAILURE),
         "lost communication with the server": str(InfraErrorV1.RUNNER_COMM_FAILURE),
         "runner has received a shutdown signal": str(InfraErrorV1.RUNNER_SHUTDOWN_FAILURE),
@@ -107,7 +108,19 @@ def get_job_failure_signature_(github_job, failure_description) -> Optional[Unio
     # Check the mapping dictionary for specific failure signature types
     for error_snippet in error_snippet_to_signature_mapping:
         if error_snippet in failure_description:
-            return error_snippet_to_signature_mapping[error_snippet]
+            error_signature = error_snippet_to_signature_mapping[error_snippet]
+            # Determine if timeout is a hang
+            if error_signature in [
+                str(InfraErrorV1.JOB_CUMULATIVE_TIMEOUT_FAILURE),
+                str(InfraErrorV1.JOB_UNIT_TIMEOUT_FAILURE),
+            ] and is_job_hanging_from_job_log(
+                error_snippet,
+                workflow_outputs_dir=workflow_outputs_dir,
+                workflow_run_id=github_job["run_id"],
+                workflow_job_id=github_job["id"],
+            ):
+                error_signature = str(InfraErrorV1.JOB_HANG)
+            return error_signature
 
     # If failure occurred in runner setup, classify as set up failure
     for step in github_job["steps"]:
@@ -125,7 +138,9 @@ def get_job_failure_signature_(github_job, failure_description) -> Optional[Unio
     return str(InfraErrorV1.GENERIC_FAILURE)
 
 
-def get_failure_signature_and_description_from_annotations(github_job, github_job_id_to_annotations):
+def get_failure_signature_and_description_from_annotations(
+    github_job, github_job_id_to_annotations, workflow_outputs_dir
+):
     failure_signature, failure_description = None, None
 
     # Don't return any failure info if job passed
@@ -153,12 +168,14 @@ def get_failure_signature_and_description_from_annotations(github_job, github_jo
                     # Infrastructure error
                     failure_description = _annot.get("message")
                     if failure_description:
-                        failure_signature = get_job_failure_signature_(github_job, failure_description)
+                        failure_signature = get_job_failure_signature_(
+                            github_job, failure_description, workflow_outputs_dir
+                        )
                         return failure_signature, failure_description
     return failure_signature, failure_description
 
 
-def get_job_row_from_github_job(github_job, github_job_id_to_annotations):
+def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workflow_outputs_dir):
     github_job_id = github_job["id"]
 
     logger.info(f"Processing github job with ID {github_job_id}")
@@ -266,7 +283,7 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations):
     github_job_link = github_job["html_url"]
 
     failure_signature, failure_description = get_failure_signature_and_description_from_annotations(
-        github_job, github_job_id_to_annotations
+        github_job, github_job_id_to_annotations, workflow_outputs_dir
     )
 
     return {
@@ -291,9 +308,12 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations):
     }
 
 
-def get_job_rows_from_github_info(github_pipeline_json, github_jobs_json, github_job_id_to_annotations):
+def get_job_rows_from_github_info(workflow_outputs_dir, github_jobs_json, github_job_id_to_annotations):
     job_rows = list(
-        map(lambda job: get_job_row_from_github_job(job, github_job_id_to_annotations), github_jobs_json["jobs"])
+        map(
+            lambda job: get_job_row_from_github_job(job, github_job_id_to_annotations, workflow_outputs_dir),
+            github_jobs_json["jobs"],
+        )
     )
     return [x for x in job_rows if x is not None]
 

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -57,7 +57,6 @@ def parse_github_log_timestamp(line):
     # Wacky github workaround: truncate to 26 chars because github's timestamp
     # is 7 digits for fractional seconds instead of 6, which is the ISO format
     # E.g. 2024-09-25T14:33:11.1060679Z -> 2024-09-25T14:33:11.106067
-    # This isn't an issue for python versions > 3.10 (infra runs python 3.8)
     return datetime.fromisoformat(timestamp_str[:26])
 
 

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -67,10 +67,13 @@ def is_job_hanging_from_job_log(error_snippet, workflow_outputs_dir, workflow_ru
     When we encounter the timeout error message, compare the timestamp of the generated message
     against the last output line, as well as the last line against the 2nd last.
 
+    We calculate two time deltas because some hangs can generate a line of output the moment the process is terminated/timed out.
+    Therefore we need to also check the second-last line's timestamp to confirm a hang has occurred.
+
     If the time delta between the lines is greater than 5 minutes** (max_time_delta_seconds)
     then consider the job as a hang. Otherwise it's most likely a regular timeout.
 
-    ** Threshold may want to be reduced in the future
+    ** Threshold may be reduced in the future
     """
     log_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
     log_file = log_dir.joinpath(str(workflow_job_id) + ".log")

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -54,11 +54,7 @@ def get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, workflow_run_id:
 
 def parse_github_log_timestamp(line):
     timestamp_str = line.split("T")[0] + "T" + line.split("T")[1].split("Z")[0]
-    # Wacky github workaround: truncate to 26 chars because github's timestamp
-    # is 7 digits for fractional seconds instead of 6, which is the ISO format
-    # E.g. 2024-09-25T14:33:11.1060679Z -> 2024-09-25T14:33:11.106067
-    # This isn't an issue for python versions > 3.10 (infra runs python 3.8)
-    return datetime.fromisoformat(timestamp_str[:26])
+    return datetime.fromisoformat(timestamp_str)
 
 
 def is_job_hanging_from_job_log(error_snippet, workflow_outputs_dir, workflow_run_id: int, workflow_job_id: int):

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -54,7 +54,11 @@ def get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, workflow_run_id:
 
 def parse_github_log_timestamp(line):
     timestamp_str = line.split("T")[0] + "T" + line.split("T")[1].split("Z")[0]
-    return datetime.fromisoformat(timestamp_str)
+    # Wacky github workaround: truncate to 26 chars because github's timestamp
+    # is 7 digits for fractional seconds instead of 6, which is the ISO format
+    # E.g. 2024-09-25T14:33:11.1060679Z -> 2024-09-25T14:33:11.106067
+    # This isn't an issue for python versions > 3.10 (infra runs python 3.8)
+    return datetime.fromisoformat(timestamp_str[:26])
 
 
 def is_job_hanging_from_job_log(error_snippet, workflow_outputs_dir, workflow_run_id: int, workflow_job_id: int):

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -15,6 +15,8 @@ from infra.data_collection import junit_xml_utils, pydantic_models
 
 
 smi_pattern = re.compile(r'.*"tt_smi":\s*"([a-zA-Z0-9\-\.]+)"')
+# Define a regex pattern to match timestamps in ISO 8601 format (e.g., 2025-03-26T19:18:31.7521333Z)
+timestamp_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z")
 
 
 def search_for_tt_smi_version_in_log_file_(log_file):
@@ -48,6 +50,73 @@ def get_github_job_ids_to_tt_smi_versions(workflow_outputs_dir, workflow_run_id:
             github_job_id = int(github_job_id)
             github_job_ids_to_tt_smi_versions[github_job_id] = tt_smi_version
     return github_job_ids_to_tt_smi_versions
+
+
+def parse_github_log_timestamp(line):
+    timestamp_str = line.split("T")[0] + "T" + line.split("T")[1].split("Z")[0]
+    return datetime.fromisoformat(timestamp_str)
+
+
+def is_job_hanging_from_job_log(error_snippet, workflow_outputs_dir, workflow_run_id: int, workflow_job_id: int):
+    """
+    Read the job output log to determine if a job is hanging or genuinely timed out.
+    For each line, we store the associated github timestamp (if it exists)
+    When we encounter the timeout error message, compare the timestamp of the generated message
+    against the last output line, as well as the last line against the 2nd last.
+
+    If the time delta between the lines is greater than 5 minutes** (max_time_delta_seconds)
+    then consider the job as a hang. Otherwise it's most likely a regular timeout.
+
+    ** Threshold may want to be reduced in the future
+    """
+    log_dir = workflow_outputs_dir / str(workflow_run_id) / "logs"
+    log_file = log_dir.joinpath(str(workflow_job_id) + ".log")
+    max_time_delta_seconds = 300
+
+    if not log_file.exists():
+        logger.warning(f"Unable to find github job log file: {log_file}")
+        return False
+
+    log_lines = []
+    log_timestamps = []
+    with open(log_file, "r", encoding="utf-8-sig") as log_f:
+        log_lines = log_f.readlines()
+
+    for line in log_lines:
+        # Skip lines that are empty or do not start with a valid timestamp
+        if not line.strip() or not timestamp_pattern.match(line):
+            continue
+
+        if error_snippet in line:
+            timeout_timestamp = parse_github_log_timestamp(line)
+
+            # Check if we have the previous two timestamps
+            if len(log_timestamps) < 2:
+                logger.warning("Not enough previous lines to compare time deltas.")
+                return False
+
+            # Compare with the last two timestamps
+            # Hang message vs last output line
+            delta_1 = timeout_timestamp - log_timestamps[-1]
+            # Last output line vs 2nd last output line
+            delta_2 = log_timestamps[-1] - log_timestamps[-2]
+
+            # Check if any of the deltas is greater than 5 minutes
+            if delta_1.total_seconds() > max_time_delta_seconds or delta_2.total_seconds() > max_time_delta_seconds:
+                logger.info(f"Time difference between the timeout line and previous lines is greater than 5 minutes.")
+                logger.info(f"Timeout timestamp: {timeout_timestamp}")
+                logger.info(f"Previous timestamps: {log_timestamps[-2]}, {log_timestamps[-1]}")
+                logger.info(f"Hang detected for job: {str(workflow_job_id)}")
+                return True
+            else:
+                logger.info(
+                    f"No hang detected for job: {str(workflow_job_id)}, Time differences are within the expected range."
+                )
+                return False
+
+        # Always store the timestamp of the current line
+        log_timestamps.append(parse_github_log_timestamp(line))
+    return False
 
 
 def get_workflow_run_uuids_to_test_reports_paths_(workflow_outputs_dir, workflow_run_id: int):

--- a/infra/data_collection/models.py
+++ b/infra/data_collection/models.py
@@ -11,6 +11,7 @@ class InfraErrorV1(enum.Enum):
     RUNNER_SHUTDOWN_FAILURE = enum.auto()
     API_RATE_LIMIT_FAILURE = enum.auto()
     RUNNER_CARD_IN_USE_FAILURE = enum.auto()
+    JOB_HANG = enum.auto()
 
 
 class TestErrorV1(enum.Enum):

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -180,6 +180,7 @@ def test_create_pipeline_json_for_timeout_bad_testcase(workflow_run_gh_environme
 
     for job in pipeline.jobs:
         if job.github_job_id == 36492361640:
+            assert job.failure_signature == str(InfraErrorV1.JOB_HANG)
             assert len(job.tests) > 0
             assert job.job_status == JobStatus.failure
 


### PR DESCRIPTION
### Ticket
Resolves #20057

### Problem description
Currently we classify regular timeouts and hangs into the same job timeout error signature bucket.
We want to distinguish regular timeouts from hangs: where the time delta between the last lines of output and the job termination message are large (e.g. > 5 minutes)

### What's changed
Add a function `is_job_hanging_from_job_log` that does the following when we encounter a timeout error signature:

- Read the job output log to determine if a job is hanging or genuinely timed out.
- For each line, we store the associated github timestamp (if it exists)
- When we encounter the timeout error message, compare the timestamp of the generated message against the last output line, as well as the last line against the 2nd last.
- If the time delta between the lines is greater than 5 minutes** (max_time_delta_seconds) then consider the job as a hang. Otherwise it's most likely a regular timeout.
- ** Threshold may be reduced in the future

### Checklist
- [x] New/Existing tests provide coverage for changes
Data pipeline run on branch with hanging job: https://github.com/tenstorrent/tt-metal/actions/runs/14246378144/job/39928326718#step:10:196