### PR TITLE
#19961: Add ring/deadlock avoidance support for 1D fabric at device init

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -115,10 +115,7 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
         num_hops};
 
     // append the EDM connection rt args
-    static constexpr std::size_t edm_buffer_size =
-        tt::tt_fabric::FabricEriscDatamoverBuilder::default_packet_payload_size_bytes +
-        sizeof(tt::tt_fabric::PacketHeader);
-    const auto edm_config = tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size);
+    const auto edm_config = get_1d_fabric_config();
 
     tt::tt_fabric::SenderWorkerAdapterSpec edm_connection = {
         .edm_noc_x = edm_eth_core.x,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -6,6 +6,7 @@
 #include <fmt/base.h>
 #include <nlohmann/json_fwd.hpp>
 #include <stdint.h>
+#include <tt_stl/span.hpp>
 #include <tt-metalium/control_plane.hpp>
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -490,7 +491,7 @@ typedef struct test_board {
         return control_plane->get_fabric_route(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id, src_chan_id);
     }
 
-    inline std::vector<chip_id_t> get_intra_chip_neighbors(
+    inline stl::Span<const chip_id_t> get_intra_chip_neighbors(
         mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) {
         return control_plane->get_intra_chip_neighbors(src_mesh_id, src_chip_id, routing_direction);
     }
@@ -806,7 +807,7 @@ typedef struct test_device {
         }
     }
 
-    inline std::vector<chip_id_t> get_intra_chip_neighbors(RoutingDirection routing_direction) {
+    inline stl::Span<const chip_id_t> get_intra_chip_neighbors(RoutingDirection routing_direction) {
         return board_handle->get_intra_chip_neighbors(mesh_id, logical_chip_id, routing_direction);
     }
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel.hpp>
 #include "tt-metalium/kernel_types.hpp"
+#include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/test_utils/df/df.hpp"
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/fabric_edm_packet_header.hpp>
@@ -66,9 +67,9 @@ using tt::tt_metal::distributed::MeshDevice;
 using tt::tt_metal::distributed::MeshDeviceConfig;
 using tt::tt_metal::distributed::MeshDeviceView;
 using tt::tt_metal::distributed::MeshShape;
-class T3000TestDevice {
+class Fabric1DFixture {
 public:
-    T3000TestDevice() : device_open(false) {
+    void SetupDevices() {
         constexpr size_t TG_num_devices = 36;
         constexpr size_t galaxy_6u_num_devices = 32;
 
@@ -79,7 +80,8 @@ public:
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ >= 8 and tt::tt_metal::GetNumPCIeDevices() == 4) {
+        if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ >= 8 and
+            (tt::tt_metal::GetNumPCIeDevices() == 4 || tt::tt_metal::GetNumPCIeDevices() == galaxy_6u_num_devices)) {
             if (num_devices_ == TG_num_devices || num_devices_ == galaxy_6u_num_devices) {
                 mesh_device_ = MeshDevice::create(MeshDeviceConfig(MeshShape{8, 4}));
             } else {
@@ -94,10 +96,19 @@ public:
         }
         device_open = true;
     }
-    ~T3000TestDevice() {
+
+    Fabric1DFixture() : device_open(false) { this->SetupDevices(); }
+
+    Fabric1DFixture(tt::tt_metal::FabricConfig fabric_config) : device_open(false) {
+        tt::tt_metal::detail::InitializeFabricConfig(fabric_config);
+        this->SetupDevices();
+    }
+
+    virtual ~Fabric1DFixture() {
         if (device_open) {
             TearDown();
         }
+        tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::DISABLED);
     }
 
     void TearDown() {
@@ -111,6 +122,11 @@ public:
 
 private:
     bool device_open;
+};
+
+class Fabric1DRingDeviceInitFixture : public Fabric1DFixture {
+public:
+    Fabric1DRingDeviceInitFixture() : Fabric1DFixture(tt::tt_metal::FabricConfig::FABRIC_1D_RING) {}
 };
 
 struct BankedConfig {
@@ -1135,7 +1151,7 @@ int TestLineFabricEntrypoint(
         return 0;
     }
 
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     // build a line of devices
@@ -1221,7 +1237,7 @@ int TestLoopbackEntrypoint(
         return 0;
     }
 
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     const auto& device_0 = view.get_device(MeshCoordinate(0, 0));
@@ -1397,7 +1413,7 @@ bool TestMultiInputReaderKernel(
         log_info("Test must be run on WH");
         return true;
     }
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
 
     TT_FATAL(
         !enable_persistent_fabric || test_mode != TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK,
@@ -1696,7 +1712,7 @@ bool RunPipelinedWorkersTest(
     auto programs = std::vector<Program>(1);
     Program& program = programs[0];
 
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     IDevice* device = view.get_device(MeshCoordinate(0, 0));
@@ -1988,7 +2004,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
         log_info("Test must be run on WH");
         return;
     }
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     // build a line of devices
@@ -2088,7 +2104,7 @@ void run_ring_all_gather_with_persistent_fabric(
         log_info("Test must be run on WH");
         return;
     }
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     // build a line of devices
@@ -2350,7 +2366,7 @@ void Run1DFabricPacketSendTest(
     size_t dest_buffer_size = max_packet_payload_size_bytes * 4;
     static constexpr tt::DataFormat cb_df = tt::DataFormat::Bfp8;
 
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     // Get the inner 4 device ring on a WH T3K device so that we can use both links for all devices
@@ -2643,12 +2659,6 @@ void Run1DFabricPacketSendTest(
                 .set_page_size(source_payload_cb_index, max_packet_payload_size_bytes);
         CBHandle sender_workers_payload_cb = CreateCircularBuffer(program, worker_cores, cb_src1_config);
 
-        TT_FATAL(
-            local_device_fabric_handle.get_num_links() == num_links,
-            "Error in test setup. Expected two links between devices but got {} links for device {}",
-            local_device_fabric_handle.get_num_links(),
-            device->id());
-
         std::vector<uint32_t> worker_ct_args = {params.line_sync, params.line_sync};
 
         auto worker_kernel_id = tt_metal::CreateKernel(
@@ -2862,7 +2872,7 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     size_t dest_buffer_size = packet_payload_size_bytes * 4;
     static constexpr tt::DataFormat cb_df = tt::DataFormat::Bfp8;
 
-    T3000TestDevice test_fixture;
+    Fabric1DRingDeviceInitFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     std::vector<IDevice*> devices_ = {
@@ -2884,21 +2894,6 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
 
     // Persistent Fabric Setup
     std::vector<Program> dummy_worker_programs;
-    std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
-    std::optional<std::vector<Program>> fabric_programs;
-    std::vector<Program*> fabric_program_ptrs;
-    std::optional<ttnn::ccl::EdmLineFabricOpInterface> fabric_handle;
-    setup_test_with_persistent_fabric(
-        devices,
-        dummy_worker_programs,
-        subdevice_managers,
-        fabric_programs,
-        fabric_program_ptrs,
-        fabric_handle,
-        enable_persistent_fabric_mode,
-        num_links,
-        topology,
-        tt::tt_fabric::FabricEriscDatamoverBuilder::default_firmware_context_switch_interval);
 
     // Other boiler plate setup
     CoreRangeSet worker_cores = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(num_links - 1, 0)));
@@ -2981,10 +2976,6 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
         mcast_bwd_hops = has_backward_connection ? line_size - 1 : 0;
         unicast_hops = has_forward_connection ? mcast_fwd_hops : mcast_bwd_hops;
 
-        auto local_device_fabric_handle =
-            ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
-                device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links, topology);
-
         // reserve CB
         tt_metal::CircularBufferConfig cb_src0_config =
             tt_metal::CircularBufferConfig(
@@ -2998,12 +2989,6 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
                 .set_page_size(source_payload_cb_index, packet_payload_size_bytes);
         CBHandle sender_workers_payload_cb = CreateCircularBuffer(program, worker_cores, cb_src1_config);
 
-        TT_FATAL(
-            local_device_fabric_handle.get_num_links() == num_links,
-            "Error in test setup. Expected two links between devices but got {} links for device {}",
-            local_device_fabric_handle.get_num_links(),
-            device->id());
-
         std::vector<uint32_t> worker_ct_args = {line_sync, line_sync};
 
         auto worker_kernel_id = tt_metal::CreateKernel(
@@ -3016,25 +3001,15 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
             auto worker_core = worker_cores_vec[l];
             const size_t dest_noc_x = device->worker_core_from_logical_core(dest_core_coord[l]).x;
             const size_t dest_noc_y = device->worker_core_from_logical_core(dest_core_coord[l]).y;
-            auto build_connection_args = [&local_device_fabric_handle, device, &program, &worker_core](
-                                             bool is_connected_in_direction,
-                                             ttnn::ccl::EdmLineFabricOpInterface::Direction direction,
-                                             std::vector<uint32_t>& rt_args_out) {
-                rt_args_out.push_back(is_connected_in_direction);
-                if (is_connected_in_direction) {
-                    const auto connection = local_device_fabric_handle.uniquely_connect_worker(device, direction);
-                    const auto new_rt_args =
-                        ttnn::ccl::worker_detail::generate_edm_connection_rt_args(connection, program, {worker_core});
-                    log_info(
-                        tt::LogTest,
-                        "On device: {}, connecting to EDM fabric in {} direction. EDM noc_x: {}, noc_y: {}",
-                        device->id(),
-                        direction,
-                        connection.edm_noc_x,
-                        connection.edm_noc_y);
-                    std::copy(new_rt_args.begin(), new_rt_args.end(), std::back_inserter(rt_args_out));
-                }
-            };
+            auto build_connection_args =
+                [device, &program, &worker_core, l](
+                    bool is_connected_in_direction, IDevice* connected_device, std::vector<uint32_t>& rt_args_out) {
+                    rt_args_out.push_back(is_connected_in_direction);
+                    if (is_connected_in_direction) {
+                        tt::tt_fabric::append_fabric_connection_rt_args(
+                            device->id(), connected_device->id(), l, program, {worker_core}, rt_args_out);
+                    }
+                };
 
             // Define the send type parameters
             // There is no atomic in
@@ -3085,8 +3060,8 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
             rt_args.push_back(packet_header_cb_size_in_headers);
 
             // Add fabric connection args
-            build_connection_args(has_forward_connection, ttnn::ccl::EdmLineFabricOpInterface::FORWARD, rt_args);
-            build_connection_args(has_backward_connection, ttnn::ccl::EdmLineFabricOpInterface::BACKWARD, rt_args);
+            build_connection_args(has_forward_connection, forward_device, rt_args);
+            build_connection_args(has_backward_connection, backward_device, rt_args);
 
             if (line_sync) {
                 rt_args.push_back(sync_core_noc_x);
@@ -3123,18 +3098,11 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
         build_and_enqueue(worker_devices, programs, i != 0);
 
         log_info(tt::LogTest, "Waiting for Op finish on all devices");
-        wait_for_worker_subdevice_program_completion(worker_devices, subdevice_managers);
+        for (IDevice* d : devices) {
+            tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
+        }
         log_info(tt::LogTest, "Main op done");
     }
 
-    TT_FATAL(fabric_programs->size() == devices.size(), "Expected fabric programs size to be same as devices size");
-    log_info(tt::LogTest, "Fabric teardown");
-    persistent_fabric_teardown_sequence(
-        devices, subdevice_managers, fabric_handle.value(), tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE);
-
-    log_info(tt::LogTest, "Waiting for teardown completion");
-    for (IDevice* d : devices) {
-        tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
-    }
     log_info(tt::LogTest, "Finished");
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -862,7 +862,7 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
         log_info("Test must be run on WH");
         return;
     }
-    T3000TestDevice test_fixture;
+    Fabric1DFixture test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
     // build a line of devices

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <tt_stl/span.hpp>
 #include <tt-metalium/routing_table_generator.hpp>
 #include <tt-metalium/fabric_host_interface.h>
 #include <tt-metalium/core_coord.hpp>
@@ -12,88 +13,86 @@
 namespace tt::tt_fabric {
 
 class ControlPlane {
-   public:
-       explicit ControlPlane(const std::string& mesh_graph_desc_yaml_file);
-       ~ControlPlane() = default;
-       void initialize_from_mesh_graph_desc_file(const std::string& mesh_graph_desc_file);
+public:
+    explicit ControlPlane(const std::string& mesh_graph_desc_yaml_file);
+    ~ControlPlane() = default;
+    void initialize_from_mesh_graph_desc_file(const std::string& mesh_graph_desc_file);
 
-       void write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chip_id) const;
-       void write_routing_tables_to_all_chips() const;
+    void write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chip_id) const;
+    void write_routing_tables_to_all_chips() const;
 
-       // Printing functions
-       void print_routing_tables() const;
-       void print_ethernet_channels() const;
+    // Printing functions
+    void print_routing_tables() const;
+    void print_ethernet_channels() const;
 
-       // Converts chip level routing tables to per ethernet channel
-       void configure_routing_tables_for_fabric_ethernet_channels();
+    // Converts chip level routing tables to per ethernet channel
+    void configure_routing_tables_for_fabric_ethernet_channels();
 
-       // Return mesh_id, chip_id from physical chip id
-       std::pair<mesh_id_t, chip_id_t> get_mesh_chip_id_from_physical_chip_id(chip_id_t physical_chip_id) const;
-       chip_id_t get_physical_chip_id_from_mesh_chip_id(const std::pair<mesh_id_t, chip_id_t>& mesh_chip_id) const;
+    // Return mesh_id, chip_id from physical chip id
+    std::pair<mesh_id_t, chip_id_t> get_mesh_chip_id_from_physical_chip_id(chip_id_t physical_chip_id) const;
+    chip_id_t get_physical_chip_id_from_mesh_chip_id(const std::pair<mesh_id_t, chip_id_t>& mesh_chip_id) const;
 
-       std::vector<mesh_id_t> get_user_physical_mesh_ids() const;
-       tt::tt_metal::distributed::MeshShape get_physical_mesh_shape(mesh_id_t mesh_id) const;
+    std::vector<mesh_id_t> get_user_physical_mesh_ids() const;
+    tt::tt_metal::distributed::MeshShape get_physical_mesh_shape(mesh_id_t mesh_id) const;
 
-       // Return valid ethernet channels on the specificed routing plane
-       std::vector<chan_id_t> get_valid_eth_chans_on_routing_plane(
-           mesh_id_t mesh_id, chip_id_t chip_id, routing_plane_id_t routing_plane_id) const;
+    // Return valid ethernet channels on the specificed routing plane
+    std::vector<chan_id_t> get_valid_eth_chans_on_routing_plane(
+        mesh_id_t mesh_id, chip_id_t chip_id, routing_plane_id_t routing_plane_id) const;
 
-       // Return path from device to device in the fabric
-       std::vector<std::pair<chip_id_t, chan_id_t>> get_fabric_route(
-           mesh_id_t src_mesh_id,
-           chip_id_t src_chip_id,
-           mesh_id_t dst_mesh_id,
-           chip_id_t dst_chip_id,
-           chan_id_t src_chan_id) const;
+    // Return path from device to device in the fabric
+    std::vector<std::pair<chip_id_t, chan_id_t>> get_fabric_route(
+        mesh_id_t src_mesh_id,
+        chip_id_t src_chip_id,
+        mesh_id_t dst_mesh_id,
+        chip_id_t dst_chip_id,
+        chan_id_t src_chan_id) const;
 
-       // Return routers to get to the destination chip, avoid local eth to eth routing. CoreCoord is a virtual coord.
-       std::vector<std::pair<routing_plane_id_t, CoreCoord>> get_routers_to_chip(
-           mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id) const;
+    // Return routers to get to the destination chip, avoid local eth to eth routing. CoreCoord is a virtual coord.
+    std::vector<std::pair<routing_plane_id_t, CoreCoord>> get_routers_to_chip(
+        mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id) const;
 
-       std::vector<chip_id_t> get_intra_chip_neighbors(
-           mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;
+    stl::Span<const chip_id_t> get_intra_chip_neighbors(
+        mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;
 
-       routing_plane_id_t get_routing_plane_id(chan_id_t eth_chan_id) const;
+    routing_plane_id_t get_routing_plane_id(chan_id_t eth_chan_id) const;
 
-       size_t get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t chip_id) const;
+    size_t get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t chip_id) const;
 
-       std::set<chan_id_t> get_active_fabric_eth_channels_in_direction(
-           mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const;
+    std::set<chan_id_t> get_active_fabric_eth_channels_in_direction(
+        mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const;
 
-       eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const;
+    eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const;
 
-   private:
-       std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
-       std::vector<std::vector<chip_id_t>> logical_mesh_chip_id_to_physical_chip_id_mapping_;
-       // map[mesh_id][chip_id][direction] has a list of ethernet channels in that direction
-       std::vector<std::vector<std::unordered_map<RoutingDirection, std::vector<chan_id_t>>>>
-           router_port_directions_to_physical_eth_chan_map_;
-       // tables[mesh_id][chip_id][eth_chan]
-       std::vector<std::vector<std::vector<std::vector<chan_id_t>>>>
-           intra_mesh_routing_tables_;  // table that will be written to each ethernet core
-       std::vector<std::vector<std::vector<std::vector<chan_id_t>>>>
-           inter_mesh_routing_tables_;  // table that will be written to each ethernet core
+private:
+    std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
+    std::vector<std::vector<chip_id_t>> logical_mesh_chip_id_to_physical_chip_id_mapping_;
+    // map[mesh_id][chip_id][direction] has a list of ethernet channels in that direction
+    std::vector<std::vector<std::unordered_map<RoutingDirection, std::vector<chan_id_t>>>>
+        router_port_directions_to_physical_eth_chan_map_;
+    // tables[mesh_id][chip_id][eth_chan]
+    std::vector<std::vector<std::vector<std::vector<chan_id_t>>>>
+        intra_mesh_routing_tables_;  // table that will be written to each ethernet core
+    std::vector<std::vector<std::vector<std::vector<chan_id_t>>>>
+        inter_mesh_routing_tables_;  // table that will be written to each ethernet core
 
-       // Tries to get a valid downstream channel from the candidate_target_chans
-       // First along same routing plane, but if not available, take round robin from candidates
-       chan_id_t get_downstream_eth_chan_id(
-           chan_id_t src_chan_id, const std::vector<chan_id_t>& candidate_target_chans) const;
+    // Tries to get a valid downstream channel from the candidate_target_chans
+    // First along same routing plane, but if not available, take round robin from candidates
+    chan_id_t get_downstream_eth_chan_id(
+        chan_id_t src_chan_id, const std::vector<chan_id_t>& candidate_target_chans) const;
 
-       chip_id_t get_physical_chip_id_from_eth_coord(const eth_coord_t& eth_coord) const;
+    chip_id_t get_physical_chip_id_from_eth_coord(const eth_coord_t& eth_coord) const;
 
-       void validate_mesh_connections(mesh_id_t mesh_id) const;
+    void validate_mesh_connections(mesh_id_t mesh_id) const;
 
-       std::vector<chip_id_t> get_mesh_physical_chip_ids(
-           std::uint32_t mesh_ns_size,
-           std::uint32_t mesh_ew_size,
-           chip_id_t nw_chip_physical_chip_id) const;
+    std::vector<chip_id_t> get_mesh_physical_chip_ids(
+        std::uint32_t mesh_ns_size, std::uint32_t mesh_ew_size, chip_id_t nw_chip_physical_chip_id) const;
 
-       std::tuple<mesh_id_t, chip_id_t, chan_id_t> get_connected_mesh_chip_chan_ids(
-           mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t chan_id) const;
+    std::tuple<mesh_id_t, chip_id_t, chan_id_t> get_connected_mesh_chip_chan_ids(
+        mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t chan_id) const;
 
-       // Takes RoutingTableGenerator table and converts to routing tables for each ethernet port
-       void convert_fabric_routing_table_to_chip_routing_table();
-       eth_chan_directions routing_direction_to_eth_direction(RoutingDirection direction) const;
+    // Takes RoutingTableGenerator table and converts to routing tables for each ethernet port
+    void convert_fabric_routing_table_to_chip_routing_table();
+    eth_chan_directions routing_direction_to_eth_direction(RoutingDirection direction) const;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -5,6 +5,13 @@
 #pragma once
 
 namespace tt::tt_metal {
-enum class FabricConfig : uint32_t { DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, FABRIC_2D_PUSH = 3, CUSTOM = 4 };
+enum class FabricConfig : uint32_t {
+    DISABLED = 0,
+    FABRIC_1D = 1,       // Instatiates fabric with 1D routing and no deadlock avoidance
+    FABRIC_1D_RING = 2,  // Instatiates fabric with 1D routing and with deadlock avoidance using datelines
+    FABRIC_2D = 3,       // Instatiates fabric with 2D routing in pull mode
+    FABRIC_2D_PUSH = 4,  // Instatiates fabric with 2D routing in push mode
+    CUSTOM = 5
+};
 
 }  // namespace tt::tt_metal

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -841,7 +841,7 @@ std::vector<std::pair<routing_plane_id_t, CoreCoord>> ControlPlane::get_routers_
     return routers;
 }
 
-std::vector<chip_id_t> ControlPlane::get_intra_chip_neighbors(
+stl::Span<const chip_id_t> ControlPlane::get_intra_chip_neighbors(
     mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const {
     for (const auto& [_, routing_edge] :
          this->routing_table_generator_->get_intra_mesh_connectivity()[src_mesh_id][src_chip_id]) {

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -5,12 +5,13 @@
 #pragma once
 
 #include <stdint.h>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/erisc_datamover_builder.hpp>
+#include <tt-metalium/fabric_host_interface.h>
+#include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/program_impl.hpp>
+#include <tt-metalium/system_memory_manager.hpp>
 #include <vector>
-
-#include "core_coord.hpp"
-#include "fabric_host_interface.h"
-#include "system_memory_manager.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -19,6 +20,13 @@ class Program;
 }  // namespace tt
 
 namespace tt::tt_fabric {
+
+bool is_1d_fabric_config(const tt::tt_metal::FabricConfig& fabric_config);
+bool is_2d_fabric_config(const tt::tt_metal::FabricConfig& fabric_config);
+
+Topology get_1d_topology(const tt::tt_metal::FabricConfig& fabric_config);
+
+tt::tt_fabric::FabricEriscDatamoverConfig get_1d_fabric_config();
 
 // Used to get the run-time args for estabilishing connection with the fabric router.
 // The API appends the connection specific run-time args to the set of exisiting

--- a/ttnn/cpp/pybind11/fabric.cpp
+++ b/ttnn/cpp/pybind11/fabric.cpp
@@ -16,6 +16,7 @@ void py_bind_fabric_api(pybind11::module& module) {
     py::enum_<tt::tt_metal::FabricConfig>(module, "FabricConfig")
         .value("DISABLED", tt::tt_metal::FabricConfig::DISABLED)
         .value("FABRIC_1D", tt::tt_metal::FabricConfig::FABRIC_1D)
+        .value("FABRIC_1D_RING", tt::tt_metal::FabricConfig::FABRIC_1D_RING)
         .value("FABRIC_2D", tt::tt_metal::FabricConfig::FABRIC_2D)
         .value("CUSTOM", tt::tt_metal::FabricConfig::CUSTOM);  // DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19961

### Problem description
We need to be able to enable the ring/deadlock avoidance support when initializing 1D fabric at device init.

### What's changed
Add support for enabling deadlock avoidance when initializing 1D fabric at device init.
On chips with corners, we insert the dateline at the N/S connection of logical chip 0.
For full 2d torus, we insert the dateline at the wraparound connections between N/S edges and E/W edges.

Rename `get_default_fabric_config` to `get_1d_fabric_config` to clarify the usage, and add proper support for it to grab the Linear or Ring config depending on fabric configuration.

Update the T3K deadlock test to use the new device init flow to verify functionality. 2D torus functionality will be tested offline.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14256641599
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/14256644162