### PR TITLE
#20037: Fix MCast in Conv2D Width Sharded

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -158,7 +158,6 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         all_cores = input_cores;
     }
     CoreRange all_reader_cores = all_cores.bounding_box();
-    log_debug("Conv2D Width Sharded All Reader Cores = {}", all_reader_cores);
     auto input_num_cores = input_cores.num_cores();
     auto output_num_cores = output_cores.num_cores();
 
@@ -547,6 +546,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         log_debug(LogOp, "fp32_dest_acc_en: {}", fp32_dest_acc_en);
         log_debug(LogOp, "packer_l1_acc: {}", packer_l1_acc);
         log_debug(LogOp, "all_cores: {}", all_cores.str());
+        log_debug(LogOp, "all_reader_cores: {}", all_reader_cores.str());
     }
 
     std::string compute_kernel_path =
@@ -887,7 +887,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     if (bias) {
         bias_base_address = bias.value().buffer()->address();
     }
-    auto total_num_cores = std::max(input_num_cores, output_num_cores);
+    auto total_num_active_cores = std::max(input_num_cores, output_num_cores);
+    auto total_num_cores = all_reader_cores.size();
     for (uint32_t core_index = 0; core_index < total_num_cores; core_index++) {
         uint32_t core_x = core_index % full_core_grid.x;
         uint32_t core_y = core_index / full_core_grid.x;
@@ -904,14 +905,18 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         rt_args.insert(rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
 
         SetRuntimeArgs(program, act_kernel_id, CoreCoord(core_x, core_y), rt_args);
-        SetRuntimeArgs(
-            program,
-            weights_kernel_id,
-            CoreCoord(core_x, core_y),
-            {core_index * weight_block_w_ntiles,
-             b.buffer()->address(),
-             bias_base_address,
-             (uint32_t)(core_index < output_num_cores)});
+
+        // Weights kernel is not placed on inactive cores.
+        if (core_index < total_num_active_cores) {
+            SetRuntimeArgs(
+                program,
+                weights_kernel_id,
+                CoreCoord(core_x, core_y),
+                {core_index * weight_block_w_ntiles,
+                 b.buffer()->address(),
+                 bias_base_address,
+                 (uint32_t)(core_index < output_num_cores)});
+        }
     }
 
     // Capture conv_reader_indices_buffer to cache this with the program

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -157,6 +157,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     if (input_cores.num_cores() > output_cores.num_cores()) {
         all_cores = input_cores;
     }
+    CoreRange all_reader_cores = all_cores.bounding_box();
+    log_debug("Conv2D Width Sharded All Reader Cores = {}", all_reader_cores);
     auto input_num_cores = input_cores.num_cores();
     auto output_num_cores = output_cores.num_cores();
 
@@ -814,6 +816,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
         (uint32_t)act_mcast_end.y,
         (uint32_t)act_block_num_tiles * tt_metal::detail::TileSize(tilized_act_df),
         (uint32_t)output_num_cores,
+        (uint32_t)all_reader_cores.size(),
         (uint32_t)cb_indices.act_cb,
         (uint32_t)cb_indices.weight_cb,
         (uint32_t)cb_indices.sharded_act_cb,
@@ -842,7 +845,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
     auto act_kernel_id = CreateKernel(
         program,
         activation_kernel_path,
-        all_cores,
+        all_reader_cores,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt::tt_metal::NOC::RISCV_0_default,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -60,13 +60,15 @@ void kernel_main() {
     constexpr uint32_t act_mcast_dest_noc_end_y = get_compile_time_arg_val(18);
     constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(19);
     constexpr uint32_t num_output_cores = get_compile_time_arg_val(20);
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
-    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(22);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(24);
-    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(25);
-    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(26);
-    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(27);
+    constexpr uint32_t num_reader_cores = get_compile_time_arg_val(21);
+
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
+    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(26);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(27);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(28);
 
     constexpr uint32_t num_mcast_cores = num_input_cores > num_output_cores ? num_input_cores : num_output_cores;
     uint32_t i = 0;  // Runtime arg index
@@ -90,6 +92,9 @@ void kernel_main() {
     // Equivalent to Core Index.
     uint32_t this_core_id = this_core_x + (num_cores_x * this_core_y);
 
+    if (this_core_id >= num_mcast_cores) {
+        return;
+    }
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_reader_indices));
 
@@ -206,13 +211,14 @@ void kernel_main() {
                         tilized_act_start_address,
                         act_multicast_data_addr,
                         act_mcast_sender_size_bytes,
-                        num_mcast_cores,
+                        num_reader_cores,
                         false,
                         false);
 
                     // Note: no need for write barrier, since these two multicasts are done on the same noc id and same
                     // vc even though cmd bufs are different Also, this only works because we are setting VCs statically
                     // (using NOC_CMD_STATIC_VC).
+
 #ifdef ARCH_BLACKHOLE
                     // On Blackhole the flush is needed because the commands go into separate cmd buffer FIFOs and may
                     // not be sent in order they are issued
@@ -222,7 +228,7 @@ void kernel_main() {
                     noc_semaphore_set_multicast_loopback_src(
                         act_mcast_sender_semaphore_valid_addr,
                         act_mcast_receiver_semaphore_noc_addr,
-                        num_mcast_cores,
+                        num_reader_cores,
                         false,
                         false);
 
@@ -257,4 +263,6 @@ void kernel_main() {
             cb_pop_front(tilized_in0_cb_id, act_block_num_tiles);
         }
     }
+    noc_async_read_barrier();
+    noc_async_write_barrier();
 }


### PR DESCRIPTION
### Ticket
#20037 

### Problem description
Conv2d Width Sharded fails because not all multi-cast rx cores had kernels placed on them.

### What's changed
Places kernels on all mcast rx cores. Cores that don't have an input or output return early.


### ToDo
Some Width Sharded Conv2Ds still fail due to L1 corruption at address 0. This is yet to be debugged. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes