### PR TITLE
[Integration Branch] Resolve T3K Demo Tests Performance Issues

### DIFF
--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -369,8 +369,8 @@ def test_multimodal_demo_text(
         tt_device_name = model_args[0].device_name
         base_model_name = model_args[0].base_model_name
         target_prefill_tok_s = {
-            "N300_Llama3.2-11B": 6.7,
-            "T3K_Llama3.2-11B": 3.3,
+            "N300_Llama3.2-11B": 8.6,
+            "T3K_Llama3.2-11B": 6.4,
         }[f"{tt_device_name}_{base_model_name}"]
 
         target_decode_tok_s_u = {

--- a/models/tt_transformers/tt/multimodal/llama_vision_encoder.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_encoder.py
@@ -228,7 +228,7 @@ class TtLlamaVisionEncoder(LightweightModule):
         attn_mask = encoder_utils.build_encoder_attention_mask(fake_x, ar, ntok, num_chunks, 1)
         # Mask stripes for the extra padding required on TT hardware
         attn_mask = mask_tile_padding(attn_mask, ntok, npad, num_chunks)
-        attn_mask = ttnn.as_tensor(
+        attn_mask = ttnn.from_torch(
             attn_mask,
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,

--- a/models/tt_transformers/tt/multimodal/llama_vision_model.py
+++ b/models/tt_transformers/tt/multimodal/llama_vision_model.py
@@ -216,7 +216,7 @@ class CrossAttentionTransformer(torch.nn.Module):
             # TT vision_model
             vision_tokens = self.vision_model(stacked_images, aspect_ratios)
             # Back to torch
-            vision_tokens = ttnn.to_torch(vision_tokens, mesh_composer=ttnn.ConcatMeshToTensor(self.mesh_device, dim=0))
+            vision_tokens = ttnn.to_torch(ttnn.get_device_tensors(vision_tokens)[0])
             chunk_seq_len = self.configuration.vision_chunk_ntok
             # NOTE: slicing up to chunk_seq_len is necessary because padding information is lost by this point
             vision_tokens = (

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -243,6 +243,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             dispatch_metadata,
             mesh_workload.get_program_binary_status(mesh_device_id),
             std::pair<bool, int>(unicast_go_signals, num_virtual_eth_cores));
+
         if (sysmem_manager.get_bypass_mode()) {
             this->capture_program_trace_on_subgrid(
                 device_range, program_cmd_seq, dispatch_metadata.stall_first, dispatch_metadata.stall_before_program);


### PR DESCRIPTION
 - LLAMA Vision 11B prefill requires tilization on host
 - On main this is multi-threaded when async mode is enabled. On the TT-Mesh integration branch this is currently not the case, resulting in a performance regression
 - Multi-Thread Host Tilize using the thread-pool exposed by the `MeshDevice`
 - Additionally, the prefill step has a redundant all-gather on host (`ConcatMeshToTensor`) that reads all outputs of a device side all-gather, and discards all but the first shard. This is wasteful - we perform 7 unnecessary host untilize operations on a T3K
 - Read a single all-gather shard and untilize once