### PR TITLE
Make profiler regression test script readable

### DIFF
--- a/models/demos/t3000/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/t3000/resnet50/tests/test_resnet50_performant.py
@@ -32,6 +32,9 @@ def test_run_resnet50_inference(
     enable_async_mode,
     model_location_generator,
 ):
+    if len(mesh_device.get_devices()) != 8:
+        pytest.skip("Not T3K!")
+
     run_resnet50_inference(
         mesh_device,
         device_batch_size,
@@ -59,6 +62,9 @@ def test_run_resnet50_trace_inference(
     enable_async_mode,
     model_location_generator,
 ):
+    if len(mesh_device.get_devices()) != 8:
+        pytest.skip("Not T3K!")
+
     run_resnet50_trace_inference(
         mesh_device,
         device_batch_size,
@@ -86,6 +92,9 @@ def test_run_resnet50_2cqs_inference(
     enable_async_mode,
     model_location_generator,
 ):
+    if len(mesh_device.get_devices()) != 8:
+        pytest.skip("Not T3K!")
+
     run_resnet50_2cqs_inference(
         mesh_device,
         device_batch_size,
@@ -115,6 +124,9 @@ def test_run_resnet50_trace_2cqs_inference(
     enable_async_mode,
     model_location_generator,
 ):
+    if len(mesh_device.get_devices()) != 8:
+        pytest.skip("Not T3K!")
+
     run_resnet50_trace_2cqs_inference(
         mesh_device,
         device_batch_size,


### PR DESCRIPTION
### Ticket
N/A

### Changes
2 key problems:
1. `test_run_resnet50_inference` in T3K folder doesn't filter that the device is T3K.
    * As the result, profiler regression test currently runs `run_tracing_async_mode_T3000_test` under "not skipped" condition within the body of `run_additional_T3000_test`. 
2. Test functions are named confusingly. E.g. `run_additional_T3000_test`.

\+ other minor improvements. See comments inline.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14315122055)
- [X] [T3K profiler regression test](https://github.com/tenstorrent/tt-metal/actions/runs/14315119331)
- [X] [BH tests](https://github.com/tenstorrent/tt-metal/actions/runs/14318634248)