### PR TITLE
#20168: [skip ci] Add benchmark upload steps for falcon7b TG demo

### DIFF
--- a/.github/actions/upload-data-via-sftp/action.yaml
+++ b/.github/actions/upload-data-via-sftp/action.yaml
@@ -13,8 +13,8 @@ inputs:
   hostname:
     description: "Hostname of server"
     required: true
-  working-directory:
-    description: "Current working directory where data and batchfile are located"
+  path:
+    description: "Path where data and batchfile are located"
     required: false
 
 runs:
@@ -28,10 +28,10 @@ runs:
     - name: Upload files
       shell: bash
       run: |
-        # Change dir to working-directory if its set
+        # Change dir to path if its set
         # Example: when running in containers the batchfile and data files are located under /work
-        if [ -n "${{ inputs.working-directory }}" ]; then
-          echo "Changing dir to ${{ inputs.working-directory }}"
-          cd "${{ inputs.working-directory }}"
+        if [ -n "${{ inputs.path }}" ]; then
+          echo "Changing dir to ${{ inputs.path }}"
+          cd "${{ inputs.path }}"
         fi
         sftp  -oStrictHostKeyChecking=no -i id_key -b ${{ inputs.sftp-batchfile }} ${{ inputs.username }}@${{ inputs.hostname }}

--- a/.github/actions/upload-data-via-sftp/action.yaml
+++ b/.github/actions/upload-data-via-sftp/action.yaml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: |
         # Change dir to path if its set
-        # Example: when running in containers the batchfile and data files are located under /work
+        # If provided, generate key file in inputs.path location for the upload step
         if [ -n "${{ inputs.path }}" ]; then
           echo "Changing dir to ${{ inputs.path }}"
           cd "${{ inputs.path }}"

--- a/.github/actions/upload-data-via-sftp/action.yaml
+++ b/.github/actions/upload-data-via-sftp/action.yaml
@@ -13,6 +13,9 @@ inputs:
   hostname:
     description: "Hostname of server"
     required: true
+  working-directory:
+    description: "Current working directory where data and batchfile are located"
+    required: false
 
 runs:
   using: "composite"
@@ -24,4 +27,11 @@ runs:
         chmod go-rwx id_key
     - name: Upload files
       shell: bash
-      run: sftp  -oStrictHostKeyChecking=no -i id_key -b ${{ inputs.sftp-batchfile }} ${{ inputs.username }}@${{ inputs.hostname }}
+      run: |
+        # Change dir to working-directory if its set
+        # Example: when running in containers the batchfile and data files are located under /work
+        if [ -n "${{ inputs.working-directory }}" ]; then
+          echo "Changing dir to ${{ inputs.working-directory }}"
+          cd "${{ inputs.working-directory }}"
+        fi
+        sftp  -oStrictHostKeyChecking=no -i id_key -b ${{ inputs.sftp-batchfile }} ${{ inputs.username }}@${{ inputs.hostname }}

--- a/.github/actions/upload-data-via-sftp/action.yaml
+++ b/.github/actions/upload-data-via-sftp/action.yaml
@@ -23,6 +23,12 @@ runs:
     - name: Create key file
       shell: bash
       run: |
+        # Change dir to path if its set
+        # Example: when running in containers the batchfile and data files are located under /work
+        if [ -n "${{ inputs.path }}" ]; then
+          echo "Changing dir to ${{ inputs.path }}"
+          cd "${{ inputs.path }}"
+        fi
         echo "${{ inputs.ssh-private-key }}" > id_key
         chmod go-rwx id_key
     - name: Upload files

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -68,7 +68,7 @@ jobs:
           python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
           ls -la generated/benchmark_data
           ls -la /work/generated/benchmark_data
-          cat /work/.github/actions/upload-data-via-sftp
+          cat /work/.github/actions/upload-data-via-sftp/action.yaml
       - name: Upload benchmark data
         if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
         uses: ./.github/actions/upload-data-via-sftp

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -71,7 +71,7 @@ jobs:
           cat /work/.github/actions/upload-data-via-sftp/action.yaml
       - name: Upload benchmark data
         if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
-        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@031e2f80dc9dfa4b5753d1f6fb1a8027c5fd5b41
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@6ff122dfc90962dabcb7e7048728a0647cfd01ae
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
           sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -74,6 +74,7 @@ jobs:
           sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
           username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
+          working-directory: /work
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -66,6 +66,9 @@ jobs:
         if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
         run: |
           python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+          ls -la generated/benchmark_data
+          ls -la /work/generated/benchmark_data
+          cat /work/.github/actions/upload-data-via-sftp
       - name: Upload benchmark data
         if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
         uses: ./.github/actions/upload-data-via-sftp

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -62,6 +62,18 @@ jobs:
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           owner: ${{ matrix.test-group.owner_id }}
+      - name: Save environment data
+        if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
+        run: |
+          python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
+      - name: Upload benchmark data
+        if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
+        uses: ./.github/actions/upload-data-via-sftp
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -77,7 +77,7 @@ jobs:
           sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt
           username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
-          working-directory: /work
+          path: /work
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         test-group: [
           # Deleting for now - LLM team will put in a new version soon
-          # { name: "TG Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 180, owner_id: U044T8U8DEF}, # Johanna Rock
+          { name: "TG Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 180, owner_id: U044T8U8DEF}, # Johanna Rock
           { name: "TG Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 120, owner_id: U05RWH3QUPM}, # Salar Hosseini
         ]
     runs-on:
@@ -66,12 +66,9 @@ jobs:
         if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
         run: |
           python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
-          ls -la generated/benchmark_data
-          ls -la /work/generated/benchmark_data
-          cat /work/.github/actions/upload-data-via-sftp/action.yaml
       - name: Upload benchmark data
         if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
-        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@6ff122dfc90962dabcb7e7048728a0647cfd01ae
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
           sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         test-group: [
           # Deleting for now - LLM team will put in a new version soon
-          { name: "TG Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 180, owner_id: U044T8U8DEF}, # Johanna Rock
+          # { name: "TG Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 180, owner_id: U044T8U8DEF}, # Johanna Rock
           { name: "TG Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 120, owner_id: U05RWH3QUPM}, # Salar Hosseini
         ]
     runs-on:

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -71,7 +71,7 @@ jobs:
           cat /work/.github/actions/upload-data-via-sftp/action.yaml
       - name: Upload benchmark data
         if: ${{ (matrix.test-group.name == 'TG Falcon7b demo tests') && !cancelled() }}
-        uses: ./.github/actions/upload-data-via-sftp
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@031e2f80dc9dfa4b5753d1f6fb1a8027c5fd5b41
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
           sftp-batchfile: .github/actions/upload-data-via-sftp/benchmark_data_batchfile.txt


### PR DESCRIPTION
### Ticket
Resolves #20168

### Problem description
TG demos doesn't upload benchmark data

### What's changed
Add benchmark data upload steps.
Update upload-data-via-sftp action to change dir if `inputs.path` is provided, set input to `/work`. This is required due to running inside docker container.

### Checklist
- [x] TG demos: https://github.com/tenstorrent/tt-metal/actions/runs/14338037173/job/40192095817
- [x] t3k demos (test that action didn't break anything): https://github.com/tenstorrent/tt-metal/actions/runs/14338892606