### PR TITLE
Bug Fix for Max Pool with KernelHW % 16 = 0

### DIFF
--- a/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py
@@ -57,6 +57,8 @@ parameters = {
             [1, 832, 14, 14, 2, 2, 2, 2, 0, 0, 1, 1, True],
             [1, 832, 7, 7, 3, 3, 1, 1, 1, 1, 1, 1, True],
             [1, 96, 112, 112, 3, 3, 2, 2, 1, 1, 1, 1, False],
+            [1, 256, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel
+            [1, 512, 20, 20, 8, 8, 6, 6, 0, 0, 1, 1, False],  # max rows per reduction multiple large kernel wide
         ],
     },
     "test_run_max_pool": {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
@@ -130,8 +130,8 @@ void MAIN {
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, interm_cb_id, num_faces_in_input_tile, max_rows_for_reduction);
 
-    uint32_t remaining_elems = window_size_hw % max_rows_for_reduction;
-    uint32_t interm_reduction_chunks =
+    constexpr uint32_t remaining_elems = window_size_hw % max_rows_for_reduction;
+    constexpr uint32_t interm_reduction_chunks =
         remaining_elems ? window_size_hw / max_rows_for_reduction + 1 : window_size_hw / max_rows_for_reduction;
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; ++i) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core_large_kernel.cpp
@@ -130,7 +130,9 @@ void MAIN {
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, interm_cb_id, num_faces_in_input_tile, max_rows_for_reduction);
 
-    uint32_t interm_reduction_chunks = window_size_hw / max_rows_for_reduction;
+    uint32_t remaining_elems = window_size_hw % max_rows_for_reduction;
+    uint32_t interm_reduction_chunks =
+        remaining_elems ? window_size_hw / max_rows_for_reduction + 1 : window_size_hw / max_rows_for_reduction;
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; ++i) {
         for (uint32_t b_i = 0; b_i < in_nblocks_c - 1; b_i++) {
@@ -141,7 +143,7 @@ void MAIN {
             // For 5x5 kernel as an example, reduction over first 16 sticks AND next 9 sticks. It runs
             // twice, and both results are written to interm_cb_id. interm_cb_id will be the input to the
             // next level of reduction.
-            for (uint32_t h = 0; h <= interm_reduction_chunks; h++) {
+            for (uint32_t h = 0; h < interm_reduction_chunks; h++) {
                 reduce_h_fused_interm<
                     max_tiles_per_iter,
                     is_partial_tile,
@@ -162,7 +164,8 @@ void MAIN {
         pack_untilize_uninit(interm_cb_id);
         pack_untilize_dst_init_short<max_tiles_per_iter>(interm_cb_id, num_out_rows, num_faces_in_output_tile);
         cb_reserve_back(interm_cb_id, 1);
-        for (uint32_t h = 0; h <= interm_reduction_chunks; h++) {
+        for (uint32_t h = 0; h < interm_reduction_chunks; h++) {
+            // DPRINT << "interm h: " << h << ENDL();
             reduce_h_fused_interm<
                 max_tiles_per_iter,
                 is_partial_tile,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20324

### Problem description
Max pool would hang if the number of elements in the kernel was greater than 16 and a multiple of 16 (max rows per reduction)

### What's changed
The count for the intermediate reductions in the large compute kernel has been adjusted to properly handle the case where the kernel size is an even multiple of the max rows per reduction.  Additionally test coveraged has been added for this case.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14388371164
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14388373231
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14388378446
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14388375557
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
(wormhole) https://github.com/tenstorrent/tt-metal/actions/runs/14388386653
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/14388383089
- [x] New/Existing tests provide coverage for changes