### PR TITLE
Add mini stress test (2k iterations) to nightly

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -31,6 +31,13 @@ jobs:
             timeout: 25,
             owner_id: U071CKL4AFK
           }, # Ammar Vora
+          {
+            name: "Llama TG Demo Long Generation Test",
+            arch: wormhole_b0,
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_WORKER_RINGBUFFER_SIZE=122880 TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_llama_demo.py  -k mini-stress-test",
+            timeout: 40,
+            owner_id: U044T8U8DEF
+          }, # Johanna Rock
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -34,7 +34,7 @@ jobs:
           {
             name: "Llama TG Demo Long Generation Test",
             arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_WORKER_RINGBUFFER_SIZE=122880 TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_llama_demo.py  -k mini-stress-test",
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_WORKER_RINGBUFFER_SIZE=122880 TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k mini-stress-test",
             timeout: 40,
             owner_id: U044T8U8DEF
           }, # Johanna Rock

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -554,6 +554,21 @@ def run_llama3_demo(
             True,  # stress_test
             0,  # start_pos
         ),
+        (  # full demo, long generation test
+            "instruct",
+            80,
+            "models/demos/llama3_subdevices/demo/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            1024,  # max_seq_len
+            32,  # batch_size
+            2048,  # max_generated_tokens (same index for stress test)
+            False,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks": 1024},  # page_params  # TODO This will be serviced by vLLM
+            {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)
+            True,  # stress_test
+            0,  # start_pos
+        ),
         (  # 10 layers for devive perf measurements
             "instruct",
             10,
@@ -574,6 +589,7 @@ def run_llama3_demo(
         "full",  # full demo
         "quick",  # 1L demo
         "stress-test",  # stress test with many iterations and same token index, full model
+        "mini-stress-test",  # mini stress test with 2048 max_generated_tokens
         "measure-device-perf",  # 10L demo for device performance measurements
     ],
 )


### PR DESCRIPTION
### Ticket
None

### Problem description
Stress test is run only once a week. In order to catch hangs better we need a small version of that stress test in nightly.

### What's changed
2k iteration stress test of 80L full demo is added to nightly.

### Checklist
- [ ] [Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/14353843508)