### PR TITLE
Fix tg quick pipeline

### DIFF
--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -31,6 +31,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
+        TT_METAL_WORKER_RINGBUFFER_SIZE: 122880
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /work

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Run quick tests
         timeout-minutes: 20
         run: |
-          pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick-stress"
+          pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick"
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -52,7 +52,8 @@ jobs:
       - name: Run quick tests
         timeout-minutes: 20
         run: |
-          pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick"
+          pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick";
+          pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "quick";
       - uses: ./.github/actions/slack-report
         if: ${{ failure() }}
         with:

--- a/models/demos/llama3_subdevices/tests/test_llama_model.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model.py
@@ -29,10 +29,9 @@ from models.utility_functions import skip_for_grayskull
     "weights, layers, iterations",
     [
         ("random", 1, 6),
-        ("random", 1, 200),
         ("instruct", 80, 5),
     ],
-    ids=["quick", "quick-stress", "full"],
+    ids=["quick", "full"],
 )
 @pytest.mark.parametrize(
     "paged_attention",


### PR DESCRIPTION
Reverting change to run 200 iterations on model quick test; instead added demo quick

tg quick pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/14267980768/job/39994610146

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes