### PR TITLE
Remove reshards in decoder.

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_decoder.py
+++ b/models/demos/llama3_subdevices/tt/llama_decoder.py
@@ -145,7 +145,6 @@ class TtTransformerBlock(LightweightModule):
         # Attention takes replicated inputs and produces fractured outputs
         # pad attn input
         if mode == "decode":
-            attn_in = ttnn.to_memory_config(attn_in, ttnn.DRAM_MEMORY_CONFIG)
             attn_in_sharded = ttnn.to_memory_config(attn_in, self.model_config["SHARDED_ATTN_INPUT_RING_MEMCFG"])
             attn_in.deallocate(True)
         else:
@@ -174,7 +173,6 @@ class TtTransformerBlock(LightweightModule):
 
         # MLP takes replicated inputs and produces fractured outputs
         if mode == "decode":
-            ff_in = ttnn.to_memory_config(ff_in, ttnn.DRAM_MEMORY_CONFIG)
             ff_in_sharded = ttnn.to_memory_config(ff_in, self.model_config["SHARDED_FF12_RING_MEMCFG"])
             ff_in.deallocate(True)
         else:


### PR DESCRIPTION
### Ticket
- #19913
TODO: Update ticket with details about fixes

### Problem description
The model used to segfault on a reshard (details in the issue above), however, it seems to be non-reproducible on main. As such, we can now remove the workarounds that were added. 

### What's changed
- Remove the workaround for the layernorm reshards

### Checklist
- [ ] [All post commit]() CI passes