### PR TITLE
#19987: fix loop bounds in matmul reader and add missed validation

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
     // In case we need to send multiple blocks per shard, and shard height in tiles is greater than 1
     // Than we first need to extract the sub-blocks from the shard, and then send them to the destinations
     constexpr bool extract_shard_sub_blocks = shard_height_in_tiles > 1 && num_blocks_per_shard > 1;
-    constexpr uint32_t out_subblock_h = shard_height_in_tiles / num_blocks_h_dim;
+    constexpr uint32_t out_block_h = shard_height_in_tiles / num_blocks_h_dim;
     constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
     constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
     constexpr uint32_t in0_tensor_next_h_dim_block_stride = shard_read_stride * in0_block_h;
@@ -157,7 +157,7 @@ void kernel_main() {
                             uint32_t l1_write_extract_shard_in0 = in0_tensor_local_l1_write_addr;
                             uint64_t noc_shard_read_addr = get_noc_addr(in0_tensor_current_inner_dim_block_start_addr);
 
-                            for (uint32_t i = 0; i < out_subblock_h; i++) {
+                            for (uint32_t i = 0; i < out_block_h; i++) {
                                 noc_async_read(noc_shard_read_addr, l1_write_extract_shard_in0, shard_read_width);
                                 l1_write_extract_shard_in0 += shard_read_width;
                                 noc_shard_read_addr += shard_read_stride;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_receiver_padding_block_sharded.cpp
@@ -53,6 +53,7 @@ void kernel_main() {
     // In case we need to send multiple blocks per shard, and shard height in tiles is greater than 1
     // Than we first need to extract the sub-blocks from the shard, and then send them to the destinations
     constexpr bool extract_shard_sub_blocks = shard_height_in_tiles > 1 && num_blocks_per_shard > 1;
+    constexpr uint32_t out_subblock_h = shard_height_in_tiles / num_blocks_h_dim;
     constexpr uint32_t shard_read_stride = shard_width_in_tiles * in0_single_tile_size_bytes;
     constexpr uint32_t shard_read_width = in0_single_tile_size_bytes * in0_block_w;
     constexpr uint32_t in0_tensor_next_h_dim_block_stride = shard_read_stride * in0_block_h;
@@ -156,9 +157,8 @@ void kernel_main() {
                             uint32_t l1_write_extract_shard_in0 = in0_tensor_local_l1_write_addr;
                             uint64_t noc_shard_read_addr = get_noc_addr(in0_tensor_current_inner_dim_block_start_addr);
 
-                            for (uint32_t i = 0; i < shard_height_in_tiles; i++) {
+                            for (uint32_t i = 0; i < out_subblock_h; i++) {
                                 noc_async_read(noc_shard_read_addr, l1_write_extract_shard_in0, shard_read_width);
-
                                 l1_write_extract_shard_in0 += shard_read_width;
                                 noc_shard_read_addr += shard_read_stride;
                             }
@@ -225,7 +225,7 @@ void kernel_main() {
                                 // All work is done on one core (the current one).
                                 // noc_semaphore_set_multicast_loopback_src is a no-op in this case.
                                 // Data needs to be written directly in the core.
-                                in0_mcast_receiver_semaphore_addr_ptr[0] = in0_mcast_sender_semaphore_valid_addr_ptr[0];
+                                in0_mcast_receiver_semaphore_addr_ptr[0] = VALID;
                             } else {
                                 noc_semaphore_set_multicast_loopback_src(
                                     in0_mcast_sender_semaphore_valid_addr,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1674,6 +1674,9 @@ void Matmul::validate(
                         TT_FATAL(
                             program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
                             "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
+                        TT_FATAL(
+                            program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
+                            "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
                     }
                     if (input_tensor_b.buffer()->buffer_type() == tt_metal::BufferType::L1 &&
                         input_tensor_b.memory_config().is_sharded()) {
@@ -1743,6 +1746,9 @@ void Matmul::validate(
                         TT_FATAL(
                             program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
                             "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
+                        TT_FATAL(
+                            program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
+                            "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
                     }
                     TT_FATAL(
                         input_tensor_b.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
@@ -1875,7 +1881,11 @@ void Matmul::validate(
                     uint32_t per_core_N = program_config.per_core_N;
 
                     TT_FATAL(
-                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1, "Error");
+                        program_config.out_subblock_w == per_core_N || program_config.out_subblock_h == 1,
+                        "Error: out_subblock_w must be equal to per_core_N or out_subblock_h must be equal to 1.");
+                    TT_FATAL(
+                        program_config.out_block_w == per_core_N || program_config.out_block_h == 1,
+                        "Error: out_block_w must be equal to per_core_N or out_block_h must be equal to 1.");
                 }
             } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseProgramConfig>) {
                 uint32_t M = input_tensor_a.get_padded_shape()[-2] / in0_tile_shape[0];


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/19987

### Problem description
- There was a loop bound that was missed when adding out_block_h/w - bound was left as per_core_M while starting point kept on increasing, instead of adjusting bound to be out_block_h
- For sharded output, there was a validation that was missed when adding out_block_h/w - when out_block_h is not 1, then out_block_w needs to equal per_core_N

### What's changed
- fix the loop bound
- add the validation
- also changed a read of a constant from L1 into just using a constant value directly.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14252323441
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14251648585
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes