### PR TITLE
Add SD1.4 VAE upsample component

### DIFF
--- a/models/demos/blackhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py
+++ b/models/demos/blackhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py
@@ -1,0 +1,1 @@
+../../../../wormhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_sd14_vae_convs.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_sd14_vae_convs.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (
+    get_default_compute_config,
+    get_default_conv_config,
+    prepare_split_conv_weights_bias,
+    split_conv_and_run,
+)
+from models.utility_functions import is_wormhole_b0
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "in_channels, input_height, input_width, out_channels, output_height, output_width, conv_in_channel_split_factor, conv_out_channel_split_factor",
+    [
+        (512, 128, 128, 512, 128, 128, 1, 1),
+        (512, 256, 256, 512, 256, 256, 8 if is_wormhole_b0() else 2, 1 if is_wormhole_b0() else 2),
+        (256, 512, 512, 256, 512, 512, 8 if is_wormhole_b0() else 4, 2),
+    ],
+)
+def test_split_conv(
+    device,
+    in_channels,
+    input_height,
+    input_width,
+    out_channels,
+    output_height,
+    output_width,
+    conv_in_channel_split_factor,
+    conv_out_channel_split_factor,
+    use_program_cache,
+):
+    torch_input = torch.randn([1, in_channels, input_height, input_width])
+    torch_weights = torch.randn([out_channels, in_channels, 3, 3])
+    torch_biases = torch.randn([out_channels])
+
+    torch_output = torch.nn.functional.conv2d(
+        torch_input, torch_weights, bias=torch_biases, stride=(1, 1), padding=(1, 1), groups=1
+    )
+
+    conv_weights, conv_bias = prepare_split_conv_weights_bias(
+        in_channels,
+        out_channels,
+        conv_in_channel_split_factor,
+        conv_out_channel_split_factor,
+        torch_weights,
+        torch_biases.unsqueeze(0).unsqueeze(0).unsqueeze(0),
+    )
+
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]),
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn_output = split_conv_and_run(
+        ttnn_input,
+        conv_weights,
+        conv_bias,
+        device,
+        in_channels,
+        input_height,
+        input_width,
+        out_channels,
+        conv_in_channel_split_factor,
+        conv_out_channel_split_factor,
+        get_default_compute_config(device),
+        get_default_conv_config(),
+    )
+
+    ttnn_output = ttnn.to_memory_config(ttnn_output, ttnn.DRAM_MEMORY_CONFIG)
+    ttnn_output = ttnn.reshape(ttnn_output, [1, output_height, output_width, out_channels])
+    ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, 0.99)

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from diffusers import AutoencoderKL
+
+import ttnn
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
+from models.utility_functions import is_wormhole_b0
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "input_channels, input_height, input_width, out_channels, output_height, output_width, conv_in_channel_split_factor, conv_out_channel_split_factor, block_id",
+    [
+        (512, 64, 64, 512, 128, 128, 1, 1, 0),
+        (512, 128, 128, 512, 256, 256, 8 if is_wormhole_b0() else 2, 1 if is_wormhole_b0() else 2, 1),
+        (256, 256, 256, 256, 512, 512, 8 if is_wormhole_b0() else 4, 2, 2),
+    ],
+)
+def test_upsample(
+    device,
+    input_channels,
+    input_height,
+    input_width,
+    out_channels,
+    output_height,
+    output_width,
+    conv_in_channel_split_factor,
+    conv_out_channel_split_factor,
+    block_id,
+    use_program_cache,
+):
+    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+    torch_upsample = vae.decoder.up_blocks[block_id].upsamplers[0]
+
+    # Run pytorch model
+    torch_input = torch.randn([1, input_channels, input_height, input_width])
+    torch_output = torch_upsample(torch_input)
+
+    # Initialize ttnn model
+    ttnn_model = UpsampleBlock(
+        torch_upsample,
+        device,
+        input_channels,
+        out_channels,
+        output_height,
+        output_width,
+        conv_in_channel_split_factor,
+        conv_out_channel_split_factor,
+    )
+
+    # Prepare ttnn input
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]),
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # Run ttnn model twice to test program cache and weights reuse
+    ttnn_output = ttnn_model(ttnn_input)
+    ttnn_output.deallocate(True)
+    ttnn_output = ttnn_model(ttnn_input)
+
+    ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, 0.97)

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upsample.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (
+    get_default_compute_config,
+    get_default_conv_config,
+    prepare_split_conv_weights_bias,
+    split_conv_and_run,
+)
+
+
+class UpsampleBlock:
+    def __init__(
+        self,
+        torch_upsample,
+        device,
+        in_channels,
+        out_channels,
+        output_height,
+        output_width,
+        conv_in_channel_split_factor,
+        conv_out_channel_split_factor,
+        scale_factor=2,
+    ):
+        self.device = device
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.output_height = output_height
+        self.output_width = output_width
+        self.conv_in_channel_split_factor = conv_in_channel_split_factor
+        self.conv_out_channel_split_factor = conv_out_channel_split_factor
+        self.scale_factor = scale_factor
+        self.return_weights_and_bias = True
+
+        self.compute_config = get_default_compute_config(device)
+        self.conv_config = get_default_conv_config()
+
+        self.conv_weights, self.conv_bias = prepare_split_conv_weights_bias(
+            in_channels,
+            out_channels,
+            conv_in_channel_split_factor,
+            conv_out_channel_split_factor,
+            torch_upsample.conv.weight,
+            torch_upsample.conv.bias.unsqueeze(0).unsqueeze(0).unsqueeze(0),
+        )
+
+    def __call__(self, hidden_states):
+        if hidden_states.layout == ttnn.TILE_LAYOUT:
+            # Upsample op requires row-major input
+            hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
+
+        hidden_states = ttnn.upsample(hidden_states, self.scale_factor)
+
+        conv_result = split_conv_and_run(
+            hidden_states,
+            self.conv_weights,
+            self.conv_bias,
+            self.device,
+            self.in_channels,
+            self.output_height,
+            self.output_width,
+            self.out_channels,
+            self.conv_in_channel_split_factor,
+            self.conv_out_channel_split_factor,
+            self.compute_config,
+            self.conv_config,
+            return_weights_and_bias=self.return_weights_and_bias,
+        )
+
+        if self.return_weights_and_bias:
+            # In the first pass, we pass in weights on host,
+            # so we want to keep the weights on device and reuse them
+            hidden_states, self.conv_weights, self.conv_bias = conv_result
+            self.return_weights_and_bias = False
+        else:
+            hidden_states = conv_result
+
+        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+        hidden_states = ttnn.reshape(hidden_states, [1, self.output_height, self.output_width, self.out_channels])
+        return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_utils.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_utils.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+
+def get_default_conv_config():
+    return ttnn.Conv2dConfig(
+        dtype=ttnn.bfloat8_b,
+        weights_dtype=ttnn.bfloat8_b,
+        activation="",
+    )
+
+
+def get_default_compute_config(device):
+    return ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+
+def prepare_split_conv_weights_bias(
+    in_channels,
+    out_channels,
+    conv_in_channel_split_factor,
+    conv_out_channel_split_factor,
+    torch_weight_tensor,
+    torch_bias_tensor,
+):
+    split_output_channels = out_channels // conv_out_channel_split_factor
+    split_input_channels = in_channels // conv_in_channel_split_factor
+
+    # Split weights
+    if conv_out_channel_split_factor > 1:
+        split_weight_tensors = list(torch.split(torch_weight_tensor, split_output_channels, 0))
+    else:
+        split_weight_tensors = [torch_weight_tensor]
+
+    for i in range(len(split_weight_tensors)):
+        split_weight_tensors[i] = torch.split(split_weight_tensors[i], split_input_channels, 1)
+
+    ttnn_split_weights = [
+        [
+            ttnn.from_torch(
+                weight,
+                dtype=ttnn.float32,
+            )
+            for weight in output_channel_spit_weights
+        ]
+        for output_channel_spit_weights in split_weight_tensors
+    ]
+
+    # Split bias
+    if conv_in_channel_split_factor > 1:
+        split_bias_tensors = list(torch.split(torch_bias_tensor, split_output_channels, 3))
+    else:
+        split_bias_tensors = [torch_bias_tensor]
+
+    ttnn_split_bias = [
+        ttnn.from_torch(
+            bias,
+            dtype=ttnn.float32,
+        )
+        for bias in split_bias_tensors
+    ]
+
+    return ttnn_split_weights, ttnn_split_bias
+
+
+# --- Input channel split
+# When splitting by input channels, we split input tensor and weights tensors on the input channel dimension.
+# We call conv op on each input and weight slice and accumulate the result in a DRAM tensor.
+# --- Ouptut channel split
+# When splitting by output channels, we split conv weights and bias tensors.
+# We call conv op on the whole input tensor and each output slice of weights and bias.
+# The result is concatenated along the output channel dimension in DRAM.
+def split_conv_and_run(
+    hidden_states,
+    conv_weight,
+    conv_bias,
+    device,
+    in_channels,
+    input_height,
+    input_width,
+    out_channels,
+    conv_in_channel_split_factor,
+    conv_out_channel_split_factor,
+    compute_config,
+    conv_config,
+    kernel_size=3,
+    padding=1,
+    return_weights_and_bias=False,
+):
+    # The function currently accepts input in ROW_MAJOR layout only
+    # since ttnn.split has some issues with TILED version, to be debugged
+    assert hidden_states.layout == ttnn.ROW_MAJOR_LAYOUT, "Input tensor must be in ROW_MAJOR layout"
+
+    split_input_channels = in_channels // conv_in_channel_split_factor
+    split_output_channels = out_channels // conv_out_channel_split_factor
+
+    conv_kwargs = {
+        "in_channels": split_input_channels,
+        "out_channels": split_output_channels,
+        "batch_size": 1,
+        "input_height": input_height,
+        "input_width": input_width,
+        "kernel_size": (kernel_size, kernel_size),
+        "stride": (1, 1),
+        "padding": (padding, padding),
+        "dilation": (1, 1),
+        "groups": 1,
+        "device": device,
+        "conv_config": conv_config,
+    }
+
+    # Split input tensor if needed
+    if conv_in_channel_split_factor > 1:
+        hidden_states_split = ttnn.split(hidden_states, split_input_channels, 3)
+        hidden_states.deallocate(True)
+    else:
+        hidden_states_split = [hidden_states]
+
+    outputs = []
+    device_weights = []
+    device_bias = []
+    # First loop goes over output channel slices and saves outputs in a list
+    for out_channel_slice_id in range(conv_out_channel_split_factor):
+        out_channel_slice_output = None
+        device_weights.append([])
+        # Second loop goes over input channel slices and accumulates the outputs
+        for in_channel_slice_id in range(conv_in_channel_split_factor):
+            results = ttnn.conv2d(
+                input_tensor=hidden_states_split[in_channel_slice_id],
+                weight_tensor=conv_weight[out_channel_slice_id][in_channel_slice_id],
+                bias_tensor=conv_bias[out_channel_slice_id],
+                **conv_kwargs,
+                compute_config=compute_config,
+                return_weights_and_bias=return_weights_and_bias,
+            )
+
+            if return_weights_and_bias:
+                # First time we call this function, weights and biases are passed in on host;
+                # Save them so that we can reuse them on the next calls
+                in_channel_slice_output, [weights, bias] = results
+                device_weights[out_channel_slice_id].append(weights)
+                if in_channel_slice_id == 0:
+                    device_bias.append(bias)
+            else:
+                in_channel_slice_output = results
+
+            if in_channel_slice_id == 0:
+                out_channel_slice_output = ttnn.to_memory_config(in_channel_slice_output, ttnn.DRAM_MEMORY_CONFIG)
+                in_channel_slice_output.deallocate(True)
+            else:
+                out_channel_slice_output = ttnn.add(
+                    out_channel_slice_output, in_channel_slice_output, output_tensor=out_channel_slice_output
+                )
+                in_channel_slice_output.deallocate(True)
+
+        if out_channel_slice_output.memory_config() != ttnn.DRAM_MEMORY_CONFIG:
+            out_channel_slice_output = ttnn.to_memory_config(out_channel_slice_output, ttnn.DRAM_MEMORY_CONFIG)
+        outputs.append(out_channel_slice_output)
+
+    # Concatenate the outputs, if we split by output channels
+    if len(outputs) > 1:
+        output = ttnn.concat(outputs, dim=-1)
+        for output_slice in outputs:
+            output_slice.deallocate(True)
+    else:
+        output = outputs[0]
+
+    if return_weights_and_bias:
+        return output, device_weights, device_bias
+
+    return output

--- a/tests/nightly/single_card/stable_diffusion/vae/test_vae_decoder_upsample.py
+++ b/tests/nightly/single_card/stable_diffusion/vae/test_vae_decoder_upsample.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -73,7 +73,7 @@ run_python_model_tests_slow_runtime_mode_wormhole_b0() {
 }
 
 run_python_model_tests_blackhole() {
-    pytest models/demos/blackhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+    pytest models/demos/blackhole/stable_diffusion/tests
 
     # Llama3.1-8B
     llama8b=/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/


### PR DESCRIPTION
### Ticket
#17138

### Problem description
VAE decoder is currently run on host for Stable Diffusion 1.4

### What's changed
- Added Upsample component that is a part of the decoder
- Added component tests, running both on WH and BH
- Added split conv unit tests that aren't run on the CI, but useful for debug of components with split convs

### Checklist
Frequent model on WH: https://github.com/tenstorrent/tt-metal/actions/runs/14315510142 ✅ 
Blackhole post commit: https://github.com/tenstorrent/tt-metal/actions/runs/14315486304 ✅ (same error as on main on unrelated test)