### PR TITLE
Fix args in fabric_router_vc kernel config

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -376,7 +376,7 @@ void DispatchKernel::CreateKernel() {
         dependent_config_.downstream_chip_id.value_or(0),
         dependent_config_.upstream_mesh_id.value_or(0),
         dependent_config_.upstream_chip_id.value_or(0),
-        dependent_config_.fabric_router_noc_xy.value_or(0xdeadbeef),
+        dependent_config_.fabric_router_noc_xy.value_or(0),
         static_config_.client_interface_addr.value_or(0),
 
         static_config_.first_stream_used.value(),

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -21,8 +21,11 @@ void FabricRouterVC::GenerateDependentConfigs() {
     TT_ASSERT(
         upstream_kernels_.size() == downstream_kernels_.size(),
         "Fabric Router VC requires upstream.size() == downstream.size()");
-    const auto& control_plane = tt::Cluster::instance().get_control_plane();
-    TT_FATAL(control_plane, "Control plane is nullptr. Is fabric initialized yet?");
+    auto& cluster = tt::Cluster::instance();
+    const auto& control_plane = cluster.get_control_plane();
+    TT_FATAL(
+        cluster.get_fabric_config() != FabricConfig::DISABLED && control_plane,
+        "Control plane is nullptr. Is fabric initialized yet?");
 
     // Zip upstream and downstream kernels together
     for (int i = 0; i < upstream_kernels_.size(); ++i) {
@@ -37,13 +40,27 @@ void FabricRouterVC::GenerateDependentConfigs() {
         const auto& [dst_mesh_id, dst_chip_id] =
             control_plane->get_mesh_chip_id_from_physical_chip_id(ds_kernel->GetDeviceId());
         const auto& routers = control_plane->get_routers_to_chip(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
+        TT_ASSERT(
+            !routers.empty(),
+            "No routers for (mesh {}, chip {}) to (mesh {}, chip{})",
+            src_mesh_id,
+            src_chip_id,
+            dst_mesh_id,
+            dst_chip_id);
         const auto& [routing_plane, fabric_router] = routers.front();
 
-        const auto& routers_reversed =
+        const auto& routers_rev =
             control_plane->get_routers_to_chip(dst_mesh_id, dst_chip_id, src_mesh_id, src_chip_id);
-        const auto& [routing_plane_rev, fabric_router_rev] = routers_reversed.front();
-        bool valid_path{false};
+        TT_ASSERT(
+            !routers_rev.empty(),
+            "No routers for return path (mesh {}, chip {}) to (mesh {}, chip{})",
+            dst_mesh_id,
+            dst_chip_id,
+            src_mesh_id,
+            src_chip_id);
+        const auto& [routing_plane_rev, fabric_router_rev] = routers_rev.front();
 
+        bool valid_path{false};
         if (auto prefetch_us = dynamic_cast<PrefetchKernel*>(us_kernel);
             auto prefetch_ds = dynamic_cast<PrefetchKernel*>(ds_kernel)) {
             valid_path = true;
@@ -54,12 +71,11 @@ void FabricRouterVC::GenerateDependentConfigs() {
             valid_path = true;
         }
 
-        TT_FATAL(valid_path, "FabricRouterVC is not implemented for this path\n");
+        TT_FATAL(valid_path, "FabricRouterVC is not implemented for this path");
 
         // Downstream path. src -> dst
         us_kernel->UpdateArgsForFabric(fabric_router, src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
-        // Upstream path. dst -> src
-        ds_kernel->UpdateArgsForFabric(fabric_router_rev, dst_mesh_id, dst_chip_id, src_mesh_id, src_chip_id);
+        ds_kernel->UpdateArgsForFabric(fabric_router_rev, src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
     }
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -383,7 +383,7 @@ void PrefetchKernel::CreateKernel() {
         dependent_config_.downstream_chip_id.value_or(0),
         dependent_config_.upstream_mesh_id.value_or(0),
         dependent_config_.upstream_chip_id.value_or(0),
-        dependent_config_.fabric_router_noc_xy.value_or(0xdeadbeef),
+        dependent_config_.fabric_router_noc_xy.value_or(0),
         static_config_.client_interface_addr.value_or(0),
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -121,6 +121,8 @@ enum CQNocSend {
     CQ_NOC_SEND = 1,
 };
 
+constexpr bool use_fabric(uint64_t fabric_router_xy) { return fabric_router_xy != 0; }
+
 template <
     enum CQNocFlags flags,
     enum CQNocWait wait = CQ_NOC_WAIT,

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -56,9 +56,9 @@ constexpr uint32_t dev_completion_q_rd_ptr = get_compile_time_arg_val(28);
 
 // used for fd on fabric
 constexpr uint32_t downstream_mesh_id = get_compile_time_arg_val(29);
-constexpr uint32_t downstream_chip_id = get_compile_time_arg_val(30);
+constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(30);
 constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(31);
-constexpr uint32_t upstream_chip_id = get_compile_time_arg_val(32);
+constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(32);
 constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(33);
 constexpr uint32_t client_interface_addr = get_compile_time_arg_val(34);
 
@@ -1233,6 +1233,10 @@ static inline bool process_cmd_h(
 
 void kernel_main() {
     // DPRINT << "dispatch_" << is_h_variant << is_d_variant << ": start" << ENDL();
+    if constexpr (use_fabric(fabric_router_noc_xy)) {
+        tt::tt_fabric::fabric_endpoint_init(client_interface, 0 /*unused*/);
+    }
+
     // Initialize local state of any additional nocs used instead of the default
     static_assert(my_noc_index != upstream_noc_index);
     if constexpr (my_noc_index != upstream_noc_index) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -66,9 +66,9 @@ constexpr uint32_t dispatch_s_cb_log_page_size = get_compile_time_arg_val(25);
 
 // used for fd on fabric
 constexpr uint32_t downstream_mesh_id = get_compile_time_arg_val(26);
-constexpr uint32_t downstream_chip_id = get_compile_time_arg_val(27);
+constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(27);
 constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(28);
-constexpr uint32_t upstream_chip_id = get_compile_time_arg_val(29);
+constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(29);
 constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(30);
 constexpr uint32_t client_interface_addr = get_compile_time_arg_val(31);
 
@@ -1477,6 +1477,9 @@ void kernel_main_hd() {
 
 void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
+    if constexpr (use_fabric(fabric_router_noc_xy)) {
+        tt::tt_fabric::fabric_endpoint_init(client_interface, 0 /*unused*/);
+    }
 
     if (is_h_variant and is_d_variant) {
         kernel_main_hd();


### PR DESCRIPTION
### Ticket
#18726

### Problem description
- Downstream kernel was not receiving the correct upstream mesh and device id
- Assertion to check fabric was initialized wasn't being triggered as expected

### What's changed
- Fix issues

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14247898299
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14247898972
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14247900464