### PR TITLE
[INTEGRATION BRANCH] Additional changes to integrate profiler with TT-Mesh

### DIFF
--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -119,7 +119,7 @@ struct kernel_config_msg_t {
     rta_offset_t rta_offset[DISPATCH_CLASS_MAX];
     volatile uint32_t kernel_text_offset[NUM_PROCESSORS_PER_CORE_TYPE];
 
-    volatile uint16_t host_assigned_id;
+    volatile uint8_t pad1[2];
 
     volatile uint8_t mode;  // dispatch mode host/dev
     volatile uint8_t brisc_noc_id;
@@ -130,7 +130,14 @@ struct kernel_config_msg_t {
     volatile uint8_t enables;
     volatile uint8_t sub_device_origin_x;  // Logical X coordinate of the sub device origin
     volatile uint8_t sub_device_origin_y;  // Logical Y coordinate of the sub device origin
-    volatile uint8_t pad2[6];
+    // 32 bit program/launch_msg_id used by the performance profiler
+    // [9:0]: physical device id
+    // [30:10]: program id
+    // [31:31]: 0 (specifies that this id corresponds to a program running on device)
+    volatile uint32_t host_assigned_id;
+
+    volatile uint8_t pad2[2];
+
     volatile uint8_t preload;  // Must be at end, so it's only written when all other data is written.
 } __attribute__((packed));
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -287,6 +287,22 @@ void SetDeviceProfilerDir(const std::string& output_dir = "");
 void FreshProfilerDeviceLog();
 
 /**
+ * Generate a (unique) per device ID for a program (potentially) running across multiple devices. The generated ID is
+ * used by the performance profiler.
+ *
+ * Return value: uint32_t
+ *
+ * | Argument             | Description                                                                         |  Data
+ * type            | Valid range              | required |
+ * |----------------------|-------------------------------------------------------------------------------------|-----------------------|--------------------------|----------|
+ * | base_program_id      | ID assigned to a program or an op by the user, for use by the performance profiler  |
+ * uint32_t              | 0 - 2^21 - 1             | yes      | | device_id            | The device id this op will be
+ * launched on (0 if this op runs on host only)          | uint32_t              | 0 - 2^32 - 1             | yes      |
+ * | is_host_fallback_op  | (Optional): Specifies if this op runs entirely on host                              | bool
+ * |                          | no       |
+ */
+uint32_t EncodePerDeviceProgramID(uint32_t base_program_id, uint32_t device_id, bool is_host_fallback_op = false);
+/**
  * Copies data from a host buffer into a buffer within the device DRAM channel
  *
  * Return value: bool

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -36,7 +36,8 @@ private:
         const MeshCoordinateRange& sub_grid,
         ProgramCommandSequence& program_cmd_seq,
         bool stall_first,
-        bool stall_before_program);
+        bool stall_before_program,
+        uint32_t program_runtime_id);
     // For a given MeshWorkload, a subgrid is unused if no programs are run on it. Go signals
     // must be sent to this subgrid, to ensure consistent global state across the Virtual Mesh.
     // When running trace, the dispatch commands responsible for forwarding go signals must be
@@ -54,7 +55,8 @@ private:
         ProgramCommandSequence& program_cmd_seq,
         bool stall_first,
         bool stall_before_program,
-        std::unordered_set<uint32_t>& chip_ids_in_workload);
+        std::unordered_set<uint32_t>& chip_ids_in_workload,
+        uint32_t program_runtime_id);
     // For a given MeshWorkload, a subgrid is unused if no programs are run on it.  Go signals
     // must be sent to this subgrid, to ensure consistent global state across the Virtual Mesh.
     // This function generates and writes dispatch commands forwarding go signals to these subgrids.
@@ -64,6 +66,13 @@ private:
         uint32_t expected_num_workers_completed,
         bool mcast_go_signals,
         bool unicast_go_signals);
+    // When the device profiler is not enabled, launch messages are identical across all physical devices running the
+    // same program, to reduce state managed on host. When the profiler is enabled, the host_assigned_id field in the
+    // launch message must be unique across physical devices to accurately capture program execution time on host and
+    // device. This API is repsonsible for updating the launch message before writing it to each device (see
+    // tt_metal/api/tt-metalium/dev_msgs.h for a description of how the host_assigned_id field is generated).
+    void update_launch_messages_for_device_profiler(
+        ProgramCommandSequence& program_cmd_seq, uint32_t program_runtime_id, IDevice* device);
     // Clear the num_workers_completed counter on the dispatcher cores corresponding to this CQ.
     void clear_expected_num_workers_completed();
     // Access a reference system memory manager, which acts as a global host side state manager for

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -117,7 +117,6 @@ private:
     void logPacketData(
         std::ofstream& log_file_ofs,
         nlohmann::ordered_json& noc_trace_json_log,
-        uint32_t runID,
         uint32_t runHostID,
         const std::string& opname,
         chip_id_t device_id,
@@ -138,7 +137,6 @@ private:
         uint32_t timer_id,
         uint64_t timestamp,
         uint64_t data,
-        uint32_t run_id,
         uint32_t run_host_id,
         const std::string_view opname,
         const std::string_view zone_name,
@@ -157,7 +155,6 @@ private:
         uint32_t timer_id,
         uint64_t timestamp,
         uint64_t data,
-        uint32_t run_id,
         uint32_t run_host_id,
         const std::string_view opname,
         const std::string_view zone_name,

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -860,6 +860,15 @@ void FreshProfilerDeviceLog() {
 #endif
 }
 
+uint32_t EncodePerDeviceProgramID(uint32_t base_program_id, uint32_t device_id, bool is_host_fallback_op) {
+    // Given the base (host assigned id) for a program running on multiple devices, generate a unique per-device
+    // id by coalescing the physical_device id with the program id.
+    // For ops running on device, the MSB is 0. For host-fallback ops, the MSB is 1. This avoids aliasing.
+    constexpr uint32_t DEVICE_ID_NUM_BITS = 10;
+    constexpr uint32_t DEVICE_OP_ID_NUM_BITS = 31;
+    return (is_host_fallback_op << DEVICE_OP_ID_NUM_BITS) | (base_program_id << DEVICE_ID_NUM_BITS) | device_id;
+}
+
 }  // namespace detail
 
 }  // namespace tt_metal

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -109,8 +109,6 @@ __attribute__((noinline)) void init_profiler(
             // TODO(MO): Clean up magic numbers
             profiler_data_buffer[riscID][i] = 0x80000000;
         }
-        profiler_data_buffer[riscID][ID_LL] =
-            (runCounter & 0xFFFF) | (profiler_data_buffer[riscID][ID_LL] & 0xFFFF0000);
     }
 #endif
 }
@@ -155,7 +153,7 @@ inline __attribute__((always_inline)) void mark_dropped_timestamps(uint32_t inde
 
 inline __attribute__((always_inline)) void set_host_counter(uint32_t counterValue) {
     for (uint32_t riscID = 0; riscID < PROFILER_RISC_COUNT; riscID++) {
-        profiler_data_buffer[riscID][ID_LL] = (counterValue << 16) | (profiler_data_buffer[riscID][ID_LL] & 0xFFFF);
+        profiler_data_buffer[riscID][ID_LL] = counterValue;
     }
 }
 

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -210,15 +210,14 @@ def import_device_profile_log(logPath):
                 timerID = {"id": int(row[4].strip()), "zone_name": "", "type": "", "src_line": "", "src_file": ""}
                 timeData = int(row[5].strip())
                 statData = 0
-                if len(row) == 14:
+                if len(row) == 13:
                     statData = int(row[6].strip())
-                    timerID["run_id"] = int(row[7].strip())
-                    timerID["run_host_id"] = int(row[8].strip())
-                    timerID["zone_name"] = row[9].strip()
-                    timerID["type"] = row[10].strip()
-                    timerID["src_line"] = int(row[11].strip())
-                    timerID["src_file"] = row[12].strip()
-                    timerID["meta_data"] = row[13].strip()
+                    timerID["run_host_id"] = int(row[7].strip())
+                    timerID["zone_name"] = row[8].strip()
+                    timerID["type"] = row[9].strip()
+                    timerID["src_line"] = int(row[10].strip())
+                    timerID["src_file"] = row[11].strip()
+                    timerID["meta_data"] = row[12].strip()
 
                 if chipID in devicesData["devices"].keys():
                     if core in devicesData["devices"][chipID]["cores"].keys():

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -34,6 +34,8 @@ from tt_metal.tools.profiler.common import (
 
 yaml.SafeDumper.ignore_aliases = lambda *args: True
 
+TRACE_OP_ID_BITSHIFT = 32
+
 OUT_NAME = "ops_perf_results"
 
 OPS_CSV_HEADER = [
@@ -170,6 +172,7 @@ def import_tracy_op_logs(logFolder):
                         traceIDs[deviceID] = None
                     elif "REPLAY" in opDataStr:
                         replayIDTime = opDataTime
+
                         if deviceID in traceReplays:
                             if traceID in traceReplays[deviceID]:
                                 traceReplays[deviceID][traceID].append(replayIDTime)
@@ -296,7 +299,7 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces):
                         deviceOpID = timeID["run_host_id"]
                         assert (
                             deviceOpID in opIDHostDataDict
-                        ), f"Device op ID not present: Device op ID {deviceOpID} not present in host data"
+                        ), f"Device op ID not present: Device op ID {deviceOpID} not present in host data on device {device}"
                         traceID = opIDHostDataDict[deviceOpID]["metal_trace_id"]
                         if traceID is not None:
                             if device in traceOps:
@@ -370,7 +373,8 @@ def append_device_data(ops, traceReplays, logFolder, analyze_noc_traces):
                 for deviceOp in devicesOps[device]:
                     if "metal_trace_replay_session_id" in deviceOp.keys():
                         deviceOp["global_call_count"] = (
-                            deviceOp["global_call_count"] | deviceOp["metal_trace_replay_session_id"] << 16
+                            deviceOp["global_call_count"]
+                            | deviceOp["metal_trace_replay_session_id"] << TRACE_OP_ID_BITSHIFT
                         )
                         traceOps[deviceOp["global_call_count"]] = deviceOp
                     else:
@@ -608,7 +612,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
             if type(row) is str and "sp" in row:
                 ret = signposts[row]["tracy_time"]
             elif type(row) is int:
-                if row > ((1 << 16) - 1):
+                if row > ((1 << TRACE_OP_ID_BITSHIFT) - 1):
                     ret = traceOps[row]["tracy_time"]
                 else:
                     ret = ops[row]["host_time"]["ns_since_start"]
@@ -620,7 +624,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
         childCallKeys = set()
         for row in rowKeys:
             if type(row) is int:
-                if row > ((1 << 16) - 1):
+                if row > ((1 << TRACE_OP_ID_BITSHIFT) - 1):
                     opData = traceOps[row]
                 else:
                     opData = ops[row]
@@ -639,9 +643,9 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                 rowDict["HOST START TS"] = int(signposts[row]["tracy_time"])
             elif type(row) is int:
                 op = row
-                if op > ((1 << 16) - 1):
+                if op > ((1 << TRACE_OP_ID_BITSHIFT) - 1):
                     opData = traceOps[op]
-                    opData["global_call_count"] = ((1 << 16) - 1) & op
+                    opData["global_call_count"] = ((1 << TRACE_OP_ID_BITSHIFT) - 1) & op
                 else:
                     opData = ops[op]
                     opData["metal_trace_replay_session_id"] = ""

--- a/tt_metal/tools/profiler/tt_metal_tracy.hpp
+++ b/tt_metal/tools/profiler/tt_metal_tracy.hpp
@@ -20,11 +20,41 @@
 #define TracyTTMetalReleaseTrace(device_id, trace_id)                                                 \
     std::string trace_message = fmt::format("`TT_METAL_TRACE_RELEASE: {}, {}`", device_id, trace_id); \
     TracyMessage(trace_message.c_str(), trace_message.size());
+
+#define TracyTTMetalBeginMeshTrace(device_ids, trace_id)                                                \
+    for (auto device_id : device_ids) {                                                                 \
+        std::string trace_message = fmt::format("`TT_METAL_TRACE_BEGIN: {}, {}`", device_id, trace_id); \
+        TracyMessage(trace_message.c_str(), trace_message.size());                                      \
+    }
+
+#define TracyTTMetalEndMeshTrace(device_ids, trace_id)                                                \
+    for (auto device_id : device_ids) {                                                               \
+        std::string trace_message = fmt::format("`TT_METAL_TRACE_END: {}, {}`", device_id, trace_id); \
+        TracyMessage(trace_message.c_str(), trace_message.size());                                    \
+    }
+
+#define TracyTTMetalReplayMeshTrace(device_ids, trace_id)                                                \
+    for (auto device_id : device_ids) {                                                                  \
+        std::string trace_message = fmt::format("`TT_METAL_TRACE_REPLAY: {}, {}`", device_id, trace_id); \
+        TracyMessage(trace_message.c_str(), trace_message.size());                                       \
+    }
+
+#define TracyTTMetalReleaseMeshTrace(device_ids, trace_id)                                                \
+    for (auto device_id : device_ids) {                                                                   \
+        std::string trace_message = fmt::format("`TT_METAL_TRACE_RELEASE: {}, {}`", device_id, trace_id); \
+        TracyMessage(trace_message.c_str(), trace_message.size());                                        \
+    }
+
 #else
 
 #define TracyTTMetalBeginTrace(device_id, trace_id)
 #define TracyTTMetalEndTrace(device_id, trace_id)
 #define TracyTTMetalReplayTrace(device_id, trace_id)
 #define TracyTTMetalReleaseTrace(device_id, trace_id)
+
+#define TracyTTMetalBeginMeshTrace(device_ids, trace_id)
+#define TracyTTMetalEndMeshTrace(device_ids, trace_id)
+#define TracyTTMetalReplayMeshTrace(device_ids, trace_id)
+#define TracyTTMetalReleaseMeshTrace(device_ids, trace_id)
 
 #endif

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -375,16 +375,15 @@ void enqueue_mesh_workload(
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     distributed::MeshDevice* mesh_device,
     tt::tt_metal::distributed::MeshWorkload& workload) {
-    // Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed profiler
-    // regresion
-    // tests well-formed data.
-    ZoneScopedN("TT_DNN_DEVICE_OP");
-    mesh_device_operation_utils::set_runtime_id(workload, mesh_device);
+    mesh_device_operation_utils::set_runtime_id(workload);
     if (mesh_device_operation_utils::track_workload(workload, mesh_device)) {
         return;
     }
+    {
+        ZoneScopedN("EnqueueMeshWorkload");
+        tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
+    }
 
-    tt::tt_metal::distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(*cq_id), workload, false);
 
     TracyOpMeshWorkload(
         mesh_device, workload, mesh_device_operation_t{}, operation_attributes, tensor_args, tensor_return_value);

--- a/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
@@ -90,7 +90,7 @@ std::vector<ttnn::MeshCoordinate> extract_tensor_coordinates(const TensorArgs& t
 }
 
 // Sets runtime ID for all programs in `workload`.
-inline void set_runtime_id(tt::tt_metal::distributed::MeshWorkload& workload, ttnn::MeshDevice* mesh_device) {
+inline void set_runtime_id(tt::tt_metal::distributed::MeshWorkload& workload) {
     for (auto& [_, program] : workload.get_programs()) {
         program.set_runtime_id(ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
     }

--- a/ttnn/tools/profiler/op_profiler.hpp
+++ b/ttnn/tools/profiler/op_profiler.hpp
@@ -485,7 +485,10 @@ inline std::string op_meta_data_serialized_json(
     ZoneText(op_text.c_str(), op_text.size());                                                                \
     TracyMessage(op_message.c_str(), op_message.size());
 
-#define TracyOpTTNNExternal(op_id, op, input_tensors)                                                           \
+#define TracyOpTTNNExternal(op, input_tensors, base_op_id)                                                      \
+    /* This op runs entirely on host, but its ID must be generated using the same data-path as device-side */   \
+    /* ops, for accurate reporting by the performance post-processor. */                                        \
+    auto op_id = tt::tt_metal::detail::EncodePerDeviceProgramID(base_op_id, 0, true);                           \
     std::string op_message = tt::tt_metal::op_profiler::op_meta_data_serialized_json(op_id, op, input_tensors); \
     std::string op_text = fmt::format("id:{}", op_id);                                                          \
     ZoneText(op_text.c_str(), op_text.size());                                                                  \
@@ -494,9 +497,14 @@ inline std::string op_meta_data_serialized_json(
 #define TracyOpMeshWorkload(                                                                                   \
     mesh_device, mesh_workload, operation, operation_attributes, tensor_args, tensor_return_value)             \
     for (const auto& [range, program] : mesh_workload.get_programs()) {                                        \
+        auto base_program_id = program.get_runtime_id();                                                       \
         for (auto coord : range) {                                                                             \
+            /* Important! `TT_DNN_DEVICE_OP` must be used in conjunction with `TracyOpMeshWorkload` to feed */ \
+            /* regression tests well-formed data. */                                                           \
+            /* TODO: (Issue #20233): Move the zone below outside TracyOpMeshWorkload. */                       \
+            ZoneScopedN("TT_DNN_DEVICE_OP");                                                                   \
             auto device_id = mesh_device->get_device(coord)->id();                                             \
-            auto op_id = program.get_runtime_id();                                                             \
+            auto op_id = tt::tt_metal::detail::EncodePerDeviceProgramID(base_program_id, device_id);           \
             std::string op_message = tt::tt_metal::op_profiler::op_meta_data_serialized_json(                  \
                 operation, op_id, device_id, program, operation_attributes, tensor_args, tensor_return_value); \
             std::string op_text = fmt::format("id:{}", op_id);                                                 \
@@ -509,7 +517,7 @@ inline std::string op_meta_data_serialized_json(
 
 #define TracyOpTTNNDevice( \
     operation, operation_id, device_id, program, operation_attributes, tensor_args, tensor_return_value)
-#define TracyOpTTNNExternal(op_id, op, input_tensors)
+#define TracyOpTTNNExternal(op, input_tensors, base_op_id)
 #define TracyOpMeshWorkload( \
     mesh_device, mesh_workload, operation, operation_attributes, tensor_args, tensor_return_value)
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20082

### Problem description
T3K Profiler Tests are currently broken on the TT-Mesh integration branch.

### What's changed
- Track unique program ids across all physical devices on host (using the new `GeneratePerDeviceProgramID` API) and on device using a unique launch message per device, if profiler is enabled
- Add trace messages to all `MeshTrace` APIs, for the post-processor to decode
- This PR also includes changes from @mo-tenstorrent, making the `launch_msg` 32 bits and propagating the new size to multiple profiler files 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes