### PR TITLE
Fix moreh sum in BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_sum.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_sum.py
@@ -496,7 +496,6 @@ def test_moreh_sum_backward_fp32_dest_acc(input_shape, dim, compute_kernel_optio
     assert passing
 
 
-@skip_for_blackhole("Fails on BH. Issue #19911")
 @pytest.mark.parametrize(
     "input_shape",
     [

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -16,47 +16,21 @@ using namespace sfpi;
 namespace ckernel {
 namespace sfpu {
 
-#define BIT_MASK_32 0xFFFFFFFF
-#define SIGN 0x80000000
-#define MAGNITUDE 0x7FFFFFFF
-
-sfpi_inline vInt sfpu_twos_comp_to_sign_mag(vInt value) {
-    v_if(value & SIGN) {
-        vInt magnitude = (~value + 1) & MAGNITUDE;
-        value = SIGN | magnitude;
-    }
-    v_endif;
-    return value;
-}
-
-sfpi_inline vInt sfpu_sign_mag_to_twos_comp(vInt value) {
-    v_if(value & SIGN) {
-        vInt magnitude = value & MAGNITUDE;
-        value = (~magnitude + 1) & BIT_MASK_32;
-    }
-    v_endif;
-    return value;
-}
-
 template <bool APPROXIMATION_MODE>
 inline void calculate_sum_int_col() {
     for (size_t i = 0; i < 2; ++i) {
         vInt a = dst_reg[i];
-        a = sfpu_twos_comp_to_sign_mag(a);
 
         for (size_t j = 2; j < 8; j += 2) {
             vInt b = dst_reg[i + j];
-            b = sfpu_twos_comp_to_sign_mag(b);
             a += b;
         }
 
         for (size_t j = 16; j < 24; j += 2) {
             vInt b = dst_reg[i + j];
-            b = sfpu_twos_comp_to_sign_mag(b);
             a += b;
         }
 
-        a = sfpu_sign_mag_to_twos_comp(a);
         dst_reg[i] = a;
     }
 }
@@ -65,16 +39,13 @@ template <bool APPROXIMATION_MODE>
 inline void calculate_sum_int_row() {
     for (size_t i = 0; i < 8; i += 2) {
         vInt a = dst_reg[i];
-        a = sfpu_twos_comp_to_sign_mag(a);
 
         int arr[] = {1, 8, 9};
         for (size_t j = 0; j < sizeof(arr) / sizeof(arr[0]); ++j) {
             vInt b = dst_reg[i + arr[j]];
-            b = sfpu_twos_comp_to_sign_mag(b);
             a += b;
         }
 
-        a = sfpu_sign_mag_to_twos_comp(a);
         dst_reg[i] = a;
     }
 }
@@ -88,11 +59,8 @@ inline void add_int(const uint dst_offset) {
     for (int d = 0; d < ITERATIONS; d++) {
         vInt a = dst_reg[0];
         vInt b = dst_reg[32];
-        a = sfpu_twos_comp_to_sign_mag(a);
-        b = sfpu_sign_mag_to_twos_comp(b);
 
         vInt r = a + b;
-        r = sfpu_sign_mag_to_twos_comp(r);
 
         dst_reg[0] = r;
         dst_reg++;


### PR DESCRIPTION
### Ticket
#19911 

### Problem description
BH TTNN Unit test failure in moreh sum test

### What's changed
Remove conversion of 2's complement <-> sign magnitude

negative int numbers are not adding properly in WH, so they are converting it to sign magnitude, then add then convert it to 2's complement to get the actual result

<img width="1046" alt="Image" src="https://github.com/user-attachments/assets/1bda6290-bf30-4555-b147-f1adcd1f1159" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/14350752082
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/14350754948
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes