### PR TITLE
[1D Fabric] Update downstream connections for setup via device init

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -60,13 +60,13 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
 
     // get a port to connect to
-    std::vector<chan_id_t> eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
+    std::set<chan_id_t> eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
         src_mesh_chip_id.first, src_mesh_chip_id.second, RoutingDirection::E);
     if (eth_chans.size() == 0) {
         GTEST_SKIP() << "No active eth chans to connect to";
     }
 
-    auto edm_port = eth_chans[0];
+    auto edm_port = *(eth_chans.begin());
     CoreCoord edm_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
         src_physical_device_id, edm_port);
 

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -57,7 +57,7 @@ class ControlPlane {
 
        size_t get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t chip_id) const;
 
-       std::vector<chan_id_t> get_active_fabric_eth_channels_in_direction(
+       std::set<chan_id_t> get_active_fabric_eth_channels_in_direction(
            mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const;
 
        eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -863,12 +863,12 @@ size_t ControlPlane::get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t 
     return num_routers;
 }
 
-std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction(
+std::set<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction(
     mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const {
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
         if (routing_direction == direction) {
-            return eth_chans;
+            return std::set<chan_id_t>(eth_chans.begin(), eth_chans.end());
         }
     }
     return {};

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -30,7 +30,7 @@ namespace tt::tt_fabric {
 // Inputs:
 // src_chip_id: physical chip id/device id of the sender chip
 // dst_chip_id: physical chip id/device id of the receiver chip
-// routing_plane: the link (0..n) to use b/w the src_chip_id and dst_chip_id. On WH for
+// link_idx: the link (0..n) to use b/w the src_chip_id and dst_chip_id. On WH for
 //                instance we can have upto 4 active links b/w two chips
 // worker_program: program handle
 // worker_core: worker core logical coordinates
@@ -45,7 +45,7 @@ namespace tt::tt_fabric {
 void append_fabric_connection_rt_args(
     chip_id_t src_chip_id,
     chip_id_t dst_chip_id,
-    routing_plane_id_t routing_plane,
+    uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1015,7 +1015,7 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
     std::unique_ptr<Program> fabric_program_ptr;
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     std::pair<mesh_id_t, chip_id_t> mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
-    std::unordered_map<RoutingDirection, std::vector<chan_id_t>> active_fabric_eth_channels;
+    std::unordered_map<RoutingDirection, std::set<chan_id_t>> active_fabric_eth_channels;
     std::unordered_map<RoutingDirection, chip_id_t> chip_neighbors;
     std::unordered_map<chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder> edm_builders;
     auto routing_directions = {RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
@@ -1076,17 +1076,6 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
         edm_channels_mask += 0x1 << (uint32_t)router_chan;
     }
 
-    auto get_eth_chan_on_same_routing_plane = [&](chan_id_t src_eth_chan,
-                                                  std::vector<chan_id_t>& target_eth_chans) -> chan_id_t {
-        routing_plane_id_t src_plane_id = control_plane->get_routing_plane_id(src_eth_chan);
-        for (const auto& target_eth_chan : target_eth_chans) {
-            if (src_plane_id == control_plane->get_routing_plane_id(target_eth_chan)) {
-                return target_eth_chan;
-            }
-        }
-        return eth_chan_magic_values::INVALID_DIRECTION;
-    };
-
     auto connect_downstream_builders = [&](RoutingDirection dir1, RoutingDirection dir2) {
         bool can_connect =
             (chip_neighbors.find(dir1) != chip_neighbors.end()) && (chip_neighbors.find(dir2) != chip_neighbors.end());
@@ -1094,19 +1083,22 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, b
             auto& eth_chans_dir1 = active_fabric_eth_channels.at(dir1);
             auto& eth_chans_dir2 = active_fabric_eth_channels.at(dir2);
 
-            for (const auto& eth_chan_dir1 : eth_chans_dir1) {
-                // connect with the router on the same routing plane
-                auto eth_chan_dir2 = get_eth_chan_on_same_routing_plane(eth_chan_dir1, eth_chans_dir2);
-                if (eth_chan_dir2 == eth_chan_magic_values::INVALID_DIRECTION) {
-                    // potentially eth chan in one of the direction is reserved for tunneling
-                    continue;
-                }
+            auto eth_chans_dir1_it = eth_chans_dir1.begin();
+            auto eth_chans_dir2_it = eth_chans_dir2.begin();
+
+            // since tunneling cores are not guaraneteed to be reserved on the same routing plane, iterate through
+            // the sorted eth channels in both directions
+            while (eth_chans_dir1_it != eth_chans_dir1.end() && eth_chans_dir2_it != eth_chans_dir2.end()) {
+                auto eth_chan_dir1 = *eth_chans_dir1_it;
+                auto eth_chan_dir2 = *eth_chans_dir2_it;
 
                 auto& edm_builder1 = edm_builders.at(eth_chan_dir1);
                 auto& edm_builder2 = edm_builders.at(eth_chan_dir2);
-
                 edm_builder1.connect_to_downstream_edm(edm_builder2);
                 edm_builder2.connect_to_downstream_edm(edm_builder1);
+
+                eth_chans_dir1_it++;
+                eth_chans_dir2_it++;
             }
         }
     };


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Current implementation assumes that the cores reserved for tunneling will be in the same routing plane and hence uses routing plane IDs to connect downstream EDMs, which is incorrect and the cores can be reserved on different routing planes.

### What's changed
Instead of using routing plane IDs, just walk through the sorted list of eth channels in either directions when connecting. Also use a similar approach for the worker connection API.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14256082381/job/39959173533)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes