### PR TITLE
#18485: update mm test shard for BH and skip non-working and unskip fixed tests for BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -13,7 +13,7 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     compare_equal,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import is_grayskull, skip_for_grayskull
+from models.utility_functions import is_grayskull, skip_for_grayskull, skip_for_blackhole
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -271,6 +271,7 @@ def test_binary_subalpha_ttnn(input_shapes, alpha, device):
     assert comp_pass
 
 
+@skip_for_blackhole("Fails on BH. Issue #19642")
 @pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/test_dropout.py
+++ b/tests/ttnn/unit_tests/operations/test_dropout.py
@@ -7,12 +7,8 @@ import torch
 import pytest
 import ttnn
 import numpy as np
-from models.utility_functions import (
-    skip_for_blackhole,
-)
 
 
-@skip_for_blackhole("Fails on BH. Issue #19638")
 def test_dopout(device):
     t = torch.ones(
         (

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -174,7 +174,7 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
     # in1 shard config
     in1_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
     in1_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), in1_shard_grid)})
-    in1_shard_shape = (8192, 96)
+    in1_shard_shape = (8192, 128) if is_blackhole() else (8192, 96)
     in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     in1_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec)
     input_tensor_in1 = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 import ttnn.operations
-from models.utility_functions import comp_allclose_and_pcc, skip_for_grayskull
+from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
@@ -320,7 +320,7 @@ def test_moreh_matmul_enable_cache(params, device, use_program_cache):
     assert device.num_program_cache_entries() == 2
 
 
-@skip_for_grayskull("GS does not support fp32")
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "params",
     (
@@ -417,7 +417,6 @@ def test_moreh_matmul_backward(params, requires_grad, dtype, device):
     moreh_matmul_backward(params, requires_grad, device, dtype=dtype)
 
 
-@skip_for_grayskull("GS does not support fp32")
 @pytest.mark.parametrize(
     "params",
     (

--- a/tests/ttnn/unit_tests/operations/test_moreh_sum.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_sum.py
@@ -10,7 +10,7 @@ from loguru import logger
 import ttnn
 from models.utility_functions import (
     comp_allclose_and_pcc,
-    skip_for_grayskull,
+    skip_for_blackhole,
 )
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
@@ -496,7 +496,7 @@ def test_moreh_sum_backward_fp32_dest_acc(input_shape, dim, compute_kernel_optio
     assert passing
 
 
-@skip_for_grayskull()
+@skip_for_blackhole("Fails on BH. Issue #19911")
 @pytest.mark.parametrize(
     "input_shape",
     [

--- a/tests/ttnn/unit_tests/test_tutorials.py
+++ b/tests/ttnn/unit_tests/test_tutorials.py
@@ -9,7 +9,7 @@ import os
 from loguru import logger
 from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
 
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
 
 import ttnn
 
@@ -35,6 +35,7 @@ def collect_tutorials():
             yield file_name
 
 
+@skip_for_blackhole("Fails on BH. Issue #19644")
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("notebook_path", collect_tutorials())
 def test_tutorials(notebook_path, clear_wh_arch_yaml_var):


### PR DESCRIPTION
### Ticket
Link to Github Issue #18485

### Problem description
One test was fixed, one test had WH specific sharding, and several tests have not been worked on yet

### What's changed
- unskip one fixed test
- update sharding to be different for BH for one test
- skip the other tests to not waste time analyzing their failures

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14272122443 all ttnn tests pass. two failures in other jobs are unrelated to these tests and are due to infra issues
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes