### PR TITLE
#20289: Basic prefetcher ringbuffer implementation.

### DIFF
--- a/tests/scripts/run_cpp_fd2_tests.sh
+++ b/tests/scripts/run_cpp_fd2_tests.sh
@@ -48,6 +48,7 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${A
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 5 -i 5"  # Paged DRAM Write + Read Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 6 -i 5"  # Host Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 7 -i 5"  # Packed Read Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 8 -i 5"  # Ringbuffer Test
 run_test_with_watcher "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 7 -i 10 -x -mpps" # Packed Read Test w/ max num subcmds
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 1 -i 1000 -rb"  # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 2 -i 1000 -rb"  # Random Test
@@ -61,6 +62,7 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${A
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 5 -i 5 -spre -sdis" # Paged DRAM Write + Read Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 6 -i 5 -spre -sdis" # Host Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 7 -i 5 -spre -sdis" # Packed Read Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 8 -i 5 -spre -sdis"  # Ringbuffer Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 1 -i 1000 -rb -spre -sdis"  # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 2 -i 1000 -rb -spre -sdis"  # Random Test
 
@@ -73,6 +75,7 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${A
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 5 -i 5 -x" # Paged DRAM Write + Read Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 6 -i 5 -x" # Host Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 7 -i 5 -x" # Packed Read Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 8 -i 5 -x" # Rinbuffer Test
 
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 1 -i 5 -x -spre" # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 1 -i 5 -x -spre -sdis" # Smoke Test
@@ -87,6 +90,7 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${A
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 2 -i 5 -spre -sdis -packetized_en" # Random Test with packetized path
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 6 -i 5 -spre -sdis -packetized_en" # Host Test with packetized path
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 7 -i 5 -spre -sdis -packetized_en" # Packed Read Test
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 8 -i 5 -spre -sdis -packetized_en" # Ringbuffer Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 1 -i 1000 -rb -spre -sdis -packetized_en"  # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 2 -i 1000 -rb -spre -sdis -packetized_en"  # Random Test
 
@@ -95,6 +99,7 @@ run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${A
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 2 -i 5 -x -spre -sdis -packetized_en" # Random Test with packetized path+exec
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 6 -i 5 -x -spre -sdis -packetized_en" # Host Test with packetized path+exec
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 7 -i 5 -x -spre -sdis -packetized_en" # Packed Read Test+exec
+run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 8 -i 5 -x -spre -sdis -packetized_en" # Ringbuffer Test+exec
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 1 -i 1000 -x -rb -spre -sdis -packetized_en"  # Smoke Test
 run_test "./build/test/tt_metal/perf_microbenchmark/dispatch/test_prefetcher_${ARCH_NAME} -t 2 -i 1000 -x -rb -spre -sdis -packetized_en"  # Random Test
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -566,7 +566,7 @@ void configure_kernel_variant(
         path,
         {my_core},
         tt::tt_metal::DataMovementConfig{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = my_noc_index,
             .compile_args = compile_args,
             .defines = defines,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -166,6 +166,7 @@ void init(int argc, char** argv) {
         log_info(
             LogTest,
             "  -t: test type: 0:Terminate 1:Smoke 2:Random 3:PCIe 4:DRAM-read 5:DRAM-write-read 6:Host 7:Packed-read "
+            "8:Ringbuffer-read"
             "(default {})",
             DEFAULT_TEST_TYPE);
         log_info(LogTest, "  -w: warm-up before starting timer (default disabled)");
@@ -1017,6 +1018,164 @@ void gen_packed_read_test(
     }
 }
 
+template <typename T>
+void update_cmd_sizes(std::vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, T updater) {
+    auto prior_end = prefetch_cmds.size();
+    updater();
+    uint32_t new_size = (prefetch_cmds.size() - prior_end) * sizeof(uint32_t);
+    cmd_sizes.push_back(new_size >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE);
+}
+
+template <typename T>
+void copy_struct_to_vector(std::vector<uint32_t>& prefetch_cmds, T& cmd) {
+    static_assert(
+        sizeof(T) % sizeof(uint32_t) == 0, "CQPrefetchCmd must be a multiple of 4 bytes to be copied to vector");
+    size_t current_size = prefetch_cmds.size();
+    prefetch_cmds.resize(current_size + sizeof(T) / sizeof(uint32_t));
+    memcpy(&prefetch_cmds[current_size], &cmd, sizeof(T));
+}
+
+void pad_vector(std::vector<uint32_t>& prefetch_cmds, uint32_t pad_bytes) {
+    TT_ASSERT(pad_bytes % sizeof(uint32_t) == 0, "Padding must be a multiple of 4 bytes to be copied to vector");
+    for (int i = 0; i < pad_bytes / sizeof(uint32_t); i++) {
+        prefetch_cmds.push_back(0);
+    }
+}
+
+// ringbuffer read from dram to linear write to worker
+void gen_dram_ringbuffer_read_cmd(
+    IDevice* device,
+    vector<uint32_t>& prefetch_cmds,
+    vector<uint32_t>& cmd_sizes,
+    DeviceData& device_data,
+    CoreCoord worker_core,
+    uint32_t log_page_size,
+    vector<uint32_t>& lengths) {
+    vector<uint32_t> dispatch_cmds;
+
+    uint32_t total_length = 0;
+    for (auto length : lengths) {
+        total_length += length;
+    }
+    gen_bare_dispatcher_unicast_write_cmd(device, dispatch_cmds, worker_core, device_data, total_length);
+    bool reset = false;
+    uint32_t page_size = 1 << log_page_size;
+    int count = 0;
+
+    std::vector<CQPrefetchRelayRingbufferSubCmd> sub_cmds;
+    for (auto length : lengths) {
+        constexpr uint32_t max_page_offset = 5;
+        CQPrefetchCmd cmd{};
+        cmd.base.cmd_id = CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER;
+        auto& ringbuffer_cmd = cmd.paged_to_ringbuffer;
+        if (!reset) {
+            ringbuffer_cmd.flags = CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
+            reset = true;
+        }
+        ringbuffer_cmd.start_page = rand() % max_page_offset;
+        ringbuffer_cmd.log2_page_size = log_page_size;
+        ringbuffer_cmd.base_addr = DRAM_DATA_BASE_ADDR + count * page_size;
+        ringbuffer_cmd.length = length;
+        count++;
+
+        update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() { add_bare_prefetcher_cmd(prefetch_cmds, cmd, true); });
+
+        // Model the paged to ringbuffer read in this function by updating worker data with interleaved/paged DRAM data,
+        // for validation later.
+        uint32_t length_words = length / sizeof(uint32_t);
+        uint32_t base_addr_words = (ringbuffer_cmd.base_addr - DRAM_DATA_BASE_ADDR) / sizeof(uint32_t);
+        uint32_t page_size_words = page_size / sizeof(uint32_t);
+
+        // Get data from DRAM map, add to worker.
+        uint32_t page_idx = ringbuffer_cmd.start_page;
+        for (uint32_t i = 0; i < length_words; i += page_size_words) {
+            uint32_t dram_bank_id = page_idx % num_dram_banks_g;
+            auto dram_channel = device->allocator()->get_dram_channel_from_bank_id(dram_bank_id);
+            CoreCoord bank_core = device->logical_core_from_dram_channel(dram_channel);
+            uint32_t bank_offset = base_addr_words + page_size_words * (page_idx / num_dram_banks_g);
+
+            uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
+            for (uint32_t j = 0; j < words; j++) {
+                uint32_t datum = device_data.at(bank_core, dram_bank_id, bank_offset + j);
+                device_data.push_one(worker_core, datum);
+            }
+
+            page_idx++;
+        }
+    }
+
+    constexpr uint32_t kWriteOffset = 1234;  // arbitrary
+
+    update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() {
+        CQPrefetchCmd cmd{};
+        cmd.base.cmd_id = CQ_PREFETCH_CMD_SET_RINGBUFFER_OFFSET;
+        cmd.set_ringbuffer_offset.offset = kWriteOffset;
+        add_bare_prefetcher_cmd(prefetch_cmds, cmd, true);
+    });
+
+    size_t current_offset = 0;
+    for (auto length : lengths) {
+        CQPrefetchRelayRingbufferSubCmd sub_cmd;
+        sub_cmd.start = current_offset - kWriteOffset;
+        sub_cmd.length = length;
+        current_offset += length;
+        sub_cmds.push_back(sub_cmd);
+    }
+
+    add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH, dispatch_cmds);
+    update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() {
+        CQPrefetchCmd cmd{};
+        cmd.base.cmd_id = CQ_PREFETCH_CMD_RELAY_RINGBUFFER;
+
+        uint32_t stride = sub_cmds.size() * sizeof(CQPrefetchRelayRingbufferSubCmd) + sizeof(CQPrefetchCmd);
+        uint32_t aligned_stride = round_cmd_size_up(stride);
+        cmd.relay_ringbuffer.stride = aligned_stride;
+        cmd.relay_ringbuffer.count = sub_cmds.size();
+
+        copy_struct_to_vector(prefetch_cmds, cmd);
+
+        for (const auto& sub_cmd : sub_cmds) {
+            copy_struct_to_vector(prefetch_cmds, sub_cmd);
+        }
+        pad_vector(prefetch_cmds, aligned_stride - stride);
+    });
+}
+
+void gen_ringbuffer_read_test(
+    IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
+    static constexpr uint32_t min_read_size = 128;
+    bool done = false;
+    while (!done) {
+        uint32_t ringbuffer_read_page_size_log2 = std::rand() % 3 + 9;  // log2 values. i.e., 512, 1024, 2048
+        uint32_t max_read_size = (1 << ringbuffer_read_page_size_log2) * num_dram_banks_g;
+        auto dram_alignment = hal_ref.get_alignment(HalMemType::DRAM);
+        // arbitrary.
+        uint32_t n_sub_cmds = (std::rand() % 7) + 1;
+        vector<uint32_t> lengths;
+        uint32_t total_length = 0;
+        for (uint32_t i = 0; i < n_sub_cmds; i++) {
+            // limit the length to min and max read size
+            uint32_t length = tt::align(
+                std::min(max_read_size, std::max(min_read_size, std::rand() % scratch_db_size_g)), dram_alignment);
+            length = std::min(scratch_db_size_g - total_length, length);
+            if (length == 0) {
+                break;
+            }
+            total_length += length;
+            lengths.push_back(length);
+        }
+
+        if (device_data.size() * sizeof(uint32_t) + total_length > DEVICE_DATA_SIZE) {
+            // got close-ish to the end anyway...
+            done = true;
+        } else {
+            gen_dram_ringbuffer_read_cmd(
+                device, prefetch_cmds, cmd_sizes, device_data, first_worker_g, ringbuffer_read_page_size_log2, lengths);
+        }
+        done = true;
+    }
+}
+
 void gen_rnd_test(
     IDevice* device, vector<uint32_t>& prefetch_cmds, vector<uint32_t>& cmd_sizes, DeviceData& device_data) {
     while (device_data.size() * sizeof(uint32_t) < DEVICE_DATA_SIZE) {
@@ -1485,6 +1644,7 @@ void gen_prefetcher_cmds(
             break;
         case 6: gen_host_test(device, prefetch_cmds, cmd_sizes, device_data); break;
         case 7: gen_packed_read_test(device, prefetch_cmds, cmd_sizes, device_data); break;
+        case 8: gen_ringbuffer_read_test(device, prefetch_cmds, cmd_sizes, device_data); break;
         default:
             log_fatal("Unknown test: {}", test_type_g);
             exit(0);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -130,6 +130,11 @@ constexpr uint32_t l1_cache_elements_rounded =
         l1_to_local_cache_copy_chunk +
     (l1_to_local_cache_copy_chunk - 1);
 
+static_assert(
+    CQ_PREFETCH_CMD_RELAY_RINGBUFFER_MAX_SUB_CMDS * sizeof(CQPrefetchRelayRingbufferSubCmd) / sizeof(uint32_t) <
+        l1_cache_elements_rounded,
+    "CQ_PREFETCH_CMD_RELAY_RINGBUFFER_MAX_SUB_CMDS is too large for l1_cache_elements_rounded");
+
 // Define these constexpr structs for a cleaner interface for process_relay_inline_cmd and
 // process_exec_buf_relay_inline_cmd while ensuring that state for dispatch_master and dispatch_slave is passed in
 // during compile time.
@@ -168,6 +173,8 @@ static uint32_t downstream_data_ptr_s = dispatch_s_buffer_base;
 static uint32_t block_next_start_addr[cmddat_q_blocks];
 static uint32_t rd_block_idx = 0;
 static uint32_t upstream_total_acquired_page_count = 0;
+static uint32_t ringbuffer_wp = scratch_db_base;
+static uint32_t ringbuffer_offset = 0;
 static auto client_interface =
     reinterpret_cast<volatile tt_l1_ptr fabric_pull_client_interface_t*>(client_interface_addr);
 
@@ -1051,16 +1058,12 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     return stride;
 }
 
-// Separate implementation that fetches more data from exec buf when cmd has been split
-static uint32_t process_exec_buf_relay_paged_packed_cmd(
-    uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
-    uint32_t total_length = cmd->relay_paged_packed.total_length;
-    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
-    uint32_t stride = cmd->relay_paged_packed.stride;
-    ASSERT(total_length > 0);
-    // DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
-
+void* copy_into_l1_cache(
+    uint32_t& cmd_ptr,
+    uint32_t sub_cmds_length,
+    uint32_t* l1_cache,
+    PrefetchExecBufState& exec_buf_state,
+    uint32_t& stride) {
     uint32_t remaining_stride = exec_buf_state.length;
     uint32_t remaining = (exec_buf_state.length - sizeof(CQPrefetchCmd));
     volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchCmd));
@@ -1081,7 +1084,6 @@ static uint32_t process_exec_buf_relay_paged_packed_cmd(
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
     }
-
     uint32_t amt = sub_cmds_length / sizeof(uint32_t);
     // Check that the final write does not overflow the L1 cache and corrupt the stack.
     // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
@@ -1092,8 +1094,25 @@ static uint32_t process_exec_buf_relay_paged_packed_cmd(
                    l1_cache) < l1_cache_elements_rounded);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
         l1_ptr, amt, l1_cache_pos);
+
+    // Return a pointer to right after the last copy
+    return &l1_cache_pos[amt];
+}
+
+// Separate implementation that fetches more data from exec buf when cmd has been split
+static uint32_t process_exec_buf_relay_paged_packed_cmd(
+    uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t total_length = cmd->relay_paged_packed.total_length;
+    uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
+    uint32_t stride = cmd->relay_paged_packed.stride;
+    ASSERT(total_length > 0);
+    // DPRINT << "paged_packed: " << total_length << " " << cmd->relay_paged_packed.stride << ENDL();
+
+    void* end = copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
+
     // Store a sentinal non 0 value at the end to save a test/branch in read path
-    ((CQPrefetchRelayPagedPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
+    ((CQPrefetchRelayPagedPackedSubCmd*)end)->length = 1;
 
     process_relay_paged_packed_sub_cmds(total_length, l1_cache);
     return stride;
@@ -1133,6 +1152,134 @@ uint32_t process_exec_buf_cmd(
     }
 
     return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+uint32_t process_paged_to_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr) {
+    // This ensures that a previous cmd using the ringbuffer have completed.
+    noc_async_writes_flushed();
+
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t start_page = cmd->paged_to_ringbuffer.start_page;
+    uint32_t base_addr = cmd->paged_to_ringbuffer.base_addr;
+    uint8_t log2_page_size = cmd->paged_to_ringbuffer.log2_page_size;
+    uint32_t page_size = 1 << log2_page_size;
+    uint32_t length = cmd->paged_to_ringbuffer.length;
+    uint8_t flags = cmd->paged_to_ringbuffer.flags;
+
+    if (flags & CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START) {
+        ringbuffer_wp = scratch_db_base;
+    }
+
+    ASSERT(length % DRAM_ALIGNMENT == 0);
+    ASSERT(length + ringbuffer_wp <= scratch_db_end);
+
+    const bool is_dram = true;
+    InterleavedPow2AddrGen<is_dram> addr_gen{.bank_base_address = base_addr, .log_base_2_of_page_size = log2_page_size};
+
+    uint32_t scratch_read_addr = ringbuffer_wp;
+    uint32_t page_id = start_page;
+    while (length >= page_size) {
+        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+        noc_async_read(noc_addr, scratch_read_addr, page_size);
+        scratch_read_addr += page_size;
+        page_id++;
+        length -= page_size;
+    }
+    if (length > 0) {
+        uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
+        noc_async_read(noc_addr, scratch_read_addr, length);
+        scratch_read_addr += length;
+    }
+
+    ringbuffer_wp = scratch_read_addr;
+
+    // The consumer will perforam a read barrier.
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+uint32_t process_set_ringbuffer_offset(uint32_t cmd_ptr) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t offset = cmd->set_ringbuffer_offset.offset;
+
+    ringbuffer_offset = offset;
+
+    return CQ_PREFETCH_CMD_BARE_MIN_SIZE;
+}
+
+void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
+    CQPrefetchRelayRingbufferSubCmd tt_l1_ptr* sub_cmd = (CQPrefetchRelayRingbufferSubCmd tt_l1_ptr*)(l1_cache);
+    ASSERT(count > 0);
+
+    noc_async_read_barrier();
+    uint32_t ringbuffer_start = ringbuffer_offset + scratch_db_base;
+
+    for (uint32_t i = 0; i < count - 1; i++) {
+        uint32_t start = ringbuffer_start + sub_cmd->start;
+        uint32_t length = sub_cmd->length;
+
+        uint32_t npages = write_pages_to_dispatcher<0, false>(downstream_data_ptr, start, length);
+
+        cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages);
+        sub_cmd++;
+    }
+    uint32_t start = ringbuffer_start + sub_cmd->start;
+    uint32_t length = sub_cmd->length;
+    uint32_t npages = write_pages_to_dispatcher<1, false>(downstream_data_ptr, start, length);
+
+    // One page was acquired w/ the cmd in CMD_RELAY_INLINE_NOFLUSH with 16 bytes written
+    cb_release_pages<my_noc_index, downstream_noc_xy, downstream_cb_sem_id>(npages + 1);
+    downstream_data_ptr = round_up_pow2(downstream_data_ptr, downstream_cb_page_size);
+}
+
+template <bool cmddat_wrap_enable>
+uint32_t process_relay_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t count = cmd->relay_ringbuffer.count;
+    uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
+    uint32_t stride = cmd->relay_ringbuffer.stride;
+    // DPRINT << "relay_ringbuffer: " << count << " " << cmd->relay_ringbuffer.stride << ENDL();
+
+    uint32_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
+    uint32_t remaining = cmddat_q_end - data_ptr;
+    uint32_t* l1_cache_pos = l1_cache;
+    if (cmddat_wrap_enable && sub_cmds_length > remaining) {
+        // wrap cmddat
+        uint32_t amt = remaining / sizeof(uint32_t);
+        careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+        sub_cmds_length -= remaining;
+        data_ptr = cmddat_q_base;
+        l1_cache_pos += amt;
+    }
+
+    uint32_t amt = sub_cmds_length / sizeof(uint32_t);
+    // Check that the final write does not overflow the L1 cache and corrupt the stack
+    // End address of final write is: curr_offset_into_cache + write_size_rounded_up_to_copy_chunk
+    ASSERT(
+        (uint32_t)(l1_cache_pos +
+                   ((amt + l1_to_local_cache_copy_chunk - 1) / l1_to_local_cache_copy_chunk) *
+                       l1_to_local_cache_copy_chunk -
+                   l1_cache) < l1_cache_elements_rounded);
+    careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
+        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+
+    process_relay_ringbuffer_sub_cmds(count, l1_cache);
+    return stride;
+}
+
+// Separate implementation that fetches more data from exec buf when cmd has been split
+static uint32_t process_exec_buf_relay_ringbuffer_cmd(
+    uint32_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    uint32_t count = cmd->relay_ringbuffer.count;
+    uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
+    uint32_t stride = cmd->relay_ringbuffer.stride;
+
+    copy_into_l1_cache(cmd_ptr, sub_cmds_length, l1_cache, exec_buf_state, stride);
+
+    process_relay_ringbuffer_sub_cmds(count, l1_cache);
+    return stride;
 }
 
 template <bool cmddat_wrap_enable, bool exec_buf>
@@ -1242,6 +1389,25 @@ bool process_cmd(
             // DPRINT << "prefetch terminating_" << is_h_variant << is_d_variant << ENDL();
             ASSERT(!exec_buf);
             done = true;
+            break;
+
+        case CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER:
+            // DPRINT << "paged to ringbuffer" << ENDL();
+            stride = process_paged_to_ringbuffer_cmd(cmd_ptr, downstream_data_ptr);
+            break;
+
+        case CQ_PREFETCH_CMD_SET_RINGBUFFER_OFFSET:
+            // DPRINT << "set ringbuffer offset" << ENDL();
+            stride = process_set_ringbuffer_offset(cmd_ptr);
+            break;
+
+        case CQ_PREFETCH_CMD_RELAY_RINGBUFFER:
+            // DPRINT << "relay paged packed" << ENDL();
+            if (exec_buf) {
+                stride = process_exec_buf_relay_ringbuffer_cmd(cmd_ptr, downstream_data_ptr, l1_cache, exec_buf_state);
+            } else {
+                stride = process_relay_ringbuffer_cmd<cmddat_wrap_enable>(cmd_ptr, downstream_data_ptr, l1_cache);
+            }
             break;
 
         default:


### PR DESCRIPTION
### Ticket
#20289 

### Problem description
Currently we always load kernel binaries from DRAM, even if they've been used very recently.

### What's changed
Implement a ringbuffer in the prefetcher that can be used to dispatch the same kernel binaries multiple times without re-reading them from DRAM.

The current implementation doesn't yet support transaction IDs or other advanced features.


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes