### PR TITLE
Add more support to Reduce-Scatter

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -25,6 +25,7 @@ from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
     NORM_CRS,
     check_mesh_tensor_alloc,
 )
+from tracy import signpost
 
 PACKET_WORKER_CRS = ttnn.CoreRangeSet(
     [
@@ -69,38 +70,75 @@ def run_reduce_scatter_test(
     trace_mode,
     num_links=3,
     scheme="random",
+    use_regular_grid=False,
+    input_grid=None,
+    output_grid=None,
+    dtype=ttnn.bfloat8_b,
 ):
     mesh_device.enable_async(True)
     mesh_device.enable_program_cache()
     num_pages_per_packet = 4
 
+    # input, output, interm core range set
+    device = mesh_device.get_device(mesh_device.get_device_ids()[0])
+    compute_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
+    subdevice_shard_cores_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(compute_grid[0] - 1, compute_grid[1] - 1),
+            ),
+        }
+    )
+    if input_grid is not None:
+        input_shard_cores_grid = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(input_grid[0] - 1, input_grid[1] - 1),
+                ),
+            }
+        )
+    if output_grid is not None:
+        output_shard_cores_grid = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(output_grid[0] - 1, output_grid[1] - 1),
+                ),
+            }
+        )
+        tensor_width_in_tiles = num_cores * shard_width
+        output_num_cores = output_grid[0] * output_grid[1]
+
+    # input, output, interm memory config
     sharded_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,
         ttnn.ShardSpec(
-            RING_CRS,
+            input_shard_cores_grid if use_regular_grid else RING_CRS,
             [shard_height, shard_width],
             ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
-
-    output_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(
-            FF1_CRS_RS_OUT,
-            [shard_height, 32],
-            ttnn.ShardOrientation.ROW_MAJOR,
-        ),
-    )
-
-    # have to allocate a tensor for buffers that are written to across devices as there's no way to synchronize lifetime of buffers across devices
     packet_workers_persistent_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.BufferType.L1,
         ttnn.ShardSpec(
-            SUB_DEVICE_CRS,
+            subdevice_shard_cores_grid if use_regular_grid else SUB_DEVICE_CRS,
             [shard_height, num_devices_scatter * num_pages_per_packet * 32],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        ),
+    )
+    output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            output_shard_cores_grid if use_regular_grid else FF1_CRS_RS_OUT,
+            [
+                shard_height,
+                tensor_width_in_tiles // output_num_cores // num_devices_scatter if use_regular_grid else 32,
+            ],
             ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
@@ -140,7 +178,7 @@ def run_reduce_scatter_test(
             input,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
+            dtype=dtype,
             memory_config=sharded_mem_config,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device, dims=(0, 1), mesh_shape=[num_devices_fracture, num_devices_scatter]
@@ -150,7 +188,7 @@ def run_reduce_scatter_test(
             intermediate_tensor,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
-            dtype=ttnn.bfloat8_b,
+            dtype=dtype,
             memory_config=packet_workers_persistent_mem_config,
             mesh_mapper=ttnn.ShardTensor2dMesh(
                 mesh_device, dims=(0, 1), mesh_shape=[num_devices_fracture, num_devices_scatter]
@@ -162,7 +200,7 @@ def run_reduce_scatter_test(
         tt_intermediate_tensors_list.append(tt_intermediate)
 
     enable_persistent_fabric = True
-    ccl_sub_device_crs = SUB_DEVICE_CRS
+    ccl_sub_device_crs = subdevice_shard_cores_grid if use_regular_grid is not None else SUB_DEVICE_CRS
     worker_sub_device = ttnn.SubDevice(
         [
             ccl_sub_device_crs,
@@ -218,7 +256,9 @@ def run_reduce_scatter_test(
         ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
         ttnn.synchronize_device(mesh_device)
 
+        signpost(header="start")
         ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+        signpost(header="stop")
         ttnn.release_trace(mesh_device, trace_id)
         ttnn.synchronize_device(mesh_device)
     else:
@@ -243,6 +283,7 @@ def run_reduce_scatter_test(
     passed = True
     first_failed_tensor_index = None
     failed_indices = []
+    expected_pcc = 0.999 if dtype == ttnn.bfloat8_b else 0.9999
     for tensor_index in range(len(tt_out_tensor_list)):
         tt_torch_tensor = ttnn.to_torch(
             tt_out_tensor_list[tensor_index],
@@ -250,7 +291,7 @@ def run_reduce_scatter_test(
                 mesh_device, mesh_shape=[num_devices_fracture, num_devices_scatter], dims=(0, 1)
             ),
         )
-        eq, output_results = comp_pcc(tt_torch_tensor, output_tensor_goldens_list[tensor_index], 0.999)
+        eq, output_results = comp_pcc(tt_torch_tensor, output_tensor_goldens_list[tensor_index], expected_pcc)
         logger.info(f"Output tensor {tensor_index} has result {output_results}")
         if not eq:
             passed = False
@@ -337,4 +378,92 @@ def test_fabric_reduce_scatter_tg_no_trace(mesh_device, trace_mode):
         trace_mode,
         num_links=3,
         scheme="random",
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 90000, "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}], indirect=True
+)
+@pytest.mark.parametrize("trace_mode", [True, False])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (1, 2),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("shard_height", [32])
+@pytest.mark.parametrize("shard_width", [64])
+@pytest.mark.parametrize("input_grid", [(5, 4)])
+@pytest.mark.parametrize("output_grid", [(5, 2)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_fabric_reduce_scatter_regular_grid_2_dev(
+    mesh_device, trace_mode, shard_height, shard_width, input_grid, output_grid, dtype
+):
+    dim = 3
+    num_devices_scatter = 2
+    num_devices_fracture = 1
+    num_cores = input_grid[0] * input_grid[1]
+    num_iters = 30
+
+    run_reduce_scatter_test(
+        mesh_device,
+        dim,
+        shard_height,
+        shard_width,
+        num_devices_scatter,
+        num_devices_fracture,
+        num_cores,
+        num_iters,
+        trace_mode,
+        num_links=1,
+        scheme="random",
+        use_regular_grid=True,
+        input_grid=input_grid,
+        output_grid=output_grid,
+        dtype=dtype,
+    )
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"trace_region_size": 90000, "dispatch_core_axis": ttnn.DispatchCoreAxis.ROW}], indirect=True
+)
+@pytest.mark.parametrize("trace_mode", [True])
+@pytest.mark.parametrize(
+    "mesh_device",
+    [
+        (1, 4),
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("shard_height", [32])
+@pytest.mark.parametrize("shard_width", [64])
+@pytest.mark.parametrize("input_grid", [(5, 5)])
+@pytest.mark.parametrize("output_grid", [(5, 1)])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16])
+def test_fabric_reduce_scatter_regular_grid_4_dev(
+    mesh_device, trace_mode, shard_height, shard_width, input_grid, output_grid, dtype
+):
+    dim = 3
+    num_devices_scatter = 4
+    num_devices_fracture = 1
+    num_cores = input_grid[0] * input_grid[1] - 5  # test padding
+    num_iters = 30
+
+    run_reduce_scatter_test(
+        mesh_device,
+        dim,
+        shard_height,
+        shard_width,
+        num_devices_scatter,
+        num_devices_fracture,
+        num_cores,
+        num_iters,
+        trace_mode,
+        num_links=3,
+        scheme="random",
+        use_regular_grid=True,
+        input_grid=input_grid,
+        output_grid=output_grid,
+        dtype=dtype,
     )

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/reader_llama_reduce_scatter.cpp
@@ -49,6 +49,7 @@ void kernel_main() {
     constexpr uint32_t packet_worker_end_x = get_compile_time_arg_val(16);
     constexpr uint32_t packet_worker_end_y = get_compile_time_arg_val(17);
     constexpr uint32_t num_sender_cores = get_compile_time_arg_val(18);
+    constexpr uint32_t total_num_read_txns = get_compile_time_arg_val(19);
 
     // Derived compile-time constants
     constexpr uint32_t input_tensor_cores = input_shard_cores_per_device * num_devices;
@@ -66,7 +67,7 @@ void kernel_main() {
         DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
     constexpr uint8_t input_core_xy[input_tensor_cores][2] = INPUT_CORE_XY;
     constexpr uint8_t output_core_xy[output_cores_per_device][2] = OUTPUT_CORE_XY;
-    constexpr uint8_t schedule[num_packets_total_per_device][3] = SCHEDULE;
+    constexpr uint8_t schedule[total_num_read_txns][3] = SCHEDULE;
     constexpr uint32_t total_senders = num_sender_cores * other_devices;
 
     // Runtime arguments
@@ -76,20 +77,30 @@ void kernel_main() {
     bool worker_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t linear_input_packet_start_idx = get_arg_val<uint32_t>(rt_arg_idx++);
     bool receiver_core = (bool)get_arg_val<uint32_t>(rt_arg_idx++);
-    uint32_t sender_packet_start = get_arg_val<uint32_t>(rt_arg_idx++);
-    uint32_t sender_packet_end = get_arg_val<uint32_t>(rt_arg_idx++);
+    uint32_t sender_shard_start = get_arg_val<uint32_t>(rt_arg_idx++);
+    uint32_t sender_shard_end = get_arg_val<uint32_t>(rt_arg_idx++);
+    uint32_t sender_total_num_pages = get_arg_val<uint32_t>(rt_arg_idx++);
 
     // Bank base addresses (compute once)
     const uint32_t bank_base_address = get_write_ptr(input_tensor_cb_id);
+
+    uint32_t sender_read_addr = get_write_ptr(fabric_sender_cb_id);
 
     if (sender_core) {
         for (uint32_t target_device_id : device_order) {
             const uint32_t base_core = target_device_id * input_shard_cores_per_device;
 
-            for (uint32_t packet_idx = sender_packet_start; packet_idx < sender_packet_end; packet_idx++) {
-                const uint8_t curr_core = base_core + schedule[packet_idx][0];
-                const uint32_t read_offset = schedule[packet_idx][1];
-                const uint32_t read_size = schedule[packet_idx][2];
+            uint32_t num_pages_read = 0;
+            uint32_t num_pages_reserve_push = 0;
+            uint32_t shard_idx = sender_shard_start;
+            while (num_pages_read < sender_total_num_pages) {
+                const uint8_t curr_core = base_core + schedule[shard_idx][0];
+                const uint32_t read_offset = schedule[shard_idx][1];
+                const uint32_t read_size = schedule[shard_idx][2];
+                num_pages_reserve_push += read_size;
+
+                auto num_pages_left = sender_total_num_pages - num_pages_read;
+                const uint32_t curr_packet_num_pages = std::min(num_pages_per_packet, num_pages_left);
 
                 const uint32_t x = input_core_xy[curr_core][x_index];
                 const uint32_t y = input_core_xy[curr_core][y_index];
@@ -97,12 +108,18 @@ void kernel_main() {
                 const uint64_t shard_noc_addr = get_noc_addr(x, y, offset_address);
                 const uint32_t transfer_size = read_size * page_size_bytes;
 
-                cb_reserve_back(fabric_sender_cb_id, read_size);
-                const uint32_t sender_read_addr = get_write_ptr(fabric_sender_cb_id);
-
+                cb_reserve_back(fabric_sender_cb_id, num_pages_reserve_push);
                 noc_async_read(shard_noc_addr, sender_read_addr, transfer_size);
-                noc_async_read_barrier();
-                cb_push_back(fabric_sender_cb_id, read_size);
+
+                if (num_pages_reserve_push >= curr_packet_num_pages) {
+                    noc_async_read_barrier();
+                    cb_push_back(fabric_sender_cb_id, num_pages_reserve_push);
+                    num_pages_reserve_push = 0;
+                }
+
+                sender_read_addr += transfer_size;
+                num_pages_read += read_size;
+                shard_idx++;
             }
         }
     } else if (worker_core) {
@@ -115,6 +132,10 @@ void kernel_main() {
             const uint32_t linear_input_core_idcs = rem / tiles_per_core_width;
             const uint32_t linear_input_tile_offsets = rem % tiles_per_core_width;
 
+            if (linear_input_core_idcs >= input_tensor_cores) {
+                break;
+            }
+
             const uint32_t core_x = input_core_xy[linear_input_core_idcs][x_index];
             const uint32_t core_y = input_core_xy[linear_input_core_idcs][y_index];
             const uint32_t tile_offset = linear_input_tile_offsets * page_size_bytes;
@@ -126,6 +147,7 @@ void kernel_main() {
         }
         if (receiver_core) {
             // Precompute multicast semaphore address once
+#ifndef SKIP_MCAST
             const uint64_t multicast_semaphore_addr = static_noc_multicast_addr(
                 packet_worker_start_x,
                 packet_worker_start_y,
@@ -137,7 +159,10 @@ void kernel_main() {
             noc_semaphore_set_multicast(
                 receiver_semaphore_address,
                 multicast_semaphore_addr,
-                num_dests);  // could do different mcast for each device by having num_devices - 1 receiver cores
+                num_dests - 1);  // could do different mcast for each device by having num_devices - 1 receiver cores
+#else
+            noc_semaphore_wait((uint32_t*)receiver_semaphore_address, total_senders);
+#endif
         } else {
             noc_semaphore_wait((uint32_t*)local_semaphore_address, total_senders);
         }
@@ -147,4 +172,5 @@ void kernel_main() {
     }
     noc_semaphore_set((uint32_t*)local_semaphore_address, INVALID);
     noc_semaphore_set((uint32_t*)receiver_semaphore_address, INVALID);
+    noc_async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/writer_llama_reduce_scatter.cpp
@@ -50,6 +50,7 @@ void kernel_main() {
     constexpr uint32_t output_cores_per_device = get_compile_time_arg_val(13);
     constexpr uint32_t packet_receiver_core_x = get_compile_time_arg_val(14);
     constexpr uint32_t packet_receiver_core_y = get_compile_time_arg_val(15);
+    constexpr uint32_t num_packet_worker_cores = get_compile_time_arg_val(16);
 
     // Derived compile-time constants
     constexpr uint32_t input_tensor_cores = input_shard_cores_per_device * num_devices;
@@ -74,6 +75,7 @@ void kernel_main() {
     uint32_t linear_output_page_start_idx = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t sender_packet_start = get_arg_val<uint32_t>(rt_arg_idx++);
     uint32_t sender_packet_end = get_arg_val<uint32_t>(rt_arg_idx++);
+    uint32_t sender_total_num_pages = get_arg_val<uint32_t>(rt_arg_idx++);
 
     if (sender_core) {
         auto fabric_connection =
@@ -82,7 +84,7 @@ void kernel_main() {
         // Set up packet headers once
         constexpr uint8_t device_order[other_devices] =
             DEVICE_ORDER;  // this is code gen'd in the program factory using the defines
-        constexpr uint8_t packet_worker_cores[num_packets_total_per_device][2] = PACKET_WORKER_CORES;
+        constexpr uint8_t packet_worker_cores[num_packet_worker_cores][2] = PACKET_WORKER_CORES;
         const auto packet_header_buffer_addr = get_read_ptr(packet_header_cb_id);
         auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
         auto* sem_inc_packet_header =
@@ -109,10 +111,12 @@ void kernel_main() {
             auto& fabric_conn = target_device_id > chip_id ? fabric_connection.get_forward_connection()
                                                            : fabric_connection.get_backward_connection();
 
-            for (uint32_t packet = sender_packet_start; packet < sender_packet_end; packet++) {
+            uint32_t num_pages_sent = 0;
+            uint32_t packet = sender_packet_start;
+            while (num_pages_sent < sender_total_num_pages) {
                 // Determine packet size based on whether it's the last packet
-                const uint32_t curr_packet_num_pages =
-                    packet == num_packets_total_per_device - 1 ? last_packet_num_pages : num_pages_per_packet;
+                auto num_pages_left = sender_total_num_pages - num_pages_sent;
+                const uint32_t curr_packet_num_pages = std::min(num_pages_per_packet, num_pages_left);
                 const uint32_t curr_packet_size_bytes = curr_packet_num_pages * page_size_bytes;
 
                 const uint32_t receiver_core_x = packet_worker_cores[packet][x_index];
@@ -134,6 +138,9 @@ void kernel_main() {
                     (uint32_t)unicast_packet_header, packet_header_size);
 
                 cb_pop_front(fabric_sender_cb_id, curr_packet_num_pages);
+
+                num_pages_sent += curr_packet_num_pages;
+                packet++;
             }
 
             // Write the mcast packet (forward)
@@ -147,6 +154,7 @@ void kernel_main() {
             fabric_connection.close();
         }
     } else if (worker_core) {
+#ifndef SKIP_WRITE_BACK
         constexpr uint8_t output_core_xy[output_cores_per_device][2] = OUTPUT_CORE_XY;
         uint64_t noc_addresses[num_pages_per_packet];
         uint32_t accumulator_l1_addresses[num_pages_per_packet];
@@ -177,5 +185,8 @@ void kernel_main() {
         }
         noc_async_write_barrier();
         cb_pop_front(accumulator_cb_id, num_pages_per_packet);
+#else
+        cb_wait_front(output_tensor_cb_id, num_pages_per_packet);
+#endif
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_device_operation.cpp
@@ -25,48 +25,37 @@ void LlamaReduceScatterDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(attributes.dim == 3, "dim must be 1, got {}", attributes.dim);
     TT_FATAL(attributes.cluster_axis == 1, "cluster_axis must be 1, got {}", attributes.cluster_axis);
-    TT_FATAL(attributes.ring_devices == 4, "ring_devices must be 4, got {}", attributes.ring_devices);
+    TT_FATAL(
+        attributes.ring_devices == 4 or attributes.ring_devices == 2,
+        "ring_devices must be 4 or 2, got {}",
+        attributes.ring_devices);
     TT_FATAL(attributes.cross_device_semaphore.has_value(), "Cross device semaphore is not present");
 
     TT_FATAL(input_tensor.shard_spec().has_value(), "input_tensor must have a shard spec");
     TT_FATAL(
-        input_tensor.shard_spec().value().shape[0] == 32 && input_tensor.shard_spec().value().shape[1] == 160,
-        "input_tensor.shard_spec().value().shape ({}, {}) must be (32, 160)",
-        input_tensor.shard_spec().value().shape[0],
-        input_tensor.shard_spec().value().shape[1]);
+        input_tensor.shard_spec().value().shape[0] == 32,
+        "input_tensor shard height must be 32 but got {}",
+        input_tensor.shard_spec().value().shape[0]);
 
     TT_FATAL(
         tensor_args.intermediate_packet_buffer.shard_spec().has_value(),
         "intermediate_packet_buffer must have a shard spec");
     TT_FATAL(
-        tensor_args.intermediate_packet_buffer.shard_spec().value().shape[0] == 32 &&
-            tensor_args.intermediate_packet_buffer.shard_spec().value().shape[1] == 512,
-        "intermediate_packet_buffer.shard_spec().value().shape ({}, {}) must be (32, 512)",
-        tensor_args.intermediate_packet_buffer.shard_spec().value().shape[0],
-        tensor_args.intermediate_packet_buffer.shard_spec().value().shape[1]);
+        tensor_args.intermediate_packet_buffer.shard_spec().value().shape[0] == 32,
+        "intermediate_packet_buffer shard height must be 32 but got {}",
+        tensor_args.intermediate_packet_buffer.shard_spec().value().shape[0]);
     TT_FATAL(
         tensor_args.intermediate_packet_buffer.get_tensor_spec().tile().get_tile_shape() == tile_shape,
         "intermediate_packet_buffer must have the same tile shape ({}, {}) as input_tensor",
         tile_shape[0],
         tile_shape[1]);
-    TT_FATAL(
-        tensor_args.intermediate_packet_buffer.shard_spec().value().num_cores() >= 8,
-        "intermediate_packet_buffer must have at least 8 cores, got {}",
-        tensor_args.intermediate_packet_buffer.shard_spec().value().num_cores());
-
     if (attributes.output_mem_config.has_value()) {
         TT_FATAL(
             attributes.output_mem_config.value().shard_spec.has_value(), "output_mem_config must have a shard spec");
         TT_FATAL(
-            attributes.output_mem_config.value().shard_spec.value().shape[0] == 32 &&
-                attributes.output_mem_config.value().shard_spec.value().shape[1] == 32,
-            "output_mem_config.value().shard_spec.value().shape ({}, {}) must be (32, 32)",
-            attributes.output_mem_config.value().shard_spec.value().shape[0],
-            attributes.output_mem_config.value().shard_spec.value().shape[1]);
-        TT_FATAL(
-            attributes.output_mem_config.value().shard_spec.value().num_cores() == 30,
-            "output_mem_config must have 30 cores, got {}",
-            attributes.output_mem_config.value().shard_spec.value().num_cores());
+            attributes.output_mem_config.value().shard_spec.value().shape[0] == 32,
+            "output_mem_config shard height must be 32 but got {}",
+            attributes.output_mem_config.value().shard_spec.value().shape[0]);
     }
 }
 
@@ -77,12 +66,26 @@ LlamaReduceScatterDeviceOperation::spec_return_value_t LlamaReduceScatterDeviceO
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     using namespace tt::tt_metal;
 
+    // input is unpadded, output is padded. Ex, input: 3584, 112 tiles, padded to 5 tiles per core, total width is 120
+    // tiles (3840). this should be changed to use unpadded output in the future.
     auto input_tensor = tensor_args.input_tensor;
     auto tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();
     auto input_spec = input_tensor.get_tensor_spec();
-    auto input_shape = Shape({1, 1, 32, 3840});  // input_spec.logical_shape();;
+    auto input_shard_spec = input_tensor.shard_spec().value();
+    auto input_grid = input_shard_spec.grid;
+    auto input_shard_height = input_shard_spec.shape[0];
+    auto input_shard_width = input_shard_spec.shape[1];
+    auto input_num_cores = input_grid.num_cores();
+    auto input_shape = input_spec.logical_shape();
+    auto input_width = input_shape[attributes.dim];
+    auto input_width_in_tiles = input_width / tile_shape[1];
+    auto padded_input_width_in_tiles =
+        input_num_cores * ((input_width_in_tiles + input_num_cores - 1) / input_num_cores);
+    auto padded_input_width = padded_input_width_in_tiles * tile_shape[1];
 
-    uint32_t final_width = input_shape[attributes.dim] / attributes.ring_devices;
+    uint32_t final_width = input_width % input_shard_width != 0 ? padded_input_width / attributes.ring_devices
+                                                                : input_width / attributes.ring_devices;
+    TT_FATAL(input_width % attributes.ring_devices == 0, "input shape width must be divisible by num_devices");
 
     auto output_shape = input_shape;
     output_shape[attributes.dim] = final_width;
@@ -95,7 +98,7 @@ LlamaReduceScatterDeviceOperation::spec_return_value_t LlamaReduceScatterDeviceO
                 attributes.output_mem_config.value()))};
     }
 
-    auto input_shard_spec = input_tensor.shard_spec().value();
+    input_shard_spec = input_tensor.shard_spec().value();
     uint32_t num_cores = final_width / input_spec.tile().get_tile_shape()[1];
     auto device = input_tensor.device();
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -116,6 +119,7 @@ LlamaReduceScatterDeviceOperation::spec_return_value_t LlamaReduceScatterDeviceO
 LlamaReduceScatterDeviceOperation::tensor_return_value_t LlamaReduceScatterDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     auto output_spec = compute_output_specs(operation_attributes, tensor_args);
+
     auto tensor = create_device_tensor(output_spec, tensor_args.input_tensor.device());
     return tensor;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/llama_reduce_scatter_program_factory.cpp
@@ -211,12 +211,28 @@ std::string schedule_to_string(const std::vector<std::vector<ReadRequest>>& sche
     return result;
 }
 
-uint32_t max_packets_per_worker(const std::vector<std::vector<ReadRequest>>& schedule) {
-    uint32_t max_packets_per_worker = 0;
-    for (const auto& worker_schedule : schedule) {
-        max_packets_per_worker = std::max(max_packets_per_worker, (uint32_t)worker_schedule.size());
+uint32_t get_num_entries_in_schedule(const std::vector<std::vector<ReadRequest>>& schedule) {
+    std::size_t total = 0;
+    for (const auto& schedule_per_worker : schedule) {
+        total += schedule_per_worker.size();
     }
-    return max_packets_per_worker;
+    return total;
+}
+
+uint32_t get_total_num_pages_in_schedule(const std::vector<ReadRequest>& schedule_per_worker) {
+    std::size_t total = 0;
+    for (const auto& schedule : schedule_per_worker) {
+        total += schedule.read_size;
+    }
+    return total;
+}
+
+uint32_t max_shards_per_worker(const std::vector<std::vector<ReadRequest>>& schedule) {
+    uint32_t max_shards_per_worker = 0;
+    for (const auto& worker_schedule : schedule) {
+        max_shards_per_worker = std::max(max_shards_per_worker, (uint32_t)worker_schedule.size());
+    }
+    return max_shards_per_worker;
 }
 
 CoreRangeSet get_worker_cores(const CoreRangeSet& available_cores, const uint32_t num_workers, bool row_wise) {
@@ -266,11 +282,31 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
     auto& output_tensor = tensor_return_value;
     auto& output_shape = output_tensor.get_logical_shape();
     auto& padded_output_shape = output_tensor.get_padded_shape();
-    const auto& tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();
-    const auto& face_shape = input_tensor.get_tensor_spec().tile().get_face_shape();
-    auto shard_spec = input_tensor.shard_spec().value();
+    const auto& input_tile_shape = input_tensor.get_tensor_spec().tile().get_tile_shape();
+    const auto& output_tile_shape = output_tensor.get_tensor_spec().tile().get_tile_shape();
+    auto input_tensor_width = input_tensor.get_logical_shape()[-1];
+    auto output_tensor_width = output_tensor.get_logical_shape()[-1];
+    auto input_tensor_width_in_tiles = input_tensor.get_logical_shape()[-1] / input_tile_shape[1];
+    auto output_tensor_width_in_tiles = output_tensor.get_logical_shape()[-1] / output_tile_shape[1];
+    auto input_shard_spec = input_tensor.shard_spec().value();
     auto output_shard_spec = output_tensor.shard_spec().value();
     const auto& cross_device_semaphore = operation_attributes.cross_device_semaphore;
+
+    uint32_t input_shard_height = input_shard_spec.shape[0];
+    uint32_t input_shard_width = input_shard_spec.shape[1];
+    uint32_t input_tiles_per_core_width = input_shard_width / input_tile_shape[1];
+
+    uint32_t output_shard_height = output_shard_spec.shape[0];
+    uint32_t output_shard_width = output_shard_spec.shape[1];
+    uint32_t output_tiles_per_core_width = output_shard_width / input_tile_shape[1];
+
+    uint32_t ncores_input = (input_tensor_width + input_shard_width - 1) / input_shard_width;
+    if (ncores_input % num_devices != 0) {
+        ncores_input = ((ncores_input + num_devices - 1) / num_devices) * num_devices;
+    }
+    uint32_t ncores_output = (output_tensor_width + output_shard_width - 1) / output_shard_width;
+    uint32_t input_shard_cores_per_device = ncores_input / num_devices;
+    uint32_t output_cores_per_device = ncores_output;
 
     auto input_tensor_buffer = input_tensor.buffer();
     auto output_tensor_buffer = output_tensor.buffer();
@@ -287,14 +323,8 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, output_tensors, ttnn::ccl::Topology::Linear);
     LineTopology line_topology(ring_size, ring_index);
 
-    uint32_t shard_height = shard_spec.shape[0];
-    uint32_t shard_width = shard_spec.shape[1];
-    uint32_t tiles_per_core_width = shard_width / tile_shape[1];
-
-    uint32_t shard_height_output = output_shard_spec.shape[0];
-    uint32_t shard_width_output = output_shard_spec.shape[1];
-    uint32_t tiles_per_core_width_output = shard_width_output / tile_shape[1];
-    auto input_grid = shard_spec.grid;
+    // need to drop unused cores in shard spec
+    auto input_grid = input_shard_spec.grid;
     auto output_grid = output_shard_spec.grid;
 
     auto sub_device_cores = device->worker_cores(
@@ -312,31 +342,45 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
             enable_persistent_fabric,
             num_links);
 
-    const size_t packet_size_bytes = local_fabric_handle->get_edm_buffer_size_bytes();
+    auto fabric_max_packet_size = local_fabric_handle->get_edm_buffer_size_bytes();
+    size_t packet_size_bytes = input_tensor.get_dtype() == DataType::BFLOAT16 ? std::bit_floor(fabric_max_packet_size)
+                                                                              : fabric_max_packet_size;
     uint32_t num_pages_per_packet = packet_size_bytes / input_page_size;
+    auto per_worker_num_tiles = (output_tensor_width_in_tiles + num_links - 1) / num_links;
+    if (per_worker_num_tiles < num_pages_per_packet) {  // if num_tiles per worker is smaller than packet size
+        packet_size_bytes = per_worker_num_tiles * input_page_size;
+        num_pages_per_packet = packet_size_bytes / input_page_size;
+    }
+    auto num_packets_to_send = (output_tensor_width_in_tiles + num_pages_per_packet - 1) / num_pages_per_packet;
+    auto num_packets_to_send_per_worker = (num_packets_to_send + num_links - 1) / num_links;
 
-    uint32_t ncores_input = shard_spec.num_cores();
-    uint32_t input_shard_cores_per_device = ncores_input / num_devices;
-    uint32_t output_cores_per_device = output_grid.num_cores();
+    TT_FATAL(
+        num_pages_per_packet % input_tiles_per_core_width == 0 || input_tiles_per_core_width > num_pages_per_packet,
+        "must have num_pages per packet divisible by num_tiles per core, or num_tiles per core larger than num_pages "
+        "per packet");
+
     uint32_t num_workers_per_link = 1;
 
     auto intermediate_packet_buffer_grid = tensor_args.intermediate_packet_buffer.shard_spec().value().grid;
     // UNCOMMENT this once we can allocate persistent buffers across all device lifetimes
     uint32_t num_packets_total_per_device =
-        (input_shard_cores_per_device * tiles_per_core_width + num_pages_per_packet - 1) / num_pages_per_packet;
+        (input_shard_cores_per_device * input_tiles_per_core_width + num_pages_per_packet - 1) / num_pages_per_packet;
     auto packet_worker_cores_grid = detail::get_worker_cores(
         intermediate_packet_buffer_grid,
         num_packets_total_per_device,
-        shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+        input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
 
     auto available_cores = sub_device_cores.subtract(packet_worker_cores_grid);
 
     auto sender_core_grid = detail::get_worker_cores(
-        available_cores, num_workers_per_link * num_links, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+        available_cores, num_workers_per_link * num_links, input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
     auto all_cores_grid = packet_worker_cores_grid.merge(sender_core_grid);
 
     auto schedule = detail::distribute_work_evenly(
-        input_shard_cores_per_device, num_workers_per_link * num_links, tiles_per_core_width, num_pages_per_packet);
+        input_shard_cores_per_device,
+        num_workers_per_link * num_links,
+        input_tiles_per_core_width,
+        num_pages_per_packet);
     auto schedule_string = detail::schedule_to_string(schedule);
 
     // input sharded buffer
@@ -354,13 +398,13 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
 
     tt::tt_metal::CircularBufferConfig cb_input_tensor_config =
         tt::tt_metal::CircularBufferConfig(
-            tiles_per_core_width * input_page_size, {{input_tensor_cb_id, cb_data_format}})
+            input_tiles_per_core_width * input_page_size, {{input_tensor_cb_id, cb_data_format}})
             .set_page_size(input_tensor_cb_id, input_page_size)
             .set_globally_allocated_address(*input_tensor_buffer);
     // CB to represent the output sharded buffer
     tt::tt_metal::CircularBufferConfig cb_output_tensor_config =
         tt::tt_metal::CircularBufferConfig(
-            tiles_per_core_width_output * input_page_size, {{output_tensor_cb_id, cb_data_format}})
+            output_tiles_per_core_width * input_page_size, {{output_tensor_cb_id, cb_data_format}})
             .set_page_size(output_tensor_cb_id, input_page_size)
             .set_globally_allocated_address(*output_tensor_buffer);
 
@@ -374,9 +418,9 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
             {{packet_header_cb_index, DataFormat::RawUInt32}})
             .set_page_size(packet_header_cb_index, packet_header_size_bytes);
 
-    uint32_t max_packets_per_worker = detail::max_packets_per_worker(schedule);
-    uint32_t num_packets_total = max_packets_per_worker * (num_devices - 1);
-    uint32_t num_packet_pages_total = num_packets_total * num_pages_per_packet;
+    uint32_t max_shards_per_worker = detail::max_shards_per_worker(schedule);
+    uint32_t num_shards_total = max_shards_per_worker * (num_devices - 1);
+    uint32_t num_pages_total = num_shards_total * input_tiles_per_core_width;
 
     // There is one sender from link, and each sender splits the packet workload for each device
     // For llama there are 3 senders, and each device sends 30 pages to each other device
@@ -403,7 +447,7 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
     */
     tt::tt_metal::CircularBufferConfig fabric_sender_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            num_packet_pages_total * input_page_size, {{fabric_sender_cb_index, cb_data_format}})
+            num_pages_total * input_page_size, {{fabric_sender_cb_index, cb_data_format}})
             .set_page_size(fabric_sender_cb_index, input_page_size);
 
     // buffer for receiving packets from the other devices.
@@ -460,7 +504,7 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
     */
     tt::tt_metal::CircularBufferConfig accumulator_cb_config =
         tt::tt_metal::CircularBufferConfig(
-            buffering_factor * num_pages_per_packet * tiles_per_core_width_output * input_page_size * num_devices,
+            buffering_factor * num_pages_per_packet * output_tiles_per_core_width * input_page_size * num_devices,
             {{accumulator_cb_index, cb_data_format}})
             .set_page_size(accumulator_cb_index, input_page_size);
 
@@ -476,22 +520,26 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
     auto cb_accumulator_handle = tt::tt_metal::CreateCircularBuffer(program, all_cores_grid, accumulator_cb_config);
 
     auto input_cores =
-        corerange_to_cores(input_grid, std::nullopt, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+        corerange_to_cores(input_grid, std::nullopt, input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
     auto output_cores =
-        corerange_to_cores(output_grid, std::nullopt, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+        corerange_to_cores(output_grid, std::nullopt, input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
     auto sender_cores =
-        corerange_to_cores(sender_core_grid, std::nullopt, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+        corerange_to_cores(sender_core_grid, std::nullopt, input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
     auto all_cores =
-        corerange_to_cores(all_cores_grid, std::nullopt, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+        corerange_to_cores(all_cores_grid, std::nullopt, input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
     auto packet_worker_cores = corerange_to_cores(
-        packet_worker_cores_grid, std::nullopt, shard_spec.orientation == ShardOrientation::ROW_MAJOR);
+        packet_worker_cores_grid, std::nullopt, input_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
     auto packet_receiver_core = packet_worker_cores.at(0);
 
     const uint32_t chip_id = ring_index;
 
-    auto to_worker_cores = [device](const std::vector<CoreCoord>& cores) -> std::vector<CoreCoord> {
+    auto to_worker_cores = [device](
+                               const std::vector<CoreCoord>& cores,
+                               std::optional<uint32_t> num_max_cores = std::nullopt) -> std::vector<CoreCoord> {
         std::vector<CoreCoord> worker_cores;
-        for (const auto& core : cores) {
+        auto num_cores = num_max_cores.has_value() ? num_max_cores.value() : cores.size();
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            const auto& core = cores[i];
             worker_cores.push_back(device->worker_core_from_logical_core(core));
         }
         return worker_cores;
@@ -500,6 +548,7 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
     auto packet_bounding_box = packet_worker_cores_grid.bounding_box();
     auto packet_start_worker_core = to_worker_cores({packet_bounding_box.start_coord});
     auto packet_end_worker_core = to_worker_cores({packet_bounding_box.end_coord});
+    auto total_num_read_txns = detail::get_num_entries_in_schedule(schedule);
 
     std::vector<uint32_t> reader_compile_time_args = {
         input_tensor_cb_id,
@@ -509,8 +558,8 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
         accumulator_cb_index,
         output_tensor_cb_id,
         (uint32_t)chip_id,
-        tiles_per_core_width,
-        tiles_per_core_width_output,
+        input_tiles_per_core_width,
+        output_tiles_per_core_width,
         num_pages_per_packet,
         input_shard_cores_per_device,
         num_devices,
@@ -520,10 +569,14 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
         packet_start_worker_core.at(0).y,
         packet_end_worker_core.at(0).x,
         packet_end_worker_core.at(0).y,
-        sender_cores.size()};
+        sender_cores.size(),
+        total_num_read_txns};
 
-    reader_defines["INPUT_CORE_XY"] = detail::cores_to_string(to_worker_cores(input_cores));
-    reader_defines["OUTPUT_CORE_XY"] = detail::cores_to_string(to_worker_cores(output_cores));
+    if (packet_worker_cores_grid.num_cores() == 1) {
+        reader_defines["SKIP_MCAST"] = "1";
+    }
+    reader_defines["INPUT_CORE_XY"] = detail::cores_to_string(to_worker_cores(input_cores, ncores_input));
+    reader_defines["OUTPUT_CORE_XY"] = detail::cores_to_string(to_worker_cores(output_cores, ncores_output));
     reader_defines["PACKET_WORKER_CORES"] = detail::cores_to_string(to_worker_cores(packet_worker_cores));
     reader_defines["SCHEDULE"] = schedule_string;
 
@@ -542,6 +595,7 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
             .defines = reader_defines});
 
     auto packet_receiver_worker_core = to_worker_cores({packet_receiver_core}).at(0);
+    auto num_packet_worker_cores = packet_worker_cores.size();
 
     std::vector<uint32_t> writer_compile_time_args = {
         input_tensor_cb_id,
@@ -551,8 +605,8 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
         accumulator_cb_index,
         output_tensor_cb_id,
         (uint32_t)chip_id,
-        tiles_per_core_width,
-        tiles_per_core_width_output,
+        input_tiles_per_core_width,
+        output_tiles_per_core_width,
         num_pages_per_packet,
         input_shard_cores_per_device,
         num_devices,
@@ -560,9 +614,13 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
         output_cores_per_device,
         packet_receiver_worker_core.x,
         packet_receiver_worker_core.y,
-    };
+        num_packet_worker_cores};
 
     auto writer_defines = reader_defines;
+    bool skip_write_back = output_cores == packet_worker_cores and num_pages_per_packet == output_tiles_per_core_width;
+    if (skip_write_back) {
+        writer_defines["SKIP_WRITE_BACK"] = "1";
+    }
     tt::tt_metal::KernelHandle unary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/llama_reduce_scatter/device/kernels/dataflow/"
@@ -574,8 +632,9 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
             .compile_args = writer_compile_time_args,
             .defines = writer_defines});
 
+    auto output_cb_index = skip_write_back ? output_tensor_cb_id : accumulator_cb_index;
     const std::vector<uint32_t> compute_compile_time_args = {
-        fabric_receiver_cb_index, accumulator_cb_index, num_devices, tiles_per_core_width_output, num_pages_per_packet};
+        fabric_receiver_cb_index, output_cb_index, num_devices, output_tiles_per_core_width, num_pages_per_packet};
 
     bool fp32_dest_acc_en = cb_data_format == tt::DataFormat::Float32;
     const auto compute_kernel_file =
@@ -586,44 +645,56 @@ LlamaReduceScatterDeviceOperation::LlamaReduceScatterAdd::create(
         packet_worker_cores_grid,
         tt_metal::ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = compute_compile_time_args});
 
-    uint32_t offset_for_input = chip_id * input_shard_cores_per_device * tiles_per_core_width;
+    uint32_t offset_for_input = chip_id * input_shard_cores_per_device * input_tiles_per_core_width;
     uint32_t local_page = 0;
 
     std::vector<uint32_t> reader_runtime_args = {
-        cross_device_semaphore->address(), local_semaphore, false, false, 0, false, 0, 0};
+        cross_device_semaphore->address(), local_semaphore, false, false, 0, false, 0, 0, 0};
     uint32_t is_reader_sender_core_idx = 2;
     uint32_t is_reader_worker_core_idx = 3;
     uint32_t is_linear_input_packet_start_idx = 4;
     uint32_t is_reader_receiver_core_idx = 5;
     uint32_t reader_sender_packet_start_idx = 6;
     uint32_t reader_sender_packet_end_idx = 7;
+    uint32_t reader_sender_total_num_pages_idx = 8;
 
     uint32_t is_writer_sender_core_idx = 2;
     uint32_t is_writer_worker_core_idx = 3;
     uint32_t is_linear_output_page_start_idx = 4;
     uint32_t writer_sender_packet_start_idx = 5;
     uint32_t writer_sender_packet_end_idx = 6;
+    uint32_t writer_sender_total_num_pages_idx = 7;
 
-    uint32_t sender_packet_start = 0;
+    uint32_t reader_sender_packet_start = 0;
+    uint32_t writer_sender_packet_start = 0;
     uint32_t sender_core_idx = 0;
 
     for (auto core : all_cores) {
         std::vector<uint32_t> writer_runtime_args = {
-            cross_device_semaphore->address(), local_semaphore, false, false, 0, 0, 0};
+            cross_device_semaphore->address(), local_semaphore, false, false, 0, 0, 0, 0};
+
+        uint32_t num_shards_to_read_per_worker = schedule[sender_core_idx].size();
 
         if (sender_core_grid.contains(core)) {
+            auto sender_total_num_pages = detail::get_total_num_pages_in_schedule(schedule[sender_core_idx]);
+
             reader_runtime_args[is_reader_sender_core_idx] = true;
             reader_runtime_args[is_reader_worker_core_idx] = false;
             reader_runtime_args[is_reader_receiver_core_idx] = false;
-            reader_runtime_args[reader_sender_packet_start_idx] = sender_packet_start;
-            reader_runtime_args[reader_sender_packet_end_idx] = sender_packet_start + schedule[sender_core_idx].size();
+            reader_runtime_args[reader_sender_packet_start_idx] = reader_sender_packet_start;
+            reader_runtime_args[reader_sender_packet_end_idx] =
+                reader_sender_packet_start + num_shards_to_read_per_worker;
+            reader_runtime_args[reader_sender_total_num_pages_idx] = sender_total_num_pages;
 
             writer_runtime_args[is_writer_sender_core_idx] = true;
             writer_runtime_args[is_writer_worker_core_idx] = false;
-            writer_runtime_args[writer_sender_packet_start_idx] = sender_packet_start;
-            writer_runtime_args[writer_sender_packet_end_idx] = sender_packet_start + schedule[sender_core_idx].size();
+            writer_runtime_args[writer_sender_packet_start_idx] = writer_sender_packet_start;
+            writer_runtime_args[writer_sender_packet_end_idx] =
+                writer_sender_packet_start + num_packets_to_send_per_worker;
+            writer_runtime_args[writer_sender_total_num_pages_idx] = sender_total_num_pages;
 
-            sender_packet_start += schedule[sender_core_idx].size();
+            reader_sender_packet_start += num_shards_to_read_per_worker;
+            writer_sender_packet_start += num_packets_to_send_per_worker;
             sender_core_idx++;
 
             std::optional<tt::tt_fabric::SenderWorkerAdapterSpec> forward_fabric_connection =


### PR DESCRIPTION
Currently RS only support 32x3840 shape, changes here make it support more shapes like 32x1280, etc.
Add support for bfloat16.
Add support for sharding cores > actual data cores.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] TG unit  https://github.com/tenstorrent/tt-metal/actions/runs/14364268369
- [x] TG demo
- [x] TG model perf https://github.com/tenstorrent/tt-metal/actions/runs/14364272234
- [x] TG frequent https://github.com/tenstorrent/tt-metal/actions/runs/14366388367