### PR TITLE
Update Falcon7B T3K/TG targets, add ensure_devices_tg to demo, set default high tolerance for verify_perf utility to 15%

### DIFF
--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 10500, "decode_t/s": 3710, "decode_t/s/u": 14.5}, False, None),
-        (True, 1024, {"prefill_t/s": 12522, "decode_t/s": 3434, "decode_t/s/u": 13.4}, False, None),
-        (True, 2048, {"prefill_t/s": 10725, "decode_t/s": 3203, "decode_t/s/u": 12.5}, False, None),
+        (True, 128, {"prefill_t/s": 11070, "decode_t/s": 3710, "decode_t/s/u": 14.5}, False, None),
+        (True, 1024, {"prefill_t/s": 12530, "decode_t/s": 3434, "decode_t/s/u": 13.4}, False, None),
+        (True, 2048, {"prefill_t/s": 10770, "decode_t/s": 3203, "decode_t/s/u": 12.5}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 14501, "decode_t/s": 4000, "decode_t/s/u": 3.91}, False, None),
-        (True, 1024, {"prefill_t/s": 18000, "decode_t/s": 3495, "decode_t/s/u": 3.41}, False, None),
-        (True, 2048, {"prefill_t/s": 13200, "decode_t/s": 3448, "decode_t/s/u": 3.37}, False, None),
+        (True, 128, {"prefill_t/s": 14800, "decode_t/s": 3677, "decode_t/s/u": 3.59}, False, None),
+        (True, 1024, {"prefill_t/s": 19180, "decode_t/s": 3590, "decode_t/s/u": 3.51}, False, None),
+        (True, 2048, {"prefill_t/s": 13500, "decode_t/s": 3448, "decode_t/s/u": 3.37}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),
@@ -55,6 +55,7 @@ def test_demo_multichip(
     use_program_cache,
     enable_async_mode,
     is_ci_env,
+    ensure_devices_tg,
 ):
     assert is_wormhole_b0(), "Multi-chip is only supported for Wormhole B0"
     num_devices = mesh_device.get_num_devices()

--- a/models/demos/utils/llm_demo_utils.py
+++ b/models/demos/utils/llm_demo_utils.py
@@ -114,7 +114,7 @@ def check_tokens_match(generated_text: dict, expected_greedy_output_path: str):
 def verify_perf(
     measurements: dict,
     expected_perf_metrics: dict,
-    high_tol_percentage=1.1,  # 10% tolerance to account for +-5% CI variance
+    high_tol_percentage=1.15,  # 15% tolerance (approx +-5% CI variance + 5% real increase)
 ):
     """
     Verify the performance metrics against the expected values.


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Falcon7B T3K demo prefill targets needed to be slightly increased
- Falcon7B TG demo targets needed to be updated again due to relanding of perf governor on TG runners
- Default high tolerance of 10% for `llm_demo_utils.py::verify_perf` was not wide enough and resulted in too many updates to targets for multiple models over the past couple weeks

### What's changed
- Updated Falcon7B T3K/TG demo perf targets
- Changed default high tolerance of `llm_demo_utils.py::verify_perf` from 10 to 15% (+-5% CI variance, 5% real increase)
- Added `ensure_devices_tg` to Falcon7B-TG demo to ensure failures and not skips on TG runners that don't have enough devices detected

cc @tt-rkim @roseli-TT @akirby-TT 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes