### PR TITLE
Update fabric to be host configurable for noc ID and CMD buf ID to setup for unique configs per target platform

### DIFF
--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -199,6 +199,7 @@ public:
             tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE) const;
 
     void set_firmware_context_switch_interval(size_t interval);
+    void set_wait_for_host_signal(bool wait_for_host_signal);
 
     //    protected:
     friend class EdmLineFabricOpInterface;
@@ -250,6 +251,7 @@ public:
     bool enable_first_level_ack = false;
     bool fuse_receiver_flush_and_completion_ptr = true;
     bool dateline_connection = false;
+    bool wait_for_host_signal = false;
 };
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -394,7 +394,13 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         log_trace(tt::LogTest, "Receiver {} channel address: {}", i, this->local_receiver_channels_buffer_address[i]);
     }
 
-    return std::vector<uint32_t>{
+    size_t num_sender_channels = config.num_used_sender_channels;
+    size_t num_receiver_channels = config.num_used_receiver_channels;
+    auto ct_args = std::vector<uint32_t>{
+        num_sender_channels,
+        num_receiver_channels,
+        this->wait_for_host_signal ? 1 : 0,
+
         this->firmware_context_switch_interval,
         this->enable_first_level_ack,
         this->fuse_receiver_flush_and_completion_ptr,
@@ -447,7 +453,52 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
         config.senders_completed_packet_header_cb_address[1],
         FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers,
         config.senders_completed_packet_header_cb_address[2],
-        FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers};
+        FabricEriscDatamoverConfig::sender_completed_packet_header_cb_size_headers,
+
+        // Special marker to help with identifying misalignment bugs
+        0x00c0ffee};
+
+    // Sender channel args
+    constexpr size_t sender_ack_noc_id = 0;
+    // TODO: get from HAL (TODO before that - expose through HAL)
+    constexpr uint32_t WR_CMD_BUF = 0;      // for large writes
+    constexpr uint32_t RD_CMD_BUF = 1;      // for all reads
+    constexpr uint32_t WR_REG_CMD_BUF = 2;  // for small writes (e.g., registers, semaphores)
+    constexpr uint32_t AT_CMD_BUF = 3;      // for atomics
+    for (size_t i = 0; i < num_sender_channels; i++) {
+        ct_args.push_back(sender_ack_noc_id);
+    }
+
+    // Populate the sender ack cmd buf ids for each datapath
+    ct_args.push_back(WR_REG_CMD_BUF);
+    ct_args.push_back(WR_CMD_BUF);
+    if (num_sender_channels > 2) {
+        ct_args.push_back(WR_CMD_BUF);
+    }
+
+    // receiver channel args
+    constexpr size_t receiver_channel_write_noc_id = 1;
+    for (size_t i = 0; i < num_receiver_channels; i++) {
+        ct_args.push_back(receiver_channel_write_noc_id);
+    }
+    for (size_t i = 0; i < num_receiver_channels; i++) {
+        ct_args.push_back(WR_REG_CMD_BUF);  // maps to receiver_channel_forwarding_data_cmd_buf_ids
+    }
+    for (size_t i = 0; i < num_receiver_channels; i++) {
+        ct_args.push_back(RD_CMD_BUF);  // maps to receiver_channel_forwarding_sync_cmd_buf_ids
+    }
+    for (size_t i = 0; i < num_receiver_channels; i++) {
+        // TODO: pass this to the tranmission file
+        ct_args.push_back(receiver_channel_write_noc_id);  // maps to receiver_channel_local_write_noc_ids
+    }
+    for (size_t i = 0; i < num_receiver_channels; i++) {
+        ct_args.push_back(WR_CMD_BUF);  // maps to receiver_channel_local_write_cmd_buf_ids
+    }
+
+    // Special marker to help with identifying misalignment bugs
+    ct_args.push_back(0x10c0ffee);
+
+    return ct_args;
 }
 
 std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
@@ -679,6 +730,10 @@ void FabricEriscDatamoverBuilder::teardown_from_host(
 
 void FabricEriscDatamoverBuilder::set_firmware_context_switch_interval(size_t interval) {
     this->firmware_context_switch_interval = interval;
+}
+
+void FabricEriscDatamoverBuilder::set_wait_for_host_signal(bool wait_for_host_signal) {
+    this->wait_for_host_signal = wait_for_host_signal;
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -112,7 +112,8 @@ constexpr size_t remote_sender_2_channel_address = get_compile_time_arg_val(MAIN
 
 // TODO: CONVERT TO SEMAPHORE
 constexpr uint32_t termination_signal_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 23);
-constexpr uint32_t edm_local_sync_ptr_addr = wait_for_host_signal ? get_compile_time_arg_val(24) : 0;
+constexpr uint32_t edm_local_sync_ptr_addr =
+    wait_for_host_signal ? get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 24) : 0;
 constexpr uint32_t edm_status_ptr_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 25);
 
 constexpr bool persistent_mode = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 26) != 0;

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -6,35 +6,15 @@
 
 #include "dataflow_api.h"
 
+#include "tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp"
+
 #include <array>
+#include <utility>
 
 // CHANNEL CONSTANTS
-
-constexpr size_t NUM_LINE_SENDER_CHANNELS = 2;
-constexpr size_t NUM_RING_SENDER_CHANNELS = 3;
-// This is a placeholder for sizing arrays and other types properly
-// - we padd up for constexpr arrays
-constexpr size_t NUM_SENDER_CHANNELS = std::max(NUM_LINE_SENDER_CHANNELS, NUM_RING_SENDER_CHANNELS);
-
-constexpr size_t NUM_LINE_RECEIVER_CHANNELS = 1;
-constexpr size_t NUM_RING_RECEIVER_CHANNELS = 2;
-constexpr size_t NUM_RECEIVER_CHANNELS = std::max(NUM_LINE_RECEIVER_CHANNELS, NUM_RING_RECEIVER_CHANNELS);
-
-constexpr size_t VC1_RECEIVER_CHANNEL = 1;
-
-constexpr size_t receiver_channel_base_id = NUM_SENDER_CHANNELS;
-
-// TRANSACTION IDS
-constexpr uint8_t NUM_TRANSACTION_IDS = 4;
-
-constexpr uint8_t RX_CH0_TRID_START = 0;
-constexpr uint8_t RX_CH1_TRID_START = NUM_TRANSACTION_IDS;
-constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> RX_CH_TRID_STARTS = {
-    RX_CH0_TRID_START,
-    RX_CH1_TRID_START,
-};
-
 // ETH TXQ SELECTION
+
 constexpr uint32_t DEFAULT_ETH_TXQ = 0;
 constexpr uint32_t DEFAULT_NUM_ETH_TXQ_DATA_PACKET_ACCEPT_AHEAD = 32;
 
@@ -56,40 +36,53 @@ constexpr uint32_t to_sender_1_pkts_completed_id = 6;
 // receivers updates the reg on this stream
 constexpr uint32_t to_sender_2_pkts_completed_id = 7;
 
-constexpr std::array<uint32_t, NUM_RECEIVER_CHANNELS> to_receiver_packets_sent_streams = {
-    to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id};
-
-// not in symbol table - because not used
-constexpr std::array<uint32_t, NUM_SENDER_CHANNELS> to_sender_packets_acked_streams = {
-    {to_sender_0_pkts_acked_id, to_sender_1_pkts_acked_id, to_sender_2_pkts_acked_id}};
-
-// data section
-constexpr std::array<uint32_t, NUM_SENDER_CHANNELS> to_sender_packets_completed_streams = {
-    {to_sender_0_pkts_completed_id, to_sender_1_pkts_completed_id, to_sender_2_pkts_completed_id}};
-
-// Miscellaneous configuration
-constexpr uint32_t DEFAULT_ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS = 32;
-constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 0;
+constexpr size_t MAX_NUM_RECEIVER_CHANNELS = 2;
+constexpr size_t MAX_NUM_SENDER_CHANNELS = 3;
 
 // Compile Time args
+
+constexpr bool SPECIAL_MARKER_CHECK_ENABLED = true;
+constexpr size_t SENDER_CHANNEL_NOC_CONFIG_START_IDX = 0;
+constexpr size_t NUM_RECEIVER_CHANNELS_CT_ARG_IDX = SENDER_CHANNEL_NOC_CONFIG_START_IDX + 1;
+constexpr size_t NUM_SENDER_CHANNELS = get_compile_time_arg_val(SENDER_CHANNEL_NOC_CONFIG_START_IDX);
+constexpr size_t NUM_RECEIVER_CHANNELS = get_compile_time_arg_val(NUM_RECEIVER_CHANNELS_CT_ARG_IDX);
+static_assert(
+    NUM_RECEIVER_CHANNELS <= NUM_SENDER_CHANNELS,
+    "NUM_RECEIVER_CHANNELS must be less than or equal to NUM_SENDER_CHANNELS");
+static_assert(
+    NUM_RECEIVER_CHANNELS <= MAX_NUM_RECEIVER_CHANNELS,
+    "NUM_RECEIVER_CHANNELS must be less than or equal to MAX_NUM_RECEIVER_CHANNELS");
+static_assert(
+    NUM_SENDER_CHANNELS <= MAX_NUM_SENDER_CHANNELS,
+    "NUM_SENDER_CHANNELS must be less than or equal to MAX_NUM_SENDER_CHANNELS");
+
+constexpr size_t wait_for_host_signal_IDX = NUM_RECEIVER_CHANNELS_CT_ARG_IDX + 1;
+static_assert(wait_for_host_signal_IDX == 2, "wait_for_host_signal_IDX must be 3");
+static_assert(
+    get_compile_time_arg_val(wait_for_host_signal_IDX) == 0 || get_compile_time_arg_val(wait_for_host_signal_IDX) == 1,
+    "wait_for_host_signal must be 0 or 1");
+constexpr bool wait_for_host_signal = get_compile_time_arg_val(wait_for_host_signal_IDX);
+
+constexpr size_t MAIN_CT_ARGS_START_IDX = wait_for_host_signal_IDX + 1;
+static_assert(MAIN_CT_ARGS_START_IDX == 3, "MAIN_CT_ARGS_START_IDX must be 3");
 constexpr uint32_t SWITCH_INTERVAL =
 #ifndef DEBUG_PRINT_ENABLED
-    get_compile_time_arg_val(0);
+    get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 0);
 #else
     0;
 #endif
+constexpr bool enable_first_level_ack = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 1);
+static_assert(enable_first_level_ack == 0, "enable_first_level_ack must be 0");
+constexpr bool fuse_receiver_flush_and_completion_ptr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 2);
+static_assert(fuse_receiver_flush_and_completion_ptr == 1, "fuse_receiver_flush_and_completion_ptr must be 0");
+constexpr bool enable_ring_support = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 3);
+constexpr bool dateline_connection = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 4);
+constexpr bool is_handshake_sender = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 5) != 0;
+constexpr size_t handshake_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 6);
 
-constexpr bool enable_first_level_ack = get_compile_time_arg_val(1);
-constexpr bool fuse_receiver_flush_and_completion_ptr = get_compile_time_arg_val(2);
-constexpr bool enable_ring_support = get_compile_time_arg_val(3);
-constexpr bool dateline_connection = get_compile_time_arg_val(4);
-constexpr bool is_handshake_sender = get_compile_time_arg_val(5) != 0;
-constexpr size_t handshake_addr = get_compile_time_arg_val(6);
-
+static_assert(!enable_ring_support || NUM_RECEIVER_CHANNELS > 1, "Ring support requires at least 2 receiver channels");
 // TODO: Pipe from host
-constexpr size_t NUM_USED_SENDER_CHANNELS = enable_ring_support ? NUM_RING_SENDER_CHANNELS : NUM_LINE_SENDER_CHANNELS;
-constexpr size_t NUM_USED_RECEIVER_CHANNELS =
-    enable_ring_support ? NUM_RING_RECEIVER_CHANNELS : NUM_LINE_RECEIVER_CHANNELS;
+constexpr size_t NUM_USED_RECEIVER_CHANNELS = NUM_RECEIVER_CHANNELS;
 constexpr size_t VC0_RECEIVER_CHANNEL = dateline_connection ? 1 : 0;
 // On a dateline connection, we would never forward through the dateline on VC1
 
@@ -99,56 +92,141 @@ constexpr size_t worker_info_offset_past_connection_semaphore = 32;
 // the size of one of the buffers within a sender channel
 // For example if `channel_buffer_size` = 4k, with `SENDER_NUM_BUFFERS` = 2
 // then the total amount of buffering for that
-constexpr size_t channel_buffer_size = get_compile_time_arg_val(7);
+constexpr size_t channel_buffer_size = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 7);
 
-constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(8);
-constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(9);
-constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(10);
-constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(11);
-constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(12);
-constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(13);
-constexpr size_t local_sender_2_channel_address = get_compile_time_arg_val(14);
-constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(15);
-constexpr size_t local_receiver_0_channel_buffer_address = get_compile_time_arg_val(16);
-constexpr size_t remote_receiver_0_channel_buffer_address = get_compile_time_arg_val(17);
-constexpr size_t local_receiver_1_channel_buffer_address = get_compile_time_arg_val(18);
-constexpr size_t remote_receiver_1_channel_buffer_address = get_compile_time_arg_val(19);
-constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(20);
-constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(21);
-constexpr size_t remote_sender_2_channel_address = get_compile_time_arg_val(22);
+constexpr size_t SENDER_NUM_BUFFERS = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 8);
+constexpr size_t RECEIVER_NUM_BUFFERS = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 9);
+constexpr size_t local_sender_0_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 10);
+constexpr size_t local_sender_channel_0_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 11);
+constexpr size_t local_sender_1_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 12);
+constexpr size_t local_sender_channel_1_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 13);
+constexpr size_t local_sender_2_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 14);
+constexpr size_t local_sender_channel_2_connection_info_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 15);
+constexpr size_t local_receiver_0_channel_buffer_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 16);
+constexpr size_t remote_receiver_0_channel_buffer_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 17);
+constexpr size_t local_receiver_1_channel_buffer_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 18);
+constexpr size_t remote_receiver_1_channel_buffer_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 19);
+constexpr size_t remote_sender_0_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 20);
+constexpr size_t remote_sender_1_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 21);
+constexpr size_t remote_sender_2_channel_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 22);
 
 // TODO: CONVERT TO SEMAPHORE
-constexpr uint32_t termination_signal_addr = get_compile_time_arg_val(23);
-#ifdef WAIT_FOR_HOST_SIGNAL
-constexpr uint32_t edm_local_sync_ptr_addr = get_compile_time_arg_val(24);
-#endif
-constexpr uint32_t edm_status_ptr_addr = get_compile_time_arg_val(25);
+constexpr uint32_t termination_signal_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 23);
+constexpr uint32_t edm_local_sync_ptr_addr = wait_for_host_signal ? get_compile_time_arg_val(24) : 0;
+constexpr uint32_t edm_status_ptr_addr = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 25);
 
-constexpr bool persistent_mode = get_compile_time_arg_val(26) != 0;
+constexpr bool persistent_mode = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 26) != 0;
 
 // Per-channel counters
-constexpr bool enable_fabric_counters = get_compile_time_arg_val(27) != 0;
-constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(28);
-constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(29);
-constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(30);
-constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(31);
-constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(32);
+constexpr bool enable_fabric_counters = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 27) != 0;
+constexpr size_t receiver_channel_0_counters_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 28);
+constexpr size_t receiver_channel_1_counters_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 29);
+constexpr size_t sender_channel_0_counters_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 30);
+constexpr size_t sender_channel_1_counters_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 31);
+constexpr size_t sender_channel_2_counters_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 32);
 
-constexpr bool enable_packet_header_recording = get_compile_time_arg_val(33) != 0;
-constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(34);
-constexpr size_t receiver_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(35);
-constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(36);
-constexpr size_t receiver_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(37);
-constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(38);
-constexpr size_t sender_0_completed_packet_header_cb_size_headers = get_compile_time_arg_val(39);
-constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(40);
-constexpr size_t sender_1_completed_packet_header_cb_size_headers = get_compile_time_arg_val(41);
-constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(42);
-constexpr size_t sender_2_completed_packet_header_cb_size_headers = get_compile_time_arg_val(43);
+constexpr bool enable_packet_header_recording = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 33) != 0;
+constexpr size_t receiver_0_completed_packet_header_cb_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 34);
+constexpr size_t receiver_0_completed_packet_header_cb_size_headers =
+    get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 35);
+constexpr size_t receiver_1_completed_packet_header_cb_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 36);
+constexpr size_t receiver_1_completed_packet_header_cb_size_headers =
+    get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 37);
+constexpr size_t sender_0_completed_packet_header_cb_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 38);
+constexpr size_t sender_0_completed_packet_header_cb_size_headers =
+    get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 39);
+constexpr size_t sender_1_completed_packet_header_cb_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 40);
+constexpr size_t sender_1_completed_packet_header_cb_size_headers =
+    get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 41);
+constexpr size_t sender_2_completed_packet_header_cb_address = get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 42);
+constexpr size_t sender_2_completed_packet_header_cb_size_headers =
+    get_compile_time_arg_val(MAIN_CT_ARGS_START_IDX + 43);
 
-#ifdef WAIT_FOR_HOST_SIGNAL
-constexpr bool is_local_handshake_master = get_compile_time_arg_val(44);
-constexpr uint32_t local_handshake_master_eth_chan = get_compile_time_arg_val(45);
-constexpr uint32_t num_local_edms = get_compile_time_arg_val(46);
-constexpr uint32_t edm_channels_mask = get_compile_time_arg_val(47);
-#endif
+constexpr size_t SPECIAL_MARKER_0_IDX = MAIN_CT_ARGS_START_IDX + 44;
+constexpr size_t SPECIAL_MARKER_0 = 0x00c0ffee;
+static_assert(
+    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_0_IDX) == SPECIAL_MARKER_0,
+    "Special marker 0 not found. This implies some arguments were misaligned between host and device. Double check the "
+    "CT args.");
+
+constexpr size_t SENDER_CHANNEL_ACK_NOC_IDS_START_IDX = SPECIAL_MARKER_0_IDX + SPECIAL_MARKER_CHECK_ENABLED;
+constexpr size_t SENDER_CHANNEL_ACK_CMD_BUF_IDS_START_IDX = SENDER_CHANNEL_ACK_NOC_IDS_START_IDX + NUM_SENDER_CHANNELS;
+constexpr std::array<size_t, NUM_SENDER_CHANNELS> sender_channel_ack_noc_ids =
+    fill_array_with_next_n_args<size_t, SENDER_CHANNEL_ACK_NOC_IDS_START_IDX, NUM_SENDER_CHANNELS>();
+constexpr std::array<uint8_t, NUM_SENDER_CHANNELS> sender_channel_ack_cmd_buf_ids =
+    fill_array_with_next_n_args<uint8_t, SENDER_CHANNEL_ACK_CMD_BUF_IDS_START_IDX, NUM_SENDER_CHANNELS>();
+
+constexpr size_t RX_CH_FWD_NOC_IDS_START_IDX = SENDER_CHANNEL_ACK_CMD_BUF_IDS_START_IDX + NUM_SENDER_CHANNELS;
+constexpr size_t RX_CH_FWD_DATA_CMD_BUF_IDS_START_IDX = RX_CH_FWD_NOC_IDS_START_IDX + NUM_RECEIVER_CHANNELS;
+constexpr size_t RX_CH_FWD_SYNC_CMD_BUF_IDS_START_IDX = RX_CH_FWD_DATA_CMD_BUF_IDS_START_IDX + NUM_RECEIVER_CHANNELS;
+constexpr size_t RX_CH_LOCAL_WRITE_NOC_ID_IDX = RX_CH_FWD_SYNC_CMD_BUF_IDS_START_IDX + NUM_RECEIVER_CHANNELS;
+constexpr size_t RX_CH_LOCAL_WRITE_CMD_BUF_ID_IDX = RX_CH_LOCAL_WRITE_NOC_ID_IDX + NUM_RECEIVER_CHANNELS;
+
+constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_noc_ids =
+    fill_array_with_next_n_args<size_t, RX_CH_FWD_NOC_IDS_START_IDX, NUM_RECEIVER_CHANNELS>();
+constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_data_cmd_buf_ids =
+    fill_array_with_next_n_args<uint8_t, RX_CH_FWD_DATA_CMD_BUF_IDS_START_IDX, NUM_RECEIVER_CHANNELS>();
+constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_forwarding_sync_cmd_buf_ids =
+    fill_array_with_next_n_args<uint8_t, RX_CH_FWD_SYNC_CMD_BUF_IDS_START_IDX, NUM_RECEIVER_CHANNELS>();
+constexpr std::array<size_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_noc_ids =
+    fill_array_with_next_n_args<size_t, RX_CH_LOCAL_WRITE_NOC_ID_IDX, NUM_RECEIVER_CHANNELS>();
+constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS> receiver_channel_local_write_cmd_buf_ids =
+    fill_array_with_next_n_args<uint8_t, RX_CH_LOCAL_WRITE_CMD_BUF_ID_IDX, NUM_RECEIVER_CHANNELS>();
+
+// TODO: Add a special marker in CT args so we don't misalign unintentionally
+constexpr size_t SPECIAL_MARKER_1_IDX = RX_CH_LOCAL_WRITE_CMD_BUF_ID_IDX + NUM_RECEIVER_CHANNELS;
+constexpr size_t SPECIAL_MARKER_1 = 0x10c0ffee;
+static_assert(
+    !SPECIAL_MARKER_CHECK_ENABLED || get_compile_time_arg_val(SPECIAL_MARKER_1_IDX) == SPECIAL_MARKER_1,
+    "Special marker 1 not found. This implies some arguments were misaligned between host and device. Double check the "
+    "CT args.");
+
+constexpr size_t HOST_SIGNAL_ARGS_START_IDX = SPECIAL_MARKER_1_IDX + SPECIAL_MARKER_CHECK_ENABLED;
+// static_assert(HOST_SIGNAL_ARGS_START_IDX == 56, "HOST_SIGNAL_ARGS_START_IDX must be 56");
+// TODO: Add type safe getter
+constexpr bool is_local_handshake_master =
+    bool(conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 0>());
+constexpr uint32_t local_handshake_master_eth_chan =
+    conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 1>();
+constexpr uint32_t num_local_edms =
+    conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 2>();
+constexpr uint32_t edm_channels_mask =
+    conditional_get_compile_time_arg<wait_for_host_signal, HOST_SIGNAL_ARGS_START_IDX + 3>();
+
+constexpr size_t VC1_RECEIVER_CHANNEL = 1;
+
+constexpr size_t receiver_channel_base_id = NUM_SENDER_CHANNELS;
+
+// TRANSACTION IDS
+constexpr uint8_t NUM_TRANSACTION_IDS = 4;
+
+constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> RX_CH_TRID_STARTS =
+    initialize_receiver_channel_trid_starts<MAX_NUM_RECEIVER_CHANNELS, NUM_TRANSACTION_IDS>();
+
+constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_sent_streams =
+    take_first_n_elements<MAX_NUM_RECEIVER_CHANNELS, 2, uint32_t>(
+        std::array<uint32_t, 2>{to_receiver_0_pkts_sent_id, to_receiver_1_pkts_sent_id});
+
+// not in symbol table - because not used
+constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_acked_streams =
+    take_first_n_elements<MAX_NUM_SENDER_CHANNELS, 3, uint32_t>(
+        std::array<uint32_t, 3>{to_sender_0_pkts_acked_id, to_sender_1_pkts_acked_id, to_sender_2_pkts_acked_id});
+
+// data section
+constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_completed_streams =
+    take_first_n_elements<MAX_NUM_SENDER_CHANNELS, 3, uint32_t>(std::array<uint32_t, 3>{
+        to_sender_0_pkts_completed_id, to_sender_1_pkts_completed_id, to_sender_2_pkts_completed_id});
+
+// Miscellaneous configuration
+constexpr uint32_t DEFAULT_ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS = 32;
+constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 0;
+
+namespace tt::tt_fabric {
+static_assert(
+    receiver_channel_forwarding_noc_ids[0] == edm_to_local_chip_noc,
+    "edm_to_local_chip_noc must be 1 otherwise packet header setup must be modified to account for the final fabric "
+    "router not necessarily using noc1 for writing");
+
+static constexpr uint8_t local_chip_data_cmd_buf = receiver_channel_local_write_cmd_buf_ids[0];
+
+}  // namespace tt::tt_fabric

--- a/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tt_metal/hw/inc/compile_time_args.h"
+
+////////////////////////////////////////
+//  Conditional Arg Getters
+////////////////////////////////////////
+// clang-format off
+/**
+ * Initializes the transaction ID starts array where each element in the array is the start transaction ID for a
+ * receiver channel
+ *
+ * Return value: constexpr std::array<uint8_t, NUM_RECEIVER_CHANNELS>
+ *
+ * | Template Argument                | Description                              | Type                  | Valid Range                        |
+ * |----------------------------------|------------------------------------------|-----------------------|------------------------------------|
+ * | NUM_RECEIVER_CHANNELS            | number of receiver channels              | size_t                | 1 to MAX_NUM_RECEIVER_CHANNELS - 1 |
+ * | NUM_TRANSACTION_IDS_PER_CHANNEL  | number of transaction IDs per channel    | size_t                | 1 to 16                            |
+ */
+// clang-format on
+template <size_t NUM_RECEIVER_CHANNELS, size_t NUM_TRANSACTION_IDS_PER_CHANNEL>
+constexpr auto initialize_receiver_channel_trid_starts() -> std::array<uint8_t, NUM_RECEIVER_CHANNELS> {
+    std::array<uint8_t, NUM_RECEIVER_CHANNELS> arr{};
+    size_t trid_start = 0;
+    for (size_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {
+        arr[i] = trid_start;
+        trid_start += NUM_TRANSACTION_IDS_PER_CHANNEL;
+    }
+    return arr;
+}
+
+// clang-format off
+/**
+ * constexpr function that will take the first n elements from an input array and assign those values
+ * to a constexpr output array
+ *
+ * Return value: constexpr std::array<T, NUM_TO_TAKE>
+ *
+ * | Template Argument     | Description                              | Type                  | Valid Range      |
+ * |-----------------------|------------------------------------------|-----------------------|------------------|
+ * | NUM_TO_TAKE           | output array size in elem, also equal to | size_t                | 1 to max<size_t> |
+ * |                       | the number of elements to take from the  |                       |                  |
+ * |                       | input array                              |                       |                  |
+ * | IN_ARRAY_SIZE         | size of input array, in elements         | size_t                | 1 to max<size_t> |
+ * | T                     | element type                             | <typename>            | -----            |
+ */
+// clang-format on
+template <size_t NUM_TO_TAKE, size_t IN_ARRAY_SIZE, typename T>
+constexpr auto take_first_n_elements(const std::array<T, IN_ARRAY_SIZE>& arr_in) -> std::array<T, NUM_TO_TAKE> {
+    std::array<T, NUM_TO_TAKE> arr{};
+    for (size_t i = 0; i < NUM_TO_TAKE; i++) {
+        arr[i] = arr_in[i];
+    }
+    return arr;
+}
+
+// clang-format off
+/**
+ * Fills an array at compile time with a given value
+ *
+ * Return value: constexpr std::array<T, N>
+ *
+ * | Template Argument     | Description              | Type                  | Valid Range      |
+ * |-----------------------|--------------------------|-----------------------|------------------|
+ * | N                     | array size in elements   | size_t                | 1 to max<size_t> |
+ * | T                     | element type             | <typename>            | -----            |
+ * | init                  | value to fill array with | T                     | -----            |
+ */
+// clang-format on
+template <size_t N, typename T, T init>
+constexpr auto initialize_array() -> std::array<T, N> {
+    std::array<T, N> arr{};
+    for (size_t i = 0; i < N; i++) {
+        arr[i] = init;
+    }
+    return arr;
+}
+
+// clang-format off
+/**
+ * Helper type to copy a subset of a compile time args array into another array
+ *
+ * Return value: constexpr std::array<T, N>
+ *
+ * | Template Argument     | Description                         | Type                  | Valid Range      |
+ * |-----------------------|-------------------------------------|-----------------------|------------------|
+ * | T                     | element type                        | <typename>            | -----            |
+ * | INPUT_ARR_START_IDX   | index of arg element to copy from   | size_t                | 0 to max<size_t> |
+ * | NUM_ELEMS_TO_TAKE     | number of args to copy              | size_t                | 1 to max<size_t> |
+ * | TAKEN_SO_FAR          | number of elements already copied   | size_t                | 0 to max<size_t> |
+ * |                       | (internal use only)                 | size_t                | 0 to max<size_t> |
+ */
+// clang-format on
+template <typename T, size_t INPUT_ARR_START_IDX, size_t NUM_ELEMS_TO_TAKE, size_t TAKEN_SO_FAR = 0>
+struct ArraySliceCopier {
+    static constexpr void copy(std::array<T, NUM_ELEMS_TO_TAKE>& arr) {
+        // Fill the current element
+        arr[TAKEN_SO_FAR] = get_compile_time_arg_val(INPUT_ARR_START_IDX + TAKEN_SO_FAR);
+
+        // Recurse to fill the next element (if any)
+        if constexpr (TAKEN_SO_FAR + 1 < NUM_ELEMS_TO_TAKE) {
+            ArraySliceCopier<T, INPUT_ARR_START_IDX, NUM_ELEMS_TO_TAKE, TAKEN_SO_FAR + 1>::copy(arr);
+        }
+    }
+};
+
+// clang-format off
+/**
+ * Fills a compile time array with the next n compile time arguments
+ *
+ * Return value: constexpr std::array<T, NUM_ELEMS_TO_TAKE>
+ *
+ * | Template Argument     | Description              | Type                  | Valid Range      |
+ * |-----------------------|--------------------------|-----------------------|------------------|
+ * | ELEM_START_IDX        | index of first element to copy from | size_t                | 0 to max<size_t> |
+ * | NUM_ELEMS_TO_TAKE     | number of elements to copy          | size_t                | 1 to max<size_t> |
+ */
+// clang-format on
+template <typename T, size_t ELEM_START_IDX, size_t NUM_ELEMS_TO_TAKE>
+constexpr auto fill_array_with_next_n_args() -> std::array<T, NUM_ELEMS_TO_TAKE> {
+    std::array<T, NUM_ELEMS_TO_TAKE> arr{};
+    if constexpr (NUM_ELEMS_TO_TAKE > 0) {
+        ArraySliceCopier<T, ELEM_START_IDX, NUM_ELEMS_TO_TAKE>::copy(arr);
+    }
+    return arr;
+}
+
+// clang-format off
+/**
+ * Conditional compile time arg getter that is compile-time-safe in that it will not return an OoB access on a compile
+ * time array if the arg is not supposed to be retrieved (indicated by GET_THE_ARG being false)
+ * This helps with setup of dependent compile time args where some later compile time args are only conditionally consumed
+ * if some earlier compile time arg is true
+ *
+ * This first function is the generic "true" path (we want to grab the arg)
+ *
+ * Return value: uint32_t
+ *
+ * | Template Argument     | Description              | Type                  | Valid Range      |
+ * |-----------------------|--------------------------|-----------------------|------------------|
+ * | GET_THE_ARG           | whether to get the arg   | bool                  | true or false    |
+ * | ARG_IDX               | index of arg to get      | size_t                | 0 to max<size_t> |
+ */
+// clang-format on
+template <bool GET_THE_ARG, size_t ARG_IDX>
+constexpr auto conditional_get_compile_time_arg() ->
+    typename std::enable_if<GET_THE_ARG && (ARG_IDX < kernel_compile_time_args.size()), uint32_t>::type {
+    return kernel_compile_time_args[ARG_IDX];
+}
+
+// clang-format off
+/**
+ * SFINAE variant when GET_THE_ARG is false to avoid the lookup
+ */
+template <bool GET_THE_ARG, size_t ARG_IDX>
+constexpr auto conditional_get_compile_time_arg() -> typename std::enable_if<!GET_THE_ARG, uint32_t>::type {
+    return 0;
+}

--- a/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
@@ -147,9 +147,8 @@ constexpr auto fill_array_with_next_n_args() -> std::array<T, NUM_ELEMS_TO_TAKE>
  */
 // clang-format on
 template <bool GET_THE_ARG, size_t ARG_IDX>
-constexpr auto conditional_get_compile_time_arg() ->
-    typename std::enable_if<GET_THE_ARG && (ARG_IDX < kernel_compile_time_args.size()), uint32_t>::type {
-    return kernel_compile_time_args[ARG_IDX];
+constexpr auto conditional_get_compile_time_arg() -> typename std::enable_if<GET_THE_ARG, uint32_t>::type {
+    return get_compile_time_arg_val(ARG_IDX);
 }
 
 // clang-format off

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
@@ -12,14 +12,6 @@ namespace tt::tt_fabric {
 
 static constexpr uint8_t edm_to_local_chip_noc = 1;
 
-static constexpr uint8_t worker_sender0_sync_cmd_buf = write_reg_cmd_buf;
-static constexpr uint8_t worker_sender1_sync_cmd_buf = write_cmd_buf;
-static constexpr uint8_t worker_sender2_sync_cmd_buf = write_cmd_buf;
-
-static constexpr uint8_t downstream_data_cmd_buf = write_reg_cmd_buf;
-static constexpr uint8_t downstream_sync_cmd_buf = read_cmd_buf;
-static constexpr uint8_t local_chip_data_cmd_buf = write_cmd_buf;
-
 enum EDM_IO_BLOCKING_MODE { FLUSH_BLOCKING, BLOCKING, NON_BLOCKING };
 
 template <EDM_IO_BLOCKING_MODE blocking_mode = EDM_IO_BLOCKING_MODE::BLOCKING>

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1123,7 +1123,6 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, F
                 true,
                 false,
                 is_dateline);
-            edm_builder.set_wait_for_host_signal(true);
             edm_builders.insert({eth_chan, edm_builder});
         }
     }
@@ -1177,8 +1176,8 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, F
 
     // TODO: this will not be needed once tests are migrated and should be the default behavior
     std::map<string, string> defines = {};
-
-    for (const auto& [eth_chan, edm_builder] : edm_builders) {
+    for (auto& [eth_chan, edm_builder] : edm_builders) {
+        edm_builder.set_wait_for_host_signal(true);
         const std::vector<uint32_t> edm_kernel_rt_args = edm_builder.get_runtime_args();
         std::vector<uint32_t> eth_sender_ct_args = edm_builder.get_compile_time_args();
         uint32_t is_local_handshake_master = eth_chan == master_edm_chan;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1123,6 +1123,7 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, F
                 true,
                 false,
                 is_dateline);
+            edm_builder.set_wait_for_host_signal(true);
             edm_builders.insert({eth_chan, edm_builder});
         }
     }
@@ -1176,7 +1177,6 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, F
 
     // TODO: this will not be needed once tests are migrated and should be the default behavior
     std::map<string, string> defines = {};
-    defines["WAIT_FOR_HOST_SIGNAL"] = "";
 
     for (const auto& [eth_chan, edm_builder] : edm_builders) {
         const std::vector<uint32_t> edm_kernel_rt_args = edm_builder.get_runtime_args();


### PR DESCRIPTION
### Ticket
#20159 

### Problem description
Current noc and cmd buf assignments are hardcoded in the fabric router kernel. This was fine so far because we primarily cared about TG which had clean and consistent routing. With the bringup of 6U galaxy, the noc-level routing from router torouter changes drastically and with BH support on the horizon, more options will need to be supported.

### What's changed
This PR plumbs through some configuration to the kernel (namely noc ID and cmd bufs) to have more fine-grain control over how we instantiate fabric and its noc-level data-paths. This is a prerequisite for upcoming work to manage congestion on 6U (BH support/optimization should also be made easier with these changes)

### Note: Current limitation
The fabric router kernel is able to use separate nocs for the write to local noc path and the forward to next router path, in that it has variables to track each independently.

However, the implementation will not safely handle both values being different because of how transaction IDs are currently tracked. When checking for flushed transactions, the transaction ID trackker currently assumes only 1 noc is used. This has been an assumption so far for performance reasons. If we wish to lift this constraint, we will need minor changes to the tracker to pass in both NoC IDs. For the time being though, the implementation will simply `static_assert` that both noc IDs are the same.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/14366715301
- [x] T3K: https://github.com/tenstorrent/tt-metal/actions/runs/14366722293
  - Same failures as on main
- [x] Metal Benchmark: https://github.com/tenstorrent/tt-metal/actions/runs/14366723936
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes

Closes #20159