### PR TITLE
Support bfp8 inputs in convert_to_chw, improve perf

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
@@ -30,6 +30,7 @@ from models.utility_functions import (
     ),
 )
 def test_convert_to_chw(device, C, HW, core_grid, input_data_type):
+    torch.manual_seed(0)
     device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
     requested_num_cores = core_grid.x * core_grid.y
     if device_num_cores < requested_num_cores:

--- a/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
@@ -15,6 +15,7 @@ from models.utility_functions import (
 
 @skip_for_grayskull()
 @skip_for_blackhole()
+@pytest.mark.parametrize("input_data_type", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("C", [1, 2, 4])
 @pytest.mark.parametrize(
     "HW, core_grid",
@@ -23,13 +24,20 @@ from models.utility_functions import (
         (64, ttnn.CoreGrid(x=1, y=1)),
         (64, ttnn.CoreGrid(x=2, y=1)),
         (1056 * 160, ttnn.CoreGrid(x=8, y=6)),
+        (1024 * 128, ttnn.CoreGrid(x=8, y=8)),
+        (2048 * 128, ttnn.CoreGrid(x=8, y=8)),
+        (4096 * 128, ttnn.CoreGrid(x=8, y=8)),
     ),
 )
-def test_convert_to_chw(device, C, HW, core_grid):
+def test_convert_to_chw(device, C, HW, core_grid, input_data_type):
+    device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    requested_num_cores = core_grid.x * core_grid.y
+    if device_num_cores < requested_num_cores:
+        pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {device_num_cores})")
     input_tensor = torch.randn([1, 1, HW, C], dtype=torch.bfloat16)
     expected = input_tensor.transpose(2, 3)
 
-    input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.from_torch(input_tensor, dtype=input_data_type, layout=ttnn.TILE_LAYOUT)
     input_memory_config = ttnn.create_sharded_memory_config(
         [1, 1, HW, 32], core_grid, ttnn.ShardStrategy.HEIGHT, ttnn.ShardOrientation.ROW_MAJOR
     )
@@ -38,15 +46,19 @@ def test_convert_to_chw(device, C, HW, core_grid):
     output_memory_config = ttnn.create_sharded_memory_config(
         [1, 1, C, HW], core_grid, ttnn.ShardStrategy.WIDTH, ttnn.ShardOrientation.ROW_MAJOR
     )
-    actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_memory_config)
+    actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_memory_config, dtype=ttnn.bfloat16)
 
-    assert_with_pcc(expected, ttnn.to_torch(actual), 1.0)
+    expected_pcc = 1.0
+    if input_data_type == ttnn.bfloat8_b:
+        expected_pcc = 0.9999  # bfloat8_b can't be exatcly compared to torch bfloat16
+    assert_with_pcc(expected, ttnn.to_torch(actual), expected_pcc)
 
     return actual
 
 
 @skip_for_grayskull()
 @skip_for_blackhole()
+@pytest.mark.parametrize("input_data_type", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("C", [1, 2, 4])
 @pytest.mark.parametrize(
     "HW, core_grid, padded_sharded_dim",
@@ -66,11 +78,11 @@ def test_convert_to_chw(device, C, HW, core_grid):
         ),  # UNet Shallow
     ),
 )
-def test_convert_to_chw_padded(device, C, HW, core_grid, padded_sharded_dim):
-    if device.core_grid.num_cores < core_grid.num_cores():
-        pytest.skip(
-            "Not enough cores to run test case (need {core_grid.num_cores()} but have {device.core_grid.num_cores}"
-        )
+def test_convert_to_chw_padded(device, C, HW, core_grid, padded_sharded_dim, input_data_type):
+    device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    requested_num_cores = core_grid.num_cores()
+    if device_num_cores < requested_num_cores:
+        pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {device_num_cores})")
     input_tensor = torch.randn([1, 1, HW, C], dtype=torch.bfloat16)
     expected = input_tensor.transpose(2, 3)
 
@@ -82,12 +94,15 @@ def test_convert_to_chw_padded(device, C, HW, core_grid, padded_sharded_dim):
     output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec)
 
-    input_tensor = ttnn.from_torch(input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    input_tensor = ttnn.from_torch(input_tensor, dtype=input_data_type, layout=ttnn.TILE_LAYOUT)
     input_tensor = ttnn.to_device(input_tensor, device, memory_config=input_mem_config)
 
-    actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_mem_config)
+    actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
 
-    assert_with_pcc(expected, ttnn.to_torch(actual), 1.0)
+    expected_pcc = 1.0
+    if input_data_type == ttnn.bfloat8_b:
+        expected_pcc = 0.9999  # bfloat8_b can't be exatcly compared to torch bfloat16
+    assert_with_pcc(expected, ttnn.to_torch(actual), expected_pcc)
 
     return actual
 
@@ -101,14 +116,18 @@ def test_convert_to_chw_with_program_cache(device, use_program_cache):
     core_grid_padded = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))})
 
     a, b, c = None, None, None
-    for _ in range(8):
-        a = test_convert_to_chw_padded(device, C_padded, HW_padded, core_grid_padded, padded_sharded_dim)
-        b = test_convert_to_chw(device, C, HW, core_grid)
-        c = test_convert_to_chw_padded(device, C_padded, HW_padded, core_grid_padded, padded_sharded_dim)
+    for iter in range(8):
+        if iter < 4:
+            in_dtype = ttnn.bfloat16
+        else:
+            in_dtype = ttnn.bfloat8_b
+        a = test_convert_to_chw_padded(device, C_padded, HW_padded, core_grid_padded, padded_sharded_dim, in_dtype)
+        b = test_convert_to_chw(device, C, HW, core_grid, in_dtype)
+        c = test_convert_to_chw_padded(device, C_padded, HW_padded, core_grid_padded, padded_sharded_dim, in_dtype)
         dummy_shape = [1, 1, 256, 128]
         py_dummy_tensor = torch.randn(dummy_shape)
         tt_dummy_tensor = (
             ttnn.Tensor(py_dummy_tensor, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device, ttnn.L1_MEMORY_CONFIG)
         )
 
-    assert device.num_program_cache_entries() == 2
+    assert device.num_program_cache_entries() == 4

--- a/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
@@ -6,7 +6,7 @@ import pytest
 import ttnn
 import torch
 
-from tests.ttnn.utils_for_testing import assert_with_pcc
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
 from models.utility_functions import (
     skip_for_grayskull,
     skip_for_blackhole,
@@ -49,10 +49,11 @@ def test_convert_to_chw(device, C, HW, core_grid, input_data_type):
     )
     actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_memory_config, dtype=ttnn.bfloat16)
 
-    expected_pcc = 1.0
     if input_data_type == ttnn.bfloat8_b:
         expected_pcc = 0.9999  # bfloat8_b can't be exatcly compared to torch bfloat16
-    assert_with_pcc(expected, ttnn.to_torch(actual), expected_pcc)
+        assert_with_pcc(expected, ttnn.to_torch(actual), expected_pcc)
+    else:
+        assert_equal(expected, ttnn.to_torch(actual))
 
     return actual
 
@@ -100,10 +101,11 @@ def test_convert_to_chw_padded(device, C, HW, core_grid, padded_sharded_dim, inp
 
     actual = ttnn.experimental.convert_to_chw(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
 
-    expected_pcc = 1.0
     if input_data_type == ttnn.bfloat8_b:
         expected_pcc = 0.9999  # bfloat8_b can't be exatcly compared to torch bfloat16
-    assert_with_pcc(expected, ttnn.to_torch(actual), expected_pcc)
+        assert_with_pcc(expected, ttnn.to_torch(actual), expected_pcc)
+    else:
+        assert_equal(expected, ttnn.to_torch(actual))
 
     return actual
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "convert_to_chw_program_factory.hpp"
+#include "tt-metalium/tt_backend_api_types.hpp"
+#include "ttnn/tensor/types.hpp"
 
 namespace ttnn::operations::experimental::cnn::detail {
 
@@ -63,12 +65,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_chw(
     const uint32_t cb_in_page_size = input_tile_size;
     const auto cb_in = create_circular_buffer(cb_in_id, cb_in_total_size, cb_in_page_size, input_format, a.buffer());
 
+    const tt::DataFormat output_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
     const uint32_t cb_out_id = tt::CBIndex::c_1;
-    const uint32_t element_size = tt::datum_size(input_format);
+    const uint32_t element_size = tt::datum_size(output_format);
     const uint32_t cb_out_total_size = tt::div_up(C * HW * element_size, input_cores.size());
     const uint32_t cb_out_page_size = tt::div_up(HW * element_size, input_cores.size());
     const auto cb_out =
-        create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, input_format, output.buffer());
+        create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, output_format, output.buffer());
 
     const uint32_t cb_in_transpose_id = tt::CBIndex::c_2;
     const uint32_t cb_in_transpose_total_size = intermediary_tile_size;

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -87,13 +87,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_chw(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/reader_convert_to_chw.cpp",
         input_core_grid,
-        tt::tt_metal::WriterDataMovementConfig(reader_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp",
         input_core_grid,
-        tt::tt_metal::ReaderDataMovementConfig(writer_compile_time_args));
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     auto compute_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -74,26 +74,26 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_chw(
         create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, output_format, output.buffer());
 
     const uint32_t cb_in_transpose_id = tt::CBIndex::c_2;
-    const uint32_t cb_in_transpose_total_size = intermediary_tile_size;
+    const uint32_t cb_in_transpose_total_size = 16 * intermediary_tile_size;
     const uint32_t cb_in_transpose_page_size = intermediary_tile_size;
     const auto cb_in_transpose = create_circular_buffer(
         cb_in_transpose_id, cb_in_transpose_total_size, cb_in_transpose_page_size, intermediary_format);
 
     std::vector<uint32_t> reader_compile_time_args = {cb_in_id};
     std::vector<uint32_t> writer_compile_time_args = {cb_in_transpose_id, cb_out_id, C};
-    std::vector<uint32_t> compute_compile_time_args = {cb_in_id, cb_in_transpose_id, cb_out_id};
+    std::vector<uint32_t> compute_compile_time_args = {cb_in_id, cb_in_transpose_id};
 
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/reader_convert_to_chw.cpp",
         input_core_grid,
-        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+        tt::tt_metal::WriterDataMovementConfig(reader_compile_time_args));
 
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp",
         input_core_grid,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+        tt::tt_metal::ReaderDataMovementConfig(writer_compile_time_args));
 
     auto compute_kernel_id = tt::tt_metal::CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -10,10 +10,6 @@
 constexpr uint32_t ONE_TILE = 1;
 
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
-    transpose_wh_init_short(cb_in);
-
-    pack_untilize_dst_init_short<ONE_TILE, 1, false, false, 32>(cb_out);
-
     cb_wait_front(cb_in, ONE_TILE);
 
     tile_regs_acquire();
@@ -27,8 +23,6 @@ FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
 
     tile_regs_commit();
     tile_regs_release();
-
-    pack_untilize_uninit(cb_out);
 
     cb_push_back(cb_out, ONE_TILE);
     cb_pop_front(cb_in, ONE_TILE);
@@ -45,8 +39,11 @@ void MAIN {
     transpose_wh_init(cb_in, cb_transpose_in);
     pack_untilize_init(cb_in, cb_transpose_in);
 
+    transpose_wh_init_short(cb_in);
+    pack_untilize_dst_init_short<ONE_TILE, 1, false, false, 32>(cb_out);
     for (uint32_t idx = 0; idx < total_tiles; idx++) {
         transpose(cb_in, cb_transpose_in);
     }
+    pack_untilize_uninit(cb_out);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/convert_to_chw.cpp
@@ -7,43 +7,45 @@
 #include "compute_kernel_api/pack_untilize.h"
 #include "compute_kernel_api/transpose_wh.h"
 
-constexpr uint32_t ONE_TILE = 1;
-
+template <int BATCH_SIZE>
 FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
-    cb_wait_front(cb_in, ONE_TILE);
+    cb_wait_front(cb_in, BATCH_SIZE);
 
     tile_regs_acquire();
-    tile_regs_wait();
-
-    transpose_wh_tile(cb_in, 0, 0);
-
-    cb_reserve_back(cb_out, ONE_TILE);
-
-    pack_untilize_dst<ONE_TILE>(cb_out);
-
+    for (uint32_t i = 0; i < BATCH_SIZE; i++) {
+        transpose_wh_tile(cb_in, i, i);
+    }
     tile_regs_commit();
+    cb_pop_front(cb_in, BATCH_SIZE);
+
+    cb_reserve_back(cb_out, BATCH_SIZE);
+    tile_regs_wait();
+    pack_untilize_dst<1>(cb_out, BATCH_SIZE);
     tile_regs_release();
 
-    cb_push_back(cb_out, ONE_TILE);
-    cb_pop_front(cb_in, ONE_TILE);
+    cb_push_back(cb_out, BATCH_SIZE);
 }
-
 namespace NAMESPACE {
 void MAIN {
+    constexpr int BATCH_SIZE = 8;
     const uint32_t total_tiles = get_arg_val<uint32_t>(0);
-
+    const uint32_t num_batches = total_tiles / BATCH_SIZE;
+    const uint32_t leftover = total_tiles % BATCH_SIZE;
     constexpr uint32_t cb_in = get_compile_time_arg_val(0);
     constexpr uint32_t cb_transpose_in = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_out = get_compile_time_arg_val(2);
 
-    transpose_wh_init(cb_in, cb_transpose_in);
     pack_untilize_init(cb_in, cb_transpose_in);
+    transpose_wh_init(cb_in, cb_transpose_in);
 
-    transpose_wh_init_short(cb_in);
-    pack_untilize_dst_init_short<ONE_TILE, 1, false, false, 32>(cb_out);
-    for (uint32_t idx = 0; idx < total_tiles; idx++) {
-        transpose(cb_in, cb_transpose_in);
+    pack_untilize_dst_init_short<1>(cb_transpose_in);
+
+    for (uint32_t i = 0; i < num_batches; i++) {
+        transpose<BATCH_SIZE>(cb_in, cb_transpose_in);
     }
-    pack_untilize_uninit(cb_out);
+
+    for (uint32_t idx = 0; idx < leftover; idx++) {
+        transpose<1>(cb_in, cb_transpose_in);
+    }
+    pack_untilize_uninit(cb_transpose_in);
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/kernels/writer_convert_to_chw.cpp
@@ -3,32 +3,55 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-
 constexpr uint32_t TILE_SIZE = 32;
 constexpr uint32_t ELEMENT_SIZE_BYTES = 2;
 constexpr uint32_t STICK_SIZE = TILE_SIZE * ELEMENT_SIZE_BYTES;
 
 void kernel_main() {
     const uint32_t total_tiles = get_arg_val<uint32_t>(0);
+    constexpr uint32_t BATCH_SIZE = 8;
+    const uint32_t num_batches = total_tiles / BATCH_SIZE;
+    const uint32_t leftover = total_tiles % BATCH_SIZE;
 
     constexpr uint32_t cb_in_transpose = get_compile_time_arg_val(0);
+    constexpr uint32_t in_transpose_tile_size = get_tile_size(cb_in_transpose);
     constexpr uint32_t cb_out = get_compile_time_arg_val(1);
     constexpr uint32_t C = get_compile_time_arg_val(2);
 
+    cb_reserve_back(cb_out, 1);
     const uint32_t base_l1_write_addr = get_write_ptr(cb_out);
-    const uint64_t base_l1_read_addr = get_noc_addr(get_read_ptr(cb_in_transpose));
-    noc_async_read_one_packet_set_state(base_l1_read_addr, STICK_SIZE);
+    noc_async_read_one_packet_set_state(get_noc_addr(get_read_ptr(cb_in_transpose)), STICK_SIZE);
 
     const uint32_t channel_size = total_tiles * STICK_SIZE;
 
-    for (uint32_t i = 0; i < total_tiles; i++) {
-        cb_wait_front(cb_in_transpose, 1);
-        for (uint32_t j = 0; j < C; j++) {
-            const uint32_t l1_read_addr = base_l1_read_addr + (j * STICK_SIZE);
-            const uint32_t l1_write_addr = base_l1_write_addr + (j * channel_size) + (i * STICK_SIZE);
-            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+    int tile_index = 0;
+    for (uint32_t i = 0; i < num_batches; i++) {
+        cb_wait_front(cb_in_transpose, BATCH_SIZE);
+        uint64_t l1_read_addr_tile = get_noc_addr(get_read_ptr(cb_in_transpose));
+        for (uint32_t b = 0; b < BATCH_SIZE; b++) {
+            uint64_t l1_read_addr = l1_read_addr_tile;
+            for (uint32_t j = 0; j < C; j++) {
+                const uint32_t l1_write_addr = base_l1_write_addr + (j * channel_size) + (tile_index * STICK_SIZE);
+                noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+                l1_read_addr += STICK_SIZE;
+            }
+            tile_index++;
+            l1_read_addr_tile += in_transpose_tile_size;
         }
-        cb_pop_front(cb_in_transpose, 1);
-        cb_push_back(cb_out, 1);
+        cb_pop_front(cb_in_transpose, BATCH_SIZE);
     }
+
+    for (uint32_t i = 0; i < leftover; i++) {
+        cb_wait_front(cb_in_transpose, 1);
+        uint64_t l1_read_addr = get_noc_addr(get_read_ptr(cb_in_transpose));
+        for (uint32_t j = 0; j < C; j++) {
+            const uint32_t l1_write_addr = base_l1_write_addr + (j * channel_size) + (tile_index * STICK_SIZE);
+            noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+            l1_read_addr += STICK_SIZE;
+        }
+        tile_index++;
+        cb_pop_front(cb_in_transpose, 1);
+    }
+    noc_async_read_barrier();
+    cb_push_back(cb_out, 1);
 }


### PR DESCRIPTION
### Ticket
#20185: 

### Problem description
in ticket

### What's changed
Suport bfp8 inputs in convert_to_chw, improve it's perf (it was doing lots of unnecessary inits/uninits)
Shallow unet chw op: from 51k cycles down to 21k
Customer model: from 72k cycles down to 28k

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

Will update device/e2e perf following device/e2e pipelines