### PR TITLE
#18726: Fix incorrect upstream semaphore breaking the return path

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -241,7 +241,8 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.upstream_sync_sem = 0;  // Unused
         } else if (auto dispatch_d = dynamic_cast<DispatchKernel*>(upstream_kernels_[0])) {
             dependent_config_.upstream_logical_core = dispatch_d->GetLogicalCore();
-            dependent_config_.upstream_dispatch_cb_sem_id = dispatch_d->GetStaticConfig().my_dispatch_cb_sem_id.value();
+            dependent_config_.upstream_dispatch_cb_sem_id =
+                dispatch_d->GetStaticConfig().my_downstream_cb_sem_id.value();
             dependent_config_.upstream_sync_sem = 0;  // Unused
         } else {
             TT_FATAL(false, "Unimplemented path");


### PR DESCRIPTION
### Ticket
#18726

### Problem description
This semaphore is required to provide credits for the return path (e.g., EnqueueReadBuffer) in the case of split dispatcher. This error was not found earlier because it wasn't being used.

### What's changed
Fix incorrect value

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14302475556
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14302480320
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14302482350
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14302486673