### PR TITLE
Adjust UNet Shallow performance target

### DIFF
--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -98,7 +98,7 @@ def test_unet_trace_perf(
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput, use_async_mode",
     (
-        (1, 4, 256, 30.0, 1710.0, True),
+        (1, 4, 256, 30.0, 1500.0, True),  # Model using trace+2CQ is slower with async mode enabled (#16985)
         (1, 4, 256, 30.0, 1920.0, False),
     ),
 )


### PR DESCRIPTION
UNet Shallow async-mode performance has had high variance lately:
- https://github.com/tenstorrent/tt-metal/actions/runs/14330694094/job/40166828808#step:8:679
- https://github.com/tenstorrent/tt-metal/actions/runs/14335513336/job/40182707297#step:8:679

Reducing threshold since our best performance is still without async mode. (See [#16985](https://github.com/tenstorrent/tt-metal/issues/16985))

- Model performance pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/14339195974