### PR TITLE
[skip ci] Wire docker image through workflows

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -100,7 +100,6 @@ jobs:
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
-      os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -103,6 +103,8 @@ jobs:
       os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # Fabric Unit Tests
   fabric-unit-tests:
     needs: build-artifact
@@ -153,6 +155,8 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD C++ Unit Tests
   cpp-unit-tests:
     needs: build-artifact

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -40,9 +40,6 @@ permissions:
   packages: write
 
 jobs:
-  static-checks:
-    uses: ./.github/workflows/all-static-checks.yaml
-    secrets: inherit
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
@@ -96,7 +93,8 @@ jobs:
       timeout: 20
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
-      os: "ubuntu-22.04"
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # FD C++ Unit Tests
   cpp-unit-tests:
     needs: build-artifact
@@ -117,6 +115,8 @@ jobs:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       timeout: 20
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
 #   profiler-regression:
 #     needs: build-artifact-profiler

--- a/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests-wrapper.yaml
@@ -22,9 +22,10 @@ jobs:
         ]
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     with:
-      os: ubuntu-22.04
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   # TTNN FD Unit tests
   ttnn-unit-tests:
     needs: build-artifact
@@ -59,6 +60,8 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 
   # FD C++ Unit Tests
   cpp-unit-tests:

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -13,34 +13,12 @@ on:
         required: false
         type: number
         default: 45
-      os:
-        required: false
-        type: string
-        default: "ubuntu-20.04"
-  workflow_dispatch:
-    inputs:
-      arch:
+      docker-image:
         required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-      runner-label:
-        required: true
-        type: choice
-        options:
-          - E150
-          - N150
-          - N300
-          - BH
-      timeout:
-        required: false
-        type: number
-        default: 45
-      os:
-        required: false
         type: string
-        default: "ubuntu-20.04"
+      wheel-artifact-name:
+        required: true
+        type: string
 
 jobs:
   fd-tests:
@@ -49,7 +27,6 @@ jobs:
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        os: ["${{ inputs.os }}"]
         test-group: [
           {name: eager unit tests 1, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 1 },
           {name: eager unit tests 2, cmd: pytest tests/tt_eager/python_api_testing/unit_testing/ -xvvv --splits 7 --group 2 },
@@ -75,12 +52,12 @@ jobs:
       - uses: actions/download-artifact@v4
         timeout-minutes: 10
         with:
-          name: eager-dist-${{ matrix.os }}-any
+          name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
-          docker_os_arch: tt-metalium/${{ inputs.os }}-dev-amd64
+          docker_image: ${{ inputs.docker-image }}
           install_wheel: true
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |

--- a/.github/workflows/models-post-commit-wrapper.yaml
+++ b/.github/workflows/models-post-commit-wrapper.yaml
@@ -27,3 +27,5 @@ jobs:
     with:
       arch: ${{ matrix.test-group.arch}}
       runner-label: ${{ matrix.test-group.runner-label}}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -13,25 +13,12 @@ on:
         required: false
         type: number
         default: 45
-  workflow_dispatch:
-    inputs:
-      arch:
+      docker-image:
         required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-      runner-label:
+        type: string
+      wheel-artifact-name:
         required: true
-        type: choice
-        options:
-          - N150
-          - N300
-          - BH
-      timeout:
-        required: false
-        type: number
-        default: 45
+        type: string
 
 jobs:
   models:
@@ -59,11 +46,12 @@ jobs:
       - uses: actions/download-artifact@v4
         timeout-minutes: 10
         with:
-          name: eager-dist-${{ matrix.os }}-any
+          name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
+          docker_image: ${{ inputs.docker-image }}
           install_wheel: true
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |
@@ -108,11 +96,12 @@ jobs:
       - uses: actions/download-artifact@v4
         timeout-minutes: 10
         with:
-          name: eager-dist-${{ matrix.os }}-any
+          name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }} slow runtime mode tests
         timeout-minutes: ${{ inputs.timeout }}
         uses: ./.github/actions/docker-run
         with:
+          docker_image: ${{ inputs.docker-image }}
           install_wheel: true
           docker_password: ${{ secrets.GITHUB_TOKEN }}
           docker_opts: |


### PR DESCRIPTION
### Ticket
Closes [#19472](https://github.com/tenstorrent/tt-metal/issues/19472)

### Problem description
See issue

### What's changed
For consistency, we pass the docker image name from build artifact to all downstream workflows.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14274728001) CI passes
- [x] bh https://github.com/tenstorrent/tt-metal/actions/runs/14278323113
- [x] New/Existing tests provide coverage for changes