### PR TITLE
Use double buffering for untilized input CB in halo operation

### DIFF
--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -15,6 +15,9 @@ using namespace tt::tt_metal;
 thread_local std::unordered_map<std::size_t, std::uint32_t>
     HaloDeviceOperation::sliding_window_max_out_nsticks_per_core = {};
 
+// TODO: Look into increasing this to tradeoff some L1 for performance (#19980)
+constexpr int UNTILIZE_BLOCK_SIZE = 32;
+
 void HaloDeviceOperation::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -15,8 +15,6 @@ namespace ttnn::operations::sliding_window {
 namespace halo {
 
 struct HaloDeviceOperation {
-    const int UNTILIZE_BLOCK_SIZE = 32;
-
     thread_local static std::unordered_map<std::size_t, std::uint32_t> sliding_window_max_out_nsticks_per_core;
     SlidingWindowConfig config_;
     ParallelConfig parallel_config_;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
@@ -22,7 +22,7 @@ void MAIN {
 
     constexpr bool use_pack_untilize = tiles_per_row <= MAX_PACK_UNTILIZE_WIDTH;
 
-    if (use_pack_untilize) {
+    if constexpr (use_pack_untilize) {
         pack_untilize_init<tiles_per_row>(src_cb_id, out_cb_id0);
     } else {
         untilize_init(src_cb_id, out_cb_id0);
@@ -43,7 +43,7 @@ void MAIN {
         cb_pop_front(src_cb_id, tiles_per_block);
     }
 
-    if (use_pack_untilize) {
+    if constexpr (use_pack_untilize) {
         pack_untilize_uninit(out_cb_id0);
     }
 }


### PR DESCRIPTION
### Ticket
[#20075](https://github.com/tenstorrent/tt-metal/issues/20075)

### What's changed
- Enable double buffering in the untilized input CBs to allow for overlapping of untilize and halo gather operations
- Some small cleanups

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14249280888
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14249283351
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14249286366
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14249284952
- [x] L2 nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14249432232