### PR TITLE
#0: Various cleanup of fabric/ccl code

### DIFF
--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -90,7 +90,6 @@ struct FabricEriscDatamoverConfig {
     FabricEriscDatamoverConfig(std::size_t channel_buffer_size_bytes, Topology topology = Topology::Linear);
 
     std::size_t channel_buffer_size_bytes = 0;
-    std::size_t channel_buffer_size_bytes_with_channel_sync = 0;
 
     std::array<std::size_t, num_sender_channels> sender_channels_size_bytes;
     std::array<std::size_t, num_receiver_channels> receiver_channels_size_bytes;

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -134,8 +134,7 @@ struct WorkerToFabricEdmSenderImpl {
         if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
             ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
             for (size_t i = 0; i < EDM_NUM_BUFFER_SLOTS; ++i) {
-                edm_buffer_slot_addrs[i] =
-                    edm_buffer_base_addr + (i * (buffer_size_bytes + sizeof(eth_channel_sync_t)));
+                edm_buffer_slot_addrs[i] = edm_buffer_base_addr + (i * buffer_size_bytes);
             }
         }
     }
@@ -275,8 +274,7 @@ struct WorkerToFabricEdmSenderImpl {
         this->buffer_slot_wrptr = *this->buffer_slot_wrptr_ptr;
         if constexpr (!USER_DEFINED_NUM_BUFFER_SLOTS) {
             this->edm_buffer_addr =
-                this->edm_buffer_base_addr +
-                (this->get_buffer_slot_index() * (this->buffer_size_bytes + sizeof(eth_channel_sync_t)));
+                this->edm_buffer_base_addr + (this->get_buffer_slot_index() * this->buffer_size_bytes);
         }
         ASSERT(this->buffer_slot_wrptr < 20);
     }
@@ -391,8 +389,7 @@ private:
             uint8_t wrptr = this->buffer_slot_wrptr;
             this->buffer_slot_wrptr = !(wrptr == ((this->num_buffers_per_channel * 2) - 1)) ? wrptr + 1 : 0;
             this->edm_buffer_addr =
-                this->edm_buffer_base_addr +
-                (this->get_buffer_slot_index() * (this->buffer_size_bytes + sizeof(eth_channel_sync_t)));
+                this->edm_buffer_base_addr + (this->get_buffer_slot_index() * this->buffer_size_bytes);
         }
     }
 

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_erisc_datamover_channels.hpp
@@ -35,9 +35,8 @@ public:
     //                         |                |
     //                         |    payload     |
     //                         |                |
-    //        &channel_sync->  |----------------|
-    //                         |  channel_sync  |
-    //                         ------------------
+    //                         |----------------|
+
     EthChannelBuffer() : buffer_size_in_bytes(0), max_eth_payload_size_in_bytes(0) {}
 
     /*
@@ -51,7 +50,7 @@ public:
                                                // that can fit 2 eth_channel_syncs cfor ack
         uint8_t channel_id) :
         buffer_size_in_bytes(buffer_size_bytes),
-        max_eth_payload_size_in_bytes(buffer_size_in_bytes + sizeof(eth_channel_sync_t)),
+        max_eth_payload_size_in_bytes(buffer_size_in_bytes),
         channel_id(channel_id) {
         for (uint8_t i = 0; i < NUM_BUFFERS; i++) {
             this->buffer_addresses[i] = channel_base_address + i * this->max_eth_payload_size_in_bytes;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -677,5 +677,7 @@ private:
     uint32_t partition_size;
 };
 
+std::tuple<size_t, size_t, bool> get_forward_backward_configuration(size_t ring_size, size_t ring_index, Topology topology);
+
 }  // namespace ccl
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -96,28 +96,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_minimal_interleav
     std::vector<Tensor> input_tensors = {input_tensor};
     std::vector<Tensor> output_tensors = {output_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
-    size_t num_targets_forward = 0;
-    size_t num_targets_backward = 0;
-    bool dynamic_alternate = false;
-    if (topology == ccl::Topology::Linear) {
-        LineTopology line_topology(ring_size, ring_index);
-        num_targets_forward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-        num_targets_backward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
-    } else if (topology == ccl::Topology::Ring) {
-        // TODO: Commonize
-        num_targets_forward = tt::div_up(ring_size - 1, 2);
-        num_targets_backward = ring_size - 1 - num_targets_forward;
-        constexpr bool static_alternate = true;
-        if constexpr (static_alternate) {
-            if (ring_index % 2 == 0) {
-                std::swap(num_targets_forward, num_targets_backward);
-            }
-        }
-        // Even ring size will result in uneven fwd/backward distances
-        dynamic_alternate = ring_size % 2 == 0;
-    }
+    auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
+        ccl::get_forward_backward_configuration(ring_size, ring_index, topology);
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
@@ -336,28 +316,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
     std::vector<Tensor> input_tensors = {input_tensor};
     std::vector<Tensor> output_tensors = {output_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, topology);
-    size_t num_targets_forward = 0;
-    size_t num_targets_backward = 0;
-    bool dynamic_alternate = false;
-    if (topology == ccl::Topology::Linear) {
-        LineTopology line_topology(ring_size, ring_index);
-        num_targets_forward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::FORWARD);
-        num_targets_backward =
-            line_topology.get_distance_to_end_of_line(ttnn::ccl::EdmLineFabricOpInterface::Direction::BACKWARD);
-    } else if (topology == ccl::Topology::Ring) {
-        // TODO: Commonize
-        num_targets_forward = tt::div_up(ring_size - 1, 2);
-        num_targets_backward = ring_size - 1 - num_targets_forward;
-        constexpr bool static_alternate = true;
-        if constexpr (static_alternate) {
-            if (ring_index % 2 == 0) {
-                std::swap(num_targets_forward, num_targets_backward);
-            }
-        }
-        // Even ring size will result in uneven fwd/backward distances
-        dynamic_alternate = ring_size % 2 == 0;
-    }
+    auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
+        ccl::get_forward_backward_configuration(ring_size, ring_index, topology);
 
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
EDM buffers no longer use eth_channel_sync_t. We're wasting some buffering space and some calculations in kernels on it.
Some buffer validation calculations weren't comparing the correct values, and we need to support different slot counts depending on available eth L1 memory since this can now differ between machine configurations.
Some ccl kernels had some unneeded flushes/noc txns.

### What's changed
Remove erisc sync sizes/calculations from the edm buffer slots
Refactor/fix buffer slot/size determination/validation for edm in prep for 6u
Remove some extra noc flushes and unneeded noc write when local write suffices for ccls

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14269734404
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/14269739659
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14272871397
TG Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14269748594
UBench: https://github.com/tenstorrent/tt-metal/actions/runs/14269752660