### PR TITLE
Push various UBB related testing/stability changes

### DIFF
--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -93,15 +93,25 @@ protected:
     void create_devices(const std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
         const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
         const chip_id_t mmio_device_id = 0;
+        std::vector<chip_id_t> chip_ids;
+        if (tt::Cluster::instance().get_board_type(0) == BoardType::UBB) {
+            for (unsigned int id = 0; id < tt::tt_metal::GetNumAvailableDevices(); id++) {
+                chip_ids.push_back(id);
+            }
+        } else {
+            chip_ids.push_back(mmio_device_id);
+        }
         this->reserved_devices_ = tt::tt_metal::detail::CreateDevices(
-            {mmio_device_id}, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_config);
+            chip_ids, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_config);
         auto enable_remote_chip = getenv("TT_METAL_ENABLE_REMOTE_CHIP");
         if (enable_remote_chip) {
             for (const auto& [id, device] : this->reserved_devices_) {
                 this->devices_.push_back(device);
             }
         } else {
-            this->devices_.push_back(this->reserved_devices_.at(mmio_device_id));
+            for (const auto& chip_id : chip_ids) {
+                this->devices_.push_back(this->reserved_devices_.at(chip_id));
+            }
         }
     }
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -572,6 +572,13 @@ void Device::reset_cores() {
                 launch_msg->kernel_config.exit_erisc_kernel = 1;
                 llrt::write_launch_msg_to_core(this->id(), virtual_core, launch_msg, &go_msg, launch_addr, false);
                 device_to_early_exit_cores[this->id()].insert(virtual_core);
+
+                // Clear launch erisc flag
+                auto core_type_idx = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+                std::uint32_t launch_erisc_addr =
+                    tt::tt_metal::hal_ref.get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr;
+                std::vector<uint32_t> clear_flag_data = {0};
+                tt::llrt::write_hex_vec_to_core(this->id(), virtual_core, clear_flag_data, launch_erisc_addr);
             }
         }
     }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -564,7 +564,7 @@ void Device::reset_cores() {
                 launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
                 log_info(
                     tt::LogMetal,
-                    "While initializing Device {}, ethernet tunneler core {} on Device {} detected as still running, "
+                    "While initializing Device {}, active ethernet core {} on Device {} detected as still running, "
                     "issuing exit signal.",
                     this->id(),
                     virtual_core.str(),
@@ -591,7 +591,8 @@ void Device::reset_cores() {
                 if (erisc_app_still_running(virtual_core)) {
                     log_info(
                         tt::LogMetal,
-                        "While initializing device {}, ethernet dispatch core {} on Device {} detected as still running, issuing exit signal.",
+                        "While initializing device {}, idle ethernet dispatch core {} on Device {} detected as still "
+                        "running, issuing exit signal.",
                         this->id(),
                         virtual_core.str(),
                         id_and_cores.first);

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -120,6 +120,16 @@ RunTimeOptions::RunTimeOptions() {
         }
     }
 
+    const char* skip_eth_cores_with_retrain_str = std::getenv("TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN");
+    if (skip_eth_cores_with_retrain_str != nullptr) {
+        if (skip_eth_cores_with_retrain_str[0] == '0') {
+            skip_eth_cores_with_retrain = false;
+        }
+        if (skip_eth_cores_with_retrain_str[0] == '1') {
+            skip_eth_cores_with_retrain = true;
+        }
+    }
+
     const char* riscv_debug_info_enabled_str = std::getenv("TT_METAL_RISCV_DEBUG_INFO");
     set_riscv_debug_info_enabled(riscv_debug_info_enabled_str != nullptr);
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -143,6 +143,8 @@ class RunTimeOptions {
 
     bool erisc_iram_enabled = false;
 
+    bool skip_eth_cores_with_retrain = false;
+
     RunTimeOptions();
 
 public:
@@ -335,6 +337,8 @@ public:
     inline const std::filesystem::path& get_simulator_path() { return simulator_path; }
 
     inline bool get_erisc_iram_enabled() { return erisc_iram_enabled; }
+
+    inline bool get_skip_eth_cores_with_retrain() { return skip_eth_cores_with_retrain; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -327,6 +327,10 @@ private:
 
     void initialize_ethernet_sockets();
 
+    // Disable ethernet cores that retrain
+    // This should be removed when we handle retraining or dropped links in control plane properly
+    void disable_ethernet_cores_with_retrain();
+
     // Initialize control plane, which has mapping of physical device id to MeshGraph config
     void initialize_control_plane();
 
@@ -359,6 +363,7 @@ private:
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> virtual_worker_cores_;
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> virtual_eth_cores_;
     std::unordered_map<BoardType, std::unordered_map<CoreCoord, int32_t>> virtual_routing_to_profiler_flat_id_;
+    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> frequent_retrain_cores_;
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
     ClusterType cluster_type_ = ClusterType::INVALID;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19985)
https://github.com/tenstorrent/tt-metal/issues/20085

### Problem description
Various runtime work to cleanup UBB for wider testing.

### What's changed
- Add a proper clear of launch erisc app flag when a bad previous run is detected.
- Extend CommandQueue tests to run on all chips on UBB
- Add a `TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN` flag to enable disabling eth cores on UBB with lots of retraining.
- Should have no impact on existing functionality for CI
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes