### PR TITLE
Enable Watcher in Smoke tests

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -53,6 +53,8 @@ jobs:
           GTEST_COLOR: yes
           GTEST_OUTPUT: xml:/work/test-reports/
           TT_METAL_HOME: /usr/libexec/tt-metalium # TODO: Need to get away from env vars!
+          TT_METAL_WATCHER: 5
+          TT_METAL_WATCHER_TEST_MODE: 1
         run: |
           /usr/libexec/tt-metalium/validation/tt-metalium-validation-smoke
 


### PR DESCRIPTION
### Ticket
None

### Problem description
We have a tool to check for mistakes.  We should use it.  Especially in PRs and especially in lightweight tests.

### What's changed
Enabled Watcher in Smoke tests.