### PR TITLE
fix: pin wheel version for bdist_wheel

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-
 # Allow overriding Python command via environment variable
 if [ -z "$PYTHON_CMD" ]; then
     PYTHON_CMD="python3"
@@ -10,7 +9,7 @@ else
 fi
 
 # Verify Python command exists
-if ! command -v $PYTHON_CMD &> /dev/null; then
+if ! command -v $PYTHON_CMD &>/dev/null; then
     echo "Python command not found: $PYTHON_CMD"
     exit 1
 fi
@@ -30,7 +29,7 @@ pip install --force-reinstall pip==21.2.4
 
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
-python3 -m pip install setuptools wheel
+python3 -m pip install setuptools wheel==0.45.1
 
 echo "Installing dev dependencies"
 python3 -m pip install -r $(pwd)/tt_metal/python_env/requirements-dev.txt
@@ -39,7 +38,7 @@ echo "Installing tt-metal"
 pip install -e .
 
 # Do not install hooks when this is a worktree
-if [ $(git rev-parse --git-dir) = $(git rev-parse --git-common-dir) ] ; then
+if [ $(git rev-parse --git-dir) = $(git rev-parse --git-common-dir) ]; then
     echo "Generating git hooks"
     pre-commit install
     pre-commit install --hook-type commit-msg

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -257,7 +257,7 @@ COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-met
 COPY /tt_metal/python_env/requirements-dev.txt ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
 
 RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
-    python3 -m pip install setuptools wheel && \
+    python3 -m pip install setuptools wheel==0.45.1 && \
     python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
     python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools==69.5.1",
   "setuptools-scm==7.1.0",
-  "wheel",
+  "wheel==0.45.1",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20111

### Problem description
wheel 0.46.0 causes failure when trying to install tt-metal, this is due to it removing the `bdist_wheel` command

### What's changed
- Temporarily pin every instance of wheel to 0.45.1

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14242350701 (docs failed, packaging isn't)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes