### PR TITLE
feat: add dest accumulation config to SFPU reciprocal

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -17,9 +17,9 @@ sfpi_inline vFloat sfpu_reciprocal(const vFloat in) {
     return _sfpu_reciprocal_<max_iter>(in);
 }
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
 inline void calculate_reciprocal() {
-    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS>(ITERATIONS);
+    _calculate_reciprocal_<APPROXIMATION_MODE, ITERATIONS, is_fp32_dest_acc_en>(ITERATIONS);
 }
 
 template <bool APPROXIMATION_MODE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_recip.h
@@ -12,10 +12,10 @@ namespace ckernel {
 
 // New LLK SFPU APIs
 
-template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false /*unused*/>
+template <bool APPROXIMATE, bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_unary_sfpu_reciprocal(uint dst_index, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_reciprocal<APPROXIMATE>, dst_index, vector_mode);
+        ckernel::sfpu::calculate_reciprocal<APPROXIMATE, 8, is_fp32_dest_acc_en>, dst_index, vector_mode);
 }
 
 template <bool APPROXIMATE>


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19766

### Problem description
Reciprocal operation in Blackhole doesn't have support for `is_fp32_dest_acc_en`, which causes precision difference compared to WH and BH output.

### What's changed
This PR adds the missing support.

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14206569426) CI passes (if applicable)