### PR TITLE
#14692: Move ensure_devices for TG up as a fixture so other tests can use and use it in important llama smoke test for TG

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -326,6 +326,12 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
 
 
 @pytest.fixture()
+def ensure_devices_tg():
+    device_ids = ttnn.get_device_ids()
+    assert len(device_ids) == 32, f"Expected 32 devices, got {len(device_ids)}"
+
+
+@pytest.fixture()
 def clear_compile_cache():
     yield
     import ttnn

--- a/conftest.py
+++ b/conftest.py
@@ -328,6 +328,7 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
 @pytest.fixture()
 def ensure_devices_tg():
     import ttnn
+
     device_ids = ttnn.get_device_ids()
     assert len(device_ids) == 32, f"Expected 32 devices, got {len(device_ids)}"
 

--- a/conftest.py
+++ b/conftest.py
@@ -327,6 +327,7 @@ def t3k_mesh_device(request, silicon_arch_name, silicon_arch_wormhole_b0, device
 
 @pytest.fixture()
 def ensure_devices_tg():
+    import ttnn
     device_ids = ttnn.get_device_ids()
     assert len(device_ids) == 32, f"Expected 32 devices, got {len(device_ids)}"
 

--- a/models/demos/llama3_subdevices/conftest.py
+++ b/models/demos/llama3_subdevices/conftest.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import gc
-import ttnn
 
 
 @pytest.fixture(autouse=True)
@@ -12,6 +11,5 @@ def ensure_gc():
 
 
 @pytest.fixture(autouse=True)
-def ensure_devices():
-    device_ids = ttnn.get_device_ids()
-    assert len(device_ids) == 32, f"Expected 32 devices, got {len(device_ids)}"
+def ensure_devices(ensure_devices_tg):
+    pass

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -252,6 +252,7 @@ def test_all_reduce_tg_llama(
     trace_mode,
     use_program_cache,
     function_level_defaults,
+    ensure_devices_tg,
 ):
     profiler = BenchmarkProfiler()
 


### PR DESCRIPTION
… 

### Ticket

#14692

### Problem description

An important test we use for smoke testing TGs skipped the test if it didn't detect 32 chips. A TG specific test should assert it has enough chips to use.

### What's changed

Uplift fixture put in `models/` into overall `conftest.py`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14230996771
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [ ] TG unit tests https://github.com/tenstorrent/tt-metal/actions/runs/14248026599