### PR TITLE
Gridsample support

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_gridsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_gridsample.py
@@ -3,15 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import math
-from loguru import logger
-from typing import Union, Tuple
 
 import torch
 import torch.nn as nn
 import ttnn
-from models.utility_functions import skip_for_grayskull, skip_for_blackhole, is_grayskull
-from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/pool/test_gridsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_gridsample.py
@@ -5,7 +5,6 @@
 import pytest
 
 import torch
-import torch.nn as nn
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
 

--- a/tests/ttnn/unit_tests/operations/pool/test_gridsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_gridsample.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import math
+from loguru import logger
+from typing import Union, Tuple
+
+import torch
+import torch.nn as nn
+import ttnn
+from models.utility_functions import skip_for_grayskull, skip_for_blackhole, is_grayskull
+from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc_without_tensor_printout
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        [1, 1, 1, 3],
+        [1, 1, 32, 32],
+    ],
+)
+@pytest.mark.parametrize("align_corners", [True])
+@pytest.mark.parametrize(
+    "grid",
+    [
+        torch.tensor(
+            [
+                [0.25, 0.75],
+                [0.75, 0.25],
+                [0.5, 1.5],
+                [1.5, 0.5],
+                [0.0, 0.0],
+                [1.0, 1.0],
+            ],
+            dtype=torch.float32,
+        ).view(1, 6, 1, 2)
+    ],
+)
+def test_gridsample(device, input_shape, align_corners, grid):
+    torch.manual_seed(0)
+
+    input_tensor = torch.rand((input_shape), dtype=torch.float32)
+    torch_output = torch.nn.functional.grid_sample(input_tensor, grid, mode="bilinear", align_corners=align_corners)
+
+    input_tensor = ttnn.from_torch(input_tensor, device=device)
+    grid_tensor = ttnn.from_torch(grid, device=device)
+
+    output_tensor = ttnn.gridsample(input_tensor, grid_tensor, mode="bilinear", align_corners=align_corners)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(torch_output, output_tensor, 0.99999)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -543,6 +543,9 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device//upsample_bilinear_program_factory_multicore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_singlecore.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/upsample.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/gridsample/gridsample.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/gridsample/device/gridsample_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/gridsample/device/gridsample_rm_bilinear_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/argmax/argmax.cpp
@@ -953,6 +956,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/downsample/downsample_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/generic/generic_pools_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/upsample/upsample_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/pool/gridsample/gridsample_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/prefetcher/prefetcher_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/reduction_pybind.cpp

--- a/ttnn/cpp/pybind11/operations/__init__.hpp
+++ b/ttnn/cpp/pybind11/operations/__init__.hpp
@@ -48,6 +48,7 @@
 #include "ttnn/operations/transformer/transformer_pybind.hpp"
 #include "ttnn/operations/prefetcher/prefetcher_pybind.hpp"
 #include "ttnn/operations/uniform/uniform_pybind.hpp"
+#include "ttnn/operations/pool/gridsample/gridsample_pybind.hpp"
 
 namespace py = pybind11;
 
@@ -136,6 +137,7 @@ void py_module(py::module& module) {
     avgpool::py_module(m_pool);
     upsample::py_module(m_pool);
     downsample::py_bind_downsample(m_pool);
+    gridsample::py_module(m_pool);
 
     auto m_normalization = module.def_submodule("normalization", "normalization operations");
     normalization::py_module(m_normalization);

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/device/gridsample_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/device/gridsample_op.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gridsample_op.hpp"
+#include <algorithm>
+#include <cmath>
+
+#include <tt-metalium/util.hpp>
+#include "ttnn/tensor/host_buffer/functions.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
+#include <tt-metalium/work_split.hpp>
+
+namespace ttnn::operations::gridsample {
+using namespace tt;
+using namespace tt::tt_metal;
+
+void gridsample::validate(const std::vector<Tensor>& input_tensors) const {
+    const auto& input_tensor_a = input_tensors.at(0);
+    const auto& grid = input_tensors.at(1);
+
+    TT_FATAL(
+        input_tensor_a.get_logical_shape()[0] == grid.get_logical_shape()[0],
+        "Input tensor and grid should have same batch size");
+    TT_FATAL(input_tensor_a.storage_type() == StorageType::DEVICE, "Operands to copy need to be on device!");
+    TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands to copy need to be allocated in buffers on device!");
+    TT_FATAL(input_tensor_a.get_layout() == Layout::ROW_MAJOR, "Input tensor layout should be ROW_MAJOR");
+    TT_FATAL(input_tensor_a.get_dtype() == DataType::FLOAT32, "Input tensor data type should be BFLOAT16");
+    TT_FATAL(input_tensor_a.get_logical_shape().rank() == 4, "Input tensor should be in 4D");
+    TT_FATAL(mode == "bilinear", "Upsample only supports bilinear or for now");
+}
+
+ttnn::Shape gridsample::compute_output_shape(const ttnn::Shape& input_shape, const ttnn::Shape& grid_shape) const {
+    return ttnn::Shape{input_shape[0], input_shape[1], grid_shape[1], grid_shape[2]};
+}
+
+std::vector<TensorSpec> gridsample::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+    const auto& input = input_tensors.at(0);
+
+    const auto& grid = input_tensors.at(1);
+
+    auto output_shape = compute_output_shape(input.get_logical_shape(), grid.get_logical_shape());
+
+    return {
+        TensorSpec(output_shape, TensorLayout(input.get_dtype(), PageConfig(input.get_layout()), output_mem_config_))};
+}
+
+operation::ProgramWithCallbacks gridsample::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const Tensor& input_tensor_0 = input_tensors.at(0);
+    Tensor& output_tensor_0 = output_tensors.at(0);
+    const Tensor& reshaped_input = input_tensors.at(2);
+
+    return gridsample_rm_single_core(
+        input_tensor_0, output_tensor_0, reshaped_input, normalized_grid, mode, align_corners);
+}
+}  // namespace ttnn::operations::gridsample

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/device/gridsample_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/device/gridsample_op.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/run_operation.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+namespace ttnn::operations::gridsample {
+
+struct gridsample {
+    std::vector<float> normalized_grid;
+    std::string mode;
+    bool align_corners;
+    const tt::tt_metal::MemoryConfig output_mem_config_;
+    const DeviceComputeKernelConfig compute_kernel_config_;
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    ttnn::Shape compute_output_shape(const ttnn::Shape& input_shape, const ttnn::Shape& grid_shape) const;
+    std::vector<TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+tt::tt_metal::operation::ProgramWithCallbacks gridsample_rm_single_core(
+    const Tensor& input,
+    Tensor& output,
+    const Tensor& reshaped_input,
+    const std::vector<float>& normalized_grid,
+    const std::string& mode,
+    bool align_corners);
+}  // namespace ttnn::operations::gridsample

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/device/gridsample_rm_bilinear_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/device/gridsample_rm_bilinear_program_factory.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <math.h>
+
+#include "tt-metalium/circular_buffer.hpp"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "gridsample_op.hpp"
+#include "ttnn/operations/math.hpp"
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+#include <tt-metalium/math.hpp>
+// #include "ttnn/tensor/tensor_utils.hpp"
+#include "ttnn/operations/reduction/generic/device/reduce_op.hpp"  // for reduce_op_utils
+
+#include <tt_stl/reflection.hpp>
+#include "ttnn/operations/functions.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/operations/sliding_window/halo/halo.hpp"
+
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+#include <tt-metalium/command_queue.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/device.hpp>
+
+using namespace tt::constants;
+
+namespace ttnn::operations::gridsample {
+using namespace tt;
+using namespace tt::tt_metal;
+
+operation::ProgramWithCallbacks gridsample_rm_single_core(
+    const Tensor& input,
+    Tensor& output,
+    const Tensor& reshaped_input,
+    const std::vector<float>& normalized_grid,
+    const std::string& mode,
+    bool align_corners) {
+    Program program{};
+    CoreRange core({0, 0}, {0, 0});
+
+    auto output_shape = output.get_logical_shape();
+
+    auto input_shape = input.get_logical_shape();
+
+    tt::DataFormat input_cb_data_format = tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    uint32_t input_unit_size =
+        input.volume() * input.element_size();  // N * C * H * W -> As we require entire input tensor
+    tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    uint32_t output_unit_size = output.element_size();  // 1 element size as we store 1 element at a time.
+
+    int batch_size = input.get_logical_shape()[0];
+    int channels = input.get_logical_shape()[1];
+
+    int total_count = output_shape[2] * output_shape[3] * 2;  // for i and i + 1
+    // we will iterate the Normalized Grid input_num_units times to retrieve the output
+
+    // This should allocate a DRAM buffer on the device
+    tt_metal::IDevice* device = output.device();
+
+    // circular buffer for input
+    uint32_t src0_cb_index = CBIndex::c_0;
+
+    uint32_t num_input_units = 2;
+    uint32_t aligned_input_unit_size = tt::round_up(input_unit_size, hal::get_dram_alignment());
+
+    tt_metal::CircularBufferConfig cb_src0_config =
+        tt_metal::CircularBufferConfig(
+            num_input_units * aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
+            .set_page_size(src0_cb_index, aligned_input_unit_size);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
+
+    tt_metal::CircularBufferConfig cb_src1_config =
+        tt_metal::CircularBufferConfig(num_input_units * aligned_input_unit_size, {{1, input_cb_data_format}})
+            .set_page_size(1, aligned_input_unit_size);
+    auto cb_src1 = tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
+
+    tt_metal::CircularBufferConfig cb_src2_config =
+        tt_metal::CircularBufferConfig(num_input_units * aligned_input_unit_size, {{2, input_cb_data_format}})
+            .set_page_size(2, aligned_input_unit_size);
+    auto cb_src2 = tt_metal::CreateCircularBuffer(program, core, cb_src2_config);
+
+    uint32_t output_cb_index = src0_cb_index;  // same as input cb
+
+    auto src_buffer = reshaped_input.buffer();
+    auto dst_buffer = output.buffer();
+    bool src_is_dram = src_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+    bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
+
+    std::vector<uint32_t> reader_compile_time_args, writer_compile_time_args;
+
+    int Gridoffset = output_shape[2] * output_shape[3] * 2;
+    int row = input_shape[2];
+    int col = input_shape[3];
+
+    constexpr uint32_t single_tile_size = 2 * (32 * 32);
+    constexpr uint32_t num_tiles = 50;
+    constexpr uint32_t dram_buffer_size = single_tile_size * num_tiles;
+
+    tt::tt_metal::InterleavedBufferConfig l1_config{
+        .device = device,
+        .size = dram_buffer_size,
+        .page_size = dram_buffer_size,
+        .buffer_type = tt::tt_metal::BufferType::L1};
+
+    ttnn::Shape gridshape{1, 1, 1, batch_size * output_shape[2] * output_shape[3] * 2};
+
+    TensorSpec output_spec =
+        TensorSpec(gridshape, TensorLayout(DataType::FLOAT32, PageConfig(input.get_layout()), input.memory_config()));
+
+    ttnn::Tensor grid = ttnn::Tensor::from_vector<float>(normalized_grid, output_spec, device);
+
+    auto grid_buffer = grid.buffer();
+
+    uint32_t grid_size = grid.volume() * grid.element_size();
+
+    reader_compile_time_args = {
+        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)src_is_dram,
+        (std::uint32_t)channels,
+        (std::uint32_t)batch_size,
+        (std::uint32_t)total_count,
+        (std::uint32_t)Gridoffset,
+        (std::uint32_t)row,
+        (std::uint32_t)col};
+
+    std::map<string, string> kernel_defines;
+
+    // Perform Reading and Writing the data in the reader kernel
+    tt_metal::KernelHandle unary_reader_kernel_id = tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/pool/gridsample/device/kernels/"
+        "reader_gridsample_rm_bilinear_layout_interleaved_start_id.cpp",
+        core,
+        tt_metal::ReaderDataMovementConfig(reader_compile_time_args, kernel_defines));
+
+    SetRuntimeArgs(
+        program,
+        unary_reader_kernel_id,
+        core,
+        {src_buffer->address(),
+         dst_buffer->address(),
+         grid_buffer->address(),
+         input_unit_size,
+         output_unit_size,
+         grid_size});
+
+    auto override_runtime_args_callback = [unary_reader_kernel_id, grid_buffer](
+                                              const void* operation,
+                                              Program& program,
+                                              const std::vector<Tensor>& input_tensors,
+                                              const std::vector<std::optional<const Tensor>>&,
+                                              const std::vector<Tensor>& output_tensors) {
+        auto src_buffer = input_tensors.at(0).buffer();
+
+        auto dst_buffer = output_tensors.at(0).buffer();
+
+        CoreCoord core = {0, 0};
+
+        {
+            auto& runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
+            runtime_args[0] = src_buffer->address();
+            runtime_args[1] = dst_buffer->address();
+            runtime_args[2] = grid_buffer->address();
+        }
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_args_callback};
+}
+}  // namespace ttnn::operations::gridsample

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/device/kernels/reader_gridsample_rm_bilinear_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/device/kernels/reader_gridsample_rm_bilinear_layout_interleaved_start_id.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/device/kernels/reader_gridsample_rm_bilinear_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/device/kernels/reader_gridsample_rm_bilinear_layout_interleaved_start_id.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+#include <tuple>
+#include <cmath>
+#include <cstring>
+#define ALWI inline __attribute__((always_inline))
+
+ALWI bool fill_with_val(uint32_t begin_addr, float val) {
+    volatile tt_l1_ptr float* ptr = reinterpret_cast<volatile tt_l1_ptr float*>(begin_addr);
+    for (uint32_t i = 0; i < 32; ++i) {
+        ptr[i] = (val);
+    }
+    return true;
+}
+float lies_in_boundary(float x_in, float y_in, int row, int col, int offset, uint32_t data) {
+    if (x_in < 0 || y_in > row - 1 || y_in < 0 || x_in > col - 1) {
+        return 0;
+    }
+
+    uint32_t cur_pos = offset + (int)y_in * col + (int)x_in;
+
+    float* ptr_1 = (float*)(data);
+
+    float x = (ptr_1[cur_pos]);
+
+    return x;
+}
+
+bool interpolate(float x_in, float y_in, int row, int col, int offset, uint32_t data_writer, uint32_t dest_addr) {
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dest_addr);
+
+    if (x_in == std::numeric_limits<float>::max() || y_in == std::numeric_limits<float>::max()) {
+        fill_with_val(dest_addr, (0));
+
+        return true;
+    }
+
+    if (x_in - (int)x_in == 0 && y_in - (int)y_in == 0) {
+        float val = lies_in_boundary((int)x_in, (int)y_in, row, col, offset, data_writer);
+        fill_with_val(dest_addr, (val));
+        return true;
+    }
+
+    float dy = y_in - floor(y_in);
+    float dx = x_in - floor(x_in);
+
+    std::tuple<float, float> top_left = std::make_tuple(floor(x_in), floor(y_in));
+    std::tuple<float, float> top_right = std::make_tuple(ceil(x_in), floor(y_in));
+    std::tuple<float, float> bottom_left = std::make_tuple(floor(x_in), ceil(y_in));
+    std::tuple<float, float> bottom_right = std::make_tuple(ceil(x_in), ceil(y_in));
+
+    float Q11 = lies_in_boundary(
+        std::get<0>(top_left),
+        std::get<1>(top_left),
+        row,
+        col,
+        offset,
+        data_writer);  // returns the respective value in the Input Tensor or returns 0
+    float Q21 = lies_in_boundary(std::get<0>(top_right), std::get<1>(top_right), row, col, offset, data_writer);
+    float Q12 = lies_in_boundary(std::get<0>(bottom_left), std::get<1>(bottom_left), row, col, offset, data_writer);
+    float Q22 = lies_in_boundary(std::get<0>(bottom_right), std::get<1>(bottom_right), row, col, offset, data_writer);
+
+    float val = (1 - dx) * (1 - dy) * Q11 + dx * (1 - dy) * Q21 + (1 - dx) * dy * Q12 +
+                dx * dy * Q22;  // Formula to perform interpolate
+
+    fill_with_val(dest_addr, (val));
+
+    return true;
+}
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr bool src0_is_dram = get_compile_time_arg_val(1) == 1;
+    constexpr uint32_t channels = get_compile_time_arg_val(2);
+    constexpr uint32_t batch_size = get_compile_time_arg_val(3);
+    constexpr uint32_t total_count = get_compile_time_arg_val(4);
+    constexpr uint32_t Gridoffset = get_compile_time_arg_val(5);
+    constexpr uint32_t row = get_compile_time_arg_val(6);
+    constexpr uint32_t col = get_compile_time_arg_val(7);
+
+    uint32_t src_addr = get_arg_val<uint32_t>(0);   // Input address
+    uint32_t dst_addr = get_arg_val<uint32_t>(1);   //  destination address
+    uint32_t grid_addr = get_arg_val<uint32_t>(2);  // Grid address
+
+    uint32_t volume_size = get_arg_val<uint32_t>(3);
+    uint32_t element_size = get_arg_val<uint32_t>(4);
+    uint32_t grid_size = get_arg_val<uint32_t>(5);
+
+    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = volume_size};  // source
+    const InterleavedAddrGen<src0_is_dram> s1 = {
+        .bank_base_address = dst_addr, .page_size = element_size};  // destination
+    const InterleavedAddrGen<src0_is_dram> s2 = {.bank_base_address = grid_addr, .page_size = grid_size};  // grid
+
+    uint32_t idx = 0;
+
+    for (uint32_t b = 0; b < batch_size; ++b) {
+        int offset = b * Gridoffset;  // move the offset to next batch
+
+        for (uint32_t c = 0; c < channels; ++c) {
+            for (uint32_t i = 0; i < total_count; i += 2) {
+                cb_reserve_back(2, 1);
+
+                uint32_t l1_write_addr_2 = get_write_ptr(2);  // Read the entire input tensor in the cb : 2
+
+                uint64_t grid_noc_addr = get_noc_addr(0, s2);
+
+                noc_async_read(grid_noc_addr, l1_write_addr_2, grid_size);
+
+                noc_async_read_barrier();
+
+                float* ptr_2 = (float*)(l1_write_addr_2);
+
+                float x = (ptr_2[(offset + i)]);
+                float y = (ptr_2[(offset + i + 1)]);
+
+                cb_pop_front(2, 1);
+
+                // Starting point of the element in the tensor for particular batch size, channel
+
+                int offset = b * (channels * row * col) + c * (row * col);
+
+                cb_reserve_back(1, 1);
+
+                uint32_t l1_write_addr_1 = get_write_ptr(1);  // Re>ad the entire input tensor in the c
+
+                uint64_t src_noc_addr = get_noc_addr(0, s0);
+
+                noc_async_read(src_noc_addr, l1_write_addr_1, volume_size);
+
+                noc_async_read_barrier();
+
+                uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
+
+                interpolate(x, y, row, col, offset, l1_write_addr_1, l1_write_addr);
+
+                uint32_t l1_read_addr = get_read_ptr(cb_id_in0);
+
+                uint64_t dst_noc_addr = get_noc_addr(idx, s1);
+
+                noc_async_write(l1_read_addr, dst_noc_addr, element_size);
+
+                noc_async_write_barrier();
+                idx++;
+
+                cb_pop_front(1, 1);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gridsample.hpp"
+#include "device/gridsample_op.hpp"
+#include "ttnn/run_operation.hpp"
+
+namespace ttnn::operations::gridsample {
+
+template <typename T>
+float normalize_index(T val, int size, bool align_corners) {
+    if (align_corners == true) {
+        float computed = (val + 1) * 0.5 * (size - 1);
+        return computed;
+    } else {
+        if (val < -1 || val > 1) {
+            return std::numeric_limits<float>::max();
+        }
+
+        float computed = ((val + 1) * 0.5 * (size)) - 0.5;
+
+        return computed;
+    }
+}
+
+std::vector<float> normalize_grid(const ttnn::Tensor& grid, int height, int width, bool align_corners) {
+    std::vector<float> normalized_grid = grid.to_vector<float>();
+
+    for (int i = 0; i < normalized_grid.size() - 1; i += 2) {
+        normalized_grid[i] = normalize_index<float>(normalized_grid[i], width, align_corners);
+        normalized_grid[i + 1] = normalize_index<float>(normalized_grid[i + 1], height, align_corners);
+    }
+
+    return normalized_grid;
+}
+
+ttnn::Tensor ExecuteGridSample::invoke(
+    const ttnn::Tensor& input_tensor,
+    const ttnn::Tensor& grid,
+    const std::string& mode,
+    const bool align_corners,
+    const std::optional<MemoryConfig>& output_mem_config,
+    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
+    auto normalized_grid =
+        normalize_grid(grid, input_tensor.get_logical_shape()[2], input_tensor.get_logical_shape()[3], align_corners);
+
+    MemoryConfig mem_config = output_mem_config.value_or(input_tensor.memory_config());
+    ttnn::DeviceComputeKernelConfig config = compute_kernel_config.value_or(
+        ttnn::init_device_compute_kernel_config(input_tensor.device()->arch(), std::nullopt, MathFidelity::HiFi4));
+
+    ttnn::Tensor reshaped_input = ttnn::reshape(input_tensor, ttnn::Shape({1, 1, 1, -1}));
+
+    auto output_tensor =
+        tt::tt_metal::operation::run(
+            gridsample{normalized_grid, mode, align_corners, mem_config, config}, {input_tensor, grid, reshaped_input})
+            .front();
+
+    return output_tensor;
+}
+
+}  // namespace ttnn::operations::gridsample

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample.cpp
@@ -14,10 +14,6 @@ float normalize_index(T val, int size, bool align_corners) {
         float computed = (val + 1) * 0.5 * (size - 1);
         return computed;
     } else {
-        if (val < -1 || val > 1) {
-            return std::numeric_limits<float>::max();
-        }
-
         float computed = ((val + 1) * 0.5 * (size)) - 0.5;
 
         return computed;

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample.hpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/decorators.hpp"
+#include "ttnn/run_operation.hpp"
+
+namespace ttnn {
+namespace operations {
+namespace gridsample {
+
+struct ExecuteGridSample {
+    static ttnn::Tensor invoke(
+        const ttnn::Tensor& input_tensor,
+        const ttnn::Tensor& grid,
+        const std::string& mode = std::string("bilinear"),
+        const bool align_corners = false,
+        const std::optional<MemoryConfig>& output_mem_config = std::nullopt,
+        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+};
+}  // namespace gridsample
+}  // namespace operations
+constexpr auto gridsample =
+    ttnn::register_operation_with_auto_launch_op<"ttnn::gridsample", ttnn::operations::gridsample::ExecuteGridSample>();
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample_pybind.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "cpp/pybind11/decorators.hpp"
+
+#include "gridsample.hpp"
+
+namespace ttnn::operations::gridsample {
+
+namespace detail {
+
+namespace py = pybind11;
+
+void bind_gridsample(py::module& module) {
+    const auto doc = R"doc(
+        gridsample a given multi-channel 2D (spatial) data.
+        The input data is assumed to be of the form [N, H, W, C].
+
+        The algorithms available for gridsample are 'nearest' for now.
+
+
+        Args:
+            input_tensor (ttnn.Tensor): the input tensor.
+            grid (ttnn.Tensor): the grid tensor.
+
+        Keyword args:
+            memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
+
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+
+
+        )doc";
+
+    using OperationType = decltype(ttnn::gridsample);
+    ttnn::bind_registered_operation(
+        module,
+        ttnn::gridsample,
+        doc,
+        ttnn::pybind_arguments_t{
+            py::arg("input_tensor"),
+            py::arg("grid"),
+            py::kw_only(),
+            py::arg("mode") = "bilinear",
+            py::arg("align_corners") = "false",
+            py::arg("memory_config") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt});
+}
+
+}  // namespace detail
+void py_module(py::module& module) { detail::bind_gridsample(module); }
+}  // namespace ttnn::operations::gridsample

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample_pybind.cpp
@@ -20,20 +20,19 @@ void bind_gridsample(py::module& module) {
         gridsample a given multi-channel 2D (spatial) data.
         The input data is assumed to be of the form [N, H, W, C].
 
-        The algorithms available for gridsample are 'nearest' for now.
-
+        The algorithms available for gridsample are 'bilinear' for now.
 
         Args:
             input_tensor (ttnn.Tensor): the input tensor.
             grid (ttnn.Tensor): the grid tensor.
 
         Keyword args:
+            mode (string) : Mode of Grid sample. Default to Bilinear.
+            align_corners : Default to  False
             memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
-
 
         Returns:
             ttnn.Tensor: the output tensor.
-
 
         )doc";
 

--- a/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/gridsample/gridsample_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::gridsample {
+
+void py_module(py::module& module);
+
+}  // namespace ttnn::operations::gridsample


### PR DESCRIPTION
### N/A
### Problem description
ttnn doesn't have support for Gridsample 

### What's changed
Enabled support for Gridsample op  in ttnn as a device op with bilinear mode.
For now, support has been added for Float32.
Added Pytest for the Gridsample op.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes