### PR TITLE
Use libcpp toolchain to build artifacts for TG model perf pipeline

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -24,26 +24,12 @@ jobs:
       matrix:
         test-group: [
           {
-            name: "TG LLM model perf tests",
-            model-type: "LLM",
-            arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llm_model_perf_tg_device --dispatch-mode ""'
-          },  # Austin Ho
-          {
-            name: "TG CNN model perf tests",
-            model-type: "CNN",
-            arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
-          },  # Austin Ho
-          {
             name: "Llama TG Perf Unit Tests",
             arch: wormhole_b0,
             cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
             timeout: 100,
             tracy: true,
-            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "bare-metal", "pipeline-perf", "issue-20140"],
             owner_id: U071CKL4AFK # Ammar Vora
           }
         ]

--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -24,12 +24,26 @@ jobs:
       matrix:
         test-group: [
           {
+            name: "TG LLM model perf tests",
+            model-type: "LLM",
+            arch: wormhole_b0,
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type llm_model_perf_tg_device --dispatch-mode ""'
+          },  # Austin Ho
+          {
+            name: "TG CNN model perf tests",
+            model-type: "CNN",
+            arch: wormhole_b0,
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type cnn_model_perf_tg_device --dispatch-mode ""'
+          },  # Austin Ho
+          {
             name: "Llama TG Perf Unit Tests",
             arch: wormhole_b0,
             cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
             timeout: 100,
             tracy: true,
-            runs-on: ["arch-wormhole_b0", "config-tg", "bare-metal", "pipeline-perf", "issue-20140"],
+            runs-on: ["arch-wormhole_b0", "config-tg", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
             owner_id: U071CKL4AFK # Ammar Vora
           }
         ]

--- a/.github/workflows/tg-model-perf-tests.yaml
+++ b/.github/workflows/tg-model-perf-tests.yaml
@@ -12,6 +12,7 @@ jobs:
       tracy: true
       build-wheel: true
       version: 22.04
+      toolchain: "cmake/x86_64-linux-clang-17-libcpp-toolchain.cmake" # stopgap until issue 20140 is resolved
     secrets: inherit
   tg-model-perf-tests:
     needs: build-artifact-profiler


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20140

### Problem description
This stopgap solution unblocks TG model perf pipeline

### What's changed
Build artifact using libc++ instead of libstdc++ for this specific pipeline until issue is resolved

### Checklist
Confirmed no longer hanging on Llama TG perf unit tests:
https://github.com/tenstorrent/tt-metal/actions/runs/14252566948/job/39948927107

- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes