### PR TITLE
Bump setuptools-scm to fix compatbility bug with newer versions of git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools==70.1.0",
-  "setuptools-scm==8.0.4"
+  "setuptools-scm==8.1.0"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`setuptools-scm` has a bug that makes it fail to parse the ISO datetime output of newer versions of git (>= 2.45.0), see pypa/setuptools-scm/issues/1038

### What's changed
Bump `setuptools-scm` to version 8.1.0

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14317174747) CI passes