### PR TITLE
Revert "Llama TG: support persistent prefill traces "

### DIFF
--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -182,7 +182,7 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
-        (  # Batch-32 run (Throughput) - 32 users, small prompt
+        (  # Repeat-5 Batch-32 run (Throughput) - 32 users, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
@@ -195,7 +195,7 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
-        (  # Repeat-5 Batch-32 run (Throughput) - 32 users, small prompt
+        (  # Batch-32 run (Throughput) - 32 users, small prompt
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             5,  # repeat_batches
@@ -264,7 +264,7 @@ def create_tt_model(
     ids=[
         "batch-1",  # latency
         "batch-32",  # throughput
-        "repeat5",  # throughput with 5 repeat batches
+        "repeat5-batch-32",  # throughput with 5 repeat batches
         "long-context",  # max-length
         "reasoning-1",  # reasoning
         "ci-1",  # CI batch 1
@@ -275,11 +275,12 @@ def create_tt_model(
     "optimizations",
     [
         LlamaOptimizations.performance,
+        LlamaOptimizations.accuracy,
     ],
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"trace_region_size": 25000000, "num_command_queues": 1, "dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    [{"trace_region_size": 23887872, "num_command_queues": 1, "dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -321,7 +322,6 @@ def test_demo_text(
 
     mesh_device.enable_async(True)
     enable_trace = True  # Use tracing for better perf
-    prefill_enable_trace = repeat_batches > 1
     print_to_file = False  # Enable this flag to print the output of all users to a file
 
     # Override parameters from command line if they are provided
@@ -429,30 +429,25 @@ def test_demo_text(
                 v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(batch_size, -1)
 
-        if batch_idx == 0:
-            logger.info("Starting prefill warmup...")
-            profiler.start(f"compile_prefill", iteration=batch_idx)
+        logger.info("Starting prefill warmup...")
+        profiler.start(f"compile_prefill", iteration=batch_idx)
 
-            logits = generator.prefill_forward_text(
-                input_tokens_prefill_pt[0].unsqueeze(0),  # Just warmup prefill for 1 user
-                page_table=page_table,
-                kv_cache=tt_kv_cache,
-                prompt_lens=decoding_pos,
-                enable_trace=prefill_enable_trace,
-            )
-            profiler.end(f"compile_prefill", iteration=batch_idx)
-            logger.info("Finished prefill warmup")
+        logits = generator.prefill_forward_text(
+            input_tokens_prefill_pt[0].unsqueeze(0),  # Just warmup prefill for 1 user
+            page_table=page_table,
+            kv_cache=tt_kv_cache,
+            prompt_lens=decoding_pos,
+        )
+        profiler.end(f"compile_prefill", iteration=batch_idx)
+        logger.info("Finished prefill warmup")
 
         logger.info(f"Starting prefill...")
-
         profiler.start(f"inference_prefill", iteration=batch_idx)
-
         logits = generator.prefill_forward_text(
             input_tokens_prefill_pt[0].unsqueeze(0),
             page_table=page_table,
             kv_cache=tt_kv_cache,
             prompt_lens=decoding_pos,
-            enable_trace=prefill_enable_trace,
         )
         prefilled_token = torch.argmax(logits, dim=-1)
         profiler.end(f"inference_prefill", iteration=batch_idx)
@@ -534,10 +529,9 @@ def test_demo_text(
 
             # Always print perf after every iteration
             tokens_per_second_per_user = 1 / decode_iteration_time
-            if repeat_batches == 1:
-                logger.info(
-                    f"Iteration {iteration}: {1000*decode_iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
-                )
+            logger.info(
+                f"Iteration {iteration}: {1000*decode_iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
+            )
 
             current_pos += 1
 
@@ -558,8 +552,8 @@ def test_demo_text(
                             users_decoding = False
 
             # Print out generated outputs for each user at the end of every iteration
-            if not is_ci_env and repeat_batches == 1:
-                for user in range(1):
+            if not is_ci_env:
+                for user in range(batch_size):
                     text = "".join(tokenizer.decode(all_outputs[user]))
                     if len(text) > 100:
                         text = "..." + text[-97:]

--- a/models/demos/llama3_subdevices/tt/generator.py
+++ b/models/demos/llama3_subdevices/tt/generator.py
@@ -14,6 +14,8 @@ from llama_models.llama3.api.datatypes import (
 from llama_models.llama3.reference_impl.generation import (
     ChatPrediction,
     CompletionPrediction,
+    TokenResult,
+    sample_top_p,
 )
 from models.tt_transformers.tt.common import (
     copy_host_to_device,
@@ -46,9 +48,7 @@ class Generator:
         if isinstance(self.model, List):
             self.model = self.model[0]
 
-    def prefill_forward_text(
-        self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None, enable_trace=False
-    ):
+    def prefill_forward_text(self, tokens: torch.Tensor, page_table=None, kv_cache=None, prompt_lens=None):
         if self.model.is_prefill_setup is False:
             self.model.switch_mode("prefill")
         kv_cache = kv_cache[0]
@@ -61,7 +61,7 @@ class Generator:
                 page_table, torch.Tensor
             ), "page_table must be a torch.Tensor when passing into prefill_forward"
 
-            # only run 1 user prefill for now
+        # only run 1 user prefill for now
         for user_id in range(1):
             logger.info(f"Prefilling User {user_id + 1}")
             seq_len = prompt_lens[user_id]
@@ -73,21 +73,20 @@ class Generator:
             )
             if page_table is not None:
                 page_table_user = self._get_prefill_user_page_table(page_table, kv_cache, seq_len)
-            prefill_kwargs = {
-                "tokens": prefill_ids,
-                "page_table": page_table_user if page_table is not None else None,
-                "kv_cache": kv_cache,
-                "user_id": user_id,
-                "last_token_idx": last_token_idx,
-            }
-            if enable_trace:
-                tt_logits = self._easy_trace_prefill(**prefill_kwargs)
-            else:
-                tt_logits = self.prefill_forward_single_user_text(**prefill_kwargs)
+            try:
+                logits = self.prefill_forward_single_user_text(
+                    prefill_ids,
+                    page_table=page_table_user if page_table is not None else None,
+                    user_id=user_id,
+                    last_token_idx=last_token_idx,
+                    kv_cache=kv_cache,
+                )
+            except Exception as e:
+                logger.error(f"Error prefilling user {user_id}: {e}")
 
         for user_id in range(batch):
             # Since we give unpadded_seq_len, only the tile containing the last token is returned
-            output_logits[user_id] = tt_logits
+            output_logits[user_id] = logits
 
         logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
 
@@ -160,14 +159,14 @@ class Generator:
                 else:
                     del tt_logits
         else:
-            prefill_input, page_table_tt, _ = self.model.prepare_inputs_prefill(
+            prefill_input, rot_mats_prefill, page_table_tt, _ = self.model.prepare_inputs_prefill(
                 tokens,
                 page_table=page_table,
             )
 
             tt_logits = self.model.ttnn_prefill_forward(
                 prefill_input,
-                rot_mats=None,
+                rot_mats=rot_mats_prefill,
                 user_id=user_id,
                 page_table=page_table_tt,
                 get_last_token=(last_token_idx // 32) * 32,
@@ -177,96 +176,6 @@ class Generator:
             logits = self.model.process_output_prefill(tt_logits, last_token_idx=(last_token_idx % 32))
 
             return logits
-
-    def _easy_trace_prefill(self, tokens, last_token_idx, page_table=None, kv_cache=None, user_id=0):
-        """
-        Tracing is easy! Just call this method and we'll handle tracing for you.
-        """
-        if not hasattr(self, "trace_id_prefill"):
-            trace_id, tt_out_trace, *device_inputs = self._capture_trace_prefill(
-                tokens, last_token_idx, page_table=page_table, kv_cache=kv_cache, user_id=user_id
-            )
-            self.trace_id_prefill = trace_id
-            self.trace_inputs_prefill = device_inputs
-            self.trace_output_prefill = tt_out_trace
-
-        logger.info("Executing prefill trace")
-        tt_out_trace = self._prefill_forward_trace_text(
-            self.trace_id_prefill,
-            self.trace_inputs_prefill,
-            self.trace_output_prefill,
-            tokens,
-            page_table=page_table,
-        )
-        logits = self.model.process_output_prefill(tt_out_trace, last_token_idx=(last_token_idx % 32))
-
-        return logits
-
-    def _capture_trace_prefill(
-        self,
-        tokens,
-        last_token_idx,
-        user_id,
-        page_table=None,
-        kv_cache=None,
-    ):
-        """
-        Captures a trace for the decode_forward method.
-        """
-
-        # Compile run
-        # self.prefill_forward_single_user_text(tokens, page_table, user_id, last_token_idx, kv_cache)
-
-        # Get inputs ready for trace run
-        host_inputs = self.model.prepare_prefill_inputs_host(tokens, page_table=page_table)
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
-        transformed_inputs = self.model.transform_prefill_inputs_device(*device_inputs)
-        tt_out_trace = self.model.ttnn_prefill_forward(
-            *transformed_inputs, kv_cache=kv_cache, get_last_token=(last_token_idx // 32) * 32, user_id=user_id
-        )
-        ttnn.synchronize_device(self.mesh_device)
-        logger.info("Done Compiling Model")
-
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
-        transformed_inputs = self.model.transform_prefill_inputs_device(*device_inputs)
-        tt_out_trace = self.model.ttnn_prefill_forward(
-            *transformed_inputs, kv_cache=kv_cache, get_last_token=(last_token_idx // 32) * 32, user_id=user_id
-        )
-
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
-        transformed_inputs = self.model.transform_prefill_inputs_device(*device_inputs)
-
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
-        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
-        transformed_inputs = self.model.transform_prefill_inputs_device(*device_inputs)
-        tt_out_trace = self.model.ttnn_prefill_forward(
-            *transformed_inputs, kv_cache=kv_cache, get_last_token=(last_token_idx // 32) * 32, user_id=user_id
-        )
-        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
-        ttnn.synchronize_device(self.mesh_device)
-        logger.info("Done Capturing Prefill Trace")
-        return trace_id, tt_out_trace, *device_inputs
-
-    def _prefill_forward_trace_text(
-        self,
-        trace_id,
-        device_inputs,
-        tt_out_trace,
-        tokens,
-        page_table=None,
-    ):
-        """
-        Executes the trace for the decode_forward method but does not read back outputs.
-        """
-        host_inputs = self.model.prepare_prefill_inputs_host(tokens, page_table)
-
-        device_inputs = copy_host_to_device(
-            host_tensors=host_inputs,
-            device_tensors=device_inputs,
-        )
-
-        ttnn.execute_trace(self.mesh_device, trace_id, cq_id=0, blocking=False)
-        return tt_out_trace
 
     def decode_forward_text(
         self,
@@ -410,9 +319,571 @@ class Generator:
 
         return trace_logits_rm
 
+    def _prefill_forward_single_user(
+        self,
+        vision_images,
+        vision_mask,
+        tokens,
+        xattn_caches,
+        user_id,
+        total_len,
+        prefill_len,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Performs vision encode step then text prefill.
+        Returns (xattn_caches, cross_attention_masks, full_text_row_masked_out_mask, logits)
+        """
+        B = tokens.shape[0]
+        last_token_idx = prefill_len - 1
+
+        text_only_inference = vision_images is None
+        if not text_only_inference:
+            (
+                vision_tokens,
+                cross_attention_masks,
+                full_text_row_masked_out_mask,
+            ) = self.model.compute_vision_tokens_masks(
+                batch_images=[vision_images],
+                batch_masks=[vision_mask],
+                total_len=total_len,
+            )
+
+            if cross_page_table is not None:
+                num_vision_tokens = vision_tokens.shape[2]
+                cross_page_table = self._get_prefill_user_page_table(cross_page_table, kv_cache, num_vision_tokens)
+        else:
+            vision_tokens, cross_attention_masks, full_text_row_masked_out_mask = None, None, None
+
+        if page_table is not None:
+            page_table = self._get_prefill_user_page_table(page_table, kv_cache, prefill_len)
+
+        (
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            rot_mats,
+            tt_page_table,
+            tt_cross_page_table,
+        ) = self.model.prepare_inputs_prefill(
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            prefill_len=prefill_len,
+            page_table=page_table,
+            cross_page_table=cross_page_table,
+            text_only_inference=text_only_inference,
+        )
+
+        tt_logits = self.model.ttnn_prefill_forward(
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            xattn_caches,
+            rot_mats,
+            user_id,
+            vision_tokens,
+            page_table=tt_page_table,
+            kv_cache=kv_cache,
+            get_last_token=(last_token_idx // 32) * 32,
+            cross_page_table=tt_cross_page_table,
+            text_only_inference=text_only_inference,
+        )
+
+        del tt_page_table
+        del tt_cross_page_table
+
+        logits = self.model.process_output_prefill(tt_logits, B, last_token_idx=(last_token_idx % 32))
+
+        return xattn_caches, cross_attention_masks, full_text_row_masked_out_mask, logits
+
+    def prefill_forward(
+        self,
+        vision_images,
+        vision_masks,
+        tokens: torch.Tensor,
+        xattn_caches,
+        total_lens,
+        prompt_lens,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Batched version of _prefill_forward_single_user for vision model.
+        """
+        batch, batch_seq_len = tokens.shape
+        output_logits = torch.zeros(batch, 1, self.model_args.vocab_size)
+        output_xattn_masks = []
+        output_full_text_row_masked_out_masks = []
+
+        for user_id in range(batch):
+            logger.info(f"Prefilling User {user_id + 1}")
+            seq_len = prompt_lens[user_id]
+            (
+                xattn_caches,
+                cross_attention_masks,
+                full_text_row_masked_out_mask,
+                logits,
+            ) = self._prefill_forward_single_user(
+                vision_images=vision_images[user_id],
+                vision_mask=vision_masks[user_id],
+                tokens=tokens[user_id : user_id + 1, :seq_len],  # Keep batch dimension
+                xattn_caches=xattn_caches,
+                user_id=user_id,
+                total_len=total_lens[user_id],
+                prefill_len=seq_len,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                cross_page_table=cross_page_table,
+            )
+            output_logits[user_id] = logits
+            output_xattn_masks.append(cross_attention_masks)
+            output_full_text_row_masked_out_masks.append(full_text_row_masked_out_mask)
+
+        logger.info(f"Finished prefill for all users up to {batch_seq_len} tokens, Starting decode...")
+
+        return output_logits, output_xattn_masks, output_full_text_row_masked_out_masks
+
+    def decode_forward(
+        self,
+        start_pos,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches=None,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+        enable_trace=True,
+        read_from_device=True,
+    ):
+        decode_kwargs = {
+            "position_id": start_pos,
+            "tokens": tokens,
+            "cross_attention_masks": cross_attention_masks,
+            "full_text_row_masked_out_mask": full_text_row_masked_out_mask,
+            "xattn_caches": xattn_caches,
+            "page_table": page_table,
+            "kv_cache": kv_cache,
+            "cross_page_table": cross_page_table,
+        }
+        if enable_trace:
+            tt_logits = self._easy_trace(**decode_kwargs)
+        else:
+            tt_logits = self._decode_forward_no_trace(**decode_kwargs)
+
+        if read_from_device:
+            return self.read_decode_output(tt_logits, tokens.shape[0])
+        else:
+            return tt_logits
+
     def read_decode_output(self, tt_logits, unpadded_batch, argmax_on_device=False):
         logits = self.model.process_output_decode(tt_logits, B=unpadded_batch, S=1, argmax_on_device=argmax_on_device)
         return logits
+
+    def _decode_forward_no_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches=None,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Performs text decode step.
+        Returns tt_logits on device
+        """
+
+        # forward_decode should be traced callable
+        # decorator does compilation, capture, execute
+        B, S = tokens.shape
+        assert S == 1
+
+        (
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            tt_position_id,
+            tt_rot_mats,
+            tt_page_table,
+            tt_cross_page_table,
+        ) = self.model.prepare_inputs_decode(
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            position_id=position_id,
+            page_table=page_table,
+            cross_page_table=cross_page_table,
+        )
+
+        tt_logits = self.model.ttnn_decode_forward(
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            xattn_caches,
+            tt_position_id,
+            tt_rot_mats,
+            page_table=tt_page_table,
+            kv_cache=kv_cache,
+            cross_page_table=tt_cross_page_table,
+        )
+
+        return tt_logits
+
+    def _capture_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Captures a trace for the decode_forward method.
+        """
+        (
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            tt_position_id,
+            tt_rot_mats,
+            tt_page_table,
+            tt_cross_page_table,
+        ) = self.model.prepare_inputs_decode(
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            position_id=position_id,
+            page_table=page_table,
+            cross_page_table=cross_page_table,
+        )
+
+        # Compile run
+        tt_logits_rm = self.model.ttnn_decode_forward(
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            xattn_caches,
+            tt_position_id,
+            tt_rot_mats,
+            page_table=tt_page_table,
+            kv_cache=kv_cache,
+            cross_page_table=tt_cross_page_table,
+        )
+        logger.info("Done Compiling Model")
+
+        # Get inputs ready for trace run
+        (
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            tt_position_id,
+            tt_rope_id,
+            tt_page_table,
+            tt_cross_page_table,
+        ) = self.model.prepare_decode_inputs_host(
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            position_id,
+            page_table=page_table,
+            cross_page_table=cross_page_table,
+        )
+
+        (
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            tt_position_id,
+            tt_rope_id,
+            tt_page_table,
+            tt_cross_page_table,
+        ) = copy_host_to_device(
+            (
+                tt_h,
+                tt_xattn_mask,
+                tt_full_text_mask_expand_1NSH,
+                tt_full_text_mask_expand_11SD,
+                tt_position_id,
+                tt_rope_id,
+                tt_page_table,
+                tt_cross_page_table,
+            ),
+            mesh_device=self.mesh_device,
+        )
+
+        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+        tt_h_trace_input = tt_h
+        B = tokens.shape[0]
+        # Do on-device transformations of inputs before forward
+        (
+            tt_h_transform,
+            tt_rot_mats,
+            tt_xattn_mask_transform,
+            tt_full_text_mask_expand_1NSH_transform,
+            tt_full_text_mask_expand_11SD_transform,
+        ) = self.model.transform_decode_inputs_device(
+            tt_h,
+            tt_rope_id,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            B=B,
+        )
+
+        tt_logits_rm = self.model.ttnn_decode_forward(
+            tt_h_transform,
+            tt_xattn_mask_transform,
+            tt_full_text_mask_expand_1NSH_transform,
+            tt_full_text_mask_expand_11SD_transform,
+            xattn_caches,
+            tt_position_id,
+            tt_rot_mats,
+            page_table=tt_page_table,
+            kv_cache=kv_cache,
+            cross_page_table=tt_cross_page_table,
+        )
+
+        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+        logger.info("Done Capturing Decode Trace")
+
+        return (
+            trace_id,
+            tt_logits_rm,
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            tt_position_id,
+            tt_rope_id,
+            tt_page_table,
+            tt_cross_page_table,
+        )
+
+    def _decode_forward_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        page_table,
+        cross_page_table,
+        trace_id,
+        trace_logits_rm,
+        trace_h,
+        trace_xattn_mask,
+        trace_full_text_mask_expand_1NSH,
+        trace_full_text_mask_expand_11SD,
+        trace_position_id,
+        trace_rope_id,
+        trace_page_table,
+        trace_cross_page_table,
+    ):
+        """
+        Executes the trace for the decode_forward method but does not read back outputs.
+        """
+        (
+            tt_h,
+            tt_xattn_mask,
+            tt_full_text_mask_expand_1NSH,
+            tt_full_text_mask_expand_11SD,
+            tt_position_id,
+            tt_rope_id,
+            tt_page_table,
+            tt_cross_page_table,
+        ) = self.model.prepare_decode_inputs_host(
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            position_id=position_id,
+            page_table=page_table,
+            cross_page_table=cross_page_table,
+        )
+
+        copy_host_to_device(
+            host_tensors=(
+                tt_h,
+                tt_xattn_mask,
+                tt_full_text_mask_expand_1NSH,
+                tt_full_text_mask_expand_11SD,
+                tt_position_id,
+                tt_rope_id,
+                tt_page_table,
+                tt_cross_page_table,
+            ),
+            device_tensors=(
+                trace_h,
+                trace_xattn_mask,
+                trace_full_text_mask_expand_1NSH,
+                trace_full_text_mask_expand_11SD,
+                trace_position_id,
+                trace_rope_id,
+                trace_page_table,
+                trace_cross_page_table,
+            ),
+        )
+
+        ttnn.execute_trace(self.mesh_device, trace_id, cq_id=0, blocking=False)
+
+        return trace_logits_rm
+
+    def _easy_trace(
+        self,
+        position_id,
+        tokens,
+        cross_attention_masks,
+        full_text_row_masked_out_mask,
+        xattn_caches=None,
+        page_table=None,
+        kv_cache=None,
+        cross_page_table=None,
+    ):
+        """
+        Tracing is easy! Just call this method and we'll handle tracing for you.
+        """
+        if not hasattr(self, "trace_id"):
+            (
+                trace_id,
+                tt_logits_rm,
+                tt_h,
+                tt_xattn_mask,
+                tt_full_text_mask_expand_1NSH,
+                tt_full_text_mask_expand_11SD,
+                tt_position_id,
+                tt_rope_id,
+                tt_page_table,
+                tt_cross_page_table,
+            ) = self._capture_trace(
+                position_id,
+                tokens,
+                cross_attention_masks,
+                full_text_row_masked_out_mask,
+                xattn_caches,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                cross_page_table=cross_page_table,
+            )
+            self.trace_id = trace_id
+            self.trace_inputs = {
+                "tt_h": tt_h,
+                "tt_xattn_mask": tt_xattn_mask,
+                "tt_full_text_mask_expand_1NSH": tt_full_text_mask_expand_1NSH,
+                "tt_full_text_mask_expand_11SD": tt_full_text_mask_expand_11SD,
+                "tt_position_id": tt_position_id,
+                "tt_rope_id": tt_rope_id,
+                "tt_page_table": tt_page_table,
+                "tt_cross_page_table": tt_cross_page_table,
+            }
+            self.trace_outputs = {
+                "tt_logits_rm": tt_logits_rm,
+            }
+
+        trace_logits_rm = self._decode_forward_trace(
+            position_id,
+            tokens,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            page_table,
+            cross_page_table,
+            self.trace_id,
+            self.trace_outputs["tt_logits_rm"],
+            self.trace_inputs["tt_h"],
+            self.trace_inputs["tt_xattn_mask"],
+            self.trace_inputs["tt_full_text_mask_expand_1NSH"],
+            self.trace_inputs["tt_full_text_mask_expand_11SD"],
+            self.trace_inputs["tt_position_id"],
+            self.trace_inputs["tt_rope_id"],
+            self.trace_inputs["tt_page_table"],
+            self.trace_inputs["tt_cross_page_table"],
+        )
+
+        return trace_logits_rm
+
+    def generate(
+        self,
+        model_input,
+        max_gen_len: int,
+        temperature: float = 0.6,
+        top_p: float = 0.9,
+    ):
+        # Do initial prefill
+        vision_images = model_input.vision.images
+        vision_mask = model_input.vision.mask
+        prompt_tokens = model_input.tokens
+        prefill_len = len(prompt_tokens)
+        total_len = prefill_len + max_gen_len  # Prepares mask for full length of output
+
+        prompt_tokens_tensor = torch.tensor(prompt_tokens, dtype=torch.long).reshape(1, -1)  # B, S
+        # Suboptimal to allocate caches every time
+        xattn_caches = self.model.setup_cache(self.model_args.max_batch_size)
+        (
+            xattn_caches,
+            cross_attention_masks,
+            full_text_row_masked_out_mask,
+            logits,
+        ) = self._prefill_forward_single_user(
+            vision_images,
+            vision_mask,
+            prompt_tokens_tensor,
+            xattn_caches,
+            user_id=0,
+            total_len=total_len,
+            prefill_len=prefill_len,
+        )
+
+        logits = logits.view(1, 1, self.model_args.vocab_size)
+
+        def sample(logits):
+            if temperature > 0:
+                probs = torch.softmax(logits[:, -1] / temperature, dim=-1)
+                next_token = sample_top_p(probs, top_p)
+            else:
+                next_token = torch.argmax(logits[:, -1], dim=-1)
+            next_token = next_token.reshape(-1)
+            return next_token, self.tokenizer.decode(next_token.tolist())
+
+        next_token, text = sample(logits)
+
+        yield TokenResult(
+            token=next_token[0].item(),
+            text=text,
+        )
+
+        for gen_idx in range(max_gen_len - 1):
+            position_id = torch.tensor([prefill_len + gen_idx])
+            next_token_tensor = next_token.reshape(1, 1)  # B, S
+
+            logits = self.decode_forward(
+                position_id,
+                next_token_tensor,
+                [cross_attention_masks],
+                [full_text_row_masked_out_mask],
+                xattn_caches,
+                enable_trace=False,
+            )
+
+            next_token, text = sample(logits)
+            yield TokenResult(
+                token=next_token[0].item(),
+                text=text,
+            )
 
     def chat_completion(
         self,

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -233,11 +233,11 @@ class TtLlamaMLP(LightweightModule):
         # ttnn.deallocate(x)
 
         try:
-            w1_out_reduced = self.tt_ccl.line_reduce_scatter(
-                w1_out, cluster_axis=1, num_links=3, memory_config=w1_out.memory_config(), buffer_key="FF1", dim=3
+            w1_out_reduced = self.tt_ccl.line_all_reduce(
+                w1_out, cluster_axis=1, num_links=3, memory_config=w1_out.memory_config(), buffer_key="FF1"
             )
-            w3_out_reduced = self.tt_ccl.line_reduce_scatter(
-                w3_out, cluster_axis=1, num_links=3, memory_config=w3_out.memory_config(), buffer_key="FF3", dim=3
+            w3_out_reduced = self.tt_ccl.line_all_reduce(
+                w3_out, cluster_axis=1, num_links=3, memory_config=w3_out.memory_config(), buffer_key="FF3"
             )
 
         except Exception as e:
@@ -251,13 +251,11 @@ class TtLlamaMLP(LightweightModule):
             dtype=ttnn.bfloat8_b,
             memory_config=w1_out.memory_config(),
         )
-        w2_in_gathered = self.tt_ccl.line_all_gather(
-            w2_in, cluster_axis=1, num_links=3, memory_config=w3_out.memory_config(), buffer_key="FF3", dim=3
-        )
+
         # ttnn.deallocate(w3_out)
         # ttnn.deallocate(w1_out)
         w2_out = ttnn.linear(
-            w2_in_gathered,
+            w2_in,
             self.w2,
             compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
             dtype=ttnn.bfloat8_b,

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -121,7 +121,6 @@ class TtTransformer(LightweightModule):
         )
         if mode == "decode":
             self.tt_tensors = self.prefetcher_setup.get_input_tensors()
-        self.tt_rot_mats_prefill = None
 
     def setup_prefill(self, mesh_sub_device_manager_id_prefill=None):
         self.prefetcher_setup = TtLlamaPrefetcherSetup(
@@ -158,7 +157,7 @@ class TtTransformer(LightweightModule):
         else:
             self.tt_ccl = self.tt_ccl_decode
 
-    def prepare_prefill_inputs_host(self, tokens, page_table=None, chunk_page_table=None, tt_rot_mats_prefill=None):
+    def prepare_inputs_prefill(self, tokens, start_pos=0, page_table=None, chunk_page_table=None):
         """
         Inputs are torch tensors or python types. This function returns ttnn
         tensors on device.
@@ -169,29 +168,29 @@ class TtTransformer(LightweightModule):
         S = tokens.shape[-1]
         tokens = ttnn.from_torch(
             tokens,
-            device=None,
+            device=self.mesh_device,
             dtype=ttnn.uint32,
             layout=ttnn.ROW_MAJOR_LAYOUT,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
+        tokens_embd = self.embd(tokens)
+        tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
 
         # Slice the rot mats to the prefill seqlen
-        if tt_rot_mats_prefill is None and self.tt_rot_mats_prefill is None:
-            tt_rot_mats_prefill = get_prefill_rot_mat(
-                self.args.head_dim,
-                self.args.max_seq_len,
-                self.mesh_device,
-                seq_len=S,
-                scale_factor=self.args.rope_scaling_factor,
-            )
-            self.tt_rot_mats_prefill = tt_rot_mats_prefill
-        else:
-            tt_rot_mats_prefill = self.tt_rot_mats_prefill
+        tt_rot_mats_prefill = get_prefill_rot_mat(
+            self.args.head_dim,
+            self.args.max_seq_len,
+            self.mesh_device,
+            seq_len=S,
+            scale_factor=self.args.rope_scaling_factor,
+        )
+
+        # [self.rope_setup.cos_matrix[:, :, :S, :], self.rope_setup.sin_matrix[:, :, :S, :]]
 
         if page_table is not None:
             tt_page_table = ttnn.from_torch(
                 page_table,
-                device=None,
+                device=self.mesh_device,
                 dtype=ttnn.int32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
@@ -202,7 +201,7 @@ class TtTransformer(LightweightModule):
         if chunk_page_table is not None:
             tt_chunk_page_table = ttnn.from_torch(
                 chunk_page_table,
-                device=None,
+                device=self.mesh_device,
                 dtype=ttnn.int32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
@@ -210,29 +209,7 @@ class TtTransformer(LightweightModule):
         else:
             tt_chunk_page_table = None
 
-        return tokens, tt_page_table, tt_chunk_page_table
-
-    def transform_prefill_inputs_device(
-        self,
-        tokens,
-        page_table=None,
-        chunk_page_table=None,
-    ):
-        tt_tokens = self.embd(tokens)
-        tt_tokens = ttnn.unsqueeze_to_4D(tt_tokens)
-        return tt_tokens, page_table, chunk_page_table
-
-    def prepare_inputs_prefill(self, tokens, page_table=None, chunk_page_table=None, tt_rot_mats_prefill=None):
-        """
-        Inputs are torch tensors or python types. This function returns ttnn
-        tensors on device.
-        Its implementation can take advantage of a few other functions which the
-        model must implement.
-        """
-        host_inputs = self.prepare_prefill_inputs_host(tokens, page_table, chunk_page_table, tt_rot_mats_prefill)
-        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)  # Helper function
-        transformed_device_inputs = self.transform_prefill_inputs_device(*device_inputs)
-        return transformed_device_inputs
+        return tokens_embd, tt_rot_mats_prefill, tt_page_table, tt_chunk_page_table
 
     def prepare_inputs_decode(self, *inputs):
         """
@@ -355,13 +332,13 @@ class TtTransformer(LightweightModule):
     def ttnn_prefill_forward(
         self,
         x,
+        rot_mats,
+        user_id,
         page_table=None,
         chunk_page_table=None,
         chunk_start_idx=None,
         get_last_token=-1,
         kv_cache=None,
-        rot_mats=None,
-        user_id=0,
     ):
         """
         This method will take device tensors and any other args to run forward.
@@ -370,7 +347,7 @@ class TtTransformer(LightweightModule):
         return self.forward(
             x,
             current_pos=None,
-            rot_mats=rot_mats if rot_mats is not None else self.tt_rot_mats_prefill,
+            rot_mats=rot_mats,
             user_id=user_id,
             mode="prefill",
             page_table=page_table,


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#20327
breaks tg quick test

```
            # Always print perf at every iteration
            logger.info(
                f"Iteration {iteration}: {1000*iteration_time:.0f}ms @ {tokens_per_second_per_user:.1f} tok/s/user ({batch_size*tokens_per_second_per_user:.1f} tok/s throughput)"
            )
            tsu_threshold = 128 if layers == 1 else 28
            if not stress_test:
>               assert tokens_per_second_per_user > tsu_threshold, "Throughput is less than 28 tokens per second per user"
E               AssertionError: Throughput is less than 28 tokens per second per user
E               assert 69.80036611749043 > 128

models/demos/llama3_subdevices/demo/demo_decode.py:458: AssertionError
```

https://github.com/tenstorrent/tt-metal/actions/runs/14336831841/job/40187403788#step:5:2580