### PR TITLE
Update BH L1 size to be 1.5MB

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -30,7 +30,7 @@
 /////////////
 // RISC-V Address map definition (hardware)
 #define MEM_L1_BASE 0x0
-#define MEM_L1_SIZE (1464 * 1024)
+#define MEM_L1_SIZE (1536 * 1024)
 
 #define MEM_ETH_BASE 0x0
 // Top 64K is reserved for syseng

--- a/tt_metal/soc_descriptors/blackhole_140_arch.yaml
+++ b/tt_metal/soc_descriptors/blackhole_140_arch.yaml
@@ -107,7 +107,7 @@ router_only:
   ]
 
 worker_l1_size:
-  1499136
+  1572864
 
 dram_bank_size:
   4278190080


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Due to space restrictions on WH, L1 is not quite 1.5MB, it is (1464K). Throughout Metal and UMD we assumed BH L1 was the same as WH in being not quite 1.5MB but this is incorrect. 

### What's changed
Update recognized BH L1 size to be reflective of actual available space

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14361927593) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14374889898) CI passes