### PR TITLE
Support continuous batching for Llama70B-TG 

### DIFF
--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -182,6 +182,19 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
+        (  # Repeat-5 Batch-32 run (Throughput) - 32 users, small prompt
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            False,  # ci_only
+        ),
         (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
@@ -251,6 +264,7 @@ def create_tt_model(
     ids=[
         "batch-1",  # latency
         "batch-32",  # throughput
+        "repeat5-batch-32",  # throughput with 5 repeat batches
         "long-context",  # max-length
         "reasoning-1",  # reasoning
         "ci-1",  # CI batch 1

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -408,8 +408,8 @@ def test_demo_text(
 
         # when doing repeating batches, set kv-caches to zero, to avoid context leaking
         if batch_idx != 0:
+            model.switch_mode("prefill")
             for layer in model.layers:
-                model.switch_mode("prefill")
                 k_cache, v_cache = layer.attention.layer_past
                 k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
                 v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -201,6 +201,11 @@ def test_llama_decoder_inference(
         # Get cos/sin matrices for the current position of each user
         rot_mats = rope_setup.get_rot_mats(current_pos)
         tt_pf = prefetcher_setup.get_input_tensors()
+        prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
+            mesh_device,
+            prefetcher_setup.sender_receiver_mapping,
+            prefetcher_setup.global_cb_size,
+        )
         ttnn.dram_prefetcher(
             tt_pf,
             num_layers=1,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -201,6 +201,7 @@ def test_llama_decoder_inference(
         # Get cos/sin matrices for the current position of each user
         rot_mats = rope_setup.get_rot_mats(current_pos)
         tt_pf = prefetcher_setup.get_input_tensors()
+        # Explicitly allocate global CB to avoid memory fragmentation
         prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
             mesh_device,
             prefetcher_setup.sender_receiver_mapping,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -137,7 +137,11 @@ def test_llama_decoder_same(
     outs = []
     for i in range(generation_length):
         logger.info(f"[Decoder] Generating token {i}")
-
+        prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
+            mesh_device,
+            prefetcher_setup.sender_receiver_mapping,
+            prefetcher_setup.global_cb_size,
+        )
         ttnn.dram_prefetcher(
             tt_pf,
             num_layers=1,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -137,6 +137,7 @@ def test_llama_decoder_same(
     outs = []
     for i in range(generation_length):
         logger.info(f"[Decoder] Generating token {i}")
+        # Explicitly allocate global CB to avoid memory fragmentation
         prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
             mesh_device,
             prefetcher_setup.sender_receiver_mapping,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -179,6 +179,7 @@ def test_llama_attention_inference(
             mesh_shape=model_args.cluster_shape,
         ),
     )
+    # Explicitly allocate global CB to avoid memory fragmentation
     prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
         mesh_device,
         prefetcher_setup.sender_receiver_mapping,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -179,7 +179,11 @@ def test_llama_attention_inference(
             mesh_shape=model_args.cluster_shape,
         ),
     )
-
+    prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
+        mesh_device,
+        prefetcher_setup.sender_receiver_mapping,
+        prefetcher_setup.global_cb_size,
+    )
     for i in range(generation_length):
         # 70B attention block typically sees tensors with mean 0 and std 0.03 - 0.05 in layer 1
         pt_attention_input = torch.randn(batch_size, seq_len, model_args.dim) * 0.05

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -91,6 +91,11 @@ def test_llama_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache
     prev_pcc = None
 
     logger.info("Run Llama_MLP_PF")
+    prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
+        mesh_device,
+        prefetcher_setup.sender_receiver_mapping,
+        prefetcher_setup.global_cb_size,
+    )
     for i in range(20):
         ttnn.dram_prefetcher(
             prefetcher_setup.get_input_tensors(),

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -91,6 +91,7 @@ def test_llama_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache
     prev_pcc = None
 
     logger.info("Run Llama_MLP_PF")
+    # Explicitly allocate global CB to avoid memory fragmentation
     prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
         mesh_device,
         prefetcher_setup.sender_receiver_mapping,

--- a/models/demos/llama3_subdevices/tt/generator.py
+++ b/models/demos/llama3_subdevices/tt/generator.py
@@ -49,13 +49,13 @@ class Generator:
             self.model = self.model[0]
 
     def prefill_forward_text(self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None):
-        if hasattr(self, "trace_id"):
-            ttnn.release_trace(self.mesh_device, self.trace_id)
-            del self.trace_id
+        # if hasattr(self, "trace_id"):
+        #     ttnn.release_trace(self.mesh_device, self.trace_id)
+        #     del self.trace_id
 
-        if hasattr(self, "trace_id_text"):
-            ttnn.release_trace(self.mesh_device, self.trace_id_text)
-            del self.trace_id_text
+        # if hasattr(self, "trace_id_text"):
+        #     ttnn.release_trace(self.mesh_device, self.trace_id_text)
+        #     del self.trace_id_text
         if self.model.is_prefill_setup is False:
             self.model.switch_mode("prefill")
         kv_cache = kv_cache[0]

--- a/models/demos/llama3_subdevices/tt/generator.py
+++ b/models/demos/llama3_subdevices/tt/generator.py
@@ -49,13 +49,6 @@ class Generator:
             self.model = self.model[0]
 
     def prefill_forward_text(self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None):
-        # if hasattr(self, "trace_id"):
-        #     ttnn.release_trace(self.mesh_device, self.trace_id)
-        #     del self.trace_id
-
-        # if hasattr(self, "trace_id_text"):
-        #     ttnn.release_trace(self.mesh_device, self.trace_id_text)
-        #     del self.trace_id_text
         if self.model.is_prefill_setup is False:
             self.model.switch_mode("prefill")
         kv_cache = kv_cache[0]

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -4,6 +4,7 @@
 
 import ttnn
 import torch
+import gc
 from tqdm import tqdm
 from models.demos.llama3_subdevices.tt.llama_decoder import TtTransformerBlock
 from models.common.rmsnorm import RMSNorm
@@ -62,6 +63,9 @@ class TtTransformer(LightweightModule):
 
         self.is_prefill_setup = False
         self.is_decode_setup = False
+        self.prefetcher_setup = None
+        self.mesh_sub_device_manager_id_decode = None
+        self.mesh_sub_device_manager_id_prefill = None
 
         if mode == "decode":
             self.setup_decode()
@@ -118,33 +122,38 @@ class TtTransformer(LightweightModule):
         if mode == "decode":
             self.tt_tensors = self.prefetcher_setup.get_input_tensors()
 
-    def setup_prefill(self):
+    def setup_prefill(self, mesh_sub_device_manager_id_prefill=None):
         self.prefetcher_setup = TtLlamaPrefetcherSetup(
-            self.mesh_device, n_tensors=0, n_layers=self.n_layers, mode="prefill"
+            self.mesh_device,
+            n_tensors=0,
+            n_layers=self.n_layers,
+            mode="prefill",
+            mesh_sub_device_manager_id_prefill=mesh_sub_device_manager_id_prefill,
         )
+        self.mesh_sub_device_manager_id_prefill = self.prefetcher_setup.mesh_sub_device_manager_id_prefill
         self.mesh_device.set_sub_device_stall_group([self.prefetcher_setup.worker_sub_device_id])
-        self.tt_ccl = TT_CCL(self.mesh_device, self.args, self.prefetcher_setup.worker_sub_device_id, mode="prefill")
-        # self.prefetcher_setup = None
-        # self.tt_ccl = TT_CCL(
-        #     self.mesh_device,
-        #     self.args,
-        #     None,
-        #     mode="prefill",
-        #     enable_persistent_fabric=False,
-        #     create_persistent_fabric=False,
-        #     teardown_persistent_fabric=False,
-        # )
+        if mesh_sub_device_manager_id_prefill is None:
+            self.tt_ccl = TT_CCL(
+                self.mesh_device, self.args, self.prefetcher_setup.worker_sub_device_id, mode="prefill"
+            )
+        else:
+            self.tt_ccl = self.tt_ccl_prefill
 
-    def setup_decode(self):
+    def setup_decode(self, mesh_sub_device_manager_id_decode=None):
         self.prefetcher_setup = TtLlamaPrefetcherSetup(
             self.mesh_device,
             n_tensors=5,
             n_layers=self.n_layers,
+            mesh_sub_device_manager_id_decode=mesh_sub_device_manager_id_decode,
         )
+        self.mesh_sub_device_manager_id_decode = self.prefetcher_setup.mesh_sub_device_manager_id_decode
         self.mesh_device.set_sub_device_stall_group(
             [self.prefetcher_setup.prefetcher_sub_device_id, self.prefetcher_setup.worker_sub_device_id]
         )
-        self.tt_ccl = TT_CCL(self.mesh_device, self.args, self.prefetcher_setup.worker_sub_device_id)
+        if mesh_sub_device_manager_id_decode is None:
+            self.tt_ccl = TT_CCL(self.mesh_device, self.args, self.prefetcher_setup.worker_sub_device_id)
+        else:
+            self.tt_ccl = self.tt_ccl_decode
 
     def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None):
         """
@@ -315,7 +324,7 @@ class TtTransformer(LightweightModule):
             tt_out = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).float()
         else:
             tt_out = ttnn.to_torch(tt_out).float()
-        tt_out = tt_out[:, :, :B, : self.vocab_size].view(B, S, -1)
+        tt_out = tt_out[:, :, :B, : self.vocab_size].reshape(B, S, -1)
         return tt_out
 
     def ttnn_prefill_forward(
@@ -376,7 +385,12 @@ class TtTransformer(LightweightModule):
 
         # Gather the output across all devices and untilize the tensor (for argmax)
         tt_logits = self.tt_ccl.line_all_gather(
-            tt_logits[0], dim=3, num_links=2, cluster_axis=0, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            tt_logits[0],
+            dim=3,
+            num_links=2,
+            cluster_axis=0,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            buffer_key="SAMPLING",
         )
 
         tt_logits = ttnn.untilize(tt_logits, use_multicore=True, sub_core_grids=sub_core_grids)
@@ -396,18 +410,11 @@ class TtTransformer(LightweightModule):
         if mode == "decode":
             if self.is_prefill_setup:
                 self.tt_ccl.close()
-                del self.tt_ccl
-                if self.prefetcher_setup is not None:
-                    self.mesh_device.clear_loaded_sub_device_manager()
-                    self.mesh_device.remove_sub_device_manager(self.prefetcher_setup.mesh_sub_device_manager_id)
-                    del self.prefetcher_setup
-                ttnn.synchronize_device(self.mesh_device)
+                self.tt_ccl_prefill = self.tt_ccl
                 self.is_prefill_setup = False
-                self.mesh_device.disable_and_clear_program_cache()
-                self.mesh_device.enable_program_cache()
 
             if self.is_decode_setup is False:
-                self.setup_decode()
+                self.setup_decode(self.mesh_sub_device_manager_id_decode)
                 self.is_decode_setup = True
                 # prefetch
                 for layer in self.layers:
@@ -415,20 +422,22 @@ class TtTransformer(LightweightModule):
                 self.norm.tt_ccl = self.tt_ccl
                 self.lm_head.tt_ccl = self.tt_ccl
                 self.tt_tensors = self.prefetcher_setup.get_input_tensors()
+                self.prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
+                    self.mesh_device,
+                    self.prefetcher_setup.sender_receiver_mapping,
+                    self.prefetcher_setup.global_cb_size,
+                )
 
         else:
             if self.is_decode_setup:
+                del self.prefetcher_setup.global_circular_buffer
+                gc.collect()
                 self.tt_ccl.close()
-                del self.tt_ccl
-                if self.prefetcher_setup is not None:
-                    self.mesh_device.clear_loaded_sub_device_manager()
-                    self.mesh_device.remove_sub_device_manager(self.prefetcher_setup.mesh_sub_device_manager_id)
-                    del self.prefetcher_setup
-                ttnn.synchronize_device(self.mesh_device)
+                self.tt_ccl_decode = self.tt_ccl
                 self.is_decode_setup = False
 
             if self.is_prefill_setup is False:
-                self.setup_prefill()
+                self.setup_prefill(self.mesh_sub_device_manager_id_prefill)
                 self.is_prefill_setup = True
                 for layer in self.layers:
                     layer.prefetch(self.prefetcher_setup, self.tt_ccl)
@@ -449,6 +458,12 @@ class TtTransformer(LightweightModule):
         kv_cache=None,
     ):
         if mode == "decode":
+            if self.prefetcher_setup.global_circular_buffer is None:
+                self.prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
+                    self.mesh_device,
+                    self.prefetcher_setup.sender_receiver_mapping,
+                    self.prefetcher_setup.global_cb_size,
+                )
             garbage_tensor = ttnn.dram_prefetcher(
                 self.tt_tensors,
                 num_layers=self.n_layers,

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -422,6 +422,7 @@ class TtTransformer(LightweightModule):
                 self.norm.tt_ccl = self.tt_ccl
                 self.lm_head.tt_ccl = self.tt_ccl
                 self.tt_tensors = self.prefetcher_setup.get_input_tensors()
+                # Re-create global CB for decode (if it was not already created)
                 self.prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
                     self.mesh_device,
                     self.prefetcher_setup.sender_receiver_mapping,
@@ -431,7 +432,7 @@ class TtTransformer(LightweightModule):
         else:
             if self.is_decode_setup:
                 del self.prefetcher_setup.global_circular_buffer
-                gc.collect()
+                gc.collect()  # This will also release the traces (inside generator.py)
                 self.tt_ccl.close()
                 self.tt_ccl_decode = self.tt_ccl
                 self.is_decode_setup = False

--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -101,7 +101,7 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             #     self.mesh_device, self.sender_receiver_mapping, self.global_cb_size
             # )
             # logger.info(f"GlobalCB size {self.global_cb_size}")
-            self.global_circular_buffer = None
+            self.global_circular_buffer = None  # Global CB will only be allocated before decode runs
             self.prefetcher_sub_device = ttnn.SubDevice([self.sender_core_range_set])
             self.worker_sub_device = ttnn.SubDevice([self.worker_cores_range_set])
             if mesh_sub_device_manager_id_decode is None:

--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -10,6 +10,8 @@ from tests.ttnn.unit_tests.operations.ccl.test_ccl_common import (
 )
 from tests.ttnn.unit_tests.operations.prefetcher_common import get_core_ranges
 
+global_tt_tensor_address = None
+
 
 def get_buffer_address(tensor):
     addr = []
@@ -21,7 +23,15 @@ def get_buffer_address(tensor):
 
 
 class TtLlamaPrefetcherSetup(LightweightModule):
-    def __init__(self, mesh_device, n_tensors, n_layers, mode="decode"):
+    def __init__(
+        self,
+        mesh_device,
+        n_tensors,
+        n_layers,
+        mode="decode",
+        mesh_sub_device_manager_id_prefill=None,
+        mesh_sub_device_manager_id_decode=None,
+    ):
         """
         - sub devices
         - global cb
@@ -62,10 +72,19 @@ class TtLlamaPrefetcherSetup(LightweightModule):
 
         if mode == "prefill":
             self.all_sub_device = ttnn.SubDevice([self.all_core_range_set])
-            mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
-                mesh_device, [self.all_sub_device], 0, 0, True
-            )
-            self.mesh_sub_device_manager_id = mesh_sub_device_manager_id
+            if mesh_sub_device_manager_id_prefill is None:
+                mesh_sub_device_manager_id_prefill = create_and_load_sub_device_manager_with_fabric_interface(
+                    mesh_device, [self.all_sub_device], 0, 0, True
+                )
+            else:
+                mesh_device.load_sub_device_manager(mesh_sub_device_manager_id_prefill)
+                ttnn.initialize_edm_fabric(
+                    mesh_device,
+                    wrap_fabric_around_mesh=False,
+                    context_switch_interval_override=None,
+                    topology=ttnn.Topology.Linear,
+                )
+            self.mesh_sub_device_manager_id_prefill = mesh_sub_device_manager_id_prefill
             self.all_sub_device_id = ttnn.SubDeviceId(0)
             self.worker_sub_device_id = self.all_sub_device_id
         else:
@@ -78,17 +97,26 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             # TODO: Above calculation is not accurate, need to find a better lower bound
             self.global_cb_size = 600 * 1088
             self.sender_receiver_mapping = list(zip(self.all_sender_cores, self.all_receiver_cores))
-            self.global_circular_buffer = ttnn.create_global_circular_buffer(
-                self.mesh_device, self.sender_receiver_mapping, self.global_cb_size
-            )
-            logger.info(f"GlobalCB size {self.global_cb_size}")
-
+            # self.global_circular_buffer = ttnn.create_global_circular_buffer(
+            #     self.mesh_device, self.sender_receiver_mapping, self.global_cb_size
+            # )
+            # logger.info(f"GlobalCB size {self.global_cb_size}")
+            self.global_circular_buffer = None
             self.prefetcher_sub_device = ttnn.SubDevice([self.sender_core_range_set])
             self.worker_sub_device = ttnn.SubDevice([self.worker_cores_range_set])
-            mesh_sub_device_manager_id = create_and_load_sub_device_manager_with_fabric_interface(
-                mesh_device, [self.prefetcher_sub_device, self.worker_sub_device], 1, 0, True
-            )
-            self.mesh_sub_device_manager_id = mesh_sub_device_manager_id
+            if mesh_sub_device_manager_id_decode is None:
+                mesh_sub_device_manager_id_decode = create_and_load_sub_device_manager_with_fabric_interface(
+                    mesh_device, [self.prefetcher_sub_device, self.worker_sub_device], 1, 0, True
+                )
+            else:
+                mesh_device.load_sub_device_manager(mesh_sub_device_manager_id_decode)
+                ttnn.initialize_edm_fabric(
+                    mesh_device,
+                    wrap_fabric_around_mesh=False,
+                    context_switch_interval_override=None,
+                    topology=ttnn.Topology.Linear,
+                )
+            self.mesh_sub_device_manager_id_decode = mesh_sub_device_manager_id_decode
             self.prefetcher_sub_device_id = ttnn.SubDeviceId(0)
             self.worker_sub_device_id = ttnn.SubDeviceId(1)
 
@@ -138,4 +166,8 @@ class TtLlamaPrefetcherSetup(LightweightModule):
             len(self.tensors) >= self.n_tensors
         ), f"Expected at least {self.n_tensors} tensors, got {len(self.tensors)}"
 
-        return self.tensors[: self.n_tensors] + [self.get_tensor_addrs()]
+        global global_tt_tensor_address
+        if global_tt_tensor_address is None:
+            global_tt_tensor_address = self.get_tensor_addrs()
+        self.tt_tensor_address = global_tt_tensor_address
+        return self.tensors[: self.n_tensors] + [self.tt_tensor_address]


### PR DESCRIPTION
### What's changed
Added support for continuous batching on prefill + decode demo 

```
persistent buffers for decode and prefill in the beginning and never deallocate them
gsems for both  in the beginning and never deallocate them
run prefill
prefetch 80*5 tensors, and save addresses tensor and keep it persistent now
allocate global cb
run decode
deallocate  global cb
run prefill
prefetch 80*5 tensors from saved addresses tensor
and so it goes..
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14268361878) CI passes
TG pipelines: https://github.com/tenstorrent/tt-metal/actions/runs/14268378190
TG demo: https://github.com/tenstorrent/tt-metal/actions/runs/14268386215