### PR TITLE
#19461: Implement tanh accurate mode device operation

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_tanh_accuracy.py
@@ -65,7 +65,35 @@ def test_tanh_range(device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     pcc, pcc_msg = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    # print("pcc_msg", pcc_msg) # pcc_msg 0.9999663646890817, accuracy=False pcc 0.9978378297942829
+    # pcc_msg 0.9999663646890817, accuracy=False pcc 0.9978378297942829
+    # pcc_msg 0.9999583453515977 - fpu arithmetic, pcc_msg 0.9999669593009368 sfpu arithmetic
+    assert pcc
+
+
+@pytest.mark.parametrize(
+    "high, low",
+    [
+        (1, -1),
+        (100, -100),
+        (4, -4),
+    ],
+)
+def test_tanh_inplace(device, high, low):
+    torch.manual_seed(0)
+
+    torch_input_tensor_a = torch.rand([1, 9, 8192], dtype=torch.bfloat16) * (high - low) + low
+    torch_output_tensor = torch.tanh(torch_input_tensor_a)
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    ttnn.tanh(input_tensor_a, accuracy=True, memory_config=ttnn.DRAM_MEMORY_CONFIG, output_tensor=input_tensor_a)
+    output_tensor = ttnn.to_torch(input_tensor_a)
+
+    pcc, pcc_msg = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
     assert pcc
 
 
@@ -79,17 +107,17 @@ def test_tanh_range(device):
     ),
 )
 @pytest.mark.parametrize(
-    "input_range",
+    "high, low",
     [
-        {"high": 1, "low": -1},
-        {"high": 100, "low": -100},
-        {"high": 10000, "low": -10000},
-        {"high": 4, "low": -4},
+        (1, -1),  # pcc_msg 0.99989
+        (100, -100),
+        (10000, -10000),
+        (4, -4),  # pcc_msg 0.999985108313941
     ],
 )
-def test_tanh_accuracy(device, input_shapes, input_range):
-    high = input_range["high"]
-    low = input_range["low"]
+def test_tanh_accuracy(device, input_shapes, high, low):
+    torch.manual_seed(0)
+
     torch_input_tensor = torch.rand((input_shapes), dtype=torch.bfloat16) * (high - low) + low
     golden_function = ttnn.get_golden_function(ttnn.tanh)
     torch_output_tensor = golden_function(torch_input_tensor)
@@ -98,5 +126,146 @@ def test_tanh_accuracy(device, input_shapes, input_range):
     output = ttnn.tanh(input_tensor, accuracy=True)
     output_tensor = ttnn.to_torch(output)
     pcc, pcc_msg = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
-    # print("pcc_msg", pcc_msg)  # pcc_msg 0.9999 or above
+    # pcc_msg 0.9999 or above
+    assert pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 89600, 32])),),
+)
+@pytest.mark.parametrize(
+    "high, low",
+    [
+        (1, -1),
+        (100, -100),
+        (10000, -10000),
+        (4, -4),
+    ],
+)
+def test_tanh_height_sharded(device, input_shapes, high, low):
+    torch.manual_seed(0)
+
+    in_data = torch.rand((input_shapes), dtype=torch.bfloat16) * (high - low) + low
+    shard_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(7, 6),
+            ),
+        }
+    )
+    n_cores = 56
+    N, C, H, W = in_data.shape
+    shard_spec = ttnn.ShardSpec(shard_grid, [N * C * H // n_cores, W], ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    input_tensor1 = ttnn.from_torch(
+        in_data,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_mem_config,
+    )
+    output_tensor = ttnn.tanh(input_tensor1, accuracy=True)
+    output_tensor = ttnn.to_torch(output_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.tanh)
+    golden_tensor = golden_function(in_data)
+
+    pcc, pcc_msg = assert_with_pcc(golden_tensor, output_tensor, 0.999)
+    # (-4,4) pcc_msg 0.9992087814894364, accuracy: pcc_msg 0.9999851389543495
+    assert pcc
+
+
+def return_mem_config(mem_config_string):
+    if mem_config_string == "l1_height_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_height_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512, 512 // 8),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_width_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 8, 512),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_rm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    elif mem_config_string == "l1_block_sharded_cm":
+        return ttnn.create_sharded_memory_config(
+            shape=(512 // 2, 512 // 4),
+            core_grid=ttnn.CoreGrid(y=2, x=4),
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+    raise ("Input mem_config_string is not valid!")
+
+
+@pytest.mark.parametrize(
+    "high, low",
+    [
+        (1, -1),
+        (100, -100),
+        (10000, -10000),
+        (4, -4),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_mem_config",
+    [
+        "l1_height_sharded_rm",
+        "l1_height_sharded_cm",
+        "l1_width_sharded_rm",
+        "l1_width_sharded_cm",
+        "l1_block_sharded_rm",
+        "l1_block_sharded_cm",
+    ],
+)
+def test_tanh_sharded(device, high, low, input_mem_config):
+    torch.manual_seed(0)
+
+    in_data = torch.rand([1, 1, 512, 512], dtype=torch.bfloat16) * (high - low) + low
+
+    input_tensor1 = ttnn.from_torch(
+        in_data,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=return_mem_config(input_mem_config),
+    )
+    output_tensor = ttnn.tanh(input_tensor1, accuracy=True)
+    output_tensor = ttnn.to_torch(output_tensor)
+    golden_function = ttnn.get_golden_function(ttnn.tanh)
+    golden_tensor = golden_function(in_data)
+
+    pcc, pcc_msg = assert_with_pcc(golden_tensor, output_tensor, 0.999)
     assert pcc

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -407,6 +407,10 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/common/unary_op_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/unary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/embedding/embedding.cpp

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "compute_kernel_api/common.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/eltwise_unary/eltwise_unary.h"
+#include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
+#include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
+#include "compute_kernel_api/eltwise_unary/exp.h"
+#include "compute_kernel_api/eltwise_unary/recip.h"
+#include "compute_kernel_api.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+
+    constexpr auto cb_input = tt::CBIndex::c_0;   // input
+    constexpr auto cb_output = tt::CBIndex::c_2;  // output
+
+    constexpr auto cb_tanh_lut = tt::CBIndex::c_1;   // lut tanh(x)
+    constexpr auto cb_exp_2x = tt::CBIndex::c_3;     // exp(2x) and abs(x)
+    constexpr auto cb_sub = tt::CBIndex::c_4;        // exp(2x) - 1
+    constexpr auto cb_add = tt::CBIndex::c_5;        // recip ( exp(2x) + 1 )
+    constexpr auto cb_tanh_exp = tt::CBIndex::c_6;   // tanh[x] = (exp[2x] - 1) / (exp[2x] + 1)
+    constexpr auto cb_true_val = tt::CBIndex::c_7;   // output for x > 3.5
+    constexpr auto cb_false_val = tt::CBIndex::c_8;  // output for x <= 3.5
+
+    constexpr uint32_t one = 0x3f800000u;    //  1.0f
+    constexpr uint32_t two = 0x40000000u;    //  2.0f
+    constexpr uint32_t limit = 0x40600000u;  //  3.5f
+
+    init_sfpu(cb_input, cb_output);
+    binop_with_scalar_tile_init();
+
+    for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
+        cb_reserve_back(cb_output, per_core_block_dim);
+        for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
+            cb_reserve_back(cb_tanh_lut, 1);
+            cb_wait_front(cb_input, 1);
+            tile_regs_acquire();
+
+            copy_tile_to_dst_init_short(cb_input);
+            copy_tile(cb_input, 0, 0);
+            tanh_tile_init();
+            tanh_tile(0);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_tanh_lut);
+            tile_regs_release();
+            cb_push_back(cb_tanh_lut, 1);
+
+            // exp(2x)
+            cb_reserve_back(cb_exp_2x, 1);
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short(cb_input);
+            copy_tile(cb_input, 0, 0);
+
+            mul_unary_tile(0, two);
+            exp_tile_init<1u>();
+            exp_tile<1u>(0);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_exp_2x);
+            tile_regs_release();
+
+            cb_push_back(cb_exp_2x, 1);
+
+            // exp(2x) - 1
+
+            cb_reserve_back(cb_sub, 1);
+            cb_wait_front(cb_exp_2x, 1);
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile(cb_exp_2x, 0, 0);
+
+            sub_unary_tile(0, one);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_sub);
+
+            tile_regs_release();
+
+            cb_push_back(cb_sub, 1);
+
+            // recip ( exp(2x) + 1 )
+
+            cb_reserve_back(cb_add, 1);
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile(cb_exp_2x, 0, 0);
+
+            add_unary_tile(0, one);
+            recip_tile_init();
+            recip_tile(0);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_add);
+
+            tile_regs_release();
+
+            cb_push_back(cb_add, 1);
+            cb_pop_front(cb_exp_2x, 1);
+
+            // tanh[x] = (exp[2x] - 1) *  1 / (exp[2x] + 1)
+
+            cb_reserve_back(cb_tanh_exp, 1);
+            cb_wait_front(cb_sub, 1);
+            cb_wait_front(cb_add, 1);
+            tile_regs_acquire();
+
+            mul_tiles_init(cb_sub, cb_add);
+            mul_tiles(cb_sub, cb_add, 0, 0, 0);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_tanh_exp);
+
+            tile_regs_release();
+
+            cb_push_back(cb_tanh_exp, 1);
+            cb_pop_front(cb_sub, 1);
+            cb_pop_front(cb_add, 1);
+
+            // abs(x) > 3.5f in c_3
+
+            cb_reserve_back(cb_exp_2x, 1);
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short(cb_input);
+            copy_tile(cb_input, 0, 0);
+
+            abs_tile_init();
+            abs_tile(0);
+            unary_gt_tile_init();
+            unary_gt_tile(0, limit);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_exp_2x);
+
+            tile_regs_release();
+            cb_push_back(cb_exp_2x, 1);
+
+            cb_pop_front(cb_input, 1);
+
+            // t2 output for x > 3.5
+
+            cb_wait_front(cb_tanh_lut, 1);
+            cb_wait_front(cb_exp_2x, 1);
+            cb_reserve_back(cb_true_val, 1);
+
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile(cb_exp_2x, 0, 0);
+
+            gtz_tile_init();
+            gtz_tile(0);
+
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_tanh_lut);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_tanh_lut, 0, 0);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_true_val);
+
+            tile_regs_release();
+
+            cb_push_back(cb_true_val, 1);
+            cb_pop_front(cb_tanh_lut, 1);
+
+            // t1 output for x <= 3.5
+
+            cb_wait_front(cb_tanh_exp, 1);
+            cb_reserve_back(cb_false_val, 1);
+
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short(cb_exp_2x);
+            copy_tile(cb_exp_2x, 0, 0);
+
+            lez_tile_init();
+            lez_tile(0);
+
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_tanh_exp);
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_tanh_exp, 0, 0);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_false_val);
+
+            tile_regs_release();
+
+            cb_push_back(cb_false_val, 1);
+            cb_pop_front(cb_exp_2x, 1);
+            cb_pop_front(cb_tanh_exp, 1);
+
+            // out = t1 + t2
+            cb_wait_front(cb_false_val, 1);
+            cb_wait_front(cb_true_val, 1);
+
+            tile_regs_acquire();
+
+            add_tiles_init(cb_true_val, cb_false_val);
+            add_tiles(cb_true_val, cb_false_val, 0, 0, 0);
+
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, cb_output);
+
+            tile_regs_release();
+
+            cb_pop_front(cb_true_val, 1);
+            cb_pop_front(cb_false_val, 1);
+        }
+        cb_push_back(cb_output, per_core_block_dim);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tanh_accurate_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::unary {
+
+TanhAccurateDeviceOperation::program_factory_t TanhAccurateDeviceOperation::select_program_factory(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.input.is_sharded()) {
+        return program::TanhAccurateShardedProgramFactory{};
+    } else {
+        return program::TanhAccurateProgramFactory{};
+    }
+}
+
+void TanhAccurateDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(args, tensor_args);
+}
+
+void TanhAccurateDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& preallocated_output_tensor = tensor_args.preallocated_output;
+
+    auto out_memory_config = args.output_memory_config;
+    auto output_datatype = args.output_dtype;
+    if (preallocated_output_tensor.has_value()) {
+        out_memory_config = preallocated_output_tensor->memory_config();
+        output_datatype = preallocated_output_tensor->get_dtype();
+    }
+
+    TT_FATAL(
+        input_tensor.storage_type() == StorageType::DEVICE,
+        "Unary operation requires input to be on Device. Input storage type: {}",
+        static_cast<int>(input_tensor.storage_type()));
+
+    TT_FATAL(
+        input_tensor.buffer() != nullptr,
+        "Operands to eltwise unary need to be allocated in buffers on the device. Buffer is null.");
+
+    TT_FATAL(
+        input_tensor.memory_config().memory_layout == out_memory_config.memory_layout,
+        "Unary operation requires Input and Output memory layout to match. Input layout: {}, Output layout: {}",
+        static_cast<int>(input_tensor.memory_config().memory_layout),
+        static_cast<int>(out_memory_config.memory_layout));
+
+    if (!input_tensor.is_sharded()) {
+        TT_FATAL(
+            input_tensor.get_layout() == Layout::TILE,
+            "Unary operation requires tensor to be in Tile layout when working with non-sharded input tensor. Input "
+            "tensor layout: {}",
+            static_cast<int>(input_tensor.get_layout()));
+
+        TT_FATAL(
+            input_tensor.memory_config().memory_layout == TensorMemoryLayout::INTERLEAVED,
+            "Unary operation requires Interleaved memory layout when working with non-sharded input tensor. Input "
+            "memory layout: `{}`",
+            static_cast<int>(input_tensor.memory_config().memory_layout));
+    }
+
+    if (preallocated_output_tensor.has_value()) {
+        const auto computed_output_shape = compute_output_specs(args, tensor_args).logical_shape();
+        const auto preallocated_output_shape = preallocated_output_tensor.value().get_logical_shape();
+        TT_FATAL(
+            preallocated_output_shape == computed_output_shape,
+            "When preallocted output tensor is used, Unary operation requires its shape to match the computed "
+            "shape. Computed shape: {}, Shape in preallocated output tensor: {}",
+            computed_output_shape,
+            preallocated_output_shape);
+
+        if (!input_tensor.is_sharded()) {
+            TT_FATAL(
+                (preallocated_output_tensor.value().get_layout() == Layout::TILE),
+                "Unary operation requires output tensor to be in Tile layout when working with non-sharded tensor.");
+        }
+    }
+}
+
+spec_return_value_t TanhAccurateDeviceOperation::compute_output_specs(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return tensor_args.preallocated_output->get_tensor_spec();
+    }
+
+    auto output_layout = Layout::TILE;
+    if (args.output_memory_config.is_sharded()) {
+        output_layout = tensor_args.input.get_layout();
+    }
+
+    const auto output_shape = tensor_args.input.logical_shape();
+    return TensorSpec(output_shape, TensorLayout(args.output_dtype, output_layout, args.output_memory_config));
+}
+
+tensor_return_value_t TanhAccurateDeviceOperation::create_output_tensors(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    if (tensor_args.preallocated_output.has_value()) {
+        return *tensor_args.preallocated_output;
+    }
+    return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
+}
+
+tt::stl::hash::hash_t TanhAccurateDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& input_shape = input_tensor.get_padded_shape();
+
+    auto program_factory = select_program_factory(args, tensor_args);
+    operation::Hash hash = operation::hash_operation<TanhAccurateDeviceOperation>(
+        args,
+        program_factory.index(),
+        input_tensor.dtype(),
+        std::get<DeviceStorage>(input_tensor.storage()).memory_config(),
+        input_shape.volume());
+
+    return hash;
+}
+
+bool TanhAccurateDeviceOperation::skip_launch(
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    const tensor_return_value_t& tensor_return_value) {
+    return tensor_return_value.logical_shape().volume() == 0;
+}
+
+std::tuple<TanhAccurateDeviceOperation::operation_attributes_t, TanhAccurateDeviceOperation::tensor_args_t>
+TanhAccurateDeviceOperation::invoke(
+    const Tensor& input,
+    DataType output_dtype,
+    const MemoryConfig& output_memory_config,
+    bool fp32_dest_acc_en,
+    bool preserve_fp32_precision,
+    bool bfp8_pack_precise,
+    const std::optional<Tensor>& preallocated_output) {
+    return {
+        operation_attributes_t{
+            .output_dtype = output_dtype,
+            .output_memory_config = output_memory_config,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .preserve_fp32_precision = preserve_fp32_precision,
+            .bfp8_pack_precise = bfp8_pack_precise,
+        },
+        tensor_args_t{.input = input, .preallocated_output = preallocated_output}};
+}
+
+}  // namespace ttnn::operations::unary

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_device_operation.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <functional>
+#include <optional>
+
+#include "tanh_accurate_pgm_factory.hpp"
+#include "tanh_accurate_sharded_pgm_factory.hpp"
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
+#include "ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp"
+
+namespace ttnn::operations::unary {
+
+struct TanhAccurateDeviceOperation {
+    using operation_attributes_t = unary::operation_attributes_t;
+    using tensor_args_t = unary::tensor_args_t;
+    using spec_return_value_t = unary::spec_return_value_t;
+    using tensor_return_value_t = unary::tensor_return_value_t;
+    using program_factory_t =
+        std::variant<program::TanhAccurateProgramFactory, program::TanhAccurateShardedProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& operation_attributes, const tensor_args_t&);
+
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input,
+        DataType output_dtype,
+        const MemoryConfig& output_memory_config,
+        bool fp32_dest_acc_en,
+        bool preserve_fp32_precision,
+        bool bfp8_pack_precise,
+        const std::optional<Tensor>& preallocated_output);
+};
+
+}  // namespace ttnn::operations::unary
+
+namespace ttnn::prim {
+constexpr auto tanh_accurate =
+    ttnn::register_operation<"ttnn::prim::tanh_accurate", ttnn::operations::unary::TanhAccurateDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.cpp
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+
+#include "tanh_accurate_pgm_factory.hpp"
+
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/host_api.hpp>
+
+namespace ttnn::operations::unary::program {
+
+static const std::string compute_root = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/";
+
+using namespace tt::constants;
+
+TanhAccurateProgramFactory::cached_program_t TanhAccurateProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    using namespace tt;
+    using namespace tt::tt_metal;
+
+    const auto& input = tensor_args.input;
+
+    tt::tt_metal::Program program{};
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    uint32_t single_tile_size = tt::tt_metal::detail::TileSize(cb_data_format);
+    tt::DataFormat cb_data_format_output = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t single_tile_size_output = tt::tt_metal::detail::TileSize(cb_data_format_output);
+
+    uint32_t num_tiles = input.volume() / tt::constants::TILE_HW;
+
+    tt::tt_metal::IDevice* device = input.device();
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    uint32_t num_cores_x = compute_with_storage_grid_size.x;
+    uint32_t num_cores_y = compute_with_storage_grid_size.y;
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_tiles);
+
+    // input buffer
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    uint32_t num_input_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
+            .set_page_size(src0_cb_index, single_tile_size);
+    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+
+    // intermediate buffers
+
+    // LUT tanh(x)
+    uint32_t im1_cb_index = tt::CBIndex::c_1;
+    tt::tt_metal::CircularBufferConfig cb_im1_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im1_cb_index, cb_data_format}})
+            .set_page_size(im1_cb_index, single_tile_size);
+    auto cb_im1 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im1_config);
+
+    // exp(2x)
+    uint32_t im2_cb_index = tt::CBIndex::c_3;
+    tt::tt_metal::CircularBufferConfig cb_im2_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im2_cb_index, cb_data_format}})
+            .set_page_size(im2_cb_index, single_tile_size);
+    auto cb_im2 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im2_config);
+
+    // exp(2x) - 1
+    uint32_t im3_cb_index = tt::CBIndex::c_4;
+    tt::tt_metal::CircularBufferConfig cb_im3_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im3_cb_index, cb_data_format}})
+            .set_page_size(im3_cb_index, single_tile_size);
+    auto cb_im3 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im3_config);
+
+    // recip(exp(2x) + 1)
+    uint32_t im4_cb_index = tt::CBIndex::c_5;
+    tt::tt_metal::CircularBufferConfig cb_im4_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im4_cb_index, cb_data_format}})
+            .set_page_size(im4_cb_index, single_tile_size);
+    auto cb_im4 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im4_config);
+
+    // exp(2x) - 1 * recip(exp(2x) - 1)
+    uint32_t im5_cb_index = tt::CBIndex::c_6;
+    tt::tt_metal::CircularBufferConfig cb_im5_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im5_cb_index, cb_data_format}})
+            .set_page_size(im5_cb_index, single_tile_size);
+    auto cb_im5 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im5_config);
+
+    // output for x > 3.5
+    uint32_t im6_cb_index = tt::CBIndex::c_7;
+    tt::tt_metal::CircularBufferConfig cb_im6_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im6_cb_index, cb_data_format}})
+            .set_page_size(im6_cb_index, single_tile_size);
+    auto cb_im6 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im6_config);
+
+    // output for x <= 3.5
+    uint32_t im7_cb_index = tt::CBIndex::c_8;
+    tt::tt_metal::CircularBufferConfig cb_im7_config =
+        tt::tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{im7_cb_index, cb_data_format}})
+            .set_page_size(im7_cb_index, single_tile_size);
+    auto cb_im7 = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_im7_config);
+
+    // output buffer
+    uint32_t output_cb_index = tt::CBIndex::c_2;
+    uint32_t num_output_tiles = 2;
+    tt::tt_metal::CircularBufferConfig cb_output_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_output_tiles * single_tile_size_output, {{output_cb_index, cb_data_format_output}})
+            .set_page_size(output_cb_index, single_tile_size_output);
+    auto cb_output = tt::tt_metal::CreateCircularBuffer(program, all_cores, cb_output_config);
+
+    auto src_buffer = input.buffer();
+    auto dst_buffer = output.buffer();
+
+    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)src_is_dram};
+    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    std::vector<uint32_t> writer_compile_time_args = {(std::uint32_t)output_cb_index, (std::uint32_t)dst_is_dram};
+
+    tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
+
+    tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+
+    std::vector<uint32_t> compute_kernel_args_group_1 = {
+        num_tiles_per_core_group_1,  // per_core_block_cnt
+        1                            // per_core_block_size
+    };
+
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (args.preserve_fp32_precision) {
+        unpack_to_dest_mode[src0_cb_index] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    bool math_approx_mode = false;
+    std::map<string, string> unary_defines;
+    auto path = "ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/kernels/compute/tanh_accurate.cpp";
+
+    auto eltwise_unary_kernel_group_1_id = tt::tt_metal::CreateKernel(
+        program,
+        path,
+        core_group_1,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = args.fp32_dest_acc_en,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+            .bfp8_pack_precise = args.bfp8_pack_precise,
+            .math_approx_mode = math_approx_mode,
+            .compile_args = compute_kernel_args_group_1,
+            .defines = unary_defines});
+
+    if (!core_group_2.ranges().empty()) {
+        std::vector<uint32_t> compute_kernel_args_group_2 = {
+            num_tiles_per_core_group_2,  // per_core_block_cnt
+            1                            // per_core_block_size
+        };
+
+        auto eltwise_unary_kernel_group_2_id = tt::tt_metal::CreateKernel(
+            program,
+            path,
+            core_group_2,
+            tt::tt_metal::ComputeConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .fp32_dest_acc_en = args.fp32_dest_acc_en,
+                .unpack_to_dest_mode = unpack_to_dest_mode,
+                .bfp8_pack_precise = args.bfp8_pack_precise,
+                .math_approx_mode = math_approx_mode,
+                .compile_args = compute_kernel_args_group_2,
+                .defines = unary_defines});
+    }
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t num_tiles_per_core = 0;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            TT_ASSERT(false, "Core not in specified core ranges");
+        }
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_reader_kernel_id, core, {src_buffer->address(), num_tiles_per_core, num_tiles_written});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    return cached_program_t{
+        std::move(program), {unary_reader_kernel_id, unary_writer_kernel_id, num_cores, num_cores_y}};
+}
+
+void TanhAccurateProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    auto& unary_reader_kernel_id = cached_program.shared_variables.unary_reader_kernel_id;
+    auto& unary_writer_kernel_id = cached_program.shared_variables.unary_writer_kernel_id;
+    const uint32_t num_cores = cached_program.shared_variables.num_cores;
+    const uint32_t num_cores_y = cached_program.shared_variables.num_cores_y;
+
+    auto& program = cached_program.program;
+
+    const auto& input = tensor_args.input;
+    auto src_buffer = input.buffer();
+    auto dst_buffer = output.buffer();
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+        }
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, unary_writer_kernel_id, core);
+            runtime_args[0] = dst_buffer->address();
+        }
+    }
+}
+
+}  // namespace ttnn::operations::unary::program

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_pgm_factory.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp"
+
+namespace ttnn::operations::unary::program {
+
+struct TanhAccurateProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle unary_reader_kernel_id;
+        tt::tt_metal::KernelHandle unary_writer_kernel_id;
+        uint32_t num_cores;
+        uint32_t num_cores_y;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::unary::program

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/device/tanh_accurate_sharded_pgm_factory.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operations/eltwise/unary/device/unary_device_operation_types.hpp"
+
+namespace ttnn::operations::unary::program {
+
+struct TanhAccurateShardedProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::CBHandle cb_src0;
+        tt::tt_metal::CBHandle out_cb;
+    };
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::unary::program

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tanh_accurate.hpp"
+
+#include "device/tanh_accurate_device_operation.hpp"
+#include "ttnn/common/queue_id.hpp"
+
+namespace ttnn {
+
+namespace operations {
+
+namespace unary {
+
+Tensor Tanh_accurate::invoke(
+    QueueId queue_id,
+    const Tensor& input_tensor,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    TT_FATAL(
+        input_tensor.get_dtype() == DataType::BFLOAT16,
+        "Supported dtypes for tanh with accuracy mode enabled is : BFLOAT16");
+
+    auto input_dtype = input_tensor.get_dtype();
+    DataType output_dtype = input_dtype;
+
+    bool preserve_fp32_precision = (input_dtype == DataType::FLOAT32);
+
+    bool fp32_dest_acc_en = preserve_fp32_precision or output_dtype == DataType::UINT32 or
+                            output_dtype == DataType::INT32 or output_dtype == DataType::FLOAT32 or
+                            input_dtype == DataType::UINT32 or input_dtype == DataType::INT32;
+
+    bool bfp8_pack_precise = input_dtype == DataType::BFLOAT8_B;
+
+    auto output_memory_config = optional_output_tensor.has_value()
+                                    ? optional_output_tensor.value().memory_config()
+                                    : memory_config.value_or(input_tensor.memory_config());
+
+    return prim::tanh_accurate(
+        queue_id,
+        input_tensor,
+        output_dtype,
+        output_memory_config,
+        fp32_dest_acc_en,
+        preserve_fp32_precision,
+        bfp8_pack_precise,
+        optional_output_tensor);
+}
+
+}  // namespace unary
+}  // namespace operations
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+
+namespace operations {
+
+namespace unary {
+
+struct Tanh_accurate {
+    static Tensor invoke(
+        QueueId queue_id,
+        const Tensor& input,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+};
+
+}  // namespace unary
+}  // namespace operations
+
+constexpr auto tanh_accurate =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::tanh_accurate", ttnn::operations::unary::Tanh_accurate>();
+
+}  // namespace ttnn


### PR DESCRIPTION
### Ticket
Link to Github Issue #19461 

### Problem description
To improve accuracy, ttnn.tanh was modified to use input_range-specific computation #19334
This has improved results for the albert_v2_*  models which required a minimum of 0.999 PCC for tanh operation across all input ranges.
Goal is converting this composite implementation into an optimized device operation

### What's changed
- Implemented tanh accurate device operation for tanh in accuracy mode.
- The accurate mode kernel takes 2.5x longer than look-up table tanh LLK (for a set of inputs).
- For ttnn.tanh with accurate mode enabled, PCC improves to 0.999* from 0.9*

The PCC from albert v2* models
without accuracy mode enabled
0.7576, 0.2015, 0.592, 0.2143

**with accuracy mode enabled**
0.9844246610571014, 0.985679115962903, 0.9719100627693323, 0.9758368405144295.

Wormhole: 
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/20819ff2-ea70-48c2-bb5c-5194c49ecf54" />

Blackhole: 
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/e38193a0-0cf6-4a90-94eb-d5ef6503b303" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14354937710
https://github.com/tenstorrent/tt-metal/actions/runs/14399561179
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14358584332
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] Sweeps https://github.com/tenstorrent/tt-metal/actions/runs/14358581543
- [x] New/Existing tests provide coverage for changes