### PR TITLE
#20414: Fix conv2d hang with large kernel

### DIFF
--- a/models/experimental/functional_vanilla_unet/ttnn/common.py
+++ b/models/experimental/functional_vanilla_unet/ttnn/common.py
@@ -54,6 +54,7 @@ class Conv:
             reshard_if_not_optimal=self.reshard,
             deallocate_activation=self.deallocate,
             output_layout=ttnn.ROW_MAJOR_LAYOUT,
+            reallocate_halo_output=False,
         )
         if self.act_block_h is not None:
             conv_config.act_block_h_override = self.act_block_h

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -71,6 +71,7 @@ def prepare_conv_params(device, weights, bias, dtype, act_dtype=ttnn.bfloat16, a
         shard_layout=None,
         input_channels_alignment=32,
         deallocate_activation=True,
+        reallocate_halo_output=False,
         enable_act_double_buffer=False,
         enable_split_reader=False,
         enable_subblock_padding=False,

--- a/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
+++ b/tests/sweep_framework/sweeps/conv2d/short/conv2d_short_sweep.py
@@ -1619,10 +1619,6 @@ failing_parameters = [
     # [batch_size, output_channels, input_channels, input_height, input_width, kernel_height, kernel_width, stride_h, stride_w, pad_h, pad_w, groups, dilation_h, dilation_w, bias]
     [1, 528, 528, 192, 192, 3, 3, 2, 2, 1, 1, 2, 1, 1, False],  # 220
     [1, 819, 256, 100, 136, 3, 3, 1, 1, 1, 1, 1, 1, 1, True],  # 1443
-    [1, 1024, 3, 224, 224, 32, 32, 32, 32, 0, 0, 1, 1, 1, True],  # 1458
-    [1, 768, 3, 224, 224, 32, 32, 32, 32, 0, 0, 1, 1, 1, False],  # 1460
-    [1, 768, 3, 224, 224, 32, 32, 32, 32, 0, 0, 1, 1, 1, True],  # 1461
-    [1, 768, 3, 384, 512, 32, 32, 32, 32, 0, 0, 1, 1, 1, True],  # 1464
     [1, 1, 64, 480, 640, 3, 3, 1, 1, 1, 1, 1, 1, 1, True],  # 1495
     [1, 64, 64, 480, 640, 3, 3, 1, 1, 1, 1, 1, 1, 1, True],  # 1496
 ]

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -1610,6 +1610,9 @@ def test_sd14_vae_conv(
     split_factor_input_channels,
     split_factor_output_channels,
 ):
+    if device.core_grid.y != 8 and is_wormhole_b0():
+        pytest.skip("Needs 8x8 grid for wormhole_b0")
+
     batch = 1
     dtype = ttnn.bfloat8_b
     kernel = (3, 3)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_pybind.cpp
@@ -367,7 +367,7 @@ void py_bind_conv2d(py::module& module) {
         py::arg("activation") = "",
         py::arg("input_channels_alignment") = 32,
         py::arg("deallocate_activation") = false,
-        py::arg("reallocate_halo_output") = false,
+        py::arg("reallocate_halo_output") = true,
         py::arg("act_block_h_override") = 0,
         py::arg("act_block_w_div") = 1,
         py::arg("reshard_if_not_optimal") = false,


### PR DESCRIPTION
In Conv2dConfg we have an inconsistent default
between cpp code python code (pybind).

Fixing the default on python side unblocked some
test cases as they are not running out of memory
anymore.

Once they started executing, they hit a hang
in conv2d activations reader kernel.
We were allocating an array on stack with size
kernel_h * kernel_w and data type is uint32_t.
In case of large kernel size like 32x32 this is
4k bytes on stack. Which was blowing over our stack.

Code is adjusted not to use this stack allocated
array to avoid this issue.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20414)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14398657736)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14398642381)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14398635834)
- [x] [(Single-card) Frequent model and ttnn tests ](https://github.com/tenstorrent/tt-metal/actions/runs/14398627758) 
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14398650873)