### PR TITLE
1CQ Pull without stall working

### DIFF
--- a/tt_metal/api/tt-metalium/command_queue_common.hpp
+++ b/tt_metal/api/tt-metalium/command_queue_common.hpp
@@ -22,7 +22,8 @@ enum class CommandQueueDeviceAddrType : uint8_t {
     COMPLETION_Q1_LAST_EVENT = 5,
     DISPATCH_S_SYNC_SEM = 6,
     FABRIC_INTERFACE = 7,
-    UNRESERVED = 8
+    FABRIC_HEADER_RB = 8,
+    UNRESERVED = 9
 };
 
 // likely only used in impl

--- a/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
@@ -42,7 +42,7 @@ volatile tt_l1_ptr chan_req_buf* fvc_outbound_req_buf =
 volatile tt_l1_ptr fabric_router_l1_config_t* routing_table =
     reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE);
 
-#define SWITCH_THRESHOLD 0x3FFF
+#define SWITCH_THRESHOLD 0x1000
 
 void kernel_main() {
     tt_fabric_init();
@@ -220,18 +220,18 @@ void kernel_main() {
         if ((loop_count & SWITCH_THRESHOLD) == SWITCH_THRESHOLD) {
             internal_::risc_context_switch();
 
-            if (*(volatile uint32_t*)FABRIC_ROUTER_SYNC_SEM == 0) {
-                // terminate signal from host sw.
-                if constexpr (is_master) {
-                    if (!terminated_slave_routers) {
-                        notify_slave_routers(router_mask, master_router_chan, FABRIC_ROUTER_SYNC_SEM, 0);
-                        terminated_slave_routers = true;
-                    }
-                }
-                if (loop_count >= 0x1000) {
-                    break;
-                }
-            }
+            // if (*(volatile uint32_t*)FABRIC_ROUTER_SYNC_SEM == 0) {
+            //     // terminate signal from host sw.
+            //     if constexpr (is_master) {
+            //         if (!terminated_slave_routers) {
+            //             notify_slave_routers(router_mask, master_router_chan, FABRIC_ROUTER_SYNC_SEM, 0);
+            //             terminated_slave_routers = true;
+            //         }
+            //     }
+            //     if (loop_count >= 0x1000) {
+            //         break;
+            //     }
+            // }
             if (launch_msg->kernel_config.exit_erisc_kernel) {
                 return;
             }

--- a/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_router.cpp
@@ -42,7 +42,7 @@ volatile tt_l1_ptr chan_req_buf* fvc_outbound_req_buf =
 volatile tt_l1_ptr fabric_router_l1_config_t* routing_table =
     reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(eth_l1_mem::address_map::FABRIC_ROUTER_CONFIG_BASE);
 
-#define SWITCH_THRESHOLD 0x1000
+#define SWITCH_THRESHOLD 0x3FFF
 
 void kernel_main() {
     tt_fabric_init();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1120,7 +1120,7 @@ void Device::init_fabric() {
             if (core_type == CoreType::ETH) {
                 tt_cxy_pair virtual_eth_core(this->id(), physical_core);
                 // Enable internal ethernet routing
-                tt::Cluster::instance().write_core(
+                tt::tt_metal::MetalContext::instance().get_cluster().write_core(
                     (void*)&routing_info_enabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr, false);
             }
         }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1097,6 +1097,13 @@ void Device::init_fabric() {
     // Note: the l1_barrier below is needed to be sure writes to cores that
     // don't get the GO mailbox (eg, storage cores) have all landed
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
+    const routing_info_t routing_info_enabled = {
+        .routing_enabled = 1,
+        .src_sent_valid_cmd = 0,
+        .dst_acked_valid_cmd = 0,
+    };
+    uint32_t routing_info_addr = tt::tt_metal::hal_ref.get_dev_addr(
+        tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::APP_ROUTING_INFO);
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->logical_cores();
     for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
@@ -1110,6 +1117,12 @@ void Device::init_fabric() {
             auto physical_core = this->virtual_core_from_logical_core(logical_core, core_type);
             tt::llrt::write_launch_msg_to_core(
                 this->id(), physical_core, msg, go_msg, this->get_dev_addr(physical_core, HalL1MemAddrType::LAUNCH));
+            if (core_type == CoreType::ETH) {
+                tt_cxy_pair virtual_eth_core(this->id(), physical_core);
+                // Enable internal ethernet routing
+                tt::Cluster::instance().write_core(
+                    (void*)&routing_info_enabled, sizeof(routing_info_t), virtual_eth_core, routing_info_addr, false);
+            }
         }
     }
 }

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -268,7 +268,6 @@ void DevicePool::initialize(
 
     tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(
         true, target_mmio_ids);
-    _inst->wait_for_fabric_router_sync();
     _inst->init_profiler_devices();
 }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -12,6 +12,7 @@
 #include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
 #include <algorithm>
 #include <cstdlib>
+#include <functional>
 #include <set>
 #include <utility>
 
@@ -315,6 +316,7 @@ void DevicePool::initialize_active_devices() const {
         for (const auto& dev : active_devices) {
             dev->init_fabric();
         }
+        _inst->wait_for_fabric_router_sync();
     }
 
     // Activate FD kernels
@@ -323,29 +325,36 @@ void DevicePool::initialize_active_devices() const {
         return;
     }
 
-    for (auto dev : active_devices) {
-        // For Galaxy init, we only need to loop over mmio devices
-        const auto& mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev->id());
-        if (mmio_device_id != dev->id()) {
-            continue;
-        }
+    // Call the func on devices to init, skipping remote devices if not needed
+    auto iterate_required_devices = [&](IDevice* mmio_device, const std::function<void(IDevice * device)>&& func) {
+        auto tunnels_from_mmio = tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device->id());
 
-        auto tunnels_from_mmio =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
-        populate_cq_static_args(dev);
-        dev->init_command_queue_device();
-        if (not this->skip_remote_devices) {
-            for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
-                // Need to create devices from farthest to the closest.
-                for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
-                    auto device = get_device(mmio_controlled_device_id);
-                    populate_cq_static_args(device);
-                    device->init_command_queue_device();
+        for (uint32_t t = 0; t < tunnels_from_mmio.size(); ++t) {
+            // Need to create devices from farthest to the closest.
+            for (uint32_t ts = tunnels_from_mmio[t].size() - 1; ts > 0; --ts) {
+                uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
+                auto device = get_device(mmio_controlled_device_id);
+                if (!this->skip_remote_devices) {
+                    std::forward<const std::function<void(IDevice*)>>(func)(device);
                 }
             }
         }
+    };
+
+    for (auto device : active_devices) {
+        // For Galaxy init, we only need to loop over mmio devices
+        const auto& mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
+        if (mmio_device_id != device->id()) {
+            continue;
+        }
+
+        // 1. Generate static args
+        populate_cq_static_args(device);
+        iterate_required_devices(device, [](IDevice* remote_device) { populate_cq_static_args(remote_device); });
+
+        // 2. Init / compile programs
+        device->init_command_queue_device();
+        iterate_required_devices(device, [](IDevice* remote_device) { remote_device->init_command_queue_device(); });
     }
 }
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -150,7 +150,7 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_INTERFACE) {
             if (llrt::RunTimeOptions::get_instance().get_fd_fabric()) {
-                device_cq_addr_sizes_[dev_addr_idx] = tt_fabric::PACKET_HEADER_SIZE_BYTES;
+                device_cq_addr_sizes_[dev_addr_idx] = tt_fabric::CLIENT_INTERFACE_SIZE;
             } else {
                 device_cq_addr_sizes_[dev_addr_idx] = 0;
             }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -387,15 +387,16 @@ void DispatchKernel::CreateKernel() {
         dependent_config_.upstream_mesh_id.value_or(0),
         dependent_config_.upstream_dev_id.value_or(0),
         dependent_config_.fabric_router_noc_xy.value_or(0),
-        dependent_config_.outbound_eth_chan.value_or(0),
         static_config_.client_interface_addr.value_or(0),
+        dependent_config_.outbound_eth_chan.value_or(0),
+        static_config_.header_rb_addr.value_or(0),
 
         static_config_.first_stream_used.value(),
 
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-    TT_ASSERT(compile_args.size() == 39);
+    TT_ASSERT(compile_args.size() == 40);
     auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
     auto upstream_virtual_core =
         device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());
@@ -465,4 +466,6 @@ void DispatchKernel::UpdateArgsForFabric(
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
     static_config_.client_interface_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_INTERFACE);
+    static_config_.header_rb_addr =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_HEADER_RB);
 }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -51,6 +51,7 @@ typedef struct dispatch_static_config {
 
     // Populated if fabric is being used to talk to downstream
     std::optional<uint32_t> client_interface_addr;
+    std::optional<uint32_t> header_rb_addr;
 } dispatch_static_config_t;
 
 typedef struct dispatch_dependent_config {

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -138,11 +138,10 @@ void FDKernel::configure_kernel_variant(
     if (force_watcher_no_inline) {
         defines.insert({"WATCHER_NOINLINE", std::to_string(force_watcher_no_inline)});
     }
-    auto& rt_options = tt::llrt::RunTimeOptions::get_instance();
-    if (rt_options.watcher_dispatch_disabled()) {
+    if (tt::llrt::RunTimeOptions::get_instance().watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config() != FabricConfig::FABRIC_2D_PUSH) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config() == FabricConfig::FABRIC_2D) {
         defines["FVC_MODE_PULL"] = "1";
     }
     if (!DPrintServerReadsDispatchCores(device_->id())) {

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -395,7 +395,7 @@ void PrefetchKernel::CreateKernel() {
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-    TT_ASSERT(compile_args.size() == 35);
+    TT_ASSERT(compile_args.size() == 36);
     auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
     auto upstream_virtual_core =
         device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -389,8 +389,9 @@ void PrefetchKernel::CreateKernel() {
         dependent_config_.upstream_mesh_id.value_or(0),
         dependent_config_.upstream_dev_id.value_or(0),
         dependent_config_.fabric_router_noc_xy.value_or(0),
-        dependent_config_.outbound_eth_chan.value_or(0),
         static_config_.client_interface_addr.value_or(0),
+        dependent_config_.outbound_eth_chan.value_or(0),
+        static_config_.header_rb_addr.value_or(0),
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
@@ -490,4 +491,6 @@ void PrefetchKernel::UpdateArgsForFabric(
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
     static_config_.client_interface_addr =
         my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_INTERFACE);
+    static_config_.header_rb_addr =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::FABRIC_HEADER_RB);
 }

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -51,6 +51,7 @@ typedef struct prefetch_static_config {
 
     // Populated if fabric is being used to talk to downstream
     std::optional<uint32_t> client_interface_addr;
+    std::optional<uint32_t> header_rb_addr;
 } prefetch_static_config_t;
 
 typedef struct prefetch_dependent_config {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -10,6 +10,7 @@
 #include "debug/dprint.h"
 #include "debug/ring_buffer.h"
 #include "cq_helpers.hpp"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
 
 // The command queue read interface controls reads from the issue region, host owns the issue region write interface
 // Commands and data to send to device are pushed into the issue region

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -105,7 +105,7 @@ static uint32_t write_offset[3];  // added to write address on non-host writes
 static uint32_t upstream_total_acquired_page_count;
 
 static auto client_interface =
-    reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
+    reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::fabric_pull_client_interface_t*>(client_interface_addr);
 
 constexpr uint32_t packed_write_max_multicast_sub_cmds =
     get_packed_write_max_multicast_sub_cmds(packed_write_max_unicast_sub_cmds);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -12,7 +12,6 @@
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
-#include "tt_metal/fabric/hw/inc/tt_fabric_interface.h"
 #include "debug/dprint.h"
 #include "noc/noc_parameters.h"  // PCIE_ALIGNMENT
 
@@ -70,11 +69,13 @@ constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(27);
 constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(28);
 constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(29);
 constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(30);
-constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(31);
-constexpr uint32_t client_interface_addr = get_compile_time_arg_val(32);
+constexpr uint32_t client_interface_addr = get_compile_time_arg_val(31);
+constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(32);
+constexpr uint32_t header_rb = get_compile_time_arg_val(33);
+constexpr uint32_t client_interface_rb_entries = 32;
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(33);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(34);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(34);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(35);
 
 constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
 constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;
@@ -168,8 +169,8 @@ static uint32_t downstream_data_ptr_s = dispatch_s_buffer_base;
 static uint32_t block_next_start_addr[cmddat_q_blocks];
 static uint32_t rd_block_idx = 0;
 static uint32_t upstream_total_acquired_page_count = 0;
-static auto client_interface =
-    reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::fabric_pull_client_interface_t*>(client_interface_addr);
+
+static auto client_interface = reinterpret_cast<volatile fabric_pull_client_interface_t*>(client_interface_addr);
 
 // Feature to stall the prefetcher, mainly for ExecBuf impl which reuses CmdDataQ
 static enum StallState { STALL_NEXT = 2, STALLED = 1, NOT_STALLED = 0 } stall_state = NOT_STALLED;
@@ -1260,6 +1261,8 @@ bool process_cmd(
 }
 
 static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool is_exec_buf) {
+    // This function is only valid for prefetch_h relay to prefetch_d
+    ASSERT(is_h_variant && !is_d_variant);
     uint32_t length = fence - data_ptr;
 
     // Downstream doesn't have FetchQ to tell it how much data to process
@@ -1286,23 +1289,71 @@ static uint32_t process_relay_inline_all(uint32_t data_ptr, uint32_t fence, bool
 
     uint32_t downstream_pages_left = (downstream_cb_end - downstream_data_ptr) >> downstream_cb_log_page_size;
     if (downstream_pages_left >= npages) {
-        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), length);
+        if constexpr (fabric_router_noc_xy) {
+            tt::tt_fabric::fabric_async_write<ClientDataMode::RAW_DATA>(
+                client_interface,
+                fabric_router_noc_xy,
+                data_ptr,
+                downstream_mesh_id,
+                downstream_dev_id,
+                get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr),
+                length + tt::tt_fabric::PACKET_HEADER_SIZE_BYTES,
+                0);
+        } else {
+            noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), length);
+        }
         downstream_data_ptr += npages * downstream_cb_page_size;
     } else {
         uint32_t tail_pages = npages - downstream_pages_left;
         uint32_t available = downstream_pages_left * downstream_cb_page_size;
         if (available > 0) {
-            noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), available);
+            if constexpr (fabric_router_noc_xy) {
+                tt::tt_fabric::fabric_async_write<ClientDataMode::RAW_DATA>(
+                    client_interface,
+                    fabric_router_noc_xy,
+                    data_ptr,
+                    downstream_mesh_id,
+                    downstream_dev_id,
+                    get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr),
+                    available + tt::tt_fabric::PACKET_HEADER_SIZE_BYTES,
+                    0);
+            } else {
+                noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), available);
+            }
             data_ptr += available;
             length -= available;
         }
 
-        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), length);
+        if constexpr (fabric_router_noc_xy) {
+            tt::tt_fabric::fabric_async_write<ClientDataMode::RAW_DATA>(
+                client_interface,
+                fabric_router_noc_xy,
+                data_ptr,
+                downstream_mesh_id,
+                downstream_dev_id,
+                get_noc_addr_helper(downstream_noc_xy, downstream_cb_base),
+                length + tt::tt_fabric::PACKET_HEADER_SIZE_BYTES,
+                0);
+        } else {
+            noc_async_write(data_ptr,get_noc_addr_helper(downstream_noc_xy, downstream_cb_base), length);
+        }
         downstream_data_ptr = downstream_cb_base + tail_pages * downstream_cb_page_size;
     }
 
     noc_async_writes_flushed();
-    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
+
+    if constexpr (fabric_router_noc_xy) {
+        cb_release_pages_remote<
+            downstream_mesh_id,
+            downstream_dev_id,
+            fabric_router_noc_xy,
+            my_noc_index,
+            downstream_noc_xy,
+            downstream_cb_sem_id>(
+            client_interface, npages);
+    } else {
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
+    }
 
     return fence;
 }
@@ -1414,7 +1465,20 @@ void kernel_main_d() {
         // TODO: evaluate less costly free pattern (blocks?)
         uint32_t total_length = length + sizeof(CQPrefetchHToPrefetchDHeader);
         uint32_t pages_to_free = (total_length + cmddat_q_page_size - 1) >> cmddat_q_log_page_size;
-        cb_release_pages<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
+
+        if constexpr (fabric_router_noc_xy) {
+            cb_release_pages_remote<
+                upstream_mesh_id,
+                upstream_dev_id,
+                fabric_router_noc_xy,
+                my_noc_index,
+                upstream_noc_xy,
+                upstream_cb_sem_id>(
+                client_interface,
+                pages_to_free);
+        } else {
+            cb_release_pages<my_noc_index, upstream_noc_xy, upstream_cb_sem_id>(pages_to_free);
+        }
 
         // Move to next page
         cmd_ptr = round_up_pow2(cmd_ptr, cmddat_q_page_size);
@@ -1422,11 +1486,10 @@ void kernel_main_d() {
 
     // Set upstream semaphore MSB to signal completion and path teardown
     // in case prefetch_d is connected to a depacketizing stage.
-    // TODO: This should be replaced with a signal similar to what packetized
-    // components use.
-    // DPRINT << "prefetch_d done" << ENDL();
-    noc_semaphore_inc(
-        get_noc_addr_helper(upstream_noc_xy, get_semaphore<fd_core_type>(upstream_cb_sem_id)), 0x80000000);
+    if constexpr (!fabric_router_noc_xy) {
+        noc_semaphore_inc(
+            get_noc_addr_helper(upstream_noc_xy, get_semaphore<fd_core_type>(upstream_cb_sem_id)), 0x80000000);
+    }
 }
 
 void kernel_main_hd() {
@@ -1453,7 +1516,8 @@ void kernel_main_hd() {
 
 void kernel_main() {
     DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": start" << ENDL();
-    if constexpr (use_fabric(fabric_router_noc_xy)) {
+    if constexpr (!(is_h_variant && is_d_variant)) {
+        DPRINT << "fabric_endpoint_init" << ENDL();
         tt::tt_fabric::fabric_endpoint_init(client_interface, 0 /*unused*/);
     }
 
@@ -1467,6 +1531,8 @@ void kernel_main() {
         ASSERT(0);
     }
     IDLE_ERISC_RETURN();
+
+    DPRINT << "prefetcher_" << is_h_variant << is_d_variant << ": terminate" << ENDL();
 
     // Confirm expected number of pages, spinning here is a leak
     cb_wait_all_pages<my_downstream_cb_sem_id>(downstream_cb_pages);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -169,7 +169,7 @@ static uint32_t block_next_start_addr[cmddat_q_blocks];
 static uint32_t rd_block_idx = 0;
 static uint32_t upstream_total_acquired_page_count = 0;
 static auto client_interface =
-    reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
+    reinterpret_cast<volatile tt_l1_ptr tt::tt_fabric::fabric_pull_client_interface_t*>(client_interface_addr);
 
 // Feature to stall the prefetcher, mainly for ExecBuf impl which reuses CmdDataQ
 static enum StallState { STALL_NEXT = 2, STALLED = 1, NOT_STALLED = 0 } stall_state = NOT_STALLED;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -596,12 +596,12 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
                 "N300/T3K expects devices in mmio/remote pairs.");
             std::vector<DispatchKernelNode> nodes_for_one_mmio;
             // TODO: Put this in a better place
+            // Must call tt::tt_metal::detail::InitializeFabricConfig upstream
             if (llrt::RunTimeOptions::get_instance().get_fd_fabric()) {
                 TT_FATAL(num_hw_cqs == 1, "Only 1 CQ is supported at this time for FD on Fabric");
-                // Must call tt::tt_metal::detail::InitializeFabricConfig upstream
                 nodes_for_one_mmio = two_chip_arch_1cq_fabric;
             } else {
-                nodes_for_one_mmio = (num_hw_cqs == 1) ? two_chip_arch_1cq : two_chip_arch_2cq;
+                nodes_for_one_mmio = two_chip_arch_1cq;
             }
 
             uint32_t index_offset = 0;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -183,12 +183,12 @@ static const std::vector<DispatchKernelNode> two_chip_arch_1cq = {
 };
 
 static const std::vector<DispatchKernelNode> two_chip_arch_1cq_fabric = {
-    {0, 0, 0, 0, PREFETCH_HD, /*up*/ {x, x, x, x}, /*down*/ {1, 2, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_prefetcher_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_dispatcher_noc},
+    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_dispatcher_s_noc},
 
-    {3, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {7, x, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {4, 0, 1, 0, DISPATCH_H, {8, x, x, x}, {3, x, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
+    {3, 0, 1, 0, PREFETCH_H, {x, x, x, x}, {7, x, x, x}, k_prefetcher_noc},
+    {4, 0, 1, 0, DISPATCH_H, {8, x, x, x}, {3, x, x, x}, k_dispatcher_noc},
 
     // Sender path PREFETCH_H -> PREFETCH_D
     {5, 0, x, 0, FABRIC_ROUTER_VC, {3, x, x, x}, {7, x, x, x}},
@@ -196,9 +196,9 @@ static const std::vector<DispatchKernelNode> two_chip_arch_1cq_fabric = {
     // Return path DISPATCH_D -> DISPATCH_H
     {6, 0, x, 0, FABRIC_ROUTER_VC, {8, x, x, x}, {4, x, x, x}},
 
-    {7, 1, 1, 0, PREFETCH_D, {3, x, x, x}, {8, 9, x, x}, NOC::NOC_0, NOC::NOC_0, NOC::NOC_0},
-    {8, 1, 1, 0, DISPATCH_D, {7, x, x, x}, {9, 4, x, x}, NOC::NOC_0, NOC::NOC_1, NOC::NOC_0},
-    {9, 1, 1, 0, DISPATCH_S, {7, x, x, x}, {8, x, x, x}, NOC::NOC_1, NOC::NOC_1, NOC::NOC_1},
+    {7, 1, 1, 0, PREFETCH_D, {3, x, x, x}, {8, 9, x, x}, k_prefetcher_noc},
+    {8, 1, 1, 0, DISPATCH_D, {7, x, x, x}, {9, 4, x, x}, k_dispatcher_noc},
+    {9, 1, 1, 0, DISPATCH_S, {7, x, x, x}, {8, x, x, x}, k_dispatcher_s_noc},
 };
 
 static const std::vector<DispatchKernelNode> two_chip_arch_2cq = {

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdlib>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include "tt-metalium/fabric_types.hpp"
 #include "tt-metalium/kernel_types.hpp"
 
 using namespace tt;
@@ -11,9 +14,10 @@ using namespace tt::tt_metal;
 
 int main() {
     // Initialize Program and Device
+    tt::tt_metal::detail::InitializeFabricConfig(FabricConfig::FABRIC_2D);
 
     constexpr CoreCoord core = {0, 0};
-    int device_id = 0;
+    int device_id = 1;
     IDevice* device = CreateDevice(device_id);
     CommandQueue& cq = device->command_queue();
     Program program = CreateProgram();
@@ -34,12 +38,14 @@ int main() {
 
     // Configure Program and Start Program Execution on Device
 
-    SetRuntimeArgs(program, void_compute_kernel_id, core, {});
-    EnqueueProgram(cq, program, false);
     printf("Hello, Core {0, 0} on Device 0, I am sending you a compute kernel. Standby awaiting communication.\n");
 
-    // Wait Until Program Finishes, Print "Hello World!", and Close Device
+    SetRuntimeArgs(program, void_compute_kernel_id, core, {});
+    for (int i = 0; i < 10; ++i) {
+        EnqueueProgram(cq, program, false);
+    }
 
+    // Wait Until Program Finishes, Print "Hello World!", and Close Device
     Finish(cq);
     printf("Thank you, Core {0, 0} on Device 0, for the completed task.\n");
     CloseDevice(device);


### PR DESCRIPTION
Build
`./build_metal.sh --debug --build-tests -e --build-programming-examples --disable-unity-builds`

Programming Example
`TT_METAL_FD_FABRIC=1 build/programming_examples/hello_world_compute_kernel`

EnqueueReadBuffer 512M
`TT_METAL_FD_FABRIC=1 build/test/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer_wormhole_b0 --page-size 4096 --transfer-size 536870912 --device 1 --skip-write`

EnqueueWriteBuffer 512M
`TT_METAL_FD_FABRIC=1 build/test/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer_wormhole_b0 --page-size 4096 --transfer-size 536870912 --device 1 --skip-read`

- [x] EnqueueProgram
- [x] EnqueueReadBuffer
- [x] EnqueueWriteBuffer
- [x] Finish / Terminate
- [ ] EnqueueRecordEvent
- [ ] EnqueueWaitForEvent