### PR TITLE
[skip ci] Flag the ccache remote storage as RO vs RW

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -134,7 +134,7 @@ jobs:
     container:
       image: ${{ needs.build-docker-image.outputs.dev-tag || 'docker-image-unresolved!'}}
       env:
-        CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}"
+        CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}|read-only=${{ vars.REDIS_IS_READONLY }}"
         CCACHE_REMOTE_ONLY: "true"
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo
@@ -157,21 +157,13 @@ jobs:
         working-directory: /work # https://github.com/actions/runner/issues/878
 
     steps:
-      - name: Detect ccache rw ability
-        # FIXME: Can we detect the environment we're in so are always in sync with the `environment: ...` line above
-        if: ${{ github.ref != 'refs/heads/main' }}
-        shell: bash
-        run: |
-          # ccache does not support false env vars; and GHA does not support conditionally defining an envvar.
-          # So we have to do it this way
-          echo "CCACHE_READONLY=1" >> "$GITHUB_ENV"
-
       - name: Check Redis credentials
         run: |
           if [ -z "${{ secrets.REDIS_PASSWORD }}" ]; then
             echo "Redis password is missing. Did you forget 'secrets: inherit'?"
             exit 1
           fi
+          echo "CCACHE_REMOTE_STORAGE: ${CCACHE_REMOTE_STORAGE}"
 
       - name: Set artifact name
         id: set-artifact-name

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -69,7 +69,7 @@ jobs:
     container:
       image: ${{ needs.build-docker-image.outputs.dev-tag || 'docker-image-unresolved!'}}
       env:
-        CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}"
+        CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}|read-only=${{ vars.REDIS_IS_READONLY }}"
         CCACHE_REMOTE_ONLY: "true"
         CCACHE_TEMPDIR: /tmp/ccache
         CARGO_HOME: /tmp/.cargo
@@ -88,21 +88,13 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - name: Detect ccache rw ability
-        # FIXME: Can we detect the environment we're in so are always in sync with the `environment: ...` line above
-        if: ${{ github.ref != 'refs/heads/main' }}
-        shell: bash
-        run: |
-          # ccache does not support false env vars; and GHA does not support conditionally defining an envvar.
-          # So we have to do it this way
-          echo "CCACHE_READONLY=1" >> "$GITHUB_ENV"
-
       - name: Check Redis credentials
         run: |
           if [ -z "${{ secrets.REDIS_PASSWORD }}" ]; then
             echo "Redis password is missing. Did you forget 'secrets: inherit'?"
             exit 1
           fi
+          echo "CCACHE_REMOTE_STORAGE: ${CCACHE_REMOTE_STORAGE}"
 
       - name: Create ccache tmpdir
         run: |


### PR DESCRIPTION
### Ticket
None

### Problem description
CCACHE_READONLY applies only to the local storage.  Redis is being treated as RW, which results in `errors: X` in the stats from failed attempts to publish to the cache.

### What's changed
Flag the remote storage as RW or RO according to reality.