### PR TITLE
Enable maybe-uninitialized warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,6 @@ add_compile_options(
     -fvisibility-inlines-hidden
     -fno-lto # FIXME: This seems to be here for ttnn; it should go to TTNN, then.
     "$<$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>:-mavx2>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wsometimes-uninitialized>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-c++11-narrowing>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-error=local-type-template-args>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-delete-non-abstract-non-virtual-dtor>"


### PR DESCRIPTION
### Ticket
None

### Problem description
A compiler warning is disabled.

### What's changed
Enabled the compiler warning.  It appears our codebase is now clean, so no code change required.