### PR TITLE
Require Python3 package, not just Python

### DIFF
--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -123,7 +123,7 @@ add_library(ttml STATIC ${SOURCES})
 
 target_include_directories(ttml PUBLIC ${PROJECT_SOURCE_DIR})
 
-find_package(Python REQUIRED Development)
+find_package(Python3 REQUIRED Development)
 
 foreach(lib ${BoostPackages})
     target_include_directories(ttml SYSTEM PUBLIC ${Boost${lib}_SOURCE_DIR}/include)
@@ -138,7 +138,7 @@ target_link_libraries(
         atomic
         Metalium::Metal
         Metalium::TTNN
-        Python::Python
+        Python3::Python
         fmt::fmt-header-only
         magic_enum::magic_enum
         yaml-cpp::yaml-cpp


### PR DESCRIPTION
### Ticket
Closes #20221 

### Problem description
See the issue for detailed description.

### What's changed
CMake will look for Python3 explicitly, instead of assuming CMake will do the right thing if both 2 and 3 are installed on the system. This is the right thing to do anyway. And it fixes my problem, though there might be issues in other environment with Python discovery and passing `-DPython3_FIND_VIRTUALENV=ONLY` to CMake might be required for even better fix.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes