### PR TITLE
Fast pure SFPU implementation of binary GCD algorithm for int32.

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <int ITERATIONS = 8>
+inline void calculate_sfpu_gcd(const uint dst_offset)
+{
+    // Binary GCD algorithm.
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // c = a
+        TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG2, 0); // c |= b
+
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG3, 0); // d = c
+        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // d = -d
+        TTI_SFPAND(0, p_sfpu::LREG2, p_sfpu::LREG3, 0); // d &= c (isolate LSB)
+        TTI_SFPLZ(0, p_sfpu::LREG3, p_sfpu::LREG3, 0); // d = clz(d)
+
+        // Ensure that b is odd: if LSB is zero, then swap with a.
+        TTI_SFPSHFT2(p_sfpu::LREG1, p_sfpu::LREG3, p_sfpu::LREG2, SFPSHFT2_MOD1_SHFT_LREG); // c = b << d
+        TTI_SFPSETCC(0, p_sfpu::LREG2, 0, 6); // if c == 0 then b is even
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 0); // swap(a, b)
+        TTI_SFPENCC(0, 0, 0, 0);
+        TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG0, 0); // a = abs(a)
+        TTI_SFPABS(0, p_sfpu::LREG1, p_sfpu::LREG1, 0); // b = abs(b)
+
+        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // a = -a
+        TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // d = -d
+
+        if (d == 0) {
+            // Store and execute 4 iterations of binary GCD.
+            TTI_REPLAY(0, 7 * 4, 1, 1);
+
+            #pragma GCC unroll 4
+            for (int i = 0; i < 4; ++i) {
+                // We store {-a, a} in {LREG0, LREG2}, which is convenient for isolating the LSB of a.
+                TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // LREG2 = +a
+                TTI_SFPAND(0, p_sfpu::LREG2, p_sfpu::LREG0, 0); // LREG0 &= a (isolate LSB and overwrite -a)
+                TTI_SFPLZ(0, p_sfpu::LREG0, p_sfpu::LREG0, SFPLZ_MOD1_CC_NE0); // LREG0 = clz(LREG0), disable lanes where a == 0
+                TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE); // LREG0 += d
+                TTI_SFPSHFT2(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG0, SFPSHFT2_MOD1_SHFT_LREG); // LREG0 = a >> -LREG0, making a definitely odd (now both a and b are odd)
+                TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, SFPSWAP_MOD1_VEC_MIN_MAX); // ensure b < a
+                TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // a = b - a (now a is even)
+            }
+        } else {
+            TTI_REPLAY(0, 7 * 4, 0, 0);
+        }
+
+        // Replay 6 times, making a total of 28 iterations so far.
+        #pragma GCC unroll 6
+        for (int i = 0; i < 6; ++i) {
+            TTI_REPLAY(0, 7 * 4, 0, 0);
+        }
+
+        // Replay 2 more iterations, making a total of 30 iterations.
+        // The worst case for 31-bit inputs is 31 iterations, but we can skip the final iteration as it only affects a.
+        // In addition, we can skip the final operation of the 30th iteration as it only affects a.
+        TTI_REPLAY(0, 7 * 2 - 1, 0, 0);
+
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // dst_reg[0] = b;
+        TTI_SFPSTORE(p_sfpu::LREG1, 4, 3, 0);
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_gcd.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gcd_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gcd(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/gcd.h
+++ b/tt_metal/include/compute_kernel_api/gcd.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_gcd.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise GCD operation on two inputs: y = gcd(x0, x1).
+ * Both inputs must be int32.
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+ // clang-format on
+ALWI void gcd_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_gcd<APPROX>(idst0, idst1)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void gcd_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gcd_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -19,7 +19,7 @@ namespace detail {
 constexpr bool is_associative(BinaryOpType op) {
     return op == BinaryOpType::ADD || op == BinaryOpType::MUL || op == BinaryOpType::EQ || op == BinaryOpType::NE ||
            op == BinaryOpType::LOGICAL_AND || op == BinaryOpType::LOGICAL_OR || op == BinaryOpType::LOGADDEXP ||
-           op == BinaryOpType::LOGADDEXP2 || op == BinaryOpType::LOGICAL_XOR;
+           op == BinaryOpType::LOGADDEXP2 || op == BinaryOpType::LOGICAL_XOR || op == BinaryOpType::GCD;
 }
 
 // Tensor - Scalar
@@ -455,6 +455,7 @@ template struct BinaryOperation<BinaryOpType::SQUARED_DIFFERENCE>;
 template struct BinaryOperation<BinaryOpType::DIV_FAST>;
 template struct BinaryOperation<BinaryOpType::BIAS_GELU>;
 template struct BinaryOperation<BinaryOpType::RSUB>;
+template struct BinaryOperation<BinaryOpType::GCD>;
 
 template struct RelationalBinary<BinaryOpType::EQ>;
 template struct RelationalBinary<BinaryOpType::NE>;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -205,9 +205,11 @@ struct ExecuteLCM {
 
 struct ExecuteGCD {
     static Tensor invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        QueueId queue_id,
+        const Tensor& input_tensor_a_arg,
+        const Tensor& input_tensor_b_arg,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
 struct ExecuteMaximum {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -31,6 +31,10 @@ enum class BinaryOpType {
     BITWISE_AND,
     BITWISE_OR,
     LEFT_SHIFT,
-    RIGHT_SHIFT
+    RIGHT_SHIFT,
+    QUANT,
+    REQUANT,
+    DEQUANT,
+    GCD
 };
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -235,6 +235,10 @@ std::map<std::string, std::string> get_defines_fp32(
             new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});
             op_name = "binary_right_shift_tile";
             break;
+        case BinaryOpType::GCD:
+            new_defines.insert({"BINOP_INIT", fmt::format("gcd_tile_init();")});
+            op_name = "gcd_tile";
+            break;
         case BinaryOpType::LOGADDEXP:
             // PRE_IN0_0 ===> Applies prescaling for first input
             // PRE_IN1_0 ====> Applies prescaling for second input

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -537,27 +537,13 @@ Tensor _polyval(
 }
 
 Tensor ExecuteGCD::invoke(
-    const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor input_a_abs = ttnn::abs(input_a);
-    Tensor input_b_abs = ttnn::abs(input_b);
-    Tensor a_gt_b = ttnn::gt(input_a_abs, input_b_abs);
-    Tensor min = ttnn::where(a_gt_b, input_b_abs, input_a_abs);
-    Tensor max = ttnn::where(a_gt_b, input_a_abs, input_b_abs);
-    a_gt_b.deallocate();
-    // https://en.wikipedia.org/wiki/Lam%C3%A9%27s_theorem
-    // While 186 is the theoretical maximum iterations for numbers within the floating point range according to Lame's
-    // theorem, in practice when evaluating gcd of consecutive Fibonacci numbers coerced to floating point, the
-    // maximum number of iterations reached is only 14 because the remainder converges to 0 much more quickly. In
-    // addition, limited precision in bfloat16 format decreases support for input to the range [-1024, 1024]
-    constexpr std::size_t max_iterations = 14;
-    for (std::size_t iteration = 0; iteration < max_iterations; ++iteration) {
-        Tensor isz = ttnn::eqz(min);
-        //  0's in min are replaced with 1
-        Tensor rem = ttnn::remainder(max, ttnn::where(isz, isz, min));
-        max = ttnn::where(isz, max, min);
-        min = rem;
-    }
-    return max;
+    QueueId queue_id,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor) {
+    return BinaryOperationSfpu<operations::binary::BinaryOpType::GCD>::invoke(
+        queue_id, input_tensor_a, input_tensor_b, std::nullopt, memory_config, optional_output_tensor);
 }
 
 Tensor ExecuteLCM::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -39,6 +39,7 @@ namespace utils {
         case BinaryOpType::LTE:
         case BinaryOpType::EQ:
         case BinaryOpType::NE: return (a == DataType::FLOAT32 && b == DataType::FLOAT32);
+        case BinaryOpType::GCD:
         case BinaryOpType::LEFT_SHIFT:
         case BinaryOpType::RIGHT_SHIFT:
         case BinaryOpType::BITWISE_XOR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -14,6 +14,7 @@
 #include "compute_kernel_api/binary_shift.h"
 #include "compute_kernel_api/add_int32_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
+#include "compute_kernel_api/gcd.h"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -32,6 +32,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LTE:
         case EQ:
         case NE: return (a == FLOAT32 && b == FLOAT32);
+        case GCD:
         case LEFT_SHIFT:
         case RIGHT_SHIFT:
         case BITWISE_XOR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -265,6 +265,13 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>) : b
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::GCD:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::GCD;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         default: TT_THROW("Unsupported binary op {}", binary_op_type);
     }
 }
@@ -283,6 +290,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case DIV: return {"div_binary_tile_init();", "div_binary_tile"};
         case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
         case RSUB: return {"rsub_binary_tile_init();", "rsub_binary_tile"};
+        case GCD: return {"gcd_tile_init();", "gcd_tile"};
         case LEFT_SHIFT: return {"binary_shift_tile_init();", "binary_left_shift_tile"};
         case RIGHT_SHIFT: return {"binary_shift_tile_init();", "binary_right_shift_tile"};
         case BITWISE_AND: return {"binary_bitwise_tile_init();", "and_binary_tile"};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -50,6 +50,7 @@ struct OpConfig {
         DIV,
         POWER,
         RSUB,
+        GCD,
         LEFT_SHIFT,
         RIGHT_SHIFT,
         BITWISE_AND,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -12,6 +12,7 @@
 #include "compute_kernel_api/binary_shift.h"
 #include "compute_kernel_api/add_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
+#include "compute_kernel_api/gcd.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -12,6 +12,7 @@
 #include "compute_kernel_api/binary_shift.h"
 #include "compute_kernel_api/add_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
+#include "compute_kernel_api/gcd.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/types.hpp
@@ -34,6 +34,7 @@ enum class BinaryOpType {
     RIGHT_SHIFT,
     QUANT,
     REQUANT,
-    DEQUANT
+    DEQUANT,
+    GCD
 };
 }


### PR DESCRIPTION
This is considerably faster compared to the old/limited floating point implementation.

Fixes #17771.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes