### PR TITLE
Added physical_shard_shape to ShardSpec pybind

### DIFF
--- a/ttnn/cpp/pybind11/tensor.cpp
+++ b/ttnn/cpp/pybind11/tensor.cpp
@@ -257,6 +257,8 @@ void tensor_mem_config_module(py::module& m_tensor) {
         .def_readwrite("grid", &ShardSpec::grid, "Grid to layout shards.")
         .def_readwrite("orientation", &ShardSpec::orientation, "Orientation of cores to read shards")
         .def_readwrite("mode", &ShardSpec::mode, "Treat shard shape as physical (default) or logical")
+        .def_readwrite("physical_shard_shape", &ShardSpec::physical_shard_shape, "The shape of the shard including padding when logical sharding is used.")
+
         .def("num_cores", &ShardSpec::num_cores, "Number of cores")
         .def(py::self == py::self)
         .def(py::self != py::self);


### PR DESCRIPTION
### Problem description
No pybind for `ShardSpec::physical_shard_shape`

### What's changed
Added pybind for `ShardSpec::physical_shard_shape`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes