### PR TITLE
Revert "#20265: Adjust grid usage in matmul test and add check for validation

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -54,15 +54,19 @@ def test_ttnn_matmul(device, m_size, k_size, n_size):
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.parametrize("input_a_is_sharded", [True, False])
 @pytest.mark.parametrize("output_is_sharded", [True, False])
-@pytest.mark.parametrize("m_size, num_cores", [[11264, 44]])
+@pytest.mark.parametrize("m_size, num_cores", [[25088, 98]])
 @pytest.mark.parametrize("k_size, n_size", [[64, 64], [64, 256]])
 @pytest.mark.parametrize("input_a_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("input_b_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 def test_ttnn_linear(
     device, input_a_is_sharded, output_is_sharded, m_size, k_size, n_size, num_cores, input_a_dtype, input_b_dtype
 ):
-    grid_size = (7, 7)
+    grid_size = device.compute_with_storage_grid_size()
     compute_grid_size = device.compute_with_storage_grid_size()
+    if num_cores > (compute_grid_size.x * compute_grid_size.y):
+        pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
+    if input_a_dtype != input_b_dtype and is_wormhole_b0():
+        pytest.skip("WH does not work with mixed precision")
 
     input_shape_a = [1, 1, m_size, k_size]
     input_shape_b = [1, 1, k_size, n_size]
@@ -77,7 +81,7 @@ def test_ttnn_linear(
     output_memory_config = sharded_memory_config if output_is_sharded else interleaved_memory_config
 
     program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=grid_size,
+        compute_with_storage_grid_size=(12, 9),
         in0_block_w=k_size // 32,
         out_subblock_h=8 // (n_size // 32),
         out_subblock_w=n_size // 32,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1536,36 +1536,6 @@ void Matmul::validate(
             // TODO: For 1D and 2D mcasts, we don't check if tensor is single core
             // or single row/col We can uplift these variants to skip mcasting to
             // support single core (1D) or single row/col (2D)
-            if constexpr (
-                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig> ||
-                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig>) {
-                // Validate input tensor A is within grid if sharded and not in DRAM
-                if (input_tensor_a.memory_config().is_sharded() &&
-                    input_tensor_a.memory_config().buffer_type != BufferType::DRAM) {
-                    const auto& shard_spec = input_tensor_a.memory_config().shard_spec.value();
-                    const auto& shard_grid = shard_spec.grid;
-                    CoreRange range(CoreCoord(0, 0), program_config.compute_with_storage_grid_size);
-                    TT_FATAL(
-                        range.contains(shard_grid),
-                        "Input tensor A shard spec grid must be within config grid! Shard grid: {}, Config grid: {}",
-                        shard_grid,
-                        program_config.compute_with_storage_grid_size);
-                }
-
-                // Validate input tensor B is within grid if sharded and not in DRAM
-                if (input_tensor_b.memory_config().is_sharded() &&
-                    input_tensor_b.memory_config().buffer_type != BufferType::DRAM) {
-                    const auto& shard_spec = input_tensor_b.memory_config().shard_spec.value();
-                    const auto& shard_grid = shard_spec.grid;
-                    CoreRange range(CoreCoord(0, 0), program_config.compute_with_storage_grid_size);
-                    TT_FATAL(
-                        range.contains(shard_grid),
-                        "Input tensor B shard spec grid must be within config grid! Shard grid: {}, Config grid: ()",
-                        shard_grid,
-                        program_config.compute_with_storage_grid_size);
-                }
-            }
-
             if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
                 TT_FATAL(
                     program_config.per_core_M % program_config.out_block_h == 0,


### PR DESCRIPTION
### Problem description
Introduced validation in matmul breaks TG unit, demo and frequent tests. Here is the list:
- https://github.com/tenstorrent/tt-metal/actions/runs/14396875660/job/40374402960#step:5:684
- https://github.com/tenstorrent/tt-metal/actions/runs/14392609155/job/40362776928
- https://github.com/tenstorrent/tt-metal/actions/runs/14396656095/job/40373695774

and here is error message for reference to commit: 
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  TT_FATAL @ /work/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp:1552: range.contains(shard_grid)
info:
Input tensor A shard spec grid must be within config grid! Shard grid: {[(x=6,y=6) - (x=6,y=6)], [(x=6,y=7) - (x=6,y=7)], [(x=6,y=9) - (x=6,y=9)], [(x=6,y=0) - (x=6,y=0)], [(x=6,y=1) - (x=6,y=1)], [(x=6,y=2) - (x=6,y=2)], [(x=6,y=4) - (x=6,y=4)], [(x=6,y=5) - (x=6,y=5)], [(x=5,y=5) - (x=5,y=5)], [(x=5,y=6) - (x=5,y=6)], [(x=5,y=7) - (x=5,y=7)], [(x=5,y=9) - (x=5,y=9)], [(x=5,y=0) - (x=5,y=0)], [(x=5,y=1) - (x=5,y=1)], [(x=5,y=2) - (x=5,y=2)], [(x=5,y=4) - (x=5,y=4)], [(x=1,y=4) - (x=1,y=4)], [(x=1,y=5) - (x=1,y=5)], [(x=1,y=9) - (x=1,y=9)], [(x=1,y=0) - (x=1,y=0)], [(x=2,y=0) - (x=2,y=0)], [(x=2,y=4) - (x=2,y=4)], [(x=2,y=5) - (x=2,y=5)], [(x=2,y=9) - (x=2,y=9)]}, Config grid: (x=8,y=3)
backtrace:
```
For any change inside ops atleast Llama3-70b TG demo needs to be run before merging PR.

### What's changed
Commit 22df6178a235f03383b3b93323568ec6eda7718e is reverted