### PR TITLE
#20495: Fix ttnn tensor print where extra ellipses was added

### DIFF
--- a/tests/ttnn/unit_tests/test_print_tensor.py
+++ b/tests/ttnn/unit_tests/test_print_tensor.py
@@ -112,7 +112,6 @@ def test_print_short_profile_limit(device):
     ttnn.set_printoptions(profile="short")  # This is the default profile
     torch_tensor = torch.arange(16, dtype=torch.bfloat16).reshape(4, 4)
     tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
-    print(tensor)
 
     tensor_as_string = str(tensor)
 

--- a/tests/ttnn/unit_tests/test_print_tensor.py
+++ b/tests/ttnn/unit_tests/test_print_tensor.py
@@ -106,3 +106,24 @@ def test_print_0d(device):
     torch_tensor = torch.ones((), dtype=torch.bfloat16)
     tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
     assert str(tensor) == "ttnn.Tensor( 1.00000, shape=Shape([]), dtype=DataType::BFLOAT16, layout=Layout::TILE)"
+
+
+def test_print_short_profile_limit(device):
+    ttnn.set_printoptions(profile="short")  # This is the default profile
+    torch_tensor = torch.arange(16, dtype=torch.bfloat16).reshape(4, 4)
+    tensor = ttnn.from_torch(torch_tensor, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device)
+    print(tensor)
+
+    tensor_as_string = str(tensor)
+
+    # Check that ellipsis is NOT used for dimensions of size 4 with short profile
+    assert "..." not in tensor_as_string
+
+    # Check the full string representation
+    expected_string = (
+        "ttnn.Tensor([[ 0.00000,  1.00000,  2.00000,  3.00000],\n"
+        "             [ 4.00000,  5.00000,  6.00000,  7.00000],\n"
+        "             [ 8.00000,  9.00000, 10.00000, 11.00000],\n"
+        "             [12.00000, 13.00000, 14.00000, 15.00000]], shape=Shape([4, 4]), dtype=DataType::BFLOAT16, layout=Layout::TILE)"
+    )
+    assert tensor_as_string == expected_string

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -298,7 +298,7 @@ struct DimensionShortener {
 
     bool print_parenthesis_and_advance_index_if_reached_half_of_max_and_check_if_loop_is_done(
         std::ostream& ss, std::size_t& index, const std::string& before, const std::string& after) const {
-        if (this->max.has_value() and this->size >= this->max.value() and index == this->max.value() / 2) {
+        if (this->max.has_value() and this->size > this->max.value() and index == this->max.value() / 2) {
             ss << before << "...," << after;
             index = this->size - (this->max.value() / 2);
         }


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/20495)

### Problem description
Printing a 4x4 Tensor emitted extra `...` in the middle, which makes it misleading to user where they might think that there are more values in the middle.

### What's changed
There was an off-by-one issue in the condition used to emit the ellipsis.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14375972415)