### PR TITLE
Add test for all_gather on TG submeshes

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_tg.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_tg.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 32)], indirect=True)
+def test_all_gather_submeshes(mesh_device):
+    submesh_devices = mesh_device.create_submeshes(ttnn.MeshShape(1, 8))
+
+    for device in submesh_devices:
+        torch_input_tensor = torch.rand((1, 1, 32, 256), dtype=torch.bfloat16)
+
+        mesh_tensor = ttnn.from_torch(
+            torch_input_tensor,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            mesh_mapper=ttnn.ShardTensorToMesh(device, dim=3),
+        )
+
+        ttnn.visualize_mesh_device(device, tensor=mesh_tensor)
+
+        _ = ttnn.all_gather(
+            mesh_tensor,
+            dim=3,
+            num_links=1,
+            topology=ttnn.Topology.Ring,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Since https://github.com/tenstorrent/tt-metal/pull/19373 was merged we are having failures of using `ttnn.all_gather` on submeshes in llama tg tests.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes