### PR TITLE
tt_transformers/tt/mlp: Fix bug for layer=-1

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -409,8 +409,8 @@ def prepare_generator_args(
 @pytest.mark.parametrize(
     "optimizations",
     [
-        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
-        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
     ],
     ids=["performance", "accuracy"],
 )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -448,7 +448,7 @@ def test_demo_text(
     Simple demo with limited dependence on reference code.
     """
     test_id = request.node.callspec.id
-    if is_ci_env and (test_id == "accuracy" or not ci_only):
+    if is_ci_env and (("accuracy" in test_id) or not ci_only):
         pytest.skip("CI only runs the CI-only tests")
 
     # TODO: Remove this once all batch sizes are supported on TG

--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -81,8 +81,8 @@ def get_accuracy_thresholds(model_args, optimizations):
 @pytest.mark.parametrize(
     "optimizations",
     [
-        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
-        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
     ],
     ids=["performance", "accuracy"],
 )

--- a/models/tt_transformers/tests/test_chunked_generation.py
+++ b/models/tt_transformers/tests/test_chunked_generation.py
@@ -12,7 +12,7 @@ from models.tt_transformers.tt.common import (
     num_blocks_in_seq,
 )
 from models.tt_transformers.tt.model import Transformer
-from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.model_config import ModelArgs, DecodersPrecision
 from models.tt_transformers.tt.generator import Generator
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.model import Transformer as ReferenceTransformer
 from models.utility_functions import (
@@ -73,10 +73,10 @@ def test_chunked_prefill_single_user(
 
     # This sets the minimum PCC for each iteration based on optimization mode
     test_id = request.node.callspec.id
-    if test_id == "accuracy":
+    if "accuracy" in test_id:
         pcc = 0.91  # TODO Look on improving PCC
     else:  # performance mode
-        assert test_id == "performance"
+        assert "performance" in test_id
         pcc = 0.869  # TODO Look on improving PCC
 
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, optimizations=optimizations, max_seq_len=seq_len)

--- a/models/tt_transformers/tests/test_chunked_generation.py
+++ b/models/tt_transformers/tests/test_chunked_generation.py
@@ -50,7 +50,9 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "optimizations",
     [
-        pytest.param(lambda model_args: DecodersPrecision.accuracy(model_args.n_layers), id="accuracy"),
+        pytest.param(
+            lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name), id="accuracy"
+        ),
     ],
 )
 def test_chunked_prefill_single_user(

--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -57,8 +57,8 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "optimizations",
     [
-        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
-        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
     ],
     ids=["performance", "accuracy"],
 )

--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -90,7 +90,7 @@ def test_model_inference(
     dtype = ttnn.bfloat8_b
     mesh_device.enable_async(True)
     test_id = request.node.callspec.id
-    mode_accuracy = test_id == "accuracy"
+    mode_accuracy = "accuracy" in test_id
     instruct = False  # True if weights == "instruct" else False
     dummy_weights = True if weights == "random" else False
     model_args = ModelArgs(

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -12,7 +12,7 @@ from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
 )
 from models.tt_transformers.tt.model import Transformer
-from models.tt_transformers.tt.model_config import ModelArgs
+from models.tt_transformers.tt.model_config import ModelArgs, DecodersPrecision
 from models.utility_functions import (
     comp_pcc,
     comp_allclose,
@@ -74,7 +74,7 @@ def test_model_inference(
     request,
 ):
     test_id = request.node.callspec.id
-    if is_ci_env and test_id == "accuracy":
+    if is_ci_env and "accuracy" in test_id:
         pytest.skip("CI test only runs performance mode to reduce CI pipeline load")
 
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
@@ -84,10 +84,10 @@ def test_model_inference(
     batch_size = 1  # For prefill we only support batch_size = 1
 
     # This sets the minimum PCC for each iteration based on optimization mode
-    if test_id == "accuracy":
+    if "accuracy" in test_id:
         pcc = 0.91  # TODO Look on improving PCC
     else:  # performance mode
-        assert test_id == "performance"
+        assert "performance" in test_id
         pcc = 0.869  # TODO Look on improving PCC
 
     mesh_device.enable_async(True)

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -56,8 +56,8 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "optimizations",
     [
-        lambda model_args: DecodersPrecision.performance(model_args.n_layers),
-        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers),
+        lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
+        lambda model_args: DecodersPrecision.accuracy(model_args.n_layers, model_args.model_name),
     ],
     ids=["performance", "accuracy"],
 )

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -78,7 +78,7 @@ def initialize_vllm_text_transformer(
                 "Instruct" in hf_config._name_or_path or "DeepSeek-R1-Distill-Llama-70B" in hf_config._name_or_path
             ),
             max_batch_size=max_batch_size // tt_data_parallel,
-            optimizations=lambda model_args: optimizations(model_args.n_layers),
+            optimizations=lambda model_args: optimizations(model_args.n_layers, model_args.model_name),
             max_seq_len=max_seq_len,
         )
 

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -55,6 +55,8 @@ class MLP(LightweightModule):
         w1_dims = (-1, -2) if args.is_galaxy else (-2, -1)
         w2_dims = (-2, -1) if args.is_galaxy else (-1, -2)
 
+        layer_num = max(layer_num, 0)  # cross_block uses the configutation of the first decoder
+
         ff1_3_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
             decoder_id=layer_num, tensor=TensorGroup.FF1_FF3
         )
@@ -77,11 +79,12 @@ class MLP(LightweightModule):
         """
         seq_len = x.shape[-2]
         TG = self.args.is_galaxy
+        layer_num = max(self.layer_num, 0)  # cross_block uses the configutation of the first decoder
         activation_dtype = self.model_config["DECODERS_OPTIMIZATIONS"].get_tensor_dtype(
-            decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION
+            decoder_id=layer_num, tensor=TensorGroup.ACTIVATION
         )
         li_ff1_3_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
-            decoder_id=self.layer_num, op=OpGroup.LI_FF1_FF3, configuration=self.args
+            decoder_id=layer_num, op=OpGroup.LI_FF1_FF3, configuration=self.args
         )
 
         if mode == "decode":  # Sharded config
@@ -199,7 +202,7 @@ class MLP(LightweightModule):
                 w2_in = ttnn.to_memory_config(w2_in, ttnn.L1_MEMORY_CONFIG)
 
         li_ff2_compute_kernel_cfg = self.model_config["DECODERS_OPTIMIZATIONS"].get_math_fidelity(
-            decoder_id=self.layer_num, op=OpGroup.LI_FF2, configuration=self.args
+            decoder_id=layer_num, op=OpGroup.LI_FF2, configuration=self.args
         )
         w2_out = ttnn.linear(
             w2_in,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2085,13 +2085,13 @@ class HfModelWrapper:
 class DecodersPrecision:
     @classmethod
     def accuracy(cls, num_decoders, model_name):
-        inst = cls(num_decoders, ModelOptimizations.accuracy(model_name))
+        inst = cls(num_decoders, model_name, ModelOptimizations.accuracy(model_name))
         inst.__name__ = "accuracy"
         return inst
 
     @classmethod
     def performance(cls, num_decoders, model_name):
-        inst = cls(num_decoders, ModelOptimizations.performance(model_name))
+        inst = cls(num_decoders, model_name, ModelOptimizations.performance(model_name))
         inst.__name__ = "performance"
         return inst
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -75,7 +75,7 @@ class MathFidelitySetting(Enum):
 
 class ModelOptimizations:
     @classmethod
-    def accuracy(cls, model_name=None):
+    def accuracy(cls, model_name):
         """Configuration optimized for accuracy
         Only 70B models uses bfp4 MLPs in this configuration
         """
@@ -87,7 +87,7 @@ class ModelOptimizations:
         return inst
 
     @classmethod
-    def performance(cls, model_name=None):
+    def performance(cls, model_name):
         """Configuration optimized for performance
         All models use bfp4 in FF1 and FF3 MLPs in this configuration
         """
@@ -238,7 +238,7 @@ def parse_optimizations(string):
     model_opt = ModelOptimizations(settings)
 
     def apply_settings(model_args):
-        return DecodersPrecision(model_args.n_layers, model_opt)
+        return DecodersPrecision(model_args.n_layers, model_arg.model_name, model_opt)
 
     apply_settings.__name__ = model_opt.__name__
     return apply_settings
@@ -263,7 +263,7 @@ def parse_decoder_json(json_file_path):
             raise ValueError("Invalid JSON format: Missing 'decoders' key")
 
         num_decoders = max(int(decoder_id) for decoder_id in config_data["decoders"].keys()) + 1
-        decoders_precision = DecodersPrecision(num_decoders)
+        decoders_precision = DecodersPrecision(num_decoders, "model")
 
         for decoder_id, settings in config_data["decoders"].items():
             decoder_id = int(decoder_id)
@@ -559,7 +559,7 @@ class ModelArgs:
 
             # Configure data precision and math fidelity for tensors and kernels
             if self.optimizations is None:
-                self.optimizations = DecodersPrecision(num_decoders=self.n_layers)
+                self.optimizations = DecodersPrecision.accuracy(num_decoders=self.n_layers, model_name=self.model_name)
             self.model_config["DECODERS_OPTIMIZATIONS"] = self.optimizations
 
             # Create memory config for sharded tensors
@@ -2084,18 +2084,20 @@ class HfModelWrapper:
 
 class DecodersPrecision:
     @classmethod
-    def accuracy(cls, num_decoders):
-        inst = cls(num_decoders, ModelOptimizations.accuracy())
+    def accuracy(cls, num_decoders, model_name):
+        inst = cls(num_decoders, ModelOptimizations.accuracy(model_name))
         inst.__name__ = "accuracy"
         return inst
 
     @classmethod
-    def performance(cls, num_decoders):
-        inst = cls(num_decoders, ModelOptimizations.performance())
+    def performance(cls, num_decoders, model_name):
+        inst = cls(num_decoders, ModelOptimizations.performance(model_name))
         inst.__name__ = "performance"
         return inst
 
-    def __init__(self, num_decoders, decoder_conf: dict = ModelOptimizations.accuracy()):
+    def __init__(self, num_decoders, model_name, decoder_conf: dict = None):
+        if decoder_conf is None:
+            decoder_conf = ModelOptimizations.accuracy(model_name)
         self.decoder_optimizations = {decoder_id: decoder_conf for decoder_id in range(num_decoders)}
         self._update_full_name()
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20515

### Problem description
The PR https://github.com/tenstorrent/tt-metal/pull/19431 that allows using different configuration for each decoder, created a bug since it did not take into account that there are instances of layer=-1.

### What's changed
This PR solves the issue by setting the configuration of layer=-1 to that of layer=0 (I guess we can also allow to specify a different configuration for layer=-1 if needed).