### PR TITLE
#0: [skip ci] Add arch name and runner-label to metal L2 test names

### DIFF
--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -53,7 +53,7 @@ jobs:
       run:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
-    name: ${{ matrix.test-group.name }}
+    name: ${{ matrix.test-group.name }} ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on:
       - ${{ inputs.runner-label }}
       - "in-service"


### PR DESCRIPTION
### Ticket
None

### Problem description
Metal L2 job names don't specify arch and card type.

### What's changed
Changes job name from e.g.  `ttnn nightly conv tests` -> `ttnn nightly conv tests wormhole_b0 N150` so that we can easily tell what card type we're running with. Using inputs.arch and inputs.runner-label

### Checklist
- [ ] New/Existing tests provide coverage for changes