### PR TITLE
Validate user compute grid in matmul benchmark, and remove invalid configurations from testing

### DIFF
--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -112,7 +112,6 @@ matmul_shapes_bfloat8_b = [
     (2048, 3072, 3072, True, True, 1, 1, 1),
     (3072, 3072, 3072, True, True, 2, 1, 1),
     (3072, 3072, 4096, True, True, 2, 1, 1),
-    (3072, 4096, 4096, True, True, 1, 2, 2),
     (4096, 4096, 4096, False, False, 1, 2, 2),
     (8192, 8192, 8192, False, False, 2, 4, 4),
     (16384, 16384, 16384, False, False, 4, 8, 8),
@@ -155,8 +154,8 @@ matmul_configs = [
 @pytest.mark.parametrize("grid_size", [(8, 8)])
 @pytest.mark.parametrize("tile_h", [32])
 @pytest.mark.parametrize("tile_w", [32])
-@pytest.mark.parametrize("num_warmup_iterations", [5])
-@pytest.mark.parametrize("num_measurement_iterations", [100])
+@pytest.mark.parametrize("num_warmup_iterations", [0])
+@pytest.mark.parametrize("num_measurement_iterations", [1])
 def test_matmul_2d_host_perf(
     device,
     grid_size,
@@ -172,7 +171,7 @@ def test_matmul_2d_host_perf(
     FILE_NAME = ARTIFACTS_DIR / "matmul_2d_host_perf_report.csv"
 
     compute_grid_size = device.compute_with_storage_grid_size()
-    if compute_grid_size.y < grid_size[0] or compute_grid_size.x < grid_size[1]:
+    if compute_grid_size.y < grid_size[1] or compute_grid_size.x < grid_size[0]:
         pytest.skip(
             f"Skipping test as requested compute grid size {grid_size} exceeds available compute grid {compute_grid_size}"
         )
@@ -456,7 +455,7 @@ def test_matmul_2d_host_perf_out_of_box(
     FILE_NAME = ARTIFACTS_DIR / "matmul_2d_host_perf_out_of_box_report.csv"
 
     compute_grid_size = device.compute_with_storage_grid_size()
-    if compute_grid_size.y < grid_size[0] or compute_grid_size.x < grid_size[1]:
+    if compute_grid_size.y < grid_size[1] or compute_grid_size.x < grid_size[0]:
         pytest.skip(
             f"Skipping test as requested compute grid size {grid_size} exceeds available compute grid {compute_grid_size}"
         )

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -154,8 +154,8 @@ matmul_configs = [
 @pytest.mark.parametrize("grid_size", [(8, 8)])
 @pytest.mark.parametrize("tile_h", [32])
 @pytest.mark.parametrize("tile_w", [32])
-@pytest.mark.parametrize("num_warmup_iterations", [0])
-@pytest.mark.parametrize("num_measurement_iterations", [1])
+@pytest.mark.parametrize("num_warmup_iterations", [5])
+@pytest.mark.parametrize("num_measurement_iterations", [100])
 def test_matmul_2d_host_perf(
     device,
     grid_size,

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -171,6 +171,11 @@ def test_matmul_2d_host_perf(
     ARTIFACTS_DIR = TT_METAL_HOME / "generated"
     FILE_NAME = ARTIFACTS_DIR / "matmul_2d_host_perf_report.csv"
 
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if compute_grid_size.y < grid_size[0] or compute_grid_size.x < grid_size[1]:
+        pytest.skip(
+            f"Skipping test as requested compute grid size {grid_size} exceeds available compute grid {compute_grid_size}"
+        )
     LoFi_cycle = 16
     HiFi2_cycle = LoFi_cycle * 2
     HiFi3_cycle = LoFi_cycle * 3
@@ -450,6 +455,11 @@ def test_matmul_2d_host_perf_out_of_box(
     ARTIFACTS_DIR = TT_METAL_HOME / "generated"
     FILE_NAME = ARTIFACTS_DIR / "matmul_2d_host_perf_out_of_box_report.csv"
 
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if compute_grid_size.y < grid_size[0] or compute_grid_size.x < grid_size[1]:
+        pytest.skip(
+            f"Skipping test as requested compute grid size {grid_size} exceeds available compute grid {compute_grid_size}"
+        )
     LoFi_cycle = 16
     HiFi2_cycle = LoFi_cycle * 2
     HiFi3_cycle = LoFi_cycle * 3
@@ -549,7 +559,6 @@ def test_matmul_2d_host_perf_out_of_box(
                 elif math_fidelity == ttnn.MathFidelity.HiFi4:
                     cycle_per_tile = HiFi4_cycle
                 num_cores_user_grid = grid_size[0] * grid_size[1]
-                compute_grid_size = device.compute_with_storage_grid_size()
                 num_cores_full_grid = compute_grid_size.x * compute_grid_size.y
                 ideal_cycle_full_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_full_grid
                 ideal_cycle_user_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_user_grid

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -368,7 +368,6 @@ def test_matmul_2d_host_perf(
                 elif math_fidelity == ttnn.MathFidelity.HiFi4:
                     cycle_per_tile = HiFi4_cycle
                 num_cores_user_grid = grid_size[0] * grid_size[1]
-                compute_grid_size = device.compute_with_storage_grid_size()
                 num_cores_full_grid = compute_grid_size.x * compute_grid_size.y
                 ideal_cycle_full_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_full_grid
                 ideal_cycle_user_grid = m * k * n / tile_h / tile_w / 32 * cycle_per_tile / num_cores_user_grid

--- a/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
+++ b/tests/ttnn/unit_tests/benchmarks/test_benchmark.py
@@ -149,7 +149,7 @@ matmul_configs = [
 ]
 
 
-@pytest.mark.skip(reason="WH didt hang, need to skip CI and run locally only")
+@pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 3855488}], indirect=True)
 @pytest.mark.parametrize("grid_size", [(8, 8)])
 @pytest.mark.parametrize("tile_h", [32])
@@ -432,7 +432,7 @@ matmul_configs_oob = [
 ]
 
 
-@pytest.mark.skip(reason="WH didt hang, need to skip CI and run locally only")
+@pytest.mark.skip(reason="Benchmark is not intended to be run as part of CI and can be manually run locally")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 3855488}], indirect=True)
 @pytest.mark.parametrize("grid_size", [(8, 8)])
 @pytest.mark.parametrize("tile_h", [32])

--- a/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
@@ -135,7 +135,7 @@ public:
 };
 
 TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
-    GTEST_SKIP() << "WH di/dt hang, need to skip CI and run locally only";
+    GTEST_SKIP() << "Benchmark is not intended to be run as part of CI and can be manually run locally";
 
     // Parse test config
     const MatmulTestConfig& test_config = std::get<0>(GetParam());
@@ -179,8 +179,8 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
 
     auto compute_grid_size = device->compute_with_storage_grid_size();
     if (compute_grid_size.y < grid_size.height() || compute_grid_size.x < grid_size.width()) {
-        GTEST_SKIP() << "Requested grid size of " << grid_size << " exceeds device's available compute grid of size "
-                     << compute_grid_size.str();
+        GTEST_SKIP() << "Skipping test as requested compute grid size " << grid_size
+                     << " exceeds available compute grid " << compute_grid_size.str();
     }
 
     const char* tt_metal_home = std::getenv("TT_METAL_HOME");

--- a/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
@@ -174,13 +174,14 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
     const int num_out_blocks_h = MatmulShape.num_out_blocks_h;
     const int num_out_blocks_w = MatmulShape.num_out_blocks_w;
 
+    // Validate user compute grid is feasible
     TT_FATAL(grid_size.height() > 0 && grid_size.width() > 0, "Invalid grid size");
 
     auto compute_grid_size = device->compute_with_storage_grid_size();
-    if (compute_grid_size.height() < grid_size.height || compute_grid_size.width() < grid_size.width) {
+    if (compute_grid_size.y < grid_size.height() || compute_grid_size.x < grid_size.width()) {
         GTEST_SKIP() << "Requested grid size of " << grid_size << " exceeds device's available compute grid of size "
-                     << compute_grid_size;
-    })
+                     << compute_grid_size.str();
+    }
 
     const char* tt_metal_home = std::getenv("TT_METAL_HOME");
     std::string artifacts_dir = std::string(tt_metal_home) + "/generated";
@@ -634,14 +635,6 @@ INSTANTIATE_TEST_SUITE_P(
              /*in0_block_w_div=*/2,
              /*num_out_blocks_h=*/1,
              /*num_out_blocks_w=*/1},
-            {/*m=*/3072,
-             /*k=*/4096,
-             /*n=*/4096,
-             /*in0_sharded=*/true,
-             /*out_sharded=*/true,
-             /*in0_block_w_div=*/1,
-             /*num_out_blocks_h=*/2,
-             /*num_out_blocks_w=*/2},
             {/*m=*/4096,
              /*k=*/4096,
              /*n=*/4096,

--- a/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
@@ -176,6 +176,12 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
 
     TT_FATAL(grid_size.height() > 0 && grid_size.width() > 0, "Invalid grid size");
 
+    auto compute_grid_size = device->compute_with_storage_grid_size();
+    if (compute_grid_size.height() < grid_size.height || compute_grid_size.width() < grid_size.width) {
+        GTEST_SKIP() << "Requested grid size of " << grid_size << " exceeds device's available compute grid of size "
+                     << compute_grid_size;
+    })
+
     const char* tt_metal_home = std::getenv("TT_METAL_HOME");
     std::string artifacts_dir = std::string(tt_metal_home) + "/generated";
     std::string file_name =
@@ -360,7 +366,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
     double tflops = 2.0 * m * k * n / 1e12 / inference_time_avg_s;
     int cycle_per_tile = get_cycles_per_tile_for_fidelity(math_fidelity);
     int num_cores_user_grid = grid_size.height() * grid_size.width();
-    auto compute_grid_size = device->compute_with_storage_grid_size();
+
     int num_cores_full_grid = compute_grid_size.x * compute_grid_size.y;
     const double dim_per_tile = (double)m * (double)k * (double)n / tile_h / tile_w;
     double ideal_cycle_full_grid = dim_per_tile / 32 * cycle_per_tile / num_cores_full_grid;


### PR DESCRIPTION
### Ticket
#20184

### Problem description
Matmul benchmark was designed to run on 8x8 compute grids, which causes unexpected behaviour when run on N300 devices with 7x8 compute grids enabled. 

Matmul validation was also recently updated, and some configurations in the benchmarks are now flagged as illegal.

### What's changed
Invalid configurations were removed from the benchmarks.

Benchmark skips user configs that request a grid exceeding the device's total compute grid. New output from Python benchmark when run on an N300:
> SKIPPED [1] tests/ttnn/unit_tests/benchmarks/test_benchmark.py:176: Skipping test as requested compute grid size (8, 8) exceeds available compute grid (x=8,y=7)

And similarly with the C++ version:
>test_matmul_benchmark.cpp:181: Skipped
>Requested grid size of (8, 8) exceeds device's available compute grid of size (x=8,y=7)


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14272359468)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes