### PR TITLE
Remove VLAs to satisfy clang. Part of #20313.

### DIFF
--- a/tt_metal/api/tt-metalium/hlk_desc.hpp
+++ b/tt_metal/api/tt-metalium/hlk_desc.hpp
@@ -133,11 +133,21 @@ public:
 
 // Hash for hlk_args
 inline void hash_hlk_args(size_t& seed, void* hlk_args, size_t hlk_args_size) {
-    char buffer[hlk_args_size];
-    std::memcpy(buffer, hlk_args, hlk_args_size);
+    // C++20 standard, section 7.2.1, paragraph 11:
+    // If a program attempts to access the stored value of an object through a glvalue whose type is not
+    // similar to one of the following types the behavior is undefined:
+    // - the dynamic type of the object,
+    // - a type that is the signed or unsigned type corresponding to the dynamic type of the object, or
+    // - a char, unsigned char, or std::byte type
+    // </standard>
+    //
+    // Since we are accessing the raw bytes through a char type,
+    // reinterpret_casting is well defined.
 
-    for (int i = 0; i < hlk_args_size; i++) {
-        tt::utils::hash_combine(seed, std::hash<char>{}(buffer[i]));
+    const char* const raw_bytes = reinterpret_cast<char*>(hlk_args);
+
+    for (size_t i = 0; i < hlk_args_size; ++i) {
+        tt::utils::hash_combine(seed, std::hash<char>{}(raw_bytes[i]));
     }
 }
 

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -97,16 +97,15 @@ std::vector<std::vector<std::vector<std::pair<chip_id_t, mesh_id_t>>>> RoutingTa
     mesh_id_t src, const InterMeshConnectivity& inter_mesh_connectivity) {
     // TODO: add more tests for this
     std::uint32_t num_meshes = inter_mesh_connectivity.size();
-    bool visited[num_meshes];
-    std::fill_n(visited, num_meshes, false);
+    // avoid vector<bool> specialization
+    std::vector<std::uint8_t> visited(num_meshes, false);
 
     // paths[target_mesh_id][path_count][next_chip and next_mesh];
     std::vector<std::vector<std::vector<std::pair<chip_id_t, mesh_id_t>>>> paths;
     paths.resize(num_meshes);
     paths[src] = {{{}}};
 
-    std::uint32_t dist[num_meshes];
-    std::fill_n(dist, num_meshes, std::numeric_limits<std::uint32_t>::max());
+    std::vector<std::uint32_t> dist(num_meshes, std::numeric_limits<std::uint32_t>::max());
     dist[src] = 0;
 
     std::queue<mesh_id_t> q;

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -974,9 +974,14 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                         while (contains_newline) {
                             const char* pos_after_newline = newline_pos + 1;
                             const uint32_t substr_len = pos_after_newline - cptr;
-                            char substr_upto_newline[substr_len + 1];
-                            strncpy(substr_upto_newline, cptr, substr_len);
-                            substr_upto_newline[substr_len] = '\0';
+
+                            // strchr returns nullptr if it encounters a null terminator,
+                            // so we can guarentee that this is valid data since it was
+                            // already checked. We don't need to append a '\0' because
+                            // the stream operator only takes upto '\0' when passed
+                            // a char* (wrt the previous impl)
+                            const std::string_view substr_upto_newline(cptr, substr_len);
+
                             *intermediate_stream << substr_upto_newline;
                             TransferToAndFlushOutputStream(risc_key, intermediate_stream);
                             cptr = pos_after_newline;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20313.
This PR addresses one of the issues outlined in the ticket. I am breaking the work up into singly-focused hermetic PRs for ease of review.

### Problem description
Clang 19 errors out on variable length arrays (VLAs) as a C++ extension. 

### What's changed
Replaced usage of VLAs with standard compliant alternatives.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes