### PR TITLE
#18485: skip more ttnn unit tests that fail on BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_backward_embedding.py
+++ b/tests/ttnn/unit_tests/operations/test_backward_embedding.py
@@ -68,6 +68,7 @@ def test_embedding_bw(input_dtype, output_dtype, batch_size, seq_len, embedding_
     assert comp_pass
 
 
+@skip_for_blackhole("Fails on BH. Issue #11816")
 @pytest.mark.parametrize(
     "batch_size, seq_len, embedding_dim, num_embeddings",
     [

--- a/tests/ttnn/unit_tests/operations/test_clone.py
+++ b/tests/ttnn/unit_tests/operations/test_clone.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc
+from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
 from loguru import logger
 
 from tests.ttnn.unit_tests.operations.test_utils import (
@@ -94,6 +94,7 @@ memory_config_list = [
 ]
 
 
+@skip_for_blackhole("Fails on BH. Issue #20576")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from loguru import logger
 
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc, is_grayskull
+from models.utility_functions import comp_allclose_and_pcc, is_grayskull, skip_for_blackhole
 from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
     compute_kernel_options,
@@ -195,6 +195,7 @@ def run_moreh_bmm_backward(
         assert passing
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -212,6 +213,7 @@ def test_moreh_bmm_shape(shape, device):
     run_moreh_bmm(shape, True, False if is_grayskull() else True, device)
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize("optional_output", [False, True])
 def test_moreh_bmm_optional_output(optional_output, device):
     """
@@ -230,6 +232,7 @@ def test_moreh_bmm_compute_kernel_options(compute_kernel_options, device):
     run_moreh_bmm([10, 191, 447, 159], True, compute_kernel_options, device)
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_bmm_ttnn_dtype(ttnn_dtype, device):
     """
@@ -242,6 +245,7 @@ def test_moreh_bmm_ttnn_dtype(ttnn_dtype, device):
     run_moreh_bmm([10, 191, 447, 159], True, False if is_grayskull() else True, device, ttnn_dtype=ttnn_dtype)
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shape",
     [[10, 191, 447, 159]],
@@ -263,6 +267,7 @@ def test_moreh_bmm_callback(shape, device, use_program_cache):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -280,6 +285,7 @@ def test_moreh_bmm_backward_shape(shape, device):
     run_moreh_bmm_backward(shape, [True, True], False if is_grayskull() else True, device)
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "requires_grad",
     [
@@ -305,6 +311,7 @@ def test_moreh_bmm_backward_compute_kernel_options(compute_kernel_options, devic
     run_moreh_bmm_backward([7, 511, 313, 765], [True, True], compute_kernel_options, device)
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_bmm_backward_ttnn_dtype(ttnn_dtype, device):
     """
@@ -319,6 +326,7 @@ def test_moreh_bmm_backward_ttnn_dtype(ttnn_dtype, device):
     )
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "requires_grad",
     [

--- a/tests/ttnn/unit_tests/operations/test_moreh_fold.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_fold.py
@@ -7,7 +7,7 @@ import torch
 import ttnn
 
 from loguru import logger
-from models.utility_functions import comp_allclose_and_pcc
+from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
 
 
 def run_fold_test(device, input_shape, output_size, kernel_size, dilation, padding, stride, dtype):
@@ -33,6 +33,7 @@ def run_fold_test(device, input_shape, output_size, kernel_size, dilation, paddi
     assert passing
 
 
+@skip_for_blackhole("Fails on BH. Issue #20577")
 @pytest.mark.parametrize(
     "input_shape,output_size,kernel_size,dilation,padding,stride",
     [

--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -417,6 +417,7 @@ def test_moreh_matmul_backward(params, requires_grad, dtype, device):
     moreh_matmul_backward(params, requires_grad, device, dtype=dtype)
 
 
+@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "params",
     (

--- a/tests/ttnn/unit_tests/operations/test_moreh_nll_loss.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_nll_loss.py
@@ -6,7 +6,7 @@ import torch
 
 import ttnn
 import pytest
-from models.utility_functions import comp_allclose_and_pcc
+from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
 from loguru import logger
 
 from tests.ttnn.unit_tests.operations.test_utils import (
@@ -159,6 +159,7 @@ def run_moreh_nll_loss_backward(
     assert passing
 
 
+@skip_for_blackhole("Fails on BH. Issue #20579")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -213,6 +214,7 @@ def test_moreh_nll_loss_callback(shape, reduction, device, use_program_cache):
     )
 
 
+@skip_for_blackhole("Fails on BH. Issue #20579")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -238,6 +240,7 @@ def test_moreh_nll_loss_compute_kernel_options(
     )
 
 
+@skip_for_blackhole("Fails on BH. Issue #20579")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -293,6 +296,7 @@ def test_moreh_nll_loss_backward_test_callback(shape, reduction_mean, device, us
     )
 
 
+@skip_for_blackhole("Fails on BH. Issue #20579")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/tests/ttnn/unit_tests/operations/test_moreh_nll_loss_unreduced.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_nll_loss_unreduced.py
@@ -6,7 +6,7 @@ import torch
 
 import ttnn
 import pytest
-from models.utility_functions import comp_allclose_and_pcc
+from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
 from loguru import logger
 
 from tests.ttnn.unit_tests.operations.test_utils import (
@@ -205,6 +205,7 @@ def test_moreh_nll_loss_unreduced_callback(shape, device, use_program_cache):
     )
 
 
+@skip_for_blackhole("Fails on BH. Issue #20579")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/tests/ttnn/unit_tests/operations/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/test_sampling.py
@@ -147,6 +147,7 @@ def test_sampling_callback(shape, k, p, seed, device, use_program_cache):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
+@skip_for_blackhole("Requires wormhole_b0 to run. Issue #19640")
 @pytest.mark.parametrize(
     "shape",
     [


### PR DESCRIPTION
### Ticket
Link to Github Issue #18485

### Problem description
After the past weekend's run, more tests were identified as failing, and one of the failures results in a hang.

### What's changed
Skip these tests while the underlying issues are being worked on to avoid a hang, move the pipeline towards a green status, and reduce triage time.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14318451087 and new one https://github.com/tenstorrent/tt-metal/actions/runs/14409140231/job/40413163156 has ttnn tests passing
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A