### PR TITLE
Workaround ND Falcon7B TG slice crash by changing problematic reshape to transpose

### DIFF
--- a/models/demos/falcon7b_common/tt/falcon_attention.py
+++ b/models/demos/falcon7b_common/tt/falcon_attention.py
@@ -646,12 +646,9 @@ class TtFalconAttentionDecode(nn.Module):
                 -2,
                 -3,
             )
-            query_layer = ttnn.reshape_on_device(
+            query_layer = ttnn.reshape(
                 query_layer,
-                batch,
-                1,
-                self.padded_local_heads,
-                self.head_dim,  # Batch must be in dim 0 to match K cache
+                (batch, 1, self.padded_local_heads, self.head_dim),  # Batch must be in dim 0 to match K cache
             )
             query_layer = ttnn.interleaved_to_sharded(
                 query_layer,
@@ -792,7 +789,7 @@ class TtFalconAttentionDecode(nn.Module):
             )
 
             # Get batch in dim 1
-            attn_output = ttnn.reshape_on_device(attn_output, 1, batch, self.padded_local_heads, self.head_dim)
+            attn_output = ttnn.reshape(attn_output, (1, batch, self.padded_local_heads, self.head_dim))
 
             # Get batch in dim 2
             attn_output = ttnn.transpose(

--- a/models/demos/falcon7b_common/tt/falcon_attention.py
+++ b/models/demos/falcon7b_common/tt/falcon_attention.py
@@ -799,19 +799,7 @@ class TtFalconAttentionDecode(nn.Module):
             )
 
             # UNPAD
-            attn_output_shape = attn_output.padded_shape
-            attn_output = ttnn.slice(
-                attn_output,
-                starts=(0, 0, 0, 0),
-                ends=(
-                    attn_output_shape[0],
-                    self.num_heads,
-                    attn_output_shape[2],
-                    attn_output_shape[3],
-                ),
-                steps=(1, 1, 1, 1),
-                memory_config=self.model_config["POST_SOFTMAX_MM_OUTPUT_MEMCFG"],
-            )
+            attn_output = attn_output[:, : self.num_heads, :, :]
         else:
             # TODO: switch to group_attn_matmul once multiple q heads is supported (issue #5318)
             if is_wormhole_b0():

--- a/models/demos/falcon7b_common/tt/falcon_attention.py
+++ b/models/demos/falcon7b_common/tt/falcon_attention.py
@@ -799,7 +799,7 @@ class TtFalconAttentionDecode(nn.Module):
             )
 
             # UNPAD
-            attn_output = attn_output[:, : self.num_heads, :, :]
+            attn_output = attn_output[:, : self.num_heads, :batch, :]  # Specify batch due to ND Issue #15059
         else:
             # TODO: switch to group_attn_matmul once multiple q heads is supported (issue #5318)
             if is_wormhole_b0():

--- a/models/demos/falcon7b_common/tt/falcon_attention.py
+++ b/models/demos/falcon7b_common/tt/falcon_attention.py
@@ -789,17 +789,13 @@ class TtFalconAttentionDecode(nn.Module):
             )
 
             # Get batch in dim 1
-            attn_output = ttnn.reshape(attn_output, (1, batch, self.padded_local_heads, self.head_dim))
+            attn_output = ttnn.transpose(attn_output, 0, 1)
 
             # Get batch in dim 2
-            attn_output = ttnn.transpose(
-                attn_output,
-                -2,
-                -3,
-            )
+            attn_output = ttnn.transpose(attn_output, -2, -3)
 
             # UNPAD
-            attn_output = attn_output[:, : self.num_heads, :batch, :]  # Specify batch due to ND Issue #15059
+            attn_output = attn_output[:, : self.num_heads, :, :]
         else:
             # TODO: switch to group_attn_matmul once multiple q heads is supported (issue #5318)
             if is_wormhole_b0():

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -35,12 +35,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)  # Option to run Falcon in Async mode
 @pytest.mark.parametrize(
     "mesh_device",
-    (
-        (4, 4),
-        (8, 4),
-    ),
+    ((8, 4),),
     indirect=True,
-    ids=["16chipTG", "32chipTG"],
+    ids=["32chipTG"],
 )
 def test_demo_multichip(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
@@ -61,7 +58,7 @@ def test_demo_multichip(
     num_devices = mesh_device.get_num_devices()
 
     if is_ci_env:
-        if num_devices != 32 or (not expected_greedy_output_path and not expected_perf_metrics):
+        if not expected_greedy_output_path and not expected_perf_metrics:
             pytest.skip("Skipping test in CI since it provides redundant testing")
         if expected_greedy_output_path:
             pytest.skip("Skipping test in CI due to Issue #11254")

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -11,7 +11,7 @@ from models.utility_functions import is_wormhole_b0
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
         (True, 128, {"prefill_t/s": 14800, "decode_t/s": 3677, "decode_t/s/u": 3.59}, False, None),
-        (True, 1024, {"prefill_t/s": 19180, "decode_t/s": 3590, "decode_t/s/u": 3.51}, False, None),
+        (True, 1024, {"prefill_t/s": 19180, "decode_t/s": 3325, "decode_t/s/u": 3.25}, False, None),
         (True, 2048, {"prefill_t/s": 13500, "decode_t/s": 3448, "decode_t/s/u": 3.37}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),


### PR DESCRIPTION
### Ticket
#15059

### Problem description
Falcon7B is ND crashing (often for TG, rarely for T3K, almost never for single-chip) on a slice assertion which indicates that the slice input shape and ends are corrupted

### What's changed
- Made a workaround by changing a reshape before the failing slice to a transpose, as it looks like the output shape of the reshape is being corrupted.
- Other cleanup: changed other instances of `ttnn.reshape_on_device` to `ttnn.reshape` since reshape_on_device is no longer meant to be used, updated tg 1k decode target, removed 16 chip tg test which is always skipped

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes