### PR TITLE
Reuse SD weights on weka

### DIFF
--- a/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
+++ b/.github/workflows/fast-dispatch-full-regressions-and-models-impl.yaml
@@ -150,7 +150,7 @@ jobs:
       matrix:
         test-config:
           - model: "stable_diffusion"
-            cmd: SLOW_MATMULS=1 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
+            cmd: TRANSFORMERS_CACHE=/mnt/MLPerf/tt_dnn-models/StableDiffusion HF_HOME=/mnt/MLPerf/tt_dnn-models/StableDiffusion SLOW_MATMULS=1 pytest --timeout 1000 -n auto tests/nightly/single_card/stable_diffusion
               # Skipping due to issue #15932
               # - model: "mamba 1"
               # cmd: pytest --timeout 900 -n auto tests/nightly/single_card/mamba --splits 6 --group 1

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -61,7 +61,7 @@ jobs:
           if [[ "${{ matrix.test-info.arch }}" == "wormhole_b0" ]]; then
             export MAGIC_ENV=wormhole_b0_80_arch_eth_dispatch.yaml
           fi
-          pytest models/demos/wormhole/stable_diffusion/tests -m models_device_performance_bare_metal --timeout=600
+          TRANSFORMERS_CACHE=/mnt/MLPerf/tt_dnn-models/StableDiffusion HF_HOME=/mnt/MLPerf/tt_dnn-models/StableDiffusion pytest models/demos/wormhole/stable_diffusion/tests -m models_device_performance_bare_metal --timeout=600
           pytest models/demos/distilbert/tests -m models_device_performance_bare_metal
           pytest models/demos/vgg/tests/ -m models_device_performance_bare_metal
           pytest models/demos/convnet_mnist/tests/ -m models_device_performance_bare_metal

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -84,7 +84,7 @@ run_perf_models_cnn_javelin() {
 
     # Run tests
     env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/functional_unet/tests -m $test_marker
-    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480
+    env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml TRANSFORMERS_CACHE=/mnt/MLPerf/tt_dnn-models/StableDiffusion HF_HOME=/mnt/MLPerf/tt_dnn-models/StableDiffusion pytest -n auto models/demos/wormhole/stable_diffusion/tests -m $test_marker --timeout=480
 
     ## Merge all the generated reports
     env python3 models/perf/merge_perf_results.py

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -119,7 +119,7 @@ run_roberta_func() {
 
 run_stable_diffusion_func() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings --input-path="models/demos/wormhole/stable_diffusion/demo/input_data.json" models/demos/wormhole/stable_diffusion/demo/demo.py::test_demo --timeout 900
+  TRANSFORMERS_CACHE=/mnt/MLPerf/tt_dnn-models/StableDiffusion HF_HOME=/mnt/MLPerf/tt_dnn-models/StableDiffusion WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings --input-path="models/demos/wormhole/stable_diffusion/demo/input_data.json" models/demos/wormhole/stable_diffusion/demo/demo.py::test_demo --timeout 900
 
 }
 


### PR DESCRIPTION
### Ticket
#19906

### Problem description
For SD 1.4, weights were downloaded every time pipeline was triggered. It took some time in the test itself, and caused tests to randomly crash due to loss of HF connection.

### What's changed
- Weights were to home folder downloaded to shared storage (`/mnt/MLPerf/tt_dnn-models/StableDiffusion`)
- `TRANSFORMERS_CACHE` and `HF_HOME` are set to point there, and downloaded weights are reused

### Checklist
- [ ] [(Single-card) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/14469397769)
- [ ] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/14469412610)
- [ ] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/14469420915)
- [ ] [(Single-card) Frequent model and ttnn tests) Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/14469430112)