### PR TITLE
Cutover Clang-Tidy to CI v2

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -64,12 +64,13 @@ jobs:
     name: 🤖 Clang Tidy
     needs: [ build-docker-image, determine-scan-type ]
     if: ${{ needs.determine-scan-type.outputs.do-scan == 'true' }}
-    runs-on:
-      - build
-      - in-service
+    runs-on: tt-beta-ubuntu-2204-xlarge
+    environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
       image: ${{ needs.build-docker-image.outputs.dev-tag || 'docker-image-unresolved!'}}
       env:
+        CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}"
+        CCACHE_REMOTE_ONLY: "true"
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo
         TT_FROM_PRECOMPILED_DIR: /work
@@ -87,16 +88,14 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - name: Verify ccache availability
+      - name: Detect ccache rw ability
+        # FIXME: Can we detect the environment we're in so are always in sync with the `environment: ...` line above
+        if: ${{ github.ref != 'refs/heads/main' }}
+        shell: bash
         run: |
-          if [ ! -d "/mnt/MLPerf/ccache" ]; then
-            echo "::error title=ccache-mlperf-not-mounted::NFS drive is not mounted; build machine not properly provisioned."
-            exit 1
-          fi
-          if [ ! -d "$HOME/.ccache" ]; then
-            echo "::error title=ccache-not-provisioned::Ccache is not properly provisioned."
-            exit 1
-          fi
+          # ccache does not support false env vars; and GHA does not support conditionally defining an envvar.
+          # So we have to do it this way
+          echo "CCACHE_READONLY=1" >> "$GITHUB_ENV"
 
       - name: Create ccache tmpdir
         run: |


### PR DESCRIPTION
### Ticket
None

### Problem description
Forgot to cutover Clang-Tidy when I cutover the other C++ builds in #20284

### What's changed
Flip ClangTidy over to the new builders