### PR TITLE
Support plus_one for 4D tensors and move increment to device in TG Llama3-70b

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -319,6 +319,10 @@ def run_llama3_demo(
             current_pos_tensor,
             sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
         )
+        ttnn.plus_one(
+            rot_mat_idxs,
+            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+        )
     # profiler.end(f"plus one position done")
 
     # Capture Trace
@@ -354,7 +358,10 @@ def run_llama3_demo(
             current_pos_tensor,
             sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
         )
-    # ttnn.plus_one(rot_mat_idxs)  # FIXME <- This won't work since embedding requires uint32 and plus_one only works for int32
+        ttnn.plus_one(
+            rot_mat_idxs,
+            sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))]),
+        )
 
     ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
     ttnn.synchronize_device(mesh_device)
@@ -420,8 +427,6 @@ def run_llama3_demo(
         # If this tensor is int32, it won't be supported by ttnn.embedding
         if not stress_test:
             current_pos += 1
-        rot_mat_idxs_updated = tt_model.rope_setup.get_rot_idxs(current_pos, on_host=True)
-        ttnn.copy_host_to_device_tensor(rot_mat_idxs_updated, rot_mat_idxs)
         # ttnn.synchronize_device(mesh_device)
         # Write to host
         tt_output_torch = ttnn.to_torch(

--- a/tests/ttnn/unit_tests/operations/test_plus_one.py
+++ b/tests/ttnn/unit_tests/operations/test_plus_one.py
@@ -38,9 +38,9 @@ def test_plus_one_subdevice(device, w):
     device.enable_async(False)
 
 
-@pytest.mark.parametrize("w", [(16, 32), (32, 32), (4, 16, 32), (4, 8, 16, 32)])
-def test_plus_one_subdevice_nd(device, w):
-    torch_input_tensor = torch.randint(32000, w)
+@pytest.mark.parametrize("input_shape", [(16, 32), (32, 32), (4, 16, 32), (4, 8, 16, 32)])
+def test_plus_one_subdevice_nd(device, input_shape):
+    torch_input_tensor = torch.randint(32000, input_shape)
     torch_output_tensor = torch_input_tensor + 1
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.int32, device=device)
     ttnn.plus_one(

--- a/tests/ttnn/unit_tests/operations/test_plus_one.py
+++ b/tests/ttnn/unit_tests/operations/test_plus_one.py
@@ -36,3 +36,16 @@ def test_plus_one_subdevice(device, w):
     output_tensor = ttnn.to_torch(input_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
     device.enable_async(False)
+
+
+@pytest.mark.parametrize("w", [(16, 32), (32, 32), (4, 16, 32), (4, 8, 16, 32)])
+def test_plus_one_subdevice_nd(device, w):
+    torch_input_tensor = torch.randint(32000, w)
+    torch_output_tensor = torch_input_tensor + 1
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.int32, device=device)
+    ttnn.plus_one(
+        input_tensor,
+        sub_core_grids=ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(1, 1), ttnn.CoreCoord(1, 1))]),
+    )
+    output_tensor = ttnn.to_torch(input_tensor)
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
@@ -20,7 +20,7 @@ void PlusOne::validate_with_output_tensors(
         "Only ROW_MAJOR layout is supported for inputs!");
 
     auto input_shape = input_tensor_a.get_padded_shape();
-    TT_FATAL(input_shape.size() == 1, "must have 1 dimension");
+    TT_FATAL(input_shape.size() == 1 || input_shape.size() == 2, "must have 1 or 2 dimension(s)");
 }
 
 std::vector<ttnn::TensorSpec> PlusOne::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_op.cpp
@@ -20,7 +20,7 @@ void PlusOne::validate_with_output_tensors(
         "Only ROW_MAJOR layout is supported for inputs!");
 
     auto input_shape = input_tensor_a.get_padded_shape();
-    TT_FATAL(input_shape.size() == 1 || input_shape.size() == 2, "must have 1 or 2 dimension(s)");
+    TT_FATAL(input_shape.size() >= 1 && input_shape.size() <= 4, "must have 1 to 4 dimensions for input tensor");
 }
 
 std::vector<ttnn::TensorSpec> PlusOne::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -32,7 +32,8 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
     }
 
     const auto& input_shape = input.get_padded_shape();
-    const uint32_t W = input_shape[0];
+    uint32_t W = input_shape[-1];
+    uint32_t H = input_shape.size() == 1 ? 1 : input_shape[0];
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_units = W;
@@ -50,6 +51,7 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
         src_is_dram,
         aligned_input_unit_size,
         W,
+        H,
     };
 
     std::map<string, string> kernel_defines;

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_program_factory.cpp
@@ -33,7 +33,12 @@ tt::tt_metal::operation::ProgramWithCallbacks plusone_single_core(
 
     const auto& input_shape = input.get_padded_shape();
     uint32_t W = input_shape[-1];
-    uint32_t H = input_shape.size() == 1 ? 1 : input_shape[0];
+    uint32_t H = 1;
+    if (input_shape.size() > 1) {
+        for (uint32_t i = 0; i < input_shape.size() - 1; ++i) {
+            H *= input_shape[i];
+        }
+    }
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_units = W;


### PR DESCRIPTION
### Problem description
Llama3-70b used plus_one on host since op didn't support 2D tensors.

### What's changed
Support for 4D tensors in plus_one op is added by multiplying 1st 3 dims and passing W and H dims to kernel which increments tensor values in data movement kernel.

Current perf for Llama3-70b plus_one op is 20us (2us dispatch) which is high but due to the fact it's one time per inference it's not significant compared to ops in decoder and whole inference. 
**TODO** in future: Look into this in future to optimize it by either parallelising across cores or use ttnn.add instead (Currently it requires TILE_LAYOUT for input while input needs to be RM for another op in runtime).
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14334012278) - Check group6 where plus_one tests added 
- [x] [TG Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/14334033631)