### PR TITLE
#19751: Re-enable skipped blackhole distributed tests

### DIFF
--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -45,7 +45,7 @@ jobs:
           {name: dispatch, cmd: "./build/test/tt_metal/unit_tests_dispatch"},
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth_${{ inputs.arch }}"},
           {name: stl, cmd: "./build/test/tt_metal/unit_tests_stl"},
-          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }} ${{ inputs.arch == 'blackhole' && '--gtest_filter=\"-MeshEventsTestSuite.*\"' || '' }}"},
+          {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }}"},
           {name: lightmetal, cmd: "./build/test/tt_metal/unit_tests_lightmetal"},
           {name: dispatch multicmd queue, cmd: "TT_METAL_GTEST_NUM_HW_CQS=2 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter=MultiCommandQueue*Fixture.*"},
           {name: ttnn cpp unit tests, cmd: ./build/test/ttnn/unit_tests_ttnn},

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -141,9 +141,13 @@ protected:
                 magic_enum::enum_name(*mesh_device_type),
                 boost::algorithm::join(requested_device_types, ", "));
         }
+
         // Use ethernet dispatch for more than 1 CQ on T3K/N300
-        auto core_type = (config_.num_cqs >= 2 and *mesh_device_type != MeshDeviceType::TG) ? DispatchCoreType::ETH
-                                                                                            : DispatchCoreType::WORKER;
+        auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+        bool is_n300_or_t3k_cluster = cluster_type == tt::ClusterType::T3K or cluster_type == tt::ClusterType::N300;
+        auto core_type =
+            (config_.num_cqs >= 2 and is_n300_or_t3k_cluster) ? DispatchCoreType::ETH : DispatchCoreType::WORKER;
+
         mesh_device_ = MeshDevice::create(
             MeshDeviceConfig(get_mesh_shape(*mesh_device_type)),
             0,


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/19751)

### Problem description
Distributed BH tests (MeshEventsTestSuite) were being skipped because tests running on P100 were trying to use ethernet dispatch.

### What's changed
- Originally the test was intended to check for N300/T3000 so the condition check is just updated to reflect that.
- Re-enable Distributed tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14456851765) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14456848602)
