### PR TITLE
Revert model integration of fused RMS norm.

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -325,8 +325,8 @@ def test_llama_TG_perf_device(reset_seeds):
     expected_times_dict = {
         "Embeddings": [7230.0, 7241.0],
         "DramPrefetcher": [20261638.0],
-        "RMSAllGather": [7100.0, 5200.0, 7200.0, 5200.0],
-        "AllGatherAsync": [11958.0],
+        "LayerNorm": [6230.0, 6449.0, 7743.0, 7426.0],
+        "AllGatherAsync": [2572.0, 11958.0, 2570.0],
         "ReshardDeviceOperation": [1456.0, 1939.0, 2776.0],
         "Matmul": [8022.0, 9004.0, 9727.0, 10140.0, 16769.0],
         "AllReduceAsync": [219371.0, 11674841.0, 772010.0, 33516.0, 3713658.0],

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -595,8 +595,19 @@ def tt_sharded_distributed_rmsnorm(
     # inp = ttnn.to_memory_config(inp, memory_config=ln_sharded_input_memcfg)
 
     # Run distributed rmsnorm part 1
-    cluster_axis = 1
-    semaphore = tt_ccl.gather_semaphore_handles[cluster_axis][tt_ccl.gather_idx[cluster_axis]]
+    tt_stats = ttnn.rms_norm_pre_all_gather(inp, residual_input_tensor=res, program_config=ln_sharded_progcfg)
+    # print("tt_stats")
+    # All gather stats
+    # tt_stats = ttnn.all_gather(
+    #     tt_stats,
+    #     3,
+    #     num_links=1,
+    #     cluster_axis=1,
+    #     mesh_device=mesh_device,
+    #     memory_config=ln_sharded_stats_memcfg,
+    #     topology=ttnn.Topology.Linear,
+    # )
+    # tt_stats_dram = ttnn.to_memory_config(tt_stats, ttnn.DRAM_MEMORY_CONFIG)
     grid_offset = ttnn.CoreCoord(1, 0)
     tt_stats_sharded_config = ttnn.create_sharded_memory_config(
         shape=(32, 128),
@@ -604,26 +615,28 @@ def tt_sharded_distributed_rmsnorm(
         strategy=ttnn.ShardStrategy.WIDTH,
         use_height_and_width_as_shard_shape=True,
     )
-    tt_stats = ttnn.fused_rms_1_1_32_8192(
-        inp,
-        ln_sharded_progcfg,
-        cluster_axis,
-        tt_ccl.mesh_device,
-        semaphore,
-        residual_input_tensor=res,
-        num_links=1,
-        memory_config=tt_stats_sharded_config,
-        is_pre=True,
+
+    # print("mem cfg")
+
+    # Note: Persistent output buffer used, do not deallocate output!
+    tt_global_stats_sharded = tt_ccl.line_all_gather(
+        tt_stats, dim=3, cluster_axis=1, num_links=1, memory_config=tt_stats_sharded_config, buffer_key="LAYERNORM"
     )
-    tt_out = ttnn.fused_rms_1_1_32_8192(
+    # ttnn.synchronize_device(tt_ccl.mesh_device, sub_device_ids=[tt_ccl.worker_sub_device_id])
+    # ttnn.deallocate(tt_stats_dram)
+    # print("all gather stats", tt_global_stats.shape)
+
+    # tt_global_stats_sharded = ttnn.to_memory_config(tt_global_stats, memory_config=tt_stats_sharded_config)
+    ttnn.deallocate(tt_stats)
+    # print("sharded stats")
+
+    # Run distributed rmsnorm part 2
+    tt_out = ttnn.rms_norm_post_all_gather(
         inp,
-        ln_sharded_progcfg,
-        cluster_axis,
-        tt_ccl.mesh_device,
-        semaphore,
         epsilon=epsilon,
         weight=gamma,
-        stats=tt_stats,
-        is_pre=False,
+        program_config=ln_sharded_progcfg,
+        stats=tt_global_stats_sharded,
     )
+    # print("rmsnorm post all gather", tt_out.shape)
     return tt_out, inp


### PR DESCRIPTION
### Problem description
The model integration of the fused RMS Norm (https://github.com/tenstorrent/tt-metal/pull/19816) is causing regressions in the TG Llama Quick tests pipelines

### What's changed
- Revert model integration of the fused RMS Norm.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes