### PR TITLE
[skip ci] Fix call to checkout in GHA

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -19,8 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history so 'origin/main' is available
-          fetch-refs: true  # Ensure all refs are fetched
+          fetch-depth: 0  # Fetch all history and all branches / tags so 'origin/main' is available
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
### Ticket
None

### Problem description
Warnings are showing up in Merge Gate.

### What's changed
There is no `fetch-refs`, and the apparent motivation for that is covered by `fetch-depth: 0`.  Just nuke it.