### PR TITLE
[skip ci] Use a smaller machine for normal builds

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -125,7 +125,7 @@ jobs:
     name: "🛠️ Build ${{ inputs.build-type }} ${{ inputs.distro }} ${{ inputs.version }}"
     needs: build-docker-image
     timeout-minutes: 30
-    runs-on: tt-beta-ubuntu-2204-xlarge
+    runs-on: tt-beta-ubuntu-2204-large
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     outputs:
       packages-artifact-name: ${{ steps.set-artifact-name.outputs.name }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Normal builds only see ~10% improvement between large vs xlarge.  Using xlarge for them is a waste of resources.  Instead we could use large and have more builders active at once to pick up jobs with less wait time.

ClangTidy fully uses xlarge and should NOT drop down to a large!

### What's changed
Moved build-artifact to large.