### PR TITLE
Fix issue in global CB allocation

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -186,6 +186,9 @@ def test_llama_decoder_inference(
             mesh_shape=model_args.cluster_shape,
         ),
     )
+    # Explicitly allocate global CB to avoid memory fragmentation
+    prefetcher_setup.create_global_cb()
+
     for i in range(generation_length):
         logger.info(f"[Decoder] Generating token {i}")
 
@@ -201,12 +204,6 @@ def test_llama_decoder_inference(
         # Get cos/sin matrices for the current position of each user
         rot_mats = rope_setup.get_rot_mats(current_pos)
         tt_pf = prefetcher_setup.get_input_tensors()
-        # Explicitly allocate global CB to avoid memory fragmentation
-        prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
-            mesh_device,
-            prefetcher_setup.sender_receiver_mapping,
-            prefetcher_setup.global_cb_size,
-        )
         ttnn.dram_prefetcher(
             tt_pf,
             num_layers=1,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -133,16 +133,13 @@ def test_llama_decoder_same(
     rot_mats = rope_setup.get_rot_mats(current_pos)
     tt_pf = prefetcher_setup.get_input_tensors()
 
+    # Explicitly allocate global CB to avoid memory fragmentation
+    prefetcher_setup.create_global_cb()
+
     ##### Run the decoder #####
     outs = []
     for i in range(generation_length):
         logger.info(f"[Decoder] Generating token {i}")
-        # Explicitly allocate global CB to avoid memory fragmentation
-        prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
-            mesh_device,
-            prefetcher_setup.sender_receiver_mapping,
-            prefetcher_setup.global_cb_size,
-        )
         ttnn.dram_prefetcher(
             tt_pf,
             num_layers=1,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -180,11 +180,8 @@ def test_llama_attention_inference(
         ),
     )
     # Explicitly allocate global CB to avoid memory fragmentation
-    prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
-        mesh_device,
-        prefetcher_setup.sender_receiver_mapping,
-        prefetcher_setup.global_cb_size,
-    )
+    prefetcher_setup.create_global_cb()
+
     for i in range(generation_length):
         # 70B attention block typically sees tensors with mean 0 and std 0.03 - 0.05 in layer 1
         pt_attention_input = torch.randn(batch_size, seq_len, model_args.dim) * 0.05

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -92,11 +92,7 @@ def test_llama_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache
 
     logger.info("Run Llama_MLP_PF")
     # Explicitly allocate global CB to avoid memory fragmentation
-    prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
-        mesh_device,
-        prefetcher_setup.sender_receiver_mapping,
-        prefetcher_setup.global_cb_size,
-    )
+    prefetcher_setup.create_global_cb()
     for i in range(20):
         ttnn.dram_prefetcher(
             prefetcher_setup.get_input_tensors(),

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -425,11 +425,7 @@ class TtTransformer(LightweightModule):
                 self.lm_head.tt_ccl = self.tt_ccl
                 self.tt_tensors = self.prefetcher_setup.get_input_tensors()
                 # Re-create global CB for decode (if it was not already created)
-                self.prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
-                    self.mesh_device,
-                    self.prefetcher_setup.sender_receiver_mapping,
-                    self.prefetcher_setup.global_cb_size,
-                )
+                self.prefetcher_setup.create_global_cb()
 
         else:
             if self.is_decode_setup:
@@ -461,12 +457,7 @@ class TtTransformer(LightweightModule):
         kv_cache=None,
     ):
         if mode == "decode":
-            if self.prefetcher_setup.global_circular_buffer is None:
-                self.prefetcher_setup.global_circular_buffer = ttnn.create_global_circular_buffer(
-                    self.mesh_device,
-                    self.prefetcher_setup.sender_receiver_mapping,
-                    self.prefetcher_setup.global_cb_size,
-                )
+            self.prefetcher_setup.create_global_cb()
             garbage_tensor = ttnn.dram_prefetcher(
                 self.tt_tensors,
                 num_layers=self.n_layers,

--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -125,6 +125,14 @@ class TtLlamaPrefetcherSetup(LightweightModule):
         self.tensor_addrs = []  # List of buffer addresses
         self.save_tensor_addresses = save_tensor_addresses
 
+    def create_global_cb(self):
+        if not hasattr(self, "global_circular_buffer") or self.global_circular_buffer is None:
+            self.global_circular_buffer = ttnn.create_global_circular_buffer(
+                self.mesh_device,
+                self.sender_receiver_mapping,
+                self.global_cb_size,
+            )
+
     def buffer_address(self, tensor):
         addr = []
         for i, ten in enumerate(ttnn.get_device_tensors(tensor)):


### PR DESCRIPTION
### Problem description
Currently, the global CB allocation is sometimes done in a loop in certain module test, causing the test to go OOM.

### What's changed
- Bring the allocation outside of the loop
- Add a helper function to reduce code duplication

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes