### PR TITLE
Introduce MetalContext to manage all other Metal singletons

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -35,7 +35,7 @@
 #include <tt-metalium/shape2d.hpp>
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/util.hpp>
 
 namespace tt::tt_metal::distributed::test {
@@ -80,7 +80,7 @@ struct DeviceLocalShardedBufferTestConfig {
 };
 
 void skip_for_tg() {
-    if (tt::Cluster::instance().is_galaxy_cluster()) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
         GTEST_SKIP();
     }
 }

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -9,7 +9,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "rtoptions.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests {
@@ -64,7 +64,7 @@ public:
         chip_id_t& src_physical_device_id,
         chip_id_t& dst_physical_device_id,
         RoutingDirection direction) {
-        auto* control_plane = tt::Cluster::instance().get_control_plane();
+        auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
         for (auto* device : devices_) {
             src_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
 
@@ -89,7 +89,7 @@ public:
         chip_id_t& src_physical_device_id,
         std::unordered_map<RoutingDirection, std::vector<chip_id_t>>& dst_physical_device_ids_by_dir,
         const std::unordered_map<RoutingDirection, uint32_t>& mcast_hops) {
-        auto control_plane = tt::Cluster::instance().get_control_plane();
+        auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
 
         // Find a device with enough neighbours in the specified direction
         bool connection_found = false;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -30,9 +30,10 @@
 #include "span.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
-#include "tt_metal/llrt/tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/tt_core_coordinates.h"
 
 namespace tt::tt_fabric {
@@ -42,7 +43,7 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    auto* control_plane = tt::Cluster::instance().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
 
     std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
     std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
@@ -66,8 +67,8 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     }
 
     auto edm_port = eth_chans[0];
-    CoreCoord edm_eth_core =
-        tt::Cluster::instance().get_virtual_eth_core_from_channel(src_physical_device_id, edm_port);
+    CoreCoord edm_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+        src_physical_device_id, edm_port);
 
     auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
@@ -199,7 +200,7 @@ TEST_F(Fabric1DFixture, TestUnicastConnAPI) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    auto* control_plane = tt::Cluster::instance().get_control_plane();
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
 
     std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
     std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
@@ -320,7 +321,7 @@ TEST_F(Fabric1DFixture, TestMCastConnAPI) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    auto control_plane = tt::Cluster::instance().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
 
     // use control plane to find a mesh with 3 devices
     auto user_meshes = control_plane->get_user_physical_mesh_ids();

--- a/tests/tt_metal/tt_fabric/fabric_router/test_cluster_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_cluster_apis.cpp
@@ -12,25 +12,31 @@
 #include "fabric_fixture.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/system_memory_manager.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests {
 
 TEST_F(ControlPlaneFixture, TestUBBConnectivity) {
-      const auto& eth_connections = tt::Cluster::instance().get_ethernet_connections();
-      EXPECT_EQ(eth_connections.size(), 32);
-      for (const auto& [chip, connections] : eth_connections) {
-          std::map<chip_id_t, int> num_connections_to_chip;
-          for (const auto &[channel, remote_chip_and_channel] : connections) {
-              log_debug(tt::LogTest, "Chip: {} Channel: {} Remote Chip: {} Remote Channel: {}", chip, channel, std::get<0>(remote_chip_and_channel), std::get<1>(remote_chip_and_channel));
-              num_connections_to_chip[std::get<0>(remote_chip_and_channel)]++;
-          }
-          EXPECT_EQ(num_connections_to_chip.size(), 4);
-          for (const auto &[other_chip, count]: num_connections_to_chip) {
-              EXPECT_EQ(count, 4);
-          }
-      }
+    const auto& eth_connections = tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connections();
+    EXPECT_EQ(eth_connections.size(), 32);
+    for (const auto& [chip, connections] : eth_connections) {
+        std::map<chip_id_t, int> num_connections_to_chip;
+        for (const auto& [channel, remote_chip_and_channel] : connections) {
+            log_debug(
+                tt::LogTest,
+                "Chip: {} Channel: {} Remote Chip: {} Remote Channel: {}",
+                chip,
+                channel,
+                std::get<0>(remote_chip_and_channel),
+                std::get<1>(remote_chip_and_channel));
+            num_connections_to_chip[std::get<0>(remote_chip_and_channel)]++;
+        }
+        EXPECT_EQ(num_connections_to_chip.size(), 4);
+        for (const auto& [other_chip, count] : num_connections_to_chip) {
+            EXPECT_EQ(count, 4);
+        }
+    }
 }
 
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -13,7 +13,7 @@
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include "rtoptions.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
 
 namespace tt::tt_fabric {
@@ -36,7 +36,7 @@ TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
-    const auto control_plane = tt::Cluster::instance().get_control_plane();
+    const auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto user_meshes = control_plane->get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], 4);
@@ -103,7 +103,7 @@ TEST_F(ControlPlaneFixture, TestQuantaGalaxyControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestQuantaGalaxyMeshAPIs) {
-    const auto control_plane = tt::Cluster::instance().get_control_plane();
+    const auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto user_meshes = control_plane->get_user_physical_mesh_ids();
     EXPECT_EQ(user_meshes.size(), 1);
     EXPECT_EQ(user_meshes[0], 0);

--- a/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_l1_banking_allocator.cpp
@@ -22,12 +22,13 @@
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace unit_tests::test_l1_banking_allocator {
 
 uint64_t get_alloc_limit(const tt::tt_metal::IDevice* device) {
-    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
+    const metal_SocDescriptor& soc_desc =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
     uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
     auto dispatch_core_config = tt::tt_metal::get_dispatch_core_config();
     auto storage_core_bank_size =

--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -14,7 +14,7 @@
 #include "dispatch_fixture.hpp"
 #include <tt-metalium/hal_types.hpp>
 #include "llrt.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/types/xy_pair.h"
 
 namespace tt::tt_metal {
@@ -105,7 +105,7 @@ TEST_F(DispatchFixture, ResetGlobalSemaphores) {
                     device->id(), device->worker_core_from_logical_core(core), overwrite_value, address);
                 EXPECT_EQ(sem_vals[0], initial_value);
             }
-            tt::Cluster::instance().l1_barrier(device->id());
+            tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
             for (const auto& core : cores_vec) {
                 auto sem_vals = tt::llrt::read_hex_vec_from_core(
                     device->id(), device->worker_core_from_logical_core(core), address, sizeof(uint32_t));

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -21,7 +21,7 @@
 #include "llrt.hpp"
 #include "span.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/types/xy_pair.h"
 
@@ -84,7 +84,7 @@ std::pair<std::shared_ptr<Buffer>, std::vector<uint32_t>> l1_buffer_write_wait(
 
     tt::tt_metal::detail::WriteToBuffer(buffer, input);
 
-    tt::Cluster::instance().l1_barrier(device->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
     return std::move(std::pair(buffer, input));
 }
 
@@ -207,7 +207,7 @@ TEST_F(DeviceFixture, TestUnorderedHeightShardReadWrite) {
         auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_size / sizeof(uint32_t));
 
         tt::tt_metal::detail::WriteToBuffer(buffer, input);
-        tt::Cluster::instance().l1_barrier(device->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
         auto input_it = input.begin();
         for (const auto& physical_core : physical_cores) {
             auto readback = tt::llrt::read_hex_vec_from_core(device->id(), physical_core, buffer->address(), page_size);

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -16,7 +16,7 @@
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/system_memory_manager.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "umd/device/coordinate_manager.h"
 #include "umd/device/types/arch.h"
@@ -28,7 +28,8 @@ using namespace tt::test_utils;
 namespace unit_tests::basic::soc_desc {
 std::unordered_set<int> get_harvested_rows(chip_id_t device_id) {
     uint32_t harvested_rows_mask = CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
-        tt::Cluster::instance().get_soc_desc(device_id).arch, tt::Cluster::instance().get_harvesting_mask(device_id));
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).arch,
+        tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id));
     std::unordered_set<int> harvested_rows;
     int row_coordinate = 0;
     int tmp = harvested_rows_mask;
@@ -63,8 +64,10 @@ TEST(SOC, TensixValidateLogicalToPhysicalCoreCoordHostMapping) {
     num_devices = (arch == tt::ARCH::GRAYSKULL) ? 1 : num_devices;
     for (int device_id = 0; device_id < num_devices; device_id++) {
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
-        uint32_t harvested_rows_mask = tt::Cluster::instance().get_harvesting_mask(device_id);
-        const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+        uint32_t harvested_rows_mask =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
+        const metal_SocDescriptor& soc_desc =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
         log_info(LogTest, "Device {} harvesting mask {}", device_id, harvested_rows_mask);
         std::unordered_set<int> harvested_rows = unit_tests::basic::soc_desc::get_harvested_rows(device_id);
 

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -94,7 +94,7 @@ protected:
         const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
         const chip_id_t mmio_device_id = 0;
         std::vector<chip_id_t> chip_ids;
-        if (tt::Cluster::instance().get_board_type(0) == BoardType::UBB) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0) == BoardType::UBB) {
             for (unsigned int id = 0; id < tt::tt_metal::GetNumAvailableDevices(); id++) {
                 chip_ids.push_back(id);
             }

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -95,7 +95,7 @@ protected:
     }
 
     void TearDown() override {
-        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
         // Close all opened devices
         for (unsigned int id = 0; id < devices_.size(); id++) {
             // The test may ahve closed the device already, so only close if active.

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_before_finish.cpp
@@ -19,7 +19,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/utils.hpp>
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -43,7 +43,7 @@ static void RunTest(DPrintFixture* fixture, IDevice* device) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Run the program, use a large delay for the last print to emulate a long-running kernel.
-    uint32_t clk_mhz = tt::Cluster::instance().get_device_aiclk(device->id());
+    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
     uint32_t delay_cycles = clk_mhz * 2000000; // 2 seconds
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
         for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 
@@ -62,7 +62,7 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
         ComputeConfig{});
 
     // Write runtime args
-    uint32_t clk_mhz = tt::Cluster::instance().get_device_aiclk(device->id());
+    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
     uint32_t delay_cycles = clk_mhz * 500000; // .5 secons
     const std::vector<uint32_t> args = { delay_cycles };
     for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -26,7 +26,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
@@ -68,7 +68,7 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
 
     // The kernels need arguments to be passed in: the number of cycles to delay while syncing,
     // and an L1 buffer to use for the syncing.
-    uint32_t clk_mhz = tt::Cluster::instance().get_device_aiclk(device->id());
+    uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
     uint32_t delay_cycles = clk_mhz * 2000000; // 2 seconds
     tt_metal::InterleavedBufferConfig l1_config {
         .device = device,

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program_impl.hpp>
 #include <tt-metalium/system_memory_manager.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/tt_core_coordinates.h"
 #include <tt-metalium/utils.hpp>
@@ -250,16 +250,20 @@ TEST_F(DeviceFixture, TensixValidateKernelDoesNotTargetHarvestedCores) {
 TEST_F(DeviceFixture, TestDeviceToHostMemChannelAssignment) {
     std::unordered_map<chip_id_t, std::set<chip_id_t>> mmio_device_to_device_group;
     for (unsigned int dev_id = 0; dev_id < num_devices_; dev_id++) {
-        chip_id_t assoc_mmio_dev_id = tt::Cluster::instance().get_associated_mmio_device(dev_id);
+        chip_id_t assoc_mmio_dev_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev_id);
         std::set<chip_id_t>& device_ids = mmio_device_to_device_group[assoc_mmio_dev_id];
         device_ids.insert(dev_id);
     }
 
     for (const auto& [mmio_dev_id, device_group] : mmio_device_to_device_group) {
-        EXPECT_EQ(tt::Cluster::instance().get_num_host_channels(mmio_dev_id), device_group.size());
+        EXPECT_EQ(
+            tt::tt_metal::MetalContext::instance().get_cluster().get_num_host_channels(mmio_dev_id),
+            device_group.size());
         std::unordered_set<uint16_t> channels;
         for (const chip_id_t& device_id : device_group) {
-            channels.insert(tt::Cluster::instance().get_assigned_channel_for_device(device_id));
+            channels.insert(
+                tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id));
         }
         EXPECT_EQ(channels.size(), device_group.size());
     }
@@ -298,9 +302,12 @@ TEST_F(DeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
     tt_metal::detail::LaunchProgram(device, program);
 
     std::vector<uint32_t> result(size_bytes / sizeof(uint32_t));
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
-    tt::Cluster::instance().read_sysmem(result.data(), size_bytes, base_pcie_dst_address, mmio_device_id, channel);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
+        result.data(), size_bytes, base_pcie_dst_address, mmio_device_id, channel);
 
     EXPECT_EQ(src, result);
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -49,7 +49,7 @@
 #include "span.hpp"
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
@@ -779,7 +779,7 @@ bool verify_rt_args(
     bool pass = true;
     std::string label = unique ? "Unique" : "Common";
     // Same idea as ReadFromDeviceL1() but with ETH support.
-    tt::Cluster::instance().l1_barrier(device->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
     auto noc_xy = riscv == tt::RISCV::ERISC ? device->ethernet_core_from_logical_core(logical_core)
                                             : device->worker_core_from_logical_core(logical_core);
     std::vector<uint32_t> args_readback = tt::llrt::read_hex_vec_from_core(device->id(), noc_xy, addr, expected_rt_args.size() * sizeof(uint32_t));

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
@@ -54,7 +54,7 @@
 #include "span.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/arch.h"
@@ -230,7 +230,7 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
         log_info(LogTest, "Running test on {}", device->id());
         EnqueueProgram(device->command_queue(), *program, false);
         Finish(device->command_queue());
-        tt::Cluster::instance().l1_barrier(device->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
 
         for (const CoreCoord& core_coord : cr0) {
             const auto& virtual_core_coord = device->worker_core_from_logical_core(core_coord);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_test_utils.hpp
@@ -116,7 +116,7 @@ inline void verify_kernel_coordinates(
     tt::tt_metal::SubDeviceId sub_device_id,
     uint32_t cb_addr,
     bool idle_eth = false) {
-    tt::Cluster::instance().l1_barrier(device->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
     tt::tt_metal::HalProgrammableCoreType hal_core_type = processor_class == tt::RISCV::ERISC
                                                               ? tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH
                                                               : tt::tt_metal::HalProgrammableCoreType::TENSIX;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -14,7 +14,7 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/hal_types.hpp>
 #include "llrt/hal.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/tt_core_coordinates.h"
 
 namespace tt::tt_metal {
@@ -38,7 +38,7 @@ void ForEachCoreTypeXHWCQs(const std::function<void(const CoreType& core_type, c
 }
 
 TEST(DispatchSettingsTest, TestDispatchSettingsDefaultUnsupportedCoreType) {
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     const auto unsupported_core = CoreType::ARC;
     EXPECT_THROW(DispatchSettings::get(unsupported_core, 1), std::runtime_error);
 }
@@ -50,7 +50,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsMissingArgs) {
 
 TEST(DispatchSettingsTest, TestDispatchSettingsEq) {
     const uint32_t hw_cqs = 2;
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     auto settings_2 = settings; // Copy
     EXPECT_EQ(settings, settings_2);
@@ -63,7 +63,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchDBuffer) {
     const uint32_t expected_buffer_bytes = 0xcafe;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.prefetch_d_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.prefetch_d_buffer_size_, expected_buffer_bytes);
@@ -74,7 +74,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetPrefetchQBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_entries = 0x1000;
     const uint32_t expected_buffer_bytes = expected_buffer_entries * sizeof(DispatchSettings::prefetch_q_entry_type);
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.prefetch_q_entries(expected_buffer_entries);
     EXPECT_EQ(settings.prefetch_q_entries_, expected_buffer_entries);
@@ -85,7 +85,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchBuffer) {
     const uint32_t hw_cqs = 2;
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count = expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.dispatch_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_size_, expected_buffer_bytes);
@@ -97,7 +97,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetDispatchSBuffer) {
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.dispatch_s_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.dispatch_s_buffer_size_, expected_buffer_bytes);
@@ -109,7 +109,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetTunnelerBuffer) {
     const uint32_t expected_buffer_bytes = 0x2000;
     const uint32_t expected_page_count =
         expected_buffer_bytes / (1 << DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE);
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     auto settings = DispatchSettings::get(CoreType::WORKER, hw_cqs);
     settings.tunneling_buffer_size(expected_buffer_bytes);
     EXPECT_EQ(settings.tunneling_buffer_size_, expected_buffer_bytes);
@@ -133,7 +133,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsMutations) {
     const uint32_t prefetch_q_entries = 512;
     const uint32_t scratch_db_size = 5120;
 
-    DispatchSettings::initialize(tt::Cluster::instance());
+    DispatchSettings::initialize(tt::tt_metal::MetalContext::instance().get_cluster());
     auto& settings = DispatchSettings::get(core_type, hw_cqs);
     DispatchSettings original_settings = settings;  // Copy the original to be restored later
 

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -36,7 +36,7 @@
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
@@ -333,7 +333,8 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsSendDramBufferChip0ToChip1) {
     const auto& receiver_device = devices_.at(1);
 
     for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(sender_device->id(), sender_eth_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                sender_device->id(), sender_eth_core)) {
             continue;
         }
         CoreCoord receiver_eth_core = std::get<1>(sender_device->get_connected_ethernet_core(sender_eth_core));
@@ -377,7 +378,8 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsSendDramBufferChip1ToChip0) {
     const auto& receiver_device = devices_.at(0);
 
     for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(sender_device->id(), sender_eth_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                sender_device->id(), sender_eth_core)) {
             continue;
         }
         CoreCoord receiver_eth_core = std::get<1>(sender_device->get_connected_ethernet_core(sender_eth_core));
@@ -489,7 +491,8 @@ TEST_F(DeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips) {
                 continue;
             }
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
-                if (not tt::Cluster::instance().is_ethernet_link_up(sender_device->id(), sender_eth_core)) {
+                if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        sender_device->id(), sender_eth_core)) {
                     continue;
                 }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
@@ -564,7 +567,8 @@ TEST_F(CommandQueueMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllC
                 continue;
             }
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
-                if (not tt::Cluster::instance().is_ethernet_link_up(sender_device->id(), sender_eth_core)) {
+                if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        sender_device->id(), sender_eth_core)) {
                     continue;
                 }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
@@ -620,7 +624,8 @@ TEST_F(CommandQueueMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuf
                 continue;
             }
             for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
-                if (not tt::Cluster::instance().is_ethernet_link_up(sender_device->id(), sender_eth_core)) {
+                if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        sender_device->id(), sender_eth_core)) {
                     continue;
                 }
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -37,7 +37,7 @@
 #include "multi_device_fixture.hpp"
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_memory.h>
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -542,7 +542,8 @@ TEST_F(DeviceFixture, ActiveEthKernelsDirectSendAllConnectedChips) {
                 continue;
             }
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
-                if (not tt::Cluster::instance().is_ethernet_link_up(sender_device->id(), sender_core)) {
+                if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        sender_device->id(), sender_core)) {
                     continue;
                 }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);
@@ -599,7 +600,7 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
     const size_t dst_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
 
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(device_0->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
             continue;
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
@@ -623,7 +624,7 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
             sender_core));
     }
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(device_0->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
             continue;
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
@@ -647,7 +648,7 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
             sender_core));
     }
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(device_0->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
             continue;
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
@@ -671,7 +672,7 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsBidirectionalDirectSend) {
             sender_core));
     }
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(device_0->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
             continue;
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
@@ -705,7 +706,7 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsRepeatedDirectSends) {
     const size_t dst_eth_l1_byte_address = eth_l1_mem::address_map::ERISC_L1_UNRESERVED_BASE;
 
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(device_0->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
             continue;
         }
         CoreCoord receiver_core = std::get<1>(device_0->get_connected_ethernet_core(sender_core));
@@ -756,7 +757,8 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsRandomDirectSendTests) {
         const auto& send_chip = devices_.at(std::get<0>(it->first));
         CoreCoord sender_core = std::get<1>(it->first);
 
-        if (not tt::Cluster::instance().is_ethernet_link_up(send_chip->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                send_chip->id(), sender_core)) {
             continue;
         }
 
@@ -791,14 +793,14 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsRandomEthPacketSizeDirectSendTests) {
 
     std::map<std::tuple<int, CoreCoord>, std::tuple<int, CoreCoord>> connectivity = {};
     for (const auto& sender_core : device_0->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(device_0->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_0->id(), sender_core)) {
             continue;
         }
         const auto& receiver_core = device_0->get_connected_ethernet_core(sender_core);
         connectivity.insert({{0, sender_core}, receiver_core});
     }
     for (const auto& sender_core : device_1->get_active_ethernet_cores(true)) {
-        if (not tt::Cluster::instance().is_ethernet_link_up(device_1->id(), sender_core)) {
+        if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(device_1->id(), sender_core)) {
             continue;
         }
         const auto& receiver_core = device_1->get_connected_ethernet_core(sender_core);
@@ -853,7 +855,8 @@ TEST_F(CommandQueueMultiDeviceProgramFixture, ActiveEthKernelsDirectSendAllConne
                 continue;
             }
             for (const auto& sender_core : sender_device->get_active_ethernet_cores(true)) {
-                if (not tt::Cluster::instance().is_ethernet_link_up(sender_device->id(), sender_core)) {
+                if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        sender_device->id(), sender_core)) {
                     continue;
                 }
                 auto [device_id, receiver_core] = sender_device->get_connected_ethernet_core(sender_core);

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -36,7 +36,7 @@
 #include "span.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -104,7 +104,8 @@ std::vector<tt_metal::IDevice*> get_device_ring(std::vector<tt::tt_metal::IDevic
     std::vector<std::vector<int>> adj(devices.size(), std::vector<int>(devices.size(), 0));
     for (uint32_t i = 0; i < devices.size(); ++i) {
         const auto& device = devices[i];
-        auto ethernet_connected_device_ids = tt::Cluster::instance().get_ethernet_connected_device_ids(device->id());
+        auto ethernet_connected_device_ids =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connected_device_ids(device->id());
         for (const auto& connected_device_id : ethernet_connected_device_ids) {
             for (uint32_t j = 0; j < devices.size(); ++j) {
                 if (devices[j]->id() == connected_device_id) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -52,7 +52,7 @@
 #include "test_common.hpp"
 #include "tests/tt_metal/test_utils/tilization.hpp"
 #include <tt-metalium/tilize_utils.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
@@ -623,7 +623,7 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
         input_buffer = CreateBuffer(config);
     }
     tt::tt_metal::detail::WriteToBuffer(input_buffer, input_vec);
-    tt::Cluster::instance().l1_barrier(device->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     log_info("created sharded tensor");
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -53,7 +53,7 @@
 #include "test_common.hpp"
 #include "tests/tt_metal/test_utils/tilization.hpp"
 #include <tt-metalium/tilize_utils.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "umd/device/types/arch.h"
 #include "umd/device/types/xy_pair.h"
@@ -606,7 +606,7 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
         input_buffer = CreateBuffer(config);
     }
     tt::tt_metal::detail::WriteToBuffer(input_buffer, input_vec);
-    tt::Cluster::instance().l1_barrier(device->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
 
     log_info("created sharded tensor");
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -26,7 +26,7 @@
 #include "fmt/base.h"
 #include <tt-metalium/logger.hpp>
 #include "test_common.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 
 using namespace tt;
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
             page_size);
 
         // Device setup
-        if (device_id >= tt::Cluster::instance().number_of_devices()) {
+        if (device_id >= tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices()) {
             log_info(LogTest, "Skip! Device id {} is not applicable on this system", device_id);
             return 1;
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -74,7 +74,7 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
 }
 
 inline int get_tt_npu_clock(tt::tt_metal::IDevice* device) {
-    return tt::Cluster::instance().get_device_aiclk(device->id());
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
 }
 
 template <typename T>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -122,7 +122,7 @@ DeviceData::DeviceData(
     this->banked = is_banked;
     this->amt_written = 0;
 
-    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device->id());
+    const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
     const std::vector<tt::umd::CoreCoord>& pcie_cores = soc_d.get_cores(CoreType::PCIE, soc_d.get_umd_coord_system());
     for (const CoreCoord& core_coord : pcie_cores) {
         CoreCoord core = {core_coord.x, core_coord.y};

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -40,7 +40,7 @@
 #include "rtoptions.hpp"
 #include "span.hpp"
 #include "test_common.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "umd/device/tt_core_coordinates.h"
 #include <tt-metalium/utils.hpp>
@@ -470,7 +470,7 @@ int main(int argc, char** argv) {
         TT_ASSERT((l1_buf_base & (dispatch_buffer_page_size_g - 1)) == 0);
 
         // Make sure user doesn't exceed available L1 space with cmd line arguments.
-        auto& soc_desc = tt::Cluster::instance().get_soc_desc(device->id());
+        auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
         if (prefetcher_buffer_size_g + l1_buf_base > soc_desc.worker_l1_size) {
             log_fatal(
                 LogTest,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_read_and_send_data.cpp
@@ -27,6 +27,8 @@
 #include <tt-metalium/buffer_constants.hpp>
 #include <tt-metalium/data_types.hpp>
 #include "df/float32.hpp"
+#include "impl/context/metal_context.hpp"
+
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"
 #include <tt-metalium/kernel_types.hpp>
@@ -34,7 +36,7 @@
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/types/arch.h"
@@ -60,7 +62,7 @@ public:
                 auto* device = tt::tt_metal::CreateDevice(id);
                 devices_.push_back(device);
             }
-            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+            tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(true);
 
         } else {
             TT_THROW("This suite can only be run on N300 Wormhole devices");
@@ -75,7 +77,7 @@ public:
 
     void TearDown() {
         device_open = false;
-        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_send_data_looping.cpp
@@ -15,7 +15,7 @@
 #include <tt-metalium/kernel.hpp>
 #include <thread>
 #include "llrt.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "eth_l1_address_map.h"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/df/df.hpp"
@@ -43,7 +43,7 @@ public:
                 auto* device = tt::tt_metal::CreateDevice(id);
                 devices_.push_back(device);
             }
-            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+            tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(true);
 
         } else {
             TT_THROW("This suite can only be run on N300 Wormhole devices");
@@ -58,7 +58,7 @@ public:
 
     void TearDown() {
         device_open = false;
-        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_workers_and_erisc_datamover_unidirectional.cpp
@@ -29,6 +29,8 @@
 #include <tt-metalium/circular_buffer_types.hpp>
 #include <tt-metalium/data_types.hpp>
 #include "df/float32.hpp"
+#include "impl/context/metal_context.hpp"
+
 // TODO: ARCH_NAME specific, must remove
 #include "eth_l1_address_map.h"
 #include "hostdevcommon/kernel_structs.h"
@@ -37,7 +39,7 @@
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "umd/device/tt_core_coordinates.h"
@@ -64,7 +66,7 @@ public:
                 auto* device = tt::tt_metal::CreateDevice(id);
                 devices_.push_back(device);
             }
-            tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true);
+            tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(true);
 
         } else {
             TT_THROW("This suite can only be run on N300 Wormhole devices");
@@ -79,7 +81,7 @@ public:
 
     void TearDown() {
         device_open = false;
-        tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+        tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             tt::tt_metal::CloseDevice(devices_.at(id));
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -18,8 +18,7 @@
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program_impl.hpp>
-#include "tt_cluster.hpp"
-#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/utils.hpp>
 
 using namespace tt;
@@ -28,11 +27,12 @@ void measure_latency(const string& kernel_name) {
     const int device_id = 0;
     tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
 
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
     CoreCoord producer_logical_core =
-        tt_metal::dispatch_core_manager::instance().prefetcher_core(device->id(), channel, 0);
+        tt_metal::MetalContext::instance().get_dispatch_core_manager().prefetcher_core(device->id(), channel, 0);
     CoreCoord consumer_logical_core =
-        tt_metal::dispatch_core_manager::instance().dispatcher_core(device->id(), channel, 0);
+        tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_core(device->id(), channel, 0);
 
     TT_ASSERT(
         producer_logical_core != consumer_logical_core,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -39,7 +39,7 @@
 #include "span.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_interface.h"
 // #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
@@ -341,7 +341,9 @@ int main(int argc, char** argv) {
         log_info(LogTest, "GK Socket Info Addr = 0x{:08X}", socket_info_addr);
 
         for (auto device : device_map) {
-            auto neighbors = tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(device.second->id());
+            auto neighbors =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
+                    device.second->id());
             std::vector<CoreCoord> device_router_cores;
             std::vector<CoreCoord> device_router_phys_cores;
             uint32_t router_mask = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -39,7 +39,7 @@
 #include "span.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_interface.h"
 // #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
@@ -339,7 +339,8 @@ int main(int argc, char** argv) {
         log_info(LogTest, "GK Socket Info Addr = 0x{:08X}", socket_info_addr);
 
         for (auto device : device_map) {
-            auto neighbors = tt::Cluster::instance().get_ethernet_connected_device_ids(device.first);
+            auto neighbors =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connected_device_ids(device.first);
             std::vector<CoreCoord> device_router_cores;
             std::vector<CoreCoord> device_router_phys_cores;
             uint32_t router_mask = 0;
@@ -350,7 +351,8 @@ int main(int argc, char** argv) {
                         // sender device.
                         router_logical_core = device.second->get_ethernet_sockets(neighbor)[0];
                         router_phys_core = device.second->ethernet_core_from_logical_core(router_logical_core);
-                        auto eth_chan = tt::Cluster::instance()
+                        auto eth_chan = tt::tt_metal::MetalContext::instance()
+                                            .get_cluster()
                                             .get_soc_desc(test_device_id_l)
                                             .logical_eth_core_to_chan_map.at(router_logical_core);
                         routing_plane = control_plane->get_routing_plane_id(eth_chan);

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -32,7 +32,7 @@
 #include <tt-metalium/program_impl.hpp>
 #include "span.hpp"
 #include "test_common.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/types/xy_pair.h"
 
 using namespace tt;
@@ -236,13 +236,16 @@ int main(int argc, char** argv) {
         CoreCoord mcast_physical;
         if (mcast_from_eth_g) {
             mcast_virtual = device->ethernet_core_from_logical_core(mcast_logical);
-            mcast_physical = tt::Cluster::instance()
+            mcast_physical = tt::tt_metal::MetalContext::instance()
+                                 .get_cluster()
                                  .get_soc_desc(device_num_g)
                                  .get_physical_ethernet_core_from_logical(mcast_logical);
         } else {
             mcast_virtual = device->worker_core_from_logical_core(mcast_logical);
-            mcast_physical =
-                tt::Cluster::instance().get_soc_desc(device_num_g).get_physical_tensix_core_from_logical(mcast_logical);
+            mcast_physical = tt::tt_metal::MetalContext::instance()
+                                 .get_cluster()
+                                 .get_soc_desc(device_num_g)
+                                 .get_physical_tensix_core_from_logical(mcast_logical);
         }
 
         log_info(

--- a/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_ccl_on_galaxy.cpp
@@ -26,7 +26,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/shape_base.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
 #include "ttnn/async_runtime.hpp"
 #include "ttnn/common/queue_id.hpp"
@@ -92,16 +92,16 @@ std::vector<Tensor> run_operation(
 }  // namespace async_detail
 
 bool is_tg_system() {
-    const bool is_galaxy_system = tt::Cluster::instance().is_galaxy_cluster();
-    const size_t num_mmio_devices = tt::Cluster::instance().number_of_pci_devices();
-    const size_t num_devices = tt::Cluster::instance().number_of_user_devices();
+    const bool is_galaxy_system = tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
+    const size_t num_mmio_devices = tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices();
+    const size_t num_devices = tt::tt_metal::MetalContext::instance().get_cluster().number_of_user_devices();
     return is_galaxy_system && (num_mmio_devices == 4) && (num_devices == 32);
 }
 
 bool is_tgg_system() {
-    const bool is_galaxy_system = tt::Cluster::instance().is_galaxy_cluster();
-    const size_t num_mmio_devices = tt::Cluster::instance().number_of_pci_devices();
-    const size_t num_devices = tt::Cluster::instance().number_of_user_devices();
+    const bool is_galaxy_system = tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
+    const size_t num_mmio_devices = tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices();
+    const size_t num_devices = tt::tt_metal::MetalContext::instance().get_cluster().number_of_user_devices();
     return is_galaxy_system && (num_mmio_devices == 8) && (num_devices == 64);
 }
 
@@ -116,9 +116,9 @@ ttnn::MeshShape get_mesh_shape() {
 }
 
 void validate_num_tunnels_and_tunnel_depth() {
-    const uint32_t num_devices_in_tunnel = tt::Cluster::instance().get_mmio_device_max_tunnel_depth(0);
-    const uint32_t num_mmio_devices = tt::Cluster::instance().number_of_pci_devices();
-    const uint32_t cluster_tunnel_count = tt::Cluster::instance().get_mmio_device_tunnel_count(0);
+    const uint32_t num_devices_in_tunnel = tt::tt_metal::MetalContext::instance().get_cluster().get_mmio_device_max_tunnel_depth(0);
+    const uint32_t num_mmio_devices = tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices();
+    const uint32_t cluster_tunnel_count = tt::tt_metal::MetalContext::instance().get_cluster().get_mmio_device_tunnel_count(0);
     TT_FATAL(
         num_devices_in_tunnel == 4,
         "Expected Galaxy to have tunnel depth of 4, detected tunnel depth of {}",
@@ -141,7 +141,7 @@ std::shared_ptr<bfloat16[]> create_container_for_readback_data(const uint32_t bu
 }
 
 TEST(GalaxyTests, TestAllGatherDeadlock) {
-    if (not tt::Cluster::instance().is_galaxy_cluster()) {
+    if (not tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
         GTEST_SKIP() << "Skipping Galaxy test, since this is not a Galaxy System";
     }
     tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
@@ -232,7 +232,7 @@ TEST(GalaxyTests, TestAllGatherDeadlock) {
 }
 
 TEST(GalaxyTests, TestReduceScatterDeadlock) {
-    if (not tt::Cluster::instance().is_galaxy_cluster()) {
+    if (not tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
         GTEST_SKIP() << "Skipping Galaxy test, since this is not a Galaxy System";
     }
     tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED);

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -21,7 +21,7 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/shape_base.hpp>
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "ttnn/decorators.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
@@ -202,7 +202,7 @@ class EltwiseUnaryOpIfTest : public TTNNFixtureWithDevice,
 TEST_P(EltwiseUnaryOpIfTest, UnaryRelu) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const auto& expected_resource_usage_map = std::get<ResourceUsageMap>(GetParam());
-    const BoardType board_type = tt::Cluster::instance().get_board_type(0);
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
     if (expected_resource_usage_map.count(board_type) == 0) {
         GTEST_SKIP();
     }
@@ -282,7 +282,7 @@ TEST_P(SoftmaxOpIfTest, Softmax) {
     const auto& input_spec = std::get<ttnn::TensorSpec>(GetParam());
     const auto& dim_arg = std::get<int>(GetParam());
     const auto& expected_resource_usage_map = std::get<ResourceUsageMap>(GetParam());
-    const BoardType board_type = tt::Cluster::instance().get_board_type(0);
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
     if (expected_resource_usage_map.count(board_type) == 0) {
         GTEST_SKIP();
     }
@@ -365,7 +365,7 @@ TEST_P(EltwiseBinaryOpIfTest, BinaryAdd) {
     const auto& input_spec_a = std::get<0>(GetParam());
     const auto& input_spec_b = std::get<1>(GetParam());
     const auto& expected_resource_usage_map = std::get<ResourceUsageMap>(GetParam());
-    const BoardType board_type = tt::Cluster::instance().get_board_type(0);
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
     if (expected_resource_usage_map.count(board_type) == 0) {
         GTEST_SKIP();
     }
@@ -496,7 +496,7 @@ TEST_P(MatmulOpIfTest, Matmul) {
     const auto& matmul_program_config =
         std::get<std::optional<ttnn::operations::matmul::MatmulProgramConfig>>(GetParam());
     const auto& expected_resource_usage_map = std::get<ResourceUsageMap>(GetParam());
-    const BoardType board_type = tt::Cluster::instance().get_board_type(0);
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
     if (expected_resource_usage_map.count(board_type) == 0) {
         GTEST_SKIP();
     }
@@ -652,7 +652,7 @@ TEST_F(Conv2dOpIfTest, Conv2d) {
         {BoardType::N300,
          ttnn::graph::ResourceUsage{
              .cb_peak_size_per_core = 229440, .l1_buffers_peak_per_core = 190568, .l1_output_buffer_per_core = 0}}};
-    const BoardType board_type = tt::Cluster::instance().get_board_type(0);
+    const BoardType board_type = tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0);
     if (expected_resource_usage_map.count(board_type) == 0) {
         GTEST_SKIP();
     }

--- a/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
@@ -29,7 +29,7 @@
 #include "span.hpp"
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/tile.hpp>
-#include "tt_metal/llrt/tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "ttnn/any_device.hpp"
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/cpp/ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -366,7 +366,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
     double ideal_cycle_full_grid = dim_per_tile / 32 * cycle_per_tile / num_cores_full_grid;
     double ideal_cycle_user_grid = dim_per_tile / 32 * cycle_per_tile / num_cores_user_grid;
 
-    const int freq_mhz = tt::Cluster::instance().get_device_aiclk(device->id());
+    const int freq_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
     double inference_cycle = inference_time_avg_s * freq_mhz * 1e6;
 
     double utilization_full_grid = ideal_cycle_full_grid / inference_cycle;

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -14,14 +14,14 @@
 #include "indestructible.hpp"
 #include "logger.hpp"
 #include "mesh_coord.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.h>
 
 namespace tt::tt_metal::distributed {
 
 const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translation_map() {
     static tt::stl::Indestructible<MeshContainer<PhysicalMeshCoordinate>> kTranslationMap([]() {
-        const auto* control_plane = tt::Cluster::instance().get_control_plane();
+        const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
         TT_FATAL(control_plane != nullptr, "Control plane must be initialized before MeshDevice can be created.");
 
         const auto mesh_ids = control_plane->get_user_physical_mesh_ids();

--- a/tt_metal/distributed/mesh_command_queue.cpp
+++ b/tt_metal/distributed/mesh_command_queue.cpp
@@ -19,7 +19,7 @@
 #include "buffer.hpp"
 #include "buffer_constants.hpp"
 #include "device.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
@@ -31,7 +31,7 @@
 #include "strong_type.hpp"
 #include "system_memory_manager.hpp"
 #include "trace_buffer.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/common/thread_pool.hpp"
 #include "tt_metal/distributed/mesh_workload_utils.hpp"
 #include "tt_metal/impl/buffers/dispatch.hpp"
@@ -131,10 +131,11 @@ void MeshCommandQueue::populate_dispatch_core_type() {
     for (auto device : this->mesh_device_->get_devices()) {
         if (device_idx) {
             TT_FATAL(
-                this->dispatch_core_type_ == dispatch_core_manager::instance().get_dispatch_core_type(),
+                this->dispatch_core_type_ ==
+                    MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type(),
                 "Expected the Dispatch Core Type to match across device in a Mesh");
         } else {
-            this->dispatch_core_type_ = dispatch_core_manager::instance().get_dispatch_core_type();
+            this->dispatch_core_type_ = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
         }
         device_idx++;
     }
@@ -184,7 +185,7 @@ void MeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool b
     SubDeviceId sub_device_id = *(sub_device_ids.begin());
     auto mesh_device_id = this->mesh_device_->id();
     auto& sysmem_manager = this->reference_sysmem_manager();
-    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
 
     TT_FATAL(
@@ -702,8 +703,10 @@ MultiProducerSingleConsumerQueue<CompletionReaderVariant>& MeshCommandQueue::get
 void MeshCommandQueue::copy_buffer_data_to_user_space(MeshBufferReadDescriptor& read_buffer_descriptor) {
     auto reader_lambda = [this](IDevice* device, uint32_t num_reads) {
         auto& read_descriptor_queue = this->get_read_descriptor_queue(device);
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+        chip_id_t mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
 
         for (int i = 0; i < num_reads; i++) {
             buffer_dispatch::copy_completion_queue_data_into_user_space(
@@ -738,8 +741,10 @@ void MeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& read
     auto& device_range = read_event_descriptor.device_range;
     for (const auto& coord : device_range) {
         auto device = mesh_device_->get_device(coord);
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device->id());
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device->id());
+        chip_id_t mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
         device->sysmem_manager().completion_queue_wait_front(id_, exit_condition_);
 
         event_dispatch::read_events_from_completion_queue(
@@ -778,7 +783,7 @@ void MeshCommandQueue::write_program_cmds_to_subgrid(
     bool stall_first,
     bool stall_before_program,
     std::unordered_set<uint32_t>& chip_ids_in_workload) {
-    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
 
     for (const auto& coord : sub_grid) {
@@ -823,7 +828,7 @@ void MeshCommandQueue::capture_program_trace_on_subgrid(
     auto& sysmem_manager_for_trace = mesh_device_->get_device(sub_grid.start_coord())->sysmem_manager();
     uint32_t sysmem_manager_offset = sysmem_manager_for_trace.get_issue_queue_write_ptr(id_);
 
-    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
 
     program_dispatch::write_program_command_sequence(

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -4,7 +4,7 @@
 
 #include "dev_msgs.h"
 #include "device.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_mem_map.hpp"
@@ -15,7 +15,7 @@
 #include "tt_align.hpp"
 #include "tt_metal/distributed/mesh_workload_utils.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
 
 enum class CoreType;
 
@@ -40,7 +40,7 @@ void write_go_signal(
 
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
 
-    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
     auto sub_device_index = *sub_device_id;
 
@@ -60,7 +60,7 @@ void write_go_signal(
     // There is no need for dispatch_d to barrier before sending the dispatch_s notification or go signal,
     // since this go signal is not preceeded by NOC txns for program config data
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
-    if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
         uint16_t index_bitmask = 1 << sub_device_index;
         go_signal_cmd_sequence.add_notify_dispatch_s_go_signal_cmd(
             0,                                   /* wait */

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -33,7 +33,7 @@
 #include "mesh_graph.hpp"
 #include "metal_soc_descriptor.h"
 #include "routing_table_generator.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
@@ -43,25 +43,28 @@ namespace tt::tt_fabric {
 
 // Get the physical chip ids for a mesh
 std::unordered_map<chip_id_t, std::vector<CoreCoord>> get_ethernet_cores_grouped_by_connected_chips(chip_id_t chip_id) {
-    return tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(chip_id);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(chip_id);
 }
 
 // Get the physical chip ids for a mesh
 // TODO: get this from Cluster, once UMD unique id changes are merged
 std::uint32_t get_ubb_asic_id(chip_id_t physical_chip_id) {
     std::vector<uint32_t> ubb_asic_loc_vec;
-    const auto& eth_cores = tt::Cluster::instance().get_active_ethernet_cores(physical_chip_id, false);
-    auto virtual_eth_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
+    const auto& eth_cores = tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(physical_chip_id, false);
+    auto virtual_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
         physical_chip_id, *eth_cores.begin(), CoreType::ETH);
 
     std::uint32_t addr = 0x1ec0 + 65 * sizeof(uint32_t);
-    tt::Cluster::instance().read_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
         ubb_asic_loc_vec, sizeof(uint32_t), tt_cxy_pair(physical_chip_id, virtual_eth_core), addr);
     return ((ubb_asic_loc_vec[0] >> 24) & 0xFF);
 }
 
 bool is_external_ubb_cable(chip_id_t physical_chip_id, CoreCoord eth_core) {
-    auto chan_id = tt::Cluster::instance().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
+    auto chan_id = tt::tt_metal::MetalContext::instance()
+                       .get_cluster()
+                       .get_soc_desc(physical_chip_id)
+                       .logical_eth_core_to_chan_map.at(eth_core);
     auto ubb_asic_id = get_ubb_asic_id(physical_chip_id);
     bool is_external_cable = false;
     if (ubb_asic_id == 1) {
@@ -82,7 +85,7 @@ bool is_chip_on_edge_of_mesh(
     int num_ports_per_side,
     const std::unordered_map<chip_id_t, std::vector<CoreCoord>>& ethernet_cores_grouped_by_connected_chips) {
     // Chip is on edge if it does not have full connections to four sides
-    if (tt::Cluster::instance().get_board_type(physical_chip_id) == BoardType::UBB) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(physical_chip_id) == BoardType::UBB) {
         auto ubb_asic_id = get_ubb_asic_id(physical_chip_id);
         return (ubb_asic_id >= 2) and (ubb_asic_id <= 5);
     } else {
@@ -100,7 +103,7 @@ bool is_chip_on_corner_of_mesh(
     chip_id_t physical_chip_id,
     int num_ports_per_side,
     const std::unordered_map<chip_id_t, std::vector<CoreCoord>>& ethernet_cores_grouped_by_connected_chips) {
-    if (tt::Cluster::instance().get_board_type(physical_chip_id) == BoardType::UBB) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(physical_chip_id) == BoardType::UBB) {
         auto ubb_asic_id = get_ubb_asic_id(physical_chip_id);
         return (ubb_asic_id == 1);
     } else {
@@ -131,7 +134,8 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
 
 chip_id_t ControlPlane::get_physical_chip_id_from_eth_coord(const eth_coord_t& eth_coord) const {
     chip_id_t nw_chip_physical_chip_id = 0;
-    for (const auto& [physical_chip_id, coord] : tt::Cluster::instance().get_user_chip_ethernet_coordinates()) {
+    for (const auto& [physical_chip_id, coord] :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_user_chip_ethernet_coordinates()) {
         if (coord == eth_coord) {
             return physical_chip_id;
         }
@@ -192,7 +196,7 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
     chip_id_t nw_chip_physical_chip_id) const {
     std::uint32_t num_ports_per_side = routing_table_generator_->get_chip_spec().num_eth_ports_per_direction;
 
-    const auto user_chips = tt::Cluster::instance().user_exposed_chip_ids();
+    const auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
     std::set<chip_id_t> corner_chips;
     std::set<chip_id_t> edge_chips;
     // Check if user provided chip is on corner or edge of mesh
@@ -234,7 +238,8 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
         auto eth_links = get_ethernet_cores_grouped_by_connected_chips(current_chip_id);
         for (const auto& [connected_chip_id, eth_ports] : eth_links) {
             // Do not include any corner to corner links on UBB
-            if (tt::Cluster::instance().get_board_type(connected_chip_id) == BoardType::UBB) {
+            if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(connected_chip_id) ==
+                BoardType::UBB) {
                 if (is_external_ubb_cable(current_chip_id, eth_ports[0])) {
                     continue;
                 }
@@ -414,8 +419,11 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
         for (chip_id_t src_chip_id = 0; src_chip_id < router_intra_mesh_routing_table[mesh_id].size(); src_chip_id++) {
             const auto& physical_chip_id =
                 this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][src_chip_id];
-            std::uint32_t num_ports_per_chip =
-                tt::Cluster::instance().get_soc_desc(physical_chip_id).get_cores(CoreType::ETH).size();
+            std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
+                                                   .get_cluster()
+                                                   .get_soc_desc(physical_chip_id)
+                                                   .get_cores(CoreType::ETH)
+                                                   .size();
             this->intra_mesh_routing_tables_[mesh_id][src_chip_id].resize(
                 num_ports_per_chip);  // contains more entries than needed, this size is for all eth channels on chip
             for (int i = 0; i < num_ports_per_chip; i++) {
@@ -465,8 +473,11 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
              src_chip_id++) {
             const auto& physical_chip_id =
                 this->logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
-            std::uint32_t num_ports_per_chip =
-                tt::Cluster::instance().get_soc_desc(physical_chip_id).get_cores(CoreType::ETH).size();
+            std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
+                                                   .get_cluster()
+                                                   .get_soc_desc(physical_chip_id)
+                                                   .get_cores(CoreType::ETH)
+                                                   .size();
             this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id].resize(
                 num_ports_per_chip);  // contains more entries than needed
             for (int i = 0; i < num_ports_per_chip; i++) {
@@ -526,10 +537,10 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
                                                       const CoreCoord& eth_core,
                                                       RoutingDirection direction) {
         auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
-        auto fabric_router_channels_on_chip = tt::Cluster::instance().get_fabric_ethernet_channels(physical_chip_id);
-        auto chan_id = tt::Cluster::instance().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
+        auto fabric_router_channels_on_chip = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_chip_id);
+        auto chan_id = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
         // TODO: remove this from Cluster, manage retraining links only in control plane
-        auto active_eth_cores = tt::Cluster::instance().get_active_ethernet_cores(physical_chip_id, false);
+        auto active_eth_cores = tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(physical_chip_id, false);
         // TODO: add logic here to disable unsed routers, e.g. Mesh on Torus system
         if (fabric_router_channels_on_chip.contains(chan_id) and active_eth_cores.contains(eth_core)) {
             this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id][direction].push_back(chan_id);
@@ -546,7 +557,8 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
         for (chip_id_t chip_id = 0; chip_id < intra_mesh_connectivity[mesh_id].size(); chip_id++) {
             auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
             const auto& connected_chips_and_eth_cores =
-                tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
+                    physical_chip_id);
             for (const auto& [logical_connected_chip_id, edge] : intra_mesh_connectivity[mesh_id][chip_id]) {
                 const auto& physical_connected_chip_id =
                     this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_connected_chip_id];
@@ -570,7 +582,8 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
         for (chip_id_t chip_id = 0; chip_id < inter_mesh_connectivity[mesh_id].size(); chip_id++) {
             auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
             const auto& connected_chips_and_eth_cores =
-                tt::Cluster::instance().get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
+                    physical_chip_id);
             for (const auto& [connected_mesh_id, edge] : inter_mesh_connectivity[mesh_id][chip_id]) {
                 // Loop over edges connected chip ids, they could connect to different chips for intermesh traffic
                 for (const auto& logical_connected_chip_id : edge.connected_chip_ids) {
@@ -653,7 +666,8 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
 
             // Write data to physical eth core
             CoreCoord virtual_eth_core =
-                tt::Cluster::instance().get_virtual_eth_core_from_channel(physical_chip_id, eth_chan);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                    physical_chip_id, eth_chan);
 
             TT_ASSERT(
                 tt_metal::hal_ref.get_dev_size(
@@ -666,7 +680,7 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
                 mesh_id,
                 chip_id,
                 eth_chan);
-            tt::Cluster::instance().write_core(
+            tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                 (void*)&fabric_router_config,
                 sizeof(tt::tt_fabric::fabric_router_l1_config_t),
                 tt_cxy_pair(physical_chip_id, virtual_eth_core),
@@ -675,7 +689,7 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
                 false);
         }
     }
-    tt::Cluster::instance().l1_barrier(physical_chip_id);
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_chip_id);
 }
 
 std::pair<mesh_id_t, chip_id_t> ControlPlane::get_mesh_chip_id_from_physical_chip_id(chip_id_t physical_chip_id) const {
@@ -701,14 +715,18 @@ std::tuple<mesh_id_t, chip_id_t, chan_id_t> ControlPlane::get_connected_mesh_chi
     mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t chan_id) const {
     // TODO: simplify this and maybe have this functionality in ControlPlane
     auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
-    tt::umd::CoreCoord eth_core =
-        tt::Cluster::instance().get_soc_desc(physical_chip_id).get_eth_core_for_channel(chan_id, CoordSystem::LOGICAL);
-    auto [connected_physical_chip_id, connected_eth_core] = tt::Cluster::instance().get_connected_ethernet_core(
-        std::make_tuple(physical_chip_id, CoreCoord{eth_core.x, eth_core.y}));
+    tt::umd::CoreCoord eth_core = tt::tt_metal::MetalContext::instance()
+                                      .get_cluster()
+                                      .get_soc_desc(physical_chip_id)
+                                      .get_eth_core_for_channel(chan_id, CoordSystem::LOGICAL);
+    auto [connected_physical_chip_id, connected_eth_core] =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
+            std::make_tuple(physical_chip_id, CoreCoord{eth_core.x, eth_core.y}));
 
     auto [connected_mesh_id, connected_chip_id] =
         this->get_mesh_chip_id_from_physical_chip_id(connected_physical_chip_id);
-    auto connected_chan_id = tt::Cluster::instance()
+    auto connected_chan_id = tt::tt_metal::MetalContext::instance()
+                                 .get_cluster()
                                  .get_soc_desc(connected_physical_chip_id)
                                  .logical_eth_core_to_chan_map.at(connected_eth_core);
     return std::make_tuple(connected_mesh_id, connected_chip_id, connected_chan_id);
@@ -816,7 +834,8 @@ std::vector<std::pair<routing_plane_id_t, CoreCoord>> ControlPlane::get_routers_
                 this->logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
             routers.emplace_back(
                 this->get_routing_plane_id(src_chan_id),
-                tt::Cluster::instance().get_virtual_eth_core_from_channel(physical_chip_id, src_chan_id));
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                    physical_chip_id, src_chan_id));
         }
     }
     return routers;
@@ -873,7 +892,7 @@ void ControlPlane::write_routing_tables_to_all_chips() const {
 
 std::vector<mesh_id_t> ControlPlane::get_user_physical_mesh_ids() const {
     std::vector<mesh_id_t> physical_mesh_ids;
-    const auto user_chips = tt::Cluster::instance().user_exposed_chip_ids();
+    const auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
     for (int mesh_id = 0; mesh_id < this->logical_mesh_chip_id_to_physical_chip_id_mapping_.size(); mesh_id++) {
         bool add_mesh = true;
         for (int chip_id = 0; chip_id < this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id].size();

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -2,6 +2,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager_tracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sub_device/sub_device_manager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/context/metal_context.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device/device_pool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/buffers/buffer.cpp

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -16,7 +16,7 @@
 #include "assert.hpp"
 #include "buffer_constants.hpp"
 #include "dispatch.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch_mem_map.hpp"
 #include "hal_types.hpp"
@@ -25,7 +25,7 @@
 #include "strong_type.hpp"
 #include "sub_device_types.hpp"
 #include "tt_align.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
@@ -273,7 +273,7 @@ uint32_t calculate_max_data_size(const CoreType& dispatch_core_type) {
 }
 
 bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer) {
-    const CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
+    const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     const uint32_t max_data_size = calculate_max_data_size(dispatch_core_type);
     return buffer.aligned_page_size() > max_data_size;
 }
@@ -1084,7 +1084,7 @@ void copy_completion_queue_data_into_user_space(
             void* contiguous_dst = (void*)(uint64_t(dst) + contig_dst_offset);
             if (page_size == padded_page_size) {
                 uint32_t data_bytes_xfered = bytes_xfered - offset_in_completion_q_data;
-                tt::Cluster::instance().read_sysmem(
+                tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
                     contiguous_dst,
                     data_bytes_xfered,
                     completion_q_read_ptr + offset_in_completion_q_data,
@@ -1133,7 +1133,7 @@ void copy_completion_queue_data_into_user_space(
                         num_bytes_to_copy = page_size;
                     }
 
-                    tt::Cluster::instance().read_sysmem(
+                    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
                         (char*)(uint64_t(contiguous_dst) + dst_offset_bytes),
                         num_bytes_to_copy,
                         completion_q_read_ptr + src_offset_bytes,
@@ -1206,7 +1206,7 @@ void copy_completion_queue_data_into_user_space(
                     }
                 }
 
-                tt::Cluster::instance().read_sysmem(
+                tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
                     (char*)(uint64_t(dst) + dst_offset_bytes),
                     num_bytes_to_copy,
                     completion_q_read_ptr + src_offset_bytes,

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -28,7 +28,7 @@
 #include "mesh_device.hpp"
 #include "reflection.hpp"
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.h>
 
 namespace tt::tt_metal {
@@ -152,7 +152,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         } else {
             if (device->using_slow_dispatch()) {
                 detail::WriteToBuffer(*cb_config_buffer.get_buffer(), cb_config_host_buffer);
-                tt::Cluster::instance().l1_barrier(device->id());
+                tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
             } else {
                 EnqueueWriteBuffer(
                     device->command_queue(), *cb_config_buffer.get_buffer(), cb_config_host_buffer.data(), false);

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -19,7 +19,7 @@
 
 #include "mesh_device.hpp"
 #include "reflection.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 
@@ -68,7 +68,7 @@ void GlobalSemaphore::reset_semaphore_value(uint32_t reset_value) const {
         std::vector<uint32_t> host_buffer(num_cores, reset_value);
         if (device->using_slow_dispatch()) {
             detail::WriteToBuffer(*buffer.get_buffer(), host_buffer);
-            tt::Cluster::instance().l1_barrier(device->id());
+            tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
         } else {
             if (auto mesh_buffer = buffer.get_mesh_buffer()) {
                 distributed::EnqueueWriteMeshBuffer(

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -6,7 +6,7 @@
 #include <tt-metalium/dispatch_settings.hpp>
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
-#include <tt-metalium/metal_context.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "metal_context.hpp"
+#include <tt-metalium/dispatch_settings.hpp>
+#include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
+#include "tt_metal/impl/dispatch/topology.hpp"
+#include <tt-metalium/metal_context.hpp>
+#include "tt_metal/impl/debug/dprint_server.hpp"
+#include "tt_metal/impl/debug/noc_logging.hpp"
+#include "tt_metal/impl/debug/watcher_server.hpp"
+#include "tt_metal/impl/debug/debug_helpers.hpp"
+#include "tt_metal/jit_build/build_env_manager.hpp"
+#include "tt_metal/llrt/llrt.hpp"
+
+namespace tt::tt_metal {
+
+void MetalContext::initialize(
+    const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, const BankMapping& l1_bank_remap) {
+    if (initialized_) {
+        if (this->dispatch_core_config_ != dispatch_core_config or num_hw_cqs != this->num_hw_cqs_ or
+            l1_bank_remap != this->l1_bank_remap_) {
+            log_warning("Closing and re-initializing MetalContext with new parameters.");
+        } else {
+            // Re-init request with the same parameters, do nothing
+            return;
+        }
+    }
+
+    initialized_ = true;
+    dispatch_core_config_ = dispatch_core_config;
+    num_hw_cqs_ = num_hw_cqs;
+    l1_bank_remap_ = l1_bank_remap;
+
+    // Initialize dispatch state
+    dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
+    dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(num_hw_cqs);
+    tt_metal::DispatchSettings::initialize(cluster_);
+
+    // TODO: Move FW, fabric, dispatch init here
+}
+
+MetalContext& MetalContext::instance() {
+    static tt::stl::Indestructible<MetalContext> inst;
+    return inst.get();
+}
+
+MetalContext::MetalContext() {}
+
+Cluster& MetalContext::get_cluster() { return cluster_; }
+
+dispatch_core_manager& MetalContext::get_dispatch_core_manager() {
+    TT_FATAL(dispatch_core_manager_, "Trying to get dispatch_core_manager before intializing it.");
+    return *dispatch_core_manager_;
+}
+
+DispatchQueryManager& MetalContext::get_dispatch_query_manager() {
+    TT_FATAL(dispatch_query_manager_, "Trying to get dispatch_query_manager before intializing it.");
+    return *dispatch_query_manager_;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt_stl/indestructible.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
+#include <tt-metalium/core_descriptor.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/dev_msgs.h>
+#include <tt-metalium/allocator_types.hpp>
+#include <llrt/tt_cluster.hpp>
+#include <impl/dispatch/dispatch_core_manager.hpp>
+#include <impl/dispatch/dispatch_query_manager.hpp>
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace tt::tt_metal {
+
+// A class to manage one-time initialization and teardown (FW, dispatch, fabric, cluster) and access to related state.
+// Dispatch-independent state (Cluster) is initialized with the creation of MetalContext and accessible right after.
+// Dispatch-dependent state (FW, dispatch, fabric) is initialized explicitly with a MetalContext::initialize() call, and
+// only accessible after that.
+class MetalContext {
+public:
+    MetalContext& operator=(const MetalContext&) = delete;
+    MetalContext& operator=(MetalContext&& other) noexcept = delete;
+    MetalContext(const MetalContext&) = delete;
+    MetalContext(MetalContext&& other) noexcept = delete;
+    static MetalContext& instance();
+
+    Cluster& get_cluster();
+    dispatch_core_manager& get_dispatch_core_manager();
+    DispatchQueryManager& get_dispatch_query_manager();
+
+    void initialize(
+        const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, const BankMapping& l1_bank_remap);
+
+private:
+    friend class tt::stl::Indestructible<MetalContext>;
+    MetalContext();
+    ~MetalContext();
+
+    bool initialized_ = false;
+
+    uint8_t num_hw_cqs_ = 0;
+    BankMapping l1_bank_remap_;
+    DispatchCoreConfig dispatch_core_config_;
+
+    Cluster cluster_;
+    std::unique_ptr<dispatch_core_manager> dispatch_core_manager_;
+    std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -17,7 +17,7 @@
 #include "debug_helpers.hpp"
 #include "hostdevcommon/dprint_common.h"
 #include "llrt.hpp"
-#include "llrt/tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "logger.hpp"
 #include "rtoptions.hpp"
 #include <umd/device/tt_soc_descriptor.h>
@@ -48,8 +48,9 @@ void PrintNocData(noc_data_t noc_data, const string& file_name) {
 }
 
 void DumpCoreNocData(chip_id_t device_id, const CoreDescriptor& logical_core, noc_data_t& noc_data) {
-    CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-        device_id, logical_core.coord, logical_core.type);
+    CoreCoord virtual_core =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core.coord, logical_core.type);
     for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
         // Read out the DPRINT buffer, we stored our data in the "data field"
         uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
@@ -108,8 +109,9 @@ void ClearNocData(chip_id_t device_id) {
 
     CoreDescriptorSet all_cores = GetAllCores(device_id);
     for (const CoreDescriptor& logical_core : all_cores) {
-        CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-            device_id, logical_core.coord, logical_core.type);
+        CoreCoord virtual_core =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                device_id, logical_core.coord, logical_core.type);
         for (int risc_id = 0; risc_id < GetNumRiscs(logical_core); risc_id++) {
             uint64_t addr = GetDprintBufAddr(device_id, virtual_core, risc_id);
             std::vector<uint32_t> initbuf = std::vector<uint32_t>(DPRINT_BUFFER_SIZE / sizeof(uint32_t), 0);

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -11,7 +11,7 @@
 #include <logger.hpp>
 #include <metal_soc_descriptor.h>
 #include <rtoptions.hpp>
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <algorithm>
 #include <cstddef>
 #include <functional>
@@ -27,7 +27,7 @@
 #include "dispatch_core_common.hpp"
 #include "hal_types.hpp"
 #include "hw/inc/debug/ring_buffer.h"
-#include "impl/dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "llrt.hpp"
 #include "llrt/hal.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -79,13 +79,13 @@ static uint32_t get_riscv_stack_size(const CoreDescriptor& core, uint32_t type) 
 
 // Helper function to determine core type from virtual coord. TODO: Remove this once we fix code types.
 static CoreType core_type_from_virtual_core(chip_id_t device_id, const CoreCoord& virtual_coord) {
-    if (tt::Cluster::instance().is_worker_core(virtual_coord, device_id)) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(virtual_coord, device_id)) {
         return CoreType::WORKER;
-    } else if (tt::Cluster::instance().is_ethernet_core(virtual_coord, device_id)) {
+    } else if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_coord, device_id)) {
         return CoreType::ETH;
     }
 
-    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
     CoreType core_type =
         soc_desc.translate_coord_to(virtual_coord, CoordSystem::PHYSICAL, CoordSystem::PHYSICAL).core_type;
     if (core_type == CoreType::TENSIX) {
@@ -96,7 +96,7 @@ static CoreType core_type_from_virtual_core(chip_id_t device_id, const CoreCoord
 
 // Helper function to convert noc coord -> virtual coord. TODO: Remove this once we fix code types.
 static CoreCoord virtual_noc_coordinate(chip_id_t device_id, uint8_t noc_index, CoreCoord coord) {
-    auto grid_size = tt::Cluster::instance().get_soc_desc(device_id).grid_size;
+    auto grid_size = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).grid_size;
     if (coord.x >= grid_size.x || coord.y >= grid_size.y) {
         // Coordinate already in virtual space: NOC0 and NOC1 are the same
         return coord;
@@ -107,7 +107,8 @@ static CoreCoord virtual_noc_coordinate(chip_id_t device_id, uint8_t noc_index, 
         CoreCoord physical_coord = {
             hal_ref.noc_coordinate(noc_index, grid_size.x, coord.x),
             hal_ref.noc_coordinate(noc_index, grid_size.y, coord.y)};
-        return tt::Cluster::instance().get_virtual_coordinate_from_physical_coordinates(device_id, physical_coord);
+        return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_physical_coordinates(
+            device_id, physical_coord);
     }
 }
 
@@ -185,12 +186,14 @@ WatcherDeviceReader::WatcherDeviceReader(
     kernel_names(kernel_names),
     set_watcher_exception_message(set_watcher_exception_message) {
     // On init, read out eth link retraining register so that we can see if retraining has occurred. WH only for now.
-    if (tt::Cluster::instance().arch() == ARCH::WORMHOLE_B0 &&
+    if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::WORMHOLE_B0 &&
         tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
-        for (const CoreCoord& eth_core : tt::Cluster::instance().get_active_ethernet_cores(device_id)) {
-            CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-                device_id, eth_core, CoreType::ETH);
+        for (const CoreCoord& eth_core :
+             tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
+            CoreCoord virtual_core =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                    device_id, eth_core, CoreType::ETH);
             read_data = tt::llrt::read_hex_vec_from_core(
                 device_id,
                 virtual_core,
@@ -203,12 +206,14 @@ WatcherDeviceReader::WatcherDeviceReader(
 
 WatcherDeviceReader::~WatcherDeviceReader() {
     // On close, read out eth link retraining register so that we can see if retraining has occurred.
-    if (tt::Cluster::instance().arch() == ARCH::WORMHOLE_B0 &&
+    if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::WORMHOLE_B0 &&
         tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
         std::vector<uint32_t> read_data;
-        for (const CoreCoord& eth_core : tt::Cluster::instance().get_active_ethernet_cores(device_id)) {
-            CoreCoord virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-                device_id, eth_core, CoreType::ETH);
+        for (const CoreCoord& eth_core :
+             tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
+            CoreCoord virtual_core =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                    device_id, eth_core, CoreType::ETH);
             read_data = tt::llrt::read_hex_vec_from_core(
                 device_id,
                 virtual_core,
@@ -251,15 +256,16 @@ void WatcherDeviceReader::Dump(FILE* file) {
 
     // Ignore storage-only cores
     std::unordered_set<CoreCoord> storage_only_cores;
-    uint8_t num_hw_cqs = tt::tt_metal::dispatch_core_manager::instance().get_num_hw_cqs();
+    uint8_t num_hw_cqs = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_num_hw_cqs();
     DispatchCoreConfig dispatch_core_config =
-        tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_config();
+        tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     for (auto core_coord : tt::get_logical_storage_cores(device_id, num_hw_cqs, dispatch_core_config)) {
         storage_only_cores.insert(core_coord);
     }
 
     // Dump worker cores
-    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    CoreCoord grid_size =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreDescriptor logical_core = {{x, y}, CoreType::WORKER};
@@ -270,11 +276,13 @@ void WatcherDeviceReader::Dump(FILE* file) {
     }
 
     // Dump eth cores
-    for (const CoreCoord& eth_core : tt::Cluster::instance().get_active_ethernet_cores(device_id)) {
+    for (const CoreCoord& eth_core :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
         CoreDescriptor logical_core = {eth_core, CoreType::ETH};
         DumpCore(logical_core, true);
     }
-    for (const CoreCoord& eth_core : tt::Cluster::instance().get_inactive_ethernet_cores(device_id)) {
+    for (const CoreCoord& eth_core :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id)) {
         CoreDescriptor logical_core = {eth_core, CoreType::ETH};
         DumpCore(logical_core, false);
     }
@@ -364,8 +372,9 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
     // Watcher only treats ethernet + worker cores.
     bool is_eth_core = (logical_core.type == CoreType::ETH);
     CoreDescriptor virtual_core;
-    virtual_core.coord = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-        device_id, logical_core.coord, logical_core.type);
+    virtual_core.coord =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            device_id, logical_core.coord, logical_core.type);
     virtual_core.type = logical_core.type;
 
     // Print device id, core coords (logical)
@@ -377,8 +386,9 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
         virtual_core.coord.x,
         virtual_core.coord.y);
     if (tt::llrt::RunTimeOptions::get_instance().get_watcher_phys_coords()) {
-        CoreCoord phys_core = tt::Cluster::instance().get_physical_coordinate_from_logical_coordinates(
-            device_id, logical_core.coord, logical_core.type, true);
+        CoreCoord phys_core =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_physical_coordinate_from_logical_coordinates(
+                device_id, logical_core.coord, logical_core.type, true);
         core_coord_str += fmt::format(" phys(x={:2},y={:2})", phys_core.x, phys_core.y);
     }
     string core_str = fmt::format("Device {} {} {}", device_id, core_type, core_coord_str);
@@ -456,7 +466,7 @@ void WatcherDeviceReader::DumpCore(CoreDescriptor& logical_core, bool is_active_
             f,
             "k_id:%d",
             mbox_data->launch[launch_msg_read_ptr].kernel_config.watcher_kernel_ids[DISPATCH_CLASS_ETH_DM0]);
-        if (tt::Cluster::instance().arch() == ARCH::BLACKHOLE) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE) {
             fprintf(f, "|%d", mbox_data->launch[launch_msg_read_ptr].kernel_config.watcher_kernel_ids[DISPATCH_CLASS_ETH_DM1]);
         }
     } else {
@@ -794,7 +804,7 @@ void WatcherDeviceReader::DumpLaunchMessage(CoreDescriptor& core, const mailboxe
         } else {
             fprintf(f, "e");
         }
-        if (tt::Cluster::instance().arch() == ARCH::BLACKHOLE) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE) {
             if (launch_msg->kernel_config.enables & DISPATCH_CLASS_MASK_ETH_DM1) {
                 fprintf(f, "E");
             } else {
@@ -812,7 +822,7 @@ void WatcherDeviceReader::DumpLaunchMessage(CoreDescriptor& core, const mailboxe
         DumpRunState(core, launch_msg, slave_sync->trisc1);
         DumpRunState(core, launch_msg, slave_sync->trisc2);
         fprintf(f, " ");
-    } else if (tt::Cluster::instance().arch() == ARCH::BLACKHOLE) {
+    } else if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE) {
         fprintf(f, "smsg:");
         DumpRunState(core, launch_msg, slave_sync->dm1);
         fprintf(f, " ");

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -34,7 +34,7 @@
 #include "logger.hpp"
 #include "metal_soc_descriptor.h"
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
@@ -306,8 +306,10 @@ void watcher_init(chip_id_t device_id) {
                     CoreCoord virtual_core;
                     bool valid_logical_core = true;
                     try {
-                        virtual_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-                            device_id, logical_core, core_type);
+                        virtual_core =
+                            tt::tt_metal::MetalContext::instance()
+                                .get_cluster()
+                                .get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, core_type);
                     } catch (std::runtime_error& error) {
                         valid_logical_core = false;
                     }
@@ -358,12 +360,14 @@ void watcher_init(chip_id_t device_id) {
     // cores from that to consolidate the loops below
 
     // Initialize worker cores debug values
-    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    CoreCoord grid_size =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     for (uint32_t y = 0; y < grid_size.y; y++) {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord logical_core(x, y);
-            CoreCoord worker_core = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-                device_id, logical_core, CoreType::WORKER);
+            CoreCoord worker_core =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                    device_id, logical_core, CoreType::WORKER);
             if (debug_delays_val.find(worker_core) != debug_delays_val.end()) {
                 data->debug_insert_delays = debug_delays_val[worker_core];
             } else {
@@ -380,7 +384,8 @@ void watcher_init(chip_id_t device_id) {
     // Initialize ethernet cores debug values
     auto init_eth_debug_values = [&](const CoreCoord& eth_core, bool is_active_eth_core) {
         CoreCoord virtual_core =
-            tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(device_id, eth_core, CoreType::ETH);
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                device_id, eth_core, CoreType::ETH);
         if (debug_delays_val.find(virtual_core) != debug_delays_val.end()) {
             data->debug_insert_delays = debug_delays_val[virtual_core];
         } else {
@@ -392,10 +397,12 @@ void watcher_init(chip_id_t device_id) {
             watcher_init_val,
             is_active_eth_core ? GET_WATCHER_ERISC_DEV_ADDR() : GET_WATCHER_IERISC_DEV_ADDR());
     };
-    for (const CoreCoord& active_eth_core : tt::Cluster::instance().get_active_ethernet_cores(device_id)) {
+    for (const CoreCoord& active_eth_core :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id)) {
         init_eth_debug_values(active_eth_core, true);
     }
-    for (const CoreCoord& inactive_eth_core : tt::Cluster::instance().get_inactive_ethernet_cores(device_id)) {
+    for (const CoreCoord& inactive_eth_core :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id)) {
         init_eth_debug_values(inactive_eth_core, false);
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -46,7 +46,7 @@
 #include "common/core_assignment.hpp"
 #include "core_coord.hpp"
 #include "device.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_settings.hpp"
 #include "dprint_server.hpp"
@@ -67,7 +67,7 @@
 #include "system_memory_manager.hpp"
 #include "trace_buffer.hpp"
 #include "tracy/Tracy.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
@@ -114,7 +114,8 @@ Device::Device(
 }
 
 std::unordered_set<CoreCoord> Device::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
-    return tt::Cluster::instance().get_active_ethernet_cores(this->id_, skip_reserved_tunnel_cores);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(
+        this->id_, skip_reserved_tunnel_cores);
 }
 
 bool Device::is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_tunnel_cores) const {
@@ -123,24 +124,26 @@ bool Device::is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_
 }
 
 std::unordered_set<CoreCoord> Device::get_inactive_ethernet_cores() const {
-    return tt::Cluster::instance().get_inactive_ethernet_cores(this->id_);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(this->id_);
 }
 
 bool Device::is_inactive_ethernet_core(CoreCoord logical_core) const {
-    auto inactive_ethernet_cores = tt::Cluster::instance().get_inactive_ethernet_cores(this->id_);
+    auto inactive_ethernet_cores =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(this->id_);
     return inactive_ethernet_cores.find(logical_core) != inactive_ethernet_cores.end();
 }
 
 std::tuple<chip_id_t, CoreCoord> Device::get_connected_ethernet_core(CoreCoord eth_core) const {
-    return tt::Cluster::instance().get_connected_ethernet_core(std::make_tuple(this->id_, eth_core));
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
+        std::make_tuple(this->id_, eth_core));
 }
 
 std::vector<CoreCoord> Device::get_ethernet_sockets(chip_id_t connected_chip_id) const {
-    return tt::Cluster::instance().get_ethernet_sockets(this->id_, connected_chip_id);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_sockets(this->id_, connected_chip_id);
 }
 
 bool Device::is_mmio_capable() const {
-    return tt::Cluster::instance().get_associated_mmio_device(this->id_) == this->id_;
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_) == this->id_;
 }
 
 CoreRangeSet Device::worker_cores(HalProgrammableCoreType core_type, SubDeviceId sub_device_id) const {
@@ -160,32 +163,43 @@ void Device::get_associated_dispatch_virtual_cores(
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &my_dispatch_cores,
     std::unordered_map<chip_id_t,std::unordered_set<CoreCoord>> &other_dispatch_cores) {
     if (this->is_mmio_capable()) {
-        for (const chip_id_t &device_id : tt::Cluster::instance().get_devices_controlled_by_mmio_device(this->id_)) {
+        for (const chip_id_t& device_id :
+             tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(this->id_)) {
             uint8_t num_hw_cqs = this->num_hw_cqs();
-            uint16_t curr_channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-            CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
+            uint16_t curr_channel =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+            CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
             for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
                 if (device_id == this->id_) {
                     //mmio device.
                     bool dispatch_hd_allocated = false;
                     CoreCoord virtual_core_dispatch_hd;
-                    if (dispatch_core_manager::instance().is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_location = dispatch_core_manager::instance().dispatcher_core(device_id, curr_channel, cq_id);
+                    if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
+                            device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair dispatch_location =
+                            MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
+                                device_id, curr_channel, cq_id);
                         virtual_core_dispatch_hd = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
                         my_dispatch_cores[this->id_].insert(virtual_core_dispatch_hd);
                         dispatch_hd_allocated = true;
                         log_debug(tt::LogMetal, "MMIO Device Dispatch core: Logical: {} - Physical: {}", dispatch_location.str(), virtual_core_dispatch_hd.str());
                     }
                     // Include dispatch_s in the dispatch core location set, if its not on the same core as dispatch_hd
-                    if (dispatch_core_manager::instance().is_dispatcher_s_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_s_location = dispatch_core_manager::instance().dispatcher_s_core(device_id, curr_channel, cq_id);
+                    if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_s_core_allocated(
+                            device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair dispatch_s_location =
+                            MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(
+                                device_id, curr_channel, cq_id);
                         CoreCoord virtual_core_dispatch_s = this->virtual_core_from_logical_core(dispatch_s_location, dispatch_core_type);
                         if ((!dispatch_hd_allocated) or (virtual_core_dispatch_s != virtual_core_dispatch_hd)) {
                             my_dispatch_cores[dispatch_s_location.chip].insert(virtual_core_dispatch_s);
                         }
                     }
-                    if (dispatch_core_manager::instance().is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair prefetch_location = dispatch_core_manager::instance().prefetcher_core(device_id, curr_channel, cq_id);
+                    if (MetalContext::instance().get_dispatch_core_manager().is_prefetcher_core_allocated(
+                            device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair prefetch_location =
+                            MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
+                                device_id, curr_channel, cq_id);
                         CoreCoord virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
                         my_dispatch_cores[this->id_].insert(virtual_core);
                         log_debug(tt::LogMetal, "MMIO Device Prefetch core: Logical: {} - Physical: {}", prefetch_location.str(), virtual_core.str());
@@ -193,26 +207,36 @@ void Device::get_associated_dispatch_virtual_cores(
                 } else if (tt::DevicePool::instance().is_device_active(device_id)) {
                     //non mmio devices serviced by this mmio capable device.
                     //skip remote dispatch cores only if respective remote device is active.
-                    if (dispatch_core_manager::instance().is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_location = dispatch_core_manager::instance().dispatcher_core(device_id, curr_channel, cq_id);
+                    if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
+                            device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair dispatch_location =
+                            MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
+                                device_id, curr_channel, cq_id);
                         CoreCoord virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(virtual_core);
                         log_debug(tt::LogMetal, "Remote Device Dispatch core: Logical: {} - Physical: {} will keep running on MMIO Device.", dispatch_location.str(), virtual_core.str());
                     }
-                    if (dispatch_core_manager::instance().is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair prefetch_location = dispatch_core_manager::instance().prefetcher_core(device_id, curr_channel, cq_id);
+                    if (MetalContext::instance().get_dispatch_core_manager().is_prefetcher_core_allocated(
+                            device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair prefetch_location =
+                            MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
+                                device_id, curr_channel, cq_id);
                         CoreCoord virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(virtual_core);
                         log_debug(tt::LogMetal, "Remote Device Prefetch core: Logical: {} - Physical: {} will keep running on MMIO Device.", prefetch_location.str(), virtual_core.str());
                     }
-                    if (dispatch_core_manager::instance().is_mux_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair mux_location = dispatch_core_manager::instance().mux_core(device_id, curr_channel, cq_id);
+                    if (MetalContext::instance().get_dispatch_core_manager().is_mux_core_allocated(
+                            device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair mux_location = MetalContext::instance().get_dispatch_core_manager().mux_core(
+                            device_id, curr_channel, cq_id);
                         CoreCoord virtual_core = this->virtual_core_from_logical_core(mux_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(virtual_core);
                         log_debug(tt::LogMetal, "Remote Device Mux core: Logical: {} - Physical: {} will keep running on MMIO Device.", mux_location.str(), virtual_core.str());
                     }
-                    if (dispatch_core_manager::instance().is_demux_core_allocated(device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair demux_location = dispatch_core_manager::instance().demux_core(device_id, curr_channel, cq_id);
+                    if (MetalContext::instance().get_dispatch_core_manager().is_demux_core_allocated(
+                            device_id, curr_channel, cq_id)) {
+                        tt_cxy_pair demux_location = MetalContext::instance().get_dispatch_core_manager().demux_core(
+                            device_id, curr_channel, cq_id);
                         CoreCoord virtual_core = this->virtual_core_from_logical_core(demux_location, dispatch_core_type);
                         other_dispatch_cores[this->id_].insert(virtual_core);
                         log_debug(tt::LogMetal, "Remote Device Demux core: Logical: {} - Physical: {} will keep running on MMIO Device.", demux_location.str(), virtual_core.str());
@@ -224,60 +248,71 @@ void Device::get_associated_dispatch_virtual_cores(
         //remote device that is active
         uint8_t num_hw_cqs = this->num_hw_cqs();
         auto device_id = this->id_;
-        uint16_t curr_channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-        CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
+        uint16_t curr_channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+        CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            if (dispatch_core_manager::instance().is_dispatcher_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair dispatch_location = dispatch_core_manager::instance().dispatcher_core(device_id, curr_channel, cq_id);
+            if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
+                    device_id, curr_channel, cq_id)) {
+                tt_cxy_pair dispatch_location = MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
+                    device_id, curr_channel, cq_id);
                 CoreCoord virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
                 my_dispatch_cores[dispatch_location.chip].insert(virtual_core);
                 log_debug(tt::LogMetal, "Remote Device Dispatch core: Logical: {} - Physical: {} will be reset on MMIO Device.", dispatch_location.str(), virtual_core.str());
             }
-            if (dispatch_core_manager::instance().is_prefetcher_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair prefetch_location = dispatch_core_manager::instance().prefetcher_core(device_id, curr_channel, cq_id);
+            if (MetalContext::instance().get_dispatch_core_manager().is_prefetcher_core_allocated(
+                    device_id, curr_channel, cq_id)) {
+                tt_cxy_pair prefetch_location = MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
+                    device_id, curr_channel, cq_id);
                 CoreCoord virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
                 my_dispatch_cores[prefetch_location.chip].insert(virtual_core);
                 log_debug(tt::LogMetal, "Remote Device Prefetch core: Logical: {} - Physical: {} will be reset on MMIO Device.", prefetch_location.str(), virtual_core.str());
             }
-            if (dispatch_core_manager::instance().is_mux_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair mux_location = dispatch_core_manager::instance().mux_core(device_id, curr_channel, cq_id);
+            if (MetalContext::instance().get_dispatch_core_manager().is_mux_core_allocated(
+                    device_id, curr_channel, cq_id)) {
+                tt_cxy_pair mux_location =
+                    MetalContext::instance().get_dispatch_core_manager().mux_core(device_id, curr_channel, cq_id);
                 CoreCoord virtual_core = this->virtual_core_from_logical_core(mux_location, dispatch_core_type);
                 my_dispatch_cores[mux_location.chip].insert(virtual_core);
                 log_debug(tt::LogMetal, "Remote Device Mux core: Logical: {} - Physical: {} will be reset on MMIO Device.", mux_location.str(), virtual_core.str());
             }
-            if (dispatch_core_manager::instance().is_demux_core_allocated(device_id, curr_channel, cq_id)) {
-                tt_cxy_pair demux_location = dispatch_core_manager::instance().demux_core(device_id, curr_channel, cq_id);
+            if (MetalContext::instance().get_dispatch_core_manager().is_demux_core_allocated(
+                    device_id, curr_channel, cq_id)) {
+                tt_cxy_pair demux_location =
+                    MetalContext::instance().get_dispatch_core_manager().demux_core(device_id, curr_channel, cq_id);
                 CoreCoord virtual_core = this->virtual_core_from_logical_core(demux_location, dispatch_core_type);
                 my_dispatch_cores[demux_location.chip].insert(virtual_core);
                 log_debug(tt::LogMetal, "Remote Device Demux core: Logical: {} - Physical: {} will be reset on MMIO Device.", demux_location.str(), virtual_core.str());
             }
         }
         CoreCoord virtual_core;
-        tt_cxy_pair mux_location = dispatch_core_manager::instance().mux_d_core(device_id, curr_channel, 0);
+        tt_cxy_pair mux_location =
+            MetalContext::instance().get_dispatch_core_manager().mux_d_core(device_id, curr_channel, 0);
         virtual_core = this->virtual_core_from_logical_core(mux_location, dispatch_core_type);
         my_dispatch_cores[mux_location.chip].insert(virtual_core);
-        tt_cxy_pair demux_location = dispatch_core_manager::instance().demux_d_core(device_id, curr_channel, 0);
+        tt_cxy_pair demux_location =
+            MetalContext::instance().get_dispatch_core_manager().demux_d_core(device_id, curr_channel, 0);
         virtual_core = this->virtual_core_from_logical_core(demux_location, dispatch_core_type);
         my_dispatch_cores[demux_location.chip].insert(virtual_core);
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             tt_cxy_pair prefetch_location =
-                dispatch_core_manager::instance().prefetcher_d_core(device_id, curr_channel, cq_id);
+                MetalContext::instance().get_dispatch_core_manager().prefetcher_d_core(device_id, curr_channel, cq_id);
             virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
             my_dispatch_cores[prefetch_location.chip].insert(virtual_core);
         }
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             tt_cxy_pair dispatch_location =
-                dispatch_core_manager::instance().dispatcher_d_core(device_id, curr_channel, cq_id);
+                MetalContext::instance().get_dispatch_core_manager().dispatcher_d_core(device_id, curr_channel, cq_id);
             virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
             my_dispatch_cores[dispatch_location.chip].insert(virtual_core);
         }
         for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             // Include dispatch_s in the dispatch core location set, if its not on the same core as dispatch_d
             tt_cxy_pair dispatch_location =
-                dispatch_core_manager::instance().dispatcher_d_core(device_id, curr_channel, cq_id);
+                MetalContext::instance().get_dispatch_core_manager().dispatcher_d_core(device_id, curr_channel, cq_id);
             virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
             tt_cxy_pair dispatch_s_location =
-                dispatch_core_manager::instance().dispatcher_s_core(device_id, curr_channel, cq_id);
+                MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(device_id, curr_channel, cq_id);
             CoreCoord virtual_core_dispatch_s = this->virtual_core_from_logical_core(dispatch_s_location, dispatch_core_type);
             if (virtual_core_dispatch_s != virtual_core) {
                 my_dispatch_cores[dispatch_s_location.chip].insert(virtual_core_dispatch_s);
@@ -291,7 +326,7 @@ void Device::initialize_cluster() {
     if (llrt::RunTimeOptions::get_instance().get_clear_l1()) {
         this->clear_l1_state();
     }
-    int ai_clk = tt::Cluster::instance().get_device_aiclk(this->id_);
+    int ai_clk = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(this->id_);
     log_info(tt::LogMetal, "AI CLK for device {} is:   {} MHz", this->id_, ai_clk);
 }
 
@@ -315,8 +350,8 @@ void Device::initialize_default_sub_device_state(size_t l1_small_size, size_t tr
 
 std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, size_t trace_region_size, tt::stl::Span<const std::uint32_t> l1_bank_remap) {
     ZoneScoped;
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
+    const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
     // Construct allocator config from soc_desc
     // Take max alignment to satisfy NoC rd/wr constraints
@@ -341,8 +376,10 @@ std::unique_ptr<Allocator> Device::initialize_allocator(size_t l1_small_size, si
          .l1_small_size = align(l1_small_size, hal_ref.get_alignment(HalMemType::DRAM)),
          .trace_region_size = align(trace_region_size, hal_ref.get_alignment(HalMemType::DRAM)),
          .core_type_from_noc_coord_table = {},  // Populated later
-         .worker_log_to_virtual_routing_x = tt::Cluster::instance().get_worker_logical_to_virtual_x(this->id()),
-         .worker_log_to_virtual_routing_y = tt::Cluster::instance().get_worker_logical_to_virtual_y(this->id()),
+         .worker_log_to_virtual_routing_x =
+             tt::tt_metal::MetalContext::instance().get_cluster().get_worker_logical_to_virtual_x(this->id()),
+         .worker_log_to_virtual_routing_y =
+             tt::tt_metal::MetalContext::instance().get_cluster().get_worker_logical_to_virtual_y(this->id()),
          .l1_bank_remap = {l1_bank_remap.begin(), l1_bank_remap.end()},
          .compute_grid = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(compute_size.x - 1, compute_size.y - 1))),
          .l1_alignment = hal_ref.get_alignment(HalMemType::L1),
@@ -404,14 +441,18 @@ void Device::initialize_device_bank_to_noc_tables(const HalProgrammableCoreType 
     TT_ASSERT((dram_to_noc_sz_in_bytes + l1_to_noc_sz_in_bytes + dram_offset_sz_in_bytes + l1_offset_sz_in_bytes) <= mem_bank_to_noc_size,
         "Size of bank_to_noc table is greater than available space");
 
-    tt::Cluster::instance().write_core(&dram_bank_to_noc_xy_[0], dram_to_noc_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), mem_bank_to_noc_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        &dram_bank_to_noc_xy_[0], dram_to_noc_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), mem_bank_to_noc_addr);
     uint64_t l1_noc_addr = mem_bank_to_noc_addr + dram_to_noc_sz_in_bytes;
-    tt::Cluster::instance().write_core(&l1_bank_to_noc_xy_[0], l1_to_noc_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), l1_noc_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        &l1_bank_to_noc_xy_[0], l1_to_noc_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), l1_noc_addr);
 
     uint64_t dram_offset_addr = l1_noc_addr + l1_to_noc_sz_in_bytes;
-    tt::Cluster::instance().write_core(&dram_bank_offset_map_[0], dram_offset_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), dram_offset_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        &dram_bank_offset_map_[0], dram_offset_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), dram_offset_addr);
     uint64_t l1_offset_addr = dram_offset_addr + dram_offset_sz_in_bytes;
-    tt::Cluster::instance().write_core(&l1_bank_offset_map_[0], l1_offset_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), l1_offset_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        &l1_bank_offset_map_[0], l1_offset_sz_in_bytes, tt_cxy_pair(this->id(), virtual_core), l1_offset_addr);
 }
 
 void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreCoord virtual_core, launch_msg_t *launch_msg, go_msg_t* go_msg) {
@@ -452,8 +493,10 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                 launch_msg->kernel_config.mode = DISPATCH_MODE_HOST;
             } else {
                 std::vector<CoreCoord> physical_dispatch_cores = {};
-                if (dispatch_core_manager::instance().get_dispatch_core_type() == CoreType::WORKER) {
-                    physical_dispatch_cores = this->worker_cores_from_logical_cores(dispatch_core_manager::instance().get_all_logical_dispatch_cores(this->id()));
+                if (MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type() == CoreType::WORKER) {
+                    physical_dispatch_cores = this->worker_cores_from_logical_cores(
+                        MetalContext::instance().get_dispatch_core_manager().get_all_logical_dispatch_cores(
+                            this->id()));
                 }
                 if (std::find(physical_dispatch_cores.begin(), physical_dispatch_cores.end(), virtual_core) != physical_dispatch_cores.end()) {
                     // Dispatch cores - Host writes launch messages
@@ -476,7 +519,8 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                                     ~std::underlying_type<TensixSoftResetOptions>::type(TensixSoftResetOptions::BRISC));
             }
             if (is_idle_eth or !hal_ref.get_eth_fw_is_cooperative()) {
-                tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), virtual_core), reset_val);
+                tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
+                    tt_cxy_pair(this->id(), virtual_core), reset_val);
             }
             if (not llrt::RunTimeOptions::get_instance().get_skip_loading_fw()) {
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
@@ -502,8 +546,11 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
             TT_THROW("Unsupported programable core type {} to initialize build states", magic_enum::enum_name(core_type));
     }
 
-    tt::Cluster::instance().write_core(
-        &jit_build_config.fw_launch_addr_value, sizeof(uint32_t), tt_cxy_pair(this->id_, virtual_core), jit_build_config.fw_launch_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        &jit_build_config.fw_launch_addr_value,
+        sizeof(uint32_t),
+        tt_cxy_pair(this->id_, virtual_core),
+        jit_build_config.fw_launch_addr);
 
     // Initialize each entry in the launch_msg ring buffer with the correct dispatch mode - Cores that don't get a valid
     // launch_message during program execution need to at least have the correct dispatch mode.
@@ -516,12 +563,18 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
         // worker cores (Tensix and active eth) configured with DISPATCH_MODE_DEV
     // When using Slow Dispatch, all cores initialized with DISPATCH_MODE_HOST
     std::vector<launch_msg_t> init_launch_msg_data(launch_msg_buffer_num_entries, *launch_msg);
-    tt::Cluster::instance().write_core(init_launch_msg_data.data(), launch_msg_buffer_num_entries * sizeof(launch_msg_t), tt_cxy_pair(this->id(), virtual_core), this->get_dev_addr(virtual_core, HalL1MemAddrType::LAUNCH));
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        init_launch_msg_data.data(),
+        launch_msg_buffer_num_entries * sizeof(launch_msg_t),
+        tt_cxy_pair(this->id(), virtual_core),
+        this->get_dev_addr(virtual_core, HalL1MemAddrType::LAUNCH));
     uint32_t go_addr = this->get_dev_addr(virtual_core, HalL1MemAddrType::GO_MSG);
-    tt::Cluster::instance().write_core(go_msg, sizeof(go_msg_t), tt_cxy_pair(this->id(), virtual_core), go_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        go_msg, sizeof(go_msg_t), tt_cxy_pair(this->id(), virtual_core), go_addr);
     uint64_t launch_msg_buffer_read_ptr_addr = this->get_dev_addr(virtual_core, HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR);
     uint32_t zero = 0;
-    tt::Cluster::instance().write_core(&zero, sizeof(uint32_t), tt_cxy_pair(this->id(), virtual_core), launch_msg_buffer_read_ptr_addr);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+        &zero, sizeof(uint32_t), tt_cxy_pair(this->id(), virtual_core), launch_msg_buffer_read_ptr_addr);
 }
 
 void Device::reset_cores() {
@@ -537,7 +590,7 @@ void Device::reset_cores() {
         // assert if so
         TT_ASSERT(
             (this->arch() == ARCH::WORMHOLE_B0) and
-                (tt::Cluster::instance().is_ethernet_core(virtual_core, this->id())),
+                (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, this->id())),
             "Invalid core type for context switch check");
         auto core_type_idx = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
         std::uint32_t launch_erisc_addr =
@@ -547,7 +600,7 @@ void Device::reset_cores() {
         return (data[0] != 0);
     };
 
-    auto mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->id_);
+    auto mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_);
     // Assert worker cores + dispatch cores, in case they were in a bad state from before.
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> dispatch_cores, other_dispatch_cores, device_to_early_exit_cores;
     go_msg_t go_msg;
@@ -593,7 +646,8 @@ void Device::reset_cores() {
                 continue;
 
             // Only need to manually reset ethernet dispatch cores, tensix cores are all reset below.
-            if (tt::Cluster::instance().is_ethernet_core(virtual_core, id_and_cores.first)) {
+            if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(
+                    virtual_core, id_and_cores.first)) {
                 // Ethernet cores won't be reset, so just signal the dispatch cores to early exit.
                 if (erisc_app_still_running(virtual_core)) {
                     log_info(
@@ -642,7 +696,8 @@ void Device::reset_cores() {
             // Don't reset dispatch cores for other devices, in case they're still running.
             if (other_dispatch_cores[this->id_].find(worker_core) == other_dispatch_cores[this->id_].end()) {
                 if (this->storage_only_cores_.find(logical_core) == this->storage_only_cores_.end()) {
-                    tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), worker_core));
+                    tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
+                        tt_cxy_pair(this->id(), worker_core));
                 }
             }
         }
@@ -661,12 +716,14 @@ void Device::initialize_and_launch_firmware() {
     std::vector<uint32_t> core_info_vec(sizeof(core_info_msg_t) / sizeof(uint32_t));
     core_info_msg_t *core_info = (core_info_msg_t *) core_info_vec.data();
 
-    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(this->id());
-    uint64_t pcie_chan_base_addr = tt::Cluster::instance().get_pcie_base_addr_from_device(this->id());
-    uint32_t num_host_channels = tt::Cluster::instance().get_num_host_channels(this->id());
+    const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id());
+    uint64_t pcie_chan_base_addr =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_pcie_base_addr_from_device(this->id());
+    uint32_t num_host_channels = tt::tt_metal::MetalContext::instance().get_cluster().get_num_host_channels(this->id());
     uint64_t pcie_chan_end_addr = pcie_chan_base_addr;
     for (int pcie_chan = 0; pcie_chan < num_host_channels; pcie_chan++) {
-        pcie_chan_end_addr += tt::Cluster::instance().get_host_channel_size(this->id(), pcie_chan);
+        pcie_chan_end_addr +=
+            tt::tt_metal::MetalContext::instance().get_cluster().get_host_channel_size(this->id(), pcie_chan);
     }
     core_info->noc_pcie_addr_base = pcie_chan_base_addr;
     core_info->noc_pcie_addr_end = pcie_chan_end_addr;
@@ -715,7 +772,8 @@ void Device::initialize_and_launch_firmware() {
     // TODO(PGK/Almeet): fix this w/ new UMD
     std::vector<uint32_t> harvested_rows;
     uint32_t harvested_noc_rows = CoordinateManager::shuffle_tensix_harvesting_mask_to_noc0_coords(
-        tt::Cluster::instance().get_soc_desc(this->id()).arch, tt::Cluster::instance().get_harvesting_mask(this->id()));
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id()).arch,
+        tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(this->id()));
     for (uint32_t y = 0; y < soc_d.grid_size.y; y++) {
         bool row_harvested = (harvested_noc_rows >> y) & 0x1;
         if (row_harvested) {
@@ -807,7 +865,7 @@ void Device::initialize_and_launch_firmware() {
     }
 
     // Barrier between L1 writes above and deassert below
-    tt::Cluster::instance().l1_barrier(this->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
 
     // Deassert worker cores
     TensixSoftResetOptions reset_val;
@@ -820,7 +878,8 @@ void Device::initialize_and_launch_firmware() {
         } else {
             reset_val = TENSIX_DEASSERT_SOFT_RESET;
         }
-        tt::Cluster::instance().deassert_risc_reset_at_core(tt_cxy_pair(this->id(), worker_core), reset_val);
+        tt::tt_metal::MetalContext::instance().get_cluster().deassert_risc_reset_at_core(
+            tt_cxy_pair(this->id(), worker_core), reset_val);
     }
 
     // Wait until fw init is done, ensures the next launch msg doesn't get
@@ -875,7 +934,7 @@ void Device::clear_l1_state() {
             hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, zero_vec_addr));
     }
     // TODO: clear idle eriscs as well
-    tt::Cluster::instance().l1_barrier(this->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
 }
 
 void Device::compile_command_queue_programs() {
@@ -884,15 +943,19 @@ void Device::compile_command_queue_programs() {
         auto command_queue_program_ptr = create_and_compile_cq_program(this);
         this->command_queue_programs_.push_back(std::move(command_queue_program_ptr));
         // Since devices could be set up in any order, on mmio device do a pass and populate cores for tunnelers.
-        if (tt::Cluster::instance().get_mmio_device_tunnel_count(this->id_) > 0) {
-            tunnels_from_mmio_ = tt::Cluster::instance().get_tunnels_from_mmio_device(this->id_);
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_mmio_device_tunnel_count(this->id_) > 0) {
+            tunnels_from_mmio_ =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(this->id_);
             for (auto& tunnel : tunnels_from_mmio_) {
                 for (uint32_t tunnel_stop = 0; tunnel_stop < tunnel.size() - 1; tunnel_stop++) {
                     chip_id_t device_id = tunnel[tunnel_stop];
                     chip_id_t ds_device_id = tunnel[tunnel_stop + 1];
-                    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(ds_device_id);
+                    uint16_t channel =
+                        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
+                            ds_device_id);
                     // Only one tunneler per connection, use CQ ID 0
-                    dispatch_core_manager::instance().tunneler_core(device_id, ds_device_id, channel, 0);
+                    MetalContext::instance().get_dispatch_core_manager().tunneler_core(
+                        device_id, ds_device_id, channel, 0);
                 }
             }
         }
@@ -905,7 +968,8 @@ void Device::compile_command_queue_programs() {
 // Writes issue and completion queue pointers to device and in sysmem and loads fast dispatch program onto dispatch cores
 void Device::configure_command_queue_programs() {
     chip_id_t device_id = this->id();
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     IDevice* mmio_device = tt::DevicePool::instance().get_active_device(mmio_device_id);
 
     std::vector<uint32_t> zero = {0x0}; // Reset state in case L1 Clear is disabled.
@@ -918,9 +982,11 @@ void Device::configure_command_queue_programs() {
 
     // Reset host-side command queue pointers for all channels controlled by this mmio device
     if (this->is_mmio_capable()) {
-        for (chip_id_t serviced_device_id : tt::Cluster::instance().get_devices_controlled_by_mmio_device(device_id)) {
-            uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(serviced_device_id);
-            CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
+        for (chip_id_t serviced_device_id :
+             tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(device_id)) {
+            uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
+                serviced_device_id);
+            CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
             uint32_t host_issue_q_rd_ptr = DispatchMemMap::get(dispatch_core_type)
                                                .get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
             uint32_t host_issue_q_wr_ptr = DispatchMemMap::get(dispatch_core_type)
@@ -943,7 +1009,12 @@ void Device::configure_command_queue_programs() {
                 pointers[host_completion_q_wr_ptr / sizeof(uint32_t)] = (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
                 pointers[host_completion_q_rd_ptr / sizeof(uint32_t)] = (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + get_absolute_cq_offset(channel, cq_id, cq_size)) >> 4;
 
-                tt::Cluster::instance().write_sysmem(pointers.data(), pointers.size() * sizeof(uint32_t), get_absolute_cq_offset(channel, cq_id, cq_size), mmio_device_id, get_umd_channel(channel));
+                tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
+                    pointers.data(),
+                    pointers.size() * sizeof(uint32_t),
+                    get_absolute_cq_offset(channel, cq_id, cq_size),
+                    mmio_device_id,
+                    get_umd_channel(channel));
             }
         }
     }
@@ -954,7 +1025,7 @@ void Device::configure_command_queue_programs() {
     // Run the cq program
     program_dispatch::finalize_program_offsets(command_queue_program, this);
     detail::ConfigureDeviceWithProgram(this, command_queue_program, true);
-    tt::Cluster::instance().l1_barrier(this->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
 }
 
 void Device::init_command_queue_host() {
@@ -1016,7 +1087,7 @@ void Device::init_fabric() {
 
     // Note: the l1_barrier below is needed to be sure writes to cores that
     // don't get the GO mailbox (eg, storage cores) have all landed
-    tt::Cluster::instance().l1_barrier(this->id());
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->logical_cores();
     for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
@@ -1092,7 +1163,7 @@ bool Device::close() {
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> cores_to_skip;
     this->get_associated_dispatch_virtual_cores(not_done_dispatch_cores, cores_to_skip);
 
-    auto mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->id_);
+    auto mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_);
     std::unordered_set<CoreCoord> wait_for_cores = not_done_dispatch_cores[mmio_device_id];
 
     llrt::internal_::wait_until_cores_done(mmio_device_id, RUN_MSG_GO, wait_for_cores);
@@ -1109,7 +1180,8 @@ bool Device::close() {
 
             if (cores_to_skip[mmio_device_id].find(worker_core) == cores_to_skip[mmio_device_id].end()) {
                 if (this->storage_only_cores_.find(logical_core) == this->storage_only_cores_.end()) {
-                    tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), worker_core));
+                    tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
+                        tt_cxy_pair(this->id(), worker_core));
                 }
             } else {
                 log_debug(tt::LogMetal, "{} will not be Reset when closing Device {}", worker_core.str(), this->id());
@@ -1124,23 +1196,25 @@ bool Device::close() {
                 TENSIX_ASSERT_SOFT_RESET &
                 static_cast<TensixSoftResetOptions>(
                     ~std::underlying_type<TensixSoftResetOptions>::type(TensixSoftResetOptions::BRISC));
-            tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(this->id(), virtual_eth_core), reset_val);
+            tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
+                tt_cxy_pair(this->id(), virtual_eth_core), reset_val);
         }
     }
 
     if (this->id_ != mmio_device_id) {
         for (auto it = not_done_dispatch_cores[mmio_device_id].begin(); it != not_done_dispatch_cores[mmio_device_id].end(); it++) {
             const auto &virtual_core = *it;
-            if(tt::Cluster::instance().is_ethernet_core(virtual_core, this->id_)) {
+            if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, this->id_)) {
                 log_debug(tt::LogMetal, "Ethernet dispatch core {} on Device {} is idle. Closing Device {}", virtual_core.str(), mmio_device_id, this->id());
             } else {
                 log_debug(tt::LogMetal, "Resetting core {} on Device {} when closing Device {}", virtual_core.str(), mmio_device_id, this->id());
-                tt::Cluster::instance().assert_risc_reset_at_core(tt_cxy_pair(mmio_device_id, virtual_core));
+                tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
+                    tt_cxy_pair(mmio_device_id, virtual_core));
             }
         }
     }
 
-    tt::Cluster::instance().l1_barrier(id_);
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(id_);
 
     this->compute_cores_.clear();
     this->storage_only_cores_.clear();
@@ -1161,31 +1235,33 @@ Device::~Device() {
     }
 }
 
-tt::ARCH Device::arch() const {
-    return tt::Cluster::instance().arch();
-}
+tt::ARCH Device::arch() const { return tt::tt_metal::MetalContext::instance().get_cluster().arch(); }
 
-int Device::num_dram_channels() const { return tt::Cluster::instance().get_soc_desc(id_).get_num_dram_views(); }
+int Device::num_dram_channels() const {
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_num_dram_views();
+}
 
 uint32_t Device::l1_size_per_core() const {
-    return tt::Cluster::instance().get_soc_desc(id_).worker_l1_size;
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).worker_l1_size;
 }
-uint32_t Device::dram_size_per_channel() const { return tt::Cluster::instance().get_soc_desc(id_).dram_view_size; }
+uint32_t Device::dram_size_per_channel() const {
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).dram_view_size;
+}
 
 CoreCoord Device::grid_size() const {
-    return tt::Cluster::instance().get_soc_desc(id_).grid_size;
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).grid_size;
 }
 
 CoreCoord Device::logical_grid_size() const {
-    return tt::Cluster::instance().get_soc_desc(id_).get_grid_size(CoreType::TENSIX);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_grid_size(CoreType::TENSIX);
 }
 
 CoreCoord Device::dram_grid_size() const {
-    return tt::Cluster::instance().get_soc_desc(id_).get_dram_grid_size();
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_dram_grid_size();
 }
 
 CoreCoord Device::compute_with_storage_grid_size() const {
-    const auto& dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     return tt::get_compute_grid_size(id_, num_hw_cqs_, dispatch_core_config);
 }
 
@@ -1206,7 +1282,7 @@ CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) co
 }
 
 CoreCoord Device::physical_worker_core_from_logical_core(const CoreCoord &logical_core) const {
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
     return soc_desc.get_physical_tensix_core_from_logical(logical_core);
 }
 
@@ -1227,11 +1303,13 @@ std::vector<CoreCoord> Device::ethernet_cores_from_logical_cores(const std::vect
 }
 
 CoreCoord Device::virtual_core_from_logical_core(const CoreCoord &logical_coord, const CoreType& core_type) const {
-    return tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(this->id_, logical_coord, core_type);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+        this->id_, logical_coord, core_type);
 }
 
 CoreCoord Device::virtual_core_from_physical_core(const CoreCoord& physical_coord) const {
-    return tt::Cluster::instance().get_virtual_coordinate_from_physical_coordinates(this->id_, physical_coord);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_physical_coordinates(
+        this->id_, physical_coord);
 }
 
 CoreCoord Device::worker_core_from_logical_core(const CoreCoord &logical_core) const {
@@ -1243,7 +1321,8 @@ CoreCoord Device::ethernet_core_from_logical_core(const CoreCoord &logical_core)
 }
 
 CoreCoord Device::logical_core_from_ethernet_core(const CoreCoord &ethernet_core) const {
-    return tt::Cluster::instance().get_logical_ethernet_core_from_virtual(this->id(), ethernet_core);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
+        this->id(), ethernet_core);
 }
 
 uint32_t Device::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
@@ -1278,17 +1357,22 @@ uint32_t Device::num_sub_devices() const {
 }
 
 CoreCoord Device::dram_core_from_dram_channel(uint32_t dram_channel) const {
-    return tt::Cluster::instance().get_soc_desc(id_).get_preferred_worker_core_for_dram_view(dram_channel);
+    return tt::tt_metal::MetalContext::instance()
+        .get_cluster()
+        .get_soc_desc(id_)
+        .get_preferred_worker_core_for_dram_view(dram_channel);
 }
 
 CoreCoord Device::logical_core_from_dram_channel(uint32_t dram_channel) const {
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    return tt::Cluster::instance().get_soc_desc(id_).get_logical_core_for_dram_view(dram_channel);
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_logical_core_for_dram_view(
+        dram_channel);
 }
 
 uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(this->id_);
-    return tt::Cluster::instance().get_soc_desc(id_).get_dram_channel_from_logical_core(logical_core);
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id_);
+    return tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(id_).get_dram_channel_from_logical_core(
+        logical_core);
 }
 
 std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address() const {
@@ -1511,7 +1595,7 @@ void Device::generate_device_bank_to_noc_tables()
         l1_bank_offset_map_[bank_id] = allocator->get_bank_offset(BufferType::L1, bank_id);
     }
 
-    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(this->id());
+    const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id());
 
     dram_bank_to_noc_xy_.clear();
     dram_bank_to_noc_xy_.reserve(tt::tt_metal::hal_ref.get_num_nocs() * dram_noc_coord_per_bank.size());
@@ -1659,7 +1743,7 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
 }
 
 HalProgrammableCoreType Device::get_programmable_core_type(CoreCoord virtual_core) const {
-    if (!tt::Cluster::instance().is_ethernet_core(virtual_core, this->id_)) {
+    if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, this->id_)) {
         return HalProgrammableCoreType::TENSIX;
     }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -31,13 +31,13 @@
 #include "profiler_types.hpp"
 #include "rtoptions.hpp"
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt_metal.hpp>
-#include <tt-metalium/metal_context.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
-#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -79,7 +79,8 @@ std::pair<int, int> get_cpu_cores_for_dispatch_threads(
     int core_assigned_to_device_completion_queue_reader = 0;
     uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
     // Get NUMA node that the current device is mapped to through UMD
-    int numa_node_for_device = tt::Cluster::instance().get_numa_node_for_device(mmio_controlled_device_id);
+    int numa_node_for_device =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_numa_node_for_device(mmio_controlled_device_id);
 
     if (numa_available() != -1 and
         cpu_cores_per_numa_node.find(numa_node_for_device) != cpu_cores_per_numa_node.end()) {
@@ -184,11 +185,13 @@ void DevicePool::init_profiler_devices() const {
 #if defined(TRACY_ENABLE)
     for (const auto& dev : this->get_all_active_devices()) {
         // For Galaxy init, we only need to loop over mmio devices
-        const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(dev->id());
+        const auto& mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id());
         if (mmio_device_id != dev->id()) {
             continue;
         }
-        auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id);
+        auto tunnels_from_mmio =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         detail::InitDeviceProfiler(dev);
         log_info(tt::LogMetal, "Profiler started on device {}", mmio_device_id);
         if (not this->skip_remote_devices) {
@@ -236,21 +239,22 @@ void DevicePool::initialize(
     _inst->device_pool_creation_thread_id = std::this_thread::get_id();
 
     // Never skip for TG Cluster
-    bool skip = not tt::Cluster::instance().is_galaxy_cluster();
+    bool skip = not tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
     std::vector<chip_id_t> target_mmio_ids;
     for (const auto& device_id : device_ids) {
         TT_FATAL(
-            device_id < tt::Cluster::instance().number_of_devices(),
+            device_id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(),
             "Device index {} out of range. There are {} devices available.",
             device_id,
-            tt::Cluster::instance().number_of_devices());
-        const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+            tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices());
+        const auto& mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
         if (std::find(target_mmio_ids.begin(), target_mmio_ids.end(), mmio_device_id) == target_mmio_ids.end()) {
             target_mmio_ids.push_back(mmio_device_id);
         }
         skip &= (device_id == mmio_device_id);
     }
-    if (target_mmio_ids.size() != tt::Cluster::instance().number_of_pci_devices()) {
+    if (target_mmio_ids.size() != tt::tt_metal::MetalContext::instance().get_cluster().number_of_pci_devices()) {
         log_warning(
             tt::LogMetal,
             "Opening subset of mmio devices slows down UMD read/write to remote chips. If opening more devices, "
@@ -262,7 +266,8 @@ void DevicePool::initialize(
     _inst->add_devices_to_pool(device_ids);
     _inst->init_firmware_on_active_devices();
 
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(true, target_mmio_ids);
+    tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(
+        true, target_mmio_ids);
     _inst->wait_for_fabric_router_sync();
     _inst->init_profiler_devices();
 }
@@ -297,12 +302,15 @@ void DevicePool::initialize_active_devices() const {
     const auto& active_devices = this->get_all_active_devices();
 
     // Activate fabric (must be before FD)
-    FabricConfig fabric_config = tt::Cluster::instance().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_1D || fabric_config == FabricConfig::FABRIC_2D ||
         fabric_config == FabricConfig::FABRIC_2D_PUSH) {
         if (fabric_config == FabricConfig::FABRIC_2D || fabric_config == FabricConfig::FABRIC_2D_PUSH) {
             // write routing tables to all ethernet cores
-            tt::Cluster::instance().get_control_plane()->write_routing_tables_to_all_chips();
+            tt::tt_metal::MetalContext::instance()
+                .get_cluster()
+                .get_control_plane()
+                ->write_routing_tables_to_all_chips();
         }
 
         // Initialize fabric on mmio device
@@ -319,12 +327,14 @@ void DevicePool::initialize_active_devices() const {
 
     for (auto dev : active_devices) {
         // For Galaxy init, we only need to loop over mmio devices
-        const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(dev->id());
+        const auto& mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id());
         if (mmio_device_id != dev->id()) {
             continue;
         }
 
-        auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id);
+        auto tunnels_from_mmio =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         populate_cq_static_args(dev);
         dev->init_command_queue_device();
         if (not this->skip_remote_devices) {
@@ -343,10 +353,10 @@ void DevicePool::initialize_active_devices() const {
 
 void DevicePool::activate_device(chip_id_t id) {
     TT_FATAL(
-        id < tt::Cluster::instance().number_of_devices(),
+        id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(),
         "Device index {} out of range. There are {} devices available.",
         id,
-        tt::Cluster::instance().number_of_devices());
+        tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices());
     const std::lock_guard<std::mutex> lock(this->lock);
     if (this->devices.size() < id + 1) {
         this->devices.reserve(id + 1);
@@ -410,7 +420,8 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
     std::set<chip_id_t> devices_to_activate;
     if (this->skip_remote_devices) {
         for (const auto& device_id : device_ids) {
-            const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+            const auto& mmio_device_id =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
             TT_ASSERT(device_id == mmio_device_id, "Skipping remote devices is only available for mmio devices");
             devices_to_activate.insert(device_id);
         }
@@ -418,9 +429,11 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         std::vector<chip_id_t> all_device_ids = {};
         for (const auto& device_id : device_ids) {
             // Get list of all devices in the cluster connected to the passed in device_ids
-            const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+            const auto& mmio_device_id =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
             for (const auto& mmio_controlled_device_id :
-                 tt::Cluster::instance().get_devices_controlled_by_mmio_device(mmio_device_id)) {
+                 tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(
+                     mmio_device_id)) {
                 devices_to_activate.insert(mmio_controlled_device_id);
             }
         }
@@ -432,11 +445,11 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
         }
     }
 
-    FabricConfig fabric_config = tt::Cluster::instance().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     // Only can launch Fabric if all devices are active
     if (fabric_config == FabricConfig::FABRIC_1D || fabric_config == FabricConfig::FABRIC_2D ||
         fabric_config == FabricConfig::FABRIC_2D_PUSH) {
-        for (int i = 0; i < tt::Cluster::instance().number_of_devices(); i++) {
+        for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
             if (not _inst->is_device_active(i)) {
                 // Fabric currently requires all devices to be active
                 log_fatal(tt::LogMetal, "Fabric is being used but {} is not active", i);
@@ -451,7 +464,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 }
 
 void DevicePool::wait_for_fabric_router_sync() const {
-    FabricConfig fabric_config = tt::Cluster::instance().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_1D) {
         static constexpr std::size_t edm_buffer_size =
             tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
@@ -461,14 +474,16 @@ void DevicePool::wait_for_fabric_router_sync() const {
 
         auto wait_for_handshake = [&](IDevice* dev) {
             std::vector<std::uint32_t> master_router_status{0};
-            auto fabric_ethernet_channels = tt::Cluster::instance().get_fabric_ethernet_channels(dev->id());
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
             if (fabric_ethernet_channels.empty()) {
                 return;
             }
 
             tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
-                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                    dev->id(), fabric_master_router_chan);
             auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
             while (master_router_status[0] != tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE) {
                 tt_metal::detail::ReadFromDeviceL1(
@@ -485,11 +500,13 @@ void DevicePool::wait_for_fabric_router_sync() const {
         };
 
         for (const auto& dev : this->get_all_active_devices()) {
-            if (tt::Cluster::instance().get_associated_mmio_device(dev->id()) != dev->id()) {
+            if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id()) !=
+                dev->id()) {
                 continue;
             }
 
-            auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(dev->id());
+            auto tunnels_from_mmio =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(dev->id());
             for (auto i = 0; i < tunnels_from_mmio.size(); i++) {
                 // Need to poll on devices from farthest to the closest.
                 for (auto j = tunnels_from_mmio[i].size() - 1; j > 0; j--) {
@@ -497,7 +514,7 @@ void DevicePool::wait_for_fabric_router_sync() const {
                 }
             }
 
-            if (tt::Cluster::instance().get_cluster_type() != tt::ClusterType::TG) {
+            if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() != tt::ClusterType::TG) {
                 // 1d fabric is not launched on TG gateways
                 wait_for_handshake(dev);
             }
@@ -508,20 +525,25 @@ void DevicePool::wait_for_fabric_router_sync() const {
 
         std::vector<std::uint32_t> master_router_status{0};
         for (const auto& dev : this->get_all_active_devices()) {
-            auto fabric_ethernet_channels = tt::Cluster::instance().get_fabric_ethernet_channels(dev->id());
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
             if (fabric_ethernet_channels.empty()) {
                 continue;
             }
 
             tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
-                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                    dev->id(), fabric_master_router_chan);
             auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
 
-            auto [mesh_id, chip_id] =
-                tt::Cluster::instance().get_control_plane()->get_mesh_chip_id_from_physical_chip_id(dev->id());
+            auto [mesh_id, chip_id] = tt::tt_metal::MetalContext::instance()
+                                          .get_cluster()
+                                          .get_control_plane()
+                                          ->get_mesh_chip_id_from_physical_chip_id(dev->id());
             auto num_routers =
-                tt::Cluster::instance().get_control_plane()->get_num_active_fabric_routers(mesh_id, chip_id);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane()->get_num_active_fabric_routers(
+                    mesh_id, chip_id);
             while (master_router_status[0] != num_routers) {
                 tt_metal::detail::ReadFromDeviceL1(
                     dev,
@@ -572,7 +594,8 @@ void DevicePool::init_firmware_on_active_devices() const {
     const auto& active_devices = this->get_all_active_devices();
     for (const auto& dev : active_devices) {
         // For Galaxy init, we only need to loop over mmio devices
-        const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(dev->id());
+        const auto& mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id());
         if (mmio_device_id != dev->id()) {
             continue;
         }
@@ -580,19 +603,20 @@ void DevicePool::init_firmware_on_active_devices() const {
             tt::LogMetal,
             "MMIO Device {} Tunnel Count: {}",
             mmio_device_id,
-            tt::Cluster::instance().get_mmio_device_tunnel_count(mmio_device_id));
+            tt::tt_metal::MetalContext::instance().get_cluster().get_mmio_device_tunnel_count(mmio_device_id));
         log_debug(
             tt::LogMetal,
             "MMIO Device {} Tunnel Depth: {}",
             mmio_device_id,
-            tt::Cluster::instance().get_mmio_device_max_tunnel_depth(mmio_device_id));
+            tt::tt_metal::MetalContext::instance().get_cluster().get_mmio_device_max_tunnel_depth(mmio_device_id));
         log_debug(
             tt::LogMetal,
             "MMIO Device {} Tunnel Stop: {}",
             mmio_device_id,
-            tt::Cluster::instance().get_device_tunnel_depth(mmio_device_id));
+            tt::tt_metal::MetalContext::instance().get_cluster().get_device_tunnel_depth(mmio_device_id));
 
-        auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id);
+        auto tunnels_from_mmio =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         this->initialize_host(dev);
         if (not this->skip_remote_devices) {
             for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
@@ -615,7 +639,7 @@ DevicePool::DevicePool() {
     log_debug(tt::LogMetal, "DevicePool constructor");
     bool use_numa_node_based_thread_binding = parse_env("TT_METAL_NUMA_BASED_AFFINITY", false);
     std::vector<chip_id_t> all_device_ids;
-    for (int i = 0; i < tt::Cluster::instance().number_of_devices(); i++) {
+    for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
         all_device_ids.emplace_back((chip_id_t)i);
     }
     std::unordered_set<uint32_t> free_cores = {};
@@ -654,11 +678,12 @@ bool DevicePool::close_device(chip_id_t device_id) {
     // from device close, we can call this on remote devices too
     ZoneScoped;
     detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+    tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
     bool pass = true;
-    const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    const auto& mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     for (const auto& mmio_controlled_device_id :
-         tt::Cluster::instance().get_devices_controlled_by_mmio_device(mmio_device_id)) {
+         tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id)) {
         auto device = get_device(mmio_controlled_device_id);
         if (device && device->is_initialized()) {
             pass &= device->close();
@@ -678,12 +703,14 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
     // For Galaxy if an mmio device's tunnels are being closed, close the mmio device as well
     std::unordered_set<chip_id_t> mmio_devices_to_close;
     for (const auto& dev : devices) {
-        const auto& mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(dev->id());
+        const auto& mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id());
         if (mmio_devices_to_close.find(mmio_device_id) != mmio_devices_to_close.end()) {
             continue;
         }
         auto mmio_dev_handle = tt::DevicePool::instance().get_active_device(mmio_device_id);
-        auto tunnels_from_mmio = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id);
+        auto tunnels_from_mmio =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         // iterate over all tunnels origination from this mmio device
         for (auto t : tunnels_from_mmio) {
             // iterate over all tunneled devices (tunnel stops) in this tunnel
@@ -706,7 +733,7 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
     // any workloads on them
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
-        if (tt::Cluster::instance().is_galaxy_cluster() and dev->is_mmio_capable()) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() and dev->is_mmio_capable()) {
             continue;
         }
         dev->synchronize();  // Synchronize worker queue
@@ -714,7 +741,7 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
     }
 
     // Terminate fabric routers
-    FabricConfig fabric_config = tt::Cluster::instance().get_fabric_config();
+    FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_1D) {
         std::vector<uint32_t> signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
         static constexpr std::size_t edm_buffer_size =
@@ -724,19 +751,22 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
 
         auto fabric_router_sync_sem_addr = edm_config.termination_signal_address;
         for (const auto& dev : this->get_all_active_devices()) {
-            if (dev->is_mmio_capable() && (tt::Cluster::instance().get_cluster_type() == tt::ClusterType::TG)) {
+            if (dev->is_mmio_capable() &&
+                (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG)) {
                 // 1d fabric is not launched on TG gateways
                 continue;
             }
 
-            auto fabric_ethernet_channels = tt::Cluster::instance().get_fabric_ethernet_channels(dev->id());
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
             if (fabric_ethernet_channels.empty()) {
                 continue;
             }
 
             tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
-                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                    dev->id(), fabric_master_router_chan);
             auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
             tt_metal::detail::WriteToDeviceL1(
                 dev, fabric_master_router_core, fabric_router_sync_sem_addr, signal, CoreType::ETH);
@@ -746,21 +776,23 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
         auto fabric_router_sync_sem_addr =
             hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
         for (const auto& dev : this->get_all_active_devices()) {
-            auto fabric_ethernet_channels = tt::Cluster::instance().get_fabric_ethernet_channels(dev->id());
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
             if (fabric_ethernet_channels.empty()) {
                 continue;
             }
 
             tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
-                tt::Cluster::instance().get_virtual_eth_core_from_channel(dev->id(), fabric_master_router_chan);
+                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                    dev->id(), fabric_master_router_chan);
             auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
             tt_metal::detail::WriteToDeviceL1(
                 dev, fabric_master_router_core, fabric_router_sync_sem_addr, master_router_terminate, CoreType::ETH);
         }
     }
 
-    tt::Cluster::instance().set_internal_routing_info_for_ethernet_cores(false);
+    tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
         dev->close();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -32,6 +32,8 @@
 #include "rtoptions.hpp"
 #include "span.hpp"
 #include "tt_cluster.hpp"
+#include <tt_metal.hpp>
+#include <tt-metalium/metal_context.hpp>
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
@@ -217,12 +219,8 @@ void DevicePool::initialize(
     tt::stl::Span<const std::uint32_t> l1_bank_remap) noexcept {
     ZoneScoped;
     log_debug(tt::LogMetal, "DevicePool initialize");
-    // Initialize the dispatch core manager, responsible for assigning dispatch cores
-    tt::tt_metal::dispatch_core_manager::initialize(dispatch_core_config, num_hw_cqs);
-    // Initialize the dispatch query layer, used by runtime command generation
-    tt_metal::DispatchQueryManager::initialize(num_hw_cqs);
-    // Initialize DispatchSettings with defaults
-    tt_metal::DispatchSettings::initialize(tt::Cluster::instance());
+    tt::tt_metal::MetalContext::instance().initialize(
+        dispatch_core_config, num_hw_cqs, {l1_bank_remap.begin(), l1_bank_remap.end()});
 
     if (_inst == nullptr) {
         static DevicePool device_pool{};

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -6,8 +6,8 @@
 #include <tt-metalium/dispatch_mem_map.hpp>
 #include <tt-metalium/dispatch_settings.hpp>
 
-#include "dispatch_core_manager.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/context/metal_context.hpp"
 
 enum class CoreType;
 
@@ -25,13 +25,13 @@ uint32_t get_absolute_cq_offset(uint16_t channel, uint8_t cq_id, uint32_t cq_siz
 template <bool addr_16B>
 uint32_t get_cq_issue_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
+    chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
     uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t issue_q_rd_ptr =
         DispatchMemMap::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
-    tt::Cluster::instance().read_sysmem(
+    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
         &recv,
         sizeof(uint32_t),
         issue_q_rd_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
@@ -49,12 +49,12 @@ template uint32_t get_cq_issue_rd_ptr<false>(chip_id_t chip_id, uint8_t cq_id, u
 template <bool addr_16B>
 uint32_t get_cq_issue_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t issue_q_wr_ptr =
         DispatchMemMap::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
-    tt::Cluster::instance().read_sysmem(
+    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
         &recv, sizeof(uint32_t), issue_q_wr_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
     if constexpr (!addr_16B) {
         return recv << 4;
@@ -68,13 +68,13 @@ template uint32_t get_cq_issue_wr_ptr<false>(chip_id_t chip_id, uint8_t cq_id, u
 template <bool addr_16B>
 uint32_t get_cq_completion_wr_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
+    chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
     uint32_t channel_offset = (channel >> 2) * tt::tt_metal::DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t completion_q_wr_ptr =
         DispatchMemMap::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
-    tt::Cluster::instance().read_sysmem(
+    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
         &recv,
         sizeof(uint32_t),
         completion_q_wr_ptr + channel_offset + get_relative_cq_offset(cq_id, cq_size),
@@ -92,12 +92,12 @@ template uint32_t get_cq_completion_wr_ptr<false>(chip_id_t chip_id, uint8_t cq_
 template <bool addr_16B>
 inline uint32_t get_cq_completion_rd_ptr(chip_id_t chip_id, uint8_t cq_id, uint32_t cq_size) {
     uint32_t recv;
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(chip_id);
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(chip_id);
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(chip_id);
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t completion_q_rd_ptr =
         DispatchMemMap::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
-    tt::Cluster::instance().read_sysmem(
+    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
         &recv, sizeof(uint32_t), completion_q_rd_ptr + get_relative_cq_offset(cq_id, cq_size), mmio_device_id, channel);
     if constexpr (!addr_16B) {
         return recv << 4;

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dispatch_core_common.hpp"
-#include "dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "get_platform_architecture.hpp"
 #include <umd/device/types/arch.h>
 
@@ -16,8 +16,12 @@ DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
                                                                               : DispatchCoreAxis::ROW;
 }
 
-DispatchCoreConfig get_dispatch_core_config() { return dispatch_core_manager::instance().get_dispatch_core_config(); }
+DispatchCoreConfig get_dispatch_core_config() {
+    return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
+}
 
-CoreType get_dispatch_core_type() { return dispatch_core_manager::instance().get_dispatch_core_type(); };
+CoreType get_dispatch_core_type() {
+    return MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
+};
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -19,23 +19,6 @@
 
 namespace tt::tt_metal {
 
-dispatch_core_manager* dispatch_core_manager::_inst = nullptr;
-
-void dispatch_core_manager::initialize(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) noexcept {
-    log_debug(tt::LogMetal, "DevicePool initialize");
-    if (_inst == nullptr) {
-        static dispatch_core_manager dispatch_core_manager(dispatch_core_config, num_hw_cqs);
-        _inst = &dispatch_core_manager;
-    } else if (_inst->dispatch_core_config_ != dispatch_core_config or num_hw_cqs != _inst->num_hw_cqs) {
-        _inst->reset_dispatch_core_manager(dispatch_core_config, num_hw_cqs);
-    }
-}
-
-dispatch_core_manager& dispatch_core_manager::instance() {
-    TT_ASSERT(dispatch_core_manager::_inst != nullptr, "Trying to get dispatch_core_manager without initializing it");
-    return *dispatch_core_manager::_inst;
-}
-
 const tt_cxy_pair& dispatch_core_manager::prefetcher_core(chip_id_t device_id, uint16_t channel, uint8_t cq_id) {
     dispatch_core_placement_t& assignment = this->dispatch_core_assignments[device_id][channel][cq_id];
     if (assignment.prefetcher.has_value()) {

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -14,7 +14,7 @@
 #include "core_descriptor.hpp"
 #include "dispatch_core_common.hpp"
 #include "logger.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.h>
 
 namespace tt::tt_metal {
@@ -25,7 +25,8 @@ const tt_cxy_pair& dispatch_core_manager::prefetcher_core(chip_id_t device_id, u
         return assignment.prefetcher.value();
     }
     // Issue queue interface is on the MMIO device
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     CoreCoord issue_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.prefetcher = tt_cxy_pair(mmio_device_id, issue_queue_coord.x, issue_queue_coord.y);
     log_dispatch_assignment("Prefetcher", assignment.prefetcher.value(), device_id, channel, cq_id);
@@ -65,7 +66,8 @@ const tt_cxy_pair& dispatch_core_manager::mux_core(chip_id_t device_id, uint16_t
         return assignment.mux.value();
     }
     // Mux interface is on the MMIO device
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     CoreCoord mux_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.mux = tt_cxy_pair(mmio_device_id, mux_coord.x, mux_coord.y);
     log_dispatch_assignment("Mux", assignment.mux.value(), device_id, channel, cq_id);
@@ -98,7 +100,8 @@ const tt_cxy_pair& dispatch_core_manager::demux_core(chip_id_t device_id, uint16
         return assignment.demux.value();
     }
     // demux interface is on the MMIO device
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     CoreCoord demux_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.demux = tt_cxy_pair(mmio_device_id, demux_coord.x, demux_coord.y);
     log_dispatch_assignment("Demux", assignment.demux.value(), device_id, channel, cq_id);
@@ -132,8 +135,8 @@ const tt_cxy_pair& dispatch_core_manager::tunneler_core(
         return assignment.tunneler.value();
     }
 
-    auto [us_core, ds_core] =
-        tt::Cluster::instance().get_eth_tunnel_core(upstream_device_id, device_id, EthRouterMode::BI_DIR_TUNNELING);
+    auto [us_core, ds_core] = tt::tt_metal::MetalContext::instance().get_cluster().get_eth_tunnel_core(
+        upstream_device_id, device_id, EthRouterMode::BI_DIR_TUNNELING);
 
     assignment.tunneler = us_core;
     assignment.tunneler_d = ds_core;
@@ -160,7 +163,8 @@ const tt_cxy_pair& dispatch_core_manager::completion_queue_writer_core(
         return assignment.completion_queue_writer.value();
     }
     // Completion queue interface is on the MMIO device
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     CoreCoord completion_queue_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.completion_queue_writer =
         tt_cxy_pair(mmio_device_id, completion_queue_coord.x, completion_queue_coord.y);
@@ -189,7 +193,8 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_core(chip_id_t device_id, u
     if (assignment.dispatcher.has_value()) {
         return assignment.dispatcher.value();
     }
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
     CoreCoord dispatcher_coord = this->get_next_available_dispatch_core(mmio_device_id);
     assignment.dispatcher = tt_cxy_pair(mmio_device_id, dispatcher_coord.x, dispatcher_coord.y);
     TT_ASSERT(
@@ -237,7 +242,8 @@ const tt_cxy_pair& dispatch_core_manager::dispatcher_s_core(chip_id_t device_id,
     }
     CoreCoord dispatcher_s_coord;
     if (this->get_dispatch_core_type() == CoreType::WORKER) {
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
+        chip_id_t mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
         if (mmio_device_id == device_id) {
             // dispatch_s is on the same tensix core as dispatch_hd
             dispatcher_s_coord = this->dispatcher_core(device_id, channel, cq_id);
@@ -280,7 +286,8 @@ void dispatch_core_manager::reset_dispatch_core_manager(
     this->dispatch_core_assignments.clear();
     this->available_dispatch_cores_by_device.clear();
     this->dispatch_core_config_ = dispatch_core_config;
-    for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
+    for (chip_id_t device_id = 0; device_id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices();
+         device_id++) {
         std::list<CoreCoord>& logical_dispatch_cores = this->available_dispatch_cores_by_device[device_id];
         for (const CoreCoord& logical_dispatch_core :
              tt::get_logical_dispatch_cores(device_id, MAX_NUM_HW_CQS, dispatch_core_config)) {
@@ -293,7 +300,8 @@ void dispatch_core_manager::reset_dispatch_core_manager(
         // the core descriptor (ex: 2 CQs on N300 need 10 dispatch cores and the core descriptor only allocates 6).
         // Infer the remaining dispatch cores from the idle eth core list (this is device dependent).
         if (dispatch_core_config.get_core_type() == CoreType::ETH) {
-            for (const auto& idle_eth_core : tt::Cluster::instance().get_inactive_ethernet_cores(device_id)) {
+            for (const auto& idle_eth_core :
+                 tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id)) {
                 add_dispatch_core_to_device(device_id, idle_eth_core);
             }
         }
@@ -322,7 +330,8 @@ void dispatch_core_manager::log_dispatch_assignment(
         "Allocated {} Core: {}({}) for Device {} Channel {} CQ ID {}",
         name,
         cxy.str(),
-        tt::Cluster::instance()
+        tt::tt_metal::MetalContext::instance()
+            .get_cluster()
             .get_virtual_coordinate_from_logical_coordinates(
                 cxy, force_ethernet ? CoreType::ETH : get_dispatch_core_type())
             .str(),

--- a/tt_metal/impl/dispatch/dispatch_core_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.hpp
@@ -11,9 +11,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "core_coord.hpp"
-#include "core_descriptor.hpp"
-#include "dispatch_core_common.hpp"
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/core_descriptor.hpp>
+#include <tt-metalium/dispatch_core_common.hpp>
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
@@ -62,11 +62,15 @@ public:
     dispatch_core_manager(const dispatch_core_manager&) = delete;
     dispatch_core_manager(dispatch_core_manager&& other) noexcept = delete;
 
+    /// @brief dispatch_core_manager constructor initializes a list of cores per device that are designated for any
+    /// dispatch functionality
+    ///         This list contains dispatch cores that have not been assigned to a particular dispatch function
+    /// @param num_hw_cqs is used to get the correct collection of dispatch cores for a particular device
+    /// @param dispatch_core_config specfies the core type that is designated for dispatch functionality
+    dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
+
     // TODO: this should probably be in command_queue_interface.hpp, but it's here for now due to circular dependency
     static constexpr uint8_t MAX_NUM_HW_CQS = 2;
-    static void initialize(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) noexcept;
-
-    static dispatch_core_manager& instance();
 
     /// @brief Gets the location of the kernel desginated to read from the issue queue region from a particular command
     /// queue
@@ -185,13 +189,6 @@ public:
     std::vector<CoreCoord> get_all_logical_dispatch_cores(chip_id_t device_id);
 
 private:
-    /// @brief dispatch_core_manager constructor initializes a list of cores per device that are designated for any
-    /// dispatch functionality
-    ///         This list contains dispatch cores that have not been assigned to a particular dispatch function
-    /// @param num_hw_cqs is used to get the correct collection of dispatch cores for a particular device
-    /// @param dispatch_core_config specfies the core type that is designated for dispatch functionality
-    dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);
-
     /// @brief reset_dispatch_core_manager initializes vector of cores per device for dispatch kernels
     /// @param dispatch_core_config specfies the core type for dispatch kernels
     void reset_dispatch_core_manager(const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs);

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -94,21 +94,6 @@ tt::tt_metal::DispatchQueryManager* inst = nullptr;
 
 namespace tt::tt_metal {
 
-void DispatchQueryManager::initialize(uint8_t num_hw_cqs) {
-    if (inst == nullptr) {
-        static DispatchQueryManager DispatchQueryManager(num_hw_cqs);
-        inst = &DispatchQueryManager;
-    } else if (num_hw_cqs != inst->num_hw_cqs_ or dispatch_core_config() != inst->dispatch_core_config_) {
-        inst->reset(num_hw_cqs);
-        inst->num_hw_cqs_ = num_hw_cqs;
-    }
-}
-
-const DispatchQueryManager& DispatchQueryManager::instance() {
-    TT_FATAL(inst != nullptr, "Trying to acess the dispatch query layer without initializing it.");
-    return *inst;
-}
-
 bool DispatchQueryManager::dispatch_s_enabled() const { return dispatch_s_enabled_; }
 
 bool DispatchQueryManager::distributed_dispatcher() const { return distributed_dispatcher_; }

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "dispatch_query_manager.hpp"
 
 #include <initializer_list>
 #include <optional>
@@ -12,41 +12,44 @@
 
 #include "assert.hpp"
 #include "core_descriptor.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/cluster_descriptor_types.h>
 #include <umd/device/types/xy_pair.h>
-
-using dispatch_core_mgr = tt::tt_metal::dispatch_core_manager;
 
 namespace {
 
 tt::tt_metal::DispatchCoreConfig dispatch_core_config() {
-    return dispatch_core_mgr::instance().get_dispatch_core_config();
+    return tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
 }
 
 tt_cxy_pair dispatch_core(uint8_t cq_id) {
     tt_cxy_pair dispatch_core = tt_cxy_pair(0, 0, 0);
     std::optional<tt_cxy_pair> first_dispatch_core = std::nullopt;
-    for (chip_id_t device_id = 0; device_id < tt::Cluster::instance().number_of_devices(); device_id++) {
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-        if (tt::Cluster::instance().get_associated_mmio_device(device_id) == device_id) {
+    for (chip_id_t device_id = 0; device_id < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices();
+         device_id++) {
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id) {
             // Dispatch core is not allocated on this MMIO device or this is a TG system, skip it
             // On TG, local dispatch cores are allocated on MMIO devices, but are not used
             // since programs are not run on these devices. The placement of these cores is
             // irrelevant for the runtime layer, since these are not used. Hence, these are
             // skipped.
-            if (not dispatch_core_mgr::instance().is_dispatcher_core_allocated(device_id, channel, cq_id) or
-                tt::Cluster::instance().is_galaxy_cluster()) {
+            if (not tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
+                    device_id, channel, cq_id) or
+                tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
                 continue;
             }
-            dispatch_core = dispatch_core_mgr::instance().dispatcher_core(device_id, channel, cq_id);
+            dispatch_core = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
+                device_id, channel, cq_id);
         } else {
             // Dispatch core is not allocated on this Non-MMIO device, skip it
-            if (not dispatch_core_mgr::instance().is_dispatcher_d_core_allocated(device_id, channel, cq_id)) {
+            if (not tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().is_dispatcher_d_core_allocated(
+                    device_id, channel, cq_id)) {
                 continue;
             }
-            dispatch_core = dispatch_core_mgr::instance().dispatcher_d_core(device_id, channel, cq_id);
+            dispatch_core = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_d_core(
+                device_id, channel, cq_id);
         }
         if (not first_dispatch_core.has_value()) {
             first_dispatch_core = dispatch_core;
@@ -63,7 +66,7 @@ tt_cxy_pair dispatch_core(uint8_t cq_id) {
 template <typename F>
 std::vector<CoreCoord> get_consistent_logical_cores(
     uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config, F&& func) {
-    auto user_chips = tt::Cluster::instance().user_exposed_chip_ids();
+    auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
     std::vector<CoreCoord> first_core_set;
     std::vector<CoreCoord> current_cores;
 

--- a/tt_metal/impl/dispatch/dispatch_query_manager.hpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <stdint.h>
 #include <mutex>
 #include <vector>
@@ -28,9 +30,8 @@ public:
     DispatchQueryManager& operator=(DispatchQueryManager&& other) noexcept = delete;
     DispatchQueryManager(const DispatchQueryManager&) = delete;
     DispatchQueryManager(DispatchQueryManager&& other) noexcept = delete;
+    DispatchQueryManager(uint8_t num_hw_cqs);
 
-    static void initialize(uint8_t num_hw_cqs);
-    static const DispatchQueryManager& instance();
     // dispatch_s related queries
     bool dispatch_s_enabled() const;
     bool distributed_dispatcher() const;
@@ -44,7 +45,6 @@ public:
 
 private:
     void reset(uint8_t num_hw_cqs);
-    DispatchQueryManager(uint8_t num_hw_cqs);
 
     bool dispatch_s_enabled_ = false;
     bool distributed_dispatcher_ = false;

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -25,7 +25,7 @@
 #include "command_queue.hpp"
 #include "device.hpp"
 #include "dispatch/device_command.hpp"
-#include "dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dprint_server.hpp"
 #include "hal_types.hpp"
 #include "lightmetal/host_api_capture_helpers.hpp"
@@ -37,7 +37,7 @@
 #include "tracy/Tracy.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/data_collection.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/program/dispatch.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
@@ -119,7 +119,7 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     unicast_cores_launch_message_wptr(unicast_cores_launch_message_wptr),
     sub_device_id(sub_device_id) {
     this->device = device;
-    this->dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
+    this->dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     this->packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(this->device);
 }
 
@@ -190,7 +190,7 @@ void EnqueueTerminateCommand::process() {
     this->manager.issue_queue_push_back(cmd_sequence_sizeB, this->command_queue_id);
     this->manager.fetch_queue_reserve_back(this->command_queue_id);
     this->manager.fetch_queue_write(cmd_sequence_sizeB, this->command_queue_id);
-    if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
         // Terminate dispatch_s if enabled
         cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);
         HugepageDeviceCommand dispatch_s_command_sequence(cmd_region, cmd_sequence_sizeB);

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -14,13 +14,13 @@
 #include "assert.hpp"
 #include "device.hpp"
 #include "dispatch.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_mem_map.hpp"
 #include "eth_tunneler.hpp"
 #include "hal.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include "utils.hpp"
 
@@ -28,9 +28,10 @@ using namespace tt::tt_metal;
 
 void DemuxKernel::GenerateStaticConfigs() {
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
-    uint16_t channel =
-        tt::Cluster::instance().get_assigned_channel_for_device(servicing_device_id_);  // TODO: this can be mmio
-    logical_core_ = dispatch_core_manager::instance().demux_core(servicing_device_id_, channel, placement_cq_id_);
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
+        servicing_device_id_);  // TODO: this can be mmio
+    logical_core_ = MetalContext::instance().get_dispatch_core_manager().demux_core(
+        servicing_device_id_, channel, placement_cq_id_);
     static_config_.endpoint_id_start_index = 0xD1;
     static_config_.rx_queue_start_addr_words = my_dispatch_constants.dispatch_buffer_base() >> 4;
     static_config_.rx_queue_size_words = 0x10000 >> 4;
@@ -174,7 +175,8 @@ void DemuxKernel::CreateKernel() {
     TT_ASSERT(compile_args.size() == 30);
     const auto& grid_size = device_->grid_size();
     tt_cxy_pair my_virtual_core =
-        tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(logical_core_, GetCoreType());
+        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            logical_core_, GetCoreType());
     std::map<string, string> defines = {
         // All of these unused, remove later
         {"MY_NOC_X",

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -26,14 +26,15 @@
 #include "llrt/hal.hpp"
 #include "mux.hpp"
 #include "prefetch.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.h>
 #include "utils.hpp"
 
 using namespace tt::tt_metal;
 
 void DispatchKernel::GenerateStaticConfigs() {
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
 
@@ -74,7 +75,8 @@ void DispatchKernel::GenerateStaticConfigs() {
             (hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
                 ? hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher = DispatchQueryManager::instance().distributed_dispatcher();
+        static_config_.distributed_dispatcher =
+            MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
         static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
@@ -85,7 +87,8 @@ void DispatchKernel::GenerateStaticConfigs() {
             my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
     } else if (static_config_.is_h_variant.value()) {
         // DISPATCH_H services a remote chip, and so has a different channel
-        channel = tt::Cluster::instance().get_assigned_channel_for_device(servicing_device_id_);
+        channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
         uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
@@ -109,7 +112,7 @@ void DispatchKernel::GenerateStaticConfigs() {
 
         static_config_.split_dispatch_page_preamble_size = 0;
         // TODO: why is this hard-coded to 1 CQ on Galaxy?
-        if (tt::Cluster::instance().is_galaxy_cluster()) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
             static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(1);
         } else {
             static_config_.prefetch_h_max_credits = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
@@ -172,7 +175,8 @@ void DispatchKernel::GenerateStaticConfigs() {
             (hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
                 ? hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
-        static_config_.distributed_dispatcher = DispatchQueryManager::instance().distributed_dispatcher();
+        static_config_.distributed_dispatcher =
+            MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
         static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
 
         static_config_.host_completion_q_wr_ptr =
@@ -210,7 +214,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         }
 
         // Downstream
-        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 1);
             auto dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
             TT_ASSERT(dispatch_s_kernel);
@@ -321,7 +325,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         }
 
         TT_FATAL(
-            !DispatchQueryManager::instance().dispatch_s_enabled() || found_dispatch_s,
+            !MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() || found_dispatch_s,
             "dispatch_d is missing dispatch_s downstream");
         TT_FATAL(
             found_mux || found_dispatch_h,

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -5,10 +5,10 @@
 #include <stdint.h>
 #include <optional>
 
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "fd_kernel.hpp"
 #include "system_memory_manager.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 
 typedef struct dispatch_s_static_config {
@@ -37,9 +37,10 @@ public:
     DispatchSKernel(
         int node_id, chip_id_t device_id, chip_id_t servicing_device_id, uint8_t cq_id, noc_selection_t noc_selection) :
         FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-        this->logical_core_ =
-            tt::tt_metal::dispatch_core_manager::instance().dispatcher_s_core(device_id, channel, cq_id_);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+        this->logical_core_ = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(
+            device_id, channel, cq_id_);
     }
     void CreateKernel() override;
     void GenerateStaticConfigs() override;

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -11,13 +11,13 @@
 #include "assert.hpp"
 #include "demux.hpp"
 #include "device.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch_core_common.hpp"
 #include "eth_router.hpp"
 #include "hal.hpp"
 #include "mux.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include "utils.hpp"
 
@@ -31,12 +31,15 @@ void EthTunnelerKernel::GenerateStaticConfigs() {
         downstream_device_id = servicing_device_id_;
     }
     if (this->IsRemote()) {
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(downstream_device_id);
-        logical_core_ =
-            dispatch_core_manager::instance().tunneler_core(device_->id(), downstream_device_id, channel, cq_id_);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(downstream_device_id);
+        logical_core_ = MetalContext::instance().get_dispatch_core_manager().tunneler_core(
+            device_->id(), downstream_device_id, channel, cq_id_);
     } else {
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
-        logical_core_ = dispatch_core_manager::instance().us_tunneler_core_local(device_->id(), channel, cq_id_);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
+        logical_core_ =
+            MetalContext::instance().get_dispatch_core_manager().us_tunneler_core_local(device_->id(), channel, cq_id_);
     }
     static_config_.endpoint_id_start_index = 0xDACADACA;
     static_config_.in_queue_start_addr_words = 0x19A00 >> 4;
@@ -60,11 +63,13 @@ void EthTunnelerKernel::GenerateDependentConfigs() {
         // For remote tunneler, we don't actually have the device constructed for the paired tunneler, so can't pull
         // info from it. Core coord can be computed without the device, and relevant fields match this tunneler.
         chip_id_t downstream_device_id = FDKernel::GetDownstreamDeviceId(device_id_);
-        uint16_t downstream_channel = tt::Cluster::instance().get_assigned_channel_for_device(downstream_device_id);
-        tt_cxy_pair paired_logical_core =
-            dispatch_core_manager::instance().us_tunneler_core_local(downstream_device_id, downstream_channel, cq_id_);
+        uint16_t downstream_channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(downstream_device_id);
+        tt_cxy_pair paired_logical_core = MetalContext::instance().get_dispatch_core_manager().us_tunneler_core_local(
+            downstream_device_id, downstream_channel, cq_id_);
         tt_cxy_pair paired_physical_coord =
-            tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(paired_logical_core, CoreType::ETH);
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                paired_logical_core, CoreType::ETH);
 
         // Upstream, we expect a US_TUNNELER_LOCAL and one or more PACKET_ROUTER
         EthTunnelerKernel* tunneler_kernel = nullptr;
@@ -158,11 +163,13 @@ void EthTunnelerKernel::GenerateDependentConfigs() {
         // Upstream, we expect a US_TUNNELER_REMOTE and a MUX_D. Same deal where upstream tunneler may not be populated
         // yet since its device may not be created yet.
         chip_id_t upstream_device_id = FDKernel::GetUpstreamDeviceId(device_id_);
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id_);
-        tt_cxy_pair paired_logical_core =
-            dispatch_core_manager::instance().tunneler_core(upstream_device_id, device_id_, channel, cq_id_);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id_);
+        tt_cxy_pair paired_logical_core = MetalContext::instance().get_dispatch_core_manager().tunneler_core(
+            upstream_device_id, device_id_, channel, cq_id_);
         tt_cxy_pair paired_physical_coord =
-            tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(paired_logical_core, CoreType::ETH);
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                paired_logical_core, CoreType::ETH);
 
         TT_ASSERT(upstream_kernels_.size() == 2);
         auto tunneler_kernel = dynamic_cast<EthTunnelerKernel*>(upstream_kernels_[0]);

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -10,7 +10,7 @@
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/kernel_config/prefetch.hpp"
 #include "fabric_router_vc.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 
@@ -21,7 +21,7 @@ void FabricRouterVC::GenerateDependentConfigs() {
     TT_ASSERT(
         upstream_kernels_.size() == downstream_kernels_.size(),
         "Fabric Router VC requires upstream.size() == downstream.size()");
-    auto& cluster = tt::Cluster::instance();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& control_plane = cluster.get_control_plane();
     TT_FATAL(
         cluster.get_fabric_config() != FabricConfig::DISABLED && control_plane,

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -30,8 +30,10 @@ using namespace tt::tt_metal;
 
 // Helper function to get upstream device in the tunnel from current device, not valid for mmio
 chip_id_t FDKernel::GetUpstreamDeviceId(chip_id_t device_id) {
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-    for (auto tunnel : tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id)) {
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    for (auto tunnel :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
         for (int idx = 0; idx < tunnel.size(); idx++) {
             if (tunnel[idx] == device_id) {
                 // MMIO device doesn't have an upsream, just return itself
@@ -45,8 +47,10 @@ chip_id_t FDKernel::GetUpstreamDeviceId(chip_id_t device_id) {
 
 // Same thing for downstream, is ambiuous for mmio device though if it drives more than one tunnel
 chip_id_t FDKernel::GetDownstreamDeviceId(chip_id_t device_id) {
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-    for (auto tunnel : tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id)) {
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    for (auto tunnel :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
         for (int idx = 0; idx < tunnel.size(); idx++) {
             if (tunnel[idx] == device_id) {
                 // End of tunnel doesn't have downstream, just return itself
@@ -60,8 +64,10 @@ chip_id_t FDKernel::GetDownstreamDeviceId(chip_id_t device_id) {
 
 // Helper function to get the tunnel stop of current device
 uint32_t FDKernel::GetTunnelStop(chip_id_t device_id) {
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-    for (auto tunnel : tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id)) {
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    for (auto tunnel :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
         for (uint32_t idx = 0; idx < tunnel.size(); idx++) {
             if (tunnel[idx] == device_id) {
                 return idx;

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -14,8 +14,8 @@
 #include "core_coord.hpp"
 #include "mesh_graph.hpp"
 #include "system_memory_manager.hpp"
-#include "tt_cluster.hpp"
-#include "tt_metal/impl/dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include "utils.hpp"
@@ -111,10 +111,13 @@ public:
     void AddUpstreamKernel(FDKernel* upstream) { upstream_kernels_.push_back(upstream); }
     void AddDownstreamKernel(FDKernel* downstream) { downstream_kernels_.push_back(downstream); }
 
-    virtual CoreType GetCoreType() { return tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type(); }
+    virtual CoreType GetCoreType() {
+        return tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
+    }
     tt_cxy_pair GetLogicalCore() { return logical_core_; }
     tt_cxy_pair GetVirtualCore() {
-        return tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(logical_core_, GetCoreType());
+        return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            logical_core_, GetCoreType());
     }
     chip_id_t GetDeviceId() { return device_id_; }  // Since this->device may not exist yet
 

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -14,20 +14,22 @@
 #include "assert.hpp"
 #include "device.hpp"
 #include "dispatch.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_mem_map.hpp"
 #include "eth_tunneler.hpp"
 #include "hal.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "utils.hpp"
 
 using namespace tt::tt_metal;
 
 void MuxKernel::GenerateStaticConfigs() {
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
-    logical_core_ = dispatch_core_manager::instance().mux_d_core(device_->id(), channel, this->cq_id_);
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
+    logical_core_ =
+        MetalContext::instance().get_dispatch_core_manager().mux_d_core(device_->id(), channel, this->cq_id_);
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
     static_config_.reserved = 0;
     static_config_.rx_queue_start_addr_words = my_dispatch_constants.dispatch_buffer_base() >> 4;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -25,7 +25,7 @@
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "rtoptions.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/xy_pair.h>
 #include "utils.hpp"
@@ -33,7 +33,8 @@
 using namespace tt::tt_metal;
 
 void PrefetchKernel::GenerateStaticConfigs() {
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     uint8_t cq_id_ = this->cq_id_;
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
 
@@ -73,7 +74,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.cmddat_q_blocks = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 
         uint32_t dispatch_s_buffer_base = 0xff;
-        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base();
             if (GetCoreType() == CoreType::WORKER) {
                 // dispatch_s is on the same Tensix core as dispatch_d. Shared resources. Offset CB start idx.
@@ -92,7 +93,8 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.dispatch_s_cb_log_page_size = DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE;
     } else if (static_config_.is_h_variant.value()) {
         // PREFETCH_H services a remote chip, and so has a different channel
-        channel = tt::Cluster::instance().get_assigned_channel_for_device(servicing_device_id_);
+        channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(servicing_device_id_);
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();
         uint32_t command_queue_start_addr = get_absolute_cq_offset(channel, cq_id_, cq_size);
@@ -123,7 +125,9 @@ void PrefetchKernel::GenerateStaticConfigs() {
         // Workaround for now. Need downstream to initialize my semaphore. Can't defer creating semaphore yet
         {
             uint32_t downstream_cb_pages;
-            if (tt::Cluster::instance().is_galaxy_cluster()) {  // TODO: whys is this hard-coded for galaxy?
+            if (tt::tt_metal::MetalContext::instance()
+                    .get_cluster()
+                    .is_galaxy_cluster()) {  // TODO: whys is this hard-coded for galaxy?
                 downstream_cb_pages = my_dispatch_constants.mux_buffer_pages(1);
             } else {
                 downstream_cb_pages = my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs());
@@ -171,7 +175,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.cmddat_q_blocks = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 
         uint32_t dispatch_s_buffer_base = 0xff;
-        if (DispatchQueryManager::instance().dispatch_s_enabled() ||
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() ||
             true) {  // Just to make it match previous implementation
             uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base();
             if (GetCoreType() == CoreType::WORKER) {
@@ -188,9 +192,10 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.my_dispatch_s_cb_sem_id = tt::tt_metal::CreateSemaphore(
             *program_, logical_core_, my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
         static_config_.dispatch_s_buffer_size = my_dispatch_constants.dispatch_s_buffer_size();
-        static_config_.dispatch_s_cb_log_page_size = DispatchQueryManager::instance().dispatch_s_enabled()
-                                                         ? DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE
-                                                         : DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
+        static_config_.dispatch_s_cb_log_page_size =
+            MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()
+                ? DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE
+                : DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE;
     } else {
         TT_FATAL(false, "PrefetchKernel must be one of (or both) H and D variants");
     }
@@ -204,7 +209,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
         dependent_config_.upstream_cb_sem_id = 0;  // Used in prefetch_d only
 
         // Downstream
-        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 2);
         } else {
             TT_ASSERT(downstream_kernels_.size() == 1);
@@ -234,7 +239,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 TT_FATAL(false, "Unrecognized downstream kernel.");
             }
         }
-        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             // Should have found dispatch_s in the downstream kernels
             TT_ASSERT(found_dispatch && found_dispatch_s);
         } else {
@@ -304,7 +309,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
 
         // Downstream, expect a DISPATCH_D and s DISPATCH_S
         // Prefetch_d will always be local with dispatch_d
-        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             TT_ASSERT(downstream_kernels_.size() == 2);
         } else {
             TT_ASSERT(downstream_kernels_.size() == 1);
@@ -334,7 +339,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 TT_FATAL(false, "Unrecognized downstream kernel.");
             }
         }
-        if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+        if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
             // Should have found dispatch_s in the downstream kernels
             TT_ASSERT(found_dispatch && found_dispatch_s);
         } else {
@@ -342,7 +347,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
             TT_ASSERT(found_dispatch && ~found_dispatch_s);
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
             dependent_config_.downstream_dispatch_s_cb_sem_id =
-                DispatchQueryManager::instance().dispatch_s_enabled()
+                MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()
                     ? UNUSED_SEM_ID
                     : 1;  // Just to make it match previous implementation
         }
@@ -432,7 +437,8 @@ void PrefetchKernel::ConfigureCore() {
     // Only H-type prefetchers need L1 configuration
     if (static_config_.is_h_variant.value()) {
         // Initialize the FetchQ
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_->id());
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
         auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
         uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         uint32_t cq_size = device_->sysmem_manager().get_cq_size();

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -8,11 +8,11 @@
 #include <optional>
 
 #include "core_coord.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
 #include "system_memory_manager.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 
@@ -86,15 +86,17 @@ public:
         bool h_variant,
         bool d_variant) :
         FDKernel(node_id, device_id, servicing_device_id, cq_id, noc_selection) {
-        auto& core_manager = tt::tt_metal::dispatch_core_manager::instance();  // Not thread safe
+        auto& core_manager = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager();  // Not thread safe
         static_config_.is_h_variant = h_variant;
         static_config_.is_d_variant = d_variant;
-        uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
+        uint16_t channel =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
 
         if (h_variant && d_variant) {
             this->logical_core_ = core_manager.prefetcher_core(device_id, channel, cq_id);
         } else if (h_variant) {
-            channel = tt::Cluster::instance().get_assigned_channel_for_device(servicing_device_id);
+            channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
+                servicing_device_id);
             this->logical_core_ = core_manager.prefetcher_core(servicing_device_id, channel, cq_id);
         } else if (d_variant) {
             this->logical_core_ = core_manager.prefetcher_d_core(device_id, channel, cq_id);

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <llrt/tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/command_queue_common.hpp>
 #include <tt-metalium/dispatch_mem_map.hpp>
 #include <tt-metalium/system_memory_manager.hpp>
@@ -16,7 +16,7 @@
 
 #include "assert.hpp"
 #include "core_coord.hpp"
-#include "dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch_settings.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
@@ -37,7 +37,8 @@ namespace tt::tt_metal {
 SystemMemoryManager::SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs) :
     device_id(device_id),
     num_hw_cqs(num_hw_cqs),
-    fast_write_callable(tt::Cluster::instance().get_fast_pcie_static_tlb_write_callable(device_id)),
+    fast_write_callable(
+        tt::tt_metal::MetalContext::instance().get_cluster().get_fast_pcie_static_tlb_write_callable(device_id)),
     bypass_enable(false),
     bypass_buffer_write_offset(0) {
     this->completion_byte_addrs.resize(num_hw_cqs);
@@ -47,9 +48,11 @@ SystemMemoryManager::SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs
     this->prefetch_q_dev_fences.resize(num_hw_cqs);
 
     // Split hugepage into however many pieces as there are CQs
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(device_id);
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(device_id);
-    char* hugepage_start = (char*)tt::Cluster::instance().host_dma_address(0, mmio_device_id, channel);
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
+    char* hugepage_start =
+        (char*)tt::tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_device_id, channel);
     hugepage_start += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
     this->cq_sysmem_start = hugepage_start;
 
@@ -59,8 +62,10 @@ SystemMemoryManager::SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs
         uint32_t cq_size_override = std::stoi(string(cq_size_override_env));
         this->cq_size = cq_size_override;
     } else {
-        this->cq_size = tt::Cluster::instance().get_host_channel_size(mmio_device_id, channel) / num_hw_cqs;
-        if (tt::Cluster::instance().is_galaxy_cluster()) {
+        this->cq_size =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_host_channel_size(mmio_device_id, channel) /
+            num_hw_cqs;
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
             // We put 4 galaxy devices per huge page since number of hugepages available is less than number of
             // devices.
             this->cq_size = this->cq_size / DispatchSettings::DEVICES_PER_UMD_CHANNEL;
@@ -69,7 +74,7 @@ SystemMemoryManager::SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs
     this->channel_offset = DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel) +
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t completion_q_rd_ptr =
         DispatchMemMap::get(core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
     uint32_t prefetch_q_base =
@@ -78,21 +83,26 @@ SystemMemoryManager::SystemMemoryManager(chip_id_t device_id, uint8_t num_hw_cqs
         DispatchMemMap::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
         tt_cxy_pair prefetcher_core =
-            tt::tt_metal::dispatch_core_manager::instance().prefetcher_core(device_id, channel, cq_id);
-        auto prefetcher_virtual = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-            prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
+            tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
+                device_id, channel, cq_id);
+        auto prefetcher_virtual =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
         this->prefetcher_cores[cq_id] = tt_cxy_pair(prefetcher_core.chip, prefetcher_virtual.x, prefetcher_virtual.y);
         this->prefetch_q_writers.emplace_back(
-            tt::Cluster::instance().get_static_tlb_writer(this->prefetcher_cores[cq_id]));
+            tt::tt_metal::MetalContext::instance().get_cluster().get_static_tlb_writer(this->prefetcher_cores[cq_id]));
 
         tt_cxy_pair completion_queue_writer_core =
-            tt::tt_metal::dispatch_core_manager::instance().completion_queue_writer_core(device_id, channel, cq_id);
-        auto completion_queue_writer_virtual = tt::Cluster::instance().get_virtual_coordinate_from_logical_coordinates(
-            completion_queue_writer_core.chip,
-            CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
-            core_type);
+            tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().completion_queue_writer_core(
+                device_id, channel, cq_id);
+        auto completion_queue_writer_virtual =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+                completion_queue_writer_core.chip,
+                CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
+                core_type);
 
-        const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = tt::Cluster::instance()
+        const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = tt::tt_metal::MetalContext::instance()
+                                                                                 .get_cluster()
                                                                                  .get_tlb_data(tt_cxy_pair(
                                                                                      completion_queue_writer_core.chip,
                                                                                      completion_queue_writer_virtual.x,
@@ -287,7 +297,7 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
         align(push_size_B, tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST)) >> 4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t issue_q_wr_ptr =
         DispatchMemMap::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
 
@@ -299,9 +309,11 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     }
 
     // Also store this data in hugepages, so if a hang happens we can see what was written by host.
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_id);
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_id);
-    tt::Cluster::instance().write_sysmem(
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_id);
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_id);
+    tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
         &cq_interface.issue_fifo_wr_ptr,
         sizeof(uint32_t),
         issue_q_wr_ptr + get_relative_cq_offset(cq_id, this->cq_size),
@@ -316,12 +328,14 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
     this->fast_write_callable(this->completion_byte_addrs[cq_id], 4, (uint8_t*)&read_ptr_and_toggle);
 
     // Also store this data in hugepages in case we hang and can't get it from the device.
-    chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(this->device_id);
-    uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(this->device_id);
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    chip_id_t mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_id);
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_id);
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t completion_q_rd_ptr =
         DispatchMemMap::get(core_type).get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
-    tt::Cluster::instance().write_sysmem(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_sysmem(
         &read_ptr_and_toggle,
         sizeof(uint32_t),
         completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
@@ -334,7 +348,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         return;
     }
 
-    CoreType core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     const uint32_t prefetch_q_rd_ptr =
         DispatchMemMap::get(core_type).get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD);
 
@@ -343,7 +357,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
     auto wait_for_fetch_q_space = [&]() {
         // Loop until space frees up
         while (this->prefetch_q_dev_ptrs[cq_id] == this->prefetch_q_dev_fences[cq_id]) {
-            tt::Cluster::instance().read_core(
+            tt::tt_metal::MetalContext::instance().get_cluster().read_core(
                 &fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
         }
@@ -409,7 +423,8 @@ void SystemMemoryManager::completion_queue_pop_front(uint32_t num_pages_read, co
 }
 
 void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8_t cq_id, bool stall_prefetcher) {
-    CoreType dispatch_core_type = tt::tt_metal::dispatch_core_manager::instance().get_dispatch_core_type();
+    CoreType dispatch_core_type =
+        tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t max_command_size_B = DispatchMemMap::get(dispatch_core_type, num_hw_cqs).max_prefetch_command_size();
     TT_ASSERT(
         command_size_B <= max_command_size_B,

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -26,7 +26,7 @@
 #include "core_coord.hpp"
 #include "data_types.hpp"
 #include "device.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_mem_map.hpp"
 #include "fabric_edm_packet_header.hpp"
@@ -43,7 +43,7 @@
 #include "program_impl.hpp"
 #include "rtoptions.hpp"
 #include "span.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/tt_xy_pair.h>
 #include "utils.hpp"
@@ -510,7 +510,7 @@ std::unordered_map<chip_id_t, std::unique_ptr<Program>> command_queue_pgms;
 std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device_ids, uint32_t num_hw_cqs) {
     // Select/generate the right input table, depends on (1) board [detected from total # of devices], and (2) number
     // of active devices. TODO: read this out of YAML instead of the structs above?
-    uint32_t total_devices = tt::Cluster::instance().number_of_devices();
+    uint32_t total_devices = tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices();
     TT_ASSERT(
         total_devices == 1 or total_devices == 2 or total_devices == 4 or total_devices == 8 or total_devices == 32 or
             total_devices == 36,
@@ -523,7 +523,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
     std::set<chip_id_t> mmio_devices;
     std::set<chip_id_t> remote_devices;
     for (auto id : device_ids) {
-        if (tt::Cluster::instance().get_associated_mmio_device(id) == id) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(id) == id) {
             mmio_devices.insert(id);
         } else {
             remote_devices.insert(id);
@@ -537,7 +537,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
         } else {
             // TODO: determine whether dispatch_s is inserted at this level, instead of inside
             // Device::dispatch_s_enabled().
-            if (dispatch_core_manager::instance().get_dispatch_core_type() == CoreType::WORKER) {
+            if (MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type() == CoreType::WORKER) {
                 return single_chip_arch_2cq_dispatch_s;
             } else {
                 return single_chip_arch_2cq;
@@ -560,7 +560,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
         }
     } else {
         // Need to handle N300/T3000 separately from TG/TGG since they have different templates/tunnel depths
-        if (tt::Cluster::instance().is_galaxy_cluster()) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
             // For Galaxy, we always init all remote devices associated with an mmio device.
             const std::vector<DispatchKernelNode>* nodes_for_one_mmio =
                 (num_hw_cqs == 1) ? &galaxy_nine_chip_arch_1cq : &galaxy_nine_chip_arch_2cq;
@@ -569,7 +569,9 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
                 // Need a mapping from templated device id (1-8) to actual device id (from the tunnel)
                 std::vector<chip_id_t> template_id_to_device_id;
                 template_id_to_device_id.push_back(mmio_device_id);
-                for (const auto& tunnel : tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id)) {
+                for (const auto& tunnel :
+                     tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(
+                         mmio_device_id)) {
                     TT_ASSERT(tunnel.size() == 5, "Galaxy expected 4-deep tunnels.");
                     for (auto remote_device_id : tunnel) {
                         if (remote_device_id != mmio_device_id) {
@@ -608,7 +610,8 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
                 chip_id_t remote_device_id;
                 bool found_remote = false;
                 for (auto id : remote_devices) {
-                    if (tt::Cluster::instance().get_associated_mmio_device(id) == mmio_device_id) {
+                    if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(id) ==
+                        mmio_device_id) {
                         remote_device_id = id;
                         found_remote = true;
                         break;
@@ -671,7 +674,8 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
         TT_ASSERT(node_id_to_kernel.size() == node.id);
         node_id_to_kernel.push_back(FDKernel::Generate(
             node.id, node.device_id, node.servicing_device_id, node.cq_id, node.noc_selection, node.kernel_type));
-        if (tt::Cluster::instance().get_associated_mmio_device(node.device_id) == node.device_id) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(node.device_id) ==
+            node.device_id) {
             mmio_device_ids.insert(node.device_id);
         }
         hw_cq_ids.insert(node.cq_id);
@@ -697,7 +701,8 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     std::map<chip_id_t, std::vector<chip_id_t>> mmio_device_id_to_serviced_devices;
     uint32_t tunnel_depth;
     for (auto mmio_device_id : mmio_device_ids) {
-        if (tt::Cluster::instance().get_associated_mmio_device(mmio_device_id) != mmio_device_id) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(mmio_device_id) !=
+            mmio_device_id) {
             continue;
         }
 
@@ -706,7 +711,8 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
             mmio_device_id_to_serviced_devices[mmio_device_id].push_back(mmio_device_id);
         }
         std::vector<chip_id_t> remote_devices;
-        for (auto tunnel : tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id)) {
+        for (auto tunnel :
+             tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
             tunnel_depth = tunnel.size();
             for (uint32_t tunnel_stop = 0; tunnel_stop < tunnel.size(); tunnel_stop++) {
                 chip_id_t remote_device_id = tunnel[tunnel_stop];
@@ -727,7 +733,8 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     // per tunnel. TODO: We can fix dispatch_core_manager so we don't hard-code separate channels for this.
     std::map<chip_id_t, std::vector<FDKernel*>> mmio_device_id_to_kernels;
     for (auto fd_kernel : node_id_to_kernel) {
-        chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(fd_kernel->GetDeviceId());
+        chip_id_t mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(fd_kernel->GetDeviceId());
         if (fd_kernel->GetDeviceId() == mmio_device_id) {
             mmio_device_id_to_kernels[mmio_device_id].push_back(fd_kernel);
         }
@@ -752,7 +759,8 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     for (auto fd_kernel : node_id_to_kernel) {
         if (auto router_kernel = dynamic_cast<EthRouterKernel*>(fd_kernel)) {
             chip_id_t router_device_id = router_kernel->GetDeviceId();
-            chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(router_device_id);
+            chip_id_t mmio_device_id =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(router_device_id);
 
             // Router placement CQID already set for mmio device above, just need to do this for remotes
             if (router_device_id != mmio_device_id) {
@@ -783,9 +791,13 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
             uint32_t num_routers = device_id_to_num_routers[router_kernel->GetDeviceId()];
 
             // Special case for MMIO chips, can have routers servicing different tunnels
-            chip_id_t mmio_device_id = tt::Cluster::instance().get_associated_mmio_device(router_kernel->GetDeviceId());
+            chip_id_t mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(
+                router_kernel->GetDeviceId());
             if (router_kernel->GetDeviceId() == mmio_device_id) {
-                uint32_t num_tunnels = tt::Cluster::instance().get_tunnels_from_mmio_device(mmio_device_id).size();
+                uint32_t num_tunnels = tt::tt_metal::MetalContext::instance()
+                                           .get_cluster()
+                                           .get_tunnels_from_mmio_device(mmio_device_id)
+                                           .size();
                 num_routers /= num_tunnels;
                 uint32_t router_vcs = (router_vcs_for_device + num_routers - 1) / num_routers;
                 router_kernel->SetVCCount(router_vcs);
@@ -850,7 +862,7 @@ std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
 void configure_dispatch_cores(IDevice* device) {
     // Set up completion_queue_writer core. This doesn't actually have a kernel so keep it out of the struct and config
     // it here. TODO: should this be in the struct?
-    CoreType dispatch_core_type = dispatch_core_manager::instance().get_dispatch_core_type();
+    CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     auto& my_dispatch_constants = DispatchMemMap::get(dispatch_core_type);
     uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
     uint32_t cq_size = device->sysmem_manager().get_cq_size();
@@ -859,11 +871,13 @@ void configure_dispatch_cores(IDevice* device) {
     // Need to set up for all devices serviced by an mmio chip
     if (device->is_mmio_capable()) {
         for (chip_id_t serviced_device_id :
-             tt::Cluster::instance().get_devices_controlled_by_mmio_device(device->id())) {
-            uint16_t channel = tt::Cluster::instance().get_assigned_channel_for_device(serviced_device_id);
+             tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(device->id())) {
+            uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
+                serviced_device_id);
             for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
                 tt_cxy_pair completion_q_writer_location =
-                    dispatch_core_manager::instance().completion_queue_writer_core(serviced_device_id, channel, cq_id);
+                    MetalContext::instance().get_dispatch_core_manager().completion_queue_writer_core(
+                        serviced_device_id, channel, cq_id);
                 IDevice* mmio_device = tt::DevicePool::instance().get_active_device(completion_q_writer_location.chip);
                 uint32_t completion_q_wr_ptr =
                     my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
@@ -909,9 +923,9 @@ void configure_dispatch_cores(IDevice* device) {
 std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, FabricConfig fabric_config) {
     std::unique_ptr<Program> fabric_program_ptr;
     std::uint32_t router_mask = 0;
-    auto control_plane = tt::Cluster::instance().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
 
-    auto router_chans = tt::Cluster::instance().get_fabric_ethernet_channels(device->id());
+    auto router_chans = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(device->id());
     if (router_chans.empty()) {
         return nullptr;
     }
@@ -954,7 +968,8 @@ std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, F
 
     for (const auto& router_chan : router_chans) {
         CoreCoord virtual_eth_core =
-            tt::Cluster::instance().get_virtual_eth_core_from_channel(device->id(), router_chan);
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                device->id(), router_chan);
         auto router_logical_core = device->logical_core_from_ethernet_core(virtual_eth_core);
         if (master_router_chan == router_chan) {
             router_compile_args[4] = 1;
@@ -981,10 +996,11 @@ std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, F
 void configure_2d_fabric_cores(IDevice* device) {
     std::vector<uint32_t> router_zero_buf(1, 0);
 
-    auto router_chans = tt::Cluster::instance().get_fabric_ethernet_channels(device->id());
+    auto router_chans = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(device->id());
     for (const auto& router_chan : router_chans) {
         CoreCoord virtual_eth_core =
-            tt::Cluster::instance().get_virtual_eth_core_from_channel(device->id(), router_chan);
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                device->id(), router_chan);
         auto router_logical_core = device->logical_core_from_ethernet_core(virtual_eth_core);
         // initialize the semaphore
         auto fabric_router_sync_sem_addr =
@@ -997,14 +1013,15 @@ void configure_2d_fabric_cores(IDevice* device) {
 std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, bool wrap_around_mesh = true) {
     using namespace tt_fabric;
     std::unique_ptr<Program> fabric_program_ptr;
-    auto control_plane = tt::Cluster::instance().get_control_plane();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     std::pair<mesh_id_t, chip_id_t> mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
     std::unordered_map<RoutingDirection, std::vector<chan_id_t>> active_fabric_eth_channels;
     std::unordered_map<RoutingDirection, chip_id_t> chip_neighbors;
     std::unordered_map<chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder> edm_builders;
     auto routing_directions = {RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
 
-    if (device->is_mmio_capable() && (tt::Cluster::instance().get_cluster_type() == tt::ClusterType::TG)) {
+    if (device->is_mmio_capable() &&
+        (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG)) {
         // skip lauching on gateways for TG
         return nullptr;
     }
@@ -1041,7 +1058,8 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
 
     for (const auto& [direction, remote_chip_id] : chip_neighbors) {
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
-            auto eth_logical_core = tt::Cluster::instance()
+            auto eth_logical_core = tt::tt_metal::MetalContext::instance()
+                                        .get_cluster()
                                         .get_soc_desc(device->id())
                                         .get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
             auto edm_builder = tt::tt_fabric::FabricEriscDatamoverBuilder::build(
@@ -1051,7 +1069,8 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
     }
 
     uint32_t num_edm_chans = edm_builders.size();
-    uint32_t master_edm_chan = *(tt::Cluster::instance().get_fabric_ethernet_channels(device->id()).begin());
+    uint32_t master_edm_chan =
+        *(tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(device->id()).begin());
     uint32_t edm_channels_mask = 0;
     for (const auto& [router_chan, _] : edm_builders) {
         edm_channels_mask += 0x1 << (uint32_t)router_chan;
@@ -1118,8 +1137,10 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
         eth_sender_ct_args.push_back(num_edm_chans);
         eth_sender_ct_args.push_back(edm_channels_mask);
 
-        auto eth_logical_core =
-            tt::Cluster::instance().get_soc_desc(device->id()).get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
+        auto eth_logical_core = tt::tt_metal::MetalContext::instance()
+                                    .get_cluster()
+                                    .get_soc_desc(device->id())
+                                    .get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
 
         if (is_local_handshake_master) {
             std::vector<uint32_t> router_zero_buf(1, 0);
@@ -1142,7 +1163,7 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
 }
 
 std::unique_ptr<Program> create_and_compile_fabric_program(IDevice* device) {
-    auto fabric_config = tt::Cluster::instance().get_fabric_config();
+    auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_1D) {
         return create_and_compile_1d_fabric_program(device);
     } else if (fabric_config == FabricConfig::FABRIC_2D || fabric_config == FabricConfig::FABRIC_2D_PUSH) {
@@ -1152,7 +1173,7 @@ std::unique_ptr<Program> create_and_compile_fabric_program(IDevice* device) {
 }
 
 void configure_fabric_cores(IDevice* device) {
-    auto fabric_config = tt::Cluster::instance().get_fabric_config();
+    auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (fabric_config == FabricConfig::FABRIC_2D || fabric_config == FabricConfig::FABRIC_2D_PUSH) {
         configure_2d_fabric_cores(device);
     }

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -6,7 +6,7 @@
 #include <limits.h>
 #include <tt-metalium/dev_msgs.h>
 #include <tt-metalium/dispatch_settings.hpp>
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -14,7 +14,7 @@
 #include "command_queue_common.hpp"
 #include "core_coord.hpp"
 #include "device.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_mem_map.hpp"
@@ -22,10 +22,10 @@
 #include "logger.hpp"
 #include "strong_type.hpp"
 #include "sub_device_types.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/dispatch/device_command_calculator.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/tt_xy_pair.h>
 
@@ -86,7 +86,7 @@ void issue_record_event_commands(
 
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
-    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
 
     uint32_t last_index = num_worker_counters - 1;
@@ -110,7 +110,7 @@ void issue_record_event_commands(
     std::vector<std::pair<const void*, uint32_t>> event_payloads(num_command_queues);
 
     for (auto cq_id = 0; cq_id < num_command_queues; cq_id++) {
-        tt_cxy_pair dispatch_location = DispatchQueryManager::instance().get_dispatch_core(cq_id);
+        tt_cxy_pair dispatch_location = MetalContext::instance().get_dispatch_query_manager().get_dispatch_core(cq_id);
         CoreCoord dispatch_virtual_core = device->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
         unicast_sub_cmds[cq_id] = CQDispatchWritePackedUnicastSubCmd{
             .noc_xy_addr = device->get_noc_unicast_encoding(k_dispatch_downstream_noc, dispatch_virtual_core)};
@@ -151,7 +151,7 @@ void issue_wait_for_event_commands(
     calculator.add_dispatch_wait();
     const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
-    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
 
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
@@ -186,7 +186,7 @@ void read_events_from_completion_queue(
     uint32_t read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
     thread_local static std::vector<uint32_t> dispatch_cmd_and_event(
         (sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE) / sizeof(uint32_t));
-    tt::Cluster::instance().read_sysmem(
+    tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
         dispatch_cmd_and_event.data(),
         sizeof(CQDispatchCmd) + DispatchSettings::EVENT_PADDED_SIZE,
         read_ptr,

--- a/tt_metal/impl/kernels/kernel_types.cpp
+++ b/tt_metal/impl/kernels/kernel_types.cpp
@@ -4,7 +4,7 @@
 
 #include <kernel_types.hpp>
 #include <stdint.h>
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <utility>
 
 #include "util.hpp"
@@ -15,7 +15,7 @@ ReaderDataMovementConfig::ReaderDataMovementConfig(
     std::vector<uint32_t> compile_args, std::map<std::string, std::string> defines, KernelBuildOptLevel opt_level) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_1,
-        .noc = detail::GetPreferredNOCForDRAMRead(tt::Cluster::instance().arch()),
+        .noc = detail::GetPreferredNOCForDRAMRead(tt::tt_metal::MetalContext::instance().get_cluster().arch()),
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
         .compile_args = std::move(compile_args),
         .defines = std::move(defines),
@@ -25,7 +25,7 @@ WriterDataMovementConfig::WriterDataMovementConfig(
     std::vector<uint32_t> compile_args, std::map<std::string, std::string> defines, KernelBuildOptLevel opt_level) :
     DataMovementConfig{
         .processor = DataMovementProcessor::RISCV_0,
-        .noc = detail::GetPreferredNOCForDRAMWrite(tt::Cluster::instance().arch()),
+        .noc = detail::GetPreferredNOCForDRAMWrite(tt::tt_metal::MetalContext::instance().get_cluster().arch()),
         .noc_mode = NOC_MODE::DM_DEDICATED_NOC,
         .compile_args = std::move(compile_args),
         .defines = std::move(defines),

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -31,7 +31,7 @@
 #include "tools/profiler/event_metadata.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_backend_api_types.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/xy_pair.h>
@@ -56,13 +56,16 @@ void DeviceProfiler::readRiscProfilerResults(
     HalProgrammableCoreType CoreType;
     int riscCount;
 
-    if (tt::Cluster::instance().is_worker_core(worker_core, device_id)) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(worker_core, device_id)) {
         CoreType = HalProgrammableCoreType::TENSIX;
         riscCount = 5;
     } else {
-        auto active_eth_cores = tt::Cluster::instance().get_active_ethernet_cores(device_id);
-        bool is_active_eth_core = active_eth_cores.find(tt::Cluster::instance().get_logical_ethernet_core_from_virtual(
-                                      device_id, worker_core)) != active_eth_cores.end();
+        auto active_eth_cores =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+        bool is_active_eth_core =
+            active_eth_cores.find(
+                tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
+                    device_id, worker_core)) != active_eth_cores.end();
 
         CoreType = is_active_eth_core ? tt_metal::HalProgrammableCoreType::ACTIVE_ETH
                                       : tt_metal::HalProgrammableCoreType::IDLE_ETH;
@@ -71,7 +74,9 @@ void DeviceProfiler::readRiscProfilerResults(
     }
     profiler_msg_t* profiler_msg = hal_ref.get_dev_addr<profiler_msg_t*>(CoreType, HalL1MemAddrType::PROFILER);
 
-    uint32_t coreFlatID = tt::Cluster::instance().get_virtual_routing_to_profiler_flat_id(device_id).at(worker_core);
+    uint32_t coreFlatID =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_routing_to_profiler_flat_id(device_id).at(
+            worker_core);
     uint32_t startIndex = coreFlatID * MAX_RISCV_PER_CORE * PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC;
 
     std::vector<std::uint32_t> control_buffer = tt::llrt::read_hex_vec_from_core(
@@ -620,7 +625,8 @@ CoreCoord DeviceProfiler::getPhysicalAddressFromVirtual(chip_id_t device_id, con
     bool coord_is_translated =
         c.x >= hal_ref.get_virtual_worker_start_x() && c.y >= hal_ref.get_virtual_worker_start_y();
     if (device_architecture == tt::ARCH::WORMHOLE_B0 && coord_is_translated) {
-        const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+        const metal_SocDescriptor& soc_desc =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
         // disable linting here; slicing is __intended__
         // NOLINTBEGIN
         return soc_desc.translate_coord_to(c, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
@@ -712,7 +718,7 @@ void DeviceProfiler::dumpResults(
     ZoneScoped;
 
     auto device_id = device->id();
-    device_core_frequency = tt::Cluster::instance().get_device_aiclk(device_id);
+    device_core_frequency = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
 
     generateZoneSourceLocationsHashes();
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -7,7 +7,7 @@
 #include <dispatch_core_common.hpp>
 #include <host_api.hpp>
 #include <profiler.hpp>
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <tt_metal.hpp>
 #include <algorithm>
 #include <atomic>
@@ -108,25 +108,30 @@ constexpr CoreCoord SYNC_CORE = {0, 0};
 
 void setControlBuffer(chip_id_t device_id, std::vector<uint32_t>& control_buffer) {
 #if defined(TRACY_ENABLE)
-    const metal_SocDescriptor& soc_d = tt::Cluster::instance().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
 
     control_buffer[kernel_profiler::CORE_COUNT_PER_DRAM] = soc_d.profiler_ceiled_core_count_perf_dram_bank;
 
-    for (auto core : tt::Cluster::instance().get_virtual_routing_to_profiler_flat_id(device_id)) {
+    for (auto core :
+         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_routing_to_profiler_flat_id(device_id)) {
         HalProgrammableCoreType CoreType;
         auto curr_core = core.first;
-        if (tt::Cluster::instance().is_worker_core(curr_core, device_id)) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(curr_core, device_id)) {
             CoreType = HalProgrammableCoreType::TENSIX;
         } else {
             CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
-            auto active_eth_cores = tt::Cluster::instance().get_active_ethernet_cores(device_id);
-            if (active_eth_cores.find(tt::Cluster::instance().get_logical_ethernet_core_from_virtual(
-                    device_id, curr_core)) != active_eth_cores.end()) {
+            auto active_eth_cores =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
+            if (active_eth_cores.find(
+                    tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
+                        device_id, curr_core)) != active_eth_cores.end()) {
                 CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
             }
-            auto idle_eth_cores = tt::Cluster::instance().get_inactive_ethernet_cores(device_id);
-            if (idle_eth_cores.find(tt::Cluster::instance().get_logical_ethernet_core_from_virtual(
-                    device_id, curr_core)) != idle_eth_cores.end()) {
+            auto idle_eth_cores =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_inactive_ethernet_cores(device_id);
+            if (idle_eth_cores.find(
+                    tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
+                        device_id, curr_core)) != idle_eth_cores.end()) {
                 CoreType = tt_metal::HalProgrammableCoreType::IDLE_ETH;
             }
         }
@@ -147,7 +152,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     auto device_id = device->id();
     auto core = device->worker_core_from_logical_core(logical_core);
 
-    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
     auto phys_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
 
     deviceHostTimePair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
@@ -194,7 +199,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         int64_t writeStart = TracyGetCpuTime();
         uint32_t sinceStart = writeStart - hostStartTime;
 
-        tt::Cluster::instance().write_reg(&sinceStart, tt_cxy_pair(device_id, core), control_addr);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_reg(
+            &sinceStart, tt_cxy_pair(device_id, core), control_addr);
         writeTimes[i] = (TracyGetCpuTime() - writeStart);
     }
 
@@ -392,7 +398,8 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
         chip_id_t device_id_receiver_curr = std::numeric_limits<chip_id_t>::max();
         while ((device_id_receiver != device_id_receiver_curr) and (eth_sender_core_iter != active_eth_cores.end())) {
             eth_sender_core = *eth_sender_core_iter;
-            if (not tt::Cluster::instance().is_ethernet_link_up(device_sender->id(), eth_sender_core)) {
+            if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                    device_sender->id(), eth_sender_core)) {
                 eth_sender_core_iter++;
                 continue;
             }
@@ -500,7 +507,7 @@ void ProfilerSync(ProfilerSyncState state) {
     if (state == ProfilerSyncState::INIT) {
         do_sync_on_close = true;
         sync_set_devices.clear();
-        auto ethernet_connections = tt::Cluster::instance().get_ethernet_connections();
+        auto ethernet_connections = tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connections();
         std::set<chip_id_t> visited_devices = {};
         constexpr int TOTAL_DEVICE_COUNT = 36;
         for (int sender_device_id = 0; sender_device_id < TOTAL_DEVICE_COUNT; sender_device_id++) {
@@ -512,7 +519,8 @@ void ProfilerSync(ProfilerSyncState state) {
                 tt_xy_pair receiver_eth_core;
                 bool doSync = true;
                 for (auto& sender_eth_core : active_eth_cores) {
-                    if (not tt::Cluster::instance().is_ethernet_link_up(sender_device_id, sender_eth_core)) {
+                    if (not tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                            sender_device_id, sender_eth_core)) {
                         continue;
                     }
                     doSync = false;
@@ -637,9 +645,12 @@ void InitDeviceProfiler(IDevice* device) {
             }
         }
 
-        uint32_t dramBankCount = tt::Cluster::instance().get_soc_desc(device_id).get_num_dram_views();
-        uint32_t coreCountPerDram =
-            tt::Cluster::instance().get_soc_desc(device_id).profiler_ceiled_core_count_perf_dram_bank;
+        uint32_t dramBankCount =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_num_dram_views();
+        uint32_t coreCountPerDram = tt::tt_metal::MetalContext::instance()
+                                        .get_cluster()
+                                        .get_soc_desc(device_id)
+                                        .profiler_ceiled_core_count_perf_dram_bank;
 
         uint32_t pageSize = PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC * PROFILER_RISC_COUNT * coreCountPerDram;
 
@@ -733,13 +744,16 @@ void DumpDeviceProfileResults(IDevice* device, std::vector<CoreCoord>& worker_co
                     auto curr_core = device->virtual_core_from_logical_core(dispatchCores[0], dispatch_core_type);
 
                     HalProgrammableCoreType CoreType;
-                    if (tt::Cluster::instance().is_worker_core(curr_core, device_id)) {
+                    if (tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(curr_core, device_id)) {
                         CoreType = HalProgrammableCoreType::TENSIX;
                     } else {
-                        auto active_eth_cores = tt::Cluster::instance().get_active_ethernet_cores(device_id);
+                        auto active_eth_cores =
+                            tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
                         bool is_active_eth_core =
-                            active_eth_cores.find(tt::Cluster::instance().get_logical_ethernet_core_from_virtual(
-                                device_id, curr_core)) != active_eth_cores.end();
+                            active_eth_cores.find(tt::tt_metal::MetalContext::instance()
+                                                      .get_cluster()
+                                                      .get_logical_ethernet_core_from_virtual(device_id, curr_core)) !=
+                            active_eth_cores.end();
 
                         CoreType = is_active_eth_core ? tt_metal::HalProgrammableCoreType::ACTIVE_ETH
                                                       : tt_metal::HalProgrammableCoreType::IDLE_ETH;

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -24,9 +24,9 @@
 #include "hal.hpp"
 #include "strong_type.hpp"
 #include "sub_device_manager.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/xy_pair.h>
 #include "vector_aligned.hpp"
@@ -208,7 +208,8 @@ void SubDeviceManager::validate_sub_devices() const {
         if (sub_device.has_core_type(HalProgrammableCoreType::ACTIVE_ETH)) {
             const auto& eth_cores = sub_device.cores(HalProgrammableCoreType::ACTIVE_ETH);
             uint32_t num_eth_cores = 0;
-            const auto& device_eth_cores = tt::Cluster::instance().get_active_ethernet_cores(device_->id());
+            const auto& device_eth_cores =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_->id());
             for (const auto& dev_eth_core : device_eth_cores) {
                 if (eth_cores.contains(dev_eth_core)) {
                     num_eth_cores++;
@@ -324,7 +325,7 @@ void SubDeviceManager::populate_noc_data() {
     noc_mcast_data_start_index_.resize(num_sub_devices);
     noc_unicast_data_start_index_.resize(num_sub_devices);
 
-    NOC noc_index = DispatchQueryManager::instance().go_signal_noc();
+    NOC noc_index = MetalContext::instance().get_dispatch_query_manager().go_signal_noc();
     uint32_t idx = 0;
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
         const auto& tensix_cores = sub_devices_[i].cores(HalProgrammableCoreType::TENSIX).merge_ranges();

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -8,7 +8,7 @@
 
 #include "assert.hpp"
 #include "device.hpp"
-#include "dispatch/dispatch_core_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_mem_map.hpp"
@@ -20,7 +20,7 @@
 #include "trace_buffer.hpp"
 #include "tt_align.hpp"
 #include "tt_metal/impl/dispatch/device_command.hpp"
-#include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include "worker_config_buffer.hpp"
 
@@ -91,7 +91,7 @@ void issue_trace_commands(
     HugepageDeviceCommand command_sequence(cmd_region, dispatch_md.cmd_sequence_sizeB);
 
     DispatcherSelect dispatcher_for_go_signal = DispatcherSelect::DISPATCH_MASTER;
-    if (DispatchQueryManager::instance().dispatch_s_enabled()) {
+    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
         uint16_t index_bitmask = 0;
         for (const auto& id : dispatch_md.sub_device_ids) {
             index_bitmask |= 1 << *id;
@@ -99,7 +99,7 @@ void issue_trace_commands(
         command_sequence.add_notify_dispatch_s_go_signal_cmd(false, index_bitmask);
         dispatcher_for_go_signal = DispatcherSelect::DISPATCH_SLAVE;
     }
-    auto dispatch_core_config = dispatch_core_manager::instance().get_dispatch_core_config();
+    auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     auto dispatch_core_type = dispatch_core_config.get_core_type();
 
     go_msg_t reset_launch_message_read_ptr_go_signal;
@@ -145,7 +145,7 @@ void issue_trace_commands(
             expected_num_workers += device->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, id);
         }
 
-        if (DispatchQueryManager::instance().distributed_dispatcher()) {
+        if (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) {
             command_sequence.add_dispatch_wait(
                 CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_CLEAR_STREAM,
                 0,
@@ -182,7 +182,7 @@ uint32_t compute_trace_cmd_size(uint32_t num_sub_devices) {
         align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) * num_sub_devices;
 
     uint32_t cmd_sequence_sizeB =
-        DispatchQueryManager::instance().dispatch_s_enabled() *
+        MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() *
             hal_ref.get_alignment(
                 HalMemType::HOST) +  // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
         go_signals_cmd_size +        // go signal cmd
@@ -192,7 +192,8 @@ uint32_t compute_trace_cmd_size(uint32_t num_sub_devices) {
                                   // dispatch_s is responsible for resetting worker count and giving dispatch_d the
                                   // latest worker state. This is encapsulated in the dispatch_s wait command (only to
                                   // be sent when dispatch is distributed on 2 cores)
-         (DispatchQueryManager::instance().distributed_dispatcher()) * hal_ref.get_alignment(HalMemType::HOST)) *
+         (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) *
+             hal_ref.get_alignment(HalMemType::HOST)) *
             num_sub_devices +
         hal_ref.get_alignment(HalMemType::HOST);  // CQ_PREFETCH_CMD_EXEC_BUF
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -20,7 +20,7 @@
 #include "metal_soc_descriptor.h"
 #include "rtoptions.hpp"
 #include "tt_backend_api_types.hpp"
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/cluster_descriptor_types.h>
@@ -84,8 +84,8 @@ const core_descriptor_t& get_core_descriptor_config(
             std::unordered_map<tt_metal::DispatchCoreConfig, std::unordered_map<uint8_t, core_descriptor_t>>>>
         config_by_arch;
 
-    ARCH arch = tt::Cluster::instance().arch();
-    uint32_t harvesting_mask = tt::Cluster::instance().get_harvesting_mask(device_id);
+    ARCH arch = tt::tt_metal::MetalContext::instance().get_cluster().arch();
+    uint32_t harvesting_mask = tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
     std::bitset<32> mask_bitset(harvesting_mask);
     uint32_t num_harvested_rows = mask_bitset.count();
 
@@ -97,14 +97,14 @@ const core_descriptor_t& get_core_descriptor_config(
     }
 
     std::string product_name = get_product_name(arch, num_harvested_rows);
-    if (tt::Cluster::instance().is_galaxy_cluster()) {
-        if (tt::Cluster::instance().get_board_type(device_id) == BoardType::N150) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster()) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(device_id) == BoardType::N150) {
             // some Galaxy machines are setup with N150s that have 0 harvested rows.
             // get_product_name ( ) returns those chips as galaxy. Override that to nebula_x1.
             product_name = "nebula_x1";
         } else {
             TT_ASSERT(
-                tt::Cluster::instance().get_board_type(device_id) == BoardType::GALAXY,
+                tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(device_id) == BoardType::GALAXY,
                 "Invalid Board Type in Galaxy Cluster. Only GALAXY and N150 are supported.");
         }
     }
@@ -148,7 +148,7 @@ const core_descriptor_t& get_core_descriptor_config(
 
     auto compute_with_storage_start = desc_yaml["compute_with_storage_grid_range"]["start"];
     auto compute_with_storage_end = desc_yaml["compute_with_storage_grid_range"]["end"];
-    if (tt::Cluster::instance().is_galaxy_cluster() and product_name == "nebula_x1") {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() and product_name == "nebula_x1") {
         compute_with_storage_start = desc_yaml["tg_compute_with_storage_grid_range"]["start"];
         compute_with_storage_end = desc_yaml["tg_compute_with_storage_grid_range"]["end"];
     }
@@ -169,12 +169,14 @@ const core_descriptor_t& get_core_descriptor_config(
 
     std::vector<RelativeCoreCoord> dispatch_cores;
     auto dispatch_cores_string = "dispatch_cores";
-    if (tt::Cluster::instance().is_galaxy_cluster() and product_name == "nebula_x1") {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() and product_name == "nebula_x1") {
         dispatch_cores_string = "tg_dispatch_cores";
     }
 
-    CoreCoord grid_size = tt::Cluster::instance().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-    auto logical_active_eth_cores = tt::Cluster::instance().get_active_ethernet_cores(device_id);
+    CoreCoord grid_size =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    auto logical_active_eth_cores =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(device_id);
 
     for (const auto& core_node : desc_yaml[dispatch_cores_string]) {
         RelativeCoreCoord coord = {};
@@ -248,7 +250,8 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
         std::size_t tensix_num_worker_cols = worker_grid.x;
         std::size_t tensix_num_worker_rows = worker_grid.y;
         uint32_t tensix_num_worker_cores = tensix_num_worker_cols * tensix_num_worker_rows;
-        const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+        const metal_SocDescriptor& soc_desc =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
         // Get physical compute grid range based on SOC Desc and Logical Coords
         // Logical Worker Coords start at 0,0
         CoreCoord tensix_worker_start_phys = soc_desc.get_physical_tensix_core_from_logical(CoreCoord(0, 0));
@@ -264,7 +267,7 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
 std::optional<uint32_t> get_storage_core_bank_size(
     chip_id_t device_id, const uint8_t num_hw_cqs, const tt_metal::DispatchCoreConfig& dispatch_core_config) {
     const core_descriptor_t& core_desc = get_core_descriptor_config(device_id, num_hw_cqs, dispatch_core_config);
-    const metal_SocDescriptor& soc_desc = tt::Cluster::instance().get_soc_desc(device_id);
+    const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
     if (core_desc.storage_core_bank_size.has_value()) {
         TT_FATAL(
             core_desc.storage_core_bank_size.value() % tt_metal::hal_ref.get_alignment(tt_metal::HalMemType::L1) == 0,

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -14,7 +14,7 @@
 #include "core_coord.hpp"
 #include "span.hpp"
 // clang-format off
-#include "tt_cluster.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
@@ -73,7 +73,7 @@ void write_hex_vec_to_core(
     const std::vector<DType>& hex_vec,
     uint64_t addr,
     bool small_access = false) {
-    tt::Cluster::instance().write_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
 }
 template <typename DType>
@@ -83,7 +83,7 @@ void write_hex_vec_to_core(
     tt::stl::Span<const DType> hex_vec,
     uint64_t addr,
     bool small_access = false) {
-    tt::Cluster::instance().write_core(
+    tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr, small_access);
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -88,11 +88,6 @@ inline std::string get_soc_description_file(
 }  // namespace
 namespace tt {
 
-Cluster& Cluster::instance() {
-    static Cluster inst;
-    return inst;
-}
-
 Cluster::Cluster() {
     ZoneScoped;
     log_info(tt::LogDevice, "Opening user mode device driver");
@@ -502,7 +497,7 @@ CoreCoord Cluster::get_physical_coordinate_from_logical_coordinates(
 }
 
 CoreCoord Cluster::get_logical_ethernet_core_from_virtual(chip_id_t chip, CoreCoord core) const {
-    const metal_SocDescriptor &soc_desc = tt::Cluster::instance().get_soc_desc(chip);
+    const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip);
     tt::umd::CoreCoord logical_core =
         get_soc_desc(chip).translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
     return {logical_core.x, logical_core.y};
@@ -510,7 +505,7 @@ CoreCoord Cluster::get_logical_ethernet_core_from_virtual(chip_id_t chip, CoreCo
 
 const std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_x(chip_id_t chip_id) const {
     std::unordered_map<int, int> worker_logical_to_virtual_x;
-    const auto& soc_desc = tt::Cluster::instance().get_soc_desc(chip_id);
+    const auto& soc_desc = this->get_soc_desc(chip_id);
     for (const tt::umd::CoreCoord& logical_core : soc_desc.get_cores(CoreType::TENSIX, CoordSystem::LOGICAL)) {
         tt::umd::CoreCoord translated_core = soc_desc.translate_coord_to(logical_core, CoordSystem::TRANSLATED);
         worker_logical_to_virtual_x[logical_core.x] = translated_core.x;
@@ -520,7 +515,7 @@ const std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_x(chip
 
 const std::unordered_map<int, int> Cluster::get_worker_logical_to_virtual_y(chip_id_t chip_id) const {
     std::unordered_map<int, int> worker_logical_to_virtual_y;
-    const auto& soc_desc = tt::Cluster::instance().get_soc_desc(chip_id);
+    const auto& soc_desc = this->get_soc_desc(chip_id);
     for (const tt::umd::CoreCoord& logical_core : soc_desc.get_cores(CoreType::TENSIX, CoordSystem::LOGICAL)) {
         tt::umd::CoreCoord translated_core = soc_desc.translate_coord_to(logical_core, CoordSystem::TRANSLATED);
         worker_logical_to_virtual_y[logical_core.y] = translated_core.y;
@@ -1033,7 +1028,7 @@ void Cluster::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
     } else {
         this->release_ethernet_cores_for_fabric_routers();
     }
-    tt::Cluster::instance().get_control_plane()->configure_routing_tables_for_fabric_ethernet_channels();
+    this->get_control_plane()->configure_routing_tables_for_fabric_ethernet_channels();
 }
 
 void Cluster::reserve_ethernet_cores_for_fabric_routers() {
@@ -1178,7 +1173,7 @@ void Cluster::set_internal_routing_info_for_ethernet_cores(bool enable_internal_
     std::vector<chip_id_t> non_mmio_devices;
     std::vector<chip_id_t> mmio_devices = target_mmio_devices;
     if (mmio_devices.size() == 0) {
-        mmio_devices.reserve(tt::Cluster::instance().number_of_pci_devices());
+        mmio_devices.reserve(this->number_of_pci_devices());
         for (const auto &[assoc_mmio_device, devices] : this->devices_grouped_by_assoc_mmio_device_) {
             mmio_devices.emplace_back(assoc_mmio_device);
         }

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -86,7 +86,8 @@ public:
     Cluster(const Cluster&) = delete;
     Cluster(Cluster&& other) noexcept = delete;
 
-    static Cluster& instance();
+    Cluster();
+    ~Cluster();
 
     // For TG Galaxy systems, mmio chips are gateway chips that are only used for dispatch, so user_devices are meant
     // for user facing host apis
@@ -307,9 +308,6 @@ public:
     const std::unordered_map<CoreCoord, int32_t>& get_virtual_routing_to_profiler_flat_id(chip_id_t chip_id) const;
 
 private:
-    Cluster();
-    ~Cluster();
-
     void detect_arch_and_target();
     void generate_cluster_descriptor();
     void initialize_device_drivers();

--- a/tt_metal/tools/mem_bench/host_utils.cpp
+++ b/tt_metal/tools/mem_bench/host_utils.cpp
@@ -4,7 +4,7 @@
 
 #include "host_utils.hpp"
 
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <algorithm>
 #include <chrono>
 #include <limits>
@@ -14,14 +14,14 @@
 namespace tt::tt_metal::tools::mem_bench {
 
 void* get_hugepage(int device_id, uint32_t base_offset) {
-    auto& cluster = tt::Cluster::instance();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto mmio_device_id = cluster.get_associated_mmio_device(device_id);
     auto channel = cluster.get_assigned_channel_for_device(device_id);
     return (void*)(cluster.host_dma_address(base_offset, mmio_device_id, channel));
 }
 
 uint32_t get_hugepage_size(int device_id) {
-    auto& cluster = tt::Cluster::instance();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     auto mmio_device_id = cluster.get_associated_mmio_device(device_id);
     auto channel = cluster.get_assigned_channel_for_device(device_id);
     return cluster.get_host_channel_size(mmio_device_id, channel);
@@ -43,7 +43,7 @@ double get_current_time_seconds() {
 }
 
 std::vector<int> get_mmio_device_ids(int number_of_devices, int numa_node) {
-    auto& cluster = tt::Cluster::instance();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto pcie_devices = cluster.number_of_pci_devices();
     std::vector<int> device_ids;
 
@@ -64,7 +64,7 @@ std::vector<int> get_mmio_device_ids(int number_of_devices, int numa_node) {
 }
 
 std::vector<int> get_mmio_device_ids_unique_nodes(int number_of_devices) {
-    auto& cluster = tt::Cluster::instance();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto pcie_devices = cluster.number_of_pci_devices();
     std::vector<int> device_ids;
     std::unordered_set<uint32_t> numa_nodes;
@@ -81,7 +81,7 @@ std::vector<int> get_mmio_device_ids_unique_nodes(int number_of_devices) {
 }
 
 int get_number_of_mmio_devices() {
-    auto& cluster = tt::Cluster::instance();
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     return cluster.number_of_pci_devices();
 }
 

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -8,7 +8,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <iostream>
 #include <map>
 #include <numeric>
@@ -37,7 +37,7 @@ void read_inc_data_from_cores(const Context& ctx, IDevice* device, const CoreRan
     auto dev_cycles = read_cores(device, cores, ctx.device_address.cycles);
     auto dev_bytes_read = read_cores(device, cores, ctx.device_address.rd_bytes);
     auto dev_bytes_written = read_cores(device, cores, ctx.device_address.wr_bytes);
-    auto dev_clk = tt::Cluster::instance().get_device_aiclk(device->id()) * 1e6;  // Hz
+    auto dev_clk = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id()) * 1e6;  // Hz
 
     double total_cycles = std::reduce(dev_cycles.begin(), dev_cycles.end(), 0ULL);
 

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stdint.h>
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <tt_stl/span.hpp>
 #include <unistd.h>
 #include <cstdlib>
@@ -20,7 +20,7 @@
 
 void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory vector to L1 for all cores at a specific start address.
-    const metal_SocDescriptor& sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
+    const metal_SocDescriptor& sdesc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(chip_id);
     for (auto& worker_core : sdesc.get_cores(CoreType::TENSIX, CoordSystem::PHYSICAL)) {
         tt::llrt::write_hex_vec_to_core(chip_id, worker_core, mem_vec, start_addr);
     }
@@ -28,12 +28,12 @@ void memset_l1(tt::stl::Span<const uint32_t> mem_vec, uint32_t chip_id, uint32_t
 
 void memset_dram(std::vector<uint32_t> mem_vec, uint32_t chip_id, uint32_t start_addr) {
     // Utility function that writes a memory to all channels and subchannels at a specific start address.
-    const metal_SocDescriptor& sdesc = tt::Cluster::instance().get_soc_desc(chip_id);
+    const metal_SocDescriptor& sdesc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(chip_id);
     for (uint32_t dram_view = 0; dram_view < sdesc.get_num_dram_views(); dram_view++) {
         for (uint32_t dram_src_subchannel_id = 0;
              dram_src_subchannel_id < sdesc.get_dram_cores().at(sdesc.get_channel_for_dram_view(dram_view)).size();
              dram_src_subchannel_id++) {
-            tt::Cluster::instance().write_dram_vec(
+            tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
                 mem_vec, tt_target_dram{chip_id, dram_view, dram_src_subchannel_id}, start_addr);
         }
     }

--- a/tt_metal/tools/tt_gdb/tt_gdb.hpp
+++ b/tt_metal/tools/tt_gdb/tt_gdb.hpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <string>
-#include <tt_cluster.hpp>
+#include "impl/context/metal_context.hpp"
 #include <device.hpp>
 
 namespace tt_gdb {


### PR DESCRIPTION
Metal has multiple singletons: cluster, dispatch_core_manager, dispatch_query_manager, dispatch_settings, debug_tools, etc. The goal is to clean up all of the global init (dispatch, fabric, fw, cluster) into a single class, MetalContext. This is a preliminary PR to introduce the class and remove other metal singletons to have their state managed through this one.

Future PRs will move global init/teardown out of Device/DevicePool and into this class. They have a dependency on this PR due to issues with singleton teardown ordering.

First commit is the new code, second commit is all the usage changes.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/14252954459