### PR TITLE
[skip ci] Add a hook to test `create_venv.sh` in CI

### DIFF
--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -13,6 +13,11 @@ inputs:
     required: false
     description: Where to checkout
     default: docker-job
+  create-venv:
+    required: false
+    description: Whether to create a virtual environment
+    default: false
+    type: boolean
 runs:
   using: "composite"
   steps:
@@ -42,15 +47,21 @@ runs:
       run: tar -xf ttm_any.tar
       shell: bash
 
+    - name: 🐍 Create Virtual Environment
+      if: ${{ inputs.create-venv }}
+      working-directory: ${{ inputs.path }}
+      run: ./create_venv.sh
+      shell: bash
+
     - name: 🧪 Download Python Wheel
-      if: ${{ inputs.wheel-artifact-name != '' }}
+      if: ${{ inputs.wheel-artifact-name != '' && !inputs.create-venv }}
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.wheel-artifact-name }}
         path: ${{ inputs.path }}
 
     - name: 💿 Install Wheel
-      if: ${{ inputs.wheel-artifact-name != '' }}
+      if: ${{ inputs.wheel-artifact-name != '' && !inputs.create-venv }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "📂 In directory: $(pwd)"

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -48,7 +48,7 @@ runs:
       shell: bash
 
     - name: 🐍 Create Virtual Environment
-      if: ${{ inputs.create-venv }}
+      if: ${{ inputs.create-venv == true }}
       working-directory: ${{ inputs.path }}
       run: ./create_venv.sh
       shell: bash

--- a/.github/actions/setup-job/action.yml
+++ b/.github/actions/setup-job/action.yml
@@ -54,14 +54,14 @@ runs:
       shell: bash
 
     - name: 🧪 Download Python Wheel
-      if: ${{ inputs.wheel-artifact-name != '' && !inputs.create-venv }}
+      if: ${{ inputs.wheel-artifact-name != '' && inputs.create-venv != true }}
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.wheel-artifact-name }}
         path: ${{ inputs.path }}
 
     - name: 💿 Install Wheel
-      if: ${{ inputs.wheel-artifact-name != '' && !inputs.create-venv }}
+      if: ${{ inputs.wheel-artifact-name != '' && inputs.create-venv != true }}
       working-directory: ${{ inputs.path }}
       run: |
         echo "📂 In directory: $(pwd)"

--- a/.github/workflows/ttnn-post-commit-wrapper.yaml
+++ b/.github/workflows/ttnn-post-commit-wrapper.yaml
@@ -2,14 +2,29 @@ name: "[post-commit] ttnn unit tests"
 
 on:
   workflow_call:
+    inputs:
+      test-mode:
+        description: 'Select test mode'
+        required: false
+        type: string
+        default: 'wheel'
   workflow_dispatch:
+    inputs:
+      test-mode:
+        description: 'Select test mode'
+        required: true
+        type: choice
+        options:
+          - wheel
+          - venv
+        default: 'wheel'
 
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
     with:
-      build-wheel: true
+      build-wheel: ${{ inputs.test-mode == 'wheel' }}
 
   ttnn-unit-tests:
     needs: build-artifact
@@ -28,3 +43,4 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      create-venv: ${{ inputs.test-mode == 'venv' }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -91,7 +91,7 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
       - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@blozano-test-venv
         timeout-minutes: 10
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -1,5 +1,13 @@
 name: "[internal] ttnn unit tests impl"
 
+# This workflow is being used to test both the wheel and venv test modes.
+# The wrapper workflow will set the appropriate inputs for each mode.
+# If the create-venv input is true, then the workflow will call the create_venv.sh script.
+# This is a bit of a misnomer, because there is already a venv in the container.
+# It really is just installing the local python packages (ttnn) into the venv in editable install mode.
+# This mode of operation actually requires TT_METAL_HOME to be set to /work.
+# If the create-venv input is false, then the workflow will install the wheel and run the tests using the wheel.
+
 on:
   workflow_call:
     inputs:
@@ -97,6 +105,11 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           create-venv: ${{ inputs.create-venv }}
+
+      - name: Set TT_METAL_HOME if create-venv is true
+        if: ${{ inputs.create-venv }}
+        run: |
+          echo "TT_METAL_HOME=/work" >> $GITHUB_ENV
 
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -26,39 +26,10 @@ on:
       wheel-artifact-name:
         required: true
         type: string
-
-  workflow_dispatch:
-    inputs:
-      arch:
-        required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-      runner-label:
-        required: true
-        type: choice
-        options:
-          - N150
-          - N300
-          - BH
-      timeout:
+      create-venv:
         required: false
-        type: number
-        default: 45
-      num-groups:
-        required: false
-        type: number
-        default: 12
-      docker-image:
-        required: true
-        type: string
-      build-artifact-name:
-        required: true
-        type: string
-      wheel-artifact-name:
-        required: true
-        type: string
+        default: false
+        type: boolean
 
 jobs:
   ttnn:
@@ -123,7 +94,9 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/setup-job@main
         timeout-minutes: 10
         with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+          create-venv: ${{ inputs.create-venv }}
 
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}


### PR DESCRIPTION
### Problem description
We currently have no workflows that test create_venv.sh.
This script is used to treat the repo clone + build artifacts collectively as a python package in editable install mode.

### What's changed
- Add option to invoke create_venv.sh in setup job action
- Add support in ttnn-post-commit*.yaml to invoke create_venv.sh instead of using the wheel

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14239553913) CI passes
- [x] [ttnn post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14241878554) CI passes
- [x] New/Existing tests provide coverage for changes