### PR TITLE
#20006: Add flush wait to end of stream_increment_reg_write.cpp

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
@@ -40,4 +40,6 @@ void kernel_main() {
                                      ((1 << REMOTE_DEST_WORDS_FREE_WIDTH) - 1))) {
         }
     }
+
+    noc_async_writes_flushed();
 }


### PR DESCRIPTION

### Ticket
#20006 

### Problem description
The watcher asserst if the inline write in stream_increment_reg_write.cpp isn't flushed when the kernel finishes.

### What's changed
Add flush wait to end of stream_increment_reg_write.cpp


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes