### PR TITLE
Add outbound_eth_chan compile arg to dispatch kernel

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -600,6 +600,8 @@ int main(int argc, char** argv) {
             0,
             0,
             0,
+            0,
+            0,
             true,  // is_dram_variant
             true,  // is_host_variant
         };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1903,6 +1903,7 @@ void configure_for_single_chip(
         0,
         0,
         0,
+        0,
     };
 
     constexpr NOC my_noc_index = NOC::NOC_0;
@@ -2185,6 +2186,7 @@ void configure_for_single_chip(
         host_completion_queue_wr_ptr,
         dev_completion_queue_wr_ptr,
         dev_completion_queue_rd_ptr,
+        0,
         0,
         0,
         0,

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -73,9 +73,10 @@ typedef struct dispatch_dependent_config {
     // Populated if fabric is being used to talk to downstream
     std::optional<uint32_t> fabric_router_noc_xy;
     std::optional<uint32_t> upstream_mesh_id;
-    std::optional<uint32_t> upstream_chip_id;
+    std::optional<uint32_t> upstream_dev_id;
     std::optional<uint32_t> downstream_mesh_id;
-    std::optional<uint32_t> downstream_chip_id;
+    std::optional<uint32_t> downstream_dev_id;
+    std::optional<uint32_t> outbound_eth_chan;
 } dispatch_dependent_config_t;
 
 class DispatchKernel : public FDKernel {
@@ -121,6 +122,7 @@ public:
 
     void UpdateArgsForFabric(
         const CoreCoord& fabric_router,
+        uint32_t outbound_eth_chan,
         tt::tt_fabric::mesh_id_t src_mesh_id,
         chip_id_t src_chip_id,
         tt::tt_fabric::mesh_id_t dst_mesh_id,

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -73,9 +73,17 @@ void FabricRouterVC::GenerateDependentConfigs() {
 
         TT_FATAL(valid_path, "FabricRouterVC is not implemented for this path");
 
+        // Get outbound ethernet channels
+        auto us_outbound_eth_channels = cluster.get_fabric_ethernet_channels(src_chip_id);
+        auto ds_outbound_eth_channels = cluster.get_fabric_ethernet_channels(dst_chip_id);
+        TT_FATAL(!us_outbound_eth_channels.empty(), "No outbound ethernet channels for upstream kernel");
+        TT_FATAL(!ds_outbound_eth_channels.empty(), "No outbound ethernet channels for downstream kernel");
+
         // Downstream path. src -> dst
-        us_kernel->UpdateArgsForFabric(fabric_router, src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
-        ds_kernel->UpdateArgsForFabric(fabric_router_rev, src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
+        us_kernel->UpdateArgsForFabric(
+            fabric_router, *us_outbound_eth_channels.begin(), src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
+        ds_kernel->UpdateArgsForFabric(
+            fabric_router_rev, *ds_outbound_eth_channels.begin(), src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
     }
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -93,6 +93,7 @@ public:
     // an intermediary FDKernel for indicating a fabric router path needs to be found.
     virtual void UpdateArgsForFabric(
         const CoreCoord& fabric_router_virtual,
+        uint32_t outbound_eth_chan,
         tt::tt_fabric::mesh_id_t upstream_mesh_id,
         chip_id_t upstream_chip_id,
         tt::tt_fabric::mesh_id_t downstream_mesh_id,

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -385,15 +385,16 @@ void PrefetchKernel::CreateKernel() {
         static_config_.dispatch_s_buffer_size.value(),
         static_config_.dispatch_s_cb_log_page_size.value(),
         dependent_config_.downstream_mesh_id.value_or(0),
-        dependent_config_.downstream_chip_id.value_or(0),
+        dependent_config_.downstream_dev_id.value_or(0),
         dependent_config_.upstream_mesh_id.value_or(0),
-        dependent_config_.upstream_chip_id.value_or(0),
+        dependent_config_.upstream_dev_id.value_or(0),
         dependent_config_.fabric_router_noc_xy.value_or(0),
+        dependent_config_.outbound_eth_chan.value_or(0),
         static_config_.client_interface_addr.value_or(0),
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-    TT_ASSERT(compile_args.size() == 34);
+    TT_ASSERT(compile_args.size() == 36);
     auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
     auto upstream_virtual_core =
         device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());
@@ -473,16 +474,18 @@ void PrefetchKernel::ConfigureCore() {
 
 void PrefetchKernel::UpdateArgsForFabric(
     const CoreCoord& fabric_router_virtual,
+    uint32_t outbound_eth_chan,
     tt::tt_fabric::mesh_id_t upstream_mesh_id,
-    chip_id_t upstream_chip_id,
+    chip_id_t upstream_dev_id,
     tt::tt_fabric::mesh_id_t downstream_mesh_id,
-    chip_id_t downstream_chip_id) {
+    chip_id_t downstream_dev_id) {
     dependent_config_.fabric_router_noc_xy =
         tt::tt_metal::hal_ref.noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
     dependent_config_.upstream_mesh_id = upstream_mesh_id;
-    dependent_config_.upstream_chip_id = upstream_chip_id;
+    dependent_config_.upstream_dev_id = upstream_dev_id;
     dependent_config_.downstream_mesh_id = downstream_mesh_id;
-    dependent_config_.downstream_chip_id = downstream_chip_id;
+    dependent_config_.downstream_dev_id = downstream_dev_id;
+    dependent_config_.outbound_eth_chan = outbound_eth_chan;
 
     auto& my_dispatch_constants = DispatchMemMap::get(GetCoreType());
     static_config_.client_interface_addr =

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -70,9 +70,10 @@ typedef struct prefetch_dependent_config {
     // Populated if fabric is being used to talk to downstream
     std::optional<uint32_t> fabric_router_noc_xy;
     std::optional<uint32_t> upstream_mesh_id;
-    std::optional<uint32_t> upstream_chip_id;
+    std::optional<uint32_t> upstream_dev_id;
     std::optional<uint32_t> downstream_mesh_id;
-    std::optional<uint32_t> downstream_chip_id;
+    std::optional<uint32_t> downstream_dev_id;
+    std::optional<uint32_t> outbound_eth_chan;
 } prefetch_dependent_config_t;
 
 class PrefetchKernel : public FDKernel {
@@ -108,6 +109,7 @@ public:
     void ConfigureCore() override;
     void UpdateArgsForFabric(
         const CoreCoord& fabric_router,
+        uint32_t outbound_eth_chan,
         tt::tt_fabric::mesh_id_t src_mesh_id,
         chip_id_t src_chip_id,
         tt::tt_fabric::mesh_id_t dst_mesh_id,

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -60,12 +60,13 @@ constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(30);
 constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(31);
 constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(32);
 constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(33);
-constexpr uint32_t client_interface_addr = get_compile_time_arg_val(34);
+constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(34);
+constexpr uint32_t client_interface_addr = get_compile_time_arg_val(35);
 
-constexpr uint32_t first_stream_used = get_compile_time_arg_val(35);
+constexpr uint32_t first_stream_used = get_compile_time_arg_val(36);
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(36);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(37);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(37);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(38);
 
 constexpr uint8_t upstream_noc_index = UPSTREAM_NOC_INDEX;
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -70,10 +70,11 @@ constexpr uint32_t downstream_dev_id = get_compile_time_arg_val(27);
 constexpr uint32_t upstream_mesh_id = get_compile_time_arg_val(28);
 constexpr uint32_t upstream_dev_id = get_compile_time_arg_val(29);
 constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(30);
-constexpr uint32_t client_interface_addr = get_compile_time_arg_val(31);
+constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(31);
+constexpr uint32_t client_interface_addr = get_compile_time_arg_val(32);
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(32);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(33);
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(33);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(34);
 
 constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
 constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -35,6 +35,8 @@ static const char* TT_METAL_HOME_ENV_VAR = "TT_METAL_HOME";
 static const char* TT_METAL_KERNEL_PATH_ENV_VAR = "TT_METAL_KERNEL_PATH";
 // Set this var to change the cache dir.
 static const char* TT_METAL_CACHE_ENV_VAR = "TT_METAL_CACHE";
+// Used for demonstration purposes and will be removed in the future.
+static const char* TT_METAL_FD_FABRIC_DEMO = "TT_METAL_FD_FABRIC";
 
 RunTimeOptions::RunTimeOptions() {
     const char* root_dir_str = std::getenv(TT_METAL_HOME_ENV_VAR);
@@ -145,7 +147,7 @@ RunTimeOptions::RunTimeOptions() {
         }
     }
 
-    const char* fb_fabric = getenv("TT_METAL_FD_FABRIC");
+    const char* fb_fabric = getenv(TT_METAL_FD_FABRIC_DEMO);
     fb_fabric_en = fb_fabric != nullptr;
 
     const char* dispatch_data_collection_str = std::getenv("TT_METAL_DISPATCH_DATA_COLLECTION");


### PR DESCRIPTION
### Ticket
#18726

### Problem description
Needed to Initialize 2D push fabric

### What's changed
This value is needed to initialize 2D Push fabric properly according to the test cases
Renamed chip_id args to dev_id
Added a comment in RTOptions about the `TT_METAL_FD_FABRIC` flag

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14343617731
https://github.com/tenstorrent/tt-metal/actions/runs/14387060269
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14343620211
https://github.com/tenstorrent/tt-metal/actions/runs/14343621412
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14343624404
https://github.com/tenstorrent/tt-metal/actions/runs/14387060302
Single Card
https://github.com/tenstorrent/tt-metal/actions/runs/14387060659
FD Unit Tests
https://github.com/tenstorrent/tt-metal/actions/runs/14395758505