### PR TITLE
Add allocate_kv_cache to old Llama70b vLLM Generator to maintain support for now

### DIFF
--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 import torch
+from tqdm import tqdm
+
+import ttnn
 
 from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGeneration
 from models.demos.t3000.llama2_70b.tt.llama_common import (
@@ -71,3 +74,24 @@ class TtLlamaForCausalLM(TtLlamaModelForGeneration):
 
     def prefill_forward(self, tokens: torch.Tensor, page_table, kv_cache, prompt_lens):
         return super().prefill_forward(tokens, 0, page_table, kv_cache, prompt_lens)
+
+    def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
+        cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
+        kv_tt = []
+        for _ in tqdm(range(num_layers), desc=f"Allocating TT kv caches for each layer"):
+            kv_tt_i = [
+                ttnn.as_tensor(
+                    lp,
+                    device=self.mesh_device,
+                    # TODO: this could be ShardTensorToMesh, removing the need for vLLM to know about TP for num_kv_heads.
+                    # Could affect other calculations which use TTCacheEngine.num_kv_heads, though.
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    dtype=ttnn.bfloat8_b,
+                    cache_file_name=self.cache_path / f"empty_cache_paged_attention{kv_cache_shape}",
+                )
+                for lp in (cache_kv, cache_kv)
+            ]
+            kv_tt.append(kv_tt_i)
+        return kv_tt


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The `allocate_kv_cache` function is required in newer versions of our vLLM fork and was missing for old Llama70b

### What's changed
- Added `allocate_kv_cache` to old Llama70b vLLM Generator to maintain compatibility until its deletion

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes