### PR TITLE
#18572: Changes supporting TTNN mesh dispatch infra

### DIFF
--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TTNN_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_matmul_benchmark.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multiprod_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_multi_cq_multi_dev.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_launch_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_capture_arguments_morehdot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_capture_arguments_transpose.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_query_op_constraints.cpp

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <type_traits>
+
+#include "ttnn/distributed/api.hpp"
+#include "ttnn/distributed/distributed_tensor_config.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
+#include "ttnn/mesh_device_operation_utils.hpp"
+#include "ttnn/old_infra_device_operation.hpp"
+#include "ttnn/operation_concepts.hpp"
+#include "ttnn/operations/examples/example/device/example_device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
+
+#include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+
+namespace ttnn {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
+// Returns device tensor with `num_device_shards` populated.
+Tensor make_tensor_with_num_shards(const TensorSpec& tensor_spec, int num_device_shards, MeshDevice* mesh_device) {
+    TT_FATAL(num_device_shards > 0 && num_device_shards <= mesh_device->num_devices(), "Invalid number of shards");
+
+    auto host_tensor = Tensor::from_vector(std::vector<float>(tensor_spec.logical_shape().volume()), tensor_spec);
+    std::vector<Tensor> host_tensors;
+    for (int i = 0; i < num_device_shards; ++i) {
+        host_tensors.push_back(host_tensor);
+    }
+
+    return distributed::aggregate_as_tensor(host_tensors, tt::tt_metal::AllGatherTensor{}).to_device(mesh_device);
+}
+
+struct SharedVariables {};
+struct OperationAttributes {};
+
+// New-infra style program factory that uses the "create" method (non-heterogeneous dispatch)
+struct NewInfraProgramFactory {
+    using shared_variables_t = SharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+    using operation_attributes_t = OperationAttributes;
+    using tensor_args_t = Tensor;
+    using tensor_return_value_t = Tensor;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {
+        return cached_program_t(tt::tt_metal::Program(), SharedVariables{});
+    }
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {}
+};
+
+// New-infra style program factory that uses the "create_at" method (heterogeneous dispatch)
+struct NewInfraWorkloadFactory {
+    using shared_variables_t = SharedVariables;
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+    using operation_attributes_t = OperationAttributes;
+    using tensor_args_t = Tensor;
+    using tensor_return_value_t = Tensor;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const operation_attributes_t& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {
+        return cached_mesh_workload_t(
+            tt::tt_metal::distributed::MeshWorkload(),
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t>());
+    }
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value) {}
+};
+
+static_assert(ttnn::device_operation::MeshWorkloadFactoryConcept<NewInfraWorkloadFactory>);
+static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFactory>);
+
+// Old infrastructure device operation that uses the "create_program" method
+struct OldInfraDeviceOpWithCreateProgram {
+    void validate(const std::vector<Tensor>& input_tensors) const {}
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
+
+    auto create_program(const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+        return tt::tt_metal::operation::ProgramWithCallbacks();
+    }
+};
+
+// Old infrastructure device operation that uses the "create_program_at" method
+struct OldInfraDeviceOpWithCreateMeshWorkload {
+    void validate(const std::vector<Tensor>& input_tensors) const {}
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const { return {}; }
+    std::vector<Tensor> create_output_tensors(const std::vector<Tensor>& input_tensors) const { return {}; }
+
+    auto create_mesh_workload(
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const std::vector<Tensor>& input_tensors,
+        std::vector<Tensor>& output_tensors) const {
+        return tt::tt_metal::operation::MeshWorkloadWithCallbacks();
+    }
+};
+
+TEST(LaunchOperationTest, OldInfraSelectsMeshWorkloadFactory) {
+    auto old_infra_attributes_create_program =
+        tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateProgram{});
+    auto old_infra_attributes_create_mesh_workload =
+        tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateMeshWorkload{});
+
+    using OldInfraDeviceOperation = tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>;
+
+    EXPECT_TRUE(std::holds_alternative<OldInfraDeviceOperation::ProgramFactory>(
+        OldInfraDeviceOperation::select_program_factory(old_infra_attributes_create_program, {})));
+
+    EXPECT_TRUE(std::holds_alternative<OldInfraDeviceOperation::MeshWorkloadFactory>(
+        OldInfraDeviceOperation::select_program_factory(old_infra_attributes_create_mesh_workload, {})));
+}
+
+TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
+    auto old_infra_attrs = tt::tt_metal::operation::DeviceOperation(OldInfraDeviceOpWithCreateProgram{});
+
+    EXPECT_EQ(
+        device_operation::MeshDeviceOperationAdapter<
+            tt::tt_metal::operation::OldInfraDeviceOperation<Tensors>>::get_type_name(old_infra_attrs),
+        "OldInfraDeviceOpWithCreateProgram");
+
+    using ::ttnn::operations::examples::ExampleDeviceOperation;
+    EXPECT_EQ(
+        device_operation::MeshDeviceOperationAdapter<ExampleDeviceOperation>::get_type_name(
+            ExampleDeviceOperation::operation_attributes_t{.attribute = true, .some_other_attribute = 42}),
+        "ExampleDeviceOperation");
+}
+
+}  // namespace
+}  // namespace ttnn

--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -8,17 +8,76 @@
 
 #include <tt-metalium/program.hpp>
 #include <tt_stl/unique_any.hpp>
+#include <tt_stl/overloaded.hpp>
+
+#include <tt-metalium/mesh_workload.hpp>
 
 namespace tt::tt_metal::program_cache::detail {
 
 template <typename shared_variables_t>
 struct CachedProgram {
-    tt::tt_metal::Program program;
+private:
+    std::optional<tt::tt_metal::Program> owned_program;
+    std::optional<shared_variables_t> owned_shared_variables;
+
+    // Hidden to avoid misuse of `CachedProgram` as a proxy.
+    CachedProgram(tt::tt_metal::Program& program, shared_variables_t& shared_variables) :
+        program{program}, shared_variables{shared_variables} {}
+
+public:
+    tt::tt_metal::Program& program;
+
     // Cached program needs to share shared_variables between create and override_runtime_arguments functions
-    shared_variables_t shared_variables;
+    shared_variables_t& shared_variables;
 
     CachedProgram(tt::tt_metal::Program&& program, shared_variables_t&& shared_variables) :
-        program{std::move(program)}, shared_variables{std::forward<shared_variables_t>(shared_variables)} {}
+        owned_program{std::move(program)},
+        owned_shared_variables{std::move(shared_variables)},
+        program{*owned_program},
+        shared_variables{*owned_shared_variables} {}
+
+    // Move constructor is needed to make `CachedProgram` work with `unique_any`.
+    // `CachedProgram` with owned `program` and `shared_variables` are moved; unowned proxies have their references
+    // effectively copied.
+    CachedProgram(CachedProgram&& other) noexcept :
+        owned_program(std::move(other.owned_program)),
+        owned_shared_variables(std::move(other.owned_shared_variables)),
+        program(owned_program ? *owned_program : other.program),
+        shared_variables(owned_shared_variables ? *owned_shared_variables : other.shared_variables) {}
+
+    // Creates a "proxy" `CachedProgram` that references `program` and `shared_variables`.
+    // Used for adapting `CachedMeshWorkload` to `CachedProgram`, and interfacing with TTNN Ops in
+    // `override_runtime_arguments` methods.
+    static CachedProgram proxy(tt::tt_metal::Program& program, shared_variables_t& shared_variables) {
+        return CachedProgram{program, shared_variables};
+    }
+
+    CachedProgram(const CachedProgram&) = delete;
+    CachedProgram& operator=(const CachedProgram&) = delete;
+    CachedProgram& operator=(CachedProgram&&) = delete;
+};
+
+template <typename shared_variables_t>
+struct CachedMeshWorkload {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    shared_variables_t shared_variables;
+
+    CachedMeshWorkload(tt::tt_metal::distributed::MeshWorkload&& workload, shared_variables_t&& shared_variables) :
+        workload{std::move(workload)}, shared_variables{std::move(shared_variables)} {}
+};
+
+// Adapted cached mesh workload is used to interpop TT-distributed infra that dispatches MeshWorkloads and program
+// factories written for a single device: programs and shared variables are created by single-device program factories,
+// then stamped out to the entire mesh.
+template <typename shared_variables_t>
+struct AdaptedCachedMeshWorkload {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+    AdaptedCachedMeshWorkload(
+        tt::tt_metal::distributed::MeshWorkload&& workload,
+        std::unordered_map<distributed::MeshCoordinateRange, shared_variables_t>&& shared_variables) :
+        workload{std::move(workload)}, shared_variables{std::move(shared_variables)} {}
 };
 
 struct CachedProgramFactory {
@@ -26,12 +85,22 @@ struct CachedProgramFactory {
     static constexpr auto ALIGNMENT = 32;
 
     tt::stl::unique_any<MAX_SIZE, ALIGNMENT> cached_program;
-    // program_factory_index is used to map a runtime value to a program factory type that is being used
-    std::size_t program_factory_index;
+
+    // Used to map a runtime value to a program factory type that is being used
+    std::size_t program_factory_index = 0;
 
     template <typename shared_variables_t>
     CachedProgramFactory(CachedProgram<shared_variables_t>&& cached_program, std::size_t program_factory_index) :
         cached_program{std::move(cached_program)}, program_factory_index{program_factory_index} {}
+
+    template <typename shared_variables_t>
+    CachedProgramFactory(CachedMeshWorkload<shared_variables_t>&& cached_workload, std::size_t program_factory_index) :
+        cached_program{std::move(cached_workload)}, program_factory_index{program_factory_index} {}
+
+    template <typename shared_variables_t>
+    CachedProgramFactory(
+        AdaptedCachedMeshWorkload<shared_variables_t>&& cached_workload, std::size_t program_factory_index) :
+        cached_program{std::move(cached_workload)}, program_factory_index{program_factory_index} {}
 };
 
 // Generic Program Cache: This data structure is tied to a device handle and can store generic program types from

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -202,6 +202,7 @@ set(TTNN_BASE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/global_circular_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/global_semaphore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/run_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/old_infra_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/api.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_tensor_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/distributed/distributed_tensor.cpp

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -11,15 +11,14 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"  // TTNN_TENSOR_PRINT_PROFILE
 #include "ttnn/tensor/types.hpp"
-#include "ttnn/operation.hpp"
 #include "ttnn/config.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn {
 
-using tt::tt_metal::operation::OptionalConstTensors;
-using tt::tt_metal::operation::OptionalTensors;
-using tt::tt_metal::operation::Tensors;
+using OptionalConstTensors = std::vector<std::optional<const Tensor>>;
+using OptionalTensors = std::vector<std::optional<Tensor>>;
+using Tensors = std::vector<Tensor>;
 
 using tt::tt_metal::is_tensor_on_device;
 using tt::tt_metal::is_tensor_on_device_or_multidevice;

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -8,7 +8,7 @@
 #include <optional>
 #include <random>
 #include <tt_stl/overloaded.hpp>
-#include "indestructible.hpp"
+#include <tt_stl/indestructible.hpp>
 #include "ttnn/tensor/tensor.hpp"
 
 #include <tt-metalium/program_cache.hpp>

--- a/ttnn/cpp/ttnn/device_operation.hpp
+++ b/ttnn/cpp/ttnn/device_operation.hpp
@@ -6,6 +6,9 @@
 
 #include <concepts>
 #include <optional>
+#include <random>
+#include <tt_stl/overloaded.hpp>
+#include "indestructible.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 #include <tt-metalium/program_cache.hpp>
@@ -15,7 +18,13 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include "ttnn/core.hpp"
 #include "ttnn/distributed/api.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <type_traits>
 #include "tools/profiler/op_profiler.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
+#include "ttnn/operation_concepts.hpp"
+#include "ttnn/mesh_device_operation_utils.hpp"
+#include "ttnn/distributed/types.hpp"
 
 namespace ttnn {
 
@@ -24,65 +33,19 @@ namespace device_operation {
 template <typename T>
 using CachedProgram = tt::tt_metal::program_cache::detail::CachedProgram<T>;
 
-template <typename program_factory_t>
-concept ProgramFactoryConcept = requires {
-    [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
-        auto cached_program = program_factory_t::create(operation_attributes, tensor_args, tensor_return_value);
-        program_factory_t::override_runtime_arguments(
-            cached_program, operation_attributes, tensor_args, tensor_return_value);
-    };
-};
+// Used for adapting Ops that work with single-device programs and shared variables.
+// Prefer to natively implement `CachedMeshWorkload` that overrides `override_runtime_arguments` at the
+// workload level.
+template <typename T>
+using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<T>;
 
-template <typename device_operation_t>
-concept HasComputeOutputSpecs = requires(device_operation_t op,
-    const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args) {
-    {op.compute_output_specs(operation_attributes, tensor_args)} -> std::same_as<typename device_operation_t::spec_return_value_t>;
-};
-
-template <typename device_operation_t>
-concept DeviceOperationConcept = requires {
-    [](const typename device_operation_t::operation_attributes_t& operation_attributes,
-       const typename device_operation_t::tensor_args_t& tensor_args) {
-        device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
-        device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
-
-        using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;
-        static_assert(std::same_as<
-                      decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
-                      tensor_return_value_t>);
-
-        const auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
-        std::visit(
-            [](auto&& program_factory) {
-                using program_factory_t = std::decay_t<decltype(program_factory)>;
-                static_assert(ProgramFactoryConcept<program_factory_t>);
-            },
-            program_factory);
-    };
-} && HasComputeOutputSpecs<device_operation_t>;
-
-template <typename device_operation_t>
-concept DeviceOperationWithCustomProgramCacheConcept =
-    DeviceOperationConcept<device_operation_t> &&
-    requires(
-        const typename device_operation_t::operation_attributes_t& operation_attributes,
-        const typename device_operation_t::tensor_args_t& tensor_args) {
-        { device_operation_t::compute_program_hash(operation_attributes, tensor_args)} -> std::convertible_to<tt::stl::hash::hash_t>;
-    };
-
-template <typename device_operation_t>
-concept HasSkipLaunch = requires(
-    device_operation_t op,
-    const typename device_operation_t::operation_attributes_t& operation_attributes,
-    const typename device_operation_t::tensor_args_t& tensor_args,
-    const typename device_operation_t::tensor_return_value_t& tensor_return_value) {
-    {
-        device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)
-    } -> std::convertible_to<bool>;
-};
+template <typename T>
+using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorkload<T>;
 
 namespace detail {
+
+using ::tt::tt_metal::program_cache::detail::CachedProgramFactory;
+
 template <typename... Ts>
 [[nodiscard]] std::variant<Ts...> map_index_to_variant(std::size_t i, std::variant<Ts...>) {
     assert(i < sizeof...(Ts));
@@ -92,8 +55,18 @@ template <typename... Ts>
 
 inline const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
 
+// Returns `MeshCoordinateRangeSet` that covers a single coordinate (0,0).
+inline const auto& get_unit_tensor_coords() {
+    static tt::stl::Indestructible<ttnn::MeshCoordinateRangeSet> tensor_coords([]() {
+        ttnn::MeshCoordinateRangeSet res;
+        res.merge(ttnn::MeshCoordinateRange(ttnn::MeshCoordinate(0, 0), ttnn::MeshCoordinate(0, 0)));
+        return res;
+    }());
+    return tensor_coords.get();
+}
+
 template <typename device_operation_t>
-inline auto compute_program_hash(
+auto compute_program_hash(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     if constexpr (DeviceOperationWithCustomProgramCacheConcept<device_operation_t>) {
@@ -107,9 +80,9 @@ inline auto compute_program_hash(
 }
 
 template <typename device_operation_t>
-inline auto& create_or_get_program_from_cache(
-    auto& program_cache,
-    auto program_cache_hit,
+tt::tt_metal::Program& create_or_get_program_from_cache(
+    tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
+    bool program_cache_hit,
     auto program_hash,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args,
@@ -118,24 +91,46 @@ inline auto& create_or_get_program_from_cache(
         ZoneScopedN("Program Cache Miss");
         auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
 
-        auto& program = std::visit(
-            [&program_cache,
-             &program_hash,
-             &operation_attributes,
-             &tensor_args,
-             &tensor_return_value,
-             program_factory_index = program_factory.index()](auto&& program_factory) -> auto& {
-                using program_factory_t = std::decay_t<decltype(program_factory)>;
-                using cached_program_t =
-                    decltype(program_factory_t::create(operation_attributes, tensor_args, tensor_return_value));
-                program_cache.insert(
-                    program_hash,
-                    tt::tt_metal::program_cache::detail::CachedProgramFactory{
-                        program_factory_t::create(operation_attributes, tensor_args, tensor_return_value),
-                        program_factory_index});
-                auto& cached_program_factory = program_cache.get(program_hash);
-                auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
-                return cached_program.program;
+        tt::tt_metal::Program& program = std::visit(
+            tt::stl::overloaded{
+                [&program_cache,
+                 &program_hash,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value,
+                 program_factory_index = program_factory.index()]<ProgramFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> tt::tt_metal::Program& {
+                    using cached_program_t =
+                        decltype(ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value));
+                    program_cache.insert(
+                        program_hash,
+                        CachedProgramFactory{
+                            ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value),
+                            program_factory_index});
+                    auto& cached_program_factory = program_cache.get(program_hash);
+                    auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+                    return cached_program.program;
+                },
+                [&program_cache,
+                 &program_hash,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value,
+                 program_factory_index = program_factory.index()]<MeshWorkloadFactoryConcept WorkloadFactory>(
+                    const WorkloadFactory&) -> tt::tt_metal::Program& {
+                    using cached_mesh_workload_t = WorkloadFactory::cached_mesh_workload_t;
+                    program_cache.insert(
+                        program_hash,
+                        CachedProgramFactory{
+                            WorkloadFactory::create_mesh_workload(
+                                operation_attributes, get_unit_tensor_coords(), tensor_args, tensor_return_value),
+                            program_factory_index});
+                    auto& cached_program_factory = program_cache.get(program_hash);
+                    auto& cached_workload =
+                        cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
+                    TT_FATAL(cached_workload.workload.get_programs().size() == 1, "Expected 1 program in workload.");
+                    return cached_workload.workload.get_programs().begin()->second;
+                },
             },
             program_factory);
         return program;
@@ -148,19 +143,33 @@ inline auto& create_or_get_program_from_cache(
             decltype(device_operation_t::select_program_factory(operation_attributes, tensor_args));
         auto program_factory = map_index_to_variant(program_factory_index, program_factory_variant_t{});
 
-        auto& program = std::visit(
-            [&cached_program_factory, &operation_attributes, &tensor_args, &tensor_return_value](
-                auto&& program_factory) -> auto& {
-                using program_factory_t = std::decay_t<decltype(program_factory)>;
-
-                using cached_program_t =
-                    decltype(program_factory_t::create(operation_attributes, tensor_args, tensor_return_value));
-                auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
-
-                program_factory_t::override_runtime_arguments(
-                    cached_program, operation_attributes, tensor_args, tensor_return_value);
-
-                return cached_program.program;
+        tt::tt_metal::Program& program = std::visit(
+            tt::stl::overloaded{
+                [&cached_program_factory,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value]<ProgramFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> tt::tt_metal::Program& {
+                    using cached_program_t =
+                        decltype(ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value));
+                    auto& cached_program = cached_program_factory.cached_program.template get<cached_program_t>();
+                    ProgramFactory::override_runtime_arguments(
+                        cached_program, operation_attributes, tensor_args, tensor_return_value);
+                    return cached_program.program;
+                },
+                [&cached_program_factory,
+                 &operation_attributes,
+                 &tensor_args,
+                 &tensor_return_value]<MeshWorkloadFactoryConcept WorkloadFactory>(
+                    const WorkloadFactory&) -> tt::tt_metal::Program& {
+                    using cached_mesh_workload_t = WorkloadFactory::cached_mesh_workload_t;
+                    auto& cached_workload =
+                        cached_program_factory.cached_program.template get<cached_mesh_workload_t>();
+                    WorkloadFactory::override_runtime_arguments(
+                        cached_workload, operation_attributes, tensor_args, tensor_return_value);
+                    TT_FATAL(cached_workload.workload.get_programs().size() == 1, "Expected 1 program in workload.");
+                    return cached_workload.workload.get_programs().begin()->second;
+                },
             },
             program_factory);
         return program;
@@ -193,7 +202,6 @@ auto get_operation_name(const typename device_operation_t::operation_attributes_
 
 template <typename device_operation_t>
 inline void log_operation(
-    std::size_t device_operation_id,
     std::size_t device_id,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args,
@@ -228,7 +236,6 @@ inline void log_operation(
 
 template <typename device_operation_t>
 inline void log_operation(
-    std::size_t device_operation_id,
     std::size_t device_id,
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args,
@@ -240,8 +247,15 @@ inline void log_operation(
 
 
 template <DeviceOperationConcept device_operation_t>
-void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& operation_attributes, const auto& tensor_args, auto &tensor_return_value, auto& device) {
+void launch_on_worker_thread(
+    ttnn::QueueId cq_id,
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args,
+    typename device_operation_t::tensor_return_value_t& tensor_return_value,
+    tt::tt_metal::IDevice* device) {
     ZoneScopedN("TT_DNN_DEVICE_OP");
+
+    auto device_operation_id = ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id();
 
     if constexpr (HasSkipLaunch<device_operation_t>) {
         if (device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)) {
@@ -261,7 +275,6 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
     }
 
     log_operation<device_operation_t>(
-            device_operation_id,
             device->id(),
             operation_attributes,
             tensor_args,
@@ -297,7 +310,7 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
         program.set_runtime_id(device_operation_id);
 
         tt::tt_metal::GraphTracker::instance().track_program(&program, device);
-        if(tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
+        if (tt::tt_metal::GraphTracker::instance().hook_program(&program)) {
             return;
         }
 
@@ -313,20 +326,28 @@ void launch_on_worker_thread(auto cq_id, auto device_operation_id, const auto& o
             tensor_return_value);
 
     } else {
-        auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
-
-        auto program = std::visit(
-            [&](auto&& program_factory) {
-                using program_factory_t = std::decay_t<decltype(program_factory)>;
-                return std::make_shared<tt::tt_metal::Program>(
-                    program_factory_t::create(operation_attributes, tensor_args, tensor_return_value).program);
-            },
-            program_factory);
+        std::shared_ptr<tt::tt_metal::Program> program = std::visit(
+            tt::stl::overloaded{
+                [&]<ProgramFactoryConcept ProgramFactory>(
+                    const ProgramFactory&) -> std::shared_ptr<tt::tt_metal::Program> {
+                    auto cached_program =
+                        ProgramFactory::create(operation_attributes, tensor_args, tensor_return_value);
+                    return std::make_shared<tt::tt_metal::Program>(std::move(cached_program.program));
+                },
+                [&]<MeshWorkloadFactoryConcept WorkloadFactory>(
+                    const WorkloadFactory&) -> std::shared_ptr<tt::tt_metal::Program> {
+                    auto cached_workload = WorkloadFactory::create_mesh_workload(
+                        operation_attributes, get_unit_tensor_coords(), tensor_args, tensor_return_value);
+                    TT_FATAL(cached_workload.workload.get_programs().size() == 1, "Expected 1 program in workload.");
+                    return std::make_shared<tt::tt_metal::Program>(
+                        std::move(cached_workload.workload.get_programs().begin()->second));
+                }},
+            device_operation_t::select_program_factory(operation_attributes, tensor_args));
 
         program->set_runtime_id(device_operation_id);
 
         tt::tt_metal::GraphTracker::instance().track_program(program.get(), device);
-        if(tt::tt_metal::GraphTracker::instance().hook_program(program.get())) {
+        if (tt::tt_metal::GraphTracker::instance().hook_program(program.get())) {
             return;
         }
 
@@ -349,12 +370,11 @@ typename device_operation_t::tensor_return_value_t launch_on_single_device(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
     ZoneScopedN("Launch Device Operation");
-    auto device_operation_id = ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id();
 
     // Create output tensor first
     auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);
     auto device = tt::stl::reflection::get_first_object_of_type<Tensor>(tensor_args).device();
-    launch_on_worker_thread<device_operation_t>(cq_id, device_operation_id, operation_attributes, tensor_args, tensor_return_value, device);
+    launch_on_worker_thread<device_operation_t>(cq_id, operation_attributes, tensor_args, tensor_return_value, device);
     return tensor_return_value;
 }
 

--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_cache.hpp>
+
+#include <memory>
+#include <optional>
+#include <functional>
+#include <concepts>
+#include <variant>
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/mesh_device_operation_utils.hpp"
+#include "ttnn/operation_concepts.hpp"
+
+namespace ttnn::device_operation {
+
+template <typename T>
+using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<T>;
+
+/**
+ * A generic adapter that adds mesh device capabilities to any existing device operation.
+ * This adapter delegates to the base operation for standard functionality while providing
+ * default implementations for mesh-specific operations.
+ *
+ * Usage:
+ * 1. From an existing device operation, derive a new operation that uses this adapter
+ * 2. The operation will now work correctly on mesh devices without additional code
+ */
+template <typename DeviceOperation>
+struct MeshDeviceOperationAdapter {
+    // Add type aliases to identify the template parameters
+    using device_operation_t = DeviceOperation;
+
+    // Inherit all typedefs from base operation
+    using operation_attributes_t = typename DeviceOperation::operation_attributes_t;
+    using tensor_args_t = typename DeviceOperation::tensor_args_t;
+    using spec_return_value_t = typename DeviceOperation::spec_return_value_t;
+    using tensor_return_value_t = typename DeviceOperation::tensor_return_value_t;
+    using program_factory_t = typename DeviceOperation::program_factory_t;
+
+    // Delegate to base operation methods
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        return DeviceOperation::select_program_factory(attrs, tensor_args);
+    }
+
+    template <typename... Args>
+    static auto invoke(Args&&... args) {
+        return DeviceOperation::invoke(std::forward<Args>(args)...);
+    }
+
+    // Returns type name of the underlying device operation.
+    // Used for logging and debugging; in particular, Tracy profiler uses this to identify operations.
+    static std::string get_type_name(const operation_attributes_t& attribute) {
+        if constexpr (requires { device_operation_t::get_type_name(attribute); }) {
+            // OldInfraDeviceOperation path.
+            return device_operation_t::get_type_name(attribute);
+        } else {
+            return std::string(tt::stl::get_type_name<device_operation_t>());
+        }
+    }
+
+    static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        DeviceOperation::validate_on_program_cache_hit(attrs, tensor_args);
+    }
+
+    static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        DeviceOperation::validate_on_program_cache_miss(attrs, tensor_args);
+    }
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        return DeviceOperation::compute_output_specs(attrs, tensor_args);
+    }
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        return DeviceOperation::create_output_tensors(attrs, tensor_args);
+    }
+
+    static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
+            return DeviceOperation::compute_program_hash(attrs, tensor_args);
+        } else {
+            return tt::stl::hash::hash_objects_with_default_seed(
+                tt::stl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+        }
+    }
+
+    // An adapter for creating a factory that abides to `MeshWorkloadFactoryConcept` out of `ProgramFactoryConcept`
+    // types.
+    template <ProgramFactoryConcept ProgramFactory>
+    struct MeshWorkloadFactoryAdapter {
+        using shared_variables_t = typename ProgramFactory::shared_variables_t;
+        using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
+
+        static auto create_mesh_workload(
+            const operation_attributes_t& attrs,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            ProgramFactory program_factory;
+
+            tt::tt_metal::distributed::MeshWorkload mesh_workload;
+            std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+            for (const auto& range : tensor_coords.ranges()) {
+                auto cached_program = program_factory.create(attrs, tensor_args, tensor_return_value);
+                mesh_workload.add_program(range, std::move(cached_program.program));
+                shared_variables[range] = std::move(cached_program.shared_variables);
+            }
+
+            return AdaptedCachedMeshWorkload<shared_variables_t>{std::move(mesh_workload), std::move(shared_variables)};
+        }
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            ProgramFactory program_factory;
+
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                auto& shared_variables = cached_workload.shared_variables.at(coordinate_range);
+
+                mesh_device_operation_utils::apply_override_runtime_arguments(
+                    program_factory,
+                    program,
+                    shared_variables,
+                    attrs,
+                    *(coordinate_range.begin()),
+                    tensor_args,
+                    tensor_return_value);
+            }
+        }
+    };
+
+    static tt::stl::hash::hash_t compute_mesh_workload_hash(
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args) {
+        return compute_program_hash(attrs, tensor_args);
+    }
+};
+
+template <typename T>
+struct is_mesh_device_operation_adapter : std::false_type {};
+
+template <typename DeviceOp>
+struct is_mesh_device_operation_adapter<MeshDeviceOperationAdapter<DeviceOp>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_mesh_device_operation_adapter_v = is_mesh_device_operation_adapter<T>::value;
+
+/**
+ * @brief Concept that defines a device operation that has a mesh device adapter.
+ *
+ * This concept requires that the type satisfies both the DeviceOperationConcept
+ * and the MeshDeviceOperationAdapterType concept. It represents operations that
+ * can be executed across multiple devices in a mesh configuration using the
+ * adapter pattern.
+ */
+template <typename device_operation_t>
+concept DeviceOperationWithMeshDeviceAdapter =
+    DeviceOperationConcept<device_operation_t> && is_mesh_device_operation_adapter_v<device_operation_t>;
+
+}  // namespace ttnn::device_operation

--- a/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <unordered_map>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/program_cache.hpp>
+#include <tt_stl/overloaded.hpp>
+
+#include "ttnn/core.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operation_concepts.hpp"
+
+namespace ttnn::device_operation::mesh_device_operation_utils {
+
+template <typename T>
+using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<T>;
+
+// Sets runtime ID for all programs in `workload`.
+inline void set_runtime_id(tt::tt_metal::distributed::MeshWorkload& workload, ttnn::MeshDevice* mesh_device) {
+    for (auto& [_, program] : workload.get_programs()) {
+        program.set_runtime_id(ttnn::CoreIDs::instance().fetch_and_increment_device_operation_id());
+    }
+}
+
+// Tracks all programs in `workload` and returns true if any program was hooked.
+inline bool track_workload(tt::tt_metal::distributed::MeshWorkload& workload, ttnn::MeshDevice* mesh_device) {
+    bool hook_program = false;
+    for (auto& [_, program] : workload.get_programs()) {
+        tt::tt_metal::GraphTracker::instance().track_program(&program, mesh_device);
+        hook_program |= tt::tt_metal::GraphTracker::instance().hook_program(&program);
+    }
+    return hook_program;
+}
+
+// Applies override_runtime_arguments in a uniform way across different program factory interfaces because
+// we have many different program factory interfaces we're currently supporting.
+template <
+    ProgramFactoryConcept ProgramFactory,
+    typename OperationAttributes,
+    typename TensorArgs,
+    typename TensorReturnValue>
+void apply_override_runtime_arguments(
+    const ProgramFactory& factory,
+    tt::tt_metal::Program& program,
+    typename ProgramFactory::shared_variables_t& shared_vars,
+    const OperationAttributes& attrs,
+    const ttnn::MeshCoordinate& coord,
+    const TensorArgs& tensor_args,
+    TensorReturnValue& return_value) {
+    if constexpr (requires {
+                      typename ProgramFactory::cached_program_t;
+                      factory.override_runtime_arguments(
+                          std::declval<typename ProgramFactory::cached_program_t&>(), attrs, tensor_args, return_value);
+                  }) {
+        // Proxy references to `program` and `shared_vars` as a `CachedProgram` object.
+        auto cached_program_proxy = ProgramFactory::cached_program_t::proxy(program, shared_vars);
+        factory.override_runtime_arguments(cached_program_proxy, attrs, tensor_args, return_value);
+    } else {
+        factory.override_runtime_arguments(program, shared_vars, attrs, tensor_args, return_value);
+    }
+}
+
+}  // namespace ttnn::device_operation::mesh_device_operation_utils

--- a/ttnn/cpp/ttnn/old_infra_device_operation.cpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.cpp
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/old_infra_device_operation.hpp"
+
+#include "ttnn/operation.hpp"
+
+namespace tt::tt_metal::operation {
+
+template <typename OutputTensors>
+typename OldInfraDeviceOperation<OutputTensors>::ProgramFactory::cached_program_t
+OldInfraDeviceOperation<OutputTensors>::ProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto program_with_callbacks = operation_attributes.create_program(
+        tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
+    return cached_program_t{
+        std::move(program_with_callbacks.program),
+        shared_variables_t{program_with_callbacks.override_runtime_arguments_callback}};
+}
+
+template <typename OutputTensors>
+void OldInfraDeviceOperation<OutputTensors>::ProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto& override_runtime_arguments_callback = cached_program.shared_variables.override_runtime_arguments_callback;
+    auto& program = cached_program.program;
+
+    if (override_runtime_arguments_callback.has_value()) {
+        operation_attributes.override_runtime_arguments(
+            override_runtime_arguments_callback.value(),
+            program,
+            tensor_args.input_tensors,
+            tensor_args.optional_input_tensors,
+            tensor_return_value);
+    }
+}
+
+template <typename OutputTensors>
+typename OldInfraDeviceOperation<OutputTensors>::MeshWorkloadFactory::cached_mesh_workload_t
+OldInfraDeviceOperation<OutputTensors>::MeshWorkloadFactory::create_mesh_workload(
+    const operation_attributes_t& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto workload_with_callbacks = operation_attributes.create_mesh_workload(
+        tensor_coords, tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
+
+    TT_FATAL(
+        !workload_with_callbacks.workload_callback.has_value() || workload_with_callbacks.per_program_callbacks.empty(),
+        "At most one of 'workload_callback' or 'per_program_callbacks' can be specified.");
+
+    return cached_mesh_workload_t{
+        std::move(workload_with_callbacks.workload),
+        shared_variables_t{
+            std::move(workload_with_callbacks.workload_callback),
+            std::move(workload_with_callbacks.per_program_callbacks)}};
+}
+
+template <typename OutputTensors>
+void OldInfraDeviceOperation<OutputTensors>::MeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    if (cached_workload.shared_variables.workload_callback.has_value()) {
+        operation_attributes.override_runtime_arguments(
+            *cached_workload.shared_variables.workload_callback,
+            cached_workload.workload,
+            tensor_args.input_tensors,
+            tensor_args.optional_input_tensors,
+            tensor_return_value);
+    }
+
+    for (auto& [range, callback] : cached_workload.shared_variables.per_program_callbacks) {
+        auto& program = cached_workload.workload.get_programs().at(range);
+        operation_attributes.override_runtime_arguments(
+            callback, program, tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
+    }
+}
+
+template <typename OutputTensors>
+typename OldInfraDeviceOperation<OutputTensors>::program_factory_t
+OldInfraDeviceOperation<OutputTensors>::select_program_factory(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    return attributes.has_create_workload_method() ? program_factory_t{MeshWorkloadFactory{}}
+                                                   : program_factory_t{ProgramFactory{}};
+}
+
+template <typename OutputTensors>
+void OldInfraDeviceOperation<OutputTensors>::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    attributes.validate(
+        tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_args.optional_output_tensors);
+}
+
+template <typename OutputTensors>
+void OldInfraDeviceOperation<OutputTensors>::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(attributes, tensor_args);
+}
+
+template <typename OutputTensors>
+typename OldInfraDeviceOperation<OutputTensors>::spec_return_value_t
+OldInfraDeviceOperation<OutputTensors>::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    return attributes.compute_output_specs(tensor_args.input_tensors, tensor_args.optional_output_tensors);
+}
+
+template <typename OutputTensors>
+typename OldInfraDeviceOperation<OutputTensors>::tensor_return_value_t
+OldInfraDeviceOperation<OutputTensors>::create_output_tensors(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    return attributes.create_output_tensors(tensor_args.input_tensors, tensor_args.optional_output_tensors);
+}
+
+template <typename OutputTensors>
+tt::stl::hash::hash_t OldInfraDeviceOperation<OutputTensors>::compute_program_hash(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    return attributes.compute_program_hash(tensor_args.input_tensors, tensor_args.optional_input_tensors);
+}
+
+template <typename OutputTensors>
+auto OldInfraDeviceOperation<OutputTensors>::create_op_performance_model(
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    return attributes.create_op_performance_model(
+        tensor_args.input_tensors, tensor_args.optional_input_tensors, tensor_return_value);
+}
+
+template <typename OutputTensors>
+std::string OldInfraDeviceOperation<OutputTensors>::get_type_name(const operation_attributes_t& attributes) {
+    return attributes.get_type_name();
+}
+
+template <typename OutputTensors>
+std::tuple<
+    typename OldInfraDeviceOperation<OutputTensors>::operation_attributes_t,
+    typename OldInfraDeviceOperation<OutputTensors>::tensor_args_t>
+OldInfraDeviceOperation<OutputTensors>::invoke(
+    operation_attributes_t&& operation_attributes,
+    const operation::Tensors& input_tensors,
+    const operation::OptionalConstTensors& optional_input_tensors,
+    const operation::OptionalTensors& optional_output_tensors) {
+    return std::make_tuple(
+        std::move(operation_attributes), tensor_args_t{input_tensors, optional_input_tensors, optional_output_tensors});
+}
+
+template struct OldInfraDeviceOperation<Tensors>;
+template struct OldInfraDeviceOperation<OptionalTensors>;
+
+}  // namespace tt::tt_metal::operation

--- a/ttnn/cpp/ttnn/old_infra_device_operation.hpp
+++ b/ttnn/cpp/ttnn/old_infra_device_operation.hpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/decorators.hpp"
+#include "ttnn/operation_concepts.hpp"
+
+namespace tt::tt_metal::operation {
+
+template <typename OutputTensors>
+struct OldInfraDeviceOperation {
+    using operation_attributes_t = operation::DeviceOperation<OutputTensors>;
+
+    struct tensor_args_t {
+        const operation::Tensors input_tensors;
+        const operation::OptionalConstTensors optional_input_tensors;
+        const operation::OptionalTensors optional_output_tensors;
+    };
+
+    using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+
+    using tensor_return_value_t = OutputTensors;
+
+    struct ProgramFactory {
+        struct shared_variables_t {
+            std::optional<operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
+                override_runtime_arguments_callback;
+        };
+        using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+        static cached_program_t create(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_program_t& cached_program,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    struct MeshWorkloadFactory {
+        struct shared_variables_t {
+            std::optional<operation::OverrideRuntimeArgumentsWorkloadCallback<OutputTensors>> workload_callback;
+            std::unordered_map<ttnn::MeshCoordinateRange, operation::OverrideRuntimeArgumentsCallback<OutputTensors>>
+                per_program_callbacks;
+        };
+        using cached_mesh_workload_t = ttnn::device_operation::CachedMeshWorkload<shared_variables_t>;
+
+        static cached_mesh_workload_t create_mesh_workload(
+            const operation_attributes_t& operation_attributes,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    // When the wrapped operation has `create_mesh_workload` method, `OldInfraDeviceOperation` adapter will select
+    // `MeshWorkloadFactory` as the program factory.
+    static_assert(
+        !ttnn::device_operation::ProgramFactoryConcept<MeshWorkloadFactory> &&
+        ttnn::device_operation::MeshWorkloadFactoryConcept<MeshWorkloadFactory>);
+    static_assert(
+        ttnn::device_operation::ProgramFactoryConcept<ProgramFactory> &&
+        !ttnn::device_operation::MeshWorkloadFactoryConcept<ProgramFactory>);
+
+    using program_factory_t = std::variant<ProgramFactory, MeshWorkloadFactory>;
+
+    // Mandatory methods
+
+    // Select the program factory based on the operation attributes and tensor args
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Validate the operation when it creates a program. Usually will have more checks
+    static void validate_on_program_cache_miss(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Validate the operation when it reuses a program. Usually will have less checks
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Compute the output specs based on the operation attributes and tensor args
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    // Create the output tensors based on the operation attributes and tensor args
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    static tt::stl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+
+    static auto create_op_performance_model(
+        const operation_attributes_t& attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static std::string get_type_name(const operation_attributes_t& attributes);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        operation_attributes_t&& operation_attributes,
+        const operation::Tensors& input_tensors,
+        const operation::OptionalConstTensors& optional_input_tensors,
+        const operation::OptionalTensors& optional_output_tensors);
+};
+
+}  // namespace tt::tt_metal::operation
+
+namespace ttnn::prim {
+
+constexpr auto old_infra_device_operation = ttnn::register_operation<
+    "ttnn::prim::old_infra_device_operation",
+    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::Tensors>>();
+constexpr auto old_infra_device_operation_with_optional_output_tensors = ttnn::register_operation<
+    "ttnn::prim::old_infra_device_operation_with_optional_output_tensors",
+    tt::tt_metal::operation::OldInfraDeviceOperation<tt::tt_metal::operation::OptionalTensors>>();
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operation_concepts.hpp
+++ b/ttnn/cpp/ttnn/operation_concepts.hpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <concepts>
+#include <optional>
+#include <random>
+#include <type_traits>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/graph_tracking.hpp>
+#include <tt-metalium/program_cache.hpp>
+
+#include <tt_stl/reflection.hpp>
+
+#include "ttnn/distributed/types.hpp"
+
+namespace ttnn::device_operation {
+
+template <typename T>
+concept ProgramFactoryConcept = requires {
+    typename T::cached_program_t;
+
+    [](const auto& operation_attributes, const auto& tensor_args, auto& tensor_return_value) {
+        auto cached_program = T::create(operation_attributes, tensor_args, tensor_return_value);
+
+        T::override_runtime_arguments(cached_program, operation_attributes, tensor_args, tensor_return_value);
+    };
+};
+
+template <typename T>
+concept MeshWorkloadFactoryConcept = requires {
+    typename T::cached_mesh_workload_t;
+
+    [](const auto& operation_attributes,
+       const ttnn::MeshCoordinateRangeSet& tensor_coords,
+       const auto& tensor_args,
+       auto& tensor_return_value) {
+        auto cached_workload =
+            T::create_mesh_workload(operation_attributes, tensor_coords, tensor_args, tensor_return_value);
+
+        T::override_runtime_arguments(cached_workload, operation_attributes, tensor_args, tensor_return_value);
+    };
+};
+
+template <typename device_operation_t>
+concept HasComputeOutputSpecs = requires(
+    device_operation_t op,
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        op.compute_output_specs(operation_attributes, tensor_args)
+    } -> std::same_as<typename device_operation_t::spec_return_value_t>;
+};
+
+template <typename device_operation_t>
+concept DeviceOperationConcept = requires {
+    [](const typename device_operation_t::operation_attributes_t& operation_attributes,
+       const typename device_operation_t::tensor_args_t& tensor_args) {
+        device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
+        device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
+
+        using tensor_return_value_t = typename device_operation_t::tensor_return_value_t;
+        static_assert(std::same_as<
+                      decltype(device_operation_t::create_output_tensors(operation_attributes, tensor_args)),
+                      tensor_return_value_t>);
+
+        // All program factories returned by `select_program_factory` must implement exactly one of
+        // `ProgramFactoryConcept` or `MeshWorkloadFactoryConcept`.
+        const auto program_factory = device_operation_t::select_program_factory(operation_attributes, tensor_args);
+        std::visit(
+            []<typename T>(const T&) { static_assert(ProgramFactoryConcept<T> != MeshWorkloadFactoryConcept<T>); },
+            program_factory);
+    };
+} && HasComputeOutputSpecs<device_operation_t>;
+
+template <typename device_operation_t>
+concept DeviceOperationWithCustomProgramCacheConcept =
+    DeviceOperationConcept<device_operation_t> &&
+    requires(
+        const typename device_operation_t::operation_attributes_t& operation_attributes,
+        const typename device_operation_t::tensor_args_t& tensor_args) {
+        {
+            device_operation_t::compute_program_hash(operation_attributes, tensor_args)
+        } -> std::convertible_to<tt::stl::hash::hash_t>;
+    };
+
+template <typename device_operation_t>
+concept HasSkipLaunch = requires(
+    device_operation_t op,
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args,
+    const typename device_operation_t::tensor_return_value_t& tensor_return_value) {
+    {
+        device_operation_t::skip_launch(operation_attributes, tensor_args, tensor_return_value)
+    } -> std::convertible_to<bool>;
+};
+
+}  // namespace ttnn::device_operation


### PR DESCRIPTION
### Ticket
#18572

### Problem description
TTNN mesh dispatch infra was implemented on a side branch. Some changes that support the implementation can be merged to main independently.

### What's changed
Key changes used by TT-distributed:
* `MeshDeviceOperationAdapter` and `MeshWorkloadFactoryAdapter`, along with `mesh_device_operation_utils.hpp`. This is currently unused, see https://github.com/tenstorrent/tt-metal/pull/18067 for context.
* Extension to old style `DeviceOperation` to support creating mesh workload.
  * Note `has_create_workload_method` determines at runtime which factory should be selected - either program factory or mesh workload factory. See `test_launch_operation.cpp` for a sample usage.
* In `device_operation.hpp`: if an op selects to use mesh workload factory while running on a single / legacy device, the code calls the mesh workload factory and extracts the first (and only) program from it, and launches that instead.

Other minor changes:
* Overall niceties.
* Separated `OldInfraDeviceOperation` into a header.
* Separated device / program factory concepts into a header.
* Add some test coverage. 

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14348557521)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14348561646)
- [X] New/Existing tests provide coverage for changes