### PR TITLE
[skip ci] Move static checks out of APC

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -37,9 +37,6 @@ permissions:
 
 run-name: All post-commit tests${{ (github.event_name == 'workflow_dispatch' && inputs.with-retries) && ' (with retries)' || ''}}
 jobs:
-  static-checks:
-    uses: ./.github/workflows/all-static-checks.yaml
-    secrets: inherit
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -19,6 +19,14 @@ on:
   merge_group:
 
 jobs:
+  static-checks:
+    # Workaround for https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336
+    # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
+    # But we don't actually WANT to run it on PRs -- that's the whole point.  GitHub strikes again.
+    if: github.event_name != 'pull_request'
+    uses: ./.github/workflows/all-static-checks.yaml
+    secrets: inherit
+
   code-analysis:
     # Workaround for https://github.com/orgs/community/discussions/46757?sort=old#discussioncomment-4909336
     # We must have this workflow trigger on PRs in order to allow us to require them in the merge queue.
@@ -76,13 +84,13 @@ jobs:
         contains(join(needs.*.result, ','), 'success') ||
         contains(join(needs.*.result, ','), 'failure')
       }}
-    needs: [code-analysis, find-changes, build, build-docs]
+    needs: [static-checks, code-analysis, find-changes, build, build-docs]
     runs-on: ubuntu-latest
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
-          required-jobs: "code-analysis, find-changes"
+          required-jobs: "static-checks, code-analysis, find-changes"
           optional-jobs: "build, build-docs"
         env:
           NEEDS_CONTEXT: '${{ toJSON(needs) }}'


### PR DESCRIPTION
### Ticket
Closes [#19736](https://github.com/tenstorrent/tt-metal/issues/19736)

### Problem description
Some static checks were not enforced even though they are ran "on pr".
As part of merge gate they will be, and we will have less noise in APC.

### What's changed
Moved static checks to merge gate.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes