### PR TITLE
Pad op dimension support for less than 4D 

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -208,7 +208,6 @@ static ttnn::Tensor pad_impl(
                 remove_prefix(output_shape, rank_diff);
                 remove_prefix(padded_shape, rank_diff);
                 output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(output_shape), ttnn::Shape(padded_shape));
-                output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(padded_shape));
             }
         } else {
             output_tensor = ttnn::reshape(

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -199,7 +199,7 @@ static ttnn::Tensor pad_impl(
                                  {},
                                  queue_id)
                                  .front();
-        if (original_rank <= 4) {
+        if (original_rank < 4) {
             auto to_vec = [](const auto& span) { return ttnn::SmallVector<uint32_t>{span.begin(), span.end()}; };
             auto output_shape = to_vec(output_tensor.get_padded_shape().view());
             auto padded_shape = to_vec(output_tensor.get_padded_shape().view());
@@ -209,12 +209,7 @@ static ttnn::Tensor pad_impl(
                 remove_prefix(padded_shape, rank_diff);
                 output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(output_shape), ttnn::Shape(padded_shape));
             }
-        } else {
-            output_tensor = ttnn::reshape(
-                output_tensor,
-                update_original_shape(output_tensor.get_padded_shape(), input_tensor.get_logical_shape()));
         }
-
         return output_tensor;
     }
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue - https://github.com/tenstorrent/tt-metal/issues/15182

### Problem description

ttnn pad op doesn't have support when dim is less than 4D, in the following variant:
`ttnn.pad(input_tensor, output_tensor_shape, input_tensor_start, value)
` 
### What's changed
Added support for less than 4D in ttnn pad op

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes