### PR TITLE
Highlight Unused Parameters in `tt_metal`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -116,6 +116,7 @@ Checks: >
   -misc-redundant-expression,
   -misc-unconventional-assign-operator,
   -misc-uniqueptr-reset-release,
+  -misc-unused-parameters,
   -misc-unused-using-decls,
   -misc-use-anonymous-namespace,
   -modernize-avoid-bind,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -116,7 +116,6 @@ Checks: >
   -misc-redundant-expression,
   -misc-unconventional-assign-operator,
   -misc-uniqueptr-reset-release,
-  -misc-unused-parameters,
   -misc-unused-using-decls,
   -misc-use-anonymous-namespace,
   -modernize-avoid-bind,

--- a/tt_metal/common/metal_soc_descriptor.cpp
+++ b/tt_metal/common/metal_soc_descriptor.cpp
@@ -198,7 +198,7 @@ void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
 // removing the harvested physical coordiniates Metal needs the true harvesting state so we generate physical
 // descriptors from virtual coordinates We also initialize additional lookup tables to translate physical coordinates to
 // virtual coordinates because UMD APIs expect virtual coordinates.
-metal_SocDescriptor::metal_SocDescriptor(const tt_SocDescriptor& other, const BoardType& board_type) :
+metal_SocDescriptor::metal_SocDescriptor(const tt_SocDescriptor& other, const BoardType& /*board_type*/) :
     tt_SocDescriptor(other) {
     this->load_dram_metadata_from_device_descriptor();
     this->generate_logical_eth_coords_mapping();

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -554,7 +554,7 @@ CoreCoord MeshDevice::ethernet_core_from_logical_core(const CoreCoord& logical_c
         return device->ethernet_core_from_logical_core(logical_core);
     });
 }
-std::unordered_set<CoreCoord> MeshDevice::get_active_ethernet_cores(bool skip_reserved_tunnel_cores) const {
+std::unordered_set<CoreCoord> MeshDevice::get_active_ethernet_cores(bool /*skip_reserved_tunnel_cores*/) const {
     TT_THROW("get_active_ethernet_cores() is not supported on MeshDevice - use individual devices instead");
 }
 
@@ -562,19 +562,19 @@ std::unordered_set<CoreCoord> MeshDevice::get_inactive_ethernet_cores() const {
     TT_THROW("get_inactive_ethernet_cores() is not supported on MeshDevice - use individual devices instead");
 }
 
-bool MeshDevice::is_inactive_ethernet_core(CoreCoord logical_core) const {
+bool MeshDevice::is_inactive_ethernet_core(CoreCoord /*logical_core*/) const {
     TT_THROW("is_inactive_ethernet_core() is not supported on MeshDevice - use individual devices instead");
 }
 
-std::tuple<chip_id_t, CoreCoord> MeshDevice::get_connected_ethernet_core(CoreCoord eth_core) const {
+std::tuple<chip_id_t, CoreCoord> MeshDevice::get_connected_ethernet_core(CoreCoord /*eth_core*/) const {
     TT_THROW("get_connected_ethernet_core() is not supported on MeshDevice - use individual devices instead");
 }
 
-bool MeshDevice::is_active_ethernet_core(CoreCoord logical_core, bool skip_reserved_tunnel_cores) const {
+bool MeshDevice::is_active_ethernet_core(CoreCoord /*logical_core*/, bool /*skip_reserved_tunnel_cores*/) const {
     TT_THROW("is_active_ethernet_core() is not supported on MeshDevice - use individual devices instead");
 }
 
-std::vector<CoreCoord> MeshDevice::get_ethernet_sockets(chip_id_t connected_chip_id) const {
+std::vector<CoreCoord> MeshDevice::get_ethernet_sockets(chip_id_t /*connected_chip_id*/) const {
     TT_THROW("get_ethernet_sockets() is not supported on MeshDevice - use individual devices instead");
 }
 
@@ -708,11 +708,11 @@ void MeshDevice::load_trace(const uint8_t cq_id, const uint32_t trace_id, const 
 
 // Dispatch and initialization
 bool MeshDevice::initialize(
-    const uint8_t num_hw_cqs,
-    size_t l1_small_size,
-    size_t trace_region_size,
-    tt::stl::Span<const std::uint32_t> l1_bank_remap,
-    bool minimal) {
+    const uint8_t /*num_hw_cqs*/,
+    size_t /*l1_small_size*/,
+    size_t /*trace_region_size*/,
+    tt::stl::Span<const std::uint32_t> /*l1_bank_remap*/,
+    bool /*minimal*/) {
     // For MeshDevice, we support uniform sub-devices across all devices and we do not support ethernet subdevices.
     const auto& compute_grid_size = this->compute_with_storage_grid_size();
     auto sub_devices = {
@@ -764,7 +764,7 @@ void MeshDevice::synchronize() {
 }
 WorkExecutorMode MeshDevice::get_worker_mode() { return WorkExecutorMode::SYNCHRONOUS; }
 bool MeshDevice::is_worker_queue_empty() const { return true; }
-void MeshDevice::push_work(std::function<void()> work, bool blocking) {
+void MeshDevice::push_work(std::function<void()> work, bool /*blocking*/) {
     // Execute inline synchronously.
     // Using a lock to provide the same call serialization guarantee as an async single device scheduling.
     std::lock_guard lock(push_work_mutex_);

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -296,7 +296,7 @@ ProgramConfig& MeshWorkload::get_program_config(uint32_t index) {
 }
 
 uint32_t MeshWorkload::get_sem_base_addr(
-    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);
@@ -319,7 +319,7 @@ uint32_t MeshWorkload::get_sem_size(
 }
 
 uint32_t MeshWorkload::get_cb_base_addr(
-    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -158,7 +158,7 @@ std::vector<std::vector<std::vector<std::pair<chip_id_t, mesh_id_t>>>> RoutingTa
 }
 
 void RoutingTableGenerator::generate_intermesh_routing_table(
-    const InterMeshConnectivity& inter_mesh_connectivity, const IntraMeshConnectivity& intra_mesh_connectivity) {
+    const InterMeshConnectivity& inter_mesh_connectivity, const IntraMeshConnectivity& /*intra_mesh_connectivity*/) {
     for (mesh_id_t src_mesh_id = 0; src_mesh_id < this->inter_mesh_table_.size(); src_mesh_id++) {
         auto paths = get_paths_to_all_meshes(src_mesh_id, inter_mesh_connectivity);
         for (chip_id_t src_chip_id = 0; src_chip_id < this->inter_mesh_table_[src_mesh_id].size(); src_chip_id++) {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -52,7 +52,6 @@ bool is_l1_impl(BufferType buffer_type) { return buffer_type == BufferType::L1 o
 void validate_buffer_size_and_page_size(
     DeviceAddr size,
     DeviceAddr page_size,
-    const BufferType& buffer_type,
     const TensorMemoryLayout& buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters) {
     if (size == 0) {
@@ -81,7 +80,6 @@ void validate_buffer_size_and_page_size(
 }
 
 std::tuple<std::vector<std::vector<uint32_t>>, std::vector<std::array<uint32_t, 2>>> core_to_host_pages(
-    const uint32_t total_pages,
     const uint32_t pages_per_shard,
     const uint32_t num_shards,
     const TensorMemoryLayout layout,
@@ -218,7 +216,6 @@ BufferPageMapping generate_buffer_page_mapping(const Buffer& buffer) {
 
     uint32_t num_dev_pages = buffer.num_dev_pages();
     auto [core_host_page_indices, shard_shape] = core_to_host_pages(
-        num_dev_pages,
         shard_spec.num_pages(),
         num_cores,
         buffer.buffer_layout(),
@@ -293,7 +290,7 @@ Buffer::Buffer(
         this->allocator_ = device->allocator().get();
     }
     if (size != 0) {
-        validate_buffer_size_and_page_size(size, page_size, buffer_type, buffer_layout, shard_parameters);
+        validate_buffer_size_and_page_size(size, page_size, buffer_layout, shard_parameters);
     }
     unique_id_ = next_unique_id.fetch_add(1);
 }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -346,7 +346,7 @@ using InterleavedBufferWriteDispatchParamsVariant =
 
 InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_params(
     const Buffer& buffer,
-    const BufferDispatchConstants& buf_dispatch_constants,
+    const BufferDispatchConstants& /*buf_dispatch_constants*/,
     uint32_t cq_id,
     tt::stl::Span<const uint32_t> expected_num_workers_completed,
     const BufferRegion& region) {

--- a/tt_metal/impl/data_format/tilize_utils.cpp
+++ b/tt_metal/impl/data_format/tilize_utils.cpp
@@ -204,7 +204,7 @@ std::vector<T> convert_to_flat_layout(
     std::optional<PhysicalSize> tile_shape,
     std::optional<PhysicalSize> face_shape,
     const bool transpose_face,
-    const bool transpose_face_order) {
+    const bool /*transpose_face_order*/) {
     ZoneScoped;
     std::vector<T> result;
     if (data.size() == 0) {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -667,7 +667,7 @@ void WatcherDeviceReader::DumpPauseStatus(CoreDescriptor& core, const string& co
     }
 }
 
-void WatcherDeviceReader::DumpRingBuffer(CoreDescriptor& core, const mailboxes_t* mbox_data, bool to_stdout) {
+void WatcherDeviceReader::DumpRingBuffer(CoreDescriptor& /*core*/, const mailboxes_t* mbox_data, bool to_stdout) {
     const debug_ring_buf_msg_t* ring_buf_data = &mbox_data->watcher.debug_ring_buf;
     string out = "";
     if (ring_buf_data->current_ptr != DEBUG_RING_BUFFER_STARTING_INDEX) {

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -90,7 +90,7 @@ DispatchSettings DispatchSettings::worker_defaults(const tt::Cluster& cluster, c
         .build();
 }
 
-DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& cluster, const uint32_t num_hw_cqs) {
+DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& /*cluster*/, const uint32_t num_hw_cqs) {
     return DispatchSettings()
         .num_hw_cqs(num_hw_cqs)
         .core_type(CoreType::ETH)

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -376,7 +376,7 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
     build_options.bfp8_pack_precise = this->config_.bfp8_pack_precise;
 }
 
-void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
+void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_kernel_include(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
@@ -388,7 +388,7 @@ void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions &bui
         this);
 }
 
-void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
+void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_kernel_include(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t erisc_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
@@ -400,7 +400,7 @@ void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions &build_o
         this);
 }
 
-void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions &build_options) const {
+void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_triscs_src(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
     uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -27,25 +27,25 @@ namespace {
 void PrintHostDataType(const HostDataType& data) {
     std::visit(
         tt::stl::overloaded{
-            [](const std::shared_ptr<std::vector<uint8_t>>& value) {
+            [](const std::shared_ptr<std::vector<uint8_t>>& /*value*/) {
                 log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint8_t>>");
             },
-            [](const std::shared_ptr<std::vector<uint16_t>>& value) {
+            [](const std::shared_ptr<std::vector<uint16_t>>& /*value*/) {
                 log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint16_t>>");
             },
-            [](const std::shared_ptr<std::vector<int32_t>>& value) {
+            [](const std::shared_ptr<std::vector<int32_t>>& /*value*/) {
                 log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<int32_t>>");
             },
-            [](const std::shared_ptr<std::vector<uint32_t>>& value) {
+            [](const std::shared_ptr<std::vector<uint32_t>>& /*value*/) {
                 log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint32_t>>");
             },
-            [](const std::shared_ptr<std::vector<float>>& value) {
+            [](const std::shared_ptr<std::vector<float>>& /*value*/) {
                 log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<float>>");
             },
-            [](const std::shared_ptr<std::vector<bfloat16>>& value) {
+            [](const std::shared_ptr<std::vector<bfloat16>>& /*value*/) {
                 log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<bfloat16>>");
             },
-            [](const void* value) { log_info(tt::LogMetalTrace, "HostDataType contains: const void*"); },
+            [](const void* /*value*/) { log_info(tt::LogMetalTrace, "HostDataType contains: const void*"); },
             [](auto&&) { log_info(tt::LogMetalTrace, "HostDataType contains: Unknown type"); }},
         data);
 }
@@ -63,7 +63,7 @@ void CaptureCommand(tt::tt_metal::flatbuffer::CommandType cmd_type, ::flatbuffer
 }
 }  // namespace
 
-void CaptureReplayTrace(IDevice* device, uint8_t cq_id, uint32_t trace_id, bool blocking) {
+void CaptureReplayTrace(IDevice* /*device*/, uint8_t cq_id, uint32_t trace_id, bool blocking) {
     auto& ctx = LightMetalCaptureContext::get();
     log_debug(tt::LogMetalTrace, "{}: cq_id: {} trace_id: {} blocking: {}", __FUNCTION__, cq_id, trace_id, blocking);
     auto cmd = tt::tt_metal::flatbuffer::CreateReplayTraceCommand(ctx.get_builder(), cq_id, trace_id, blocking);
@@ -77,14 +77,14 @@ void CaptureEnqueueTrace(CommandQueue& cq, uint32_t trace_id, bool blocking) {
     CaptureCommand(tt::tt_metal::flatbuffer::CommandType::EnqueueTraceCommand, cmd.Union());
 }
 
-void CaptureLoadTrace(IDevice* device, uint8_t cq_id, uint32_t trace_id) {
+void CaptureLoadTrace(IDevice* /*device*/, uint8_t cq_id, uint32_t trace_id) {
     auto& ctx = LightMetalCaptureContext::get();
     log_debug(tt::LogMetalTrace, "{}: cq_id: {} trace_id: {}", __FUNCTION__, cq_id, trace_id);
     auto cmd = tt::tt_metal::flatbuffer::CreateLoadTraceCommand(ctx.get_builder(), trace_id, cq_id);
     CaptureCommand(tt::tt_metal::flatbuffer::CommandType::LoadTraceCommand, cmd.Union());
 }
 
-void CaptureReleaseTrace(IDevice* device, uint32_t trace_id) {
+void CaptureReleaseTrace(IDevice* /*device*/, uint32_t trace_id) {
     auto& ctx = LightMetalCaptureContext::get();
     log_debug(tt::LogMetalTrace, "{}: trace_id: {}", __FUNCTION__, trace_id);
     auto cmd = tt::tt_metal::flatbuffer::CreateReleaseTraceCommand(ctx.get_builder(), trace_id);
@@ -240,7 +240,7 @@ void CaptureEnqueueWriteBuffer(
 void CaptureEnqueueReadBuffer(
     CommandQueue& cq,
     std::variant<std::reference_wrapper<Buffer>, std::shared_ptr<Buffer>> buffer,
-    void* dst,
+    void* /*dst*/,
     bool blocking) {
     auto& ctx = LightMetalCaptureContext::get();
 
@@ -393,7 +393,7 @@ void CaptureSetRuntimeArgsUint32VecPerCore(
     CaptureCommand(tt::tt_metal::flatbuffer::CommandType::SetRuntimeArgsUint32VecPerCoreCommand, cmd.Union());
 }
 void CaptureSetRuntimeArgs(
-    IDevice* device,
+    IDevice* /*device*/,
     const std::shared_ptr<Kernel>& kernel,
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const std::shared_ptr<RuntimeArgs>& runtime_args) {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -289,7 +289,7 @@ void DeviceProfiler::logPacketData(
     const std::string& opname,
     chip_id_t device_id,
     CoreCoord core,
-    int core_flat,
+    int /*core_flat*/,
     int risc_num,
     uint64_t data,
     uint32_t timer_id,
@@ -446,7 +446,7 @@ void DeviceProfiler::logPacketDataToCSV(
     uint64_t data,
     uint32_t run_id,
     uint32_t run_host_id,
-    const std::string_view opname,
+    const std::string_view /*opname*/,
     const std::string_view zone_name,
     kernel_profiler::PacketTypes packet_type,
     uint64_t source_line,
@@ -483,7 +483,7 @@ void DeviceProfiler::logNocTracePacketDataToJson(
     int core_x,
     int core_y,
     const std::string_view risc_name,
-    uint32_t timer_id,
+    uint32_t /*timer_id*/,
     uint64_t timestamp,
     uint64_t data,
     uint32_t run_id,
@@ -491,8 +491,8 @@ void DeviceProfiler::logNocTracePacketDataToJson(
     const std::string_view opname,
     const std::string_view zone_name,
     kernel_profiler::PacketTypes packet_type,
-    uint64_t source_line,
-    const std::string_view source_file) {
+    uint64_t /*source_line*/,
+    const std::string_view /*source_file*/) {
     if (packet_type == kernel_profiler::ZONE_START || packet_type == kernel_profiler::ZONE_END) {
         if ((risc_name == "NCRISC" || risc_name == "BRISC") &&
             (zone_name.starts_with("TRUE-KERNEL-END") || zone_name.ends_with("-KERNEL"))) {
@@ -650,7 +650,7 @@ CoreCoord DeviceProfiler::getPhysicalAddressFromVirtual(chip_id_t device_id, con
     }
 }
 
-DeviceProfiler::DeviceProfiler(const bool new_logs) {
+DeviceProfiler::DeviceProfiler(const bool /*new_logs*/) {
 #if defined(TRACY_ENABLE)
     ZoneScopedC(tracy::Color::Green);
     output_dir = std::filesystem::path(get_profiler_logs_dir());

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -234,7 +234,7 @@ uint32_t finalize_sems(
 }
 
 uint32_t finalize_cbs(
-    uint32_t programmable_core_type_index,
+    uint32_t /*programmable_core_type_index*/,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset,
     uint32_t& cb_offset,
@@ -476,7 +476,8 @@ void insert_empty_program_dispatch_preamble_cmd(ProgramCommandSequence& program_
     program_command_sequence.preamble_command_sequence.add_dispatch_set_write_offsets(0, 0, 0);
 }
 
-void insert_stall_cmds(ProgramCommandSequence& program_command_sequence, SubDeviceId sub_device_id, IDevice* device) {
+void insert_stall_cmds(
+    ProgramCommandSequence& program_command_sequence, SubDeviceId sub_device_id, IDevice* /*device*/) {
     // Initialize stall command sequences for this program.
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     auto dispatch_core_type = dispatch_core_config.get_core_type();
@@ -537,7 +538,7 @@ void generate_runtime_args_cmds(
             return dispatch_cmd_sizeB + aligned_runtime_data_sizeB;
         };
     thread_local static auto get_runtime_args_data_offset =
-        [](uint32_t num_packed_cmds, uint32_t runtime_args_len, bool is_unicast) {
+        [](uint32_t num_packed_cmds, uint32_t /*runtime_args_len*/, bool is_unicast) {
             uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
             uint32_t sub_cmd_sizeB =
                 is_unicast ? sizeof(CQDispatchWritePackedUnicastSubCmd) : sizeof(CQDispatchWritePackedMulticastSubCmd);
@@ -2147,7 +2148,7 @@ void reset_worker_dispatch_state_on_device(
 }
 
 void set_num_worker_sems_on_dispatch(
-    IDevice* device, SystemMemoryManager& manager, uint8_t cq_id, uint32_t num_worker_sems) {
+    IDevice* /*device*/, SystemMemoryManager& manager, uint8_t cq_id, uint32_t num_worker_sems) {
     // Not needed for regular dispatch kernel
     if (!MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
         return;
@@ -2164,7 +2165,7 @@ void set_num_worker_sems_on_dispatch(
 }
 
 void set_go_signal_noc_data_on_dispatch(
-    IDevice* device,
+    IDevice* /*device*/,
     const vector_aligned<uint32_t>& go_signal_noc_data,
     SystemMemoryManager& manager,
     uint8_t cq_id) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -434,7 +434,7 @@ KernelGroup::KernelGroup(
     const detail::Program_& program,
     uint32_t programmable_core_type_index,
     kernel_id_array_t kernel_ids,
-    bool erisc_is_idle,
+    bool /*erisc_is_idle*/,
     uint32_t max_local_cb_end_index,
     uint32_t min_remote_cb_start_index,
     const CoreRangeSet& new_ranges) :
@@ -1533,13 +1533,13 @@ void detail::Program_::set_runtime_id(uint64_t id) { this->runtime_id = id; }
 
 void Program::set_runtime_id(uint64_t id) { pimpl_->set_runtime_id(id); }
 
-uint32_t Program::get_sem_base_addr(IDevice* device, CoreCoord logical_core, CoreType core_type) {
+uint32_t Program::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
     return base_addr + get_program_config(hal_ref.get_programmable_core_type_index(programmable_core_type)).sem_offset;
 }
 
-uint32_t Program::get_cb_base_addr(IDevice* device, CoreCoord logical_core, CoreType core_type) {
+uint32_t Program::get_cb_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
     return base_addr + get_program_config(hal_ref.get_programmable_core_type_index(programmable_core_type)).cb_offset;

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -791,7 +791,7 @@ void JitBuildState::link(const string& log_file, const string& out_dir, const Ji
 // weakens symbols in A so that it can be used as a "library" for B. B imports A's weakened symbols, B's symbols of the
 // same name don't result in duplicate symbols but B can reference A's symbols. Force the fw_export symbols to remain
 // strong so to propogate link addresses
-void JitBuildState::weaken(const string& log_file, const string& out_dir) const {
+void JitBuildState::weaken(const string& /*log_file*/, const string& out_dir) const {
     // ZoneScoped;
 
     std::string pathname_in = out_dir + target_name_ + ".elf";

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -139,7 +139,7 @@ uint32_t compute_build_key(chip_id_t device_id, uint8_t num_hw_cqs) {
     return build_key;
 }
 
-JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t device_id, uint8_t num_hw_cqs, bool is_fw) {
+JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_id*/, uint8_t num_hw_cqs, bool is_fw) {
     // Get the dispatch message address for this device
     CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     uint32_t dispatch_message_addr =

--- a/tt_metal/jit_build/data_format.cpp
+++ b/tt_metal/jit_build/data_format.cpp
@@ -126,7 +126,7 @@ std::vector<DataFormat> get_unpack_src_formats(DataFormat data_formats[NUM_CIRCU
 }
 
 const DataFormat get_single_unpack_dst_format(
-    const DataFormat src_format, const DataFormat pack_format, const DataFormat unpack_conditional_dst_format) {
+    const DataFormat src_format, const DataFormat /*pack_format*/, const DataFormat unpack_conditional_dst_format) {
     DataFormat dst_format = src_format;
     if (src_format == DataFormat::Float32) {
         TT_FATAL(
@@ -155,7 +155,7 @@ bool is_all_fp32_formats(const DataFormat data_format[NUM_CIRCULAR_BUFFERS]) {
 std::vector<DataFormat> get_unpack_dst_formats(
     DataFormat buf_formats[NUM_CIRCULAR_BUFFERS],
     DataFormat unpack_conditional_dst_format,
-    bool fp32_dest_acc_en,
+    bool /*fp32_dest_acc_en*/,
     std::vector<UnpackToDestMode> unpack_to_dest_mode,
     bool int_fpu_en) {
     if (!unpack_to_dest_mode.empty()) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -373,7 +373,7 @@ static void emit_pack_tile_dims(const std::string& pack_tile_dims_descs, tt_hlk_
     file_stream.close();
 }
 
-static void generate_tile_dims_descriptors(JitBuildOptions& options, const tt::ARCH arch) {
+static void generate_tile_dims_descriptors(JitBuildOptions& options) {
     string out_file_name_base = "chlkc_";
     string out_file_name_suffix = "_tile_dims.h";
     string unpack_tile_dims_descs = options.path + out_file_name_base + "unpack" + out_file_name_suffix;
@@ -450,7 +450,7 @@ void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& opt
     fs::create_directories(options.path);
     try {
         std::thread td( [&]() { generate_data_format_descriptors(options, env.get_arch()); } );
-        std::thread tt( [&]() { generate_tile_dims_descriptors(options, env.get_arch()); } );
+        std::thread tt([&]() { generate_tile_dims_descriptors(options); });
         std::thread tm( [&]() { generate_math_fidelity_descriptor(options); } );
         std::thread ta( [&]() { generate_math_approx_mode_descriptor(options); } );
         std::thread tf( [&]() { generate_dst_accum_mode_descriptor(options); } );

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -174,7 +174,7 @@ bool test_load_write_read_risc_binary(
 
 void write_binary_to_address(ll_api::memory const& mem, chip_id_t chip_id, const CoreCoord& core, uint32_t address) {
     log_debug(tt::LogLLRuntime, "vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
-    mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
+    mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t /*addr*/, uint32_t len_words) {
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             &*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), address);
     });

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -51,8 +51,7 @@ static constexpr uint32_t HOST_MEM_CHANNELS_MASK = HOST_MEM_CHANNELS - 1;
 
 namespace {
 
-inline std::string get_soc_description_file(
-    const tt::ARCH& arch, tt::TargetDevice target_device, const std::string& output_dir = "") {
+inline std::string get_soc_description_file(const tt::ARCH& arch, tt::TargetDevice target_device) {
     // Ability to skip this runtime opt, since trimmed SOC desc limits which DRAM channels are available.
     std::string tt_metal_home;
     if (getenv("TT_METAL_HOME")) {
@@ -588,7 +587,7 @@ void Cluster::read_dram_vec(
 }
 
 void Cluster::write_core(
-    const void *mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access) const {
+    const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool /*small_access*/) const {
     chip_id_t chip_id = core.chip;
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
     if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
@@ -604,7 +603,7 @@ void Cluster::write_core(
 }
 
 void Cluster::read_core(
-    void *mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access) const {
+    void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr, bool /*small_access*/) const {
     int chip_id = core.chip;
     const metal_SocDescriptor &soc_desc = this->get_soc_desc(chip_id);
 

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -9,7 +9,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-int main(int argc, char** argv) {
+int main() {
     /* Silicon accelerator setup */
     IDevice* device = CreateDevice(0);
 

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -8,7 +8,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-int main(int argc, char** argv) {
+int main() {
     /* Silicon accelerator setup */
     IDevice* device = CreateDevice(0);
 

--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -7,7 +7,7 @@
 
 // Stand-alone example demonstrating usage of native multi-device TT-Metalium APIs
 // for issuing a program dispatch across a mesh of devices.
-int main(int argc, char** argv) {
+int main() {
     using namespace tt::tt_metal;
     using namespace tt::tt_metal::distributed;
 

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -15,7 +15,7 @@
 // 2. Enqueue a Write command to the MeshBuffer with random data
 // 3. Enqueue a Read command to the MeshBuffer and read back the data to a local buffer
 // 4. Verify that the data read back matches the original data
-int main(int argc, char** argv) {
+int main() {
     using namespace tt::tt_metal;
     using namespace tt::tt_metal::distributed;
     using tt::tt_metal::distributed::ShardedBufferConfig;

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -84,7 +84,7 @@ Program CreateEltwiseAddProgram(
 //
 // The example showcases TT-Metalium's ability to abstract away the complexity
 // of distributed memory management and compute.
-int main(int argc, char** argv) {
+int main() {
     auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
 
     // Define the global buffer shape and shard shape for distributed buffers

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<Program> EltwiseBinaryProgramGenerator(
     return program;
 }
 
-int main(int argc, char** argv) {
+int main() {
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
     // Initialize constants used to define the workload

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -59,7 +59,7 @@ std::map<std::string, std::string> get_defines(BinaryOpType::Enum op_type) {
     return defines;
 }
 
-int main(int argc, char** argv) {
+int main() {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
     }

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -15,7 +15,7 @@ using namespace tt::tt_metal;
  * 3. Read result back and compare to golden.
  * */
 
-int main(int argc, char** argv) {
+int main() {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
     }

--- a/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/hello_world_compute_kernel.cpp
@@ -9,7 +9,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-int main(int argc, char** argv) {
+int main() {
     // Initialize Program and Device
 
     constexpr CoreCoord core = {0, 0};

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -5,7 +5,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 
-int main(int argc, char** argv) {
+int main() {
     using namespace tt;
     using namespace tt::tt_metal;
 

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -8,7 +8,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-int main(int argc, char** argv) {
+int main() {
     // Initialize Program and Device
 
     constexpr CoreCoord core = {0, 0};

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -15,7 +15,7 @@
 
 using namespace tt::tt_metal;
 
-int main(int argc, char** argv) {
+int main() {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
     }

--- a/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
@@ -24,7 +24,7 @@ void golden_matmul(
     uint32_t M,
     uint32_t N,
     uint32_t K,
-    uint32_t B) {
+    uint32_t /*B*/) {
     std::uint32_t idx_c = 0;
     std::uint32_t idx_a = 0;
     std::uint32_t idx_b = 0;
@@ -269,7 +269,7 @@ void matmul_multi_core(
 
 ///////////////////////////////////////
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {

--- a/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -24,7 +24,7 @@ void golden_matmul(
     uint32_t M,
     uint32_t N,
     uint32_t K,
-    uint32_t B) {
+    uint32_t /*B*/) {
     std::uint32_t idx_c = 0;
     std::uint32_t idx_a = 0;
     std::uint32_t idx_b = 0;
@@ -350,7 +350,7 @@ void matmul_multicore_reuse(
 
 ///////////////////////////////////////
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {

--- a/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -25,7 +25,7 @@ void golden_matmul(
     uint32_t M,
     uint32_t N,
     uint32_t K,
-    uint32_t B) {
+    uint32_t /*B*/) {
     std::uint32_t idx_c = 0;
     std::uint32_t idx_a = 0;
     std::uint32_t idx_b = 0;
@@ -474,7 +474,7 @@ void matmul_multicore_reuse_mcast(
 
 ///////////////////////////////////////
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {

--- a/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
@@ -23,7 +23,7 @@ void golden_matmul(
     uint32_t M,
     uint32_t N,
     uint32_t K,
-    uint32_t B) {
+    uint32_t /*B*/) {
     std::uint32_t idx_c = 0;
     std::uint32_t idx_a = 0;
     std::uint32_t idx_b = 0;
@@ -206,7 +206,7 @@ void matmul_single_core(
 
 ///////////////////////////////////////
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {

--- a/tt_metal/programming_examples/pad/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad/pad_multi_core.cpp
@@ -13,7 +13,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-int main(int argc, char** argv) {
+int main() {
     // get program/device
     int device_id = 0;
     IDevice* device = CreateDevice(device_id);

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -59,7 +59,7 @@ bool RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
     return pass;
 }
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     try {

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -61,7 +61,7 @@ bool RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
     return pass;
 }
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     try {

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -55,7 +55,7 @@ void RunCustomCycle(tt_metal::IDevice* device, int loop_count) {
     tt_metal::DumpDeviceProfileResults(device, program);
 }
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     try {

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -69,7 +69,7 @@ void RunFillUpAllBuffers(tt_metal::IDevice* device, int loop_count, bool fast_di
     }
 }
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     try {

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -43,7 +43,7 @@ void RunCustomCycle(tt_metal::IDevice* device, int fastDispatch) {
     }
 }
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     try {

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -15,7 +15,7 @@ using namespace tt::tt_metal;
  * test_device_profiler.py.
  */
 
-int main(int argc, char** argv) {
+int main() {
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr) {
         TT_THROW("Test not supported w/ slow dispatch, exiting");
     }

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -69,7 +69,7 @@ void RunFillUpAllBuffers(tt_metal::IDevice* device, int loop_count, bool fast_di
     }
 }
 
-int main(int argc, char** argv) {
+int main() {
     bool pass = true;
 
     try {

--- a/tt_metal/programming_examples/sharding/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/sharding/shard_data_rm.cpp
@@ -14,7 +14,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-int main(int argc, char** argv) {
+int main() {
     // get program/device
     int device_id = 0;
     IDevice* device = CreateDevice(device_id);

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -191,7 +191,7 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
 
         double wait_for_kernel_time = execute_work_synced_start(
             1,
-            [device, &pgm](int thread_idx) {
+            [device, &pgm](int /*thread_idx*/) {
                 // Program
                 tt::tt_metal::detail::LaunchProgram(device, pgm, true);
             },
@@ -254,7 +254,7 @@ TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) 
 
         double wait_for_kernel_time = execute_work_synced_start(
             1,
-            [device, &pgm](int thread_idx) {
+            [device, &pgm](int /*thread_idx*/) {
                 // Program
                 tt::tt_metal::detail::LaunchProgram(device, pgm, true);
             },
@@ -305,7 +305,7 @@ TestResult mem_bench_multi_mmio_devices(
         double host_copy_time = 0;
         execute_work_synced_start(
             1,
-            [devices, &programs](int thread_idx) {
+            [devices, &programs](int /*thread_idx*/) {
                 // Program
                 for (auto& [device_id, pgm] : programs) {
                     tt::tt_metal::detail::LaunchProgram(devices.at(device_id), pgm, false);
@@ -417,7 +417,7 @@ TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
 
         double wait_for_kernel_time = execute_work_synced_start(
             1,
-            [device, &pgm](int thread_idx) {
+            [device, &pgm](int /*thread_idx*/) {
                 // Program
                 tt::tt_metal::detail::LaunchProgram(device, pgm, true);
             },

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -249,8 +249,7 @@ inline void SetRuntimeArgsImpl(
 void SetRuntimeArgsImpl(
     const std::shared_ptr<Kernel>& kernel,
     const CoreCoord& core_coord,
-    const std::shared_ptr<RuntimeArgs>& runtime_args_ptr,
-    bool blocking) {
+    const std::shared_ptr<RuntimeArgs>& runtime_args_ptr) {
     std::vector<uint32_t> resolved_runtime_args = {};
     resolved_runtime_args.reserve(runtime_args_ptr->size());
 
@@ -283,14 +282,14 @@ inline void SetRuntimeArgsImpl(
             } else if constexpr (std::is_same_v<T, CoreRange>) {
                 for (auto x = core_spec.start_coord.x; x <= core_spec.end_coord.x; x++) {
                     for (auto y = core_spec.start_coord.y; y <= core_spec.end_coord.y; y++) {
-                        SetRuntimeArgsImpl(kernel, CoreCoord(x, y), runtime_args, blocking);
+                        SetRuntimeArgsImpl(kernel, CoreCoord(x, y), runtime_args);
                     }
                 }
             } else if constexpr (std::is_same_v<T, CoreRangeSet>) {
                 for (const auto& core_range : core_spec.ranges()) {
                     for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                         for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                            SetRuntimeArgsImpl(kernel, CoreCoord(x, y), runtime_args, blocking);
+                            SetRuntimeArgsImpl(kernel, CoreCoord(x, y), runtime_args);
                         }
                     }
                 }
@@ -306,7 +305,7 @@ inline void SetRuntimeArgsImpl(
     bool blocking) {
     // SetRuntimeArgs API for Async CQ Mode (support vector of runtime args)
     for (size_t i = 0; i < core_spec.size(); i++) {
-        SetRuntimeArgsImpl(kernel, core_spec[i], runtime_args[i], blocking);
+        SetRuntimeArgsImpl(kernel, core_spec[i], runtime_args[i]);
     }
 }
 
@@ -384,7 +383,7 @@ std::map<chip_id_t, IDevice*> CreateDevices(
     const size_t l1_small_size,
     const size_t trace_region_size,
     const DispatchCoreConfig& dispatch_core_config,
-    const std::vector<uint32_t>& l1_bank_remap) {
+    const std::vector<uint32_t>& /*l1_bank_remap*/) {
     ZoneScoped;
     bool is_galaxy = tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
     tt::DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, trace_region_size, dispatch_core_config);


### PR DESCRIPTION
### Problem description
We have the `misc-unused-params` check disabled in clang-tidy.
Ideally, we should have it turned on so that people don't accidentally introduce more.

### What's changed
Ran clang-tidy check `misc-unused-params` with fix-its.

### Our Options
1. We can just merge this, pending it doesn't bork anything.
2. You can make commits to this branch to remove parameters.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14279465651) CI passes
- [x] New/Existing tests provide coverage for changes