### PR TITLE
#0: [skip ci] Fix microbenchmarks artifact upload path

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -94,5 +94,5 @@ jobs:
         timeout-minutes: 10
         with:
           name: microbenchmark-report-csv-${{ join(matrix.test-group.name) }}
-          path: generated/profiler/.logs
+          path: /work/generated/profiler/.logs
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main


### PR DESCRIPTION
### Ticket
None

### Problem description
Microbenchmark artifact upload path needs to be updated after containerization

### What's changed
Prepend `/work/` to artifact path

### Checklist
- [ ] Ubench run: https://github.com/tenstorrent/tt-metal/actions/runs/14406032936