### PR TITLE
#19974: Implement min as SFPU op

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
@@ -68,6 +68,7 @@ Compute APIs
   unary_gt_tile
   unary_lt_tile
   unary_max_tile
+  unary_min_tile
 
   cb_wait_front
   cb_pop_front

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/unary_min_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/unary_min_tile.rst
@@ -1,0 +1,5 @@
+unary_min_tile
+--------------
+
+.. doxygenfunction:: unary_min_tile_init()
+.. doxygenfunction:: unary_min_tile(uint32_t idst, uint32_t param0)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -131,29 +131,6 @@ def test_binary_minimum_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@pytest.mark.parametrize(
-    "scalar",
-    {-82.5, -45.7, 0.0, 12.5, 66.4, 96, 8},
-)
-def test_binary_minimum_scalar_ttnn(input_shapes, scalar, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-
-    output_tensor = ttnn.minimum(input_tensor1, scalar)
-    golden_function = ttnn.get_golden_function(ttnn.minimum)
-    golden_tensor = golden_function(in_data1, torch.full(input_shapes, scalar))
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 def test_binary_maximum_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_maximum.py
@@ -33,7 +33,7 @@ def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,
@@ -75,7 +75,7 @@ def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.bfloat16) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,
@@ -112,7 +112,7 @@ def test_unary_max_bf16(input_shapes, low, high, scalar, device):
     torch_input = torch_input[:num_elements].reshape(input_shapes)
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,
@@ -149,7 +149,7 @@ def test_unary_max_fp32(input_shapes, low, high, scalar, device):
     torch_input = torch_input[:num_elements].reshape(input_shapes)
 
     golden_function = ttnn.get_golden_function(ttnn.maximum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -33,7 +33,7 @@ def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,
@@ -74,7 +74,7 @@ def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.bfloat16) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,
@@ -111,7 +111,7 @@ def test_unary_max_bf16(input_shapes, low, high, scalar, device):
     torch_input = torch_input[:num_elements].reshape(input_shapes).nan_to_num(0.0)
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,
@@ -148,7 +148,7 @@ def test_unary_max_fp32(input_shapes, low, high, scalar, device):
     torch_input = torch_input[:num_elements].reshape(input_shapes)
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
-    golden = golden_function(torch_input, scalar, device=device)
+    golden = golden_function(torch_input, torch.full(input_shapes, scalar), device=device)
 
     tt_in = ttnn.from_torch(
         torch_input,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_val, scalar",
+    [
+        (0.36719, 0.5),
+        (0, 0.06719),
+        (0, 0.002),
+        (3.4 * 10**38, 1),
+        (-1, -3.4 * 10**38),
+        (3.4 * 10**38, -3.4 * 10**38),
+        (float("inf"), 1),
+        (1, -float("inf")),
+        (3.4 * 10**38, float("inf")),
+        (-3.4 * 10**38, -float("inf")),
+        (11, 1),
+    ],
+)
+def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
+    torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in, scalar)
+
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_val, scalar",
+    [
+        (0.36719, 0.5),
+        (0.0034, 0.0023),
+        (0, 0.06719),
+        (0, 0.002),
+        (3.4 * 10**38, 1),
+        (-1, -3.4 * 10**38),
+        (3.4 * 10**38, -3.4 * 10**38),
+        (float("inf"), 1),
+        (1, -float("inf")),
+        (3.4 * 10**38, float("inf")),
+        (-3.4 * 10**38, -float("inf")),
+        (11, 1),
+    ],
+)
+def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
+    torch_input = torch.ones(input_shapes, dtype=torch.bfloat16) * input_val
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in, scalar)
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-100.0, 100.0),
+        (-3.3 * 10**38, 3.3 * 10**38),
+    ],
+)
+@pytest.mark.parametrize("scalar", [0.5, 0, 20, 3.4 * 10**38, -3.4 * 10**38])
+def test_unary_max_bf16(input_shapes, low, high, scalar, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
+    torch_input = torch_input[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in, scalar)
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([1, 3, 320, 320])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low, high",
+    [
+        (-100, 100),
+        (-1.7 * 10**38, 1.7 * 10**38),
+    ],
+)
+@pytest.mark.parametrize("scalar", [0.5, 0.1, 0, 1, 10, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
+def test_unary_max_fp32(input_shapes, low, high, scalar, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)
+    torch_input = torch_input[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input, scalar, device=device)
+
+    tt_in = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in, scalar)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -6,7 +6,7 @@
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_unary_sfpu_abs.h"
 #include "llk_math_eltwise_unary_sfpu_comp.h"
-#include "llk_math_eltwise_unary_sfpu_unary_max.h"
+#include "llk_math_eltwise_unary_sfpu_unary_max_min.h"
 #include "llk_math_eltwise_unary_sfpu_exp2.h"
 #include "llk_math_eltwise_unary_sfpu_expm1.h"
 #include "llk_math_eltwise_unary_sfpu_heaviside.h"

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -12,8 +12,8 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max(uint value) {
+template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max_min(uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         // Load value param to lreg1
@@ -23,31 +23,15 @@ inline void calculate_unary_max(uint value) {
         // Load input to lreg0
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
 
-        // Maximum value stored in lreg1
+        // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         TTI_SFPNOP;
 
-        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
-        dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_min(uint value) {
-#pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        // Load value param to lreg1
-        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
-        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
-
-        // Load input to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
-
-        // Minimum value stored in lreg0
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
-
-        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+        if constexpr (IS_MAX_OP) {
+            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+        }
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -32,5 +32,25 @@ inline void calculate_unary_max(uint value) {
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_min(uint value) {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Load value param to lreg1
+        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
+        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
+
+        // Load input to lreg0
+        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+
+        // Minimum value stored in lreg0
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPNOP;
+
+        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -6,7 +6,7 @@
 
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_params.h"
-#include "ckernel_sfpu_unary_max.h"
+#include "ckernel_sfpu_unary_max_min.h"
 
 namespace ckernel {
 
@@ -22,4 +22,17 @@ inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, i
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_max<APPROXIMATE>, dst_index, vector_mode, param0);
 }
+
+// Unary minimum
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_min<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -11,6 +11,7 @@
 namespace ckernel {
 
 // New LLK SFPU APIs
+
 // Unary maximum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
@@ -20,7 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 // Unary minimum
@@ -32,7 +33,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_min<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -94,4 +94,5 @@ enum SfpuType {
     round,
     cpy_values,
     unary_max,
+    unary_min,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_sfpu_api.h
@@ -7,7 +7,7 @@
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_abs.h"
 #include "llk_math_eltwise_unary_sfpu_comp.h"
-#include "llk_math_eltwise_unary_sfpu_unary_max.h"
+#include "llk_math_eltwise_unary_sfpu_unary_max_min.h"
 #include "llk_math_eltwise_unary_sfpu_exp2.h"
 #include "llk_math_eltwise_unary_sfpu_expm1.h"
 #include "llk_math_eltwise_unary_sfpu_heaviside.h"

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -33,5 +33,25 @@ inline void calculate_unary_max(uint value) {
     }
 }
 
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_min(uint value) {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        // Load value param to lreg1
+        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
+        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
+
+        // Load input to lreg0
+        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+
+        // Minimum value stored in lreg0
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPNOP;
+
+        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -13,8 +13,8 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_max(uint value) {
+template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_unary_max_min(uint value) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         // Load value param to lreg1
@@ -24,31 +24,15 @@ inline void calculate_unary_max(uint value) {
         // Load input to lreg0
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
 
-        // Maximum value stored in lreg1
+        // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         TTI_SFPNOP;
 
-        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
-        dst_reg++;
-    }
-}
-
-template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
-inline void calculate_unary_min(uint value) {
-#pragma GCC unroll 0
-    for (int d = 0; d < ITERATIONS; d++) {
-        // Load value param to lreg1
-        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
-        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
-
-        // Load input to lreg0
-        TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
-
-        // Minimum value stored in lreg0
-        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
-
-        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+        if constexpr (IS_MAX_OP) {
+            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+        }
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -21,7 +21,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_max_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_max<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<true, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 // Unary minimum
@@ -33,7 +33,7 @@ inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_unary_min<APPROXIMATE>, dst_index, vector_mode, param0);
+        ckernel::sfpu::calculate_unary_max_min<false, APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_unary_max_min.h
@@ -6,7 +6,7 @@
 
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_params.h"
-#include "ckernel_sfpu_unary_max.h"
+#include "ckernel_sfpu_unary_max_min.h"
 
 namespace ckernel {
 
@@ -22,6 +22,18 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_unary_max(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
     llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_unary_max<APPROXIMATE>, dst_index, vector_mode, param0);
+}
+
+// Unary minimum
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unary_min, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_unary_min(uint dst_index, uint param0, int vector_mode = (int)VectorMode::RC) {
+    llk_math_eltwise_unary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_unary_min<APPROXIMATE>, dst_index, vector_mode, param0);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -77,6 +77,7 @@ enum SfpuType {
     unary_gt,
     unary_lt,
     unary_max,
+    unary_min,
     softplus,
     tiled_prod,
     bitwise_xor,

--- a/tt_metal/include/compute_kernel_api.h
+++ b/tt_metal/include/compute_kernel_api.h
@@ -893,6 +893,31 @@ ALWI void unary_lt_tile(uint32_t idst, uint32_t param0) {
  */
 ALWI void unary_lt_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_lt_init<APPROX>())); }
 
+// unary_min : if x < value --> x, else value
+// clang-format off
+/**
+ * Performs element-wise computation of:  result = x if x < value , where x is each element of a tile
+ * in DST register at index tile_index. The value is provided as const param0 The DST register buffer must be in
+ * acquired state via *acquire_dst* call. This call is blocking and is only
+ * available on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument        | Description                                                                | Type     | Valid Range                                           | Required |
+ * |-----------------|----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst            | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | param0          | The value to be compared with the input tensor                             | uint32_t |                                                       | True     |
+ */
+// clang-format on
+ALWI void unary_min_tile(uint32_t idst, uint32_t param0) {
+    MATH((llk_math_eltwise_unary_sfpu_unary_min<APPROX>(idst, param0)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void unary_min_tile_init() { MATH((llk_math_eltwise_unary_sfpu_unary_min_init<APPROX>())); }
+
 ALWI uint32_t get_compute_special_value_flags() {
     uint32_t ret_val = 0;
     MATH((ret_val = llk_math_get_compute_special_value_flags()));

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -117,9 +117,8 @@ Tensor ExecuteMinimum::invoke(
 
 Tensor ExecuteMinimum::invoke(
     const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor t_diff = ttnn::subtract(input_a, value, std::nullopt, output_mem_config);
-    Tensor result = ttnn::where(t_diff, value, input_a);
-    return result;
+    return ttnn::operations::unary::ExecuteUnaryWithFloatParameter<
+        ttnn::operations::unary::UnaryOpType::MINIMUM>::invoke(ttnn::DefaultQueueId, input_a, value, output_mem_config);
 }
 
 // maximum(a,b) = a + (b - a > 0 )*(b-a)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_types.hpp
@@ -94,6 +94,7 @@ enum class UnaryOpType {
     ZERO_POINT,
     MISH,
     MAXIMUM,
+    MINIMUM,
 };
 
 struct UnaryWithParam {

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
@@ -258,6 +258,11 @@ std::pair<std::string, std::string> get_op_init_and_func_parameterized(
                 "unary_max_tile_init();",
                 fmt::format("unary_max_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
             break;
+        case UnaryOpType::MINIMUM:
+            op_init_and_name = {
+                "unary_min_tile_init();",
+                fmt::format("unary_min_tile({}, {:#x}u);", idst, std::bit_cast<uint32_t>(param0))};
+            break;
         default: TT_THROW("unexpected parameterized op type {}", op_type);
     };
     return op_init_and_name;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.hpp
@@ -67,6 +67,7 @@ bool is_parametrized_type(T val) {
         case UnaryOpType::ROUND:
         case UnaryOpType::PRELU_SFPU:
         case UnaryOpType::FMOD:
+        case UnaryOpType::MINIMUM:
         case UnaryOpType::MAXIMUM: return true;
         default: return false;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -25,6 +25,7 @@ void validate_supported_arch_dtype(
         case UnaryOpType::LEFT_SHIFT:
         case UnaryOpType::RIGHT_SHIFT:
         case UnaryOpType::MAXIMUM:
+        case UnaryOpType::MINIMUM:
             TT_FATAL(
                 arch != tt::ARCH::GRAYSKULL,
                 "UnaryOpType '{}' is not supported on Grayskull architecture.",

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -165,6 +165,7 @@ template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_GT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_LT>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::UNARY_NE>;
 template struct ExecuteUnaryWithFloatParameter<UnaryOpType::MAXIMUM>;
+template struct ExecuteUnaryWithFloatParameter<UnaryOpType::MINIMUM>;
 
 Tensor Sigmoid_accurate::invoke(
     QueueId queue_id,

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -240,6 +240,9 @@ ttnn.attach_golden_function(ttnn.maximum, golden_function=_golden_function_maxim
 def _golden_function_minimum(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
+    if not torch.is_tensor(input_tensor_b):
+        input_tensor_b = torch.full(input_tensor_a.shape, input_tensor_b)
+
     return torch.minimum(input_tensor_a, input_tensor_b)
 
 

--- a/ttnn/ttnn/operations/binary.py
+++ b/ttnn/ttnn/operations/binary.py
@@ -228,9 +228,6 @@ ttnn.attach_golden_function(ttnn.hypot, golden_function=_golden_function_hypot)
 def _golden_function_maximum(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
 
-    if not torch.is_tensor(input_tensor_b):
-        input_tensor_b = torch.full(input_tensor_a.shape, input_tensor_b)
-
     return torch.maximum(input_tensor_a, input_tensor_b)
 
 
@@ -239,9 +236,6 @@ ttnn.attach_golden_function(ttnn.maximum, golden_function=_golden_function_maxim
 
 def _golden_function_minimum(input_tensor_a, input_tensor_b, *args, **kwargs):
     import torch
-
-    if not torch.is_tensor(input_tensor_b):
-        input_tensor_b = torch.full(input_tensor_a.shape, input_tensor_b)
 
     return torch.minimum(input_tensor_a, input_tensor_b)
 


### PR DESCRIPTION
### Ticket
#19974

### Problem description
Implement Tensor-scalar version is minimum as SFPU Op

### What's changed
Implemented Tensor-scalar version is minimum as SFPU Op 

- Used TTI_ instructions
- Removed old test and created a new test file which includes testing the failing case mentioned in #18556 for min
- Tested in WH, BH
- Removed existing GS support
- Performance improvement on moving from composite 
   - Current implementation is about **86.1%** faster than the older implementation.
---> Composite Op : [main.csv](https://github.com/user-attachments/files/19627784/main.csv)
 ---> SFPU Op : [updated_implementation.csv](https://github.com/user-attachments/files/19627789/updated_implementation.csv)

<img width="375" alt="Screenshot 2025-04-07 at 1 03 12 PM" src="https://github.com/user-attachments/assets/95f2ab7a-0123-4799-b19c-169702e57af3" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14317398894) PASSED
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14317400292)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14317401654) PASSED
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14317403409) PASSED
- [x] [C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/14323268933) PASSED