### PR TITLE
Llama TG : save prefetched tensor address only for whole model

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -129,6 +129,7 @@ class TtTransformer(LightweightModule):
             n_layers=self.n_layers,
             mode="prefill",
             mesh_sub_device_manager_id_prefill=mesh_sub_device_manager_id_prefill,
+            save_tensor_addresses=True,
         )
         self.mesh_sub_device_manager_id_prefill = self.prefetcher_setup.mesh_sub_device_manager_id_prefill
         self.mesh_device.set_sub_device_stall_group([self.prefetcher_setup.worker_sub_device_id])
@@ -145,6 +146,7 @@ class TtTransformer(LightweightModule):
             n_tensors=5,
             n_layers=self.n_layers,
             mesh_sub_device_manager_id_decode=mesh_sub_device_manager_id_decode,
+            save_tensor_addresses=True,
         )
         self.mesh_sub_device_manager_id_decode = self.prefetcher_setup.mesh_sub_device_manager_id_decode
         self.mesh_device.set_sub_device_stall_group(
@@ -511,3 +513,7 @@ class TtTransformer(LightweightModule):
 
     def __del__(self):
         self.tt_ccl.close()
+
+        # clear global saved addresses
+        global global_tt_tensor_address
+        global_tt_tensor_address = None

--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -31,6 +31,7 @@ class TtLlamaPrefetcherSetup(LightweightModule):
         mode="decode",
         mesh_sub_device_manager_id_prefill=None,
         mesh_sub_device_manager_id_decode=None,
+        save_tensor_addresses=False,
     ):
         """
         - sub devices
@@ -122,6 +123,7 @@ class TtLlamaPrefetcherSetup(LightweightModule):
 
         self.tensors = []
         self.tensor_addrs = []  # List of buffer addresses
+        self.save_tensor_addresses = save_tensor_addresses
 
     def buffer_address(self, tensor):
         addr = []
@@ -165,9 +167,11 @@ class TtLlamaPrefetcherSetup(LightweightModule):
         assert (
             len(self.tensors) >= self.n_tensors
         ), f"Expected at least {self.n_tensors} tensors, got {len(self.tensors)}"
-
-        global global_tt_tensor_address
-        if global_tt_tensor_address is None:
+        if self.save_tensor_addresses:
+            global global_tt_tensor_address
+            if global_tt_tensor_address is None:
+                global_tt_tensor_address = self.get_tensor_addrs()
+        else:
             global_tt_tensor_address = self.get_tensor_addrs()
         self.tt_tensor_address = global_tt_tensor_address
         return self.tensors[: self.n_tensors] + [self.tt_tensor_address]


### PR DESCRIPTION
### Problem description
unit tests failing when run back to back 
### What's changed
 save prefetched tensor address only for whole model

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
TG Unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/14306496674