### PR TITLE
Put qkv matmul output / qkv AR in bf16

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -353,7 +353,7 @@ def test_llama_TG_perf_device(
         "Matmul_2": 10554.555555555555,
         "Matmul_3": 12118.888888888889,
         "Matmul_4": 17000.0,
-        "AllReduceAsync_0": 11840.555555555555,
+        "AllReduceAsync_0": 15395.555555555555,
         "AllReduceAsync_1": 21078.333333333332,
         "AllReduceAsync_2": 21145.777777777777,
         "LlamaReduceScatterDeviceOperation_0": 10600.555555555555,

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -71,7 +71,7 @@ def test_ag_tg_llama_perf(
     "ar_type, warmup_iters, perf_target_us",
     [
         ("ff2", 15, 18.6),
-        ("qkv", 15, 11.9),
+        ("qkv", 15, 15.5),
         ("ff1", 15, 19.2),
         ("lm_head", 15, 61.8),
     ],

--- a/models/demos/llama3_subdevices/tt/llama_attention.py
+++ b/models/demos/llama3_subdevices/tt/llama_attention.py
@@ -269,7 +269,7 @@ class TtLlamaAttention(LightweightModule):
             memory_config=self.model_config["SHARDED_QKV_OUT_RING_MEMCFG"],
             compute_kernel_config=self.compute_kernel_config_hifi2,
             global_cb=self.prefetcher_setup.global_circular_buffer if self.model_config["USE_PREFETCHER"] else None,
-            dtype=ttnn.bfloat8_b,
+            dtype=ttnn.bfloat16,
             sub_device_id=self.prefetcher_setup.worker_sub_device_id,
         )
         ttnn.deallocate(x)

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -202,7 +202,7 @@ def test_all_gather_tg_llama(
     "output_shape, cluster_axis, num_links, input_num_cores, input_core_range_set, output_num_cores, output_core_range_set, input_dtype, output_dtype",
     [
         ([1, 1, 32, 2048], 0, 4, 24, RING_CRS, 16, NORM_CRS, ttnn.bfloat8_b, None),  # FF2/DO all reduce
-        ([1, 1, 32, 1280], 1, 3, 24, RING_CRS, 10, QKV_CRS, ttnn.bfloat8_b, ttnn.bfloat16),  # QKV all reduce
+        ([1, 1, 32, 1280], 1, 3, 24, RING_CRS, 10, QKV_CRS, ttnn.bfloat16, ttnn.bfloat16),  # QKV all reduce
         ([1, 1, 32, 3584], 1, 3, 24, RING_CRS, 28, FF1_CRS, ttnn.bfloat8_b, None),  # FF1 all reduce
         ([1, 1, 32, 16 * 1024], 1, 3, 32, LM_HEAD_CRS, 32, LM_HEAD_CRS, ttnn.bfloat8_b, None),  # LM head all reduce
     ],


### PR DESCRIPTION
### Problem description
The recent change to QKV matmul output dtype causes a PCC regression

### What's changed
Revert it back to bf16.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes