### PR TITLE
Add support for using sfpi from a system path

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -125,7 +125,8 @@ function(get_alias INPUT_STRING OUTPUT_VAR)
 endfunction()
 
 # Define the compiler command
-set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++)
+set(GPP_CMD /opt/tenstorrent/sfpi/compiler/bin/riscv32-unknown-elf-g++)
+#set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++)
 
 set(GPP_DEFINES -DTENSIX_FIRMWARE)
 

--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -125,8 +125,10 @@ function(get_alias INPUT_STRING OUTPUT_VAR)
 endfunction()
 
 # Define the compiler command
-set(GPP_CMD /opt/tenstorrent/sfpi/compiler/bin/riscv32-unknown-elf-g++)
-#set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++)
+set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++)
+
+# May switch to this someday
+# set(GPP_CMD /opt/tenstorrent/sfpi/compiler/bin/riscv32-unknown-elf-g++)
 
 set(GPP_DEFINES -DTENSIX_FIRMWARE)
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -131,6 +131,8 @@ void JitBuildEnv::init(
     const static bool use_ccache = std::getenv("TT_METAL_CCACHE_KERNEL_SUPPORT") != nullptr;
     if (use_ccache) {
         this->gpp_ = "ccache ";
+    } else {
+        this->gpp_ = "";
     }
 
     // Use local sfpi for development

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -150,6 +150,7 @@ void JitBuildEnv::init(
             log_debug(tt::LogBuildKernels, "Using {} sfpi at {}", i ? "system" : "local", sfpi_roots[i]);
             sfpi_found = true;
             break;
+        }
     }
     if (!sfpi_found) {
         TT_THROW("sfpi not found at {} or {}", sfpi_roots[0], sfpi_roots[1]);

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -137,11 +137,13 @@ void JitBuildEnv::init(
     std::string local_gpp_path = this->root_ + "runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++";
     std::string system_gpp_path = "/opt/tenstorrent/sfpi/compiler/bin/riscv32-unknown-elf-g++";
     if (std::filesystem::exists(local_gpp_path)) {
-        log_info(tt::LogBuildKernels, "Using local RISC-V g++ at {}", local_gpp_path);
         this->gpp_ += local_gpp_path + " ";
+        this->gpp_include_dir_ = this->root_ + "runtime/sfpi/include";
+        log_info(tt::LogBuildKernels, "Using local RISC-V g++ at {}", this->gpp_);
     } else if (std::filesystem::exists(system_gpp_path)) {
-        log_info(tt::LogBuildKernels, "Using system RISC-V g++ at {}", system_gpp_path);
         this->gpp_ += system_gpp_path + " ";
+        this->gpp_include_dir_ = "/opt/tenstorrent/sfpi/include";
+        log_info(tt::LogBuildKernels, "Using system RISC-V g++ at {}", this->gpp_);
     } else {
         TT_THROW("RISC-V g++ not found in {} or {}", local_gpp_path, system_gpp_path);
     }
@@ -435,7 +437,7 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
         "-I" + env_.root_ + "tt_metal/hw/ckernels/" + env.arch_name_ + "/metal/llk_io " +
         "-I" + env_.root_ + "tt_metal/hw/ckernels/" + env.arch_name_ + "/metal/llk_api " +
         "-I" + env_.root_ + "tt_metal/hw/ckernels/" + env.arch_name_ + "/metal/llk_api/llk_sfpu " +
-        "-I" + env_.root_ + "runtime/sfpi/include " +
+        "-I" + env_.gpp_include_dir_ + " " +
         "-I" + env_.root_ + "tt_metal/hw/firmware/src " +
         "-I" + env_.root_ + "tt_metal/third_party/tt_llk/tt_llk_" + env.arch_name_ + "/llk_lib ";
     // clang-format on

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -134,7 +134,17 @@ void JitBuildEnv::init(
     }
 
     // Tools
-    this->gpp_ += this->root_ + "runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++ ";
+    std::string local_gpp_path = this->root_ + "runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++";
+    std::string system_gpp_path = "/opt/tenstorrent/sfpi/compiler/bin/riscv32-unknown-elf-g++";
+    if (std::filesystem::exists(local_gpp_path)) {
+        log_info(tt::LogBuildKernels, "Using local RISC-V g++ at {}", local_gpp_path);
+        this->gpp_ += local_gpp_path + " ";
+    } else if (std::filesystem::exists(system_gpp_path)) {
+        log_info(tt::LogBuildKernels, "Using system RISC-V g++ at {}", system_gpp_path);
+        this->gpp_ += system_gpp_path + " ";
+    } else {
+        TT_THROW("RISC-V g++ not found in {} or {}", local_gpp_path, system_gpp_path);
+    }
 
     // Flags
     string common_flags;

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -79,7 +79,8 @@ private:
     string out_kernel_root_;
 
     // Tools
-    string gpp_;
+    string gpp_ = "";
+    string gpp_include_dir_ = "";
 
     // Compilation options
     string cflags_;


### PR DESCRIPTION
### Problem description
The current scheme of using TT_METAL_HOME to find the sfpi compiler causes some difficulty in shipping a package.
Today, we have to bundle the sfpi compiler along with ttnn wheel.
The wheel then becomes too large to distribute on pypi, as it becomes ~180MB.
The wheel has some "tricks" to automatically set TT_METAL_HOME and symlink to site-packages.
All this gets easier if we have an installer for sfpi, to install it to a known system path.

### What's changed
If the sfpi compiler does not exist in `$TT_METAL_HOME/runtime/` fallback to `/opt/tenstorrent/`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14393337744) CI passes
- [x] [All post commit after refactor](https://github.com/tenstorrent/tt-metal/actions/runs/14413097598) CI passes
- [x] New/Existing tests provide coverage for changes