### PR TITLE
[skip ci] Run build + smoke of MergeGate on main

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -54,7 +54,8 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/find-changed-files@main
 
   build:
-    if: ${{ needs.find-changes.outputs.cmake-changed == 'true' ||
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
             needs.find-changes.outputs.any-code-changed == 'true' ||
             needs.find-changes.outputs.docs-changed == 'true'
         }}
@@ -80,7 +81,8 @@ jobs:
       wheel-artifact-name: ${{ needs.build.outputs.wheel-artifact-name }}
 
   build-tsan:
-    if: ${{ needs.find-changes.outputs.cmake-changed == 'true' ||
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
             needs.find-changes.outputs.any-code-changed == 'true' ||
             needs.find-changes.outputs.docs-changed == 'true'
         }}
@@ -95,11 +97,11 @@ jobs:
 
   smoke-tests:
     needs: [find-changes, build-tsan]
-    if: ${{
-        needs.find-changes.outputs.cmake-changed == 'true' ||
-        needs.find-changes.outputs.tt-metalium-changed == 'true' ||
-        needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
-      }}
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+            needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+        }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We're skipping the build when on main (b/c no delta from 'main').  But we need to build on main to populate ccache.
While we're there, we may as well also run the Smoke which is lightweight and provides good evidence that Main remains clean and so any failure is purely from the branch.

### What's changed
Adjusted conditionals to run builds + smoke when triggered on main.