### PR TITLE
#0: Fix merge conflicts due to llama reduce scatter CCL

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -13,7 +13,6 @@ from models.utility_functions import skip_for_grayskull
 from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
     create_and_load_sub_device_manager_with_fabric_interface,
     teardown_fabric_interface,
-    create_global_semaphore,
 )
 
 from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
@@ -180,7 +179,7 @@ def run_reduce_scatter_test(
     mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = [create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
+    ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
 
     tt_out_tensor_list = []
     if trace_mode:

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -13,7 +13,7 @@ from models.utility_functions import skip_for_grayskull
 from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
     create_and_load_sub_device_manager_with_fabric_interface,
     teardown_fabric_interface,
-    create_global_semaphore_with_same_address,
+    create_global_semaphore,
 )
 
 from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
@@ -180,9 +180,7 @@ def run_reduce_scatter_test(
     mesh_device.set_sub_device_stall_group(sub_device_stall_group)
 
     # create global semaphore handles
-    ccl_semaphore_handles = [
-        create_global_semaphore_with_same_address(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)
-    ]
+    ccl_semaphore_handles = [create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(num_iters)]
 
     tt_out_tensor_list = []
     if trace_mode:

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
@@ -272,18 +272,18 @@ operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
 
     // Capture padding_config_buffer, local_config_buffer, remote_config_buffer to cache this with the program
     if (!capture_buffers) {
-        padding_config_buffer = nullptr;
-        gather_config_buffer0 = nullptr;
-        gather_config_buffer1 = nullptr;
+        padding_config_storage = {};
+        gather_config_storage0 = {};
+        gather_config_storage1 = {};
     }
     auto override_runtime_arguments_callback = [src_cb,
                                                 out_cb,
                                                 padding_config_cb,
                                                 gather_config_cb0,
                                                 gather_config_cb1,
-                                                padding_config_buffer,
-                                                gather_config_buffer0,
-                                                gather_config_buffer1](
+                                                padding_config_storage,
+                                                gather_config_storage0,
+                                                gather_config_storage1](
                                                    const void* operation,
                                                    Program& program,
                                                    const std::vector<Tensor>& input_tensors,
@@ -400,7 +400,8 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core_v2(
         cb_indices.padding_config_cb_id,
         kernel_config_df,
         1,
-        padding_config_buffer->size() / num_cores);
+        padding_config_buffer->size() / num_cores,
+        padding_config_buffer);
 
     auto local_config_storage = local_config.device_storage();
     auto local_config_buffer = local_config_storage.get_buffer();


### PR DESCRIPTION
* Fix `create_global_semaphore` usage in Python
* Fix retaining device storage in untilize with halo program factory

- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14234212082)
- [X] Ran T3K falcon 7b and resnet50 locally.