### PR TITLE
#0: Fix miscounting of compile_args for PrefetchKernel

### DIFF
--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -394,7 +394,7 @@ void PrefetchKernel::CreateKernel() {
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-    TT_ASSERT(compile_args.size() == 36);
+    TT_ASSERT(compile_args.size() == 35);
     auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
     auto upstream_virtual_core =
         device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());


### PR DESCRIPTION
### Ticket
None

### Problem description
Recent change had gone in that miscounted compile-args manifesting w/ thrown exception:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  TT_ASSERT @ /proj_sw/user_dev/jchu/tt-metal/tt_metal/impl/dispatch/kernel_config/prefetch.cpp:397: compile_args.size() == 36
backtrace:
```

### What's changed
Fix the compile-args count assert 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14399352145) CI passes