### PR TITLE
versim support for L1 and L1 small sharded write-then-read-back gtests

### DIFF
--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -11,6 +11,8 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/device_pool.hpp>
+#include <limits>
+#include <algorithm>
 
 namespace tt::tt_metal {
 
@@ -56,6 +58,19 @@ protected:
         DispatchFixture(l1_small_size, trace_region_size) {}
 
     size_t num_devices_;
+
+public:
+    std::pair<unsigned, unsigned> worker_grid_minimum_dims(void) {
+        constexpr size_t UMAX = std::numeric_limits<unsigned>::max();
+        std::pair<size_t, size_t> min_dims = {UMAX, UMAX};
+        for (auto device : devices_) {
+            auto coords = device->compute_with_storage_grid_size();
+            min_dims.first = std::min(min_dims.first, coords.x);
+            min_dims.second = std::min(min_dims.second, coords.y);
+        }
+
+        return min_dims;
+    }
 };
 
 class DeviceFixtureWithL1Small : public DeviceFixture {


### PR DESCRIPTION
### Ticket
[Simulator doesn't work when buffers are allocated in "l1_small" #16195](https://github.com/tenstorrent/tt-metal/issues/16195)

### Problem description
The tt_metal/api gtests that we were using to verify L1 Small allocation and data transfers had to be updated to be compatible with tensix configuration used for versim

### What's changed
We updated relevant gtests to handle both versim and hardware device and tensix configurations

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes