### PR TITLE
[skip ci] Prep to run on CI v2 runners

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -128,6 +128,8 @@ jobs:
     runs-on:
       - build
       - in-service
+    # runs-on: tt-beta-ubuntu-2204-xlarge
+    environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:
       packages-artifact-name: ${{ steps.set-artifact-name.outputs.name }}
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -45,6 +45,7 @@ jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
     with:
       version: "22.04"
       toolchain: cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake


### PR DESCRIPTION
### Ticket
Probably one somewhere

### Problem description
CI v2 is ready with some CPU builders.  We want to use them.

### What's changed
A few minor changes in prep for switching over.
Split into 2 PRs for a more localized revert in case anything goes sideways.
This PR should have zero impact.