### PR TITLE
#0: Use mesh coordinate range sets in core distributed interfaces

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -81,7 +81,7 @@ struct NewInfraWorkloadFactory {
         tensor_return_value_t& tensor_return_value) {
         return cached_mesh_workload_t(
             tt::tt_metal::distributed::MeshWorkload(),
-            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t>());
+            std::unordered_map<ttnn::MeshCoordinateRangeSet, shared_variables_t>());
     }
 
     static void override_runtime_arguments(

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -37,7 +37,10 @@ namespace distributed {
 
 MeshWorkload CreateMeshWorkload();
 
+void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, const MeshCoordinate& coord);
 void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRange& device_range);
+void AddProgramToMeshWorkload(
+    MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRangeSet& device_range_set);
 
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
 
@@ -98,12 +101,12 @@ void EnqueueReadMeshBuffer(
 MeshEvent EnqueueRecordEvent(
     MeshCommandQueue& mesh_cq,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-    const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
+    const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt);
 
 MeshEvent EnqueueRecordEventToHost(
     MeshCommandQueue& mesh_cq,
     tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-    const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
+    const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt);
 
 void EnqueueWaitForEvent(MeshCommandQueue& mesh_cq, const MeshEvent& event);
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -89,7 +89,7 @@ public:
     virtual void enqueue_write_shard_to_sub_grid(
         const MeshBuffer& buffer,
         const void* host_data,
-        const MeshCoordinateRange& device_range,
+        const MeshCoordinateRangeSet& device_range_set,
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) = 0;
     virtual void enqueue_write_mesh_buffer(
@@ -109,10 +109,10 @@ public:
 
     virtual MeshEvent enqueue_record_event(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
+        const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt) = 0;
     virtual MeshEvent enqueue_record_event_to_host(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
+        const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt) = 0;
     virtual void enqueue_wait_for_event(const MeshEvent& sync_event) = 0;
     virtual void finish(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void reset_worker_state(

--- a/tt_metal/api/tt-metalium/mesh_coord.hpp
+++ b/tt_metal/api/tt-metalium/mesh_coord.hpp
@@ -179,6 +179,9 @@ public:
     // Constructs a set with a single range.
     explicit MeshCoordinateRangeSet(const MeshCoordinateRange&);
 
+    // Constructs a set with a single coordinate.
+    explicit MeshCoordinateRangeSet(const MeshCoordinate&);
+
     // Merges the given range into the set.
     void merge(const MeshCoordinateRange& range);
 

--- a/tt_metal/api/tt-metalium/mesh_event.hpp
+++ b/tt_metal/api/tt-metalium/mesh_event.hpp
@@ -22,13 +22,13 @@ namespace tt::tt_metal::distributed {
 
 class MeshEvent {
 public:
-    MeshEvent(uint32_t id, MeshDevice* device, uint32_t mesh_cq_id, const MeshCoordinateRange& device_range);
+    MeshEvent(uint32_t id, MeshDevice* device, uint32_t mesh_cq_id, const MeshCoordinateRangeSet& device_range);
 
     // Returns references to the event data.
     uint32_t id() const;
     MeshDevice* device() const;
     uint32_t mesh_cq_id() const;
-    const MeshCoordinateRange& device_range() const;
+    const MeshCoordinateRangeSet& device_range_set() const;
 
     friend std::ostream& operator<<(std::ostream& os, const MeshEvent& event);
 
@@ -36,7 +36,7 @@ private:
     uint32_t id_ = 0;
     MeshDevice* device_ = nullptr;
     uint32_t mesh_cq_id_ = 0;
-    MeshCoordinateRange device_range_;
+    MeshCoordinateRangeSet device_range_set_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_trace.hpp
+++ b/tt_metal/api/tt-metalium/mesh_trace.hpp
@@ -26,18 +26,40 @@ namespace tt::tt_metal::distributed {
 //   - The sysmem_manager coordinate the associated dispatch commands are stored in
 //   - The offset and size of the dispatch commands in the sysmem_manager
 //     staging vector
-struct MeshTraceStagingMetadata {
-    MeshCoordinateRange device_range = MeshCoordinateRange(MeshShape(0, 0));
-    MeshCoordinate sysmem_manager_coord = MeshCoordinate(0, 0);
-    std::size_t offset = 0;
-    std::size_t size = 0;
+class MeshTraceStagingMetadata {
+public:
+    MeshTraceStagingMetadata(
+        const MeshCoordinateRange& device_range,
+        const MeshCoordinate& sysmem_manager_coord,
+        std::size_t offset,
+        std::size_t size) :
+        device_range_(device_range), sysmem_manager_coord_(sysmem_manager_coord), offset_(offset), size_(size) {}
+
+    const MeshCoordinateRange& device_range() const { return device_range_; }
+    const MeshCoordinate& sysmem_manager_coord() const { return sysmem_manager_coord_; }
+    std::size_t offset() const { return offset_; }
+    std::size_t size() const { return size_; }
+
+private:
+    MeshCoordinateRange device_range_;
+    MeshCoordinate sysmem_manager_coord_;
+    std::size_t offset_ = 0;
+    std::size_t size_ = 0;
 };
 
 // Finalized/Consolidated dispatch commands on a device_range, corresponding
 // to a trace
-struct MeshTraceData {
-    MeshCoordinateRange device_range = MeshCoordinateRange(MeshShape(0, 0));
-    std::vector<uint32_t> data;
+class MeshTraceData {
+public:
+    MeshTraceData(const MeshCoordinateRange& range, std::vector<uint32_t> trace_data) :
+        device_range_(range), data_(std::move(trace_data)) {}
+
+    const MeshCoordinateRange& device_range() const { return device_range_; }
+    std::vector<uint32_t>& data() { return data_; }
+
+private:
+    MeshCoordinateRange device_range_;
+    std::vector<uint32_t> data_;
 };
 
 // Wrapper around the MeshTraceData. Captures the complete state of a MeshTrace

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -72,11 +72,11 @@ struct CachedMeshWorkload {
 template <typename shared_variables_t>
 struct AdaptedCachedMeshWorkload {
     tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t> shared_variables;
+    std::unordered_map<distributed::MeshCoordinateRangeSet, shared_variables_t> shared_variables;
 
     AdaptedCachedMeshWorkload(
         tt::tt_metal::distributed::MeshWorkload&& workload,
-        std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t>&& shared_variables) :
+        std::unordered_map<distributed::MeshCoordinateRangeSet, shared_variables_t>&& shared_variables) :
         workload{std::move(workload)}, shared_variables{std::move(shared_variables)} {}
 };
 

--- a/tt_metal/common/mesh_coord.cpp
+++ b/tt_metal/common/mesh_coord.cpp
@@ -280,6 +280,8 @@ size_t to_linear_index(const MeshShape& shape, const MeshCoordinate& coord) {
 }
 
 MeshCoordinateRangeSet::MeshCoordinateRangeSet(const MeshCoordinateRange& range) { ranges_.push_back(range); }
+MeshCoordinateRangeSet::MeshCoordinateRangeSet(const MeshCoordinate& coord) :
+    MeshCoordinateRangeSet(MeshCoordinateRange(coord)) {}
 
 void MeshCoordinateRangeSet::merge(const MeshCoordinateRange& to_merge) {
     TT_FATAL(

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -59,8 +59,7 @@ void EventSynchronize(const MeshEvent& event) {
     }
     for (const auto& coord : event.device_range_set().coords()) {
         auto physical_device = event.device()->get_device(coord);
-        while (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id())
-            ;
+        while (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id());
     }
 }
 

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -15,8 +15,17 @@ namespace tt::tt_metal::distributed {
 
 MeshWorkload CreateMeshWorkload() { return MeshWorkload(); }
 
+void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, const MeshCoordinate& coord) {
+    mesh_workload.add_program(coord, std::move(program));
+}
+
 void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRange& device_range) {
     mesh_workload.add_program(device_range, std::move(program));
+}
+
+void AddProgramToMeshWorkload(
+    MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRangeSet& device_range_set) {
+    mesh_workload.add_program(device_range_set, std::move(program));
 }
 
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking) {
@@ -31,15 +40,15 @@ void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload,
 MeshEvent EnqueueRecordEvent(
     MeshCommandQueue& mesh_cq,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
-    const std::optional<MeshCoordinateRange>& device_range) {
-    return mesh_cq.enqueue_record_event(sub_device_ids, device_range);
+    const std::optional<MeshCoordinateRangeSet>& device_range_set) {
+    return mesh_cq.enqueue_record_event(sub_device_ids, device_range_set);
 }
 
 MeshEvent EnqueueRecordEventToHost(
     MeshCommandQueue& mesh_cq,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
-    const std::optional<MeshCoordinateRange>& device_range) {
-    return mesh_cq.enqueue_record_event_to_host(sub_device_ids, device_range);
+    const std::optional<MeshCoordinateRangeSet>& device_range_set) {
+    return mesh_cq.enqueue_record_event_to_host(sub_device_ids, device_range_set);
 }
 
 void EnqueueWaitForEvent(MeshCommandQueue& mesh_cq, const MeshEvent& event) { mesh_cq.enqueue_wait_for_event(event); }
@@ -48,9 +57,10 @@ void EventSynchronize(const MeshEvent& event) {
     if (event.device()->using_slow_dispatch()) {
         return;
     }
-    for (const auto& coord : event.device_range()) {
+    for (const auto& coord : event.device_range_set().coords()) {
         auto physical_device = event.device()->get_device(coord);
-        while (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id());
+        while (physical_device->sysmem_manager().get_last_completed_event(event.mesh_cq_id()) < event.id())
+            ;
     }
 }
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -51,7 +51,7 @@ namespace tt::tt_metal::distributed {
 
 struct MeshReadEventDescriptor {
     ReadEventDescriptor single_device_descriptor;
-    MeshCoordinateRange device_range;
+    MeshCoordinateRangeSet device_range_set;
 };
 
 struct MeshBufferReadDescriptor {
@@ -151,8 +151,11 @@ CoreType FDMeshCommandQueue::dispatch_core_type() const { return this->dispatch_
 void FDMeshCommandQueue::clear_expected_num_workers_completed() {
     auto sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, {});
     auto& sysmem_manager = this->reference_sysmem_manager();
-    auto event =
-        MeshEvent(sysmem_manager.get_next_event(id_), mesh_device_, id_, MeshCoordinateRange(mesh_device_->shape()));
+    auto event = MeshEvent(
+        sysmem_manager.get_next_event(id_),
+        mesh_device_,
+        id_,
+        MeshCoordinateRangeSet(MeshCoordinateRange(mesh_device_->shape())));
 
     // Issue commands to clear expected_num_workers_completed counter(s) on the dispatcher
     for (auto device : mesh_device_->get_devices()) {
@@ -174,7 +177,7 @@ void FDMeshCommandQueue::clear_expected_num_workers_completed() {
 
     // Block after clearing counter(s) on dispatcher
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
-        std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range()));
+        std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range_set()));
     this->increment_num_entries_in_completion_queue();
     std::unique_lock<std::mutex> lock(reads_processed_cv_mutex_);
     reads_processed_cv_.wait(lock, [this] { return num_outstanding_reads_.load() == 0; });
@@ -229,12 +232,13 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         expected_num_workers_completed,
         dispatch_metadata);
 
-    std::unordered_set<uint32_t> chip_ids_in_workload = {};
-    std::vector<MeshCoordinateRange> active_sub_grids = {};
+    std::unordered_set<uint32_t> chip_ids_in_workload;
+    std::vector<MeshCoordinateRangeSet> active_sub_grids;
+
     // Iterate over all programs. Update dispatch commands per program to reflect
     // current device state. Write the finalized program command sequence to each
     // physical device tied to the program.
-    for (auto& [device_range, program] : mesh_workload.get_programs()) {
+    for (auto& [device_range_set, program] : mesh_workload.get_programs()) {
         auto& program_cmd_seq = mesh_workload.get_dispatch_cmds_for_program(program, command_hash);
         program_dispatch::update_program_dispatch_commands(
             program,
@@ -251,15 +255,14 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
 
         if (sysmem_manager.get_bypass_mode()) {
             this->capture_program_trace_on_subgrid(
-                device_range,
+                device_range_set,
                 program_cmd_seq,
                 dispatch_metadata.stall_first,
-                dispatch_metadata.stall_before_program,
-                program.get_runtime_id());
-            active_sub_grids.push_back(device_range);
+                dispatch_metadata.stall_before_program);
+            active_sub_grids.push_back(device_range_set);
         } else {
             this->write_program_cmds_to_subgrid(
-                device_range,
+                device_range_set,
                 program_cmd_seq,
                 dispatch_metadata.stall_first,
                 dispatch_metadata.stall_before_program,
@@ -272,18 +275,28 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         this->write_go_signal_to_unused_sub_grids(
             chip_ids_in_workload, sub_device_id, expected_num_workers_completed, mcast_go_signals, unicast_go_signals);
     } else {
-        MeshCoordinateRangeSet active_sub_grids_set;
+        // Flatten active coordinates, and form an unused grid by subtracting the active grid from the full grid.
+        std::vector<MeshCoordinate> active_coords;
         for (const auto& sub_grid : active_sub_grids) {
-            active_sub_grids_set.merge(sub_grid);
+            const auto coords = sub_grid.coords();
+            std::copy(coords.begin(), coords.end(), std::back_inserter(active_coords));
         }
-        TT_FATAL(active_sub_grids_set.size() == 1, "Cannot support non convex grids.");
+        std::sort(active_coords.begin(), active_coords.end());
+
+        MeshCoordinateRangeSet unused_grid;
+        auto active_coords_it = active_coords.begin();
+        for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
+            if (active_coords_it == active_coords.end() || *active_coords_it != coord) {
+                unused_grid.merge(MeshCoordinateRange(coord));
+            } else {
+                active_coords_it++;
+            }
+        }
+
         this->capture_go_signal_trace_on_unused_subgrids(
-            active_sub_grids_set.ranges().front(),
-            sub_device_id,
-            expected_num_workers_completed,
-            mcast_go_signals,
-            unicast_go_signals);
+            unused_grid, sub_device_id, expected_num_workers_completed, mcast_go_signals, unicast_go_signals);
     }
+
     // Increment Launch Message Buffer Write Pointers
     if (mcast_go_signals) {
         (*worker_launch_message_buffer_state_)[*sub_device_id].inc_mcast_wptr(1);
@@ -402,7 +415,7 @@ void FDMeshCommandQueue::submit_memcpy_request(
 MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     bool notify_host,
-    const std::optional<MeshCoordinateRange>& device_range) {
+    const std::optional<MeshCoordinateRangeSet>& device_range_set) {
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
     auto& sysmem_manager = this->reference_sysmem_manager();
@@ -410,10 +423,10 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
         sysmem_manager.get_next_event(id_),
         mesh_device_,
         id_,
-        device_range.value_or(MeshCoordinateRange(mesh_device_->shape())));
+        device_range_set.value_or(MeshCoordinateRangeSet(MeshCoordinateRange(mesh_device_->shape()))));
 
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
-    auto dispatch_lambda = [this, &event, &sub_device_ids, notify_host](const MeshCoordinate& coord) {
+    for (const auto& coord : event.device_range_set().coords()) {
         event_dispatch::issue_record_event_commands(
             mesh_device_,
             event.id(),
@@ -425,7 +438,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
             notify_host);
     };
 
-    for (const auto& coord : event.device_range()) {
+    for (const auto& coord : event.device_range_set().coords()) {
         dispatch_thread_pool_->enqueue(
             [&dispatch_lambda, coord]() { dispatch_lambda(coord); }, mesh_device_->get_device(coord)->id());
     }
@@ -433,16 +446,22 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_helper(
     return event;
 }
 
-MeshEvent FDMeshCommandQueue::enqueue_record_event(
-    tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
-    return this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/false, device_range);
+MeshEvent MeshCommandQueue::enqueue_record_event(
+    tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRangeSet>& device_range_set) {
+    TT_FATAL(
+        !device_range_set.has_value() || !device_range_set->empty(),
+        "If provided, device_range_set must be non-empty.");
+    return this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/false, device_range_set);
 }
 
-MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
-    tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRange>& device_range) {
-    auto event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/true, device_range);
+MeshEvent MeshCommandQueue::enqueue_record_event_to_host(
+    tt::stl::Span<const SubDeviceId> sub_device_ids, const std::optional<MeshCoordinateRangeSet>& device_range_set) {
+    TT_FATAL(
+        !device_range_set.has_value() || !device_range_set->empty(),
+        "If provided, device_range_set must be non-empty.");
+    auto event = this->enqueue_record_event_helper(sub_device_ids, /*notify_host=*/true, device_range_set);
     completion_queue_reads_.push(std::make_shared<MeshCompletionReaderVariant>(
-        std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range()));
+        std::in_place_type<MeshReadEventDescriptor>, ReadEventDescriptor(event.id()), event.device_range_set()));
     this->increment_num_entries_in_completion_queue();
     return event;
 }
@@ -450,7 +469,7 @@ MeshEvent FDMeshCommandQueue::enqueue_record_event_to_host(
 void FDMeshCommandQueue::enqueue_wait_for_event(const MeshEvent& sync_event) {
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Event Synchronization is not supported during trace capture.");
-    for (const auto& coord : sync_event.device_range()) {
+    for (const auto& coord : sync_event.device_range_set().coords()) {
         event_dispatch::issue_wait_for_event_commands(
             id_, sync_event.mesh_cq_id(), mesh_device_->get_device(coord)->sysmem_manager(), sync_event.id());
     }
@@ -532,9 +551,9 @@ void FDMeshCommandQueue::copy_buffer_data_to_user_space(MeshBufferReadDescriptor
     }
 }
 
-void FDMeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& read_event_descriptor) {
-    auto& device_range = read_event_descriptor.device_range;
-    for (const auto& coord : device_range) {
+void MeshCommandQueue::read_completion_queue_event(MeshReadEventDescriptor& read_event_descriptor) {
+    const auto& device_range_set = read_event_descriptor.device_range_set;
+    for (const auto& coord : device_range_set.coords()) {
         auto device = mesh_device_->get_device(coord);
         chip_id_t mmio_device_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
@@ -575,8 +594,8 @@ void FDMeshCommandQueue::reset_worker_state(
     }
 }
 
-void FDMeshCommandQueue::write_program_cmds_to_subgrid(
-    const MeshCoordinateRange& sub_grid,
+void MeshCommandQueue::write_program_cmds_to_subgrid(
+    const MeshCoordinateRangeSet& sub_grid,
     ProgramCommandSequence& program_cmd_seq,
     bool stall_first,
     bool stall_before_program,
@@ -584,9 +603,8 @@ void FDMeshCommandQueue::write_program_cmds_to_subgrid(
     uint32_t program_runtime_id) {
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-    for (const auto& coord : sub_grid) {
-        auto device = this->mesh_device_->get_device(coord);
-        this->update_launch_messages_for_device_profiler(program_cmd_seq, program_runtime_id, device);
+
+    for (const auto& coord : sub_grid.coords()) {
         program_dispatch::write_program_command_sequence(
             program_cmd_seq, device->sysmem_manager(), id_, dispatch_core_type, stall_first, stall_before_program);
         chip_ids_in_workload.insert(device->id());
@@ -650,11 +668,11 @@ void FDMeshCommandQueue::capture_program_trace_on_subgrid(
 
     program_dispatch::write_program_command_sequence(
         program_cmd_seq, sysmem_manager_for_trace, id_, dispatch_core_type, stall_first, stall_before_program);
-    auto mesh_trace_md = MeshTraceStagingMetadata{
+    auto mesh_trace_md = MeshTraceStagingMetadata(
         sub_grid,
         sub_grid.start_coord(),
         sysmem_manager_offset,
-        sysmem_manager_for_trace.get_issue_queue_write_ptr(id_) - sysmem_manager_offset};
+        sysmem_manager_for_trace.get_issue_queue_write_ptr(id_) - sysmem_manager_offset);
     ordered_mesh_trace_md_.push_back(mesh_trace_md);
 #endif
 }
@@ -665,10 +683,8 @@ void FDMeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
     uint32_t expected_num_workers_completed,
     bool mcast_go_signals,
     bool unicast_go_signals) {
-    MeshCoordinateRange full_grid(mesh_device_->shape());
-    MeshCoordinateRangeSet unused_grids = subtract(full_grid, active_grid);
-    for (const auto& unused_grid : unused_grids.ranges()) {
-        auto& sysmem_manager_for_trace = mesh_device_->get_device(unused_grid.start_coord())->sysmem_manager();
+    for (const auto& range : unused_grid.ranges()) {
+        auto& sysmem_manager_for_trace = mesh_device_->get_device(range.start_coord())->sysmem_manager();
         uint32_t sysmem_manager_offset = sysmem_manager_for_trace.get_issue_queue_write_ptr(id_);
         write_go_signal(
             id_,
@@ -678,12 +694,13 @@ void FDMeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
             expected_num_workers_completed,
             this->virtual_program_dispatch_core(),
             mcast_go_signals,
-            unicast_go_signals);
-        auto mesh_trace_md = MeshTraceStagingMetadata{
-            unused_grid,
-            unused_grid.start_coord(),
+            unicast_go_signals,
+            mesh_device_->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id));
+        auto mesh_trace_md = MeshTraceStagingMetadata(
+            range,
+            range.start_coord(),
             sysmem_manager_offset,
-            sysmem_manager_for_trace.get_issue_queue_write_ptr(id_) - sysmem_manager_offset};
+            sysmem_manager_for_trace.get_issue_queue_write_ptr(id_) - sysmem_manager_offset);
         ordered_mesh_trace_md_.push_back(mesh_trace_md);
     }
 }

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -28,12 +28,12 @@ private:
     MeshEvent enqueue_record_event_helper(
         tt::stl::Span<const SubDeviceId> sub_device_ids,
         bool notify_host,
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
+        const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt);
     // Trace capture utility functions
     // Captures dispatch commands associated with running a program on a Virtual Mesh subgrid
     // inside the appropriate trace staging vector (corresponding to the specified subgrid)
     void capture_program_trace_on_subgrid(
-        const MeshCoordinateRange& sub_grid,
+        const MeshCoordinateRangeSet& sub_grid,
         ProgramCommandSequence& program_cmd_seq,
         bool stall_first,
         bool stall_before_program,
@@ -43,7 +43,7 @@ private:
     // When running trace, the dispatch commands responsible for forwarding go signals must be
     // captured on these subgrids.
     void capture_go_signal_trace_on_unused_subgrids(
-        const MeshCoordinateRange& active_sub_grids,
+        const MeshCoordinateRangeSet& active_sub_grids,
         const SubDeviceId& sub_device_id,
         uint32_t expected_num_workers_completed,
         bool mcast_go_signals,
@@ -51,7 +51,7 @@ private:
     // Workload dispatch utility functions
     // Write dispatch commands associated with running a program on a Virtual Mesh subgrid
     void write_program_cmds_to_subgrid(
-        const MeshCoordinateRange& sub_grid,
+        const MeshCoordinateRangeSet& sub_grid,
         ProgramCommandSequence& program_cmd_seq,
         bool stall_first,
         bool stall_before_program,
@@ -162,10 +162,10 @@ public:
 
     MeshEvent enqueue_record_event(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
+        const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt) override;
     MeshEvent enqueue_record_event_to_host(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
+        const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt) override;
     void enqueue_wait_for_event(const MeshEvent& sync_event) override;
     void drain_events_from_completion_queue();
     void verify_reported_events_after_draining(const MeshEvent& event);

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -160,7 +160,7 @@ void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
 void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     const MeshBuffer& buffer,
     const void* host_data,
-    const MeshCoordinateRange& device_range,
+    const MeshCoordinateRangeSet& device_range_set,
     bool blocking,
     std::optional<BufferRegion> region) {
     if (buffer.global_layout() == MeshBufferLayout::REPLICATED) {
@@ -172,7 +172,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
             const BufferRegion buffer_region = region.value_or(BufferRegion(0, device_shard_view->size()));
             this->write_shard_to_device(device_shard_view, host_data, buffer_region);
         };
-        for (const auto& coord : device_range) {
+        for (const auto& coord : device_range_set.coords()) {
             dispatch_thread_pool_->enqueue(
                 [&dispatch_lambda, coord]() { dispatch_lambda(coord); }, mesh_device_->get_device(coord)->id());
         }
@@ -188,7 +188,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
 
 void MeshCommandQueueBase::enqueue_write_mesh_buffer(
     const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
-    MeshCoordinateRange mesh_device_extent(buffer->device()->shape());
+    MeshCoordinateRangeSet mesh_device_extent(MeshCoordinateRange(buffer->device()->shape()));
     this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
 }
 

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -40,7 +40,7 @@ public:
     void enqueue_write_shard_to_sub_grid(
         const MeshBuffer& buffer,
         const void* host_data,
-        const MeshCoordinateRange& device_range,
+        const MeshCoordinateRangeSet& device_range_set,
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) override;
     void enqueue_write_mesh_buffer(

--- a/tt_metal/distributed/mesh_event.cpp
+++ b/tt_metal/distributed/mesh_event.cpp
@@ -8,17 +8,18 @@
 
 namespace tt::tt_metal::distributed {
 
-MeshEvent::MeshEvent(uint32_t id, MeshDevice* device, uint32_t mesh_cq_id, const MeshCoordinateRange& device_range) :
-    id_(id), device_(device), mesh_cq_id_(mesh_cq_id), device_range_(device_range) {}
+MeshEvent::MeshEvent(
+    uint32_t id, MeshDevice* device, uint32_t mesh_cq_id, const MeshCoordinateRangeSet& device_range_set) :
+    id_(id), device_(device), mesh_cq_id_(mesh_cq_id), device_range_set_(device_range_set) {}
 
 uint32_t MeshEvent::id() const { return id_; }
 MeshDevice* MeshEvent::device() const { return device_; }
 uint32_t MeshEvent::mesh_cq_id() const { return mesh_cq_id_; }
-const MeshCoordinateRange& MeshEvent::device_range() const { return device_range_; }
+const MeshCoordinateRangeSet& MeshEvent::device_range_set() const { return device_range_set_; }
 
 std::ostream& operator<<(std::ostream& os, const MeshEvent& event) {
     os << "MeshEvent(id=" << event.id() << ", device_id=" << event.device()->id()
-       << ", mesh_cq_id=" << event.mesh_cq_id() << ", device_range=" << event.device_range() << ")";
+       << ", mesh_cq_id=" << event.mesh_cq_id() << ", device_range_set=" << event.device_range_set() << ")";
     return os;
 }
 

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -181,9 +181,9 @@ void MeshTrace::populate_mesh_buffer(MeshCommandQueue& mesh_cq, std::shared_ptr<
     trace_buffer->mesh_buffer =
         MeshBuffer::create(global_trace_buf_config, device_local_trace_buf_config, mesh_cq.device());
 
-    std::unordered_map<MeshCoordinateRange, uint32_t> write_offset_per_device_range = {};
+    std::unordered_map<MeshCoordinateRange, uint32_t> write_offset_per_device_range;
     for (auto& mesh_trace_data : trace_buffer->desc->ordered_trace_data) {
-        const auto& device_range = mesh_trace_data.device_range();
+        auto& device_range = mesh_trace_data.device_range();
         std::vector<uint32_t> write_data = mesh_trace_data.data();
         auto unpadded_data_size = write_data.size() * sizeof(uint32_t);
         auto padded_data_size = round_up(unpadded_data_size, page_size);

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -290,9 +290,7 @@ std::vector<uint32_t> MeshWorkload::get_program_config_sizes() {
 std::unordered_set<SubDeviceId> MeshWorkload::determine_sub_device_ids(MeshDevice* mesh_device) {
     // Get the sub device ids for all program across all devices in the Workload
     std::unordered_set<SubDeviceId> sub_devices_;
-    for (auto& [device_range_set, program] : programs_) {
-        TT_ASSERT(!device_range_set.empty());  // validated in `add_program`
-        IDevice* device = mesh_device->get_device(device_range_set.ranges().front().start_coord());
+    for (auto& [_, program] : programs_) {
         auto sub_devs_for_program = program.determine_sub_device_ids(mesh_device);
         for (auto& sub_dev : sub_devs_for_program) {
             sub_devices_.insert(sub_dev);

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -32,10 +32,10 @@ public:
 
     MeshEvent enqueue_record_event(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
+        const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt) override;
     MeshEvent enqueue_record_event_to_host(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},
-        const std::optional<MeshCoordinateRange>& device_range = std::nullopt) override;
+        const std::optional<MeshCoordinateRangeSet>& device_range_set = std::nullopt) override;
     void enqueue_wait_for_event(const MeshEvent& sync_event) override;
     void finish(tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void reset_worker_state(

--- a/ttnn/cpp/pybind11/events.cpp
+++ b/ttnn/cpp/pybind11/events.cpp
@@ -64,11 +64,11 @@ void py_module(py::module& module) {
             MeshDevice*,
             QueueId,
             const std::vector<SubDeviceId>&,
-            const std::optional<MeshCoordinateRange>&>(&record_mesh_event),
+            const std::optional<MeshCoordinateRangeSet>&>(&record_mesh_event),
         py::arg("mesh_device"),
         py::arg("cq_id"),
         py::arg("sub_device_ids") = std::vector<SubDeviceId>(),
-        py::arg("device_range") = std::nullopt,
+        py::arg("device_range_set") = std::nullopt,
         R"doc(
             Records the completion of commands on this CQ, preceeding this call.
 

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -54,8 +54,8 @@ MeshEvent record_mesh_event(
     MeshDevice* mesh_device,
     QueueId cq_id,
     const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids,
-    const std::optional<ttnn::MeshCoordinateRange>& device_range) {
-    return EnqueueRecordEventToHost(mesh_device->mesh_command_queue(*cq_id), sub_device_ids, device_range);
+    const std::optional<ttnn::MeshCoordinateRangeSet>& device_range_set) {
+    return EnqueueRecordEventToHost(mesh_device->mesh_command_queue(*cq_id), sub_device_ids, device_range_set);
 }
 
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event) {

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -36,7 +36,7 @@ MeshEvent record_mesh_event(
     MeshDevice* mesh_device,
     QueueId cq_id,
     const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids = {},
-    const std::optional<ttnn::MeshCoordinateRange>& device_range = std::nullopt);
+    const std::optional<ttnn::MeshCoordinateRangeSet>& device_range_set = std::nullopt);
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event);
 
 }  // namespace events

--- a/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
@@ -156,7 +156,6 @@ void apply_override_runtime_arguments(
     tt::tt_metal::Program& program,
     typename ProgramFactory::shared_variables_t& shared_vars,
     const OperationAttributes& attrs,
-    const ttnn::MeshCoordinate& coord,
     const TensorArgs& tensor_args,
     TensorReturnValue& return_value) {
     if constexpr (requires {

--- a/ttnn/cpp/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.hpp
@@ -47,7 +47,7 @@ struct OldInfraDeviceOperation {
     struct MeshWorkloadFactory {
         struct shared_variables_t {
             std::optional<operation::OverrideRuntimeArgumentsWorkloadCallback<OutputTensors>> workload_callback;
-            std::unordered_map<ttnn::MeshCoordinateRange, operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
+            std::unordered_map<ttnn::MeshCoordinateRangeSet, operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
                 per_program_callbacks;
         };
         using cached_mesh_workload_t = ttnn::device_operation::CachedMeshWorkload<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -60,7 +60,7 @@ struct CacheableMeshWorkload {
     // TODO: #19569 - `per_program_callbacks` is used to assist old infra migration, which relied on per-program
     // callbacks. This needs to be removed
     std::optional<OverrideRuntimeArgumentsWorkloadCallback<OutputTensors>> workload_callback = std::nullopt;
-    std::unordered_map<ttnn::MeshCoordinateRange, OverrideRuntimeArgumentsCallback<OutputTensors>>
+    std::unordered_map<ttnn::MeshCoordinateRangeSet, OverrideRuntimeArgumentsCallback<OutputTensors>>
         per_program_callbacks;
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -244,11 +244,12 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create_mesh_workload(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
     tt::tt_metal::distributed::MeshWorkload workload;
-    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+    std::unordered_map<ttnn::MeshCoordinateRangeSet, shared_variables_t> shared_variables;
     for (const auto& coord : tensor_coords.coords()) {
+        const auto coord_range_set = ttnn::MeshCoordinateRangeSet(coord);
         auto cached_program = create_at(operation_attributes, coord, tensor_args, tensor_return_value);
-        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
-        shared_variables.emplace(coord, std::move(cached_program.shared_variables));
+        workload.add_program(coord_range_set, std::move(cached_program.program));
+        shared_variables.emplace(coord_range_set, std::move(cached_program.shared_variables));
     }
     return cached_mesh_workload_t(std::move(workload), std::move(shared_variables));
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -2271,19 +2271,13 @@ std::vector<Tensor> Matmul::create_output_tensors(
 
 using MatmulCallback = tt::tt_metal::operation::OverrideRuntimeArgumentsCallback<std::vector<Tensor>>;
 
-MeshCoordinateRange get_range_from_mesh_coords(const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    TT_FATAL(tensor_coords.size() == 1, "Cannot support dispatching TTNN Ops to different device ranges.");
-    return tensor_coords.ranges().front();
-}
-
 operation::CacheableMeshWorkload<std::vector<Tensor>> create_homogenous_mesh_workload(
     tt::tt_metal::operation::ProgramWithCallbacks& matmul_program, const ttnn::MeshCoordinateRangeSet& tensor_coords) {
     tt::tt_metal::distributed::MeshWorkload matmul_workload = tt::tt_metal::distributed::CreateMeshWorkload();
-    std::unordered_map<MeshCoordinateRange, MatmulCallback> callbacks = {};
+    std::unordered_map<MeshCoordinateRangeSet, MatmulCallback> callbacks;
 
-    auto workload_device_range = get_range_from_mesh_coords(tensor_coords);
-    AddProgramToMeshWorkload(matmul_workload, std::move(matmul_program.program), workload_device_range);
-    callbacks[workload_device_range] = std::move(matmul_program.override_runtime_arguments_callback.value());
+    AddProgramToMeshWorkload(matmul_workload, std::move(matmul_program.program), tensor_coords);
+    callbacks[tensor_coords] = std::move(matmul_program.override_runtime_arguments_callback.value());
     return {.workload = std::move(matmul_workload), .per_program_callbacks = std::move(callbacks)};
 }
 
@@ -2399,11 +2393,10 @@ operation::CacheableMeshWorkload<std::vector<Tensor>> Matmul::create_mesh_worklo
                                      MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
                 // DRAM Sharded Matmul generates different programs across devices, since it depends on harvesting.
                 // Account for this by creating a heterogenous MeshWorkload.
-                auto workload_device_range = get_range_from_mesh_coords(tensor_coords);
                 tt::tt_metal::distributed::MeshWorkload dram_sharded_mm_workload;
-                std::unordered_map<MeshCoordinateRange, MatmulCallback> callbacks;
+                std::unordered_map<MeshCoordinateRangeSet, MatmulCallback> callbacks;
 
-                for (const auto& coord : workload_device_range) {
+                for (const auto& coord : tensor_coords.coords()) {
                     auto dram_sharded_mm_program = matmul_multi_core_reuse_dram_sharded_optimized(
                         coord,
                         input_tensor_a,
@@ -2420,10 +2413,8 @@ operation::CacheableMeshWorkload<std::vector<Tensor>> Matmul::create_mesh_worklo
                         false,
                         false);
                     AddProgramToMeshWorkload(
-                        dram_sharded_mm_workload,
-                        std::move(dram_sharded_mm_program.program),
-                        MeshCoordinateRange(coord, coord));
-                    callbacks[MeshCoordinateRange(coord, coord)] =
+                        dram_sharded_mm_workload, std::move(dram_sharded_mm_program.program), coord);
+                    callbacks[MeshCoordinateRangeSet(MeshCoordinateRange(coord, coord))] =
                         std::move(dram_sharded_mm_program.override_runtime_arguments_callback.value());
                 }
                 return {.workload = std::move(dram_sharded_mm_workload), .per_program_callbacks = std::move(callbacks)};


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`MeshWorkload` / `MeshEvent` should accept `MeshCoordinateRangeSet` to support a general case.

### What's changed
Use `MeshCoordinateRangeSet` in some of the key interfaces.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14249399534)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14249405945)
- [X] New/Existing tests provide coverage for changes