### PR TITLE
#20491: Support 1D Sharding of Tensor in Ring Topology

### DIFF
--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -176,6 +176,12 @@ std::vector<IDevice*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_
         // this distribution is mapped to physical devices.
         return std::visit(
             tt::stl::overloaded{
+                [&](const ShardTensor& s) {
+                    auto devices = s.linearization == DeviceLinearizationType::ROW_MAJOR
+                                       ? mesh_device.get_devices()
+                                       : mesh_device.get_view().get_ring_devices();
+                    return get_workers_for_tensor(devices);
+                },
                 [&](const ShardTensor2D& s) {
                     const tt::tt_metal::distributed::MeshCoordinateRange range(
                         MeshShape(s.shard_mesh.y, s.shard_mesh.x));

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor.hpp
@@ -28,7 +28,9 @@ public:
 std::unique_ptr<TensorToMesh> replicate_tensor_to_mesh_mapper(MeshDevice& mesh_device);
 
 // Creates a mapper that shards a tensor along a single dimension.
-std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(MeshDevice& mesh_device, int dim);
+// When `mesh_device` is N-dimensional, `linearization` defines the order in which shards are mapped to devices.
+std::unique_ptr<TensorToMesh> shard_tensor_to_mesh_mapper(
+    MeshDevice& mesh_device, int dim, DeviceLinearizationType linearization = DeviceLinearizationType::ROW_MAJOR);
 
 // Creates a mapper that shards a tensor along two dimensions, which will be intepreted as rows and columns.
 // If either dimension is not specified, the tensor is replicated along that dimension.

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor_config.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor_config.cpp
@@ -4,8 +4,10 @@
 
 #include <unordered_map>
 #include <string>
+#include <magic_enum/magic_enum.hpp>
+#include <algorithm>  // Required for std::transform
+#include <cctype>     // Required for ::toupper
 
-#include <tt-metalium/assert.hpp>
 #include "ttnn/distributed/distributed_tensor_config.hpp"
 
 namespace tt::tt_metal {
@@ -13,12 +15,18 @@ namespace {
 
 DistributedTensorConfig create_shard_distributed_tensor_config(
     const std::unordered_map<std::string, std::string>& metadata) {
-    return ShardTensor(std::stoi(metadata.at("shard_dim")));
+    std::string linearization_str = metadata.at("linearization");
+    std::transform(linearization_str.begin(), linearization_str.end(), linearization_str.begin(), ::toupper);
+    auto linearization_type = magic_enum::enum_cast<DeviceLinearizationType>(linearization_str);
+    TT_FATAL(linearization_type.has_value(), "Unsupported DeviceLinearizationType:", metadata.at("linearization"));
+    return ShardTensor(std::stoi(metadata.at("shard_dim")), linearization_type.value());
 }
+
 DistributedTensorConfig create_shard_2d_distributed_tensor_config(
     const std::unordered_map<std::string, std::string>& metadata) {
     return ShardTensor2D(ShardMesh(std::stoi(metadata.at("mesh_shape_y")), std::stoi(metadata.at("mesh_shape_x"))));
 }
+
 DistributedTensorConfig create_replicate_distributed_tensor_config(
     const std::unordered_map<std::string, std::string>& metadata) {
     if (auto it = metadata.find("replication_factor"); it != metadata.end()) {
@@ -49,7 +57,9 @@ bool operator==(const AllGatherTensor&, const AllGatherTensor&) {
     // All instances are considered equal because there are no data members.
     return true;
 }
-bool operator==(const ShardTensor& lhs, const ShardTensor& rhs) { return lhs.shard_dimension == rhs.shard_dimension; }
+bool operator==(const ShardTensor& lhs, const ShardTensor& rhs) {
+    return lhs.shard_dimension == rhs.shard_dimension && lhs.linearization == rhs.linearization;
+}
 bool operator==(const ShardTensor2D& lhs, const ShardTensor2D& rhs) {
     return lhs.shard_mesh.x == rhs.shard_mesh.x &&  //
            lhs.shard_mesh.y == rhs.shard_mesh.y;

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 #include <variant>
+#include <cstdint>
 
 namespace tt::tt_metal {
 
@@ -15,9 +16,16 @@ struct ReplicateTensor {
     ReplicateTensor(int replication_factor) : replication_factor(replication_factor) {}
 };
 bool operator==(const ReplicateTensor&, const ReplicateTensor&);
+
+enum class DeviceLinearizationType : std::uint16_t {
+    ROW_MAJOR,
+    RING,
+};
 struct ShardTensor {
-    int shard_dimension;
-    ShardTensor(int shard_dimension) : shard_dimension(shard_dimension) {}
+    std::uint16_t shard_dimension;
+    DeviceLinearizationType linearization;
+    ShardTensor(int shard_dimension, DeviceLinearizationType linearization = DeviceLinearizationType::ROW_MAJOR) :
+        shard_dimension(shard_dimension), linearization(linearization) {}
 };
 bool operator==(const ShardTensor& lhs, const ShardTensor& rhs);
 

--- a/ttnn/cpp/ttnn/distributed/types.hpp
+++ b/ttnn/cpp/ttnn/distributed/types.hpp
@@ -10,6 +10,7 @@
 
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/system_mesh.hpp>
+#include "ttnn/distributed/distributed_tensor_config.hpp"
 
 namespace ttnn::distributed {
 
@@ -22,12 +23,13 @@ using SystemMesh = tt::tt_metal::distributed::SystemMesh;
 using MeshDeviceView = tt::tt_metal::distributed::MeshDeviceView;
 using MeshDeviceConfig = tt::tt_metal::distributed::MeshDeviceConfig;
 using MeshSubDeviceManagerId = tt::tt_metal::distributed::MeshSubDeviceManagerId;
-
+using DeviceLinearizationType = tt::tt_metal::DeviceLinearizationType;
 }  // namespace ttnn::distributed
 
 namespace ttnn {
 
 // These types are exported to the ttnn namespace for convenience.
+using ttnn::distributed::DeviceLinearizationType;
 using ttnn::distributed::MeshCoordinate;
 using ttnn::distributed::MeshCoordinateRange;
 using ttnn::distributed::MeshCoordinateRangeSet;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20491)

### Problem description
When a user wants to shard a tensor along a single dimension to a `MeshDevice`, via either C++ or Python APIs, we shard the tensor into `N` chunks where `N` is the number of devices. These `N` shards are then distributed onto the devices in the mesh. When a user opens a 2D `MeshDevice`, the order that the shards are distributed follow a linearized row-major ordering of the devices in the mesh. 

This can be problematic when a user tries to shard a tensor on a 2x4-MeshDevice and then tries to execute an operation like an `ttnn::all_gather` (which by default tries to do a ring-topology). It's problematic because CCLs inherit the device ordering based on the linear ordering of the shards and which device they live. A CCL with a ring-topology gets invoked and then complains that Device X is not connected to Device Y.

So far this hasn't been a problem because the default fixture used for a lot of T3000 tests have been 1xN-MeshDevice, where the device-ordering is both a line and ring.

### What's changed
Provided an optional argument in both C++ and Python APIs to specify how the shards get mapped on to the devices (i.e. row-major (default), or ring). 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14375238524)
- [ ] [T3000 Unit Test](https://github.com/tenstorrent/tt-metal/actions/runs/14375243723)
- [x] New/Existing tests provide coverage for changes