### PR TITLE
Refactor program.cpp

### DIFF
--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -60,7 +60,7 @@ class CommandQueue;
 class HWCommandQueue;
 
 namespace detail {
-class Program_;
+class ProgramImpl;
 
 void ValidateCircularBufferRegion(const Program& program, const IDevice* device);
 KernelHandle AddKernel(
@@ -86,7 +86,7 @@ struct KernelGroup {
 
     KernelGroup();
     KernelGroup(
-        const detail::Program_& program,
+        const detail::ProgramImpl& program,
         uint32_t programmable_core_type_index,
         kernel_id_array_t kernel_ids,
         bool erisc_is_idle,
@@ -191,7 +191,7 @@ public:
     uint32_t get_cb_memory_size() const;
 
 private:
-    std::unique_ptr<detail::Program_> pimpl_;
+    std::unique_ptr<detail::ProgramImpl> pimpl_;
 
     friend CBHandle CreateCircularBuffer(
         Program& program,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -61,6 +61,7 @@
 #include "profiler_state.hpp"
 #include "program_command_sequence.hpp"
 #include "program_device_map.hpp"
+#include "program_impl.hpp"
 #include "tt-metalium/program.hpp"
 #include "rtoptions.hpp"
 #include "span.hpp"
@@ -151,199 +152,6 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions&
 }  // namespace
 namespace detail {
 
-class Program_ {
-   public:
-    Program_();
-
-    Program_(const Program_ &other) = delete;
-    Program_& operator=(const Program_ &other) = delete;
-
-    Program_(Program_ &&other) = default;
-    Program_& operator=(Program_ &&other) = default;
-
-    void set_runtime_id(uint64_t id);
-    ~Program_() noexcept = default;
-
-    uint64_t get_id() const;
-    uint64_t get_runtime_id() const;
-
-    size_t num_kernels() const;
-
-    const std::vector<std::shared_ptr<CircularBuffer>> &circular_buffers() const;
-
-    const std::vector< Semaphore > & semaphores() const;
-
-    KernelGroup * kernels_on_core(const CoreCoord &core, uint32_t programmable_core_type_index);
-    std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
-    std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
-    void add_buffer(std::shared_ptr<Buffer> buf);
-    void release_buffers();
-    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_core(const CoreCoord &core) const;
-
-    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_corerange(const CoreRange &cr) const;
-
-    std::vector<CoreRange> circular_buffers_unique_coreranges() const;
-
-    std::vector<std::reference_wrapper<const Semaphore>> semaphores_on_core(const CoreCoord &core, CoreType core_type) const;
-
-    size_t num_semaphores () const;
-    void init_semaphores ( const IDevice & device, const CoreCoord &logical_core, uint32_t programmable_core_type_index) const;
-    // XXXXX TODO: this should return a const reference
-    std::vector<std::vector<CoreCoord>> logical_cores() const;
-
-    void compile(IDevice* device, bool fd_bootloader_mode = false);
-
-    void invalidate_circular_buffer_allocation();
-
-    void allocate_circular_buffers(const IDevice* device);
-    uint32_t get_cb_memory_size() const;
-
-    bool is_finalized() const;
-    void set_finalized();
-    void allocate_kernel_bin_buf_on_device(IDevice* device);
-    bool is_cached() const { return this->cached_device_hash_.has_value(); }
-    ProgramBinaryStatus get_program_binary_status(std::size_t device_id) const {
-        if (auto it = this->binaries_on_device_.find(device_id); it != this->binaries_on_device_.end()) {
-            return it->second;
-        }
-        return ProgramBinaryStatus::NotSent;
-    }
-    void set_cached(uint64_t device_hash) { this->cached_device_hash_ = device_hash; }
-    const std::optional<uint64_t>& get_cached() const { return this->cached_device_hash_; }
-    void set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status) {
-        this->binaries_on_device_[device_id] = status;
-    }
-    std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
-
-    ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
-
-    const std::vector<SubDeviceId> &determine_sub_device_ids(const IDevice* device);
-
-    // debug/test
-    uint32_t get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
-    uint32_t get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
-    void set_last_used_command_queue_for_testing(CommandQueue* queue);
-    CommandQueue* get_last_used_command_queue() const;
-    void populate_dispatch_data(IDevice* device);
-
-   private:
-       CommandQueue* last_used_command_queue_for_testing = nullptr;
-
-       // Buffers temporarily owned by the program
-       std::vector<std::shared_ptr<Buffer>> owned_buffer_pool = {};
-
-       // The buffer that holds the kernel/binaries/etc for this program
-       std::unordered_map<chip_id_t, std::shared_ptr<Buffer>> kernels_buffer_;
-       ProgramTransferInfo program_transfer_info;
-
-       bool finalized_;
-       // Used only when devices do not have virtualization enabled and used to check that programs are only rerun on
-       // the same device
-       std::optional<uint64_t> cached_device_hash_;
-
-       // TODO: Should map based on the hash of the configured sub-devices
-       // This way we can cache it agnostic of the device
-       std::unordered_map<chip_id_t, std::unordered_map<SubDeviceManagerId, std::vector<SubDeviceId>>> sub_device_ids_;
-
-       struct CircularBufferAllocator {
-           CircularBufferAllocator(const CoreRange& core_range_) : core_range(core_range_) {}
-
-           // Circular buffers are created and allocated at core range granularity
-           CoreRange core_range;
-
-           // Holds vector of addresses where circular buffers are allocated [start, end)
-           // There are multiple ranges because per core L1 regions are not in lockstep but circular buffers spanning
-           // multiple cores must share the same address To enable this, circular buffer address is the maximum address
-           // amongst all of its target cores This vector is sorted from lower to higher address spaces
-           std::vector<std::pair<uint64_t, uint64_t>> l1_regions;
-
-           // Returns address for next circular buffer
-           // Circular buffers are placed sequentially on a core so the next available address gets appended to the last
-           // L1 region
-           uint64_t get_cb_region_end() const { return this->l1_regions.empty() ? 0 : this->l1_regions.back().second; }
-
-           // If address is the end of the last L1 region, the last region is extended by size bytes,
-           //  otherwise address must be higher than existing regions and a new L1 region [address, size) is added
-           void mark_address(uint64_t address, uint64_t size, uint64_t base_address);
-
-           // Reset when circular buffer allocation is invalidated
-           void reset_available_addresses() { this->l1_regions.clear(); }
-       };
-
-    uint64_t id; // Need to make non-const due to move constructor
-    uint64_t runtime_id;
-    static std::atomic<uint64_t> program_counter;
-    // Programmable core type index -> KernelHandle -> Kernel
-    std::vector<std::unordered_map<KernelHandle, std::shared_ptr<Kernel> >> kernels_;
-    std::vector<CoreCoord> grid_extent_;
-
-    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_;
-    std::unordered_map<CBHandle,  std::shared_ptr<CircularBuffer>> circular_buffer_by_id_;
-    // Tracks which circular buffer indices are being used
-    std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_cb_indices_;
-    std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_local_cb_indices_;
-    std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_remote_cb_indices_;
-    std::unordered_map<std::size_t, ProgramBinaryStatus> binaries_on_device_;
-    // Used to generate circular buffer addresses. There is one CircularBufferAllocator per unique CoreRange
-    std::vector<CircularBufferAllocator> cb_allocators_;
-
-    std::vector<Semaphore> semaphores_;
-
-    std::unordered_set<uint32_t> compiled_;
-    bool local_circular_buffer_allocation_needed_;
-
-    static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;
-    std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
-    std::vector<std::vector<uint8_t>> core_to_kernel_group_index_table_;
-
-    std::vector<ProgramConfig> program_configs_;
-    // Counts how much space is needed for each core + each launch buffer msg queue.
-    std::vector<uint32_t> program_config_sizes_;
-
-    // The rta_updates from one cached command sequence may reference data in another cached command sequence.
-    std::unordered_map<uint64_t, ProgramCommandSequence> cached_program_command_sequences_;
-
-    friend std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CBHandle id);
-    friend void ValidateCircularBufferRegion(const Program &program, const IDevice* device);
-
-    friend KernelHandle AddKernel(Program &program, const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType core_type);
-
-    KernelHandle add_kernel(const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType &core_type);
-
-    CBHandle add_circular_buffer_(const std::shared_ptr<CircularBuffer>& circular_buffer);
-    CBHandle add_circular_buffer(const CoreRangeSet &core_range_set, const CircularBufferConfig &config);
-    CBHandle add_circular_buffer(
-        const CoreRangeSet& core_range_set,
-        const CircularBufferConfig& config,
-        const experimental::GlobalCircularBuffer& global_circular_buffer);
-    std::shared_ptr<CircularBuffer> get_circular_buffer(CBHandle cb_id) const;
-
-    void add_semaphore(const CoreRangeSet & crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type);
-
-    // Ensures that statically allocated circular buffers do not grow into L1 buffer space
-    void validate_circular_buffer_region(const IDevice* device);
-
-    void set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const;
-
-    void set_cb_data_fmt(const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
-
-    void set_cb_tile_dims(const std::vector<CoreRange> & crs, JitBuildOptions& build_options) const;
-
-    void update_kernel_groups(uint32_t programmable_core_type_index);
-
-    uint32_t& get_program_config_size(uint32_t programmable_core_type_index);
-
-    void set_launch_msg_sem_offsets();
-
-    bool runs_on_noc_unicast_only_cores();
-    bool runs_on_noc_multicast_only_cores();
-    bool kernel_binary_always_stored_in_ringbuffer();
-
-    friend EnqueueProgramCommand;
-    friend Program;
-    friend Internal_;
-};
-
 KernelHandle AddKernel (Program &program, const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType core_type) {
     return program.pimpl_->add_kernel(std::move(kernel), core_type);
 }
@@ -367,7 +175,7 @@ void DisablePersistentKernelCache() { enable_persistent_kernel_cache = false; }
 
 class Internal_ {
    public:
-    using map_type = decltype(detail::Program_::circular_buffer_by_id_);
+    using map_type = decltype(detail::ProgramImpl::circular_buffer_by_id_);
 
     static const map_type &get_circular_buffers_by_id(const Program &program) noexcept {
         return program.pimpl_->circular_buffer_by_id_;
@@ -376,9 +184,9 @@ class Internal_ {
 
 }  // namespace detail
 
-std::atomic<uint64_t> detail::Program_::program_counter = 0;
+std::atomic<uint64_t> detail::ProgramImpl::program_counter = 0;
 
-detail::Program_::Program_() :
+detail::ProgramImpl::ProgramImpl() :
     id(program_counter++),
     runtime_id(0),
     local_circular_buffer_allocation_needed_(false),
@@ -396,12 +204,12 @@ detail::Program_::Program_() :
     program_config_sizes_.resize(programmable_core_count + 2);
 }
 
-Program::Program() : pimpl_(std::make_unique<detail::Program_>()) {
+Program::Program() : pimpl_(std::make_unique<detail::ProgramImpl>()) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureProgramConstructor, *this);
 }
 
-KernelHandle detail::Program_::add_kernel(const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType &programmable_core_type) {
+KernelHandle detail::ProgramImpl::add_kernel(const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType &programmable_core_type) {
     TT_FATAL(this->compiled_.empty(), "Cannot add kernel to an already compiled program {}", this->id);
     // Id is unique across all kernels on all core types
     KernelHandle id = this->num_kernels();
@@ -412,7 +220,7 @@ KernelHandle detail::Program_::add_kernel(const std::shared_ptr<Kernel>& kernel,
     return id;
 }
 
-std::shared_ptr<Kernel> detail::Program_::get_kernel(KernelHandle kernel_id) const {
+std::shared_ptr<Kernel> detail::ProgramImpl::get_kernel(KernelHandle kernel_id) const {
     // TT_ASSERT(kernel_id < this->kernels_.size(), "Expected Kernel with ID {} to be in Program {}", kernel_id,
     // this->id);
     //  find coretype based on kernel_id
@@ -431,7 +239,7 @@ std::shared_ptr<Kernel> Program::get_kernel(KernelHandle kernel_id) const { retu
 KernelGroup::KernelGroup() : core_ranges(CoreRangeSet()) {}
 
 KernelGroup::KernelGroup(
-    const detail::Program_& program,
+    const detail::ProgramImpl& program,
     uint32_t programmable_core_type_index,
     kernel_id_array_t kernel_ids,
     bool /*erisc_is_idle*/,
@@ -504,7 +312,7 @@ KernelGroup::KernelGroup(
 
 CoreType KernelGroup::get_core_type() const { return hal_ref.get_core_type(this->programmable_core_type_index); };
 
-std::vector<std::shared_ptr<KernelGroup>> &detail::Program_::get_kernel_groups(uint32_t programmable_core_type_index) {
+std::vector<std::shared_ptr<KernelGroup>> &detail::ProgramImpl::get_kernel_groups(uint32_t programmable_core_type_index) {
     update_kernel_groups(programmable_core_type_index);
     return kernel_groups_[programmable_core_type_index];
 }
@@ -513,7 +321,7 @@ std::vector<std::shared_ptr<KernelGroup>> &Program::get_kernel_groups(uint32_t p
     return pimpl_->get_kernel_groups(programmable_core_type_index);
 }
 
-std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& detail::Program_::get_kernels(uint32_t programmable_core_type_index) {
+std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& detail::ProgramImpl::get_kernels(uint32_t programmable_core_type_index) {
     return this->kernels_.at(programmable_core_type_index);
 }
 
@@ -521,7 +329,7 @@ std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& Program::get_kernels(
     return pimpl_->get_kernels(programmable_core_type_index);
 }
 
-KernelGroup *detail::Program_::kernels_on_core(const CoreCoord &core, uint32_t programmable_core_type_index) {
+KernelGroup *detail::ProgramImpl::kernels_on_core(const CoreCoord &core, uint32_t programmable_core_type_index) {
     update_kernel_groups(programmable_core_type_index);
     if (core.x >= grid_extent_[programmable_core_type_index].x || core.y >= grid_extent_[programmable_core_type_index].y)
         return nullptr;
@@ -563,7 +371,7 @@ struct KernelGroupIntHasher {
     }
 };
 
-void detail::Program_::update_kernel_groups(uint32_t programmable_core_type_index) {
+void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_index) {
     if (core_to_kernel_group_index_table_[programmable_core_type_index].size() == 0) {
         bool erisc_is_idle = false;
 
@@ -724,7 +532,7 @@ void detail::Program_::update_kernel_groups(uint32_t programmable_core_type_inde
 
 }
 
-void detail::Program_::CircularBufferAllocator::mark_address(uint64_t address, uint64_t size, uint64_t base_address) {
+void detail::ProgramImpl::CircularBufferAllocator::mark_address(uint64_t address, uint64_t size, uint64_t base_address) {
     if (this->l1_regions.empty()) {
         this->l1_regions.emplace_back(base_address, base_address);
     }
@@ -743,7 +551,7 @@ void detail::Program_::CircularBufferAllocator::mark_address(uint64_t address, u
     }
 }
 
-CBHandle detail::Program_::add_circular_buffer_(
+CBHandle detail::ProgramImpl::add_circular_buffer_(
     const std::shared_ptr<CircularBuffer>& circular_buffer) {
     // Globally allocated circular buffer do not invalidate allocation because their addresses are tracked by memory
     // allocator
@@ -803,14 +611,14 @@ CBHandle detail::Program_::add_circular_buffer_(
     return circular_buffer->id();
 }
 
-CBHandle detail::Program_::add_circular_buffer(const CoreRangeSet& core_range_set, const CircularBufferConfig& config) {
+CBHandle detail::ProgramImpl::add_circular_buffer(const CoreRangeSet& core_range_set, const CircularBufferConfig& config) {
     TT_FATAL(this->compiled_.empty(), "Cannot add circular buffer to an already compiled program {}", this->id);
     // Merge ranges to reduce the number of multicasts needed to initialize CBs.
     std::shared_ptr<CircularBuffer> circular_buffer = std::make_shared<CircularBuffer>(core_range_set.merge_ranges(), config);
     return add_circular_buffer_(circular_buffer);
 }
 
-CBHandle detail::Program_::add_circular_buffer(
+CBHandle detail::ProgramImpl::add_circular_buffer(
     const CoreRangeSet& core_range_set,
     const CircularBufferConfig& config,
     const experimental::GlobalCircularBuffer& global_circular_buffer) {
@@ -832,14 +640,14 @@ CBHandle Program::add_circular_buffer(
     return pimpl_->add_circular_buffer(core_range_set, config, global_circular_buffer);
 }
 
-std::shared_ptr<CircularBuffer> detail::Program_::get_circular_buffer(CBHandle cb_id) const {
+std::shared_ptr<CircularBuffer> detail::ProgramImpl::get_circular_buffer(CBHandle cb_id) const {
     if (this->circular_buffer_by_id_.find(cb_id) == this->circular_buffer_by_id_.end()) {
         TT_THROW("No circular buffer with id {} exists in Program {}", cb_id, this->id);
     }
     return this->circular_buffer_by_id_.at(cb_id);
 }
 
-std::vector<std::shared_ptr<CircularBuffer>> detail::Program_::circular_buffers_on_core(const CoreCoord &core) const {
+std::vector<std::shared_ptr<CircularBuffer>> detail::ProgramImpl::circular_buffers_on_core(const CoreCoord &core) const {
     std::vector<std::shared_ptr<CircularBuffer>> cbs_on_core;
     for (const auto& circular_buffer : circular_buffers_) {
         if (circular_buffer->is_on_logical_core(core)) {
@@ -853,7 +661,7 @@ std::vector<std::shared_ptr<CircularBuffer>> Program::circular_buffers_on_core(c
     return pimpl_->circular_buffers_on_core(core);
 }
 
-std::vector<std::shared_ptr<CircularBuffer>> detail::Program_::circular_buffers_on_corerange(const CoreRange &cr) const {
+std::vector<std::shared_ptr<CircularBuffer>> detail::ProgramImpl::circular_buffers_on_corerange(const CoreRange &cr) const {
     std::vector<std::shared_ptr<CircularBuffer>> cbs_on_core;
     for (const auto& circular_buffer : circular_buffers_) {
         if (circular_buffer->is_on_logical_corerange(cr)) {
@@ -867,7 +675,7 @@ std::vector<std::shared_ptr<CircularBuffer>> Program::circular_buffers_on_corera
     return pimpl_->circular_buffers_on_corerange(cr);
 }
 
-std::vector<CoreRange> detail::Program_::circular_buffers_unique_coreranges() const {
+std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges() const {
     std::vector<CoreRange> core_ranges;
     for (const auto& circular_buffer : circular_buffers_) {
         for (const CoreRange &core_range : circular_buffer->core_ranges().ranges()) {
@@ -883,7 +691,7 @@ std::vector<CoreRange> Program::circular_buffers_unique_coreranges() const {
     return pimpl_->circular_buffers_unique_coreranges();
 }
 
-void detail::Program_::invalidate_circular_buffer_allocation() {
+void detail::ProgramImpl::invalidate_circular_buffer_allocation() {
     if (this->local_circular_buffer_allocation_needed_) {
         return;
     }
@@ -896,7 +704,7 @@ void detail::Program_::invalidate_circular_buffer_allocation() {
 void Program::invalidate_circular_buffer_allocation() { pimpl_->invalidate_circular_buffer_allocation(); }
 
 uint32_t Program::get_cb_memory_size() const { return pimpl_->get_cb_memory_size(); }
-uint32_t detail::Program_::get_cb_memory_size() const {
+uint32_t detail::ProgramImpl::get_cb_memory_size() const {
     uint32_t total_cb_size = 0;
     for (const auto& circular_buffer : this->circular_buffers_) {
         if (circular_buffer->globally_allocated()) {
@@ -906,7 +714,7 @@ uint32_t detail::Program_::get_cb_memory_size() const {
     }
     return total_cb_size;
 }
-void detail::Program_::allocate_circular_buffers(const IDevice* device) {
+void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
     //ZoneScoped;
     if (not this->local_circular_buffer_allocation_needed_) {
         return;
@@ -950,7 +758,7 @@ void detail::Program_::allocate_circular_buffers(const IDevice* device) {
 
 void Program::allocate_circular_buffers(const IDevice* device) { pimpl_->allocate_circular_buffers(device); }
 
-void detail::Program_::validate_circular_buffer_region(const IDevice* device) {
+void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device) {
     //ZoneScoped;
 
     // TODO: Circular buffer allocation and validation could be better optimized by determining usage per sub-device
@@ -982,11 +790,11 @@ void detail::Program_::validate_circular_buffer_region(const IDevice* device) {
     }
 }
 
-size_t detail::Program_::num_semaphores() const { return semaphores_.size(); }
+size_t detail::ProgramImpl::num_semaphores() const { return semaphores_.size(); }
 
 size_t Program::num_semaphores() const { return pimpl_->num_semaphores(); }
 
-void detail::Program_::init_semaphores(const IDevice &device, const CoreCoord &logical_core, uint32_t programmable_core_type_index) const {
+void detail::ProgramImpl::init_semaphores(const IDevice &device, const CoreCoord &logical_core, uint32_t programmable_core_type_index) const {
     uint64_t kernel_config_base = hal_ref.get_dev_addr(programmable_core_type_index, HalL1MemAddrType::KERNEL_CONFIG);
     uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
     CoreType core_type = hal_ref.get_core_type(programmable_core_type_index);
@@ -1004,7 +812,7 @@ void Program::init_semaphores(const IDevice &device, const CoreCoord &logical_co
     pimpl_->init_semaphores(device, logical_core, programmable_core_type_index);
 }
 
-void detail::Program_::add_semaphore(const CoreRangeSet &crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type) {
+void detail::ProgramImpl::add_semaphore(const CoreRangeSet &crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type) {
     TT_FATAL(this->compiled_.empty(), "Cannot add semaphore to an already compiled program {}", this->id);
     semaphores_.emplace_back(Semaphore(crs, semaphore_id, init_value, core_type));
 }
@@ -1013,7 +821,7 @@ void Program::add_semaphore(const CoreRangeSet &crs, uint32_t semaphore_id, uint
     pimpl_->add_semaphore(crs, semaphore_id, init_value, core_type);
 }
 
-std::vector<std::vector<CoreCoord>> detail::Program_::logical_cores() const {
+std::vector<std::vector<CoreCoord>> detail::ProgramImpl::logical_cores() const {
     std::vector<std::vector<CoreCoord>> cores_in_program;
     std::vector<std::set<CoreCoord>> unique_cores;
     for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < kernels_.size(); programmable_core_type_index++) {
@@ -1035,7 +843,7 @@ std::vector<std::vector<CoreCoord>> detail::Program_::logical_cores() const {
 
 std::vector<std::vector<CoreCoord>> Program::logical_cores() const { return pimpl_->logical_cores(); }
 
-void detail::Program_::set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const {
+void detail::ProgramImpl::set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const {
     const auto& kernel_defines = kernel->defines();
     const std::string reserved_defines[] = {"ALIGN_LOCAL_CBS_TO_REMOTE_CBS"};
     for (const auto& str : reserved_defines) {
@@ -1078,7 +886,7 @@ void detail::Program_::set_remote_circular_buffer_init(const std::shared_ptr<Ker
     }
 }
 
-void detail::Program_::set_cb_data_fmt(const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
+void detail::ProgramImpl::set_cb_data_fmt(const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
     //ZoneScoped;
     for (const auto& logical_cr : crs) {
         const auto& cbs_on_core = this->circular_buffers_on_corerange(logical_cr);
@@ -1091,7 +899,7 @@ void detail::Program_::set_cb_data_fmt(const std::vector<CoreRange> &crs, JitBui
     }
 }
 
-void detail::Program_::set_cb_tile_dims(const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
+void detail::ProgramImpl::set_cb_tile_dims(const std::vector<CoreRange> &crs, JitBuildOptions &build_options) const {
     //ZoneScoped;
     for (const auto &logical_cr : crs) {
         const auto& cbs_on_core = this->circular_buffers_on_corerange(logical_cr);
@@ -1122,7 +930,7 @@ void detail::Program_::set_cb_tile_dims(const std::vector<CoreRange> &crs, JitBu
     }
 }
 
-void detail::Program_::populate_dispatch_data(IDevice* device) {
+void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
     auto extract_dst_noc_unicast_info =
         [&device](const auto &ranges, const CoreType core_type) -> std::vector<std::pair<transfer_info_cores, uint32_t>> {
         // This API extracts all the pairs of noc multicast encodings given a set of core ranges
@@ -1292,7 +1100,7 @@ void detail::Program_::populate_dispatch_data(IDevice* device) {
     return;
 }
 
-ProgramConfig& detail::Program_::get_program_config(uint32_t programmable_core_type_index) {
+ProgramConfig& detail::ProgramImpl::get_program_config(uint32_t programmable_core_type_index) {
     return this->program_configs_[programmable_core_type_index];
 }
 
@@ -1300,7 +1108,7 @@ ProgramConfig& Program::get_program_config(uint32_t programmable_core_type_index
     return pimpl_->get_program_config(programmable_core_type_index);
 }
 
-void detail::Program_::set_launch_msg_sem_offsets() {
+void detail::ProgramImpl::set_launch_msg_sem_offsets() {
     for (uint32_t kg_type_index = 0; kg_type_index < hal_ref.get_programmable_core_type_count(); kg_type_index++) {
         for (auto& kg : this->get_kernel_groups(kg_type_index)) {
             for (uint32_t sem_type_index = 0; sem_type_index < hal_ref.get_programmable_core_type_count();
@@ -1312,11 +1120,11 @@ void detail::Program_::set_launch_msg_sem_offsets() {
     }
 }
 
-uint32_t& detail::Program_::get_program_config_size(uint32_t programmable_core_type_index) {
+uint32_t& detail::ProgramImpl::get_program_config_size(uint32_t programmable_core_type_index) {
     return this->program_config_sizes_[programmable_core_type_index];
 }
 
-const std::vector<SubDeviceId> &detail::Program_::determine_sub_device_ids(const IDevice* device) {
+const std::vector<SubDeviceId> &detail::ProgramImpl::determine_sub_device_ids(const IDevice* device) {
     // We need to calculate the sub_device_id when we haven't compiled the program yet, or this is the first time we
     // are getting the sub_device_ids after compilation
     auto sub_device_manager_id = device->get_active_sub_device_manager_id();
@@ -1364,7 +1172,7 @@ const std::vector<SubDeviceId> &detail::Program_::determine_sub_device_ids(const
     return sub_device_ids->second;
 }
 
-void detail::Program_::allocate_kernel_bin_buf_on_device(IDevice* device) {
+void detail::ProgramImpl::allocate_kernel_bin_buf_on_device(IDevice* device) {
     // Allocate the DRAM kernel binary buffer for this program on the specified device, if not previously allocated.
     // We allocate program binaries top down to minimize fragmentation with other buffers in DRAM, which are typically allocated bottom up
     std::size_t binary_data_size_bytes = this->program_transfer_info.binary_data.size() * sizeof(uint32_t);
@@ -1410,7 +1218,7 @@ void Program::generate_dispatch_commands(IDevice* device) {
 
 void Program::allocate_kernel_bin_buf_on_device(IDevice* device) { pimpl_->allocate_kernel_bin_buf_on_device(device); }
 
-void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
+void detail::ProgramImpl::compile(IDevice* device, bool fd_bootloader_mode) {
     //ZoneScoped;
     if (compiled_.contains(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)) {
         return;
@@ -1529,7 +1337,7 @@ void detail::Program_::compile(IDevice* device, bool fd_bootloader_mode) {
 
 void Program::compile(IDevice* device, bool fd_bootloader_mode) { pimpl_->compile(device, fd_bootloader_mode); }
 
-void detail::Program_::set_runtime_id(uint64_t id) { this->runtime_id = id; }
+void detail::ProgramImpl::set_runtime_id(uint64_t id) { this->runtime_id = id; }
 
 void Program::set_runtime_id(uint64_t id) { pimpl_->set_runtime_id(id); }
 
@@ -1545,11 +1353,11 @@ uint32_t Program::get_cb_base_addr(IDevice* device, CoreCoord /*logical_core*/, 
     return base_addr + get_program_config(hal_ref.get_programmable_core_type_index(programmable_core_type)).cb_offset;
 }
 
-void detail::Program_::set_last_used_command_queue_for_testing(CommandQueue* queue) {
+void detail::ProgramImpl::set_last_used_command_queue_for_testing(CommandQueue* queue) {
     this->last_used_command_queue_for_testing = queue;
 }
 
-CommandQueue* detail::Program_::get_last_used_command_queue() const {
+CommandQueue* detail::ProgramImpl::get_last_used_command_queue() const {
     return this->last_used_command_queue_for_testing;
 }
 
@@ -1559,7 +1367,7 @@ void Program::set_last_used_command_queue_for_testing(CommandQueue* queue) {
 
 CommandQueue* Program::get_last_used_command_queue() const { return pimpl_->get_last_used_command_queue(); }
 
-uint32_t detail::Program_::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
+uint32_t detail::ProgramImpl::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
     HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(virtual_core);
     uint32_t index = hal_ref.get_programmable_core_type_index(programmable_core_type);
@@ -1571,7 +1379,7 @@ uint32_t Program::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType
     return pimpl_->get_sem_size(device, logical_core, core_type);
 }
 
-uint32_t detail::Program_::get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
+uint32_t detail::ProgramImpl::get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
 
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
     HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(virtual_core);
@@ -1585,7 +1393,7 @@ uint32_t Program::get_cb_size(IDevice* device, CoreCoord logical_core, CoreType 
 }
 
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
-bool detail::Program_::runs_on_noc_unicast_only_cores() {
+bool detail::ProgramImpl::runs_on_noc_unicast_only_cores() {
     return (
         hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1 and
         not this->get_kernel_groups(hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH))
@@ -1595,7 +1403,7 @@ bool detail::Program_::runs_on_noc_unicast_only_cores() {
 bool Program::runs_on_noc_unicast_only_cores() { return pimpl_->runs_on_noc_unicast_only_cores(); }
 
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
-bool detail::Program_::runs_on_noc_multicast_only_cores() {
+bool detail::ProgramImpl::runs_on_noc_multicast_only_cores() {
     return (
         hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX) != -1 and
         not this->get_kernel_groups(hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)).empty());
@@ -1603,7 +1411,7 @@ bool detail::Program_::runs_on_noc_multicast_only_cores() {
 
 bool Program::runs_on_noc_multicast_only_cores() { return pimpl_->runs_on_noc_multicast_only_cores(); }
 
-bool detail::Program_::kernel_binary_always_stored_in_ringbuffer() {
+bool detail::ProgramImpl::kernel_binary_always_stored_in_ringbuffer() {
     // Active ethernet cores use a fixed address for the kernel binary, because they don't have enough memory to have
     // that big of a ringbuffer.
     return !(
@@ -1622,15 +1430,15 @@ Program& Program::operator=(Program &&other) noexcept = default;
 
 Program::~Program() noexcept = default;
 
-uint64_t detail::Program_::get_id() const { return this->id; }
+uint64_t detail::ProgramImpl::get_id() const { return this->id; }
 
 uint64_t Program::get_id() const { return pimpl_->get_id(); }
 
-uint64_t detail::Program_::get_runtime_id() const { return this->runtime_id; }
+uint64_t detail::ProgramImpl::get_runtime_id() const { return this->runtime_id; }
 
 uint64_t Program::get_runtime_id() const { return pimpl_->get_runtime_id(); }
 
-size_t detail::Program_::num_kernels() const {
+size_t detail::ProgramImpl::num_kernels() const {
     size_t count = 0;
     for (const auto& kernels : kernels_) {
         count += kernels.size();
@@ -1640,23 +1448,23 @@ size_t detail::Program_::num_kernels() const {
 
 size_t Program::num_kernels() const { return pimpl_->num_kernels(); }
 
-const std::vector<std::shared_ptr<CircularBuffer>> &detail::Program_::circular_buffers() const { return circular_buffers_; }
+const std::vector<std::shared_ptr<CircularBuffer>> &detail::ProgramImpl::circular_buffers() const { return circular_buffers_; }
 
 const std::vector<std::shared_ptr<CircularBuffer>> &Program::circular_buffers() const { return pimpl_->circular_buffers(); }
 
-const std::vector< Semaphore > & detail::Program_::semaphores() const { return semaphores_; }
+const std::vector< Semaphore > & detail::ProgramImpl::semaphores() const { return semaphores_; }
 
 const std::vector< Semaphore > & Program::semaphores() const { return pimpl_->semaphores(); }
 
-void detail::Program_::add_buffer(std::shared_ptr<Buffer> buf) { owned_buffer_pool.push_back(std::move(buf)); }
+void detail::ProgramImpl::add_buffer(std::shared_ptr<Buffer> buf) { owned_buffer_pool.push_back(std::move(buf)); }
 
 void Program::add_buffer(std::shared_ptr<Buffer> buf) { pimpl_->add_buffer(std::move(buf)); }
 
-void detail::Program_::release_buffers() { owned_buffer_pool = {}; }
+void detail::ProgramImpl::release_buffers() { owned_buffer_pool = {}; }
 
 void Program::release_buffers() { pimpl_->release_buffers(); }
 
-std::vector<std::reference_wrapper<const Semaphore>> detail::Program_::semaphores_on_core(const CoreCoord &core, CoreType core_type) const {
+std::vector<std::reference_wrapper<const Semaphore>> detail::ProgramImpl::semaphores_on_core(const CoreCoord &core, CoreType core_type) const {
     std::vector<std::reference_wrapper<const Semaphore>> semaphores;
     for (const Semaphore &s : this->semaphores_) {
         if (s.initialized_on_logical_core(core) && s.core_type() == core_type) {
@@ -1670,8 +1478,8 @@ std::vector<std::reference_wrapper<const Semaphore>> Program::semaphores_on_core
     return pimpl_->semaphores_on_core(core, core_type);
 }
 
-bool detail::Program_::is_finalized() const { return this->finalized_; }
-void detail::Program_::set_finalized() { this->finalized_ = true; }
+bool detail::ProgramImpl::is_finalized() const { return this->finalized_; }
+void detail::ProgramImpl::set_finalized() { this->finalized_ = true; }
 
 bool Program::is_finalized() const { return pimpl_->is_finalized(); }
 void Program::set_finalized() { pimpl_->set_finalized(); }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "program_command_sequence.hpp"
+
+#include "tt-metalium/buffer.hpp"
+#include "tt-metalium/circular_buffer.hpp"
+#include "tt-metalium/circular_buffer_constants.h"
+#include "tt-metalium/circular_buffer_types.hpp"
+#include "tt-metalium/command_queue.hpp"
+#include "tt-metalium/core_coord.hpp"
+#include "tt-metalium/hal_types.hpp"           // HalProgrammableCoreType
+#include "tt-metalium/kernel.hpp"              // Kernel
+#include "tt-metalium/kernel_types.hpp"        // KernelHandle
+#include "tt-metalium/program.hpp"             // KernelGroup
+#include "tt-metalium/program_device_map.hpp"  // ProgramTransferInfo
+#include "tt-metalium/semaphore.hpp"
+#include "tt-metalium/sub_device_types.hpp"
+
+#include <umd/device/tt_core_coordinates.h>             // CoreType
+#include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+
+#include <atomic>
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace tt {
+namespace tt_metal {
+
+class CircularBufferConfig;
+class IDevice;
+class JitBuildOptions;
+
+namespace experimental {
+class GlobalCircularBuffer;
+}
+
+namespace detail {
+
+class ProgramImpl {
+public:
+    ProgramImpl();
+
+    ProgramImpl(const ProgramImpl& other) = delete;
+    ProgramImpl& operator=(const ProgramImpl& other) = delete;
+
+    ProgramImpl(ProgramImpl&& other) = default;
+    ProgramImpl& operator=(ProgramImpl&& other) = default;
+
+    ~ProgramImpl() noexcept = default;
+
+    void set_runtime_id(uint64_t id);
+    uint64_t get_runtime_id() const;
+    uint64_t get_id() const;
+    size_t num_kernels() const;
+    const std::vector<std::shared_ptr<CircularBuffer>>& circular_buffers() const;
+    const std::vector<Semaphore>& semaphores() const;
+    KernelGroup* kernels_on_core(const CoreCoord& core, uint32_t programmable_core_type_index);
+    std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
+    std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
+    void add_buffer(std::shared_ptr<Buffer> buf);
+    void release_buffers();
+    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_core(const CoreCoord& core) const;
+    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_corerange(const CoreRange& cr) const;
+    std::vector<CoreRange> circular_buffers_unique_coreranges() const;
+    std::vector<std::reference_wrapper<const Semaphore>> semaphores_on_core(
+        const CoreCoord& core, CoreType core_type) const;
+    size_t num_semaphores() const;
+    void init_semaphores(
+        const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const;
+    // XXXXX TODO: this should return a const reference
+    std::vector<std::vector<CoreCoord>> logical_cores() const;
+    void compile(IDevice* device, bool fd_bootloader_mode = false);
+    void invalidate_circular_buffer_allocation();
+    void allocate_circular_buffers(const IDevice* device);
+    uint32_t get_cb_memory_size() const;
+    bool is_finalized() const;
+    void set_finalized();
+    void allocate_kernel_bin_buf_on_device(IDevice* device);
+    bool is_cached() const { return this->cached_device_hash_.has_value(); }
+    ProgramBinaryStatus get_program_binary_status(std::size_t device_id) const {
+        if (auto it = this->binaries_on_device_.find(device_id); it != this->binaries_on_device_.end()) {
+            return it->second;
+        }
+        return ProgramBinaryStatus::NotSent;
+    }
+    void set_cached(uint64_t device_hash) { this->cached_device_hash_ = device_hash; }
+    const std::optional<uint64_t>& get_cached() const { return this->cached_device_hash_; }
+    void set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status) {
+        this->binaries_on_device_[device_id] = status;
+    }
+    std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
+    ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
+    const std::vector<SubDeviceId>& determine_sub_device_ids(const IDevice* device);
+
+    // debug/test
+    uint32_t get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
+    uint32_t get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
+    void set_last_used_command_queue_for_testing(CommandQueue* queue);
+    CommandQueue* get_last_used_command_queue() const;
+    void populate_dispatch_data(IDevice* device);
+
+private:
+    CommandQueue* last_used_command_queue_for_testing = nullptr;
+
+    // Buffers temporarily owned by the program
+    std::vector<std::shared_ptr<Buffer>> owned_buffer_pool = {};
+
+    // The buffer that holds the kernel/binaries/etc for this program
+    std::unordered_map<chip_id_t, std::shared_ptr<Buffer>> kernels_buffer_;
+    ProgramTransferInfo program_transfer_info;
+
+    bool finalized_;
+    // Used only when devices do not have virtualization enabled and used to check that programs are only rerun on
+    // the same device
+    std::optional<uint64_t> cached_device_hash_;
+
+    // TODO: Should map based on the hash of the configured sub-devices
+    // This way we can cache it agnostic of the device
+    std::unordered_map<chip_id_t, std::unordered_map<SubDeviceManagerId, std::vector<SubDeviceId>>> sub_device_ids_;
+
+    struct CircularBufferAllocator {
+        CircularBufferAllocator(const CoreRange& core_range_) : core_range(core_range_) {}
+
+        // Circular buffers are created and allocated at core range granularity
+        CoreRange core_range;
+
+        // Holds vector of addresses where circular buffers are allocated [start, end)
+        // There are multiple ranges because per core L1 regions are not in lockstep but circular buffers spanning
+        // multiple cores must share the same address To enable this, circular buffer address is the maximum address
+        // amongst all of its target cores This vector is sorted from lower to higher address spaces
+        std::vector<std::pair<uint64_t, uint64_t>> l1_regions;
+
+        // Returns address for next circular buffer
+        // Circular buffers are placed sequentially on a core so the next available address gets appended to the last
+        // L1 region
+        uint64_t get_cb_region_end() const { return this->l1_regions.empty() ? 0 : this->l1_regions.back().second; }
+
+        // If address is the end of the last L1 region, the last region is extended by size bytes,
+        //  otherwise address must be higher than existing regions and a new L1 region [address, size) is added
+        void mark_address(uint64_t address, uint64_t size, uint64_t base_address);
+
+        // Reset when circular buffer allocation is invalidated
+        void reset_available_addresses() { this->l1_regions.clear(); }
+    };
+
+    uint64_t id;  // Need to make non-const due to move constructor
+    uint64_t runtime_id;
+    static std::atomic<uint64_t> program_counter;
+    // Programmable core type index -> KernelHandle -> Kernel
+    std::vector<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>> kernels_;
+    std::vector<CoreCoord> grid_extent_;
+
+    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_;
+    std::unordered_map<CBHandle, std::shared_ptr<CircularBuffer>> circular_buffer_by_id_;
+    // Tracks which circular buffer indices are being used
+    std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_cb_indices_;
+    std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_local_cb_indices_;
+    std::unordered_map<CoreCoord, std::bitset<NUM_CIRCULAR_BUFFERS>> per_core_remote_cb_indices_;
+    std::unordered_map<std::size_t, ProgramBinaryStatus> binaries_on_device_;
+    // Used to generate circular buffer addresses. There is one CircularBufferAllocator per unique CoreRange
+    std::vector<CircularBufferAllocator> cb_allocators_;
+
+    std::vector<Semaphore> semaphores_;
+
+    std::unordered_set<uint32_t> compiled_;
+    bool local_circular_buffer_allocation_needed_;
+
+    static constexpr uint8_t core_to_kernel_group_invalid_index = 0xff;
+    std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
+    std::vector<std::vector<uint8_t>> core_to_kernel_group_index_table_;
+
+    std::vector<ProgramConfig> program_configs_;
+    // Counts how much space is needed for each core + each launch buffer msg queue.
+    std::vector<uint32_t> program_config_sizes_;
+
+    // The rta_updates from one cached command sequence may reference data in another cached command sequence.
+    std::unordered_map<uint64_t, ProgramCommandSequence> cached_program_command_sequences_;
+
+    friend std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program& program, CBHandle id);
+    friend void ValidateCircularBufferRegion(const Program& program, const IDevice* device);
+
+    friend KernelHandle AddKernel(
+        Program& program, const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType core_type);
+
+    KernelHandle add_kernel(const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType& core_type);
+
+    CBHandle add_circular_buffer_(const std::shared_ptr<CircularBuffer>& circular_buffer);
+    CBHandle add_circular_buffer(const CoreRangeSet& core_range_set, const CircularBufferConfig& config);
+    CBHandle add_circular_buffer(
+        const CoreRangeSet& core_range_set,
+        const CircularBufferConfig& config,
+        const experimental::GlobalCircularBuffer& global_circular_buffer);
+    std::shared_ptr<CircularBuffer> get_circular_buffer(CBHandle cb_id) const;
+
+    void add_semaphore(const CoreRangeSet& crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type);
+
+    // Ensures that statically allocated circular buffers do not grow into L1 buffer space
+    void validate_circular_buffer_region(const IDevice* device);
+
+    void set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const;
+
+    void set_cb_data_fmt(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const;
+
+    void set_cb_tile_dims(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const;
+
+    void update_kernel_groups(uint32_t programmable_core_type_index);
+
+    uint32_t& get_program_config_size(uint32_t programmable_core_type_index);
+
+    void set_launch_msg_sem_offsets();
+
+    bool runs_on_noc_unicast_only_cores();
+    bool runs_on_noc_multicast_only_cores();
+    bool kernel_binary_always_stored_in_ringbuffer();
+
+    friend EnqueueProgramCommand;
+    friend Program;
+    friend Internal_;
+};
+
+}  // namespace detail
+}  // namespace tt_metal
+}  // namespace tt


### PR DESCRIPTION
### Problem description
This is a minor cleanup, that will become more important in future refactoring.

### What's changed
Pull definition of Program_ class into its own private header, and rename it to ProgramImpl

In the future, if other classes need access to Program's implementation they can just include program_impl.hpp

No functional change for now.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14369955480) CI passes
- [x] New/Existing tests provide coverage for changes