### PR TITLE
[skip ci] Don't build gdb on ubuntu 24.04

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -261,6 +261,22 @@ RUN chmod -R 777 $VIRTUAL_ENV
 
 FROM ci-test AS dev
 
+# Install dev deps
+# libgl1-mesa-glx is needed for Yolo models https://github.com/tenstorrent/tt-metal/pull/19899
+# libgl1-mesa-glx does not exist in ubuntu 24.04 which is right around the corner
+# switching to libgl1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    acl \
+    emacs \
+    gdb \
+    less \
+    libmpfr-dev \
+    nano \
+    openssh-server \
+    vim \
+    libgl1 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # IWYU could be useful to developers
 RUN mkdir -p /tmp/iwyu \
     && wget -O /tmp/iwyu/iwyu.tar.gz https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/0.21.tar.gz \
@@ -270,12 +286,7 @@ RUN mkdir -p /tmp/iwyu \
     && cmake --install /tmp/iwyu/build \
     && rm -rf /tmp/iwyu
 
-# Need this to build GDB
-RUN apt-get -y update \
-    && apt-get install -y libmpfr-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Remove gdb if we aren't on Ubuntu 22.04
+# Remove gdb if we aren't on Ubuntu 24.04
 # 24.04 has gdb 15.1 by default, lets give that a chance before we decide we need to build something
 RUN [ "$UBUNTU_VERSION" != "24.04" ] && apt-get remove -y gdb || true
 RUN [ "$UBUNTU_VERSION" != "24.04" ] && \
@@ -286,20 +297,6 @@ RUN [ "$UBUNTU_VERSION" != "24.04" ] && \
     && make -j$(nproc) \
     && make install \
     && rm -rf /tmp/gdb-build
-
-# Install dev deps
-# libgl1-mesa-glx is needed for Yolo models https://github.com/tenstorrent/tt-metal/pull/19899
-# libgl1-mesa-glx does not exist in ubuntu 24.04 which is right around the corner
-# switching to libgl1
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    acl \
-    emacs \
-    less \
-    nano \
-    openssh-server \
-    vim \
-    libgl1 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 #############################################################
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -293,7 +293,7 @@ RUN [ "$UBUNTU_VERSION" != "24.04" ] \
     && mkdir -p /tmp/gdb-build && cd /tmp/gdb-build/ \
     && wget -O /tmp/gdb-build/gdb.tar.gz https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz \
     && tar -xvf /tmp/gdb-build/gdb.tar.gz -C /tmp/gdb-build --strip-components=1 \
-    && /tmp/gdb-build/configure --prefix=/usr/local --disable-werror \
+    && /tmp/gdb-build/configure --prefix=/usr/local \
     && make -j$(nproc) \
     && make install \
     && rm -rf /tmp/gdb-build

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -289,7 +289,7 @@ RUN mkdir -p /tmp/iwyu \
 # Remove gdb if we aren't on Ubuntu 24.04
 # 24.04 has gdb 15.1 by default, lets give that a chance before we decide we need to build something
 RUN [ "$UBUNTU_VERSION" != "24.04" ] && apt-get remove -y gdb || true
-RUN [ "$UBUNTU_VERSION" != "24.04" ] && \
+RUN [ "$UBUNTU_VERSION" != "24.04" ] \
     && mkdir -p /tmp/gdb-build && cd /tmp/gdb-build/ \
     && wget -O /tmp/gdb-build/gdb.tar.gz https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz \
     && tar -xvf /tmp/gdb-build/gdb.tar.gz -C /tmp/gdb-build --strip-components=1 \

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -275,12 +275,14 @@ RUN apt-get -y update \
     && apt-get install -y libmpfr-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the gdb that is compatible with clang-17
-RUN apt-get remove -y gdb || true \
+# Remove gdb if we aren't on Ubuntu 22.04
+# 24.04 has gdb 15.1 by default, lets give that a chance before we decide we need to build something
+RUN [ "$UBUNTU_VERSION" != "24.04" ] && apt-get remove -y gdb || true
+RUN [ "$UBUNTU_VERSION" != "24.04" ] && \
     && mkdir -p /tmp/gdb-build && cd /tmp/gdb-build/ \
     && wget -O /tmp/gdb-build/gdb.tar.gz https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz \
     && tar -xvf /tmp/gdb-build/gdb.tar.gz -C /tmp/gdb-build --strip-components=1 \
-    && /tmp/gdb-build/configure --prefix=/usr/local \
+    && /tmp/gdb-build/configure --prefix=/usr/local --disable-werror \
     && make -j$(nproc) \
     && make install \
     && rm -rf /tmp/gdb-build


### PR DESCRIPTION
### Problem description
Saw gdb build failure in docker build for 24.04

### What's changed
Don't build gdb in 24.04 docker, it already has gdb 15.1

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes