### PR TITLE
Reduce Scatter integration with LLama-TG

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -27,6 +27,7 @@ mapping_op_code_to_name = {
     "AllGatherAsync_0": "AllGatherAsync_LN_0",
     "AllGatherAsync_1": "AllGatherAsync_SDPA_0",
     "AllGatherAsync_2": "AllGatherAsync_LN_1",
+    "AllGatherAsync_3": "AllGatherAsync_Binary_Mult",
     "ShardedToInterleavedDeviceOperation_0": "ShardedToInterleavedDeviceOperation_LN_0",
     "ShardedToInterleavedDeviceOperation_1": "ShardedToInterleavedDeviceOperation_LN_1",
     "InterleavedToShardedDeviceOperation_0": "InterleavedToShardedDeviceOperation_LN_0",
@@ -42,9 +43,9 @@ mapping_op_code_to_name = {
     "Matmul_4": "FF2_MM",
     "AllReduceAsync_0": "AllReduceAsync_QKV",
     "AllReduceAsync_1": "AllReduceAsync_DO",
-    "AllReduceAsync_2": "AllReduceAsync_FF1",
-    "AllReduceAsync_3": "AllReduceAsync_FF3",
-    "AllReduceAsync_4": "AllReduceAsync_FF2",
+    "AllReduceAsync_2": "AllReduceAsync_FF2",
+    "LlamaReduceScatterDeviceOperation_0": "ReduceScatter_FF1",
+    "LlamaReduceScatterDeviceOperation_1": "ReduceScatter_FF3",
     "NLPCreateHeadsDecodeDeviceOperation_0": "CreateHeads",
     "RotaryEmbeddingLlamaFusedQK_0": "RotaryEmbeddingLlamaFusedQK",
     "PagedUpdateCacheDeviceOperation_0": "PagedUpdateCache",
@@ -257,6 +258,10 @@ def average_per_instance_dict(input_dict):
     (3000,),
 )
 @pytest.mark.parametrize(
+    "abs_tolerance_ns_reduce_scatter",
+    (2000,),
+)
+@pytest.mark.parametrize(
     "abs_tolerance_ns_all_gather",
     (1500,),
 )
@@ -281,6 +286,7 @@ def test_llama_TG_perf_device(
     reset_seeds,
     abs_tolerance_ns,
     abs_tolerance_ns_all_reduce,
+    abs_tolerance_ns_reduce_scatter,
     abs_tolerance_ns_all_gather,
     abs_tolerance_ns_sdpa,
     abs_tolerance_ns_op_to_op,
@@ -344,6 +350,7 @@ def test_llama_TG_perf_device(
         "AllGatherAsync_0": 4205.888888888889,
         "AllGatherAsync_1": 9638.666666666666,
         "AllGatherAsync_2": 4095.5555555555557,
+        "AllGatherAsync_3": 9642.0,
         "ShardedToInterleavedDeviceOperation_0": 3947.222222222222,
         "ShardedToInterleavedDeviceOperation_1": 3388.5555555555557,
         "InterleavedToShardedDeviceOperation_0": 2546.5555555555557,
@@ -355,9 +362,9 @@ def test_llama_TG_perf_device(
         "Matmul_4": 16474.222222222223,
         "AllReduceAsync_0": 15395.555555555555,
         "AllReduceAsync_1": 21078.333333333332,
-        "AllReduceAsync_2": 20948.777777777777,
-        "AllReduceAsync_3": 21195.444444444445,
-        "AllReduceAsync_4": 21145.777777777777,
+        "AllReduceAsync_2": 21145.777777777777,
+        "LlamaReduceScatterDeviceOperation_0": 10600.555555555555,
+        "LlamaReduceScatterDeviceOperation_1": 11251.222222222223,
         "NLPCreateHeadsDecodeDeviceOperation_0": 8568.222222222223,
         "RotaryEmbeddingLlamaFusedQK_0": 5023.888888888889,
         "PagedUpdateCacheDeviceOperation_0": 5606.444444444444,
@@ -365,7 +372,7 @@ def test_llama_TG_perf_device(
         "NLPConcatHeadsDecodeDeviceOperation_0": 6665.0,
         "ReshardDeviceOperation_0": 1752.7777777777778,
         "BinaryDeviceOperation_0": 2408.8888888888887,
-        "BinaryDeviceOperation_1": 11838.444444444445,
+        "BinaryDeviceOperation_1": 4572.777777777777,
         "BinaryDeviceOperation_2": 2435.5555555555557,
     }
 
@@ -377,6 +384,7 @@ def test_llama_TG_perf_device(
         "AllGatherAsync_0": 2417.5555555555557,
         "AllGatherAsync_1": 676.4444444444445,
         "AllGatherAsync_2": 2403.4444444444443,
+        "AllGatherAsync_3": 1698.7777777777778,
         "ShardedToInterleavedDeviceOperation_0": 2211.6666666666665,
         "ShardedToInterleavedDeviceOperation_1": 2212.222222222222,
         "InterleavedToShardedDeviceOperation_0": 631.8888888888889,
@@ -388,9 +396,9 @@ def test_llama_TG_perf_device(
         "Matmul_4": 658.7777777777778,
         "AllReduceAsync_0": 609.0,
         "AllReduceAsync_1": 626.5555555555555,
-        "AllReduceAsync_2": 641.2222222222222,
-        "AllReduceAsync_3": 629.7777777777778,
-        "AllReduceAsync_4": 637.1111111111111,
+        "AllReduceAsync_2": 637.1111111111111,
+        "LlamaReduceScatterDeviceOperation_0": 708.1111111111111,
+        "LlamaReduceScatterDeviceOperation_1": 736.1111111111111,
         "NLPCreateHeadsDecodeDeviceOperation_0": 761.1111111111111,
         "RotaryEmbeddingLlamaFusedQK_0": 540.7777777777778,
         "PagedUpdateCacheDeviceOperation_0": 773.8888888888889,
@@ -398,7 +406,7 @@ def test_llama_TG_perf_device(
         "NLPConcatHeadsDecodeDeviceOperation_0": 620.5555555555555,
         "ReshardDeviceOperation_0": 655.2222222222222,
         "BinaryDeviceOperation_0": 653.6666666666666,
-        "BinaryDeviceOperation_1": 717.4444444444445,
+        "BinaryDeviceOperation_1": 661.0,
         "BinaryDeviceOperation_2": 647.7777777777778,
     }
 
@@ -418,6 +426,8 @@ def test_llama_TG_perf_device(
             # Verify kernel duration is within tolerance
             if "AllReduceAsync" in op_code_with_id:
                 tolerance = abs_tolerance_ns_all_reduce
+            elif "LlamaReduceScatterDeviceOperation" in op_code_with_id:
+                tolerance = abs_tolerance_ns_reduce_scatter
             elif "AllGatherAsync" in op_code_with_id:
                 tolerance = abs_tolerance_ns_all_gather
             elif "ScaledDotProductAttentionDecode" in op_code_with_id:
@@ -485,6 +495,10 @@ def test_llama_TG_perf_device(
     (1500,),
 )
 @pytest.mark.parametrize(
+    "abs_tolerance_ns_reduce_scatter",
+    (1500,),
+)
+@pytest.mark.parametrize(
     "abs_tolerance_ns_all_gather",
     (1500,),
 )
@@ -502,7 +516,12 @@ def test_llama_TG_perf_device(
 # If the op list changed (new ops, less ops, fused ops), and not done for the above test, then update mapping_op_code_to_name and give the new ops meaningful names
 # Run at least once again to verify the new expected values are correct and margins hold
 def test_llama_TG_perf_device_non_overlapped_dispatch(
-    reset_seeds, abs_tolerance_ns, abs_tolerance_ns_all_reduce, abs_tolerance_ns_all_gather, abs_tolerance_ns_sdpa
+    reset_seeds,
+    abs_tolerance_ns,
+    abs_tolerance_ns_all_reduce,
+    abs_tolerance_ns_reduce_scatter,
+    abs_tolerance_ns_all_gather,
+    abs_tolerance_ns_sdpa,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
@@ -551,6 +570,7 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
         "AllGatherAsync_0": 2273.2,
         "AllGatherAsync_1": 2983.2,
         "AllGatherAsync_2": 2272.1,
+        "AllGatherAsync_3": 4342.0,
         "ShardedToInterleavedDeviceOperation_0": 1919.0,
         "ShardedToInterleavedDeviceOperation_1": 1910.2,
         "InterleavedToShardedDeviceOperation_0": 10347.3,
@@ -562,9 +582,9 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
         "Matmul_4": 6029.3,
         "AllReduceAsync_0": 7349.4,
         "AllReduceAsync_1": 6484.7,
-        "AllReduceAsync_2": 11900.0,
-        "AllReduceAsync_3": 11874.1,
-        "AllReduceAsync_4": 6475.9,
+        "AllReduceAsync_2": 6475.9,
+        "LlamaReduceScatterDeviceOperation_0": 8058.9,
+        "LlamaReduceScatterDeviceOperation_1": 7359.9,
         "NLPCreateHeadsDecodeDeviceOperation_0": 8156.7,
         "RotaryEmbeddingLlamaFusedQK_0": 2844.3,
         "PagedUpdateCacheDeviceOperation_0": 4670.5,
@@ -588,6 +608,8 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
             benchmark_data.add_measurement(profiler, 0, step_name, op_name + "_dispatch", avg_dispatch_duration)
             if "AllReduceAsync" in op_code_with_id:
                 tolerance = abs_tolerance_ns_all_reduce
+            elif "LlamaReduceScatterDeviceOperation" in op_code_with_id:
+                tolerance = abs_tolerance_ns_reduce_scatter
             elif "AllGatherAsync" in op_code_with_id:
                 tolerance = abs_tolerance_ns_all_gather
             elif "ScaledDotProductAttentionDecode" in op_code_with_id:

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -359,7 +359,7 @@ def test_llama_TG_perf_device(
         "Matmul_1": 8584.111111111111,
         "Matmul_2": 10554.555555555555,
         "Matmul_3": 12118.888888888889,
-        "Matmul_4": 16474.222222222223,
+        "Matmul_4": 17000.0,
         "AllReduceAsync_0": 15395.555555555555,
         "AllReduceAsync_1": 21078.333333333332,
         "AllReduceAsync_2": 21145.777777777777,

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -1076,6 +1076,33 @@ class TtModelArgs:
                 )
             )
 
+            PACKET_WORKER_CRS = ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                ]
+            )
+            self.model_config["REDUCE_SCATTER_INTERIM_MEMCFG"] = ttnn.create_sharded_memory_config(
+                shape=(32, 512),
+                core_grid=PACKET_WORKER_CRS,
+                strategy=ttnn.ShardStrategy.WIDTH,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
+            FF1_CRS_RS_OUT = ttnn.num_cores_to_corerangeset_in_subcoregrids(
+                ttnn.CoreCoord(1, 0), 30, self.sub_core_grids, row_wise=True
+            )
+            self.model_config["REDUCE_SCATTER_OUT_MEMCFG"] = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                ttnn.BufferType.L1,
+                ttnn.ShardSpec(
+                    FF1_CRS_RS_OUT,
+                    [32, 32],
+                    ttnn.ShardOrientation.ROW_MAJOR,
+                ),
+            )
+
             self.model_config["SELF_OUT_REDUCE_SCATTER_MEMCFG"] = (
                 ttnn.create_sharded_memory_config(
                     shape=(32, 2048 // 8 // 8),  # mesh_rows = 8, num_cores=8

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.cpp
@@ -124,7 +124,7 @@ void AllGatherAsync::validate_with_output_tensors(
         for (size_t i = 0; i < input_shape.size(); ++i) {
             if (i == this->dim) {
                 TT_FATAL(
-                    output_shape[i] == input_shape[i] * this->ring_size,
+                    output_shape[i] <= input_shape[i] * this->ring_size,
                     "Error, Output tensor shape at dimension {} should be {} but has {}",
                     i,
                     input_shape[i] * this->ring_size,
@@ -264,7 +264,6 @@ AllGatherAsyncVersion AllGatherAsync::select_version(const Tensor& input_tensor)
 tt::tt_metal::operation::ProgramWithCallbacks AllGatherAsync::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     tt::log_debug(tt::LogOp, "DEBUG: create_program is called");
-
     AllGatherAsyncVersion version = select_version(input_tensors[0]);
 
     log_trace(tt::LogOp, "version: {}", static_cast<uint32_t>(version));


### PR DESCRIPTION
### Problem description
Integrated Saad's new reduce scatter for FF1/FF3 into llama3_subdevices for decode mode

### What's changed
* Added persistent buffer creation for decode reduce scatter
* Replaced AllReduce after FF1/FF3 with line_reduce_scatter and line_all_gather.
* Fixed output shape assertion in all_gather validation to handle padded input but non-padded outputs
### Demo Run
With RING BUFFER and IRAM Enabled
`e2e : 39.3 t/s/u
`
```
2025-04-03 01:30:47.004 | INFO     | models.demos.llama3_subdevices.demo.demo_decode:run_llama3_demo:453 - Iteration 197: 25ms @ 39.3 tok/s/user (1256.0 tok/s throughput)
2025-04-03 01:30:47.031 | INFO     | models.demos.llama3_subdevices.demo.demo_decode:run_llama3_demo:443 - [User 0] <|begin_of_text|>This is a test. It's important to conduct tests to ensure everything is functioning correctly. Whether it's a new software application, a scientific experiment, or a simple task, testing helps us identify any issues and make improvements. In this case, we're testing the functionality of a specific feature. We want to make sure it's working as intended and that there are no bugs or errors. By conducting this test, we can ensure that everything is running smoothly and that our users will have a seamless experience. So, let's get started and see if this feature is up to par!
This is a test. It's important to conduct tests to ensure everything is functioning correctly. Whether it's a new software application, a scientific experiment, or a simple task, testing helps us identify any issues and make improvements. In this case, we're testing the functionality of a specific feature. We want to make sure it's working as intended and that there are no bugs or errors. By conducting this
2025-04-03 01:30:47.032 | INFO     | models.demos.llama3_subdevices.demo.demo_decode:run_llama3_demo:453 - Iteration 198: 25ms @ 39.3 tok/s/user (1256.0 tok/s throughput)
2025-04-03 01:30:47.059 | INFO     | models.demos.llama3_subdevices.demo.demo_decode:run_llama3_demo:443 - [User 0] <|begin_of_text|>This is a test. It's important to conduct tests to ensure everything is functioning correctly. Whether it's a new software application, a scientific experiment, or a simple task, testing helps us identify any issues and make improvements. In this case, we're testing the functionality of a specific feature. We want to make sure it's working as intended and that there are no bugs or errors. By conducting this test, we can ensure that everything is running smoothly and that our users will have a seamless experience. So, let's get started and see if this feature is up to par!
This is a test. It's important to conduct tests to ensure everything is functioning correctly. Whether it's a new software application, a scientific experiment, or a simple task, testing helps us identify any issues and make improvements. In this case, we're testing the functionality of a specific feature. We want to make sure it's working as intended and that there are no bugs or errors. By conducting this test
2025-04-03 01:30:47.059 | INFO     | models.demos.llama3_subdevices.demo.demo_decode:run_llama3_demo:453 - Iteration 199: 25ms @ 39.3 tok/s/user (1256.3 tok/s throughput)
2025-04-03 01:30:47.059 | INFO     | models.demos.llama3_subdevices.tt.llama_ccl:close:613 - Tearing down persistent fabric interface
```
### Accuracy Test
`2025-04-07 18:49:39.883 | INFO     | models.demos.llama3_subdevices.tests.test_llama_accuracy:test_tt_model_acc:474 - Top-1: 95% | Top-5: 100%`
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14231709279) CI passes
- [x] [TG Demo Test](https://github.com/tenstorrent/tt-metal/actions/runs/14314263856)
- [x] [TG Frequent Test](https://github.com/tenstorrent/tt-metal/actions/runs/14314272490)
- [ ] [TG Model Perf Test](https://github.com/tenstorrent/tt-metal/actions/runs/14323872211/job/40146197060)
- [x] [TG Unit Tests](https://github.com/tenstorrent/tt-metal/actions/runs/14314314892)