### PR TITLE
#19891: ttnn.sort-single-core-implementation

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -30,11 +30,11 @@ def test_sort_output_shape(shape, dim, descending, device):
     input = torch.randn(shape, dtype=torch_dtype)
 
     ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
-    torch_sort_values, torch_sort_indeces = torch.sort(input, dim=dim, descending=descending)
+    torch_sort_values, torch_sort_indices = torch.sort(input, dim=dim, descending=descending)
     ttnn_sort_values, ttnn_sort_indices = ttnn.experimental.sort(ttnn_input, dim=dim, descending=descending)
 
     assert torch_sort_values.shape == ttnn_sort_values.shape
-    assert torch_sort_indeces.shape == ttnn_sort_indices.shape
+    assert torch_sort_indices.shape == ttnn_sort_indices.shape
 
     assert list(ttnn_sort_values.shape) == shape
     assert list(ttnn_sort_indices.shape) == shape
@@ -66,14 +66,14 @@ def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
     input = torch.randn(shape, dtype=torch_dtype)
     ttnn_input = ttnn.from_torch(input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
 
-    torch_sort_values, torch_sort_indeces = torch.sort(input, dim=dim, descending=descending)
+    torch_sort_values, torch_sort_indices = torch.sort(input, dim=dim, descending=descending)
 
     ttnn_sort_values = ttnn.zeros_like(ttnn_input)
     ttnn_sort_indices = ttnn.zeros_like(ttnn_input)
     ttnn.experimental.sort(ttnn_input, dim=dim, descending=descending, out=(ttnn_sort_values, ttnn_sort_indices))
 
     assert torch_sort_values.shape == ttnn_sort_values.shape
-    assert torch_sort_indeces.shape == ttnn_sort_indices.shape
+    assert torch_sort_indices.shape == ttnn_sort_indices.shape
 
     assert list(ttnn_sort_values.shape) == shape
     assert list(ttnn_sort_indices.shape) == shape

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -19,7 +19,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([32, 128], 1, True),
         ([1], 0, True),
         ([], -1, True),
-        ([1, 0, 32, 64], 2, False),
+        ([1, 1, 32, 64], -1, False),
+        ([1, 2048, 1, 64], -1, False),
     ],
 )
 def test_sort_output_shape(shape, dim, descending, device):
@@ -38,9 +39,10 @@ def test_sort_output_shape(shape, dim, descending, device):
     assert list(ttnn_sort_values.shape) == shape
     assert list(ttnn_sort_indices.shape) == shape
 
-    # TODO: ADD checking indeces matrix
-    # TODO: assert_with_pcc does not work with [] or [1] - check by hand
-    assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+    if len(shape) == 0 or len(shape) == 1:
+        torch_sort_values == ttnn.to_torch(ttnn_sort_values)
+    else:
+        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
 
 @skip_for_grayskull()
@@ -53,7 +55,8 @@ def test_sort_output_shape(shape, dim, descending, device):
         ([32, 128], 1, True),
         ([1], 0, True),
         ([], -1, True),
-        ([1, 0, 32, 64], 2, False),
+        ([1, 1, 32, 64], -1, False),
+        ([1, 2048, 1, 64], -1, False),
     ],
 )
 def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
@@ -75,6 +78,7 @@ def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
     assert list(ttnn_sort_values.shape) == shape
     assert list(ttnn_sort_indices.shape) == shape
 
-    # TODO: ADD checking indeces matrix
-    # TODO: assert_with_pcc does not work with [] or [1] - check by hand
-    assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+    if len(shape) == 0 or len(shape) == 1:
+        torch_sort_values == ttnn.to_torch(ttnn_sort_values)
+    else:
+        assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -40,7 +40,7 @@ def test_sort_output_shape(shape, dim, descending, device):
     assert list(ttnn_sort_indices.shape) == shape
 
     if len(shape) == 0 or len(shape) == 1:
-        torch_sort_values == ttnn.to_torch(ttnn_sort_values)
+        assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
     else:
         assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
@@ -79,6 +79,6 @@ def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
     assert list(ttnn_sort_indices.shape) == shape
 
     if len(shape) == 0 or len(shape) == 1:
-        torch_sort_values == ttnn.to_torch(ttnn_sort_values)
+        assert torch_sort_values == ttnn.to_torch(ttnn_sort_values)
     else:
         assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -6,25 +6,20 @@ import pytest
 import torch
 import ttnn
 from models.utility_functions import skip_for_grayskull
+from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @skip_for_grayskull()
 @pytest.mark.parametrize(
     "shape, dim, descending",
     [
-        ([16, 1], -1, False),
-        ([1, 16], -1, False),
-        ([3, 3], -1, False),
-        ([16, 16, 16], -1, True),
-        ([3, 3], 1, False),
-        ([3, 16], 0, True),
-        ([32, 32], 0, False),
-        ([64, 64], 1, False),
-        ([128, 32], 1, True),
-        ([87, 87], 0, True),
+        ([64, 64], -1, False),
+        ([32, 128], -1, False),
+        ([1, 1, 32, 64], -1, True),
+        ([32, 128], 1, True),
         ([1], 0, True),
         ([], -1, True),
-        ([1, 0, 32, 32], 2, False),
+        ([1, 0, 32, 64], 2, False),
     ],
 )
 def test_sort_output_shape(shape, dim, descending, device):
@@ -43,22 +38,22 @@ def test_sort_output_shape(shape, dim, descending, device):
     assert list(ttnn_sort_values.shape) == shape
     assert list(ttnn_sort_indices.shape) == shape
 
+    # TODO: ADD checking indeces matrix
+    # TODO: assert_with_pcc does not work with [] or [1] - check by hand
+    assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+
 
 @skip_for_grayskull()
 @pytest.mark.parametrize(
     "shape, dim, descending",
     [
-        ([16, 1], -1, False),
-        ([1, 16], -1, False),
-        ([3, 3], -1, True),
-        ([3, 3], 1, False),
-        ([16, 16, 16], 0, True),
-        ([64, 64], 1, False),
-        ([128, 32], 1, True),
-        ([87, 87], 0, True),
+        ([64, 64], -1, False),
+        ([32, 128], -1, False),
+        ([1, 1, 32, 64], -1, True),
+        ([32, 128], 1, True),
         ([1], 0, True),
         ([], -1, True),
-        ([1, 0, 32, 32], 2, False),
+        ([1, 0, 32, 64], 2, False),
     ],
 )
 def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
@@ -79,3 +74,7 @@ def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
 
     assert list(ttnn_sort_values.shape) == shape
     assert list(ttnn_sort_indices.shape) == shape
+
+    # TODO: ADD checking indeces matrix
+    # TODO: assert_with_pcc does not work with [] or [1] - check by hand
+    assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -596,6 +596,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/prod/prod.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/topk/topk.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/reduction/reduction_common/reduction_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/halo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/sliding_window.cpp

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -448,6 +448,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumsum/device/cumsum_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/reduction/cumsum/device/cumsum_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -95,7 +95,7 @@ void py_module(py::module& module) {
 
     gelu_backward::detail::bind_experimental_gelu_backward_operation(module);
 
-    reduction::detail::bind_reduction_sort_operation(module);
+    reduction::sort::detail::bind_reduction_sort_operation(module);
 
     reduction::detail::bind_cumsum_operation(module);
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -102,6 +102,11 @@ void MAIN {
                 for (uint32_t i = 0; i < Wt; i++) {
                     uint32_t j = i ^ sub_dist;
                     if (j > i) {
+                        // Determine direction for this comparison block
+                        const bool ascending_block = ((i >> stage) & 1) == 0;
+                        const bool dir = ascending_block == ascending;
+
+                        // Get indexes of tiles to compare
                         const uint32_t left_tile_id = i;
                         const uint32_t right_tile_id = j;
 
@@ -117,7 +122,7 @@ void MAIN {
                         copy_tile(index_tensor_transposed_cb_index, left_tile_id, index_dest_start);
                         copy_tile(index_tensor_transposed_cb_index, right_tile_id, index_dest_end);
 
-                        ckernel::topk_local_sort(0, (int)ascending, 5);
+                        ckernel::topk_local_sort(0, (int)dir, 5);
 
                         pack_reconfig_data_format(input_tensor_transposed_cb_index);
                         pack_tile<true>(input_dest_start, input_tensor_transposed_cb_index, left_tile_id);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-
 #include "compute_kernel_api.h"
 #include "compute_kernel_api/transpose_wh.h"
 #include "compute_kernel_api/tile_move_copy.h"
@@ -12,46 +10,116 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
+#include "sort_common.hpp"
+
 #include "debug/dprint.h"
 
+// topk llk needs a global variable atm
+// this can only be removed once that's fixed
+int32_t topk_replay_init = 0;
 namespace NAMESPACE {
 
 void MAIN {
-    DPRINT << "Starting COMPUTE kernel" << ENDL();
-
     // Compile time args
-    // TODO: More arguments
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(2);
-    constexpr uint32_t Ht = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr bool descending = get_compile_time_arg_val(5);
-    constexpr bool stable = get_compile_time_arg_val(6);
+    constexpr uint32_t input_tensor_transposed_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t index_tensor_transposed_cb_index = get_compile_time_arg_val(3);
+    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(4);
+    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(5);
+    constexpr uint32_t Ht = get_compile_time_arg_val(6);
+    constexpr uint32_t Wt = get_compile_time_arg_val(7);
+    constexpr uint32_t logWt = get_compile_time_arg_val(8);
+    constexpr bool descending = get_compile_time_arg_val(9);
+    constexpr bool stable = get_compile_time_arg_val(10);
 
-    // Tensors config
     constexpr uint32_t one_tile = 1;
 
+    constexpr uint32_t input_dest_start = 0;
+    constexpr uint32_t index_dest_start = 2;
+    constexpr uint32_t input_dest_end = 1;
+    constexpr uint32_t index_dest_end = 3;
+
+    ckernel::topk_tile_init();
+    transpose_wh_init(input_tensor_cb_index, input_tensor_transposed_cb_index);
+
     for (uint32_t h = 0; h < Ht; h++) {
-        for (uint32_t w = 0; w < Wt; w++) {
-            DPRINT << "     > 2.1 Starting COMPUTE loop" << ENDL();
-            // cb_reserve_back(index_tensor_output_cb_index, one_tile);
-            // cb_wait_front(index_tensor_cb_index, one_tile);
+        const bool ascending = !descending;
 
-            // binary_op_init_common(index_tensor_cb_index, index_tensor_output_cb_index, index_tensor_output_cb_index);
-            // add_tiles_init(index_tensor_cb_index, index_tensor_output_cb_index);
-            // tile_regs_acquire();
-            // tile_regs_commit();  // signal the packer
-            // tile_regs_wait();  // packer waits here
-            // pack_tile(0, index_tensor_output_cb_index);
-            // tile_regs_release();  // packer releases
+        sort_Wt_tiles_row_to_bitonic_sequence(
+            input_tensor_cb_index,
+            index_tensor_cb_index,
+            input_tensor_transposed_cb_index,
+            index_tensor_transposed_cb_index,
+            Wt,
+            true,
+            ascending,
+            5);
 
-            // // pack_tile(0, index_tensor_output_cb_index, 0, );
+        // Wait for bitonic sequence of Wt tiles
+        cb_wait_front(input_tensor_transposed_cb_index, Wt);
+        cb_wait_front(index_tensor_transposed_cb_index, Wt);
 
-            // cb_pop_front(index_tensor_cb_index, one_tile);
-            // cb_push_back(index_tensor_output_cb_index, one_tile);
+        // Sort and merge step of bitonic merge sort
+        uint32_t stages = 0;
+        for (uint32_t temp = Wt; temp > 1; temp >>= 1) {
+            stages++;
+        }
 
-        }  // Wt loop
+        for (uint32_t stage = 2; stage <= stages; stage++) {  // TODO: Check if the first step is necessary
+            for (uint32_t sub = stage; sub > 0; sub--) {
+                uint32_t sub_dist = 1 << (sub - 1);
+                for (uint32_t i = 0; i < Wt; i++) {
+                    uint32_t j = i ^ sub_dist;
+                    if (j > i) {
+                        const uint32_t left_tile_id = i;
+                        const uint32_t right_tile_id = j;
+                        DPRINT_MATH(
+                            DPRINT << "INPUT MATRIX ROW: " << U32(h) << " SORTING TILES: " << U32(left_tile_id)
+                                   << " and " << U32(right_tile_id) << ENDL());
+
+                        acquire_dst();
+
+                        copy_tile_to_dst_init_short_with_dt(
+                            index_tensor_transposed_cb_index, input_tensor_transposed_cb_index);
+                        copy_tile(input_tensor_transposed_cb_index, left_tile_id, 0);
+                        copy_tile(input_tensor_transposed_cb_index, right_tile_id, 1);
+
+                        copy_tile_to_dst_init_short_with_dt(
+                            input_tensor_transposed_cb_index, index_tensor_transposed_cb_index);
+                        copy_tile(index_tensor_transposed_cb_index, left_tile_id, 2);
+                        copy_tile(index_tensor_transposed_cb_index, right_tile_id, 3);
+
+                        ckernel::topk_local_sort(0, (int)ascending, 5);
+
+                        pack_reconfig_data_format(input_tensor_transposed_cb_index);
+                        pack_tile<true>(0, input_tensor_transposed_cb_index, left_tile_id);
+                        pack_tile<true>(1, input_tensor_transposed_cb_index, right_tile_id);
+
+                        pack_reconfig_data_format(index_tensor_transposed_cb_index);
+                        pack_tile<true>(2, index_tensor_transposed_cb_index, left_tile_id);
+                        pack_tile<true>(3, index_tensor_transposed_cb_index, right_tile_id);
+
+                        release_dst();
+                    }
+                }
+            }
+        }
+
+        cb_reserve_back(input_tensor_transposed_cb_index, Wt);
+        cb_reserve_back(index_tensor_transposed_cb_index, Wt);
+
+        cb_pop_front(input_tensor_transposed_cb_index, Wt);
+        cb_pop_front(index_tensor_transposed_cb_index, Wt);
+
+        cb_push_back(input_tensor_transposed_cb_index, Wt);
+        cb_push_back(index_tensor_transposed_cb_index, Wt);
+
+        // Values tensor
+        transpose_and_pack(input_tensor_transposed_cb_index, value_tensor_cb_index, Wt);
+
+        // Indexes tensor
+        transpose_and_pack(index_tensor_transposed_cb_index, index_tensor_output_cb_index, Wt);
     }  // Ht loop
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api.h"
+#include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/tile_move_copy.h"
+#include "compute_kernel_api/reconfig_data_format.h"
+#include "compute_kernel_api/pack.h"
+#include "compute_kernel_api/eltwise_binary.h"
+#include "compute_kernel_api/tile_move_copy.h"
+
+#include "debug/dprint.h"
+
+namespace NAMESPACE {
+
+void MAIN {
+    DPRINT << "Starting COMPUTE kernel" << ENDL();
+
+    // Compile time args
+    // TODO: More arguments
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t Ht = get_compile_time_arg_val(3);
+    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+    constexpr bool descending = get_compile_time_arg_val(5);
+    constexpr bool stable = get_compile_time_arg_val(6);
+
+    // Tensors config
+    constexpr uint32_t one_tile = 1;
+
+    for (uint32_t h = 0; h < Ht; h++) {
+        for (uint32_t w = 0; w < Wt; w++) {
+            DPRINT << "     > 2.1 Starting COMPUTE loop" << ENDL();
+            // cb_reserve_back(index_tensor_output_cb_index, one_tile);
+            // cb_wait_front(index_tensor_cb_index, one_tile);
+
+            // binary_op_init_common(index_tensor_cb_index, index_tensor_output_cb_index, index_tensor_output_cb_index);
+            // add_tiles_init(index_tensor_cb_index, index_tensor_output_cb_index);
+            // tile_regs_acquire();
+            // tile_regs_commit();  // signal the packer
+            // tile_regs_wait();  // packer waits here
+            // pack_tile(0, index_tensor_output_cb_index);
+            // tile_regs_release();  // packer releases
+
+            // // pack_tile(0, index_tensor_output_cb_index, 0, );
+
+            // cb_pop_front(index_tensor_cb_index, one_tile);
+            // cb_push_back(index_tensor_output_cb_index, one_tile);
+
+        }  // Wt loop
+    }  // Ht loop
+}
+
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -75,9 +75,6 @@ void MAIN {
                     if (j > i) {
                         const uint32_t left_tile_id = i;
                         const uint32_t right_tile_id = j;
-                        DPRINT_MATH(
-                            DPRINT << "INPUT MATRIX ROW: " << U32(h) << " SORTING TILES: " << U32(left_tile_id)
-                                   << " and " << U32(right_tile_id) << ENDL());
 
                         acquire_dst();
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,37 @@
 // this can only be removed once that's fixed
 int32_t topk_replay_init = 0;
 namespace NAMESPACE {
+/*
+The sorting algorithm is based on Bitonic Merge Sort.
 
+ The program operates on the arrangement of input data in the form of tiles. After the data passes through
+ preprocessing, the dimension by which the data is to be sorted is the last dimension in the tensor, hence from the
+ point of view of the arrangement of tiles, the sorting is practically based on sorting successive rows of the matrix.
+
+ First, the program reads one full row of tiles (size Wt) from DRAM to L1 and generates a corresponding set of tiles
+ containing the data indices in the initial arrangement. The basis for the described sorting implementation is
+ ckernel::topk_local_sort LLK, which takes as input arguments to the DST register two tiles on which
+ the sorting is to be performed and two tiles containing the indices of this data. LLK sorts the two input tiles in the
+ inplace method and sets the indices of the data that have been changed in place. However, it performs sorting on
+ columns, hence the additional step of performing transposition. Since LLK always takes a set of two tiles, their number
+ in the Wt dimension must always be a multiple of 64 (2 * Tile_Width (32)).
+
+ sort_Wt_tiles_row_to_bitonic_sequence takes pairs of tiles and sorts them among themselves changing the sorting order
+ (for the first pair according to the desired order, for the next one vice versa, etc.), as a result we get a set of
+ sorted pairs of tiles with a variable sorting order.
+
+ The next step is to sort the tiles among themselves, so that the entire row of input data is sorted. As in the
+ bitonic merge sort algorithm, this is done in stages – the next indexes of tiles in CB are calculated, which are to be
+ sorted among themselves. Finally, all tiles have their values ​​sorted with respect to one dimension and are
+ ready to be transposed to the desired dimension and written to DRAM memory.
+
+ Example:
+ The input tensor is a 32x128 matrix, which translates to 1x4 tiles: T0 T1 T2 T3, we sort the values ​​ascending.
+ Pairwise sorting: Tiles T0 and T1 are sorted as a pair ascending, T2 and T3 are sorted as a pair descending.
+ Sorting among themselves: Stage 1 - we sort T0 and T2 ascending and T1 and T3 ascending (we do not change the order),
+                           Stage 2 – We sort T0 and T1 ascending and T2 and T3 ascending.
+ Data saving: Values ​​have been sorted by a common dimension and are ready to be saved.
+ */
 void MAIN {
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
@@ -52,9 +82,9 @@ void MAIN {
             input_tensor_transposed_cb_index,
             index_tensor_transposed_cb_index,
             Wt,
-            true,
+            /*switch_dir=*/true,
             ascending,
-            5);
+            /*end_phase(log2(K))=*/5);
 
         // Wait for bitonic sequence of Wt tiles
         cb_wait_front(input_tensor_transposed_cb_index, Wt);
@@ -62,7 +92,7 @@ void MAIN {
 
         // Sort and merge step of bitonic merge sort
         uint32_t stages = 0;
-        for (uint32_t temp = Wt; temp > 1; temp >>= 1) {
+        for (uint32_t i = Wt; i > 1; i >>= 1) {
             stages++;
         }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -8,7 +8,6 @@
 #include "compute_kernel_api/reconfig_data_format.h"
 #include "compute_kernel_api/pack.h"
 #include "compute_kernel_api/eltwise_binary.h"
-#include "compute_kernel_api/tile_move_copy.h"
 
 #include "sort_common.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
@@ -68,10 +68,12 @@ void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, ui
 
     for (uint32_t i = 0; i < Wt; ++i) {
         acquire_dst();
+
         cb_reserve_back(dest_cb_index, one_tile);
         transpose_wh_tile(transposed_cb_index, i, 0);
         pack_tile(0, dest_cb_index);
         cb_push_back(dest_cb_index, one_tile);
+
         release_dst();
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+namespace NAMESPACE {
+void sort_Wt_tiles_row_to_bitonic_sequence(
+    const uint32_t input_cb_index,
+    const uint32_t index_cb_index,
+    const uint32_t input_transposed_cb_index,
+    const uint32_t index_transposed_cb_index,
+    const uint32_t Wt,
+    const bool switch_dir,
+    const bool ascending,
+    const int end_phase) {
+    cb_reserve_back(input_transposed_cb_index, Wt);
+    cb_reserve_back(index_transposed_cb_index, Wt);
+
+    bool ascending_local = ascending;
+    for (uint32_t wt = 0; wt < Wt; wt += 2) {
+        acquire_dst();
+
+        cb_wait_front(input_cb_index, 2);
+        cb_wait_front(index_cb_index, 2);
+
+        reconfig_data_format_srca(input_cb_index);
+        transpose_wh_init_short(input_cb_index);
+        transpose_wh_tile(input_cb_index, 0, 0);
+        transpose_wh_tile(input_cb_index, 1, 1);
+
+        reconfig_data_format_srca(index_cb_index);
+        transpose_wh_init_short(index_cb_index);
+        transpose_wh_tile(index_cb_index, 0, 2);
+        transpose_wh_tile(index_cb_index, 1, 3);
+
+        // llk_topk_sort -> inplace
+        ckernel::topk_local_sort(0, (int)ascending_local, end_phase);
+
+        // pack value tiles into transposed buffer
+        pack_reconfig_data_format(input_transposed_cb_index);
+        pack_tile(0, input_transposed_cb_index);
+        pack_tile(1, input_transposed_cb_index);
+
+        // pack index tiles into index transposed buffer
+        pack_reconfig_data_format(index_transposed_cb_index);
+        pack_tile(2, index_transposed_cb_index);
+        pack_tile(3, index_transposed_cb_index);
+
+        cb_pop_front(input_cb_index, 2);
+        cb_pop_front(index_cb_index, 2);
+
+        release_dst();
+
+        ascending_local = switch_dir ? !ascending_local : ascending_local;
+    }
+
+    cb_push_back(input_transposed_cb_index, Wt);
+    cb_push_back(index_transposed_cb_index, Wt);
+}
+
+void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, uint32_t Wt) {
+    constexpr uint32_t one_tile = 1;
+
+    reconfig_data_format_srca(transposed_cb_index);
+    transpose_wh_init_short(transposed_cb_index);
+    pack_reconfig_data_format(transposed_cb_index);
+
+    cb_wait_front(transposed_cb_index, Wt);
+
+    for (uint32_t i = 0; i < Wt; ++i) {
+        acquire_dst();
+        cb_reserve_back(dest_cb_index, one_tile);
+        transpose_wh_tile(transposed_cb_index, i, 0);
+        pack_tile(0, dest_cb_index);
+        cb_push_back(dest_cb_index, one_tile);
+        release_dst();
+    }
+
+    cb_wait_front(transposed_cb_index, Wt);
+    cb_pop_front(transposed_cb_index, Wt);
+}
+
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 namespace NAMESPACE {
+
 void sort_Wt_tiles_row_to_bitonic_sequence(
     const uint32_t input_cb_index,
     const uint32_t index_cb_index,
@@ -22,6 +23,7 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
         cb_wait_front(input_cb_index, 2);
         cb_wait_front(index_cb_index, 2);
 
+        // topk_local_sort sorts by columns - transpose input tiles for sorting
         reconfig_data_format_srca(input_cb_index);
         transpose_wh_init_short(input_cb_index);
         transpose_wh_tile(input_cb_index, 0, 0);
@@ -50,6 +52,7 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
 
         release_dst();
 
+        // Switch sorting direction for bitonic merge sort
         ascending_local = switch_dir ? !ascending_local : ascending_local;
     }
 
@@ -60,6 +63,7 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
 void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, uint32_t Wt) {
     constexpr uint32_t one_tile = 1;
 
+    // Transpose from sorting by column to right structure
     reconfig_data_format_srca(transposed_cb_index);
     transpose_wh_init_short(transposed_cb_index);
     pack_reconfig_data_format(transposed_cb_index);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "dataflow_api.h"
+
+#include "debug/dprint.h"
+
+FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
+    // Reserve space
+    cb_reserve_back(cb_id, 1);
+
+    // Writer config
+    uint32_t writer_addr = get_write_ptr(cb_id);
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(writer_addr);
+    const uint16_t wt_offset = wt << 5;  // wt * 2^(5)
+
+    // Writer loop
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < 2; ++i) {
+        for (uint32_t j = 0; j < 2; ++j) {
+            for (uint32_t k = 0; k < 16; ++k) {
+                for (uint32_t l = 0; l < 16; l++) {
+                    const uint16_t value = l + 16 * j + wt_offset;
+                    ptr[count] = value;
+                    count++;
+                }  // l loop
+            }  // k loop
+        }  // j loop
+    }  // i loop
+
+    // Push the tile
+    cb_push_back(cb_id, 1);
+}
+
+void kernel_main() {
+    // Runtime args
+    const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(0);
+
+    // Compile time args
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
+    constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
+    constexpr uint32_t Ht = get_compile_time_arg_val(3);
+    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+
+    // Input tensor config
+    constexpr uint32_t one_tile = 1;
+    constexpr uint32_t tile_size_bytes = get_tile_size(input_tensor_cb_index);
+    constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
+
+    const InterleavedAddrGenFast<input_tensor_is_dram> s = {
+        .bank_base_address = input_tensor_buffer_addr,
+        .page_size = tile_size_bytes,
+        .data_format = input_tensor_data_format};
+
+    for (uint32_t h = 0; h < Ht; h++) {
+        for (uint32_t w = 0; w < Wt; w++) {
+            // TODO: Handle input tensor tile
+
+            generate_index_tile(index_tensor_cb_index, w);
+        }  // Wt loops
+    }  // Ht loop
+}

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,11 +18,18 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
 
     // Writer loop
     uint32_t count = 0;
-    for (uint32_t i = 0; i < 2; ++i) {
-        for (uint32_t j = 0; j < 2; ++j) {
-            for (uint32_t k = 0; k < 16; ++k) {
-                for (uint32_t l = 0; l < 16; l++) {
-                    const uint16_t value = l + 16 * j + wt_offset;
+    /*
+    The 32x32 tile is subdivided into four 16x16 quadrants(faces): top-left, top-right, bottom-left, and bottom-right.
+    These quadrants are stored contiguously in memory. Therefore, indices must be written in memory according
+    to their respective quadrant, rather than sequentially from left to right across the entire tile.
+    */
+    constexpr uint32_t tile_faces = 2;
+    constexpr uint32_t face_size = 16;
+    for (uint32_t i = 0; i < tile_faces; ++i) {
+        for (uint32_t j = 0; j < tile_faces; ++j) {
+            for (uint32_t k = 0; k < face_size; ++k) {
+                for (uint32_t l = 0; l < face_size; l++) {
+                    const uint16_t value = l + face_size * j + wt_offset;
                     ptr[count] = value;
                     count++;
                 }  // l loop

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
@@ -7,70 +7,65 @@
 
 #include "debug/dprint.h"
 
-FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
-    // Reserve space
-    cb_reserve_back(cb_id, 1);
+/*
+To improve performance of both reader and writer kernels the work has been split so that they both prepare input and
+save output data.
 
-    // Writer config
-    const uint32_t writer_addr = get_write_ptr(cb_id);
-    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(writer_addr);
-    const uint16_t wt_offset = wt << 5;  // wt * 2^(5)
+Reader:
+    * Reads input value data from DRAM and writes it to L1 circular buffer.
+    * Write processed index data from L1 to DRAM.
 
-    // Writer loop
-    uint32_t count = 0;
-    /*
-    The 32x32 tile is subdivided into four 16x16 quadrants(faces): top-left, top-right, bottom-left, and bottom-right.
-    These quadrants are stored contiguously in memory. Therefore, indices must be written in memory according
-    to their respective quadrant, rather than sequentially from left to right across the entire tile.
-    */
-    constexpr uint32_t tile_faces = 2;
-    constexpr uint32_t face_size = 16;
-    for (uint32_t i = 0; i < tile_faces; ++i) {
-        for (uint32_t j = 0; j < tile_faces; ++j) {
-            for (uint32_t k = 0; k < face_size; ++k) {
-                for (uint32_t l = 0; l < face_size; l++) {
-                    const uint16_t value = l + face_size * j + wt_offset;
-                    ptr[count] = value;
-                    count++;
-                }  // l loop
-            }  // k loop
-        }  // j loop
-    }  // i loop
-
-    // Push the tile
-    cb_push_back(cb_id, 1);
-}
-
+Writer:
+    * Generates index input data and writes it to L1 circular buffer.
+    * Write output values from L1 to DRAM.
+*/
 void kernel_main() {
     // Runtime args
     const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(0);
+    const uint32_t index_tensor_buffer_addr = get_arg_val<uint32_t>(1);
 
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(1);
     constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3) == 1;
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t Wt = get_compile_time_arg_val(5);
 
     // Input tensor config
     constexpr uint32_t one_tile = 1;
     constexpr uint32_t tile_size_bytes = get_tile_size(input_tensor_cb_index);
     constexpr DataFormat input_tensor_data_format = get_dataformat(input_tensor_cb_index);
-
-    const InterleavedAddrGenFast<input_tensor_is_dram> s = {
+    const InterleavedAddrGenFast<input_tensor_is_dram> interleaved_accessor0 = {
         .bank_base_address = input_tensor_buffer_addr,
         .page_size = tile_size_bytes,
         .data_format = input_tensor_data_format};
 
+    // Index tensor config
+    const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
+    const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
+    const InterleavedAddrGenFast<index_tensor_is_dram> interleaved_accessor1 = {
+        .bank_base_address = index_tensor_buffer_addr,
+        .page_size = index_tensor_output_tile_size_bytes,
+        .data_format = index_tensor_output_data_format};
+
     for (uint32_t h = 0; h < Ht; h++) {
+        // Read input value data
         for (uint32_t w = 0; w < Wt; w++) {
             cb_reserve_back(input_tensor_cb_index, one_tile);
             const uint32_t l1_write_addr = get_write_ptr(input_tensor_cb_index);
-            noc_async_read_tile(h * Wt + w, s, l1_write_addr);
+            noc_async_read_tile(h * Wt + w, interleaved_accessor0, l1_write_addr);
             noc_async_read_barrier();
             cb_push_back(input_tensor_cb_index, one_tile);
+        }  // Wt loop
 
-            generate_index_tile(index_tensor_cb_index, w);
-        }  // Wt loops
+        // Write output index data
+        for (uint32_t w = 0; w < Wt; w++) {
+            cb_wait_front(index_tensor_output_cb_index, one_tile);
+            const uint32_t l1_write_addr_index = get_read_ptr(index_tensor_output_cb_index);
+            noc_async_write_tile(h * Wt + w, interleaved_accessor1, l1_write_addr_index);
+            noc_async_write_barrier();
+            cb_pop_front(index_tensor_output_cb_index, one_tile);
+        }  // Wt loop
     }  // Ht loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
@@ -28,8 +28,10 @@ void kernel_main() {
         .page_size = value_tensor_tile_size_bytes,
         .data_format = value_tensor_data_format};
 
+    // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
     const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
+
     const InterleavedAddrGenFast<index_tensor_is_dram> interleaved_accessor1 = {
         .bank_base_address = index_tensor_buffer_addr,
         .page_size = index_tensor_output_tile_size_bytes,
@@ -39,8 +41,8 @@ void kernel_main() {
         // Value tensor
         for (uint32_t w = 0; w < Wt; w++) {
             cb_wait_front(value_tensor_cb_index, one_tile);
-            const uint32_t l1_write_addr = get_read_ptr(value_tensor_cb_index);
-            noc_async_write_tile(h * Wt + w, interleaved_accessor0, l1_write_addr);
+            const uint32_t l1_write_addr_val = get_read_ptr(value_tensor_cb_index);
+            noc_async_write_tile(h * Wt + w, interleaved_accessor0, l1_write_addr_val);
             noc_async_write_barrier();
             cb_pop_front(value_tensor_cb_index, one_tile);
         }
@@ -48,10 +50,11 @@ void kernel_main() {
         // Index tensor
         for (uint32_t w = 0; w < Wt; w++) {
             cb_wait_front(index_tensor_output_cb_index, one_tile);
-            const uint32_t l1_write_addr_2 = get_read_ptr(index_tensor_output_cb_index);
-            noc_async_write_tile(h * Wt + w, interleaved_accessor1, l1_write_addr_2);
+            const uint32_t l1_write_addr_index = get_read_ptr(index_tensor_output_cb_index);
+            noc_async_write_tile(h * Wt + w, interleaved_accessor1, l1_write_addr_index);
             noc_async_write_barrier();
             cb_pop_front(index_tensor_output_cb_index, one_tile);
         }
+
     }  // Ht loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+#include "debug/dprint.h"
+
+void kernel_main() {
+    DPRINT << "Starting WRITER kernel" << ENDL();
+
+    // Runtime args
+    const uint32_t value_tensor_buffer_addr = get_arg_val<uint32_t>(0);
+    const uint32_t index_tensor_buffer_addr = get_arg_val<uint32_t>(1);
+
+    // Compile time args
+    // TODO: More arguments
+    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(0);
+    constexpr bool value_tensor_is_dram = get_compile_time_arg_val(1);
+    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(2);
+    constexpr uint32_t Ht = get_compile_time_arg_val(3);
+    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+
+    // Output tensor config
+    constexpr uint32_t one_tile = 1;
+    // TODO: Value tensor output
+
+    const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
+    const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
+    const InterleavedAddrGenFast<index_tensor_is_dram> interleaved_accessor1 = {
+        .bank_base_address = index_tensor_buffer_addr,
+        .page_size = index_tensor_output_tile_size_bytes,
+        .data_format = index_tensor_output_data_format};
+
+    for (uint32_t h = 0; h < Ht; h++) {
+        for (uint32_t w = 0; w < Wt; w++) {
+            // Value tensor
+            // TODO: value tensor handling
+
+            // Index tensor
+            cb_wait_front(tt::CBIndex::c_1, one_tile);
+            uint32_t l1_read_addr = get_read_ptr(tt::CBIndex::c_1);
+            uint16_t* l1_read_addr_val = (uint16_t*)l1_read_addr;
+            uint32_t pointer_addr = (uint32_t)l1_read_addr_val;
+            DPRINT << "Got: " << U32(pointer_addr) << "Value: " << U32(l1_read_addr_val[0]) << ENDL();
+            noc_async_write_tile(h * Wt + w, interleaved_accessor1, l1_read_addr);
+            noc_async_write_barrier();
+            cb_pop_front(tt::CBIndex::c_1, one_tile);
+        }
+    }  // Ht loop
+}

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
@@ -31,12 +31,12 @@ void kernel_main() {
     // Index tensor config
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
     const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
-
     const InterleavedAddrGenFast<index_tensor_is_dram> interleaved_accessor1 = {
         .bank_base_address = index_tensor_buffer_addr,
         .page_size = index_tensor_output_tile_size_bytes,
         .data_format = index_tensor_output_data_format};
 
+    // Move data from L1 to DRAMs
     for (uint32_t h = 0; h < Ht; h++) {
         // Value tensor
         for (uint32_t w = 0; w < Wt; w++) {
@@ -55,6 +55,5 @@ void kernel_main() {
             noc_async_write_barrier();
             cb_pop_front(index_tensor_output_cb_index, one_tile);
         }
-
     }  // Ht loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
@@ -7,23 +7,26 @@
 #include "debug/dprint.h"
 
 void kernel_main() {
-    DPRINT << "Starting WRITER kernel" << ENDL();
-
     // Runtime args
     const uint32_t value_tensor_buffer_addr = get_arg_val<uint32_t>(0);
     const uint32_t index_tensor_buffer_addr = get_arg_val<uint32_t>(1);
 
     // Compile time args
-    // TODO: More arguments
-    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(0);
-    constexpr bool value_tensor_is_dram = get_compile_time_arg_val(1);
-    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(2);
-    constexpr uint32_t Ht = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(1);
+    constexpr bool value_tensor_is_dram = get_compile_time_arg_val(2);
+    constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3);
+    constexpr uint32_t Ht = get_compile_time_arg_val(4);
+    constexpr uint32_t Wt = get_compile_time_arg_val(5);
 
     // Output tensor config
     constexpr uint32_t one_tile = 1;
-    // TODO: Value tensor output
+    const uint32_t value_tensor_tile_size_bytes = get_tile_size(value_tensor_cb_index);
+    const DataFormat value_tensor_data_format = get_dataformat(value_tensor_cb_index);
+    const InterleavedAddrGenFast<value_tensor_is_dram> interleaved_accessor0 = {
+        .bank_base_address = value_tensor_buffer_addr,
+        .page_size = value_tensor_tile_size_bytes,
+        .data_format = value_tensor_data_format};
 
     const uint32_t index_tensor_output_tile_size_bytes = get_tile_size(index_tensor_output_cb_index);
     const DataFormat index_tensor_output_data_format = get_dataformat(index_tensor_output_cb_index);
@@ -33,19 +36,22 @@ void kernel_main() {
         .data_format = index_tensor_output_data_format};
 
     for (uint32_t h = 0; h < Ht; h++) {
+        // Value tensor
         for (uint32_t w = 0; w < Wt; w++) {
-            // Value tensor
-            // TODO: value tensor handling
-
-            // Index tensor
-            cb_wait_front(tt::CBIndex::c_1, one_tile);
-            uint32_t l1_read_addr = get_read_ptr(tt::CBIndex::c_1);
-            uint16_t* l1_read_addr_val = (uint16_t*)l1_read_addr;
-            uint32_t pointer_addr = (uint32_t)l1_read_addr_val;
-            DPRINT << "Got: " << U32(pointer_addr) << "Value: " << U32(l1_read_addr_val[0]) << ENDL();
-            noc_async_write_tile(h * Wt + w, interleaved_accessor1, l1_read_addr);
+            cb_wait_front(value_tensor_cb_index, one_tile);
+            const uint32_t l1_write_addr = get_read_ptr(value_tensor_cb_index);
+            noc_async_write_tile(h * Wt + w, interleaved_accessor0, l1_write_addr);
             noc_async_write_barrier();
-            cb_pop_front(tt::CBIndex::c_1, one_tile);
+            cb_pop_front(value_tensor_cb_index, one_tile);
+        }
+
+        // Index tensor
+        for (uint32_t w = 0; w < Wt; w++) {
+            cb_wait_front(index_tensor_output_cb_index, one_tile);
+            const uint32_t l1_write_addr_2 = get_read_ptr(index_tensor_output_cb_index);
+            noc_async_write_tile(h * Wt + w, interleaved_accessor1, l1_write_addr_2);
+            noc_async_write_barrier();
+            cb_pop_front(index_tensor_output_cb_index, one_tile);
         }
     }  // Ht loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -33,6 +33,15 @@ void SortDeviceOperation::validate_on_program_cache_miss(
 
     TT_FATAL(input_tensor_shape.rank() == 4, "Input shape must be 4D, got {}", input_tensor_shape.rank());
 
+    TT_FATAL(
+        input_tensor_shape[3] % 64 == 0,
+        "Input shape inner dim {} must be a multiple of 64, pad with +/-infinity if necessary",
+        input_tensor_shape[3]);
+    TT_FATAL(
+        (input_tensor_shape[0] * input_tensor_shape[1] * input_tensor_shape[2]) % 32 == 0,
+        "Input height (combined input_shape[0-3]) {} must be a multiple of 32",
+        input_tensor_shape[0] * input_tensor_shape[1] * input_tensor_shape[2]);
+
     TT_FATAL(attributes.output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
 
     TT_FATAL(tensor_args.input_tensor.get_layout() == Layout::TILE, "The input must be in tiled format");

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -22,6 +22,21 @@ void SortDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     // Validate shapes of input and output tensors
     const auto input_tensor_shape = tensor_args.input_tensor.get_padded_shape();
+
+    TT_FATAL(
+        tensor_args.input_tensor.buffer() != nullptr,
+        "Operands need to be allocated in buffers on the device. Buffer is null.");
+    TT_FATAL(
+        tensor_args.input_tensor.storage_type() == StorageType::DEVICE,
+        "Operation requires input to be on Device. Input storage type: {}",
+        static_cast<int>(tensor_args.input_tensor.storage_type()));
+
+    TT_FATAL(input_tensor_shape.rank() == 4, "Input shape must be 4D, got {}", input_tensor_shape.rank());
+
+    TT_FATAL(attributes.output_mem_config.is_sharded() == false, "Sharded implementation not supported yet");
+
+    TT_FATAL(tensor_args.input_tensor.get_layout() == Layout::TILE, "The input must be in tiled format");
+
     if (tensor_args.output_tensors.size() == 2) {
         if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {
             const auto output_tensor_shape = tensor_args.output_tensors.at(0)->get_padded_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -34,9 +34,9 @@ void SortDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(input_tensor_shape.rank() == 4, "Input shape must be 4D, got {}", input_tensor_shape.rank());
 
     TT_FATAL(
-        input_tensor_shape[3] % 64 == 0,
+        input_tensor_shape[-1] % 64 == 0,
         "Input shape inner dim {} must be a multiple of 64, pad with +/-infinity if necessary",
-        input_tensor_shape[3]);
+        input_tensor_shape[-1]);
     TT_FATAL(
         (input_tensor_shape[0] * input_tensor_shape[1] * input_tensor_shape[2]) % 32 == 0,
         "Input height (combined input_shape[0-3]) {} must be a multiple of 32",

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -3,26 +3,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sort_device_operation.hpp"
-#include "sort_program_factory.hpp"
 
 using namespace tt::tt_metal;
 
-namespace ttnn::operations::experimental::reduction {
+namespace ttnn::operations::experimental::reduction::sort {
 
-void SortDeviceOperation::validate_with_output_tensors(
-    const std::vector<Tensor>& input_tensor, const std::vector<std::optional<Tensor>>& output_tensors) const {
+SortDeviceOperation::program_factory_t SortDeviceOperation::select_program_factory(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    return sort::program::SortProgramFactory{};
+}
+
+void SortDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    return validate_on_program_cache_miss(attributes, tensor_args);
+}
+
+void SortDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     // Validate shapes of input and output tensors
-    const auto input_tensor_shape = input_tensor.at(0).get_padded_shape();
-    if (output_tensors.size() == 2) {
-        if (output_tensors.at(0).has_value() && output_tensors.at(1).has_value()) {
-            const auto output_tensor_shape = output_tensors.at(0)->get_padded_shape();
+    const auto input_tensor_shape = tensor_args.input_tensor.get_padded_shape();
+    if (tensor_args.output_tensors.size() == 2) {
+        if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {
+            const auto output_tensor_shape = tensor_args.output_tensors.at(0)->get_padded_shape();
             TT_FATAL(
                 output_tensor_shape == input_tensor_shape,
                 "Output tensor shape must be the same as input tensor shape. Got output tensor shape: {} and input "
                 "tensor shape: {}",
                 output_tensor_shape,
                 input_tensor_shape);
-            const auto output_indices_shape = output_tensors.at(1)->get_padded_shape();
+            const auto output_indices_shape = tensor_args.output_tensors.at(1)->get_padded_shape();
             TT_FATAL(
                 output_indices_shape == input_tensor_shape,
                 "Output tensor indices shape must be the same as input tensor shape. Got output indices tensor shape: "
@@ -34,40 +43,48 @@ void SortDeviceOperation::validate_with_output_tensors(
     }
 }
 
-std::vector<TensorSpec> SortDeviceOperation::compute_output_specs(
-    const std::vector<Tensor>& input_tensor, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    if (output_tensors.size() == 2) {
-        if (output_tensors.at(0).has_value() && output_tensors.at(1).has_value()) {
-            return {output_tensors[0]->get_tensor_spec(), output_tensors[1]->get_tensor_spec()};
+SortDeviceOperation::spec_return_value_t SortDeviceOperation::compute_output_specs(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output_tensors.size() == 2) {
+        if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {
+            return {tensor_args.output_tensors[0]->get_tensor_spec(), tensor_args.output_tensors[1]->get_tensor_spec()};
         }
     }
     // Create output tensors specs
-    auto output_shape = input_tensor.at(0).get_logical_shape();
+    auto output_shape = tensor_args.input_tensor.get_logical_shape();
     auto values_spec = TensorSpec(
-        output_shape, TensorLayout(input_tensor.at(0).get_dtype(), PageConfig(Layout::TILE), output_mem_config));
-    auto index_spec =
-        TensorSpec(output_shape, TensorLayout(DataType::UINT16, PageConfig(Layout::TILE), output_mem_config));
+        output_shape,
+        TensorLayout(tensor_args.input_tensor.get_dtype(), PageConfig(Layout::TILE), attributes.output_mem_config));
+    auto index_spec = TensorSpec(
+        output_shape, TensorLayout(DataType::UINT16, PageConfig(Layout::TILE), attributes.output_mem_config));
 
     return {values_spec, index_spec};
 }
 
-std::vector<Tensor> SortDeviceOperation::create_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const {
-    if (output_tensors.size() == 2) {
-        if (output_tensors.at(0).has_value() && output_tensors.at(1).has_value()) {
-            return {output_tensors[0].value(), output_tensors[1].value()};
+SortDeviceOperation::tensor_return_value_t SortDeviceOperation::create_output_tensors(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    if (tensor_args.output_tensors.size() == 2) {
+        if (tensor_args.output_tensors.at(0).has_value() && tensor_args.output_tensors.at(1).has_value()) {
+            return {tensor_args.output_tensors[0].value(), tensor_args.output_tensors[1].value()};
         }
     }
-    auto output_specs = compute_output_specs(input_tensors, output_tensors);
+    auto output_specs = compute_output_specs(attributes, tensor_args);
     return {
-        create_device_tensor(output_specs[0], input_tensors.at(0).device()),
-        create_device_tensor(output_specs[1], input_tensors.at(0).device()),
+        create_device_tensor(output_specs[0], tensor_args.input_tensor.device()),
+        create_device_tensor(output_specs[1], tensor_args.input_tensor.device()),
     };
 }
 
-tt::tt_metal::operation::ProgramWithCallbacks SortDeviceOperation::create_program(
-    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
-    return detail::sort_program_interleaved(
-        input_tensors.at(0), this->dim, this->descending, this->stable, output_tensors.at(0), output_tensors.at(1));
+std::tuple<SortDeviceOperation::operation_attributes_t, SortDeviceOperation::tensor_args_t> SortDeviceOperation::invoke(
+    const Tensor& input_tensor,
+    const int8_t dim,
+    const bool descending,
+    const bool stable,
+    const MemoryConfig& output_memory_config,
+    const std::vector<std::optional<Tensor>>& output_tensors) {
+    return {
+        operation_attributes_t{dim, descending, stable, output_memory_config},
+        tensor_args_t{input_tensor, output_tensors}};
 }
-}  // namespace ttnn::operations::experimental::reduction
+
+}  // namespace ttnn::operations::experimental::reduction::sort

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.hpp
@@ -4,28 +4,43 @@
 
 #pragma once
 
+#include "sort_program_factory.hpp"
+#include "sort_device_operation_types.hpp"
+
+#include "ttnn/decorators.hpp"
+
 #include <cstdint>
 #include <optional>
 
-#include "ttnn/tensor/tensor.hpp"
-#include "ttnn/run_operation.hpp"
-
-namespace ttnn::operations::experimental::reduction {
+namespace ttnn::operations::experimental::reduction::sort {
 
 struct SortDeviceOperation {
-    const int8_t dim;
-    const bool descending;
-    const bool stable;
-    const tt::tt_metal::MemoryConfig output_mem_config;
+    using operation_attributes_t = sort::operation_attributes_t;
+    using tensor_args_t = sort::tensor_args_t;
+    using spec_return_value_t = sort::spec_return_value_t;
+    using tensor_return_value_t = sort::tensor_return_value_t;
+    using program_factory_t = std::variant<sort::program::SortProgramFactory>;
 
-    void validate_with_output_tensors(
-        const std::vector<Tensor>& input_tensor, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<TensorSpec> compute_output_specs(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    std::vector<Tensor> create_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;
-    tt::tt_metal::operation::ProgramWithCallbacks create_program(
-        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor,
+        const int8_t dim,
+        const bool descending,
+        const bool stable,
+        const MemoryConfig& output_memory_config,
+        const std::vector<std::optional<Tensor>>& output_tensors);
 };
 
-}  // namespace ttnn::operations::experimental::reduction
+}  // namespace ttnn::operations::experimental::reduction::sort
+
+namespace ttnn::prim {
+constexpr auto sort = ttnn::
+    register_operation<"ttnn::prim::sort", ttnn::operations::experimental::reduction::sort::SortDeviceOperation>();
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation_types.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::reduction::sort {
+
+struct operation_attributes_t {
+    const int8_t dim;
+    const bool descending;
+    const bool stable;
+    const tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+struct tensor_args_t {
+    const Tensor& input_tensor;
+    std::vector<std::optional<Tensor>> output_tensors;
+};
+
+using spec_return_value_t = std::vector<ttnn::TensorSpec>;
+using tensor_return_value_t = std::vector<Tensor>;
+
+}  // namespace ttnn::operations::experimental::reduction::sort

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -126,7 +126,6 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
         index_tensor_output_cb_index,
         Ht,
         Wt,
-        static_cast<uint32_t>(std::log2(Wt)),
         static_cast<uint32_t>(attributes.descending),
         static_cast<uint32_t>(attributes.stable)};
     const std::string compute_kernel_path =

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -4,16 +4,118 @@
 
 #include "sort_program_factory.hpp"
 
+#include <cstdint>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/util.hpp>
+
 namespace ttnn::operations::experimental::reduction::sort::program {
 
 SortProgramFactory::cached_program_t SortProgramFactory::create(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {
+    // Program config
     tt::tt_metal::Program program{};
+    const CoreCoord core = {0, 0};
 
-    // TODO: Implementation in next PR
-    tt::log_warning("sort_program_interleaved not implemented yet!");
+    // Tensor config info
+    const tt::DataFormat input_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.get_dtype());
+    const tt::DataFormat value_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(0).get_dtype());
+    const tt::DataFormat index_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(0).get_dtype());  // Uint16
 
-    return {std::move(program), {}};
+    const uint32_t input_tensor_tile_size = tile_size(input_tensor_cb_data_format);
+    const uint32_t value_tensor_tile_size = tile_size(value_tensor_cb_data_format);
+    const uint32_t index_tensor_tile_size = tile_size(index_tensor_cb_data_format);  // 2048
+
+    auto input_buffer = tensor_args.input_tensor.buffer();
+    auto value_buffer = output_tensors.at(0).buffer();
+    auto index_buffer = output_tensors.at(1).buffer();
+
+    const bool input_tensor_is_dram = input_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    const bool value_tensor_is_dram = value_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    const bool index_tensor_is_dram = index_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    const uint32_t num_input_tiles = tensor_args.input_tensor.volume() / tt::constants::TILE_HW;
+    const uint32_t num_value_tiles = output_tensors.at(0).volume() / tt::constants::TILE_HW;
+
+    const auto input_shape = tensor_args.input_tensor.get_padded_shape();  // [1,1,32,32]
+    const uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tt::constants::TILE_HEIGHT;
+    const uint32_t Wt = input_shape[3] / tt::constants::TILE_WIDTH;
+
+    // Double buffering config
+    constexpr uint32_t num_cb_unit = 2;                // Number of circular buffer units for double buffering
+    constexpr uint32_t cb_in_units = 2 * num_cb_unit;  // Total number of circular buffer units
+
+    // Circular buffers
+    constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
+    const tt::tt_metal::CircularBufferConfig input_tensor_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_in_units * input_tensor_tile_size, {{input_tensor_cb_index, input_tensor_cb_data_format}})
+            .set_page_size(input_tensor_cb_index, input_tensor_tile_size);
+    auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, core, input_tensor_cb_config);
+
+    constexpr uint32_t index_tensor_cb_index = tt::CBIndex::c_1;
+    const tt::tt_metal::CircularBufferConfig index_tensor_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_in_units * index_tensor_tile_size, {{index_tensor_cb_index, index_tensor_cb_data_format}})
+            .set_page_size(index_tensor_cb_index, index_tensor_tile_size);
+    auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_tensor_cb_config);
+
+    // TODO: CB for transposed input tiles?
+    // TODO: CB for transposed index tiles?
+    // TODO: CB for output sort values
+
+    constexpr uint32_t index_tensor_output_cb_index = tt::CBIndex::c_17;
+    const tt::tt_metal::CircularBufferConfig index_tensor_output_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            num_cb_unit * index_tensor_tile_size, {{index_tensor_output_cb_index, index_tensor_cb_data_format}})
+            .set_page_size(index_tensor_output_cb_index, index_tensor_tile_size);
+    auto cb_index_tensor_output = tt::tt_metal::CreateCircularBuffer(program, core, index_tensor_output_cb_config);
+
+    // Kernels
+    const std::vector<uint32_t> reader_compile_time_args = {
+        input_tensor_cb_index, index_tensor_cb_index, static_cast<uint32_t>(input_tensor_is_dram), Ht, Wt};
+    const std::string reader_kernel_path =
+        "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp";
+    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+        program, reader_kernel_path, core, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
+
+    SetRuntimeArgs(program, reader_kernel_id, core, {input_buffer->address()});
+
+    const std::vector<uint32_t> writer_compile_time_args = {// value_tensor_cb_index,
+                                                            index_tensor_output_cb_index,
+                                                            static_cast<uint32_t>(value_tensor_is_dram),
+                                                            static_cast<uint32_t>(index_tensor_is_dram),
+                                                            Ht,
+                                                            Wt};
+    const std::string writer_kernel_path =
+        "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp";
+    tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
+        program, writer_kernel_path, core, tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
+
+    SetRuntimeArgs(program, writer_kernel_id, core, {value_buffer->address(), index_buffer->address()});
+
+    const std::vector<uint32_t> compute_compile_time_args = {
+        input_tensor_cb_index,
+        index_tensor_cb_index,
+        // input_tensor_transposed_cb_index,
+        // index_tensor_transposed_cb_index,
+        // value_tensor_cb_index,
+        index_tensor_output_cb_index,
+        Ht,
+        Wt,
+        static_cast<uint32_t>(attributes.descending),
+        static_cast<uint32_t>(attributes.stable),
+        // TODO: Add more params
+    };
+    const std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp";
+    tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
+        program, compute_kernel_path, core, tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+
+    return {std::move(program), {reader_kernel_id, compute_kernel_id, writer_kernel_id}};
 }
 
 void SortProgramFactory::override_runtime_arguments(
@@ -21,7 +123,22 @@ void SortProgramFactory::override_runtime_arguments(
     const operation_attributes_t& attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output_tensors) {
-    // TODO: Implement the logic to override runtime arguments for the cached program
+    auto input_tensor_buffer = tensor_args.input_tensor.buffer();
+    auto value_tensor_buffer = output_tensors.at(0).buffer();
+    auto index_tensor_buffer = output_tensors.at(1).buffer();
+
+    CoreCoord core = {0, 0};
+
+    {
+        auto& reader_runtime_args =
+            GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
+        reader_runtime_args[0] = input_tensor_buffer->address();
+
+        auto& writer_runtime_args =
+            GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
+        writer_runtime_args[0] = value_tensor_buffer->address();
+        writer_runtime_args[1] = index_tensor_buffer->address();
+    }
 }
 
 }  // namespace ttnn::operations::experimental::reduction::sort::program

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -23,7 +23,7 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
     const tt::DataFormat value_tensor_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(0).get_dtype());
     const tt::DataFormat index_tensor_cb_data_format =
-        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(0).get_dtype());
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensors.at(1).get_dtype());
 
     const uint32_t input_tensor_tile_size = tile_size(input_tensor_cb_data_format);
     const uint32_t value_tensor_tile_size = tile_size(value_tensor_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sort_program_factory.hpp"
+
+namespace ttnn::operations::experimental::reduction::sort::program {
+
+SortProgramFactory::cached_program_t SortProgramFactory::create(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {
+    tt::tt_metal::Program program{};
+
+    // TODO: Implementation in next PR
+    tt::log_warning("sort_program_interleaved not implemented yet!");
+
+    return {std::move(program), {}};
+}
+
+void SortProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output_tensors) {
+    // TODO: Implement the logic to override runtime arguments for the cached program
+}
+
+}  // namespace ttnn::operations::experimental::reduction::sort::program

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
@@ -12,12 +12,13 @@
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::experimental::reduction::sort::program {
+using namespace tt::tt_metal;
 
 struct SortProgramFactory {
     struct shared_variables_t {
-        tt::tt_metal::KernelHandle gelu_bw_reader_kernel_id;
-        tt::tt_metal::KernelHandle gelu_bw_compute_kernel_id;
-        tt::tt_metal::KernelHandle gelu_bw_writer_kernel_id;
+        KernelHandle reader_kernel_id;
+        KernelHandle compute_kernel_id;
+        KernelHandle writer_kernel_id;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "sort_device_operation_types.hpp"
 
 #include <tt-metalium/host_api.hpp>

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
@@ -2,31 +2,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sort_device_operation.hpp"
+#include "sort_device_operation_types.hpp"
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
+#include "ttnn/device_operation.hpp"
 
-using namespace tt::tt_metal;
+namespace ttnn::operations::experimental::reduction::sort::program {
 
-namespace ttnn::operations::experimental::reduction::detail {
+struct SortProgramFactory {
+    struct shared_variables_t {
+        tt::tt_metal::KernelHandle gelu_bw_reader_kernel_id;
+        tt::tt_metal::KernelHandle gelu_bw_compute_kernel_id;
+        tt::tt_metal::KernelHandle gelu_bw_writer_kernel_id;
+    };
 
-operation::ProgramWithCallbacks sort_program_interleaved(
-    const Tensor& input_tensor,
-    const int8_t dim,
-    const bool descending,
-    const bool stable,
-    Tensor& value_tensor,
-    Tensor& index_tensor) {
-    tt::tt_metal::Program program{};
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
-    // TODO: Implementation in next PR
-    tt::log_warning("sort_program_interleaved not implemented yet!");
+    static cached_program_t create(const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    static void override_runtime_arguments(
+        cached_program_t&, const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+};
 
-    return {std::move(program), {}};
-}
-
-}  // namespace ttnn::operations::experimental::reduction::detail
+}  // namespace ttnn::operations::experimental::reduction::sort::program

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -130,11 +130,8 @@ bool validate_optional_output_tensors_for_early_exit(
     auto output_tensor_0 = std::get<0>(optional_output_tensors.value());
     auto output_tensor_1 = std::get<1>(optional_output_tensors.value());
 
-    if (output_tensor_0.get_logical_shape() == original_lshape &&
-        output_tensor_1.get_logical_shape() == original_lshape) {
-        return true;
-    }
-    return false;
+    return output_tensor_0.get_logical_shape() == original_lshape &&
+           output_tensor_1.get_logical_shape() == original_lshape;
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -5,6 +5,15 @@
 #include "sort.hpp"
 #include "device/sort_device_operation.hpp"
 
+#include "ttnn/common/queue_id.hpp"
+#include "ttnn/run_operation.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
+
 namespace ttnn::operations::experimental::reduction::sort {
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
@@ -14,6 +23,69 @@ std::vector<std::optional<T>> tuple_to_vector_optional(Tuple&& tuple) {
     return std::apply(
         [](auto&&... elems) { return std::vector<std::optional<T>>{std::forward<decltype(elems)>(elems)...}; },
         std::forward<Tuple>(tuple));
+}
+
+Tensor perform_transpose(
+    const Tensor& input_tensor, const bool is_dim_last_idx, const int8_t dim1 = -1, const int8_t dim2 = -1) {
+    return is_dim_last_idx ? input_tensor : ttnn::transpose(input_tensor, dim1, dim2, input_tensor.memory_config());
+}
+
+Tensor transform_to_4d_tensor(const Tensor& input_tensor, const bool is_rank_le_4d) {
+    return is_rank_le_4d ? ttnn::unsqueeze_to_4D(input_tensor) : data_movement::squeeze_from_ND_to_4D(input_tensor);
+}
+
+Tensor pre_sort_transform_tensor(
+    const Tensor& input_tensor,
+    const int8_t dim,
+    const bool is_dim_last_idx,
+    const bool is_rank_le_4d,
+    const bool descending) {
+    if (input_tensor.get_logical_shape() == ttnn::Shape{1}) {
+        // Early exit for scalar tensors, return the same tensor
+        // Scalar tensors do not require sorting.
+        return input_tensor;
+    }
+    // If dim is not last dimension transpose it
+    const Tensor transposed_tensor = perform_transpose(input_tensor, is_dim_last_idx, dim, -1);
+    // If input is not rank 4 transorm it to 4D
+    const Tensor transformed_tensor = transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
+    // Add padding if needed
+    const Tensor padded_tensor = ttnn::fill_implicit_tile_padding(
+        transformed_tensor, descending ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
+    return padded_tensor;
+}
+
+std::vector<Tensor> post_sort_transform_tensor(
+    const Tensor& input_tensor,
+    std::vector<Tensor>& result,
+    const int8_t dim,
+    const bool is_dim_last_idx,
+    const Shape& original_lshape,
+    const MemoryConfig& input_memory_config) {
+    auto input_shape = input_tensor.get_padded_shape();
+    const auto orig_rank = input_shape.rank();
+
+    if (orig_rank < 4) {
+        result[0] = ttnn::squeeze_from_4D(result[0], orig_rank);
+        result[1] = ttnn::squeeze_from_4D(result[1], orig_rank);
+    } else if (orig_rank > 4) {
+        ttnn::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
+        result[0] = ttnn::reshape(result[0], ttnn::Shape{result_shape});
+        result[1] = ttnn::reshape(result[1], ttnn::Shape{result_shape});
+    }
+
+    if (!is_dim_last_idx) {
+        result[0] = ttnn::transpose(result[0], dim, -1, input_tensor.memory_config());
+        result[1] = ttnn::transpose(result[1], dim, -1, input_tensor.memory_config());
+    }
+
+    TT_FATAL(
+        result[0].get_logical_shape() == original_lshape,
+        "Output tensor transformation did not create correct output shape! Got: {}, expected: {}",
+        result[0].get_logical_shape(),
+        original_lshape);
+
+    return result;
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -27,14 +99,45 @@ std::vector<Tensor> ExecuteSort::invoke(
     const bool stable,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors) {
+    ttnn::Shape original_lshape = input_tensor.get_logical_shape();
+    auto rank = input_tensor.get_padded_shape().rank();
+
+    // Check for early exit for scalar or empty tensors tensors
+    if ((original_lshape == ttnn::Shape{}) || (original_lshape == ttnn::Shape{1})) {
+        if (optional_output_tensors.has_value()) {
+            return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
+        } else {
+            return {input_tensor, ttnn::zeros_like(input_tensor)};
+        }
+    }
+
+    const bool is_dim_last_idx = (dim == -1 || dim == rank - 1);
+    const bool is_rank_le_4d = rank <= 4;
+
     const auto memory_config_value = memory_config.has_value() ? memory_config.value() : input_tensor.memory_config();
-    std::vector<std::optional<Tensor>> output_tensors =
-        optional_output_tensors.has_value() ? CMAKE_UNIQUE_NAMESPACE::tuple_to_vector_optional(*optional_output_tensors)
-                                            : std::vector<std::optional<Tensor>>{
-                                                  std::nullopt,  // Placeholder for values tensor
-                                                  std::nullopt   // Placeholder for indices tensor
-                                              };
-    return ttnn::prim::sort(queue_id, input_tensor, dim, descending, stable, memory_config_value, output_tensors);
+
+    Tensor padded_input_tensor = CMAKE_UNIQUE_NAMESPACE::pre_sort_transform_tensor(
+        input_tensor, dim, is_dim_last_idx, is_rank_le_4d, descending);
+
+    std::vector<std::optional<Tensor>> output_tensors;
+    if (optional_output_tensors.has_value()) {
+        output_tensors = CMAKE_UNIQUE_NAMESPACE::tuple_to_vector_optional(*optional_output_tensors);
+        output_tensors[0] = CMAKE_UNIQUE_NAMESPACE::pre_sort_transform_tensor(
+            output_tensors[0].value(), dim, is_dim_last_idx, is_rank_le_4d, descending);
+        output_tensors[1] = CMAKE_UNIQUE_NAMESPACE::pre_sort_transform_tensor(
+            output_tensors[1].value(), dim, is_dim_last_idx, is_rank_le_4d, descending);
+    } else {
+        output_tensors = std::vector<std::optional<Tensor>>{
+            std::nullopt,  // Placeholder for values tensor
+            std::nullopt   // Placeholder for indices tensor
+        };
+    }
+
+    auto sorted_tensors =
+        ttnn::prim::sort(queue_id, padded_input_tensor, dim, descending, stable, memory_config_value, output_tensors);
+
+    return CMAKE_UNIQUE_NAMESPACE::post_sort_transform_tensor(
+        input_tensor, sorted_tensors, dim, is_dim_last_idx, original_lshape, memory_config_value);
 }
 
 std::vector<Tensor> ExecuteSort::create_async_output_tensors(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -106,6 +106,7 @@ std::vector<Tensor> ExecuteSort::invoke(
     if ((original_lshape == ttnn::Shape{}) || (original_lshape == ttnn::Shape{1})) {
         if (CMAKE_UNIQUE_NAMESPACE::validate_optional_output_tensors_for_early_exit(
                 optional_output_tensors, original_lshape)) {
+            std::get<0>(optional_output_tensors.value()).populate_buffers_and_metadata(input_tensor);
             return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
         } else {
             return {input_tensor, ttnn::zeros_like(input_tensor)};

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -72,6 +72,22 @@ std::vector<Tensor> post_sort_transform_tensor(
     return result;
 }
 
+bool validate_optional_output_tensors_for_early_exit(
+    const std::optional<std::tuple<Tensor, Tensor>>& optional_output_tensors, const Shape& original_lshape) {
+    if (!optional_output_tensors.has_value()) {
+        return false;
+    }
+
+    auto output_tensor_0 = std::get<0>(optional_output_tensors.value());
+    auto output_tensor_1 = std::get<1>(optional_output_tensors.value());
+
+    if (output_tensor_0.get_logical_shape() == original_lshape &&
+        output_tensor_1.get_logical_shape() == original_lshape) {
+        return true;
+    }
+    return false;
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -88,7 +104,8 @@ std::vector<Tensor> ExecuteSort::invoke(
 
     // Check for early exit for scalar or empty tensors tensors
     if ((original_lshape == ttnn::Shape{}) || (original_lshape == ttnn::Shape{1})) {
-        if (optional_output_tensors.has_value()) {
+        if (CMAKE_UNIQUE_NAMESPACE::validate_optional_output_tensors_for_early_exit(
+                optional_output_tensors, original_lshape)) {
             return {std::get<0>(optional_output_tensors.value()), std::get<1>(optional_output_tensors.value())};
         } else {
             return {input_tensor, ttnn::zeros_like(input_tensor)};

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -55,7 +55,8 @@ Tensor pre_sort_transform_tensor(
     const Tensor transformed_tensor = reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
     // Fill implicit tile padding with the appropriate value
     const Tensor padded_tensor = ttnn::fill_implicit_tile_padding(
-        transformed_tensor, descending ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max());
+        transformed_tensor,
+        descending ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity());
 
     // Check for need of manual padding - Bitonic sort works on dataset that are the size of power of two - add manual
     // padding if needed
@@ -71,7 +72,7 @@ Tensor pre_sort_transform_tensor(
         tt::tt_metal::Array4D(
             {current_padded_shape[0], current_padded_shape[1], current_padded_shape[2], padded_last_dim}),
         tt::tt_metal::Array4D({0, 0, 0, 0}),
-        descending ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max());
+        descending ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity());
 
     return padded_output_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -54,7 +54,7 @@ Tensor pre_sort_transform_tensor(
     // If input is not rank 4 transorm it to 4D
     const Tensor transformed_tensor = reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
     // Fill implicit tile padding with the appropriate value
-    const Tensor padded_tensor = ttnn::fill_implicit_tile_padding(
+    Tensor padded_tensor = ttnn::fill_implicit_tile_padding(
         transformed_tensor,
         descending ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity());
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -55,7 +55,7 @@ Tensor pre_sort_transform_tensor(
     const Tensor transformed_tensor = reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
     // Fill implicit tile padding with the appropriate value
     const Tensor padded_tensor = ttnn::fill_implicit_tile_padding(
-        transformed_tensor, descending ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
+        transformed_tensor, descending ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max());
 
     // Check for need of manual padding - Bitonic sort works on dataset that are the size of power of two - add manual
     // padding if needed
@@ -71,7 +71,7 @@ Tensor pre_sort_transform_tensor(
         tt::tt_metal::Array4D(
             {current_padded_shape[0], current_padded_shape[1], current_padded_shape[2], padded_last_dim}),
         tt::tt_metal::Array4D({0, 0, 0, 0}),
-        descending ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max());
+        descending ? std::numeric_limits<float>::lowest() : std::numeric_limits<float>::max());
 
     return padded_output_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <optional>
-
 #include "ttnn/decorators.hpp"
 
-namespace ttnn::operations::experimental::reduction {
+#include <optional>
+
+namespace ttnn::operations::experimental::reduction::sort {
 
 struct ExecuteSort {
     static std::vector<Tensor> invoke(
@@ -17,19 +17,19 @@ struct ExecuteSort {
         const int8_t dim,
         const bool descending,
         const bool stable,
-        const std::optional<MemoryConfig>& memory_config,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
 
     static std::vector<Tensor> create_async_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
 };
 
-}  // namespace ttnn::operations::experimental::reduction
+}  // namespace ttnn::operations::experimental::reduction::sort
 
 namespace ttnn::experimental {
 
 constexpr auto sort = ttnn::register_operation_with_auto_launch_op<
     "ttnn::experimental::sort",
-    ttnn::operations::experimental::reduction::ExecuteSort>();
+    ttnn::operations::experimental::reduction::sort::ExecuteSort>();
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #include "sort_pybind.hpp"
+
+#include "sort.hpp"
 
 #include "pybind11/decorators.hpp"
 
-#include "sort.hpp"
-#include "device/sort_device_operation.hpp"
-
-namespace ttnn::operations::experimental::reduction::detail {
+namespace ttnn::operations::experimental::reduction::sort::detail {
 namespace py = pybind11;
 
 void bind_reduction_sort_operation(py::module& module) {
@@ -66,7 +66,7 @@ void bind_reduction_sort_operation(py::module& module) {
                const bool stable,
                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
-               QueueId queue_id) {
+               QueueId queue_id) -> std::vector<ttnn::Tensor> {
                 return self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
@@ -79,4 +79,4 @@ void bind_reduction_sort_operation(py::module& module) {
             py::arg("queue_id") = DefaultQueueId});
 }
 
-}  // namespace ttnn::operations::experimental::reduction::detail
+}  // namespace ttnn::operations::experimental::reduction::sort::detail

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -33,6 +33,10 @@ void bind_reduction_sort_operation(py::module& module) {
                 * `memory_config` (MemoryConfig, optional): Specifies the memory configuration for the output tensor. Defaults to `None`.
                 * `out` (tuple of Tensors, optional): Preallocated output tensors for the sorted values and indices. Defaults to `None`.
 
+            Additional info:
+                * For now the `stable` argument is not supported.
+                * For now the input tensor shape must be a multiple of 64 in the sorting dimension.
+
             Example:
 
             .. code-block:: python

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -35,7 +35,6 @@ void bind_reduction_sort_operation(py::module& module) {
 
             Additional info:
                 * For now the `stable` argument is not supported.
-                * For now the input tensor shape must be a multiple of 64 in the sorting dimension.
 
             Example:
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.hpp
@@ -6,9 +6,9 @@
 
 #include "pybind11/pybind_fwd.hpp"
 
-namespace ttnn::operations::experimental::reduction::detail {
+namespace ttnn::operations::experimental::reduction::sort::detail {
 namespace py = pybind11;
 
 void bind_reduction_sort_operation(py::module& module);
 
-}  // namespace ttnn::operations::experimental::reduction::detail
+}  // namespace ttnn::operations::experimental::reduction::sort::detail

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduction_common.hpp"
+
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/core/core.hpp"
+
+namespace reduction_common {
+
+ttnn::Tensor perform_transpose(
+    const ttnn::Tensor& input_tensor, const bool is_dim_last_idx, const int8_t dim1, const int8_t dim2) {
+    return is_dim_last_idx ? input_tensor : ttnn::transpose(input_tensor, dim1, dim2, input_tensor.memory_config());
+}
+
+ttnn::Tensor transform_to_4d_tensor(const ttnn::Tensor& input_tensor, const bool is_rank_le_4d) {
+    return is_rank_le_4d ? ttnn::operations::core::unsqueeze_to_4D(input_tensor)
+                         : ttnn::operations::data_movement::squeeze_from_ND_to_4D(input_tensor);
+}
+
+}  // namespace reduction_common

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.hpp
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include "ttnn/tensor/tensor.hpp"
+
 #include <vector>
+#include <optional>
+#include <cstdint>
 
 namespace reduction_common {
 

--- a/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/reduction_common/reduction_common.hpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+namespace reduction_common {
+
+template <class Tuple, class T = std::decay_t<std::tuple_element_t<0, std::decay_t<Tuple>>>>
+std::vector<std::optional<T>> tuple_to_vector_optional(Tuple&& tuple) {
+    return std::apply(
+        [](auto&&... elems) { return std::vector<std::optional<T>>{std::forward<decltype(elems)>(elems)...}; },
+        std::forward<Tuple>(tuple));
+}
+
+ttnn::Tensor perform_transpose(
+    const ttnn::Tensor& input_tensor, const bool is_dim_last_idx, const int8_t dim1 = -1, const int8_t dim2 = -1);
+
+ttnn::Tensor transform_to_4d_tensor(const ttnn::Tensor& input_tensor, const bool is_rank_le_4d);
+
+}  // namespace reduction_common


### PR DESCRIPTION
### Ticket
Add ttnn.sort basic implementation - [#19891](https://github.com/tenstorrent/tt-metal/issues/19891)

### Problem description
Single core implementation on `ttnny.experimental.sort` with the use of ` ckernel::topk_local_sort` LLK.

### What's changed
- Added tensor sorting on single core,
- Updated tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes