### PR TITLE
Fix the llama-8B BH CI test and add a stress test to CI

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
           {
             name: "Llama3-8B_performance",
             arch: blackhole,
-            cmd:  HF_HOME=/localdev/blackhole_demos/huggingface_data TT_CACHE_PATH=/localdev/blackhole_demos/tt_cache HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci,
+            cmd:  HF_HOME=/localdev/blackhole_demos/huggingface_data TT_CACHE_PATH=/localdev/blackhole_demos/tt_cache HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci and not performance-ci-stress-1",
             owner_id: U03PUAKE719 # Miguel Tairum
           }
         ]

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
           {
             name: "Llama3-8B_performance",
             arch: blackhole,
-            cmd:  HF_HOME=/localdev/blackhole_demos/huggingface_data TT_CACHE_PATH=/localdev/blackhole_demos/ttnn_cache HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci,
+            cmd:  HF_HOME=/localdev/blackhole_demos/huggingface_data TT_CACHE_PATH=/localdev/blackhole_demos/tt_cache HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci,
             owner_id: U03PUAKE719 # Miguel Tairum
           }
         ]
@@ -72,7 +72,7 @@ jobs:
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
-            -v /localdev:/localdev
+            -v /localdev/blackhole_demos:/localdev/blackhole_demos
           install_wheel: true
           run_args: |
             if [[ "${{ matrix.test-group.name }}" == *"Llama"* ]]; then

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
           {
             name: "Llama3-8B_performance",
             arch: blackhole,
-            cmd: LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1,
+            cmd:  HF_HOME=/localdev/blackhole_demos/huggingface_data TT_CACHE_PATH=/localdev/blackhole_demos/ttnn_cache HF_MODEL=meta-llama/Llama-3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci,
             owner_id: U03PUAKE719 # Miguel Tairum
           }
         ]
@@ -71,8 +71,14 @@ jobs:
             -e TT_METAL_HOME=${{ github.workspace }}
             -e ARCH_NAME=${{ matrix.test-group.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
+            -e HF_TOKEN=${{ secrets.HUGGINGFACE_TOKEN }}
+            -v /localdev:/localdev
           install_wheel: true
-          run_args: ${{ matrix.test-group.cmd }}
+          run_args: |
+            if [[ "${{ matrix.test-group.name }}" == *"Llama"* ]]; then
+              pip install -r ${{ github.workspace }}/models/tt_transformers/requirements.txt
+            fi
+            ${{ matrix.test-group.cmd }}
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: BH
+      runner-label: gh01
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: gh01
+      runner-label: BH
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -31,10 +31,11 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-            { model: whisper, owner_id: U05RWH3QUPM },  #Salar Hosseini
+            { model: whisper, owner_id: U05RWH3QUPM , cmd: pytest tests/nightly/single_card/whisper },  #Salar Hosseini
+            { model: llama3.1-8b, owner_id: U03PUAKE719, cmd: LLAMA_DIR=/mnt/MLPerf/huggingface/hub/models--meta-llama--Llama-3.1-8B-Instruct/snapshots/0e9e39f249a16976918f6564b8830bc894c89659/original pytest models/tt_transformers/demo/simple_text_demo.py -k performance-ci-stress-1 }, # Miguel Tairum
           ]
-    name: Nightly ${{ inputs.runner-label }} ${{ matrix.test-group.model }} #Salar Hosseini
-    runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}"]
+    name: Nightly ${{ inputs.runner-label }} ${{ matrix.test-group.model }}
+    runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}", "pipeline-functional"]
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -45,6 +46,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - /mnt/MLPerf:/mnt/MLPerf:ro
       options: "--device /dev/tenstorrent"
     defaults:
       run:
@@ -59,8 +61,12 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
 
       - name: Run frequent reg tests scripts
-        timeout-minutes: 30
-        run: pytest tests/nightly/single_card/${{ matrix.test-group.model }}
+        timeout-minutes: 180
+        run: |
+          if [[ "${{ matrix.test-group.model }}" == *"llama"* ]]; then
+            pip install -r models/tt_transformers/requirements.txt
+          fi
+          ${{ matrix.test-group.cmd }}
 
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -29,6 +29,7 @@ jobs:
     needs: build-artifact
     uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
     strategy:
+      fail-fast: false
       matrix:
         card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
     secrets: inherit
@@ -42,6 +43,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml
     strategy:
+      fail-fast: false
       matrix:
         card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
     with:
@@ -55,6 +57,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
     strategy:
+      fail-fast: false
       matrix:
         card_type: ${{ fromJSON(inputs.runner-label || '["P100", "P150"]') }}
     with:

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -355,13 +355,13 @@ def prepare_generator_args(
             True,  # ci_only
             8,  # data_parallel
         ),
-        (  # CI stress test batch-1 run - Runs a short prefill (128) and exhaust the KV cache (128K), by running 130000 iterations
+        (  # CI stress test batch-1 run - Runs a short prefill (128) and exhaust the KV cache (128K), by running 50000 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
             128 * 1024,  # max_seq_len
             1,  # batch_size
-            130000,  # max_generated_tokens
+            50000,  # max_generated_tokens
             True,  # paged_attention
             {"page_block_size": 64, "page_max_num_blocks_per_dp": 2048},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)

--- a/models/tt_transformers/requirements.txt
+++ b/models/tt_transformers/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
-transformers >= 4.46.3
+transformers == 4.51.3
 protobuf == 3.20.0

--- a/models/tt_transformers/requirements.txt
+++ b/models/tt_transformers/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
-transformers >= 4.46.3
+transformers >= 4.46.3, < 4.52
 protobuf == 3.20.0

--- a/models/tt_transformers/requirements.txt
+++ b/models/tt_transformers/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/tenstorrent/llama-models.git@tt_metal_tag
-transformers >= 4.46.3, < 4.52
+transformers >= 4.46.3
 protobuf == 3.20.0


### PR DESCRIPTION
Main issue: 
BH pipelines don't have MLPerf mount, so we cannot store the weights. 
The alternative for now is to download the weights every time we run the demo. However we require a HF token to access these. 
Exploring solutions...

## Run pipelines
- [] [Blackhole All-post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/14385537910)
- [ ] [Blackhole Demo](https://github.com/tenstorrent/tt-metal/actions/runs/14495075223)