### PR TITLE
Add missing tiny tiles support to bcast col and reduce w

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -66,6 +66,8 @@ enum EltwiseOp : uint8_t { ADD = 0, SUB = 1, MUL = 2 };
 
 enum BroadcastDim : uint8_t { ROW = 0, COL = 1, SCALAR = 2 };
 
+enum TileShape : uint8_t { FULL_TILE = 0, TINY_TILE_16x32 = 1 };
+
 const map<EltwiseOp, string> eltwise_op_to_type = {
     {EltwiseOp::ADD, "EltwiseBinaryType::ELWADD"},
     {EltwiseOp::SUB, "EltwiseBinaryType::ELWSUB"},
@@ -86,16 +88,22 @@ const map<BroadcastDim, string> broadcast_dim_to_api_suffix = {
     {BroadcastDim::SCALAR, "scalar"},
 };
 
+const map<TileShape, tt_metal::Tile> tile_shape_to_tile = {
+    {TileShape::FULL_TILE, tt_metal::Tile({constants::TILE_HEIGHT, constants::TILE_WIDTH})},
+    {TileShape::TINY_TILE_16x32, tt_metal::Tile({constants::TILE_HEIGHT / 2, constants::TILE_WIDTH})},
+};
+
 struct BroadcastConfig {
     ApiConvention api_convention;
     EltwiseOp eltwise_op;
     BroadcastDim broadcast_dim;
+    TileShape tile_shape = TileShape::FULL_TILE;
     MathFidelity math_fidelity = MathFidelity::HiFi4;
 };
 
 void mask_src_b_for_broadcast(std::vector<bfloat16>& tile, const std::vector<uint32_t>& shape, BroadcastDim dim) {
-    int num_rows = shape.at(0);
-    int num_cols = shape.at(1);
+    int num_cols = shape.at(0);
+    int num_rows = shape.at(1);
 
     for (int i = 0; i < num_rows; i++) {
         for (int j = 0; j < num_cols; j++) {
@@ -114,8 +122,8 @@ std::vector<bfloat16> gold_broadcast(
     EltwiseOp op,
     BroadcastDim dim,
     MathFidelity math_fidelity = MathFidelity::HiFi4) {
-    int num_rows = shape.at(0);
-    int num_cols = shape.at(1);
+    int num_cols = shape.at(0);
+    int num_rows = shape.at(1);
 
     uint16_t srca_fid_mask = 0xFFFF;
     uint16_t srcb_fid_mask = 0xFFFF;
@@ -202,10 +210,14 @@ void run_single_core_broadcast(tt_metal::IDevice* device, const BroadcastConfig&
 
     CoreCoord core = {0, 0};
 
-    constexpr uint32_t tile_width = 32;
-    constexpr uint32_t tile_height = 32;
+    tt_metal::Tile tile_dims = tile_shape_to_tile.at(test_config.tile_shape);
+    uint32_t tile_width = tile_dims.get_tile_shape()[1];
+    uint32_t tile_height = tile_dims.get_tile_shape()[0];
+    if (test_config.tile_shape != TileShape::FULL_TILE) {
+        log_info("Tile shape is {{{}, {}}}", tile_height, tile_width);
+    }
 
-    constexpr uint32_t single_tile_size = tile_width * tile_height * bfloat16::SIZEOF;
+    uint32_t single_tile_size = tile_width * tile_height * bfloat16::SIZEOF;
 
     tt_metal::InterleavedBufferConfig dram_config{
         .device = device,
@@ -215,20 +227,26 @@ void run_single_core_broadcast(tt_metal::IDevice* device, const BroadcastConfig&
 
     auto src_a_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_src_a_addr = src_a_dram_buffer->address();
-    tt_metal::CircularBufferConfig l1_src_a_cb_config = tt_metal::CircularBufferConfig(single_tile_size, {{0, tt::DataFormat::Float16_b}})
-        .set_page_size(0, single_tile_size);
+    tt_metal::CircularBufferConfig l1_src_a_cb_config =
+        tt_metal::CircularBufferConfig(single_tile_size, {{0, tt::DataFormat::Float16_b}})
+            .set_page_size(0, single_tile_size)
+            .set_tile_dims(0, tile_dims);
     auto l1_src_a_cb = tt_metal::CreateCircularBuffer(program, core, l1_src_a_cb_config);
 
     auto src_b_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_src_b_addr = src_b_dram_buffer->address();
-    tt_metal::CircularBufferConfig l1_src_b_cb_config = tt_metal::CircularBufferConfig(single_tile_size, {{1, tt::DataFormat::Float16_b}})
-        .set_page_size(1, single_tile_size);
+    tt_metal::CircularBufferConfig l1_src_b_cb_config =
+        tt_metal::CircularBufferConfig(single_tile_size, {{1, tt::DataFormat::Float16_b}})
+            .set_page_size(1, single_tile_size)
+            .set_tile_dims(1, tile_dims);
     auto l1_src_b_cb = tt_metal::CreateCircularBuffer(program, core, l1_src_b_cb_config);
 
     auto dst_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
-    tt_metal::CircularBufferConfig l1_dst_cb_config = tt_metal::CircularBufferConfig(single_tile_size, {{16, tt::DataFormat::Float16_b}})
-        .set_page_size(16, single_tile_size);
+    tt_metal::CircularBufferConfig l1_dst_cb_config =
+        tt_metal::CircularBufferConfig(single_tile_size, {{16, tt::DataFormat::Float16_b}})
+            .set_page_size(16, single_tile_size)
+            .set_tile_dims(16, tile_dims);
     auto l1_dst_cb = tt_metal::CreateCircularBuffer(program, core, l1_dst_cb_config);
 
     std::map<string, string> defines = {
@@ -326,7 +344,7 @@ void run_single_core_broadcast(tt_metal::IDevice* device, const BroadcastConfig&
     auto packed_input1 = pack_vector<uint32_t, bfloat16>(input1);
     auto packed_golden = pack_vector<uint32_t, bfloat16>(golden);
     ::unit_tests::compute::GoldenConfig config = {
-        .num_tiles_r_dim = tile_width / 32, .num_tiles_c_dim = tile_height / 32};
+        .num_tiles_r_dim = 1, .num_tiles_c_dim = 1, .num_faces = tile_width / 16 * tile_height / 16};
     auto tilized_input0 = ::unit_tests::compute::gold_standard_tilize(packed_input0, config);
     auto tilized_input1 = ::unit_tests::compute::gold_standard_tilize(packed_input1, config);
 
@@ -404,6 +422,18 @@ INSTANTIATE_TEST_SUITE_P(
         (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::SUB, BroadcastDim::SCALAR},
         (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::MUL, BroadcastDim::ROW},
         (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::MUL, BroadcastDim::COL},
-        (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::MUL, BroadcastDim::SCALAR}));
+        (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::MUL, BroadcastDim::SCALAR},
+        (BroadcastConfig){ApiConvention::DEFAULT, EltwiseOp::ADD, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::DEFAULT, EltwiseOp::SUB, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::DEFAULT, EltwiseOp::MUL, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_INIT, EltwiseOp::ADD, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_INIT, EltwiseOp::SUB, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_INIT, EltwiseOp::MUL, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_INIT, EltwiseOp::ADD, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_INIT, EltwiseOp::SUB, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_INIT, EltwiseOp::MUL, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::ADD, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::SUB, BroadcastDim::COL, TileShape::TINY_TILE_16x32},
+        (BroadcastConfig){ApiConvention::SHORT_BOTH, EltwiseOp::MUL, BroadcastDim::COL, TileShape::TINY_TILE_16x32}));
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -33,7 +33,7 @@ std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_ve
     // Untilize outputs correct number of r_dim & num_faces
     // But assumes increments are still default 16x16 faces
     int face_size = 16 * 16 / 2;
-    int tile_size = face_size * config.num_faces;
+    int tile_size = face_size * (config.tiny_tile ? config.num_faces : 4);
 
     std::set<int> ind;
 

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -32,8 +32,8 @@ std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_ve
     int num_c_dim = config.face_c_dim / 2;
     // Untilize outputs correct number of r_dim & num_faces
     // But assumes increments are still default 16x16 faces
-    int face_size = 16 * 8;
-    int tile_size = face_size * 4;
+    int face_size = 16 * 16 / 2;
+    int tile_size = face_size * config.num_faces;
 
     std::set<int> ind;
 
@@ -41,7 +41,7 @@ std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_ve
     for (int t = 0; t < num_tile_rows; t++) {
         int tile_start_index = t * num_tile_cols;
 
-        int physical_start_for_tile_row = tile_start_index * 32 * 16;
+        int physical_start_for_tile_row = tile_start_index * tile_size;
 
         // Iterate over tile columns 32 times (naive, but simple for validation)
         uint32_t num_iterations = (config.num_faces > 2) ? 2 : 1;
@@ -97,14 +97,16 @@ std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t>& src_vec,
                 }
             }
 
-            // Bottom faces
-            start += 16 * num_cols;
-            for (int j = 0; j < 2; j++) {
-                int start_ = start + 8 * j;
-                for (int k = 0; k < 16; k++) {
-                    for (int i = 0; i < 8; i++) {
-                        int idx = start_ + num_cols * k + i;
-                        dst_vec.push_back(src_vec.at(idx));
+            if (config.num_faces > 2) {
+                // Bottom faces
+                start += 16 * num_cols;
+                for (int j = 0; j < 2; j++) {
+                    int start_ = start + 8 * j;
+                    for (int k = 0; k < 16; k++) {
+                        for (int i = 0; i < 8; i++) {
+                            int idx = start_ + num_cols * k + i;
+                            dst_vec.push_back(src_vec.at(idx));
+                        }
                     }
                 }
             }

--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.hpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.hpp
@@ -20,6 +20,7 @@ struct GoldenConfig {
     int face_r_dim = 16;
     int face_c_dim = 16;
     int num_faces = 4;
+    bool tiny_tile = false;
 };
 
 std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_vec, const GoldenConfig& config);

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -264,9 +264,9 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
     uint32_t W = test_config.shape[3], H = test_config.shape[2], NC = test_config.shape[1] * test_config.shape[0];
     uint32_t HW = H * W;
     uint32_t N = test_config.shape[0] * test_config.shape[1];
-    TT_FATAL((tile_H == 16 && tile_W == 32) || (tile_H == 32 && tile_W == 32), "Error");
-    TT_FATAL(W % tile_W == 0 && H % tile_H == 0, "Error");
-    TT_FATAL(H > 0 && W > 0 && NC > 0, "Error");
+    TT_FATAL((tile_H == 16 && tile_W == 32) || (tile_H == 32 && tile_W == 32), "Error: Invalid tile shape");
+    TT_FATAL(W % tile_W == 0 && H % tile_H == 0, "Error: Tensor height/width must be multiple of tile height/width");
+    TT_FATAL(H > 0 && W > 0 && NC > 0, "Error: All tensor dims must be greater than 0");
     uint32_t Wt = W / tile_W;
     uint32_t Ht = H / tile_H;
 

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -61,6 +61,7 @@ enum ReduceDim : uint8_t { H = 0, W = 1, HW = 2 };
 enum ReduceType : uint8_t { SUM = 0, AVG = 1, MAX = 2 };
 struct ReduceConfig {
     bool short_init = false;
+    tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT, TILE_WIDTH});
     std::vector<uint32_t> shape;
     ReduceDim reduce_dim;
     ReduceType reduce_type = ReduceType::SUM;
@@ -134,12 +135,13 @@ void add_reader_writer_kernels(
     const ReduceConfig& test_config,
     const std::shared_ptr<tt_metal::Buffer>& src_dram_buffer,
     const std::shared_ptr<tt_metal::Buffer>& dst_dram_buffer) {
+    uint32_t tile_H = test_config.tile_shape.get_tile_shape()[0], tile_W = test_config.tile_shape.get_tile_shape()[1];
     uint32_t W = test_config.shape[3], H = test_config.shape[2], NC = test_config.shape[1] * test_config.shape[0];
     uint32_t HW = H * W;
     uint32_t N = test_config.shape[0] * test_config.shape[1];
-    uint32_t Wt = W / TILE_WIDTH;
-    uint32_t Ht = H / TILE_HEIGHT;
-    uint32_t num_tensor_tiles = NC * H * W / (TILE_WIDTH * TILE_HEIGHT);
+    uint32_t Wt = W / tile_W;
+    uint32_t Ht = H / tile_H;
+    uint32_t num_tensor_tiles = NC * H * W / (tile_W * tile_H);
     float scaler = get_scaler(test_config);
     switch (test_config.reduce_dim) {
         case ReduceDim::H: {
@@ -213,6 +215,7 @@ void add_reader_writer_kernels(
                     Wt,
                     Ht * Wt,
                     *reinterpret_cast<uint32_t*>(&scaler),
+                    (tile_H * tile_W == 1024) ? 11 : 10,
                 });
 
             uint32_t num_tiles =
@@ -258,13 +261,15 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
 
     CoreCoord core = {0, 0};
 
+    uint32_t tile_H = test_config.tile_shape.get_tile_shape()[0], tile_W = test_config.tile_shape.get_tile_shape()[1];
     uint32_t W = test_config.shape[3], H = test_config.shape[2], NC = test_config.shape[1] * test_config.shape[0];
     uint32_t HW = H * W;
     uint32_t N = test_config.shape[0] * test_config.shape[1];
-    TT_FATAL(W % TILE_WIDTH == 0 && H % TILE_HEIGHT == 0, "Error");
+    TT_FATAL((tile_H == 16 && tile_W == 32) || (tile_H == 32 && tile_W == 32), "Error");  // validate tile shape
+    TT_FATAL(W % tile_W == 0 && H % tile_H == 0, "Error");
     TT_FATAL(H > 0 && W > 0 && NC > 0, "Error");
-    uint32_t Wt = W / TILE_WIDTH;
-    uint32_t Ht = H / TILE_HEIGHT;
+    uint32_t Wt = W / tile_W;
+    uint32_t Ht = H / tile_H;
 
     uint32_t num_golden_elements;
     switch (test_config.reduce_dim) {
@@ -272,7 +277,7 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
             num_golden_elements = NC * W * 32 / 2;
             break;  // expecting one tile in H, and half the elements since the vector packs 2 uint16_ts
         case ReduceDim::W:
-            num_golden_elements = NC * H * TILE_WIDTH / 2;
+            num_golden_elements = NC * H * tile_W / 2;
             break;  // expecting one tile in H, and half the elements since the vector packs 2 uint16_ts
         case ReduceDim::HW:
             num_golden_elements = NC * 32 * 32 / 2;
@@ -282,11 +287,11 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
 
     float scaler = get_scaler(test_config);
 
-    uint32_t num_tensor_tiles = NC * H * W / (TILE_WIDTH * TILE_HEIGHT);
+    uint32_t num_tensor_tiles = NC * H * W / (tile_W * tile_H);
     uint32_t divisor = test_config.reduce_dim == ReduceDim::W ? Wt : Ht;
     TT_FATAL(num_tensor_tiles % divisor == 0, "Error");
 
-    uint32_t single_tile_bytes = 2 * 1024;
+    uint32_t single_tile_bytes = 2 * (tile_W * tile_H);
     uint32_t dram_buffer_size = single_tile_bytes * num_tensor_tiles;
 
     uint32_t src_page_size = single_tile_bytes;
@@ -320,7 +325,8 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(
             num_buffer_tiles * single_tile_bytes, {{src0_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src0_cb_index, single_tile_bytes);
+            .set_page_size(src0_cb_index, single_tile_bytes)
+            .set_tile_dims(src0_cb_index, test_config.tile_shape);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     uint32_t ouput_cb_index = tt::CBIndex::c_16;
@@ -328,12 +334,17 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(
             num_output_buffer_tiles * single_tile_bytes, {{ouput_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(ouput_cb_index, single_tile_bytes);
+            .set_page_size(ouput_cb_index, single_tile_bytes)
+            .set_tile_dims(ouput_cb_index, test_config.tile_shape);
     auto cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 
     tt_metal::CircularBufferConfig cb_temp_reduce_tile_config =
-        tt_metal::CircularBufferConfig(2 * single_tile_bytes, {{CBIndex::c_2, tt::DataFormat::Float16_b}})
-            .set_page_size(CBIndex::c_2, single_tile_bytes);
+        tt_metal::CircularBufferConfig(
+            2 * (2 * TILE_WIDTH * TILE_HEIGHT),
+            {{CBIndex::c_2,
+              tt::DataFormat::Float16_b}})  // full tile size because reader kernel is hard-coded to full tile
+            .set_page_size(CBIndex::c_2, single_tile_bytes)
+            .set_tile_dims(CBIndex::c_2, tt_metal::Tile({32, 32}));
     auto cb_temp_reduce_tile = tt_metal::CreateCircularBuffer(program, core, cb_temp_reduce_tile_config);
 
     add_reader_writer_kernels(program, core, test_config, src_dram_buffer, dst_dram_buffer);
@@ -343,6 +354,7 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
         uint(Wt),
         uint(NC),
         test_config.at_start,
+        uint((tile_H / 16) * (tile_W / 16)),
     };
 
     std::map<string, string> reduce_defines = {{"REDUCE_DIM", get_reduce_dim_define_string(test_config.reduce_dim)}};
@@ -419,7 +431,8 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
         u16_src0_vec,
         test_config.shape,
         tests::utils::TensorLayoutType::TILED_NFACES,
-        tests::utils::TensorLayoutType::LIN_ROW_MAJOR);
+        tests::utils::TensorLayoutType::LIN_ROW_MAJOR,
+        PhysicalSize{tile_H, tile_W});
     std::vector<uint16_t> gold_reduced = test_config.golden_function(
         src_linear, test_config.shape, scaler, uint8_t(test_config.reduce_type), true);  // result is uint16_t untilized
 
@@ -428,7 +441,8 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
         gold_reduced,
         test_config.result_shape,
         tests::utils::TensorLayoutType::LIN_ROW_MAJOR,
-        tests::utils::TensorLayoutType::TILED_NFACES));
+        tests::utils::TensorLayoutType::TILED_NFACES,
+        PhysicalSize{tile_H, tile_W}));
 
     bool pass = packed_uint32_t_vector_comparison(result_vec, gold_4f_u32, comparison_function, &argfail);
     if (!pass) {
@@ -438,7 +452,10 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
     EXPECT_TRUE(pass);
     log_info(
         LogTest,
-        "MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}, at_start = {}",
+        "TileDimH = {}, TileDimW = {}, MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}, at_start = "
+        "{}",
+        test_config.tile_shape.get_tile_shape()[0],
+        test_config.tile_shape.get_tile_shape()[1],
         test_config.math_fidelity,
         test_config.reduce_type,
         test_config.fp32_dest_acc_en,
@@ -798,6 +815,47 @@ TEST_F(DeviceFixture, DISABLED_TensixComputeReduceHWShortInit) {
                             .dst_full_sync_en = dst_full_sync_en,
                             .at_start = at_start,
                             .math_fidelity = MathFidelity(math_fid)};
+                        run_single_core_reduce_program(this->devices_.at(0), test_config);
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_F(DeviceFixture, TensixComputeReduceWTinyTiles) {
+    tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT / 2, TILE_WIDTH});
+    std::vector<uint32_t> shape = {1, 1, 1 * tile_shape.get_tile_shape()[0], 13 * tile_shape.get_tile_shape()[1]};
+    std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], tile_shape.get_tile_shape()[1]};
+    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+        // MathFidelity : {0, 2, 3, 4}; so skip value 1
+        if (math_fid == 1) {
+            continue;
+        }
+        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+            for (bool fp32_dest_acc_en : {true, false}) {
+                if ((fp32_dest_acc_en == true) && (this->arch_ == tt::ARCH::GRAYSKULL)) {
+                    continue;
+                }
+                for (bool dst_full_sync_en : {true, false}) {
+                    for (bool at_start : {true, false}) {
+                        ReduceConfig test_config = {
+                            .tile_shape = tile_shape,
+                            .shape = shape,
+                            .reduce_dim = ReduceDim::W,
+                            .reduce_type = ReduceType(reduce_type),
+                            .data_gen_rand_max = 0.0f,
+                            .data_gen_seed = std::chrono::system_clock::now().time_since_epoch().count(),
+                            .data_gen_offset = 1.0f,
+                            .atol = 1e-2f,
+                            .rtol = 0.08f,
+                            .golden_function = ::unit_tests::compute::gold_reduce_w,
+                            .result_shape = result_shape,
+                            .fp32_dest_acc_en = fp32_dest_acc_en,
+                            .dst_full_sync_en = dst_full_sync_en,
+                            .at_start = at_start,
+                            .math_fidelity = MathFidelity(math_fid),
+                        };
                         run_single_core_reduce_program(this->devices_.at(0), test_config);
                     }
                 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -44,6 +44,7 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     constexpr bool at_start = get_compile_time_arg_val(3);
+    constexpr uint32_t num_faces = get_compile_time_arg_val(4);
     dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #ifndef SHORT_INIT
     reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
@@ -65,10 +66,10 @@ void MAIN {
 #if (MATH_ONLY == 1)
                 UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
-                reduce_tile_math(reduce_dst_idx);
+                reduce_tile_math(reduce_dst_idx, num_faces);
 #elif (MATH_ONLY == 0)
                 // REDUCE_OP is expected to come from add_define
-                reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx);
+                reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx, num_faces);
 #endif
                 cb_pop_front(tt::CBIndex::c_0, onetile);
             }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -44,7 +44,6 @@ void MAIN {
     constexpr uint32_t Wt = get_compile_time_arg_val(1);
     constexpr uint32_t NC = get_compile_time_arg_val(2);
     constexpr bool at_start = get_compile_time_arg_val(3);
-    constexpr uint32_t num_faces = get_compile_time_arg_val(4);
     dummy_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
 #ifndef SHORT_INIT
     reduce_init<at_start>(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_16);
@@ -66,10 +65,10 @@ void MAIN {
 #if (MATH_ONLY == 1)
                 UNPACK((llk_unpack_AB(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0)));
                 // REDUCE_OP is expected to come from add_define
-                reduce_tile_math(reduce_dst_idx, num_faces);
+                reduce_tile_math(reduce_dst_idx);
 #elif (MATH_ONLY == 0)
                 // REDUCE_OP is expected to come from add_define
-                reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx, num_faces);
+                reduce_tile(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, reduce_dst_idx);
 #endif
                 cb_pop_front(tt::CBIndex::c_0, onetile);
             }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank.cpp
@@ -47,8 +47,9 @@ void kernel_main() {
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
-    uint32_t tile_bytes = get_tile_size(cb_id_in0);
-    uint32_t log_2_tile_bytes = (tile_bytes == 2048 ? 11 : 10);
+    constexpr uint32_t tile_bytes = get_tile_size(cb_id_in0);
+    constexpr uint32_t log_2_tile_bytes = tile_bytes == 2048 ? 11 : (tile_bytes == 1024 ? 10 : 0);
+    static_assert(log_2_tile_bytes);  // catch invalid tile size
 
     constexpr bool read_from_dram = get_read_from_dram();
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank.cpp
@@ -42,6 +42,7 @@ void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t num_tiles =
         get_arg_val<uint32_t>(3);  // same arg index as in reader_unary and in reader_unary_transpose_wh_8bank
+    uint32_t pow_2 = get_arg_val<uint32_t>(9);
 
     constexpr uint32_t cb_id_in0 = 0, cb_id_in1 = 1;
 
@@ -51,7 +52,7 @@ void kernel_main() {
 
     constexpr bool read_from_dram = get_read_from_dram();
 
-    const InterleavedPow2AddrGen<read_from_dram> src_a = {src_addr, 11};
+    const InterleavedPow2AddrGen<read_from_dram> src_a = {src_addr, pow_2};
 
 #if GENERATE_BCAST_SCALER
     // TODO(AP): cleanup, probably with named args/param pack/reflection.

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -20,6 +20,19 @@ inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
     _llk_math_reduce_<type, dim, num_fidelity_phases, is_fp32_dest_acc_en, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
+template <
+    PoolType type,
+    ReduceDim dim,
+    int num_fidelity_phases = 0,
+    bool is_fp32_dest_acc_en = false,
+    bool is_int_fpu_en = false>
+inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
+    const std::uint32_t operand_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_reduce_<type, dim, num_fidelity_phases, is_fp32_dest_acc_en, is_int_fpu_en>(dst_index, false, num_faces);
+}
+
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>
 inline void llk_math_reduce_init(
     const std::uint32_t within_face_16x16_transpose =

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_reduce_api.h
@@ -20,6 +20,19 @@ inline void llk_math_reduce(const uint dst_index, const uint num_faces = 4) {
     _llk_math_reduce_<type, dim, num_fidelity_phases, is_fp32_dest_acc_en, is_int_fpu_en>(dst_index, false, num_faces);
 }
 
+template <
+    PoolType type,
+    ReduceDim dim,
+    int num_fidelity_phases = 0,
+    bool is_fp32_dest_acc_en = false,
+    bool is_int_fpu_en = false>
+inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t dst_index) {
+    const std::uint32_t operand_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_reduce_<type, dim, num_fidelity_phases, is_fp32_dest_acc_en, is_int_fpu_en>(dst_index, false, num_faces);
+}
+
 template <PoolType type, ReduceDim dim, int num_fidelity_phases = 0>
 inline void llk_math_reduce_init(
     const std::uint32_t within_face_16x16_transpose =

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -91,9 +91,8 @@ ALWI void reduce_revert_delta(uint32_t ocb) {
  */
 // clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_tile(
-    uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t num_faces = 4) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, MATH_FIDELITY, DST_ACCUM_MODE>(idst, num_faces)));
+ALWI void reduce_tile(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
+    MATH((llk_math_reduce<reduce_type, reduce_dim, MATH_FIDELITY, DST_ACCUM_MODE>(icb0, icb1, idst)));
     UNPACK((llk_unpack_AB(icb0, icb1, itile0, itile1)));
 }
 

--- a/tt_metal/include/compute_kernel_api/reduce.h
+++ b/tt_metal/include/compute_kernel_api/reduce.h
@@ -85,14 +85,15 @@ ALWI void reduce_revert_delta(uint32_t ocb) {
  * |----------------|-----------------------------------------------------------------|----------|------------------------------------------------|----------|
  * | icb0           | The identifier of the circular buffer (CB) containing A         | uint32_t | 0 to 31                                        | True     |
  * | icb1           | CB for Scaling factor applied to each element of the result.    | uint32_t | 0 to 31                                        | True     |
- * | itile0         | The index of the tile within the first CB                       | uint32_t | Must be less than the size of the CB           | True     | 
- * | itile1         | The index of the tile within the scaling factor CB.             | uint32_t | Must be less than the size of the CB           | True     | 
+ * | itile0         | The index of the tile within the first CB                       | uint32_t | Must be less than the size of the CB           | True     |
+ * | itile1         | The index of the tile within the scaling factor CB.             | uint32_t | Must be less than the size of the CB           | True     |
  * | idst           | The index of the tile in DST REG for the result                 | uint32_t | Must be less than the acquired size of DST REG | True     |
  */
- // clang-format on
+// clang-format on
 template <PoolType reduce_type = REDUCE_OP, ReduceDim reduce_dim = REDUCE_DIM>
-ALWI void reduce_tile(uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, MATH_FIDELITY, DST_ACCUM_MODE>(idst)));
+ALWI void reduce_tile(
+    uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t num_faces = 4) {
+    MATH((llk_math_reduce<reduce_type, reduce_dim, MATH_FIDELITY, DST_ACCUM_MODE>(idst, num_faces)));
     UNPACK((llk_unpack_AB(icb0, icb1, itile0, itile1)));
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20023)

### Problem description
Binary broadcast cols and reduce w kernels lack support for 16x32 tiny tiles, which can speed up SDPA decode OP. 

### What's changed
Added support for those two OPs to work on 16x32 tiles, and added unit testing for those cases.
LLK submodule update.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14482291935) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14482293296) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14408777028) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14408778051) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes