### PR TITLE
[skip ci] Fix build matrix

### DIFF
--- a/.github/workflows/build-wrapper.yaml
+++ b/.github/workflows/build-wrapper.yaml
@@ -30,9 +30,6 @@ jobs:
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
             build-type: "Release"
           - version: "22.04"
-            toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-            build-type: "Release"
-          - version: "22.04"
             toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
             build-type: "Release"
           - version: "24.04"
@@ -40,9 +37,6 @@ jobs:
             build-type: "Release"
           - version: "24.04"
             toolchain: "cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake"
-            build-type: "Release"
-          - version: "24.04"
-            toolchain: "cmake/x86_64-linux-gcc-12-toolchain.cmake"
             build-type: "Release"
     with:
       version: ${{ matrix.config.version }}


### PR DESCRIPTION
### Ticket
N/A

### Problem description
[This workflow](https://github.com/tenstorrent/tt-metal/actions/runs/14391373619) is red.
One job is duplicated (and fails due to an artifact conflict).
One job is trying to use gcc-12 on Ubuntu 24.04.

### What's changed
Delete both of those failing permutations.

### Checklist
- [x] Build Wrapper [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14392187221)