### PR TITLE
Use space optimized ci-build docker image

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -53,12 +53,12 @@ on:
         default: false
         description: "Profile the compilation"
     outputs:
-      #ci-build-docker-image:
-      #  description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
-      #  value: ${{ jobs.build-docker-image.outputs.dev-tag }}
-      #ci-test-docker-image:
-      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
-      #  value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
+      ci-build-docker-image:
+        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
+        value: ${{ jobs.build-docker-image.outputs.ci-build-tag }}
+      ci-test-docker-image:
+        description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
+        value: ${{ jobs.build-docker-image.outputs.ci-test-tag }}
       dev-docker-image:
         description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
         value: ${{ jobs.build-docker-image.outputs.dev-tag }}
@@ -132,7 +132,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.dev-tag || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.ci-build || 'docker-image-unresolved!'}}
       env:
         CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}|read-only=${{ vars.REDIS_IS_READONLY }}"
         CCACHE_REMOTE_ONLY: "true"

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -132,7 +132,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.ci-build-docker-image || 'docker-image-unresolved!'}}
       env:
         CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}|read-only=${{ vars.REDIS_IS_READONLY }}"
         CCACHE_REMOTE_ONLY: "true"

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -95,7 +95,7 @@ on:
       version:
         required: false
         type: string
-        default: "20.04"
+        default: "22.04"
       architecture:
         required: false
         type: string

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -132,7 +132,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-docker-image || 'docker-image-unresolved!'}}
+      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
       env:
         CCACHE_REMOTE_STORAGE: "redis://${{ vars.REDIS_USER }}:${{ secrets.REDIS_PASSWORD }}@${{ vars.REDIS_HOST }}:${{ vars.REDIS_PORT }}|read-only=${{ vars.REDIS_IS_READONLY }}"
         CCACHE_REMOTE_ONLY: "true"

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -72,6 +72,7 @@ jobs:
         id: tags
         run: |
           HASH=$(cat \
+            .github/workflows/build-docker-artifact.yaml \
             install_dependencies.sh \
             dockerfile/Dockerfile \
             tt_metal/python_env/requirements-dev.txt \
@@ -91,13 +92,11 @@ jobs:
             echo "ci-build-exists=true" >> $GITHUB_OUTPUT
             echo "ci-test-exists=true" >> $GITHUB_OUTPUT
             echo "dev-exists=true" >> $GITHUB_OUTPUT
-            echo "release-exists=true" >> $GITHUB_OUTPUT
           else
             echo "${{ steps.tags.outputs.dev-tag }} does not exist"
             echo "ci-build-exists=false" >> $GITHUB_OUTPUT
             echo "ci-test-exists=false" >> $GITHUB_OUTPUT
             echo "dev-exists=false" >> $GITHUB_OUTPUT
-            echo "release-exists=false" >> $GITHUB_OUTPUT
           fi
 
   # Assume if dev-tag does not exist, the others will not exist either

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -16,12 +16,15 @@ on:
         type: string
         default: "amd64"
     outputs:
+      ci-build-tag:
+        description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"
+        value: ${{ jobs.check-docker-images.outputs.ci-build-tag }}
+      ci-test-tag:
+        description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
+        value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
       dev-tag:
         description: "Docker tag for the dev Docker image for developing TT-Metalium et al"
         value: ${{ jobs.check-docker-images.outputs.dev-tag }}
-      #ci-test-tag:
-      #  description: "Docker tag for the CI Test Docker image for testing TT-Metalium et al"
-      #  value: ${{ jobs.check-docker-images.outputs.ci-test-tag }}
   workflow_dispatch:
     inputs:
       distro:
@@ -33,9 +36,8 @@ on:
       version:
         required: false
         type: choice
-        default: "20.04"
+        default: "22.04"
         options:
-            - "20.04"
             - "22.04"
             - "24.04"
       architecture:
@@ -46,16 +48,18 @@ on:
             - "amd64"
 
 env:
-  IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-dev-${{ inputs.architecture }}
+  CI_BUILD_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-ci-build-${{ inputs.architecture }}
+  CI_TEST_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-ci-test-${{ inputs.architecture }}
+  DEV_IMAGE_NAME: ${{ inputs.distro }}-${{ inputs.version }}-dev-${{ inputs.architecture }}
 
 jobs:
   check-docker-images:
     runs-on: ubuntu-latest
     outputs:
-      # ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
-      # ci-build-tag: ${{ steps.tags.outputs.ci-build-tag }}
-      # ci-test-exists: ${{ steps.images.outputs.ci-test-exists }}
-      # ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
+      ci-build-exists: ${{ steps.images.outputs.ci-build-exists }}
+      ci-build-tag: ${{ steps.tags.outputs.ci-build-tag }}
+      ci-test-exists: ${{ steps.images.outputs.ci-test-exists }}
+      ci-test-tag: ${{ steps.tags.outputs.ci-test-tag }}
       dev-exists: ${{ steps.images.outputs.dev-exists }}
       dev-tag: ${{ steps.tags.outputs.dev-tag }}
     steps:
@@ -67,33 +71,38 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          DEV_TAG=$(cat \
+          HASH=$(cat \
             install_dependencies.sh \
             dockerfile/Dockerfile \
             tt_metal/python_env/requirements-dev.txt \
             docs/requirements-docs.txt \
             tests/sweep_framework/requirements-sweeps.txt \
             | sha1sum | cut -d' ' -f1)
-          echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${DEV_TAG}" >> $GITHUB_OUTPUT
+          echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
+          echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
+          echo "dev-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.DEV_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
 
-          # TODO: When we have multiple Docker images, do something like this:
-          # TEST_TAG=$(cat tt_metal/python_env/requirements-dev.txt pyproject.toml | sha1sum | cut -d' ' -f1)
-          # echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}:${TEST_TAG}" >> $GITHUB_OUTPUT
-
+      # Assume if dev-tag exists, the others will exist too
       - name: Query images exist
         id: images
         run: |
           if docker manifest inspect ${{ steps.tags.outputs.dev-tag }} > /dev/null 2>&1; then
             echo "${{ steps.tags.outputs.dev-tag }} exists"
+            echo "ci-build-exists=true" >> $GITHUB_OUTPUT
+            echo "ci-test-exists=true" >> $GITHUB_OUTPUT
             echo "dev-exists=true" >> $GITHUB_OUTPUT
+            echo "release-exists=true" >> $GITHUB_OUTPUT
           else
             echo "${{ steps.tags.outputs.dev-tag }} does not exist"
+            echo "ci-build-exists=false" >> $GITHUB_OUTPUT
+            echo "ci-test-exists=false" >> $GITHUB_OUTPUT
             echo "dev-exists=false" >> $GITHUB_OUTPUT
+            echo "release-exists=false" >> $GITHUB_OUTPUT
           fi
 
-
+  # Assume if dev-tag does not exist, the others will not exist either
   build-docker-image:
-    name: "🐳️ Build image"
+    name: "🐳️ Build images"
     needs: check-docker-images
     if: needs.check-docker-images.outputs.dev-exists != 'true'
     timeout-minutes: 30
@@ -111,7 +120,29 @@ jobs:
           registry: https://ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Docker image and push to GHCR
+      - name: Build and push CI Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ github.workspace }}
+          file: dockerfile/Dockerfile
+          target: ci-build
+          push: true
+          tags: ${{ needs.check-docker-images.outputs.ci-build-tag }}
+          build-args: UBUNTU_VERSION=${{ inputs.version }}
+          cache-to: type=inline
+          pull: true
+      - name: Build and push CI Test image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ github.workspace }}
+          file: dockerfile/Dockerfile
+          target: ci-test
+          push: true
+          tags: ${{ needs.check-docker-images.outputs.ci-test-tag }}
+          build-args: UBUNTU_VERSION=${{ inputs.version }}
+          cache-to: type=inline
+          pull: true
+      - name: Build and push Dev image
         uses: docker/build-push-action@v6
         with:
           context: ${{ github.workspace }}
@@ -142,7 +173,7 @@ jobs:
 
       - name: Tag and push latest
         run: |
-          IMAGE_REPO="ghcr.io/${{ github.repository }}/tt-metalium/${{ env.IMAGE_NAME }}"
+          IMAGE_REPO="ghcr.io/${{ github.repository }}/tt-metalium/${{ env.DEV_IMAGE_NAME }}"
           LATEST_TAG="${IMAGE_REPO}:latest"
           DEV_TAG="${{ needs.check-docker-images.outputs.dev-tag }}"
           echo "Tagging ${DEV_TAG} as ${LATEST_TAG}"

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -216,19 +216,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgtest-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Needed for tt-train to build
-RUN python3 -m pip install numpy
-
-RUN git config --global --add safe.directory '*'
-
-ENV CCACHE_TEMPDIR=/tmp/ccache
-
-#############################################################
-
-FROM ci-build AS ci-test
-
-ARG TT_METAL_INFRA_DIR=/opt/tt_metal_infra
-
 # Set up virtual environment
 ENV PYTHON_ENV_DIR=/opt/venv
 RUN python3 -m venv $PYTHON_ENV_DIR
@@ -239,6 +226,19 @@ ENV VIRTUAL_ENV="$PYTHON_ENV_DIR"
 
 # Ensure the virtual environment is activated on shell startup
 RUN echo "source $PYTHON_ENV_DIR/bin/activate" >> /etc/bash.bashrc
+
+# Numpy needed for tt-train to build
+RUN python3 -m pip install --no-cache-dir build numpy setuptools
+
+RUN git config --global --add safe.directory '*'
+
+ENV CCACHE_TEMPDIR=/tmp/ccache
+
+#############################################################
+
+FROM ci-build AS ci-test
+
+ARG TT_METAL_INFRA_DIR=/opt/tt_metal_infra
 
 # Create directories for infra
 RUN mkdir -p ${TT_METAL_INFRA_DIR}/tt-metal/docs/
@@ -251,9 +251,8 @@ COPY /tests/sweep_framework/requirements-sweeps.txt ${TT_METAL_INFRA_DIR}/tt-met
 COPY /tt_metal/python_env/requirements-dev.txt ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/.
 
 RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu && \
-    python3 -m pip install setuptools wheel==0.45.1 && \
-    python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
-    python3 -m pip install -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
+    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/tt_metal/python_env/requirements-dev.txt && \
+    python3 -m pip install --no-cache-dir -r ${TT_METAL_INFRA_DIR}/tt-metal/docs/requirements-docs.txt
 
 # Adjust permissions to allow any user to use and modify the venv
 RUN chmod -R 777 $VIRTUAL_ENV

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -216,6 +216,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgtest-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Needed for tt-train to build
+RUN python3 -m pip install numpy
+
 RUN git config --global --add safe.directory '*'
 
 ENV CCACHE_TEMPDIR=/tmp/ccache

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -216,15 +216,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgtest-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /tmp/iwyu \
-    && wget -O /tmp/iwyu/iwyu.tar.gz https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.21.tar.gz \
-    && tar -xzf /tmp/iwyu/iwyu.tar.gz -C /tmp/iwyu --strip-components=1 \
-    && cmake -S /tmp/iwyu/ -B /tmp/iwyu/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17 \
-    && cmake --build /tmp/iwyu/build --parallel \
-    && cmake --install /tmp/iwyu/build \
-    && rm -rf /tmp/iwyu
-
-
 RUN git config --global --add safe.directory '*'
 
 ENV CCACHE_TEMPDIR=/tmp/ccache
@@ -267,6 +258,15 @@ RUN chmod -R 777 $VIRTUAL_ENV
 #############################################################
 
 FROM ci-test AS dev
+
+# IWYU could be useful to developers
+RUN mkdir -p /tmp/iwyu \
+    && wget -O /tmp/iwyu/iwyu.tar.gz https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.21.tar.gz \
+    && tar -xzf /tmp/iwyu/iwyu.tar.gz -C /tmp/iwyu --strip-components=1 \
+    && cmake -S /tmp/iwyu/ -B /tmp/iwyu/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-17 -DCMAKE_CXX_COMPILER=clang++-17 \
+    && cmake --build /tmp/iwyu/build --parallel \
+    && cmake --install /tmp/iwyu/build \
+    && rm -rf /tmp/iwyu
 
 # Need this to build GDB
 RUN apt-get -y update \


### PR DESCRIPTION
### Problem description
New ephemeral builder/runners download a 10GB docker image for every job.

### What's changed
For build artifact jobs, use the ci-build docker image which is roughly 3GB.
70% faster `initialize containers` step in all build jobs. ~42 seconds total instead of 2 minutes.

Extra detail:
- Push ci-build, ci-test, and dev images to ghcr every time Docker related files change
- Move some build time python requirements into ci-build
- 1GB improvement in the size of the `dev` image, by using `--no-cache-dir`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14345927922) CI passes
- [x] [T3K Demo Tests](https://github.com/tenstorrent/tt-metal/actions/runs/14345944897) CI passes
- [x] New/Existing tests provide coverage for changes