### PR TITLE
Throttle MM Perf

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1379,7 +1379,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         compute_defines["PACKER_L1_ACC"] = "1";
     }
 
-    bmm_op_utils::add_nops_in_matmul(compute_defines);
+    bmm_op_utils::add_nops_in_matmul(compute_defines, math_fidelity);
 
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/matmul/device/matmul_op.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -1377,6 +1378,9 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
     if (packer_l1_acc_en) {
         compute_defines["PACKER_L1_ACC"] = "1";
     }
+
+    bmm_op_utils::add_nops_in_matmul(compute_defines);
+
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);
     }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1379,7 +1379,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         compute_defines["PACKER_L1_ACC"] = "1";
     }
 
-    bmm_op_utils::throttle_mm_perf(compute_defines, math_fidelity);
+    bool tiny_tile_mm = false;  // assuming that matmul will be computed on full tiles, not tiny tiles
+    bmm_op_utils::throttle_mm_perf(device->arch(), total_num_cores, compute_defines, math_fidelity, tiny_tile_mm);
 
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -1379,7 +1379,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_sharded_
         compute_defines["PACKER_L1_ACC"] = "1";
     }
 
-    bmm_op_utils::add_nops_in_matmul(compute_defines, math_fidelity);
+    bmm_op_utils::throttle_mm_perf(compute_defines, math_fidelity);
 
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -602,7 +602,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         compute_defines["PACKER_L1_ACC"] = "1";
     }
 
-    bmm_op_utils::throttle_mm_perf(compute_defines, math_fidelity);
+    bool tiny_tile_mm = false;  // assuming that matmul will be computed on full tiles, not tiny tiles
+    bmm_op_utils::throttle_mm_perf(device->arch(), all_cores.num_cores(), compute_defines, math_fidelity, tiny_tile_mm);
 
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -602,7 +602,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         compute_defines["PACKER_L1_ACC"] = "1";
     }
 
-    bmm_op_utils::add_nops_in_matmul(compute_defines, math_fidelity);
+    bmm_op_utils::throttle_mm_perf(compute_defines, math_fidelity);
 
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -602,7 +602,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         compute_defines["PACKER_L1_ACC"] = "1";
     }
 
-    bmm_op_utils::add_nops_in_matmul(compute_defines);
+    bmm_op_utils::add_nops_in_matmul(compute_defines, math_fidelity);
 
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/matmul/device/matmul_op.hpp"
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -600,6 +601,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     if (packer_l1_acc) {
         compute_defines["PACKER_L1_ACC"] = "1";
     }
+
+    bmm_op_utils::add_nops_in_matmul(compute_defines);
 
     for (auto elem : compute_defines) {
         log_debug(LogOp, "compute_defines: {} = {}", elem.first, elem.second);

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1256,29 +1256,25 @@ void add_stagger_defines_if_needed(
 }
 
 void throttle_mm_perf(std::map<string, string>& mm_kernel_defines, MathFidelity fidelity) {
-    // Limit matmul op throughput by inserting NOP instruction every 3 MVMUL instructions
+    // Limit matmul op throughput by inserting NOP instructions every 2 MVMUL instructions
     const bool enable_throttle_mm_perf = std::getenv("TT_THROTTLE_MM_PERF");
     const uint32_t num_nops = enable_throttle_mm_perf ? std::stoi(std::getenv("TT_THROTTLE_MM_PERF")) : 0;
     if (enable_throttle_mm_perf) {
         if (num_nops == 3) {
             mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
-            log_warning(tt::LogOp, "Throttle matmul perf to max 50% by adding 3 NOPs every 3 instructions");
+            log_warning(tt::LogOp, "Throttle matmul perf to max 40% by adding 3 NOPs every 2 instructions");
         } else if (num_nops == 2) {
             mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
-            log_warning(tt::LogOp, "Throttle matmul perf to max 60% by adding 2 NOPs every 3 instructions");
+            log_warning(tt::LogOp, "Throttle matmul perf to max 50% by adding 2 NOPs every 2 instructions");
         } else if (num_nops == 1) {
             mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
-            log_warning(tt::LogOp, "Throttle matmul perf to max 75% by adding 1 NOP every 3 instructions");
+            log_warning(tt::LogOp, "Throttle matmul perf to max 67% by adding 1 NOP every 2 instructions");
         } else {
             log_warning(
                 tt::LogOp,
                 "Throttle matmul perf ignored: invalid number of NOPs requested - only 1, 2, and 3 are supported");
         }
     }
-    // if (fidelity != MathFidelity::LoFi) {
-    //     log_warning(
-    //         tt::LogOp, "Throttle matmul perf ignored: requested high-fidelity. Throttling enabled for LoFi only");
-    // }
 }
 
 }  // namespace bmm_op_utils

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1259,7 +1259,7 @@ void throttle_mm_perf(std::map<string, string>& mm_kernel_defines) {
     // Limit matmul op throughput by inserting NOP instruction ever 3 MVMUL instructions
     const bool enable_throttle_mm_perf = std::getenv("TT_THROTTLE_MM_PERF");
     if (enable_throttle_mm_perf) {
-        mm_kernel_defines["TT_THROTTLE_MM_PERF"] = "1";
+        mm_kernel_defines["THROTTLE_MM_PERF"] = "1";
         log_warning(tt::LogOp, "Throttle matmul perf to max 75% by adding NOPs as every 4th inst");
     }
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1255,25 +1255,49 @@ void add_stagger_defines_if_needed(
     }
 }
 
-void throttle_mm_perf(std::map<string, string>& mm_kernel_defines, MathFidelity fidelity) {
-    // Limit matmul op throughput by inserting NOP instructions every 2 MVMUL instructions
+void throttle_mm_perf(
+    const tt::ARCH arch,
+    const int num_cores,
+    std::map<string, string>& mm_kernel_defines,
+    MathFidelity fidelity,
+    bool tiny_tile_mm) {
+    // Empirically deduced di/dt problems appear for OPs calling matmul using more than 48 cores on WH_B0
+    constexpr uint32_t WH_B0_MM_MAX_CORES_NO_THROTTLE = 48;
+    // TODO: determine min core threshold for throttle to be needed on BH
+    constexpr uint32_t BH_MM_MAX_CORES_NO_THROTTLE = 0;
+    const bool mm_throttle_needed = (arch == tt::ARCH::WORMHOLE_B0 && num_cores > WH_B0_MM_MAX_CORES_NO_THROTTLE) ||
+                                    (arch == tt::ARCH::BLACKHOLE && num_cores > BH_MM_MAX_CORES_NO_THROTTLE);
+
+    // Limit matmul compute throughput by inserting NOP instructions between MVMUL instructions of matmul kernel
+    // This will slow down the OP if UNPACK/PACK threads are capable of feeding data sufficiently fast (MATH compute
+    // bound)
     const bool enable_throttle_mm_perf = std::getenv("TT_THROTTLE_MM_PERF");
-    const uint32_t num_nops = enable_throttle_mm_perf ? std::stoi(std::getenv("TT_THROTTLE_MM_PERF")) : 0;
-    if (enable_throttle_mm_perf) {
-        if (num_nops == 3) {
-            mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
-            log_warning(tt::LogOp, "Throttle matmul perf to max 40% by adding 3 NOPs every 2 instructions");
-        } else if (num_nops == 2) {
-            mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
-            log_warning(tt::LogOp, "Throttle matmul perf to max 50% by adding 2 NOPs every 2 instructions");
-        } else if (num_nops == 1) {
-            mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
-            log_warning(tt::LogOp, "Throttle matmul perf to max 67% by adding 1 NOP every 2 instructions");
+    const uint32_t throttle_level = enable_throttle_mm_perf ? std::stoi(std::getenv("TT_THROTTLE_MM_PERF")) : 0;
+    if (throttle_level && mm_throttle_needed) {
+        if (throttle_level == 5) {
+            mm_kernel_defines["THROTTLE_MM"] = std::to_string(throttle_level);
+            tt::log_info(tt::LogOp, "Throttle matmul perf to max 33%");
+        } else if (throttle_level == 4) {
+            mm_kernel_defines["THROTTLE_MM"] = std::to_string(throttle_level);
+            tt::log_info(tt::LogOp, "Throttle matmul perf to max 40%");
+        } else if (throttle_level == 3) {
+            mm_kernel_defines["THROTTLE_MM"] = std::to_string(throttle_level);
+            tt::log_info(tt::LogOp, "Throttle matmul perf to max 50%");
+        } else if (throttle_level == 2) {
+            mm_kernel_defines["THROTTLE_MM"] = std::to_string(throttle_level);
+            tt::log_info(tt::LogOp, "Throttle matmul perf to max 67%");
+        } else if (throttle_level == 1) {
+            mm_kernel_defines["THROTTLE_MM"] = std::to_string(throttle_level);
+            tt::log_info(tt::LogOp, "Throttle matmul perf to max 73%");
         } else {
-            log_warning(
+            log_error(
                 tt::LogOp,
-                "Throttle matmul perf ignored: invalid number of NOPs requested - only 1, 2, and 3 are supported");
+                "Throttle matmul perf ignored: invalid number of NOPs requested - only {{1,2,3,4,5}} are supported");
         }
+    } else if (mm_throttle_needed && arch == tt::ARCH::WORMHOLE_B0 && fidelity == MathFidelity::LoFi && !tiny_tile_mm) {
+        // Default throttle to level 1 for WH_B0 if LoFi math fidelity and not tiny tiles
+        mm_kernel_defines["THROTTLE_MM"] = "1";
+        tt::log_info(tt::LogOp, "Throttle matmul perf to max 73% for LoFi + full tile size");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1255,6 +1255,15 @@ void add_stagger_defines_if_needed(
     }
 }
 
+void throttle_mm_perf(std::map<string, string>& mm_kernel_defines) {
+    // Limit matmul op throughput by inserting NOP instruction ever 3 MVMUL instructions
+    const bool enable_throttle_mm_perf = std::getenv("TT_THROTTLE_MM_PERF");
+    if (enable_throttle_mm_perf) {
+        mm_kernel_defines["TT_THROTTLE_MM_PERF"] = "1";
+        log_warning(tt::LogOp, "Throttle matmul perf to max 75% by adding NOPs as every 4th inst");
+    }
+}
+
 }  // namespace bmm_op_utils
 
 namespace ttnn {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1256,26 +1256,29 @@ void add_stagger_defines_if_needed(
 }
 
 void throttle_mm_perf(std::map<string, string>& mm_kernel_defines, MathFidelity fidelity) {
-    // Limit matmul op throughput by inserting NOP instruction ever 3 MVMUL instructions
+    // Limit matmul op throughput by inserting NOP instruction every 3 MVMUL instructions
     const bool enable_throttle_mm_perf = std::getenv("TT_THROTTLE_MM_PERF");
     const uint32_t num_nops = enable_throttle_mm_perf ? std::stoi(std::getenv("TT_THROTTLE_MM_PERF")) : 0;
-    if (enable_throttle_mm_perf && fidelity == MathFidelity::LoFi) {
-        if (num_nops == 2) {
+    if (enable_throttle_mm_perf) {
+        if (num_nops == 3) {
             mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
-            log_warning(tt::LogOp, "Throttle matmul perf to max 50% by adding 2 NOPs every 2 instructions");
+            log_warning(tt::LogOp, "Throttle matmul perf to max 50% by adding 3 NOPs every 3 instructions");
+        } else if (num_nops == 2) {
+            mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
+            log_warning(tt::LogOp, "Throttle matmul perf to max 60% by adding 2 NOPs every 3 instructions");
         } else if (num_nops == 1) {
             mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
             log_warning(tt::LogOp, "Throttle matmul perf to max 75% by adding 1 NOP every 3 instructions");
         } else {
             log_warning(
                 tt::LogOp,
-                "Throttle matmul perf ignored: invalid number of NOPs requested - only 1 and 2 are supported");
+                "Throttle matmul perf ignored: invalid number of NOPs requested - only 1, 2, and 3 are supported");
         }
     }
-    if (fidelity != MathFidelity::LoFi) {
-        log_warning(
-            tt::LogOp, "Throttle matmul perf ignored: requested high-fidelity. Throttling enabled for LoFi only");
-    }
+    // if (fidelity != MathFidelity::LoFi) {
+    //     log_warning(
+    //         tt::LogOp, "Throttle matmul perf ignored: requested high-fidelity. Throttling enabled for LoFi only");
+    // }
 }
 
 }  // namespace bmm_op_utils

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1255,12 +1255,26 @@ void add_stagger_defines_if_needed(
     }
 }
 
-void throttle_mm_perf(std::map<string, string>& mm_kernel_defines) {
+void throttle_mm_perf(std::map<string, string>& mm_kernel_defines, MathFidelity fidelity) {
     // Limit matmul op throughput by inserting NOP instruction ever 3 MVMUL instructions
     const bool enable_throttle_mm_perf = std::getenv("TT_THROTTLE_MM_PERF");
-    if (enable_throttle_mm_perf) {
-        mm_kernel_defines["THROTTLE_MM_PERF"] = "1";
-        log_warning(tt::LogOp, "Throttle matmul perf to max 75% by adding NOPs as every 4th inst");
+    const uint32_t num_nops = enable_throttle_mm_perf ? std::stoi(std::getenv("TT_THROTTLE_MM_PERF")) : 0;
+    if (enable_throttle_mm_perf && fidelity == MathFidelity::LoFi) {
+        if (num_nops == 2) {
+            mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
+            log_warning(tt::LogOp, "Throttle matmul perf to max 50% by adding 2 NOPs every 2 instructions");
+        } else if (num_nops == 1) {
+            mm_kernel_defines["MM_ADD_NOPS"] = std::to_string(num_nops);
+            log_warning(tt::LogOp, "Throttle matmul perf to max 75% by adding 1 NOP every 3 instructions");
+        } else {
+            log_warning(
+                tt::LogOp,
+                "Throttle matmul perf ignored: invalid number of NOPs requested - only 1 and 2 are supported");
+        }
+    }
+    if (fidelity != MathFidelity::LoFi) {
+        log_warning(
+            tt::LogOp, "Throttle matmul perf ignored: requested high-fidelity. Throttling enabled for LoFi only");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -260,5 +260,6 @@ std::tuple<uint32_t, uint32_t> get_matmul_subblock_params(
 
 void add_stagger_defines_if_needed(
     const tt::ARCH arch, const int num_cores, std::map<string, string>& mm_kernel_defines);
+void throttle_mm_perf(std::map<string, string>& mm_kernel_defines);
 
 }  // namespace bmm_op_utils

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -260,6 +260,24 @@ std::tuple<uint32_t, uint32_t> get_matmul_subblock_params(
 
 void add_stagger_defines_if_needed(
     const tt::ARCH arch, const int num_cores, std::map<string, string>& mm_kernel_defines);
-void throttle_mm_perf(std::map<string, string>& mm_kernel_defines, MathFidelity fidelity);
+
+/*
+ * Optionally limit matmul compute throughput by inserting NOP instructions between MVMUL instructions of matmul kernel
+ * This will slow down the OP if UNPACK/PACK threads are capable of feeding data sufficiently fast (MATH compute bound)
+ *
+ * Enabled by setting env var TT_THROTTLE_MM_PERF to value in range {1,2,3,4,5}
+ * Each value corresponds to level of throttling as:
+ * Level 1: throttle to 73% of max
+ * Level 2: throttle to 67% of max
+ * Level 3: throttle to 50% of max
+ * Level 4: throttle to 40% of max
+ * Level 5: throttle to 33% of max
+ */
+void throttle_mm_perf(
+    const tt::ARCH arch,
+    const int num_cores,
+    std::map<string, string>& mm_kernel_defines,
+    MathFidelity fidelity,
+    bool tiny_tile_mm);
 
 }  // namespace bmm_op_utils

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -260,6 +260,6 @@ std::tuple<uint32_t, uint32_t> get_matmul_subblock_params(
 
 void add_stagger_defines_if_needed(
     const tt::ARCH arch, const int num_cores, std::map<string, string>& mm_kernel_defines);
-void throttle_mm_perf(std::map<string, string>& mm_kernel_defines);
+void throttle_mm_perf(std::map<string, string>& mm_kernel_defines, MathFidelity fidelity);
 
 }  // namespace bmm_op_utils

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -433,6 +433,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
 
     if (in1_is_sharded) {
         mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
@@ -1269,6 +1270,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
 
     if (in0_is_sharded) {
         mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
@@ -1915,6 +1917,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
 
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMWrite(device->arch());

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -433,7 +433,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
+    bool tiny_tile_mm =
+        !(in0_tile.get_height() == TILE_HEIGHT && in0_tile.get_width() == TILE_WIDTH &&
+          in1_tile.get_height() == TILE_HEIGHT && in1_tile.get_width() == TILE_WIDTH);
+    bmm_op_utils::throttle_mm_perf(device->arch(), num_cores, mm_kernel_defines, math_fidelity, tiny_tile_mm);
 
     if (in1_is_sharded) {
         mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
@@ -1270,7 +1273,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
+    bool tiny_tile_mm =
+        !(in0_tile.get_height() == TILE_HEIGHT && in0_tile.get_width() == TILE_WIDTH &&
+          in1_tile.get_height() == TILE_HEIGHT && in1_tile.get_width() == TILE_WIDTH);
+    bmm_op_utils::throttle_mm_perf(device->arch(), num_cores, mm_kernel_defines, math_fidelity, tiny_tile_mm);
 
     if (in0_is_sharded) {
         mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
@@ -1917,7 +1923,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
+    bool tiny_tile_mm =
+        !(in0_tile.get_height() == TILE_HEIGHT && in0_tile.get_width() == TILE_WIDTH &&
+          in1_tile.get_height() == TILE_HEIGHT && in1_tile.get_width() == TILE_WIDTH);
+    bmm_op_utils::throttle_mm_perf(device->arch(), num_cores, mm_kernel_defines, math_fidelity, tiny_tile_mm);
 
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMWrite(device->arch());

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -433,7 +433,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
 
     if (in1_is_sharded) {
         mm_kernel_in1_sender_writer_defines["IN1_SHARDED"] = "1";
@@ -1270,7 +1270,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
 
     if (in0_is_sharded) {
         mm_kernel_in0_sender_defines["IN0_SHARDED"] = "1";
@@ -1917,7 +1917,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
         mm_kernel_defines["FP32_DEST_ACC_EN"] = "1";
     }
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
 
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::GetPreferredNOCForDRAMWrite(device->arch());

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -524,7 +524,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), cores.size(), mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
+    bool tiny_tile_mm =
+        !(in0_tile.get_height() == TILE_HEIGHT && in0_tile.get_width() == TILE_WIDTH &&
+          in1_tile.get_height() == TILE_HEIGHT && in1_tile.get_width() == TILE_WIDTH);
+    bmm_op_utils::throttle_mm_perf(device->arch(), cores.size(), mm_kernel_defines, math_fidelity, tiny_tile_mm);
 
     if (in0_receiver_interleaved.num_cores() == 0) {
         mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -524,6 +524,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), cores.size(), mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
 
     if (in0_receiver_interleaved.num_cores() == 0) {
         mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -524,7 +524,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), cores.size(), mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
 
     if (in0_receiver_interleaved.num_cores() == 0) {
         mm_kernel_in0_sender_interleaved_defines["SKIP_MCAST"] = "1";

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -224,7 +224,10 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
+    bool tiny_tile_mm =
+        !(in0_tile.get_height() == TILE_HEIGHT && in0_tile.get_width() == TILE_WIDTH &&
+          in1_tile.get_height() == TILE_HEIGHT && in1_tile.get_width() == TILE_WIDTH);
+    bmm_op_utils::throttle_mm_perf(device->arch(), num_cores, mm_kernel_defines, math_fidelity, tiny_tile_mm);
 
     // Create compute kernel
     auto mm_kernel_group_1_id = tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -224,6 +224,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
 
     // Create compute kernel
     auto mm_kernel_group_1_id = tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_optimized_program_factory.cpp
@@ -224,7 +224,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program(
     }
 
     bmm_op_utils::add_stagger_defines_if_needed(device->arch(), num_cores, mm_kernel_defines);
-    bmm_op_utils::throttle_mm_perf(mm_kernel_defines);
+    bmm_op_utils::throttle_mm_perf(mm_kernel_defines, math_fidelity);
 
     // Create compute kernel
     auto mm_kernel_group_1_id = tt_metal::CreateKernel(


### PR DESCRIPTION
### Problem description
Power draw during matmul workload can be lowered by adding NOPs into the llk. Here we have enabled the throttling of MM workloads by this method, to various degrees.

### What's changed
This feature can be enabled by setting env variable `TT_THROTTLE_MM_PERF=1, 2, 3, 4, 5`.
Value of 1 produces 73% intensity MM, 2 produces 67% intensity MM, 3 produces 50% intensity MM, 4 produces 40% intensity MM, 5 produces 33% intensity MM.
This currently only works for full tile MM (32x32), but should work for all math fidelities.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (does hurt perf due to throttling LoFi cases)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)