### PR TITLE
Move smoke test to N150 for now as N300 capacity on new CI is a little low at the moment

### DIFF
--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "tt-beta-ubuntu-2204-n300-large-stable",
+          "tt-beta-ubuntu-2204-n150-large-stable",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:


### PR DESCRIPTION
…

### Ticket

GHCI related ticket probably exists - oh well

### Problem description

N300 capacity quite low 

### What's changed

Run smoke test on N150, although we may not get some critical ethernet coverage.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes