### PR TITLE
Wransom/halo fix

### DIFF
--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
@@ -299,4 +299,5 @@ void kernel_main() {
 
     noc_async_read_barrier();
     noc_async_write_barrier();
+    noc_async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
@@ -7,7 +7,7 @@
 
 #include "dataflow_api.h"
 
-#define ENABLE_DEBUG 1
+#define ENABLE_DEBUG 0
 
 #if ENABLE_DEBUG
 #include "debug/dprint_pages.h"
@@ -194,13 +194,9 @@ void kernel_main() {
     constexpr uint32_t is_width_sharded = get_compile_time_arg_val(14);
     constexpr uint32_t input_aligned_page_size = get_compile_time_arg_val(15);
     constexpr uint32_t remote_read = get_compile_time_arg_val(16);  // Unused parameter
-    constexpr uint32_t num_cores_nhw = get_compile_time_arg_val(17);
-    constexpr uint32_t num_cores_c = get_compile_time_arg_val(18);
-    constexpr uint32_t num_cores_x = get_compile_time_arg_val(19);
-    constexpr uint32_t semaphore_id = get_compile_time_arg_val(20);
-    constexpr uint32_t max_out_nsticks_per_core = get_compile_time_arg_val(21);
-
-    constexpr uint32_t num_cores = num_cores_nhw * num_cores_c;
+    constexpr uint32_t num_cores = get_compile_time_arg_val(17);
+    constexpr uint32_t semaphore_id = get_compile_time_arg_val(18);
+    constexpr uint32_t max_out_nsticks_per_core = get_compile_time_arg_val(19);
 
     uint32_t arg_idx = 0;
     tt_l1_ptr uint32_t* core_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather_in_place.cpp
@@ -245,7 +245,6 @@ void kernel_main() {
     noc_async_write_barrier();
 
     for (uint16_t noc = 0; noc < num_cores; ++noc) {
-        DPRINT << "id=" << noc << " x=" << core_noc_x[noc] << " y=" << core_noc_y[noc] << ENDL();
         const uint64_t ref_semaphore_noc_addr = get_noc_addr(core_noc_x[noc], core_noc_y[noc], semaphore_addr);
         noc_semaphore_inc(ref_semaphore_noc_addr, 1);
     }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
@@ -427,8 +427,6 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core_v2(
     const bool is_block_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
     const bool is_width_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED;
 
-    CoreCoord noc_00;
-    uint32_t num_cores_x = 0;
     uint32_t semaphore_id = 0;
     uint32_t remote_temp_cb_id = 0;
     std::vector<uint32_t> output_tensor_cores_x;
@@ -461,14 +459,6 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core_v2(
     }
 
     // Compute core data and create semaphore
-    auto core_id_to_noc_coords = [is_block_sharded, transpose_mcast, device](uint32_t core_id) -> CoreCoord {
-        auto num_cores_x = device->compute_with_storage_grid_size().x;
-        auto core_coord = is_block_sharded ? (transpose_mcast ? CoreCoord(core_id, 0) : CoreCoord(0, core_id))
-                                           : CoreCoord(core_id % num_cores_x, core_id / num_cores_x);
-        return device->worker_core_from_logical_core(core_coord);
-    };
-    noc_00 = core_id_to_noc_coords(0);
-    num_cores_x = device->compute_with_storage_grid_size().x;
     semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
 
     auto aligned_input_nstick_nbytes = out_stick_nbytes;
@@ -497,9 +487,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core_v2(
         is_width_sharded,
         aligned_input_nstick_nbytes,
         true,
-        ncores_nhw,
-        ncores_c,
-        num_cores_x,
+        cores.size(),
         semaphore_id,
         max_out_nsticks_per_core};
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
@@ -458,7 +458,7 @@ operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core_v2(
         output_tensor_cores_y.push_back(worker.y);
     }
 
-    // Compute core data and create semaphore
+    // create semaphore
     semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
 
     auto aligned_input_nstick_nbytes = out_stick_nbytes;


### PR DESCRIPTION
### Ticket
This PR addresses a bug fix:
https://github.com/tenstorrent/tt-metal/issues/20039

### Problem description
Conv hung for some inputs when in place halo was used.

### What's changed
This has been fixed by updating the number of cores used by the semaphores in the in place halo kernel, additionally a atomic barrier has been added to ensure all atomic operations are complete before kernel exit.
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14316112175
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14316130876
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14316139222
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14316136699
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14316230007
https://github.com/tenstorrent/tt-metal/actions/runs/14316145738
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14316142051
- [x] New/Existing tests provide coverage for changes