### PR TITLE
#20006: Fix DeviceFixture.TensixIncrementStreamRegWrite with watcher

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -299,7 +299,7 @@ TEST_F(DeviceFixture, TensixIncrementStreamRegWrite) {
                      bottom_right.x,
                      top_left.y,
                      bottom_right.y,
-                     all_cores.size()});
+                     all_cores.size() - 1});
             }
         }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/streams/stream_increment_reg_write.cpp
@@ -42,4 +42,7 @@ void kernel_main() {
     }
 
     noc_async_writes_flushed();
+    if (target_core_value) {
+        noc_async_write_barrier();
+    }
 }


### PR DESCRIPTION
### Ticket
#20006 

### Problem description
We're hitting a watcher assert in DeviceFixture.TensixIncrementStreamRegWrite

### What's changed
We're using non-loopback multicast writing to the entire core grid, so we need to subtract 1 from num_dests. Also add a noc_async_write_barrier at the end of kernel_main to ensure the noc_semaphore_set_multicast acks are waited for, though in practice they'll all return before the stream register writes are received.


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes