### PR TITLE
CI: Migrate single job 'run_cpp_unit_tests' from 'cpp-post-commit' wo…

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -29,7 +29,7 @@ jobs:
           {name: tools, cmd: ./tests/scripts/run_tools_tests.sh},
 
           {name: user kernel path, cmd: "rm -rf /tmp/kernels && TT_METAL_KERNEL_PATH=/tmp/kernels ./build/test/tt_metal/unit_tests_api_${{ inputs.arch }} --gtest_filter=CompileProgramWithKernelPathEnvVarFixture.*"},
-          {name: api, cmd: "./build/test/tt_metal/unit_tests_api_${{ inputs.arch }}"},
+          {name: api, beta-runner: true,  cmd: "./build/test/tt_metal/unit_tests_api_${{ inputs.arch }}"},
           {name: debug_tools, cmd: "./build/test/tt_metal/unit_tests_debug_tools_${{ inputs.arch }}"},
           {name: device, cmd: "./build/test/tt_metal/unit_tests_device"},
           {name: dispatch, cmd: "./build/test/tt_metal/unit_tests_dispatch"},
@@ -49,8 +49,7 @@ jobs:
       LOGURU_LEVEL: INFO
     runs-on: >-
       ${{
-        startsWith(inputs.runner-label, 'tt-beta-ubuntu')
-        && fromJSON(format('["{0}"]', inputs.runner-label))
+        matrix.test-group.beta-runner == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     steps:


### PR DESCRIPTION
Move single job 'run_cpp_unit_tests' from 'cpp-post-commit' workflow  to run on new beta CI infrastructure,

### Ticket
TBD

### Problem description
There is a new CI Infrastructure being developed to support running open source Tenstorrent jobs in isolated ephemeral runners. Jobs will need to be updated to test and migrate onto this infrastructure.

### What's changed
Created a copy job in the 'wrapper' that uses the new `tt-beta-ubuntu...` runners instead of `N150`/`N300`.
Copied and migrated the job into the same structured test workflow yaml.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [ ] Tests passed on new infrastructure