### PR TITLE
#19642: Fix ttnn BH div test

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -185,7 +185,6 @@ def test_binary_subalpha_ttnn(input_shapes, alpha, device):
     assert comp_pass
 
 
-@skip_for_blackhole("Fails on BH. Issue #19642")
 @pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -313,13 +313,12 @@ Tensor ExecuteDiv::invoke(
             }
             return result;
         }
-
         Tensor a = typecast(queue_id, input_a, DataType::FLOAT32);
         Tensor b = typecast(queue_id, input_b, DataType::FLOAT32);
 
         // Div operation without inf/nan handling as reciprocal(0) = 1.7014118346046923e+38 not inf/nan
-        Tensor result =
-            ttnn::multiply(queue_id, a, ttnn::reciprocal(b), std::nullopt, output_mem_config, output_tensor);
+        constexpr auto none = tt::stl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+        Tensor result = ttnn::divide(a, b, std::nullopt, output_mem_config, std::nullopt, none, none, none, false);
 
         if (round_mode == "trunc") {
             result = ttnn::trunc(queue_id, result, output_mem_config, output_tensor);

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
@@ -94,7 +94,9 @@ Tensor MorehClipGradNorm::invoke(
     // max_norm / (total_norm + 1e-6)
     Tensor max_norm_tensor = ttnn::full(Shape({1}), max_norm, inputs.at(0).get_dtype(), Layout::TILE, *device);
     Tensor added = ttnn::add(output_total_norm, 1e-6f);
-    auto clip_coef = ttnn::div(max_norm_tensor, added);
+    constexpr auto none = tt::stl::Span<const ttnn::operations::unary::UnaryWithParam>{};
+    auto clip_coef =
+        ttnn::divide(max_norm_tensor, added, std::nullopt, std::nullopt, std::nullopt, none, none, none, true);
     // min(clip_coef, 1.0f)
     Tensor scalar = ttnn::full(Shape({1}), 1.0f, inputs.at(0).get_dtype(), Layout::TILE, *device);
     auto clip_coef_clamped = ttnn::minimum(clip_coef, scalar);


### PR DESCRIPTION
### Ticket
#19642 

### Problem description
Div with accurate, rounding options were failing in BH

### What's changed
Updated code to use binary_ng version of div with use_legacy approach to fix the issue

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14375467012) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)


<img width="1728" alt="Screenshot 2025-04-10 at 3 00 16 PM" src="https://github.com/user-attachments/assets/bb6a11f5-2272-41f6-a6b7-b8341d6ba0b8" />
