### PR TITLE
[skip ci] Enable this check.  Seems we are clean.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -166,7 +166,6 @@ Checks: >
   -readability-isolate-declaration,
   -readability-magic-numbers,
   -readability-make-member-function-const,
-  -readability-misleading-indentation,
   -readability-named-parameter,
   -readability-non-const-parameter,
   -readability-qualified-auto,


### PR DESCRIPTION
### Ticket
None

### Problem description
We've disabled a check.  Probably pre-clang-format we had some bad indentation that has since been fixed.

### What's changed
Un-disable the check.