### PR TITLE
#0: Do not use MLPerf in any TG unit test except the llama ones

### DIFF
--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -73,7 +73,7 @@ jobs:
         test-group: [
           { name: "TG unit tests", arch: wormhole_b0, model: unit, timeout: 45, owner_id: XXXXX},  # Add owner
           { name: "TG Fabric tests", arch: wormhole_b0, model: fabric, timeout: 30, owner_id: UJ45FEC7M},  # Allan Liu
-          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 45, owner_id: U044T8U8DEF}, # Johanna Rock
+          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 45, owner_id: U044T8U8DEF, mlperf: true}, # Johanna Rock
           { name: "TG DRAM Prefetcher unit tests", arch: wormhole_b0, model: prefetcher, timeout: 30, owner_id: U071CKL4AFK}, # Ammar Vora, Yu Gao
           { name: "TG distributed ops tests", arch: wormhole_b0, model: distributed-ops, timeout: 15, owner_id: U044T8U8DEF},  # Johanna Rock
           { name: "TG distributed runtime tests", arch: wormhole_b0, model: distributed-runtime, timeout: 45, owner_id: U03NG0A5ND7},  # Aditya Saigal
@@ -97,7 +97,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/MLPerf:/mnt/MLPerf:ro
+        - ${{ matrix.test-group.mlperf && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -73,7 +73,7 @@ jobs:
         test-group: [
           { name: "TG unit tests", arch: wormhole_b0, model: unit, timeout: 45, owner_id: XXXXX},  # Add owner
           { name: "TG Fabric tests", arch: wormhole_b0, model: fabric, timeout: 30, owner_id: UJ45FEC7M},  # Allan Liu
-          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 45, owner_id: U044T8U8DEF, mlperf: true}, # Johanna Rock
+          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 45, owner_id: U044T8U8DEF}, # Johanna Rock
           { name: "TG DRAM Prefetcher unit tests", arch: wormhole_b0, model: prefetcher, timeout: 30, owner_id: U071CKL4AFK}, # Ammar Vora, Yu Gao
           { name: "TG distributed ops tests", arch: wormhole_b0, model: distributed-ops, timeout: 15, owner_id: U044T8U8DEF},  # Johanna Rock
           { name: "TG distributed runtime tests", arch: wormhole_b0, model: distributed-runtime, timeout: 45, owner_id: U03NG0A5ND7},  # Aditya Saigal
@@ -97,7 +97,6 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - ${{ matrix.test-group.mlperf && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -73,7 +73,7 @@ jobs:
         test-group: [
           { name: "TG unit tests", arch: wormhole_b0, model: unit, timeout: 45, owner_id: XXXXX},  # Add owner
           { name: "TG Fabric tests", arch: wormhole_b0, model: fabric, timeout: 30, owner_id: UJ45FEC7M},  # Allan Liu
-          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 45, owner_id: U044T8U8DEF}, # Johanna Rock
+          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 45, owner_id: U044T8U8DEF, mlperf: true}, # Johanna Rock
           { name: "TG DRAM Prefetcher unit tests", arch: wormhole_b0, model: prefetcher, timeout: 30, owner_id: U071CKL4AFK}, # Ammar Vora, Yu Gao
           { name: "TG distributed ops tests", arch: wormhole_b0, model: distributed-ops, timeout: 15, owner_id: U044T8U8DEF},  # Johanna Rock
           { name: "TG distributed runtime tests", arch: wormhole_b0, model: distributed-runtime, timeout: 45, owner_id: U03NG0A5ND7},  # Aditya Saigal
@@ -97,6 +97,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
+        - ${{ matrix.test-group.mlperf && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
       options: "--device /dev/tenstorrent"
     defaults:
       run:


### PR DESCRIPTION
### Ticket

As part of MLPerf slow deprecation

### Problem description

Don't mount stuff that we don't need especially if it's not very portable for later infrastructure

### What's changed

Remove MLPerf for all TG unit test jobs except for llama

### Checklist
- TG unit: https://github.com/tenstorrent/tt-metal/actions/runs/14311584765
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes