### PR TITLE
#19632: [skip ci] Use actions path for tenstorrent/tt-metal slack-report action

### DIFF
--- a/.github/workflows/_auto-retry-nightly-workflows.yaml
+++ b/.github/workflows/_auto-retry-nightly-workflows.yaml
@@ -97,7 +97,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/rerun-failed-jobs
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -79,7 +79,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/rerun-failed-jobs
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/_produce-data.yaml
+++ b/.github/workflows/_produce-data.yaml
@@ -152,7 +152,7 @@ jobs:
               pipelinecopy_*.json
               workflow.json
               workflow_jobs.json
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ contains(matrix.test-group.name, 'performance') }}
         run: |
           sudo cpupower frequency-set -g ondemand
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -60,7 +60,7 @@ jobs:
             /work/generated/test_reports/
           prefix: "test_reports_"
 
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -79,7 +79,7 @@ jobs:
         run: |
           mkdir -p generated/test_reports
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/conda-post-commit.yaml
+++ b/.github/workflows/conda-post-commit.yaml
@@ -144,7 +144,7 @@ jobs:
           export LD_LIBRARY_PATH=$CONDA_PREFIX/lib
           ${{ matrix.test-group.cmd }}
 
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
             mkdir -p generated/test_reports
             ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -64,7 +64,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -65,7 +65,7 @@ jobs:
             -e GITHUB_ACTIONS=true
           run_args: |
             ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
+++ b/.github/workflows/fast-dispatch-frequent-tests-impl.yaml
@@ -65,7 +65,7 @@ jobs:
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e GTEST_OUTPUT=xml:generated/test_reports/
           run_args: ${{ matrix.test-group.run-args }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -58,7 +58,7 @@ jobs:
             -e ARCH_NAME=${{ inputs.arch }}
           run_args: |
             source tests/scripts/run_python_model_tests.sh && run_python_model_tests_${{ inputs.arch }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -109,7 +109,7 @@ jobs:
             -e SLOW_RUNTIME_MODE=true
           run_args: |
             source tests/scripts/run_python_model_tests.sh && run_python_model_tests_slow_runtime_mode_${{ inputs.arch }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/perf-models-impl.yaml
+++ b/.github/workflows/perf-models-impl.yaml
@@ -66,7 +66,7 @@ jobs:
           install_wheel: true
           run_args: ./tests/scripts/run_tests.sh --tt-arch ${{ matrix.test-info.arch }} --pipeline-type ${{ matrix.model-type }}_models_performance_${{ matrix.test-info.machine-type }}
       # TODO: Fix the pipeline before enabling notifications.
-      #- uses: ./.github/actions/slack-report
+      #- uses: tenstorrent/tt-metal/.github/actions/slack-report@main
       #  if: ${{ failure() }}
       #  with:
       #    slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -97,7 +97,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout }}
         run: |
           ./tests/scripts/run_profiler_regressions.sh
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -104,7 +104,7 @@ jobs:
           username: ${{ secrets.SFTP_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
 
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -62,7 +62,7 @@ jobs:
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -74,7 +74,7 @@ jobs:
           source /work/tests/scripts/t3000/run_t3000_frequent_tests.sh
           ${{ matrix.test-group.cmd }}
 
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-model-perf-tests-impl.yaml
+++ b/.github/workflows/t3000-model-perf-tests-impl.yaml
@@ -100,7 +100,7 @@ jobs:
         with:
           name: perf-report-csv-${{ matrix.test-group.model-type }}-${{ matrix.test-group.arch }}-${{ matrix.test-group.model }}-bare-metal
           path: "${{ steps.check-perf-report.outputs.perf_report_filename }}"
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -202,7 +202,7 @@ jobs:
           path: |
             ${{ steps.check-perf-report.outputs.perf_report_filename_all_gather }}
             ${{ steps.check-perf-report.outputs.perf_report_filename_reduce_scatter }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -60,7 +60,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-perplexity-tests-impl.yaml
+++ b/.github/workflows/t3000-perplexity-tests-impl.yaml
@@ -68,7 +68,7 @@ jobs:
           ls -lart /dev/tenstorrent/
           source /work/tests/scripts/t3000/run_t3000_perplexity_tests.sh
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -60,7 +60,7 @@ jobs:
         timeout-minutes: 30
         run: |
           ./tests/scripts/run_profiler_regressions.sh
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -76,7 +76,7 @@ jobs:
           mkdir -p generated/test_reports
           source tests/scripts/t3000/run_t3000_unit_tests.sh
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -57,7 +57,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type demos_tg_device --dispatch-mode "" --model ${{ matrix.test-group.model }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tg-frequent-tests-impl.yaml
+++ b/.github/workflows/tg-frequent-tests-impl.yaml
@@ -62,7 +62,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type frequent_tg_device --dispatch-mode "" --model ${{ matrix.test-group.model }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -67,7 +67,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
           ${{ matrix.test-group.cmd }}
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick";
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "quick";
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -51,7 +51,7 @@ jobs:
         timeout-minutes: 360
         run: |
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "stress-test"
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -117,7 +117,7 @@ jobs:
           mkdir -p generated/test_reports
           ./tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type unit_tg_device --dispatch-mode "" --model ${{ matrix.test-group.model }}
 
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -81,7 +81,7 @@ jobs:
           path: |
             /work/generated/test_reports/
           prefix: "test_reports_"
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         # Only notify during failed scheduled runs
         if: ${{ failure() && github.event_name == 'schedule' }}
         with:

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -66,7 +66,7 @@ jobs:
           ldd tests/ttml_tests || true
           ${{ matrix.test-group.cmd }}
 
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -133,7 +133,7 @@ jobs:
         run: |
           ${{ matrix.test-group.cmd }}
 
-      - uses: ./.github/actions/slack-report
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/19632

### Problem description
If a job fails in setup, `slack-report` that uses the repo path (.e.g. `./.github/actions`) fails because tt-metal needs to be checked out for the action to exist and run. 

### What's changed
Change from `./.github/actions/slack-report` to `tenstorrent/tt-metal/.github/actions/slack-report@main`

### Checklist
- [x] All post-commit: https://github.com/tenstorrent/tt-metal/actions/runs/14313111824