### PR TITLE
EXTERNAL PR: TTNN Support for stack [adding new ttnn op]

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_stack.py
+++ b/tests/ttnn/unit_tests/operations/test_stack.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes, dim, layout",
+    [
+        ([(1, 1, 253), (1, 1, 253), (1, 1, 253)], 2, ttnn.ROW_MAJOR_LAYOUT),
+        ([(1, 253), (1, 253), (1, 253)], 1, ttnn.ROW_MAJOR_LAYOUT),
+        ([(57, 83), (57, 83), (57, 83)], 0, ttnn.TILE_LAYOUT),
+        ([(8732,), (8732,), (8732,)], 0, ttnn.ROW_MAJOR_LAYOUT),
+        ([(123, 259), (123, 259), (123, 259)], -1, ttnn.TILE_LAYOUT),
+        ([(1, 1, 253), (1, 1, 253), (1, 1, 253)], -3, ttnn.ROW_MAJOR_LAYOUT),
+    ],
+)
+def test_stack(device, input_shapes, dim, layout):
+    torch_tensors = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+
+    ttnn_tensors = [ttnn.from_torch(tensor) for tensor in torch_tensors]
+    ttnn_tensors = [ttnn.to_device(tensor, device, memory_config=ttnn.L1_MEMORY_CONFIG) for tensor in ttnn_tensors]
+    ttnn_tensors = [ttnn.to_layout(tensor, layout) for tensor in ttnn_tensors]
+    torch_result = torch.stack(torch_tensors, dim=dim)
+    ttnn_result = ttnn.stack(ttnn_tensors, dim=dim)
+
+    ttnn_result_torch = ttnn.to_torch(ttnn_result)
+    assert_with_pcc(torch_result, ttnn_result_torch)
+
+    assert torch_result.shape == ttnn_result_torch.shape

--- a/tests/ttnn/unit_tests/operations/test_stack.py
+++ b/tests/ttnn/unit_tests/operations/test_stack.py
@@ -17,6 +17,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([(8732,), (8732,), (8732,)], 0, ttnn.ROW_MAJOR_LAYOUT),
         ([(123, 259), (123, 259), (123, 259)], -1, ttnn.TILE_LAYOUT),
         ([(1, 1, 253), (1, 1, 253), (1, 1, 253)], -3, ttnn.ROW_MAJOR_LAYOUT),
+        ([(120, 1, 253, 3), (120, 1, 253, 3), (120, 1, 253, 3), (120, 1, 253, 3)], 3, ttnn.ROW_MAJOR_LAYOUT),
+        ([(57, 83), (57, 83), (57, 83), (57, 83), (57, 83), (57, 83), (57, 83)], -1, ttnn.TILE_LAYOUT),
+        ([(24, 50, 83), (24, 50, 83), (24, 50, 83), (24, 50, 83), (24, 50, 83), (24, 50, 83)], 2, ttnn.TILE_LAYOUT),
     ],
 )
 def test_stack(device, input_shapes, dim, layout):

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -889,6 +889,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/repeat/repeat_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/reshape_view/reshape_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/reshape_on_device/reshape_pybind.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/stack/stack_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded/reshard/reshard_pybind.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved_pybind.cpp

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -352,6 +352,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/squeeze/squeeze.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/stack/stack.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/device/interleaved_to_sharded_partial_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
@@ -34,6 +34,7 @@
 #include "ttnn/operations/data_movement/slice/slice_pybind.hpp"
 #include "ttnn/operations/data_movement/split/split_pybind.hpp"
 #include "ttnn/operations/data_movement/squeeze/squeeze_pybind.hpp"
+#include "ttnn/operations/data_movement/stack/stack_pybind.hpp"
 #include "ttnn/operations/data_movement/tilize/tilize_pybind.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_pybind.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose_pybind.hpp"
@@ -81,6 +82,7 @@ void py_module(py::module& module) {
     py_bind_sharded_to_interleaved(module);
     py_bind_sharded_to_interleaved_partial(module);
     py_bind_squeeze(module);
+    py_bind_stack(module);
     py_bind_unsqueeze(module);
 }
 }  // namespace data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/stack/stack.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/stack/stack.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stack.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "cpp/ttnn/operations/data_movement/unsqueeze/unsqueeze.hpp"
+#include "cpp/ttnn/operations/data_movement/concat/concat.hpp"
+
+namespace ttnn::operations::data_movement {
+
+ttnn::Tensor StackOperation::invoke(const std::vector<ttnn::Tensor>& input_tensors, const int dim) {
+    TT_FATAL(!input_tensors.empty(), "Stack expects at least one tensor");
+    std::vector<ttnn::Tensor> expanded_tensors;
+    for (const auto& tensor : input_tensors) {
+        expanded_tensors.push_back(ttnn::unsqueeze(tensor, dim));
+    }
+    return ttnn::concat(expanded_tensors, dim);
+}
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/stack/stack.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/stack/stack.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/decorators.hpp"
+
+namespace ttnn {
+namespace operations::data_movement {
+
+struct StackOperation {
+    static ttnn::Tensor invoke(const std::vector<ttnn::Tensor>& input_tensors, const int dim);
+};
+
+}  // namespace operations::data_movement
+
+constexpr auto stack = ttnn::register_operation<"ttnn::stack", ttnn::operations::data_movement::StackOperation>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/stack/stack_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/stack/stack_pybind.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stack_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "pybind11/decorators.hpp"
+#include "ttnn/operations/data_movement/stack/stack.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::data_movement {
+
+namespace detail {
+
+template <typename data_movement_operation_t>
+void bind_stack(pybind11::module& module, const data_movement_operation_t& operation, const char* doc) {
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const data_movement_operation_t& self, const std::vector<ttnn::Tensor>& input_tensors, const int dim)
+                -> ttnn::Tensor { return self(input_tensors, dim); },
+            py::arg("input_tensors"),
+            py::arg("dim")});
+}
+
+}  // namespace detail
+
+void py_bind_stack(pybind11::module& module) {
+    detail::bind_stack(
+        module,
+        ttnn::stack,
+        R"doc(stack(input_tensors: List[ttnn.Tensor], dim: int) -> ttnn.Tensor
+
+        Stacks tensors along a new dimension.
+
+        Args:
+            * :attr:`input_tensors`: List of tensors to stack.
+            * :attr:`dim`: Dimension along which to stack.
+
+        Example:
+           >>> input_tensor = ttnn.from_torch(torch.randn((2, 2), dtype=torch.bfloat16), device=device)
+           >>> output = ttnn.stack((input_tensor,input_tensor), 1)
+
+        )doc");
+}
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/stack/stack_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/stack/stack_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "pybind11/pybind_fwd.hpp"
+
+namespace ttnn::operations::data_movement {
+
+void py_bind_stack(pybind11::module& module);
+
+}  // namespace ttnn::operations::data_movement


### PR DESCRIPTION
### N/A
Link to Github Issue : N/A

### Problem description
ttnn doesn't have support for stack

### What's changed
Enabled support for stack op in ttnn as a composite op and added pytest

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes