### PR TITLE
[skip ci] Grant Merge Gate's ClangTidy scan permission to access Redis

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -97,6 +97,13 @@ jobs:
           # So we have to do it this way
           echo "CCACHE_READONLY=1" >> "$GITHUB_ENV"
 
+      - name: Check credentials
+        run: |
+          if [ -z "${{ secrets.REDIS_PASSWORD }}" ]; then
+            echo "Redis password is missing. Did you forget 'secrets: inherit'?"
+            exit 1
+          fi
+
       - name: Create ccache tmpdir
         run: |
           mkdir -p /tmp/ccache

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -97,7 +97,7 @@ jobs:
           # So we have to do it this way
           echo "CCACHE_READONLY=1" >> "$GITHUB_ENV"
 
-      - name: Check credentials
+      - name: Check Redis credentials
         run: |
           if [ -z "${{ secrets.REDIS_PASSWORD }}" ]; then
             echo "Redis password is missing. Did you forget 'secrets: inherit'?"

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -36,6 +36,7 @@ jobs:
     # But we don't actually WANT to run it on PRs -- that's the whole point.  GitHub strikes again.
     if: github.event_name != 'pull_request'
     uses: ./.github/workflows/code-analysis.yaml
+    secrets: inherit
     with:
       version: 22.04
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Merge Gate is not benefiting from ccache.  Turns out it didn't get the password.  Minor details.

### What's changed
Give it access to secrets.