### PR TITLE
#20261: Add TTNN L2 tests to blackhole nightly pipeline (for weekend runs only)

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -9,7 +9,7 @@ on:
           type: string
           default: 'BH'
       run-ttnn-tests:
-          description: "Run ttnn test suite"
+          description: "Run ttnn unit and L2 test suite"
           default: false
           type: boolean
   workflow_call:
@@ -23,7 +23,7 @@ on:
     - cron: "0 */12 * * *"  # Every day at 0:00 and 12:00 UTC
     - cron: "0 8 * * 6"     # Runs at 8am UTC every Saturday
 
-run-name: ${{ (github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)) && '(Blackhole) Blackhole nightly tests (with ttnn)' || '(Blackhole) Blackhole nightly tests' }}  # Dynamically change name based on day
+run-name: ${{ (github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)) && '(Blackhole) Blackhole nightly tests (with ttnn+L2)' || '(Blackhole) Blackhole nightly tests' }}  # Dynamically change name based on day
 
 jobs:
   build-artifact:
@@ -48,6 +48,18 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  ttnn-l2-tests:
+    needs: build-artifact
+    if: github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)  # Only run L2 on the weekends or if workflow manually triggered with ttnn enabled
+    secrets: inherit
+    uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      timeout: 120
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -1,0 +1,82 @@
+name: "[impl] Nightly tt-metal L2 tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+      docker-image:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 120
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group:
+          - name: ttnn nightly conv tests
+            cmd: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
+            owner: U052J2QDDKQ # Pavle Josipovic
+          - name: ttnn nightly matmul tests
+            cmd: pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
+            owner: U06Q7ESTFEV # Borys Bradel
+          - name: ttnn nightly pool tests
+            cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
+            owner: U052J2QDDKQ # Pavle Josipovic
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
+      env:
+        PYTHONPATH: /work
+        LD_LIBRARY_PATH: /work/build/lib
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    name: ${{ matrix.test-group.name }}
+    runs-on:
+      - ${{ inputs.runner-label }}
+      - "in-service"
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+      - name: ${{ matrix.test-group.name }} tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: ${{ matrix.test-group.cmd }}
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          prefix: "test_reports_"
+      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
+        # Only notify during failed scheduled runs
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner }}
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -32,58 +32,12 @@ jobs:
       version: 22.04
   test:
     needs: build-artifact
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group:
-          - name: ttnn nightly conv tests
-            cmd: pytest tests/ttnn/nightly/unit_tests/operations/conv -xv -m "not disable_fast_runtime_mode"
-            owner: U052J2QDDKQ # Pavle Josipovic
-          - name: ttnn nightly matmul tests
-            cmd: pytest tests/ttnn/nightly/unit_tests/operations/matmul -xv -m "not disable_fast_runtime_mode"
-            owner: U06Q7ESTFEV # Borys Bradel
-          - name: ttnn nightly pool tests
-            cmd: pytest tests/ttnn/nightly/unit_tests/operations/pool -xv -m "not disable_fast_runtime_mode"
-            owner: U052J2QDDKQ # Pavle Josipovic
-    container:
-      image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      env:
-        PYTHONPATH: /work
-        LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ inputs.arch || 'wormhole_b0' }}
-        LOGURU_LEVEL: INFO
-      volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
-    defaults:
-      run:
-        shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
-    name: ${{ matrix.test-group.name }}
-    runs-on:
-      - ${{ inputs.runner-label || 'N150' }}
-      - "in-service"
-    steps:
-      - name: ⬇️  Setup Job
-        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
-        timeout-minutes: 10
-        with:
-          build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-          wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      - name: ${{ matrix.test-group.name }} tests
-        timeout-minutes: ${{ (github.event_name == 'schedule' && 120) || fromJSON(inputs.timeout) }}
-        run: ${{ matrix.test-group.cmd }}
-      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
-        timeout-minutes: 10
-        if: ${{ !cancelled() }}
-        with:
-          prefix: "test_reports_"
-      - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
-        # Only notify during failed scheduled runs
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          owner: ${{ matrix.test-group.owner }}
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()
+    secrets: inherit
+    uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
+    with:
+      arch: ${{ inputs.arch || 'wormhole_b0' }}
+      runner-label: ${{ inputs.runner-label || 'N150' }}
+      timeout: ${{ (github.event_name == 'schedule' && 120) || fromJSON(inputs.timeout) }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
Closes #20261

### Problem description
TTNN L2 tests do not currently run on blackhole.

### What's changed
Convert L2 nightly into a wrapper and impl reusable workflow.
Call reusable L2 impl on blackhole nightly flow, to run with the remaining ttnn tests on the weekend.

### Checklist
- [x] Metal L2: https://github.com/tenstorrent/tt-metal/actions/runs/14317588809
- [x] Blackhole nightly with ttnn+L2: https://github.com/tenstorrent/tt-metal/actions/runs/14319578688