### PR TITLE
Remove decltype from fabric APIs

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_async_write_multicast_multidirectional_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_async_write_multicast_multidirectional_sender.cpp
@@ -12,7 +12,8 @@ using namespace tt::tt_fabric;
 
 void kernel_main() {
     constexpr uint32_t client_interface_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t data_mode = get_compile_time_arg_val(1);
+    constexpr tt::tt_fabric::ClientDataMode data_mode =
+        static_cast<tt::tt_fabric::ClientDataMode>(get_compile_time_arg_val(1));
     constexpr uint32_t test_mode = get_compile_time_arg_val(2);
 
     uint32_t rt_args_idx = 0;
@@ -38,14 +39,10 @@ void kernel_main() {
     volatile fabric_pull_client_interface_t* client_interface =
         (volatile fabric_pull_client_interface_t*)client_interface_addr;
     for (uint32_t i = 0; i < num_dirs; i++) {
-        fabric_endpoint_init<decltype(client_interface)>(client_interface + i, 0 /* unused */);
+        fabric_endpoint_init(client_interface + i, 0 /* unused */);
     }
 
-    fabric_async_write_multicast<
-        decltype(client_interface),
-        (ClientDataMode)data_mode,
-        AsyncWriteMode::ALL,
-        RoutingType::ROUTER_XY>(
+    fabric_async_write_multicast<data_mode, AsyncWriteMode::ALL, RoutingType::ROUTER_XY>(
         client_interface,
         e_router_noc_xy,
         src_addr,  // source address in sender’s memory
@@ -69,11 +66,7 @@ void kernel_main() {
         packet_header->packet_parameters.mcast_parameters.east = 0;
         packet_header->packet_parameters.mcast_parameters.west = w_depth;
 
-        fabric_async_write_multicast<
-            decltype(client_interface),
-            (ClientDataMode)data_mode,
-            AsyncWriteMode::ADD_AND_SEND_PR,
-            RoutingType::ROUTER_XY>(
+        fabric_async_write_multicast<data_mode, AsyncWriteMode::ADD_AND_SEND_PR, RoutingType::ROUTER_XY>(
             client_interface,
             w_router_noc_xy,
             src_addr,  // source address in sender’s memory
@@ -89,11 +82,7 @@ void kernel_main() {
         client_interface++;
         // For sideband header, we will use header slot in second client interface.
         // Use AsyncWriteMode::ALL, since the header slot needs to be initialized.
-        fabric_async_write_multicast<
-            decltype(client_interface),
-            (ClientDataMode)data_mode,
-            AsyncWriteMode::ALL,
-            RoutingType::ROUTER_XY>(
+        fabric_async_write_multicast<data_mode, AsyncWriteMode::ALL, RoutingType::ROUTER_XY>(
             client_interface,
             w_router_noc_xy,
             src_addr,  // source address in sender’s memory

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_async_write_multicast_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_async_write_multicast_sender.cpp
@@ -12,7 +12,8 @@ using namespace tt::tt_fabric;
 
 void kernel_main() {
     constexpr uint32_t client_interface_cb = get_compile_time_arg_val(0);
-    constexpr uint32_t data_mode = get_compile_time_arg_val(1);
+    constexpr tt::tt_fabric::ClientDataMode data_mode =
+        static_cast<tt::tt_fabric::ClientDataMode>(get_compile_time_arg_val(1));
     constexpr uint32_t test_mode = get_compile_time_arg_val(2);
     uint32_t rt_args_idx = 0;
     uint32_t src_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -32,13 +33,9 @@ void kernel_main() {
     volatile fabric_pull_client_interface_t* client_interface =
         (volatile fabric_pull_client_interface_t*)client_interface_addr;
 
-    fabric_endpoint_init<decltype(client_interface)>(client_interface, 0 /* unused */);
+    fabric_endpoint_init(client_interface, 0 /* unused */);
 
-    fabric_async_write_multicast<
-        decltype(client_interface),
-        (ClientDataMode)data_mode,
-        AsyncWriteMode::ALL,
-        RoutingType::ROUTER_XY>(
+    fabric_async_write_multicast<data_mode, AsyncWriteMode::ALL, RoutingType::ROUTER_XY>(
         client_interface,
         e_router_noc_xy,
         src_addr,  // source address in sender’s memory

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_async_write_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_async_write_sender.cpp
@@ -14,7 +14,8 @@ void kernel_main() {
     constexpr uint32_t client_interface_cb = get_compile_time_arg_val(0);
     constexpr uint32_t fabric_mode = get_compile_time_arg_val(1);
     constexpr uint32_t test_mode = get_compile_time_arg_val(2);
-    constexpr uint32_t data_mode = get_compile_time_arg_val(3);
+    constexpr tt::tt_fabric::ClientDataMode data_mode =
+        static_cast<tt::tt_fabric::ClientDataMode>(get_compile_time_arg_val(3));
 
     uint32_t rt_args_idx = 0;
     uint32_t src_addr = get_arg_val<uint32_t>(increment_arg_idx(rt_args_idx));
@@ -33,11 +34,7 @@ void kernel_main() {
         volatile fabric_pull_client_interface_t* client_interface =
             (volatile fabric_pull_client_interface_t*)client_interface_addr;
 
-        fabric_async_write<
-            decltype(client_interface),
-            (ClientDataMode)data_mode,
-            AsyncWriteMode::ALL,
-            RoutingType::ROUTER_XY>(
+        fabric_async_write<data_mode, AsyncWriteMode::ALL, RoutingType::ROUTER_XY>(
             client_interface,
             router_noc_xy,
             src_addr,  // source address in sender’s memory
@@ -51,12 +48,10 @@ void kernel_main() {
         volatile fabric_push_client_interface_t* client_interface =
             (volatile fabric_push_client_interface_t*)client_interface_addr;
 
-        fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(
-            client_interface, outbound_eth_chan);
+        fabric_endpoint_init<RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
         fabric_client_connect(client_interface, 0, dst_mesh_id, dst_device_id);
         fabric_async_write<
-            decltype(client_interface),
-            (ClientDataMode)data_mode,
+            data_mode,
             (AsyncWriteMode)(AsyncWriteMode::PUSH | AsyncWriteMode::ADD_HEADER),
             RoutingType::ROUTER_XY>(
             client_interface,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_atomic_inc_sender.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/kernels/fabric_atomic_inc_sender.cpp
@@ -35,7 +35,7 @@ void kernel_main() {
         volatile fabric_pull_client_interface_t* client_interface =
             (volatile fabric_pull_client_interface_t*)client_interface_addr;
 
-        fabric_atomic_inc<decltype(client_interface), ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL>(
+        fabric_atomic_inc<ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL>(
             client_interface,
             router_noc_xy,
             src_addr,  // source address in sender’s memory
@@ -50,11 +50,9 @@ void kernel_main() {
         volatile fabric_push_client_interface_t* client_interface =
             (volatile fabric_push_client_interface_t*)client_interface_addr;
 
-        fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(
-            client_interface, outbound_eth_chan);
+        fabric_endpoint_init<RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
         fabric_client_connect(client_interface, 0, dst_mesh_id, dst_device_id);
         fabric_atomic_inc<
-            decltype(client_interface),
             ClientDataMode::PACKETIZED_DATA,
             (AsyncWriteMode)(AsyncWriteMode::PUSH | AsyncWriteMode::ADD_HEADER)>(
             client_interface,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_controller.cpp
@@ -25,9 +25,9 @@ inline void send_packet(
     uint64_t dst_addr,
     uint32_t size) {
 #ifdef FVC_MODE_PULL
-    fabric_async_write<T, ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL, RoutingType::ROUTING_TABLE>(
+    fabric_async_write<ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL, RoutingType::ROUTING_TABLE>(
 #else
-    fabric_async_write<T, ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL>(
+    fabric_async_write<ClientDataMode::PACKETIZED_DATA, AsyncWriteMode::ALL>(
 #endif
         client_interface, routing_plane, src_addr, dst_mesh_id, dst_dev_id, dst_addr, size);
 
@@ -84,8 +84,7 @@ void kernel_main() {
             reinterpret_cast<volatile fabric_push_client_interface_t*>(client_interface_addr);
 #endif
 
-        fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(
-            client_interface, outbound_eth_chan);
+        fabric_endpoint_init<RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
 
 #ifndef FVC_MODE_PULL
         fabric_client_connect(client_interface, routing_plane, dest_mesh_id, dest_dev_id);
@@ -94,7 +93,7 @@ void kernel_main() {
         uint64_t dst_noc_addr = get_noc_addr_helper(remote_controller_noc_encoding, remote_notification_address);
 
         data_buf[0] = CONTROLLER_HANDSHAKE_START;
-        send_packet<decltype(client_interface)>(
+        send_packet(
             client_interface,
             routing_plane,
             pkt_hdr_address,
@@ -106,7 +105,7 @@ void kernel_main() {
         while (*poll_addr != CONTROLLER_HANDSHAKE_START);
 
         data_buf[0] = CONTROLLER_HANDSHAKE_END;
-        send_packet<decltype(client_interface)>(
+        send_packet(
             client_interface,
             routing_plane,
             pkt_hdr_address,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp
@@ -645,7 +645,7 @@ void kernel_main() {
 
     // initalize client
     tt_fabric_init();
-    fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
+    fabric_endpoint_init<RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
     routing_table = reinterpret_cast<tt_l1_ptr fabric_router_l1_config_t*>(client_interface->routing_tables_l1_offset);
 
 #ifndef FVC_MODE_PULL

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_tx_ubench.cpp
@@ -117,7 +117,7 @@ void kernel_main() {
         reinterpret_cast<tt_l1_ptr uint32_t*>(data_buffer_start_addr), data_buffer_size_words * PACKET_WORD_SIZE_BYTES);
 
     // initalize client
-    fabric_endpoint_init<decltype(client_interface), RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
+    fabric_endpoint_init<RoutingType::ROUTING_TABLE>(client_interface, outbound_eth_chan);
 
     uint64_t data_words_sent = 0;
     uint32_t packet_count = 0;
@@ -136,7 +136,7 @@ void kernel_main() {
             n_depth,
             s_depth);
     } else {
-        fabric_async_write_add_header<decltype(client_interface), (ClientDataMode)data_mode>(
+        fabric_async_write_add_header<(ClientDataMode)data_mode>(
             client_interface,
             data_buffer_start_addr,  // source address in sender’s memory
             dest_device >> 16,
@@ -193,7 +193,6 @@ void kernel_main() {
         client_interface->local_pull_request.pull_request.words_read = 0;
         if constexpr (mcast_data) {
             fabric_async_write_multicast<
-                decltype(client_interface),
                 (ClientDataMode)data_mode,
                 AsyncWriteMode::SEND_PR,
                 RoutingType::ROUTING_TABLE>(
@@ -209,11 +208,7 @@ void kernel_main() {
                 n_depth,
                 s_depth);
         } else {
-            fabric_async_write<
-                decltype(client_interface),
-                (ClientDataMode)data_mode,
-                AsyncWriteMode::SEND_PR,
-                RoutingType::ROUTING_TABLE>(
+            fabric_async_write<(ClientDataMode)data_mode, AsyncWriteMode::SEND_PR, RoutingType::ROUTING_TABLE>(
                 client_interface,
                 0,                       // the network plane to use for this transaction
                 data_buffer_start_addr,  // source address in sender’s memory
@@ -244,7 +239,7 @@ void kernel_main() {
     while (true) {
         packet_count++;
         payload[12] = packet_count;
-        fabric_async_write<decltype(client_interface), (ClientDataMode)data_mode, AsyncWriteMode::PUSH>(
+        fabric_async_write<(ClientDataMode)data_mode, AsyncWriteMode::PUSH>(
             client_interface,
             0,                       // the network plane to use for this transaction
             data_buffer_start_addr,  // source address in sender’s memory


### PR DESCRIPTION
### Ticket
#18726

### Problem description
`Decltype` makes it difficult to use the API. There are static asserts in the code already. Using decltype is superfluous.

### What's changed
Remove decltype

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14413600406
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14416107681
T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/14416396615
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14397838401
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14397840026