### PR TITLE
Add metalium api validator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,10 @@ repos:
       require_serial: true
       types_or: [c++, c]
       args: ["--style=file"]
+- repo: local
+  hooks:
+    - id: validate-metalium-api
+      name: validate-metalium-public-apis
+      entry: python scripts/validate_metalium_api.py tt_metal/api
+      language: system
+      pass_filenames: false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -234,6 +234,8 @@ dockerfile @tenstorrent/metalium-developers-infra
 
 ttnn/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt
 
-
 # tt-train
 tt-train/** @dmakoviichuk-tt @rfurko-tt @ayerofieiev-tt
+
+# tt-metal public apis
+tt_metal/api/ @ayerofieiev-tt @omilyutin-tt @afuller-TT @blozano-tt

--- a/scripts/validate_metalium_api.py
+++ b/scripts/validate_metalium_api.py
@@ -1,0 +1,251 @@
+import os
+import re
+import sys
+from collections import defaultdict
+
+# List of files or paths (relative or absolute) to skip
+SKIP_FILES = {
+    "fabric_edm_packet_header.hpp",
+    "dev_msgs.h",
+}
+
+
+ALLOWED_PREFIXES = {
+    "hostdevcommon",
+    "tt-metalium",
+    "tt_stl",
+    "umd",
+    "boost",
+    "fmt",
+    "magic_enum",
+    "nlohmann",
+    "pybind11",
+}
+
+STD_HEADERS = {
+    # C++ standard headers
+    "algorithm",
+    "any",
+    "array",
+    "atomic",
+    "barrier",
+    "bit",
+    "bitset",
+    "cassert",
+    "cctype",
+    "charconv",
+    "chrono",
+    "climits",
+    "cmath",
+    "codecvt",
+    "compare",
+    "complex",
+    "concepts",
+    "condition_variable",
+    "coroutine",
+    "deque",
+    "exception",
+    "execution",
+    "expected",
+    "filesystem",
+    "format",
+    "forward_list",
+    "fstream",
+    "functional",
+    "future",
+    "initializer_list",
+    "iomanip",
+    "ios",
+    "iosfwd",
+    "iostream",
+    "istream",
+    "iterator",
+    "latch",
+    "limits",
+    "list",
+    "locale",
+    "map",
+    "memory",
+    "memory_resource",
+    "mutex",
+    "new",
+    "numbers",
+    "numeric",
+    "optional",
+    "ostream",
+    "queue",
+    "random",
+    "ranges",
+    "ratio",
+    "regex",
+    "scoped_allocator",
+    "semaphore",
+    "set",
+    "shared_mutex",
+    "source_location",
+    "span",
+    "sstream",
+    "stack",
+    "stdexcept",
+    "stop_token",
+    "streambuf",
+    "string",
+    "string_view",
+    "strstream",
+    "syncstream",
+    "system_error",
+    "thread",
+    "tuple",
+    "type_traits",
+    "typeindex",
+    "typeinfo",
+    "unordered_map",
+    "unordered_set",
+    "utility",
+    "valarray",
+    "variant",
+    "vector",
+    "version",
+    # C library headers (C++ style)
+    "cctype",
+    "cerrno",
+    "cfenv",
+    "cfloat",
+    "cinttypes",
+    "ciso646",
+    "climits",
+    "clocale",
+    "cmath",
+    "csetjmp",
+    "csignal",
+    "cstdarg",
+    "cstdbool",
+    "cstddef",
+    "cstdint",
+    "cstdio",
+    "cstdlib",
+    "cstring",
+    "ctime",
+    "cuchar",
+    "cwchar",
+    "cwctype",
+    # Legacy C headers (frequently used)
+    "assert.h",
+    "ctype.h",
+    "errno.h",
+    "fenv.h",
+    "float.h",
+    "inttypes.h",
+    "iso646.h",
+    "limits.h",
+    "locale.h",
+    "math.h",
+    "setjmp.h",
+    "signal.h",
+    "stdarg.h",
+    "stdbool.h",
+    "stddef.h",
+    "stdint.h",
+    "stdio.h",
+    "stdlib.h",
+    "string.h",
+    "time.h",
+    "uchar.h",
+    "wchar.h",
+    "wctype.h",
+    "unistd.h",
+    # Common system / platform headers
+    "cxxabi.h",
+    "execinfo.h",
+    "dlfcn.h",
+    "pthread.h",
+    "sys/types.h",
+    "sys/stat.h",
+    "sys/mman.h",
+    "sys/time.h",
+    "sys/wait.h",
+    "sys/socket.h",
+    "netinet/in.h",
+    "arpa/inet.h",
+    "netdb.h",
+    "fcntl.h",
+}
+
+# Regex patterns
+ANGLE_INCLUDE_PATTERN = re.compile(r"^\s*#include\s*<([^>]+)>")
+QUOTED_INCLUDE_PATTERN = re.compile(r'^\s*#include\s*"([^"]+)"')
+
+# Track which prefixes were used
+used_prefix_counts = defaultdict(int)
+
+
+def is_standard_include(include: str) -> bool:
+    return "/" not in include and include in STD_HEADERS
+
+
+def is_valid_include(include: str) -> bool:
+    if is_standard_include(include):
+        return True
+    parts = include.split("/")
+    prefix = parts[0]
+    if prefix in ALLOWED_PREFIXES:
+        used_prefix_counts[prefix] += 1
+        return True
+    return False
+
+
+def check_includes_in_file(filepath):
+    errors = []
+    with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+        for line_num, line in enumerate(f, 1):
+            # Disallow quoted includes
+            if QUOTED_INCLUDE_PATTERN.match(line):
+                include = QUOTED_INCLUDE_PATTERN.match(line).group(1)
+                errors.append((line_num, include, "Quoted includes are not allowed. Use angle brackets <...>"))
+
+            # Validate angle-bracket includes
+            match = ANGLE_INCLUDE_PATTERN.match(line)
+            if match:
+                include = match.group(1)
+                if not is_valid_include(include):
+                    reason = "Invalid or missing namespace prefix"
+                    errors.append((line_num, include, reason))
+    return errors
+
+
+def main(directory):
+    has_error = False
+    for root, _, files in os.walk(directory):
+        for fname in files:
+            if fname.endswith((".hpp", ".h", ".cpp", ".cc", ".cxx")):
+                if fname in SKIP_FILES:
+                    continue
+
+                path = os.path.join(root, fname)
+
+                errors = check_includes_in_file(path)
+                if errors:
+                    has_error = True
+                    print(f"\nErrors in {path}:")
+                    for line_num, include, reason in errors:
+                        print(f"  Line {line_num}: {include} — {reason}")
+
+    unused_prefixes = ALLOWED_PREFIXES - used_prefix_counts.keys()
+    if unused_prefixes:
+        has_error = True
+        print("\nUnused allowed prefixes (not seen in any #include):")
+        for prefix in sorted(unused_prefixes):
+            print(f"  - {prefix}")
+
+    if has_error:
+        print("\nInclude check failed.")
+        sys.exit(1)
+    else:
+        print("All includes are valid and all allowed prefixes are used.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <directory>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/scripts/validate_metalium_api.py
+++ b/scripts/validate_metalium_api.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2053 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/validate_metalium_api.py
+++ b/scripts/validate_metalium_api.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2053 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import re
 import sys

--- a/tt_metal/api/tt-metalium/allocator_types.hpp
+++ b/tt_metal/api/tt-metalium/allocator_types.hpp
@@ -8,7 +8,7 @@
 #include <cstdlib>
 #include <functional>
 #include <tt-metalium/core_coord.hpp>
-#include "hostdevcommon/common_values.hpp"
+#include <hostdevcommon/common_values.hpp>
 
 namespace tt::tt_metal {
 

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -14,8 +14,8 @@
 #include <unordered_set>
 #include <vector>
 
-#include "hostdevcommon/common_values.hpp"
-#include "hostdevcommon/kernel_structs.h"  // Not used here, but leaked to programming examples
+#include <hostdevcommon/common_values.hpp>
+#include <hostdevcommon/kernel_structs.h>  // Not used here, but leaked to programming examples
 #include <tt-metalium/work_executor_types.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/program_device_map.hpp>

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -8,8 +8,8 @@
 #include <utility>
 
 #include <tt-metalium/device.hpp>
-#include "hostdevcommon/common_values.hpp"
-#include "hostdevcommon/kernel_structs.h"  // Leaked up to ttnn level from here
+#include <hostdevcommon/common_values.hpp>
+#include <hostdevcommon/kernel_structs.h>  // Leaked up to ttnn level from here
 #include <tt-metalium/work_executor_types.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/program_device_map.hpp>

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -10,7 +10,7 @@
 #include <limits>
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-#include "ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
+#include <ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp>
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
 #else
 #include <tt-metalium/assert.hpp>

--- a/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_packet_header.hpp
@@ -10,7 +10,7 @@
 #include <limits>
 
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
-#include <ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp>
+#include "ttnn/cpp/ttnn/operations/ccl/common/interpreter_backends/kernel_common/noc_addr.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
 #else
 #include <tt-metalium/assert.hpp>

--- a/tt_metal/api/tt-metalium/hlk_desc.hpp
+++ b/tt_metal/api/tt-metalium/hlk_desc.hpp
@@ -4,14 +4,17 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstring>
+#include <functional>
 #include <string>
 
-#include "hostdevcommon/kernel_structs.h"
+#include <hostdevcommon/kernel_structs.h>
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/base_types.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/utils.hpp>
-#include <tt-metalium/circular_buffer_constants.h>  // for NUM_CIRCULAR_BUFFERS
+#include <tt-metalium/circular_buffer_constants.h>
 
 namespace tt {
 /**
@@ -131,7 +134,7 @@ public:
 // Hash for hlk_args
 inline void hash_hlk_args(size_t& seed, void* hlk_args, size_t hlk_args_size) {
     char buffer[hlk_args_size];
-    memcpy(buffer, hlk_args, hlk_args_size);
+    std::memcpy(buffer, hlk_args, hlk_args_size);
 
     for (int i = 0; i < hlk_args_size; i++) {
         tt::utils::hash_combine(seed, std::hash<char>{}(buffer[i]));

--- a/tt_metal/api/tt-metalium/jit_build_options.hpp
+++ b/tt_metal/api/tt-metalium/jit_build_options.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <tt-metalium/hlk_desc.hpp>
-#include "hostdevcommon/kernel_structs.h"
+#include <hostdevcommon/kernel_structs.h>
 
 enum class MathFidelity : uint8_t;
 namespace tt {

--- a/tt_metal/api/tt-metalium/lightmetal_capture_utils.hpp
+++ b/tt_metal/api/tt-metalium/lightmetal_capture_utils.hpp
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include <tt-metalium/buffer.hpp>
 #include <functional>
 #include <memory>
 #include <variant>
-
-#include "lightmetal/host_api_capture_helpers.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/api/tt-metalium/logger.hpp
+++ b/tt_metal/api/tt-metalium/logger.hpp
@@ -15,9 +15,9 @@
 #include <pybind11/iostream.h>
 #endif
 
-#include "fmt/color.h"
-#include "fmt/core.h"
-#include "fmt/ostream.h"
+#include <fmt/color.h>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
 
 namespace tt {
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -21,11 +21,11 @@
 #include <utility>
 #include <vector>
 
+#include <hostdevcommon/common_values.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/hal_types.hpp>
-#include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/mesh_config.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device_view.hpp>

--- a/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
+++ b/tt_metal/api/tt-metalium/profiler_optional_metadata.hpp
@@ -4,7 +4,12 @@
 
 #pragma once
 
-#include "map"
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+
+#include <umd/device/types/cluster_descriptor_types.h>
 
 class ProfilerOptionalMetadata {
     using RuntimeID = uint32_t;

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include "fmt/base.h"
+#include <fmt/base.h>
 #include <umd/device/types/arch.h>
 
 namespace tt {

--- a/tt_metal/api/tt-metalium/util.hpp
+++ b/tt_metal/api/tt-metalium/util.hpp
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
+#include <hostdevcommon/common_values.hpp>
 #include <tt-metalium/assert.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <umd/device/tt_soc_descriptor.h>


### PR DESCRIPTION
### Problem description
We have had multiple breakages of the sacred invariant that belongs to any project's public API folders.

The invariant:

- Public headers should not include private headers from within the project

### What's changed
Added pre-commit hook to verify that the current changes do not break the invariant.

The hook will also error out when adding unrecognized libraries to the public API folder.
This will cause extra scrutiny to be given to PRs that add dependencies to tt_metal public interface.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes