### PR TITLE
Fix Conv2D with dilation and shallow channels.

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -2082,6 +2082,7 @@ def test_conv_core_nondivis(
         [(3, 3), (2, 1), (3, 3)],
     ],
 )
+@pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
 def test_conv_dilation(
     device,
     torch_tensor_map,
@@ -2101,6 +2102,7 @@ def test_conv_dilation(
     pad_hw,
     output_layout,
     dilation_hw,
+    auto_shard,
 ):
     config_override = {"act_block_w_div": act_block_w_div}
     run_conv(
@@ -2125,6 +2127,7 @@ def test_conv_dilation(
         dilation_h=dilation_hw[0],
         dilation_w=dilation_hw[1],
         has_bias=False,
+        auto_shard=auto_shard,
     )
 
 
@@ -2171,8 +2174,7 @@ def test_conv_dilation(
 )
 @pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.LoFi])
 @pytest.mark.parametrize("output_layout", [ttnn.TILE_LAYOUT])
-# ToDo: Renable this when auto shard heuristic is imporved, currently we run out of L1 in for some test cases
-# @pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
+@pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
 def test_conv_groups(
     device,
     torch_tensor_map,
@@ -2196,6 +2198,7 @@ def test_conv_groups(
     use_shallow_conv_variant,
     groups,
     output_layout,
+    auto_shard,
 ):
     run_conv(
         device,
@@ -2218,6 +2221,7 @@ def test_conv_groups(
         use_shallow_conv_variant=use_shallow_conv_variant,
         groups=groups,
         output_layout=output_layout,
+        auto_shard=auto_shard,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
-
 constexpr uint32_t DILATION_W = get_compile_time_arg_val(3);
 void kernel_main() {
     constexpr uint32_t stride_h = get_compile_time_arg_val(0);
@@ -129,6 +128,7 @@ void kernel_main() {
                         l1_write_addr_act += conv_act_c_read_bytes;
                         act_l1_offset += stride_w_bytes;
                     }
+                    l1_write_addr_act += act_block_w_extra_align_bytes;
 
                     act_l1_offset = reader_offset + (reader_idx_2 * conv_act_c_read_bytes);
                     for (uint32_t inner = 0; inner < weight_size_w; inner++) {
@@ -136,6 +136,7 @@ void kernel_main() {
                         l1_write_addr_act += conv_act_c_read_bytes;
                         act_l1_offset += stride_w_bytes;
                     }
+                    l1_write_addr_act += act_block_w_extra_align_bytes;
                 }
                 reader_idx++;
             }


### PR DESCRIPTION
When using Conv2D with dilation, if the input channel alignment is not a multiple of 32, we get incorrect output. The reason for this issue is that the activations reader in the dilation codepath ignores the act_block_w_extra_align_bytes argument.

In the case of the auto_shard codepath, input channel alignment is deduced automatically. This is why auto_shard is enabled in test_conv_dilation to test the codepath where input channels are smaller than 32. codepath when input channels is smaller than 32.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14354063447)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14354077192) 
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14354069010)