### PR TITLE
#20127: Remove mount_weka.sh from models-post-commit

### DIFF
--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -53,14 +53,6 @@ jobs:
       - cloud-virtual-machine
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - uses: ./.github/actions/retry-command
-        # For BH we use yyzo machines and they don't have MLPerf mounted
-        if: ${{ inputs.arch != 'blackhole' }}
-        with:
-          timeout-seconds: 100
-          max-retries: 10
-          backoff-seconds: 60
-          command: ./.github/scripts/cloud_utils/mount_weka.sh
       - uses: actions/download-artifact@v4
         timeout-minutes: 10
         with:
@@ -73,7 +65,6 @@ jobs:
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
             -e ARCH_NAME=${{ inputs.arch }}
-            -e GITHUB_ACTIONS=true
           run_args: |
             source tests/scripts/run_python_model_tests.sh && run_python_model_tests_${{ inputs.arch }}
       - uses: ./.github/actions/slack-report
@@ -108,12 +99,6 @@ jobs:
       - cloud-virtual-machine
     steps:
       - uses: tenstorrent/tt-metal/.github/actions/checkout-with-submodule-lfs@main
-      - uses: ./.github/actions/retry-command
-        with:
-          timeout-seconds: 100
-          max-retries: 10
-          backoff-seconds: 60
-          command: ./.github/scripts/cloud_utils/mount_weka.sh
       - uses: actions/download-artifact@v4
         timeout-minutes: 10
         with:


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/20127

### Problem description
As part of CI v2 transition we want to remove weka as a dependency in APC.

### What's changed
Remove weka mount step in models post commit tests in APC
Remove un-needed env var `GITHUB_ACTIONS=true`, already passed into `docker-run` action by default.
`docker-run` action doesn't mount `/mnt/MLPerf` volume by default, and the models-post-commit workflow doesn't pass it in as a docker opt, so no additional changes are needed.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes 
https://github.com/tenstorrent/tt-metal/actions/runs/14248259042
- [x] New/Existing tests provide coverage for changes
Model post commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/14248236192