### PR TITLE
Add CLI tool for PR review optimization

### DIFF
--- a/cli_tool/README.md
+++ b/cli_tool/README.md
@@ -1,0 +1,37 @@
+# PR Reviewer Tool - Review Optimizer
+
+A tool to automatically select reviewers for pull requests based on code ownership.
+
+## Installation
+
+### For Development (Editable Install)
+
+```bash
+cd /path/to/tt-metal/cli_tool
+pip install -e .
+```
+
+### For Regular Use
+
+```bash
+cd /path/to/tt-metal/cli_tool
+pip install .
+```
+
+## Usage
+
+After installation, you can use the tool from anywhere with the following command syntax:
+```bash
+get_reviewers PR_NUMBER -include name1 name2 ... -skip name3 name4 ...
+```
+
+```bash
+get_reviewers PR_NUMBER
+```
+
+
+## Features
+
+- Automatically selects reviewers based on code ownership
+- Optimizes reviewer selection to minimize the number of people needed
+- Integrates with GitHub CLI for PR information

--- a/cli_tool/README.md
+++ b/cli_tool/README.md
@@ -2,7 +2,22 @@
 
 A tool to automatically select reviewers for pull requests based on code ownership.
 
-## Installation
+# Codeowner Installation
+
+Before installing this package, ensure you have the `codeowners` CLI installed:
+
+## macOS
+```sh
+brew tap hmarr/tap
+brew install codeowners
+```
+
+## Other platforms
+```sh
+go install github.com/hmarr/codeowners/cmd/codeowners@latest
+```
+
+## Review Optimizer Installation
 
 ### For Development (Editable Install)
 

--- a/cli_tool/pr_review/__init__.py
+++ b/cli_tool/pr_review/__init__.py
@@ -1,0 +1,4 @@
+
+"""PR Reviewer package for automatic selection of code reviewers."""
+
+__version__ = "0.1.0"

--- a/cli_tool/pr_review/__init__.py
+++ b/cli_tool/pr_review/__init__.py
@@ -1,4 +1,0 @@
-
-"""PR Reviewer package for automatic selection of code reviewers."""
-
-__version__ = "0.1.0"

--- a/cli_tool/pr_review/review_optimizer.py
+++ b/cli_tool/pr_review/review_optimizer.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import json
+import re
+import sys
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Get list of reviewers for a PR.')
+    parser.add_argument('pr_number', type=int, help='Pull request number')
+    parser.add_argument('-include', type=str, nargs='*', default=[], help='List of names to include')
+    parser.add_argument('-skip', type=str, nargs='*', default=[], help='List of names to skip')
+    return parser.parse_args()
+
+def get_pr_files(pr_number, repo):
+    try:
+        result = subprocess.run(
+            ['gh', 'pr', 'view', str(pr_number), '--repo', repo, '--json', 'files'],
+            check=True, text=True, capture_output=True
+        )
+        data = json.loads(result.stdout)
+        return data['files']
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"Error fetching PR files: {e.stderr}")
+
+def get_codeowners(file_path):
+    """Get codeowners for a file path"""
+    try:
+        result = subprocess.run(
+            ["codeowners", file_path],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        # "file_path  @owner1 @owner2 ..."
+        output = result.stdout.strip()
+        
+        # add the owners to a list
+        if output and file_path in output:
+            owners_part = output.replace(file_path, "").strip()
+            owners_list = owners_part.split() if owners_part else []
+        else:
+            owners_list = []
+        # print(f"Owners for {file_path}: {owners_list}")
+        return owners_list
+    except subprocess.CalledProcessError as e:
+        print(f"Error getting codeowners for {file_path}: {e}")
+        return []
+
+def select_reviewers(file_owners, include, skip):
+    # must include reviewers and reviewers can be skipped (on vacation, etc.)
+    selected_reviewers = set(include)
+    for file in file_owners:
+        file['owners'] = [owner for owner in file['owners'] if owner.lstrip('@') not in skip]
+
+    # Mark files covered by the included reviewers as reviewed
+    for file in file_owners:
+        if any(owner in include for owner in file['owners']):
+            file['owners'] = []
+
+    # Refreshes untouched files after including reviewers
+    untouched_files = [file for file in file_owners if file['owners']]
+
+    owner_files = {}
+    for file in untouched_files:
+        for owner in file['owners']:
+            if owner in owner_files:
+                owner_files[owner].add(file['filename'])
+            else:
+                owner_files[owner] = {file['filename']}
+
+    # Sort the owners by the number of unique files they cover
+    while untouched_files:
+        max_coverage_owner = max(owner_files, key=lambda o: len(owner_files[o]), default=None)
+        
+        if not max_coverage_owner:
+            break
+        
+        selected_reviewers.add(max_coverage_owner)
+        
+        # Remove all files that the selected owner can review
+        covered_files = owner_files.pop(max_coverage_owner, set())
+        untouched_files = [file for file in untouched_files if file['filename'] not in covered_files]
+
+        # Update owner_files by removing the files already reviewed
+        for owner in owner_files:
+            owner_files[owner] -= covered_files
+
+    return sorted(selected_reviewers)
+
+
+def review_optimizer():
+    args = parse_args()
+    repo = "tenstorrent/tt-metal"
+
+    try:
+        files = get_pr_files(args.pr_number, repo)
+
+        file_owners = [
+            {"filename": file['path'], "owners": get_codeowners(file['path'])}
+            for file in files
+        ]
+        reviewers = select_reviewers(file_owners, args.include, args.skip)
+        print("Selected Reviewers:", reviewers)
+    except Exception as e:
+        print(f"Error: {e}")
+
+if __name__ == '__main__':
+    review_optimizer()
+

--- a/cli_tool/pr_review/review_optimizer.py
+++ b/cli_tool/pr_review/review_optimizer.py
@@ -49,10 +49,15 @@ def get_codeowners(file_path):
         return []
 
 def select_reviewers(file_owners, include, skip):
+    # Normalize inputs to strip '@' from include and skip lists
+    include = {name.lstrip('@') for name in include}
+    skip = {name.lstrip('@') for name in skip}
+    
     # must include reviewers and reviewers can be skipped (on vacation, etc.)
     selected_reviewers = set(include)
+
     for file in file_owners:
-        file['owners'] = [owner for owner in file['owners'] if owner.lstrip('@') not in skip]
+        file['owners'] = [owner.lstrip('@') for owner in file['owners'] if owner.lstrip('@') not in skip]
 
     # Mark files covered by the included reviewers as reviewed
     for file in file_owners:
@@ -77,7 +82,7 @@ def select_reviewers(file_owners, include, skip):
         if not max_coverage_owner:
             break
         
-        selected_reviewers.add(max_coverage_owner)
+        selected_reviewers.add(max_coverage_owner.lstrip('@'))  # Normalize before adding
         
         # Remove all files that the selected owner can review
         covered_files = owner_files.pop(max_coverage_owner, set())
@@ -87,7 +92,8 @@ def select_reviewers(file_owners, include, skip):
         for owner in owner_files:
             owner_files[owner] -= covered_files
 
-    return sorted(selected_reviewers)
+    return sorted(f"@{reviewer}" for reviewer in selected_reviewers)  # Ensure consistent output format
+
 
 
 def review_optimizer():

--- a/cli_tool/setup.py
+++ b/cli_tool/setup.py
@@ -1,0 +1,22 @@
+import os
+from setuptools import setup, find_packages
+
+def read_version():
+    version_path = os.path.join(os.path.dirname(__file__), 'pr_review', '__init__.py')
+    with open(version_path) as f:
+        for line in f:
+            if line.startswith('__version__'):
+                delim = '"' if '"' in line else "'"
+                return line.split(delim)[1]
+
+setup(
+    name='review_optimizer',
+    version=read_version(),  # dynamically read from __init__.py
+    packages=find_packages(),
+    description='PR Reviewer package for automatic selection of code reviewers.',
+    entry_points={
+        'console_scripts': [
+            'get_reviewers=pr_review.review_optimizer:review_optimizer',
+        ],
+    },
+)

--- a/cli_tool/setup.py
+++ b/cli_tool/setup.py
@@ -1,18 +1,10 @@
 import os
 from setuptools import setup, find_packages
 
-def read_version():
-    version_path = os.path.join(os.path.dirname(__file__), 'pr_review', '__init__.py')
-    with open(version_path) as f:
-        for line in f:
-            if line.startswith('__version__'):
-                delim = '"' if '"' in line else "'"
-                return line.split(delim)[1]
-
 setup(
     name='review_optimizer',
-    version=read_version(),  # dynamically read from __init__.py
     packages=find_packages(),
+    version='0.0.1', # This initial version does not dereference group members. Only individual usernames can be included or skipped in the reviewer selection. 
     description='PR Reviewer package for automatic selection of code reviewers.',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
### Problem description
This PR introduces a CLI tool to optimize PR reviewers by automatically selecting reviewers based on code ownership. The tool:
1. Retrieves the list of files changed in a PR.
2. Identifies code owners for each file.
3. Allows including or skipping specific reviewers.
4. Selects an optimal set of reviewers based on file coverage.

### What's changed
✅ Added a new CLI tool under `cli_tool/`
✅ Implemented `review_optimizer.py` to handle reviewer selection
✅ Added `setup.py` for packaging
✅ Included `README.md` with usage instructions

### For Development (Editable Install)

```bash
cd /path/to/tt-metal/cli_tool
pip install -e .
```
### For Regular Use

```bash
cd /path/to/tt-metal/cli_tool
pip install .
```
### Usage

After installation, you can use the tool from anywhere with the following command syntax:
```bash
get_reviewers PR_NUMBER -include name1 name2 ... -skip name3 name4 ...
```

```bash
get_reviewers PR_NUMBER
```

Where:
- `PR_NUMBER` is the number of the pull request. **(Mandatory)**
- `-include` allows you to specify reviewers to include in the selection process. **(Optional)**
- `-skip` allows you to specify reviewers to skip from the selection process. **(Optional)**

### Limitations
This initial version does **not** dereference group members. Only **individual** usernames can be included or skipped in the reviewer selection.