### PR TITLE
Fix CP apis to handle Torus connections

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -207,7 +207,7 @@ void RunAsyncWriteTest(
     std::vector<uint32_t> sender_compile_time_args = {
         (uint32_t)mode, (uint32_t)test_mode::TEST_ASYNC_WRITE, (uint32_t)is_raw_write};
     auto outbound_eth_channels =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
+        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -216,7 +216,7 @@ void RunAsyncWriteTest(
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
         tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
-        *outbound_eth_channels.begin()};
+        outbound_eth_channels.begin()->first};
     std::map<string, string> defines = {};
     if (mode == fabric_mode::PULL) {
         defines["FVC_MODE_PULL"] = "";
@@ -314,7 +314,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     defines["DISABLE_LOW_LATENCY_ROUTING"] = "";
     std::vector<uint32_t> sender_compile_time_args = {(uint32_t)mode, (uint32_t)TEST_ATOMIC_INC, 0};
     auto outbound_eth_channels =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
+        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -324,7 +324,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
         tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
-        *outbound_eth_channels.begin()};
+        outbound_eth_channels.begin()->first};
 
     CreateSenderKernel(
         sender_program,
@@ -432,7 +432,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
     std::vector<uint32_t> sender_compile_time_args = {
         (uint32_t)mode, (uint32_t)TEST_ASYNC_WRITE_ATOMIC_INC, (uint32_t)is_raw_write};
     auto outbound_eth_channels =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
+        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -443,7 +443,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
         tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
-        *outbound_eth_channels.begin()};
+        outbound_eth_channels.begin()->first};
 
     CreateSenderKernel(
         sender_program,
@@ -609,7 +609,7 @@ void RunAsyncWriteMulticastTest(
 
     // Prepare runtime args based on whether it's multidirectional or not
     auto outbound_eth_channels =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
+        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
     std::vector<uint32_t> sender_runtime_args;
 
     if (multidirectional) {
@@ -626,7 +626,7 @@ void RunAsyncWriteMulticastTest(
             end_mesh_chip_ids_by_dir[RoutingDirection::W][0].second,
             mcast_hops[RoutingDirection::W],
             sender_router_noc_xys[RoutingDirection::W],
-            *outbound_eth_channels.begin()};
+            outbound_eth_channels.begin()->first};
     } else {
         auto routing_direction = RoutingDirection::E;
         sender_runtime_args = {
@@ -638,7 +638,7 @@ void RunAsyncWriteMulticastTest(
             end_mesh_chip_ids_by_dir[routing_direction][0].second,
             mcast_hops[routing_direction],
             sender_router_noc_xys[routing_direction],
-            *outbound_eth_channels.begin()};
+            outbound_eth_channels.begin()->first};
     }
 
     // Choose the appropriate kernel based on whether it's multidirectional or not

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -501,7 +501,13 @@ typedef struct test_board {
     }
 
     inline eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t eth_chan) {
-        return control_plane->get_eth_chan_direction(mesh_id, chip_id, eth_chan);
+        auto active_eth_chans = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+        for (const auto& [eth_chan_, direction] : active_eth_chans) {
+            if (eth_chan_ == eth_chan) {
+                return direction;
+            }
+        }
+        TT_THROW("Cannot find ethernet channel direction");
     }
 
     inline void close_devices() { tt::tt_metal::detail::CloseDevices(device_handle_map); }

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -30,6 +30,15 @@ target_sources(
             api/tt-metalium/fabric_host_interface.h
             core_descriptors/blackhole_140_arch.yaml
             core_descriptors/wormhole_b0_80_arch.yaml
+            fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
+            fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
             impl/dispatch/kernels/cq_commands.hpp
             impl/dispatch/kernels/cq_common.hpp
             impl/dispatch/kernels/cq_helpers.hpp

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -61,7 +61,8 @@ public:
     std::set<chan_id_t> get_active_fabric_eth_channels_in_direction(
         mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const;
 
-    eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const;
+    std::set<std::pair<chan_id_t, eth_chan_directions>> get_active_fabric_eth_channels(
+        mesh_id_t mesh_id, chip_id_t chip_id) const;
 
 private:
     std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
@@ -92,6 +93,7 @@ private:
 
     // Takes RoutingTableGenerator table and converts to routing tables for each ethernet port
     void convert_fabric_routing_table_to_chip_routing_table();
+    // TODO: remove this converter, we should consolidate the directions here
     eth_chan_directions routing_direction_to_eth_direction(RoutingDirection direction) const;
 };
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -538,11 +538,13 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
                                                       RoutingDirection direction) {
         auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
         auto fabric_router_channels_on_chip = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_chip_id);
-        auto chan_id = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
-        // TODO: remove this from Cluster, manage retraining links only in control plane
-        auto active_eth_cores = tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(physical_chip_id, false);
+        // TODO: get_fabric_ethernet_channels accounts for down links, but we should manage down links in control plane
+        auto chan_id = tt::tt_metal::MetalContext::instance()
+                           .get_cluster()
+                           .get_soc_desc(physical_chip_id)
+                           .logical_eth_core_to_chan_map.at(eth_core);
         // TODO: add logic here to disable unsed routers, e.g. Mesh on Torus system
-        if (fabric_router_channels_on_chip.contains(chan_id) and active_eth_cores.contains(eth_core)) {
+        if (fabric_router_channels_on_chip.contains(chan_id)) {
             this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id][direction].push_back(chan_id);
         } else {
             log_debug(
@@ -758,16 +760,16 @@ eth_chan_directions ControlPlane::routing_direction_to_eth_direction(RoutingDire
     return dir;
 }
 
-eth_chan_directions ControlPlane::get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const {
+std::set<std::pair<chan_id_t, eth_chan_directions>> ControlPlane::get_active_fabric_eth_channels(
+    mesh_id_t mesh_id, chip_id_t chip_id) const {
+    std::set<std::pair<chan_id_t, eth_chan_directions>> active_fabric_eth_channels;
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
         for (const auto& eth_chan : eth_chans) {
-            if (chan == eth_chan) {
-                return this->routing_direction_to_eth_direction(direction);
-            }
+            active_fabric_eth_channels.insert({eth_chan, this->routing_direction_to_eth_direction(direction)});
         }
     }
-    TT_THROW("Cannot Find Ethernet Channel Direction");
+    return active_fabric_eth_channels;
 }
 
 std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -309,6 +309,9 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
                 get_ethernet_cores_grouped_by_connected_chips(physical_chip_id_from_north);
             bool found_chip = false;
             for (const auto& [connected_chip_id, eth_ports] : eth_links_grouped_by_connected_chips) {
+                if (is_external_ubb_cable(physical_chip_id_from_north, eth_ports[0])) {
+                    continue;
+                }
                 if (visited_physical_chips.find(connected_chip_id) == visited_physical_chips.end() and
                     eth_ports.size() == num_ports_per_side) {
                     physical_chip_ids[i * mesh_ew_size + j] = connected_chip_id;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -464,19 +464,21 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 
 void DevicePool::wait_for_fabric_router_sync() const {
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     if (tt_fabric::is_1d_fabric_config(fabric_config)) {
         const auto edm_config = tt_fabric::get_1d_fabric_config();
         std::vector<uint32_t> signal(1, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
 
         auto wait_for_handshake = [&](IDevice* dev) {
             std::vector<std::uint32_t> master_router_status{0};
-            auto fabric_ethernet_channels =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
-            if (fabric_ethernet_channels.empty()) {
+            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
+
+            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+            if (router_chans_and_direction.empty()) {
                 return;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
+            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);
@@ -521,25 +523,20 @@ void DevicePool::wait_for_fabric_router_sync() const {
 
         std::vector<std::uint32_t> master_router_status{0};
         for (const auto& dev : this->get_all_active_devices()) {
-            auto fabric_ethernet_channels =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
-            if (fabric_ethernet_channels.empty()) {
-                continue;
+            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
+
+            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+            if (router_chans_and_direction.empty()) {
+                return;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
+            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);
             auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
 
-            auto [mesh_id, chip_id] = tt::tt_metal::MetalContext::instance()
-                                          .get_cluster()
-                                          .get_control_plane()
-                                          ->get_mesh_chip_id_from_physical_chip_id(dev->id());
-            auto num_routers =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane()->get_num_active_fabric_routers(
-                    mesh_id, chip_id);
+            auto num_routers = router_chans_and_direction.size();
             while (master_router_status[0] != num_routers) {
                 tt_metal::detail::ReadFromDeviceL1(
                     dev,
@@ -738,6 +735,7 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
 
     // Terminate fabric routers
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     if (tt_fabric::is_1d_fabric_config(fabric_config)) {
         std::vector<uint32_t> signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
         static constexpr std::size_t edm_buffer_size =
@@ -752,14 +750,15 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
                 // 1d fabric is not launched on TG gateways
                 continue;
             }
+            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
 
-            auto fabric_ethernet_channels =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
-            if (fabric_ethernet_channels.empty()) {
-                continue;
+            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+            if (router_chans_and_direction.empty()) {
+                return;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
+            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
+
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);
@@ -772,13 +771,14 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
         auto fabric_router_sync_sem_addr =
             hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
         for (const auto& dev : this->get_all_active_devices()) {
-            auto fabric_ethernet_channels =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
-            if (fabric_ethernet_channels.empty()) {
-                continue;
+            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
+
+            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+            if (router_chans_and_direction.empty()) {
+                return;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
+            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -925,17 +925,19 @@ std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, F
     std::uint32_t router_mask = 0;
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
 
-    auto router_chans = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(device->id());
-    if (router_chans.empty()) {
+    auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+
+    auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+    if (router_chans_and_direction.empty()) {
         return nullptr;
     }
 
     fabric_program_ptr = std::make_unique<Program>();
-    size_t num_routers = router_chans.size();
-    for (const auto& router_chan : router_chans) {
-        router_mask += 0x1 << (uint32_t)router_chan;
+    size_t num_routers = router_chans_and_direction.size();
+    for (const auto& router_chan : router_chans_and_direction) {
+        router_mask += 0x1 << (uint32_t)router_chan.first;
     }
-    auto master_router_chan = (uint32_t)(*router_chans.begin());
+    auto master_router_chan = (uint32_t)(router_chans_and_direction.begin()->first);
     // setup runtime args
     std::vector<uint32_t> router_runtime_args = {
         num_routers,         // 0: number of active fabric routers
@@ -966,18 +968,18 @@ std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, F
     // TODO: Manual clear of semaphore, move this to proper Metal sempahore apis
     std::vector<uint32_t> fabric_sem_zero_buf(1, 0);
 
-    for (const auto& router_chan : router_chans) {
+    for (const auto& router_chan : router_chans_and_direction) {
         CoreCoord virtual_eth_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
-                device->id(), router_chan);
+                device->id(), router_chan.first);
         auto router_logical_core = device->logical_core_from_ethernet_core(virtual_eth_core);
-        if (master_router_chan == router_chan) {
+        if (master_router_chan == router_chan.first) {
             router_compile_args[4] = 1;
         } else {
             router_compile_args[4] = 0;
         }
         auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
-        uint32_t direction = control_plane->get_eth_chan_direction(mesh_id, chip_id, router_chan);
+        uint32_t direction = router_chan.second;
         router_compile_args[5] = direction;
         auto kernel = tt_metal::CreateKernel(
             *fabric_program_ptr,
@@ -996,8 +998,12 @@ std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, F
 void configure_2d_fabric_cores(IDevice* device) {
     std::vector<uint32_t> router_zero_buf(1, 0);
 
-    auto router_chans = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(device->id());
-    for (const auto& router_chan : router_chans) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+
+    auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+
+    auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+    for (const auto& [router_chan, direction] : router_chans_and_direction) {
         CoreCoord virtual_eth_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                 device->id(), router_chan);
@@ -1050,6 +1056,7 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, F
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     std::pair<mesh_id_t, chip_id_t> mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
     auto mesh_shape = control_plane->get_physical_mesh_shape(mesh_chip_id.first);
+    auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
     std::unordered_map<RoutingDirection, std::set<chan_id_t>> active_fabric_eth_channels;
     std::unordered_map<RoutingDirection, chip_id_t> chip_neighbors;
     std::unordered_map<chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder> edm_builders;
@@ -1127,8 +1134,9 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, F
     }
 
     uint32_t num_edm_chans = edm_builders.size();
-    uint32_t master_edm_chan =
-        *(tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(device->id()).begin());
+
+    auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+    uint32_t master_edm_chan = (uint32_t)(router_chans_and_direction.begin()->first);
     uint32_t edm_channels_mask = 0;
     for (const auto& [router_chan, _] : edm_builders) {
         edm_channels_mask += 0x1 << (uint32_t)router_chan;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1057,12 +1057,10 @@ void Cluster::release_ethernet_cores_for_fabric_routers() {
 
 std::set<tt_fabric::chan_id_t> Cluster::get_fabric_ethernet_channels(chip_id_t chip_id) const {
     std::set<tt_fabric::chan_id_t> fabric_ethernet_channels;
-    const auto& connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
-    for (const auto& [other_chip_id, eth_cores] : connected_chips) {
-        for (const auto& eth_core : eth_cores) {
-            if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
-                fabric_ethernet_channels.insert(this->get_soc_desc(chip_id).logical_eth_core_to_chan_map.at(eth_core));
-            }
+    const auto& active_eth_cores = this->get_active_ethernet_cores(chip_id, false);
+    for (const auto& eth_core : active_eth_cores) {
+        if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
+            fabric_ethernet_channels.insert(this->get_soc_desc(chip_id).logical_eth_core_to_chan_map.at(eth_core));
         }
     }
     return fabric_ethernet_channels;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20442

### Problem description
2D Torus init has been broken on 6Us for a while now... Changes are needed to bookkeep the wraparound links when we just want a Mesh on 2DTorus

### What's changed
API changes and update fabric init/close infra to use.
`control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);` returns pair of chan and direction.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes