### PR TITLE
[skip ci] Ubuntu release for .deb pkgs

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -88,6 +88,15 @@ function(ParseGitDescribe)
         string(APPEND VERSION_DEB "+m")
     endif()
 
+    # Include Ubuntu's version to disambiguate packages
+    execute_process(
+        COMMAND
+            lsb_release -sr
+        OUTPUT_VARIABLE UBUNTU_RELEASE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(APPEND VERSION_DEB "~ubuntu${UBUNTU_RELEASE}")
+
     message(STATUS "Version: ${VERSION_FULL}")
 
     # Output variables


### PR DESCRIPTION
### Ticket
None

### Problem description
.deb files may conflict and an installed package is not clear whether it was built for the active release.

### What's changed
Include Ubuntu's release that the package was built for.  This is common practice with .debs.