### PR TITLE
Depend on tt-smi only for inter-test reset

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -666,24 +666,20 @@ def pytest_handlecrashitem(crashitem, report, sched):
 
 
 def reset_tensix(tt_open_devices=None):
-    import ttnn
 
-    arch = ttnn.get_arch_name()
-    if arch != "grayskull" and arch != "wormhole_b0":
-        raise Exception(f"Unrecognized arch for tensix-reset: {arch}")
-
+    # Check if tt-smi exists
+    if not shutil.which("tt-smi"):
+        logger.error("tt-smi command not found. Cannot reset devices. Please install tt-smi.")
+        return
+        
     if tt_open_devices is None:
-        logger.info(f"Running reset with reset script: /opt/tt_metal_infra/scripts/ci/{arch}/reset.sh")
-        smi_reset_result = run_process_and_get_result(f"/opt/tt_metal_infra/scripts/ci/{arch}/reset.sh")
+        logger.info(f"Running reset for all pci devices")
+        smi_reset_result = run_process_and_get_result(f"tt-smi -r")
     else:
         tt_open_devices_str = ",".join([str(i) for i in tt_open_devices])
-        check_smi_metal = run_process_and_get_result("tt-smi-metal -h")
         logger.info(f"Running reset for pci devices: {tt_open_devices_str}")
-        if check_smi_metal.returncode > 0:
-            logger.info(f"Test failed - resetting {arch} with tt-smi")
-            smi_reset_result = run_process_and_get_result(f"tt-smi -r {tt_open_devices_str}")
-        else:
-            smi_reset_result = run_process_and_get_result(f"tt-smi-metal -r {tt_open_devices_str}")
+        smi_reset_result = run_process_and_get_result(f"tt-smi -r {tt_open_devices_str}")
+
     logger.info(f"tt-smi reset status: {smi_reset_result.returncode}")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -672,7 +672,7 @@ def reset_tensix(tt_open_devices=None):
     if not shutil.which("tt-smi"):
         logger.error("tt-smi command not found. Cannot reset devices. Please install tt-smi.")
         return
-        
+
     if tt_open_devices is None:
         logger.info(f"Running reset for all pci devices")
         smi_reset_result = run_process_and_get_result(f"tt-smi -r")

--- a/conftest.py
+++ b/conftest.py
@@ -666,6 +666,7 @@ def pytest_handlecrashitem(crashitem, report, sched):
 
 
 def reset_tensix(tt_open_devices=None):
+    import shutil
 
     # Check if tt-smi exists
     if not shutil.which("tt-smi"):


### PR DESCRIPTION
### Ticket
Closes #20322 

### Problem description
Our tests are now dockerized, but the docker container is universal. It does not have a system specific reset script.

### What's changed
Just use tt-smi inside the container to reset the cards after a test failure.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14396197840) CI passes
- [ ] [Single Card Model Perf Tests](https://github.com/tenstorrent/tt-metal/actions/runs/14396076276) CI passes
- [ ] [T3K Demo Tests](https://github.com/tenstorrent/tt-metal/actions/runs/14396174932) CI passes
- [x] New/Existing tests provide coverage for changes