### PR TITLE
Implementation of avg_pool2d as a pool operation

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.ttnn.unit_tests.operations.pool.test_avgpool2d import run_avg_pool2d
+
+import pytest
+import ttnn
+
+
+@pytest.fixture(scope="module")
+def tensor_map():
+    tensor_map = {}
+
+    return tensor_map
+
+
+parameters = {
+    "input_specs": [
+        # Contains following parameters
+        # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, ceil_mode, count_include_pad]
+        [1, 1056, 14, 14, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 128, 56, 56, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 160, 7, 7, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 192, 56, 56, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 256, 28, 28, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 384, 28, 28, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 512, 14, 14, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 640, 14, 14, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 896, 14, 14, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 1024, 17, 17, 3, 3, 1, 1, 1, 1, False, False],
+        [1, 112, 14, 14, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 1536, 8, 8, 3, 3, 1, 1, 1, 1, False, False],
+        [1, 24, 56, 56, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 384, 35, 35, 3, 3, 1, 1, 1, 1, False, False],
+        [1, 40, 28, 28, 2, 2, 2, 2, 0, 0, False, True],
+        [1, 80, 14, 14, 2, 2, 2, 2, 0, 0, False, True],
+    ],
+    "failing_parameters": [
+        # [batch_size, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, ceil_mode, count_include_pad]
+        [1, 1024, 17, 17, 3, 3, 1, 1, 1, 1, False, False],  # 10
+        [1, 112, 14, 14, 2, 2, 2, 2, 0, 0, False, True],  # 11
+        [1, 1536, 8, 8, 3, 3, 1, 1, 1, 1, False, False],  # 12
+        [1, 24, 56, 56, 2, 2, 2, 2, 0, 0, False, True],  # 13
+        [1, 384, 35, 35, 3, 3, 1, 1, 1, 1, False, False],  # 14
+        [1, 40, 28, 28, 2, 2, 2, 2, 0, 0, False, True],  # 15
+        [1, 80, 14, 14, 2, 2, 2, 2, 0, 0, False, True],  # 16
+    ],
+}
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize("input_spec", parameters["input_specs"])
+def test_ttnn_pytorch_sweep(device, tensor_map, input_spec):
+    (
+        in_n,
+        in_c,
+        in_h,
+        in_w,
+        kernel_h,
+        kernel_w,
+        stride_h,
+        stride_w,
+        pad_h,
+        pad_w,
+        ceil_mode,
+        count_include_pad,
+    ) = input_spec
+
+    # Check if input_spec is in failing_parameters
+    if input_spec in parameters["failing_parameters"]:
+        pytest.skip(f"Skipping test for failing input_spec: {input_spec}")
+
+    run_avg_pool2d(
+        device,
+        tensor_map,
+        (in_n, in_c, in_h, in_w),
+        (kernel_h, kernel_w),
+        (stride_h, stride_w),
+        (pad_h, pad_w),
+        (1, 1),  # dilation
+        ceil_mode,
+        count_include_pad,
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    )

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import pytest
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.fixture(scope="module")
+def tensor_map():
+    tensor_map = {}
+
+    return tensor_map
+
+
+def randomize_tensor(tensor_map, tensor_shape):
+    tensor_shape = tuple(tensor_shape)
+    if tensor_shape in tensor_map.keys():
+        torch_tensor = tensor_map[tensor_shape]
+    else:
+        torch_tensor = torch.rand(tensor_shape, dtype=torch.bfloat16)
+    return torch_tensor
+
+
+def run_avg_pool2d(
+    device, tensor_map, input_shape, kernel_size, stride, padding, dilation, ceil_mode, count_include_pad, shard_scheme
+):
+    ## Test setup for both.
+    in_n, in_c, in_h, in_w = input_shape
+    torch.manual_seed(0)
+    torch_input = randomize_tensor(tensor_map, input_shape)
+
+    ## Test setup for Actual.
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    ttnn_input = ttnn.permute(ttnn_input, (0, 2, 3, 1))
+    ttnn_input = ttnn.reshape(ttnn_input, (1, 1, in_n * in_h * in_w, in_c))
+
+    ## Get Expected output.
+    torch_output = torch.nn.functional.avg_pool2d(
+        torch_input,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+    )
+
+    ## Get Actual output
+    ttnn_output = ttnn.avg_pool2d(
+        input_tensor=ttnn_input,
+        batch_size=in_n,
+        input_h=in_h,
+        input_w=in_w,
+        channels=in_c,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+        ceil_mode=ceil_mode,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        applied_shard_scheme=shard_scheme,
+    )
+
+    ## Test teardown for Actual.
+    ttnn_output = ttnn_output.reshape(
+        torch_output.shape[0], torch_output.shape[2], torch_output.shape[3], torch_output.shape[1]
+    )
+    ttnn_output = ttnn.permute(ttnn_output, (0, 3, 1, 2))  # N, C, H, W
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    ## Assertion
+    assert_with_pcc(torch_output, ttnn_output, 0.99)
+    assert torch.allclose(ttnn_output, torch_output, rtol=0.02)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "input_shape",  # NCHW
+    (
+        # Case: Normal compute & Normal reader kernel.
+        [1, 32, 16, 16],
+        [1, 512, 112, 32],
+        [1, 512, 16, 16],
+        [1, 800, 16, 16],
+        [2, 32, 16, 16],
+        [2, 512, 112, 32],
+        [2, 512, 16, 16],
+        [2, 800, 16, 16],
+    ),
+)
+@pytest.mark.parametrize(
+    "kernel_size",
+    (
+        # Case: Normal compute & Normal reader kernel.
+        (2, 2),
+        (3, 3),
+        # Case: Large compute & Large reader kernel.
+        (5, 5),
+        (9, 9),
+    ),
+)
+@pytest.mark.parametrize(
+    "stride",
+    (
+        (1, 1),
+        (2, 2),
+    ),
+)
+@pytest.mark.parametrize(
+    "padding",
+    (
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (4, 4),
+    ),
+)
+@pytest.mark.parametrize("dilation", ((1, 1),))
+@pytest.mark.parametrize(
+    "ceil_mode",
+    [
+        False,
+    ],
+)
+@pytest.mark.parametrize(
+    "count_include_pad",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "shard_scheme",
+    [
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+    ],
+)
+def test_run_avg_pool2d(
+    device, tensor_map, input_shape, kernel_size, stride, padding, dilation, ceil_mode, count_include_pad, shard_scheme
+):
+    if any(p > k // 2 for p, k in zip(padding, kernel_size)):
+        pytest.skip(
+            "Known issue with this combination of parameters - RuntimeError: pad should be at most half of kernel size."
+        )
+    run_avg_pool2d(
+        device,
+        tensor_map,
+        input_shape,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        shard_scheme=shard_scheme,
+    )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -552,6 +552,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/generic_pools.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/pool_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device//upsample_bilinear_program_factory_multicore.cpp

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
@@ -55,20 +55,20 @@ void MAIN {
     // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet.
     constexpr uint32_t in_ntiles_hw = get_compile_time_arg_val(0);
     constexpr uint32_t in_ntiles_c = get_compile_time_arg_val(1);
-    constexpr uint32_t window_size_hw = get_compile_time_arg_val(3);
-    constexpr uint32_t out_h = get_compile_time_arg_val(4);
-    constexpr uint32_t out_w = get_compile_time_arg_val(5);
+    constexpr uint32_t window_size_hw = get_compile_time_arg_val(2);
+    constexpr uint32_t out_h = get_compile_time_arg_val(3);
+    constexpr uint32_t out_w = get_compile_time_arg_val(4);
 
-    constexpr uint32_t split_reader = get_compile_time_arg_val(12);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(5);
 
-    constexpr uint32_t nsticks_per_core = get_compile_time_arg_val(13);
-    constexpr uint32_t in_c = get_compile_time_arg_val(14);
-    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(15);
+    constexpr uint32_t nsticks_per_core = get_compile_time_arg_val(6);
+    constexpr uint32_t in_c = get_compile_time_arg_val(7);
+    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(8);
 
-    const uint32_t in_cb_id_0 = get_compile_time_arg_val(17);
-    const uint32_t in_cb_id_1 = get_compile_time_arg_val(18);
-    const uint32_t in_scalar_cb_id = get_compile_time_arg_val(19);
-    const uint32_t out_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t in_cb_id_0 = get_compile_time_arg_val(10);
+    constexpr uint32_t in_cb_id_1 = get_compile_time_arg_val(11);
+    constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(12);
+    constexpr uint32_t out_cb_id = get_compile_time_arg_val(13);
 
     constexpr bool is_partial_tile = in_c < 32;
     static_assert((!is_partial_tile || (in_c == 16)), "Partial tile must have c_dim 16");
@@ -81,9 +81,14 @@ void MAIN {
         in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
     constexpr uint32_t partial_iter_output_tiles =
         in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
-    tilizeA_B_reduce_init(
+
+    static_assert(REDUCE_OP == PoolType::MAX || REDUCE_OP == PoolType::SUM, "Only supports REDUCE_OP = MAX or Sum");
+    constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
+    constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::SUM) ? true : false;
+
+    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, window_size_hw);
-    pack_untilize_dst_init_short<in_ntiles_c>(out_cb_id, num_out_rows, num_faces_in_tile);
+    pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_tile);
 
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core; ++i) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_large_kernel_v2.cpp
@@ -5,7 +5,6 @@
 #include <sys/types.h>
 
 #include <cstdint>
-#include <cstring>
 
 #include "dataflow_api.h"
 
@@ -30,85 +29,84 @@ ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
 }
 
 /**
- * Max-pool 2D.
+ * Pool 2D (Max pool 2D and Avg pool 2D)
  */
 void kernel_main() {
-    const uint32_t reader_nindices = get_compile_time_arg_val(0);
-    const uint32_t window_h = get_compile_time_arg_val(1);
-    const uint32_t window_w = get_compile_time_arg_val(2);
+    constexpr uint32_t reader_nindices = get_compile_time_arg_val(0);
+    constexpr uint32_t window_h = get_compile_time_arg_val(1);
+    constexpr uint32_t window_w = get_compile_time_arg_val(2);
 
-    const int32_t pad_w = get_compile_time_arg_val(3);
+    constexpr int32_t pad_w = get_compile_time_arg_val(3);
 
     // channel size in bytes
-    const uint32_t in_nbytes_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(4);
 
     // input tensor height / width / channels
-    const int32_t in_w = get_compile_time_arg_val(5);
-    const uint32_t in_cb_nsticks = get_compile_time_arg_val(6);
+    constexpr int32_t in_w = get_compile_time_arg_val(5);
 
-    const uint32_t in_c = get_compile_time_arg_val(7);
+    constexpr uint32_t in_c = get_compile_time_arg_val(6);
 
-    const uint32_t split_reader = get_compile_time_arg_val(9);
-    const uint32_t reader_id = get_compile_time_arg_val(10);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(7);
+    constexpr uint32_t reader_id = get_compile_time_arg_val(8);
 
     // compile time args
-    // value of 1 in bf16 in a uin32_t
-    constexpr uint32_t bf16_one_u32 = get_compile_time_arg_val(11);
+    // BF16 value packed in UINT32. For maxpool, value is 1.
+    constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
+    constexpr uint32_t bf16_one_u32 = get_compile_time_arg_val(10);
+    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(11);
+
     constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(12);
     constexpr uint32_t in_cb_sz = get_compile_time_arg_val(13);
     constexpr uint32_t max_rows_for_reduction = get_compile_time_arg_val(14);
-
     constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(15);
 
-    constexpr uint32_t TILE_SIZE = 32 * 32;
-    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+    constexpr uint32_t TILE_WIDTH = 32;
     constexpr uint32_t MAX_ELE_PER_REDUCTION = 512;  // TILE_WIDTH * 8 * numbytes
-    constexpr uint32_t ROW_HW = 64;
 
     constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(17) : get_compile_time_arg_val(16);
     constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(18);
     constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
     constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
     constexpr uint32_t interm_reduction_cb_id = get_compile_time_arg_val(21);
+    constexpr uint32_t in_one_cb_id = get_compile_time_arg_val(22);
 
-    // minus infinity for bfp16
-    uint16_t minus_inf = 63487;
-    // Reduce scalar = 1
     if (reader_id == 0) {
         cb_reserve_back(in_scalar_cb_id, 1);
 
-        uint32_t bf16_one_u16 = bf16_one_u32 >> 16;
-        // fill interm buffer with minus_inf
-        fill_with_val(get_write_ptr(interm_reduction_cb_id), in_cb_sz, minus_inf);
-        // fill 1 row w/ scalar
-        fill_with_val(get_write_ptr(in_scalar_cb_id), ROW_HW, bf16_one_u16);
+        constexpr uint32_t bf16_one_u16 = bf16_one_u32 >> 16;
+        // fill interm buffer with init_value
+        fill_with_val(get_write_ptr(interm_reduction_cb_id), in_cb_sz, bf16_init_value);
+        fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, bf16_scalar >> 16);
+        if (bf16_scalar != bf16_one_u32) {
+            // Pool operation is not maxpool
+            fill_with_val(get_write_ptr(in_one_cb_id), TILE_WIDTH, bf16_one_u16);
+        }
         cb_push_back(in_scalar_cb_id, 1);
     }
 
-    uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
+    const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
     uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
     volatile tt_l1_ptr uint16_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(reader_indices_l1_addr);
 
-    uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
+    constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
 
     uint32_t counter = reader_id;
-    uint32_t total_elems_to_reduce = window_h * window_w;
-    uint32_t remaining_elems = total_elems_to_reduce % max_rows_for_reduction;
-    bool wide_reduction = in_nblocks_c > 1;
-    uint32_t read_bytes =
+    constexpr uint32_t total_elems_to_reduce = window_h * window_w;
+    constexpr uint32_t remaining_elems = total_elems_to_reduce % max_rows_for_reduction;
+    constexpr bool wide_reduction = in_nblocks_c > 1;
+    constexpr uint32_t read_bytes =
         wide_reduction ? MAX_ELE_PER_REDUCTION : in_nbytes_c;  // in_cb is MAX_ELE_PER_REDUCTION for wide reductions
     while (counter < reader_nindices) {
         for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
-            uint16_t top_left_local_index = reader_indices_ptr[counter];
+            const uint16_t top_left_local_index = reader_indices_ptr[counter];
             uint32_t processed_rows = 0;
             cb_reserve_back(in_cb_id, 1);
-            uint32_t out_l1_write_addr_base = get_write_ptr(in_cb_id);
-            uint32_t out_l1_write_addr = out_l1_write_addr_base;
+            uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
             for (uint32_t h = 0; h < window_h; ++h) {
                 for (uint32_t w = 0; w < window_w; w++) {
-                    uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
-                    uint32_t read_offset =
+                    const uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
+                    const uint32_t read_offset =
                         in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_ELE_PER_REDUCTION);
                     noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
                     out_l1_write_addr += read_bytes;
@@ -117,11 +115,10 @@ void kernel_main() {
                         noc_async_read_barrier();
                         cb_push_back(in_cb_id, 1);
                         cb_reserve_back(in_cb_id, 1);
-                        out_l1_write_addr_base = get_write_ptr(in_cb_id);
-                        out_l1_write_addr = out_l1_write_addr_base;
-                        // If next is last chunk, fill whole buffer with -inf.
+                        out_l1_write_addr = get_write_ptr(in_cb_id);
+                        // If next is last chunk, fill whole buffer with the init_value.
                         if ((total_elems_to_reduce - processed_rows) < max_rows_for_reduction) {
-                            fill_with_val(out_l1_write_addr, in_cb_sz, minus_inf);
+                            fill_with_val(out_l1_write_addr, in_cb_sz, bf16_init_value);
                         }
                     }
                 }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_wide.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_wide.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include <cstring>
 #include "dataflow_api.h"
 
 #define ENABLE_DEBUG_PRINT 0
@@ -27,35 +26,33 @@ ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
 }
 
 /**
- * Max-pool 2D.
+ * Pool 2D (Max pool 2D and Avg pool 2D)
  */
 void kernel_main() {
-    const uint32_t reader_nindices = get_compile_time_arg_val(0);
-    const uint32_t window_h = get_compile_time_arg_val(1);
-    const uint32_t window_w = get_compile_time_arg_val(2);
+    constexpr uint32_t reader_nindices = get_compile_time_arg_val(0);
+    constexpr uint32_t window_h = get_compile_time_arg_val(1);
+    constexpr uint32_t window_w = get_compile_time_arg_val(2);
 
-    const int32_t pad_w = get_compile_time_arg_val(3);
+    constexpr int32_t pad_w = get_compile_time_arg_val(3);
 
     // channel size in bytes, multiple of 32
-    const uint32_t in_nbytes_c = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(4);
 
     // input tensor height / width / channels
-    const int32_t in_w = get_compile_time_arg_val(5);
-    const uint32_t in_cb_nsticks = get_compile_time_arg_val(6);
+    constexpr int32_t in_w = get_compile_time_arg_val(5);
 
-    const uint32_t in_c = get_compile_time_arg_val(7);
+    constexpr uint32_t in_c = get_compile_time_arg_val(6);
 
-    const uint32_t split_reader = get_compile_time_arg_val(9);
-    const uint32_t reader_id = get_compile_time_arg_val(10);
+    constexpr uint32_t split_reader = get_compile_time_arg_val(7);
+    constexpr uint32_t reader_id = get_compile_time_arg_val(8);
 
-    // value of 1 in bf16 in a uin32_t
-    constexpr uint32_t bf16_one_u32 = get_compile_time_arg_val(11);
+    // compile time args
+    // BF16 value packed in UINT32. For maxpool, value is 1, for avgpool value is 1/kernel_size.
+    constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
 
     constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(12);
 
     constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(15);
-
-    // static_assert(0 == reader_nindices%2, "reader_nindices must be multiple of 2");
 
     constexpr uint32_t TILE_WIDTH = 32;
     constexpr uint32_t MAX_ELE_PER_REDUCTION = 512;  // TILE_WIDTH * 8 * numbytes
@@ -65,44 +62,39 @@ void kernel_main() {
     constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
     constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
 
-    constexpr uint32_t ROW_HW = 64;
-
-    // Reduce scalar = 1
     if (reader_id == 0) {
         cb_reserve_back(in_scalar_cb_id, 1);
-        uint32_t bf16_one_u16 = bf16_one_u32 >> 16;
-        // fill 1 row w/ scalar
-        fill_with_val(get_write_ptr(in_scalar_cb_id), ROW_HW, bf16_one_u16);
+        fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, bf16_scalar >> 16);
         cb_push_back(in_scalar_cb_id, 1);
     }
 
-    uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
+    const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
     uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
     volatile tt_l1_ptr uint16_t* reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint16_t*>(reader_indices_l1_addr);
 
-    uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
+    constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
 
-    uint32_t npages_to_reserve = 1;
+    constexpr uint32_t npages_to_reserve = 1;
     uint32_t counter = reader_id;
-    uint32_t read_bytes = MAX_ELE_PER_REDUCTION;
+    constexpr uint32_t read_bytes = MAX_ELE_PER_REDUCTION;
     while (counter < reader_nindices) {
-        uint16_t top_left_local_index = reader_indices_ptr[counter++];
+        const uint16_t top_left_local_index = reader_indices_ptr[counter++];
         for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
             cb_reserve_back(in_cb_id, npages_to_reserve);
-            uint32_t out_l1_write_addr_base = get_write_ptr(in_cb_id);
-            uint32_t out_l1_write_addr = out_l1_write_addr_base;
+            uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
             for (uint32_t h = 0; h < window_h; ++h) {
                 for (uint32_t w = 0; w < window_w; ++w) {
-                    uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
-                    uint32_t read_offset =
+                    const uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
+                    const uint32_t read_offset =
                         in_l1_read_base_addr +
                         (stick_offset * in_nbytes_c + c_i * MAX_ELE_PER_REDUCTION);  // 2 bytes, max 8 tiles
                     noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
                     out_l1_write_addr += MAX_ELE_PER_REDUCTION;
                 }
             }
-            noc_async_read_barrier();
+            noc_async_read_barrier();  // At this line, read is complete.
+
             cb_push_back(in_cb_id, npages_to_reserve);
         }
         if (split_reader) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -19,6 +19,7 @@ Pool2D::program_factory_t Pool2D::select_program_factory(const operation_attribu
 
 void validate_pool2d(
     const Tensor& input,
+    const Pool2DType pool_type,
     const sliding_window::SlidingWindowConfig& sliding_window_config,
     const MemoryConfig& out_mem_config) {
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Operands to reshape need to be on device!");
@@ -46,14 +47,20 @@ void validate_pool2d(
             input_shape[3],
             num_shards_c);
     }
+
+    TT_FATAL(
+        sliding_window_config.ceil_mode == false || pool_type == Pool2DType::MAX_POOL2D,
+        "Ceil mode set to true not supported for avg pool op");
 }
 
 void Pool2D::validate_on_program_cache_miss(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    return validate_pool2d(tensors.input_tensor_, op_attr.sliding_window_config_, op_attr.memory_config_);
+    return validate_pool2d(
+        tensors.input_tensor_, op_attr.pool_type_, op_attr.sliding_window_config_, op_attr.memory_config_);
 }
 
 void Pool2D::validate_on_program_cache_hit(const operation_attributes_t& op_attr, const tensor_args_t& tensors) {
-    return validate_pool2d(tensors.input_tensor_, op_attr.sliding_window_config_, op_attr.memory_config_);
+    return validate_pool2d(
+        tensors.input_tensor_, op_attr.pool_type_, op_attr.sliding_window_config_, op_attr.memory_config_);
 }
 
 Pool2D::spec_return_value_t Pool2D::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -9,19 +9,15 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/core.hpp"
-#include "ttnn/device_operation.hpp"
-#include "ttnn/types.hpp"
-#include "ttnn/operations/conv/conv2d/conv2d.hpp"
-#include "cpp/ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/decorators.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/conv/conv2d/conv2d.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
+#include "ttnn/types.hpp"
 
 namespace ttnn::operations {
 namespace pool {
-
-enum class Pool2DType {
-    MAX_POOL2D,
-};
-
 // Generic pool uop -- called from the macro-ops
 struct Pool2D {
     struct operation_attributes_t {

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/buffer_constants.hpp>
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/pool/pool_utils.hpp"
 #include "ttnn/operations/sliding_window/halo/halo.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include <tt-metalium/bfloat16.hpp>
@@ -16,19 +17,6 @@
 
 namespace ttnn {
 namespace operations::pool {
-
-namespace {
-
-// Return a single bf16 init value for the pool type in u32 (packed in the least 16 bits)
-uint32_t get_bf16_pool_init_value(Pool2DType pool_type) {
-    float value;
-    switch (pool_type) {
-        case Pool2DType::MAX_POOL2D: value = -std::numeric_limits<float>::infinity(); break;
-    }
-    return bfloat16(value).to_packed();
-}
-
-}  // namespace
 
 template <Pool2DType pool_type>
 Tensor Pool2DOp<pool_type>::invoke(
@@ -160,6 +148,7 @@ Tensor Pool2DOp<pool_type>::invoke(
 }
 
 template class Pool2DOp<Pool2DType::MAX_POOL2D>;
+template class Pool2DOp<Pool2DType::AVG_POOL2D>;
 
 }  // namespace operations::pool
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -39,5 +39,8 @@ struct Pool2DOp {
 constexpr auto max_pool2d = ttnn::register_operation_with_auto_launch_op<
     "ttnn::max_pool2d",
     operations::pool::Pool2DOp<operations::pool::Pool2DType::MAX_POOL2D>>();
+constexpr auto avg_pool2d = ttnn::register_operation_with_auto_launch_op<
+    "ttnn::avg_pool2d",
+    operations::pool::Pool2DOp<operations::pool::Pool2DType::AVG_POOL2D>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
@@ -125,6 +125,120 @@ void bind_max_pool2d_operation(py::module& module) {
             py::arg("queue_id") = DefaultQueueId});
 }
 
-void py_module(py::module& module) { bind_max_pool2d_operation(module); }
+void bind_avg_pool2d_operation(py::module& module) {
+    bind_registered_operation(
+        module,
+        ttnn::avg_pool2d,
+        R"doc(
+        Applies an average pool convolution to the input tensor. The resulting output Tensor will contain the average
+        value for each channel within a kernel window. The input tensor is expected to be in [NHW, C] format and
+        should be on the device. Height, width and block sharding schemes are supported.
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the tensor to be convolved.
+            batch_size (int): the number of batches (N in a [N, C, H, W] shaped tensor).
+            input_h (int): the height of the input tensor (H in a [N, C, H, W] shaped tensor).
+            input_w (int): the width of the input tensor (W in a [N, C, H, W] shaped tensor).
+            channels (int): the number of channels (C in a [N, C, H, W] shaped tensor).
+            kernel_size (List of [int]): the (h, w) size of the kernel window.
+            stride (List of [int]): the (h, w) stride of the kernel window.
+            padding (List of [int]): the (h, w) padding of the input tensor.
+            count_include_pad (bool): When True, includes zero-padding in the avg calculation. Default: True.
+            divisor_override (int): If specified, it will be used as a divisor, otherwise size of the pooling region will be used. Default: None. Not currently supported in ttnn.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration for the output tensor. Defaults to `None`.
+            applied_shard_scheme (ttnn.TensorMemoryLayout, optional): the sharding scheme to apply to a non-pre-sharded input tensor. Defaults to `None`, which should be used with pre-sharded input tensors.
+            ceil_mode (bool): When True, uses 'ceiling' function instead of 'floor' function in the formula to compute output shape. Default: False.
+            in_place (bool, optional): whether to perform the halo operation in place. Defaults to `False`.
+            queue_id (int, optional): the queue id to use for the operation. Defaults to `0`.
+
+        Returns:
+            ttnn.Tensor: the average pool convolved output tensor.
+
+        Example:
+            >>> import ttnn
+            >>> import torch
+            >>> device = ttnn.open_device(device_id=0, l1_small_size=8192)
+            >>> kernel_h, kernel_w = 2, 2
+            >>> stride_h, stride_w = 1, 1
+            >>> pad_h, pad_w = 0, 0
+            >>> nchw_shape = (4, 256, 40, 40)
+            >>> in_N, in_C, in_H, in_W = nchw_shape
+            >>> input_shape = (1, 1, in_N * in_H * in_W, in_C)
+            >>> input = torch.randn(nchw_shape, dtype=torch.bfloat16)
+            >>> input_perm = torch.permute(input, (0, 2, 3, 1)) # this op expects a [N, H, W, C] format
+            >>> input_reshape = input_perm.reshape(input_shape) # this op expects [1, 1, NHW, C]
+            >>> tt_input = ttnn.from_torch(input_reshape, device=device)
+            >>> tt_output = ttnn.avg_pool2d(
+                            input_tensor=tt_input,
+                            batch_size=in_N,
+                            input_h=in_H,
+                            input_w=in_W,
+                            channels=in_C,
+                            kernel_size=[kernel_h, kernel_w],
+                            stride=[stride_h, stride_w],
+                            padding=[pad_h, pad_w],
+                            dilation=[dilation_h, dilation_w],
+                            # count_include_pad=True,
+                            memory_config=None,
+                            applied_shard_scheme=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+                            ceil_mode=False,
+                            in_place_halo=False,
+                        )
+        )doc",
+        ttnn::pybind_overload_t{
+            [](const decltype(ttnn::avg_pool2d)& self,
+               const ttnn::Tensor& input_tensor,
+               uint32_t batch_size,
+               uint32_t input_h,
+               uint32_t input_w,
+               uint32_t channels,
+               std::array<uint32_t, 2> kernel_size,
+               std::array<uint32_t, 2> stride,
+               std::array<uint32_t, 2> padding,
+               std::array<uint32_t, 2> dilation,
+               const std::optional<const MemoryConfig>& memory_config,
+               const std::optional<const ttnn::TensorMemoryLayout> applied_shard_scheme,
+               bool ceil_mode,
+               bool in_place_halo,
+               QueueId queue_id) -> ttnn::Tensor {
+                return self(
+                    queue_id,
+                    input_tensor,
+                    batch_size,
+                    input_h,
+                    input_w,
+                    channels,
+                    kernel_size,
+                    stride,
+                    padding,
+                    dilation,
+                    memory_config,
+                    applied_shard_scheme,
+                    ceil_mode,
+                    in_place_halo);
+            },
+            py::arg("input_tensor"),
+            py::arg("batch_size"),
+            py::arg("input_h"),
+            py::arg("input_w"),
+            py::arg("channels"),
+            py::arg("kernel_size"),
+            py::arg("stride"),
+            py::arg("padding"),
+            py::arg("dilation"),
+            py::kw_only(),
+            py::arg("memory_config") = std::nullopt,
+            py::arg("applied_shard_scheme") = std::nullopt,
+            py::arg("ceil_mode") = false,
+            py::arg("in_place_halo") = false,
+            py::arg("queue_id") = 0});
+}
+
+void py_module(py::module& module) {
+    bind_max_pool2d_operation(module);
+    bind_avg_pool2d_operation(module);
+}
 
 }  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools_pybind.hpp
@@ -11,6 +11,7 @@ namespace py = pybind11;
 namespace ttnn::operations::pool {
 
 void bind_max_pool2d_operation(py::module& module);
+void bind_avg_pool2d_operation(py::module& module);
 void py_module(py::module& module);
 
 }  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pool_utils.hpp"
+#include <limits>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/assert.hpp>
+
+namespace ttnn::operations::pool {
+// Return a single bf16 scalar for the pool type in u32 (packed in the least 16 bits)
+uint32_t get_bf16_pool_scalar(Pool2DType pool_type, uint32_t kernel_size_hw) {
+    float value;
+    switch (pool_type) {
+        case Pool2DType::MAX_POOL2D: value = 1.; break;
+        case Pool2DType::AVG_POOL2D: value = 1. / (float)kernel_size_hw; break;
+        default: TT_FATAL(false, "Unsupported pool operation type");
+    }
+    return bfloat16(value).to_packed();
+}
+
+// Return a single bf16 init value for the pool type in u32 (packed in the least 16 bits)
+uint32_t get_bf16_pool_init_value(Pool2DType pool_type) {
+    float value;
+    switch (pool_type) {
+        case Pool2DType::MAX_POOL2D: value = -std::numeric_limits<float>::infinity(); break;
+        case Pool2DType::AVG_POOL2D: value = 0.; break;
+        default: TT_FATAL(false, "Unsupported pool operation type");
+    }
+    return bfloat16(value).to_packed();
+}
+
+std::map<std::string, std::string> get_defines(Pool2DType pool_type) {
+    std::map<std::string, std::string> defines;
+    switch (pool_type) {
+        case Pool2DType::MAX_POOL2D: defines["REDUCE_OP"] = "PoolType::MAX"; break;
+        case Pool2DType::AVG_POOL2D: defines["REDUCE_OP"] = "PoolType::SUM"; break;
+        default: TT_FATAL(false, "Unsupported pool operation type");
+    }
+    defines["REDUCE_DIM"] = "ReduceDim::REDUCE_COL";
+
+    return defines;
+}
+}  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+#include <string>
+#include <map>
+
+namespace ttnn::operations::pool {
+
+enum class Pool2DType {
+    MAX_POOL2D = 0,
+    AVG_POOL2D = 1,
+};
+
+uint32_t get_bf16_pool_scalar(Pool2DType pool_type, uint32_t kernel_size_hw);
+uint32_t get_bf16_pool_init_value(Pool2DType pool_type);
+std::map<std::string, std::string> get_defines(Pool2DType pool_type);
+
+}  // namespace ttnn::operations::pool


### PR DESCRIPTION
### Ticket
[16740](https://github.com/tenstorrent/tt-metal/issues/16740)

### Problem description
Ttnn implementation of pytorch avg_pool2d

### What's changed
Implementing ttnn API for average pool 2d operationas a pool operation 
Using pytorch avg_pool2d function as a reference [torch.nn.functional.avg_pool2d](https://pytorch.org/docs/stable/generated/torch.nn.functional.avg_pool2d.html) ttnn API supports default parameters values ceil_mode=False, count_include_pad=True, divisor_override=None. 
Corresponding parameterized pytest added, width, height and block sharding tested.
Added sweep tests with the most common avg_pool2d calls

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14224801323)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14224809961) 
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14224813014) 
- [x] [(Single-card) Device perf regressions ](https://github.com/tenstorrent/tt-metal/actions/runs/14224920613)