### PR TITLE
Measure SD e2e perf and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@
 | [ResNet-50 (224x224) (DP=8)](./models/demos/t3000/resnet50)                 | 128   | [QuietBox](https://tenstorrent.com/hardware/tt-quietbox) | 35,800  | 56,000     |             |
 | [ResNet-50 (224x224) (DP=32)](./models/demos/tg/resnet50)                   | 512   | [Galaxy](https://tenstorrent.com/hardware/galaxy)        | 96,800  | 224,000    |             |
 | [ViT (224x224)](./models/demos/wormhole/vit)                                | 8     | [n150](https://tenstorrent.com/hardware/wormhole)        | 1100    | 1,600      |             |
-| [Stable Diffusion 1.4 (512x512)](./models/demos/wormhole/stable_diffusion)  | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 0.167   | 0.3        |             |
+| [Stable Diffusion 1.4 (512x512)](./models/demos/wormhole/stable_diffusion)  | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 0.117   | 0.3        |             |
 | [YOLOv4 (320x320)](./models/demos/yolov4)                                   | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 120     | 300        |             |
 | [YOLOv4 (640x640)](./models/demos/yolov4)                                   | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 50      | 100        |             |
 | [SegFormer Semantic Segmentation (512x512)](./models/demos/segformer)       | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 90      | 300        |             |
 | [Stable Diffusion 3.5 medium (512x512)](https://github.com/tenstorrent/tt-metal/blob/mbahnas/sd35_medium_512_spacelike_feb05/models/experimental/stable_diffusion3)  | 1     | [n150](https://tenstorrent.com/hardware/wormhole)        | 0.06   | 0.3        |             |
+
+> **Notes:**
+>
+>- Stable Diffusion FPS is based on the time elapsed from submitting the input prompt to receiving the image from the VAE decoder.
 
 ## NLPs
 

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -220,7 +220,6 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
             noise_pred = tt_guide(ttnn_output, guidance_scale)
 
             ttnn_latents = ttnn_scheduler.step(noise_pred, t, ttnn_latents).prev_sample
-            # _save_image_and_latents(ttnn_latents, iter, vae, pre_fix=f"{experiment_name}_tt", pre_fix2="")
 
             iter += 1
 
@@ -548,7 +547,6 @@ def run_demo_inference_diffusiondb(
             # perform guidance
             noise_pred = tt_guide(ttnn_output, guidance_scale)
             ttnn_latents = ttnn_scheduler.step(noise_pred, t, ttnn_latents).prev_sample
-            # _save_image_and_latents(ttnn_latents, iter, vae, pre_fix=f"{experiment_name}_tt", pre_fix2="")
 
             iter += 1
 

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -19,10 +19,9 @@ from diffusers import (
     AutoencoderKL,
     UNet2DConditionModel,
 )
-from models.utility_functions import skip_for_grayskull
 from models.utility_functions import (
     enable_persistent_kernel_cache,
-    disable_persistent_kernel_cache,
+    profiler,
 )
 from ttnn.model_preprocessing import preprocess_model_parameters
 from models.demos.wormhole.stable_diffusion.sd_pndm_scheduler import TtPNDMScheduler
@@ -66,22 +65,6 @@ def tt_guide(noise_pred, guidance_scale):  # will return latents
     return noise_pred
 
 
-def _save_image_and_latents(latents, iter, vae, pre_fix="", pre_fix2=""):
-    latents = ttnn.to_torch(latents).to(torch.float32)
-    pre_fix = "" if pre_fix == "" else f"{pre_fix}_"
-    pre_fix2 = "" if pre_fix2 == "" else f"{pre_fix2}_"
-    _latents = 1 / 0.18215 * latents
-
-    with torch.no_grad():
-        image = vae.decode(_latents).sample
-    # Image post-processing
-    image = (image / 2 + 0.5).clamp(0, 1)
-    image = image.detach().cpu().permute(0, 2, 3, 1).numpy()
-    images = (image * 255).round().astype("uint8")
-    pil_images = [Image.fromarray(image) for image in images][0]
-    pil_images.save(f"{pre_fix}{pre_fix2}image_iter_{iter}.png")
-
-
 def calculate_fid_score(imgs_path1, imgs_path2):
     fid = FrechetInceptionDistance(normalize=True)
     fid.update(imgs_path1, real=False)
@@ -101,8 +84,9 @@ def preprocess_images(image_paths):
 
 
 def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size=(256, 256)):
-    disable_persistent_kernel_cache()
+    enable_persistent_kernel_cache()
     device.enable_program_cache()
+    profiler.clear()
 
     # Until di/dt issues are resolved
     os.environ["SLOW_MATMULS"] = "1"
@@ -189,6 +173,7 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
         logger.info(f"input prompt : {input_prompt}")
         batch_size = len(input_prompt)
 
+        profiler.start(f"inference_prompt_{i}")
         ## First, we get the text_embeddings for the prompt. These embeddings will be used to condition the UNet model.
         # Tokenizer and Text Encoder
         text_input = tokenizer(
@@ -221,22 +206,21 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
             _t = _tlist[index]
             t = time_step[index]
             # predict the noise residual
-            with torch.no_grad():
-                ttnn_output = model(
-                    ttnn_latent_model_input,  # input
-                    timestep=_t,
-                    encoder_hidden_states=ttnn_text_embeddings,
-                    class_labels=None,
-                    attention_mask=None,
-                    cross_attention_kwargs=None,
-                    return_dict=True,
-                    config=config,
-                )
+            ttnn_output = model(
+                ttnn_latent_model_input,  # input
+                timestep=_t,
+                encoder_hidden_states=ttnn_text_embeddings,
+                class_labels=None,
+                attention_mask=None,
+                cross_attention_kwargs=None,
+                return_dict=True,
+                config=config,
+            )
             # perform guidance
             noise_pred = tt_guide(ttnn_output, guidance_scale)
 
             ttnn_latents = ttnn_scheduler.step(noise_pred, t, ttnn_latents).prev_sample
-            _save_image_and_latents(ttnn_latents, iter, vae, pre_fix=f"{experiment_name}_tt", pre_fix2="")
+            # _save_image_and_latents(ttnn_latents, iter, vae, pre_fix=f"{experiment_name}_tt", pre_fix2="")
 
             iter += 1
 
@@ -244,8 +228,8 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
 
         # scale and decode the image latents with vae
         latents = 1 / 0.18215 * latents
-        with torch.no_grad():
-            image = vae.decode(latents).sample
+        image = vae.decode(latents).sample
+        profiler.end(f"inference_prompt_{i}")
 
         # Image post-processing
         image = (image / 2 + 0.5).clamp(0, 1)
@@ -255,9 +239,20 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
         ttnn_output_path = f"{experiment_name}_ttnn.png"
         pil_images.save(ttnn_output_path)
 
+    profiler.print()
+
+    # skip first for compile
+    total_time = sum([profiler.get("inference_prompt_" + str(i)) for i in range(2, num_prompts + 1)])
+    avg_time = total_time / (num_prompts - 1)
+    FPS = 1 / avg_time
+
+    print(
+        f"Average time per prompt: {avg_time}, FPS: {FPS}",
+    )
+
 
 def run_interactive_demo_inference(device, num_inference_steps, image_size=(256, 256)):
-    disable_persistent_kernel_cache()
+    enable_persistent_kernel_cache()
     device.enable_program_cache()
 
     # Until di/dt issues are resolved
@@ -379,17 +374,16 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
             _t = _tlist[index]
             t = time_step[index]
             # predict the noise residual
-            with torch.no_grad():
-                ttnn_output = model(
-                    ttnn_latent_model_input,  # input
-                    timestep=_t,
-                    encoder_hidden_states=ttnn_text_embeddings,
-                    class_labels=None,
-                    attention_mask=None,
-                    cross_attention_kwargs=None,
-                    return_dict=True,
-                    config=config,
-                )
+            ttnn_output = model(
+                ttnn_latent_model_input,  # input
+                timestep=_t,
+                encoder_hidden_states=ttnn_text_embeddings,
+                class_labels=None,
+                attention_mask=None,
+                cross_attention_kwargs=None,
+                return_dict=True,
+                config=config,
+            )
             # perform guidance
             noise_pred = tt_guide(ttnn_output, guidance_scale)
 
@@ -402,8 +396,7 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
 
         # scale and decode the image latents with vae
         latents = 1 / 0.18215 * latents
-        with torch.no_grad():
-            image = vae.decode(latents).sample
+        image = vae.decode(latents).sample
 
         # Image post-processing
         image = (image / 2 + 0.5).clamp(0, 1)
@@ -417,7 +410,7 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
 def run_demo_inference_diffusiondb(
     device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size=(256, 256)
 ):
-    disable_persistent_kernel_cache()
+    enable_persistent_kernel_cache()
     device.enable_program_cache()
 
     # Until di/dt issues are resolved
@@ -541,31 +534,28 @@ def run_demo_inference_diffusiondb(
             _t = _tlist[index]
             t = time_step[index]
             # predict the noise residual
-            with torch.no_grad():
-                ttnn_output = model(
-                    ttnn_latent_model_input,  # input
-                    timestep=_t,
-                    encoder_hidden_states=ttnn_text_embeddings,
-                    class_labels=None,
-                    attention_mask=None,
-                    cross_attention_kwargs=None,
-                    return_dict=True,
-                    config=config,
-                )
+            ttnn_output = model(
+                ttnn_latent_model_input,  # input
+                timestep=_t,
+                encoder_hidden_states=ttnn_text_embeddings,
+                class_labels=None,
+                attention_mask=None,
+                cross_attention_kwargs=None,
+                return_dict=True,
+                config=config,
+            )
 
             # perform guidance
             noise_pred = tt_guide(ttnn_output, guidance_scale)
             ttnn_latents = ttnn_scheduler.step(noise_pred, t, ttnn_latents).prev_sample
-            _save_image_and_latents(ttnn_latents, iter, vae, pre_fix=f"{experiment_name}_tt", pre_fix2="")
+            # _save_image_and_latents(ttnn_latents, iter, vae, pre_fix=f"{experiment_name}_tt", pre_fix2="")
 
             iter += 1
-            enable_persistent_kernel_cache()
 
         latents = ttnn.to_torch(ttnn_latents).to(torch.float32)
         # scale and decode the image latents with vae
         latents = 1 / 0.18215 * latents
-        with torch.no_grad():
-            image = vae.decode(latents).sample
+        image = vae.decode(latents).sample
 
         # Image post-processing
         image = (image / 2 + 0.5).clamp(0, 1)
@@ -592,11 +582,15 @@ def run_demo_inference_diffusiondb(
         logger.info(f"CLIP Score (TTNN): {clip_score_ttnn}")
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
+    "input_path",
+    (("models/demos/wormhole/stable_diffusion/demo/input_data.json"),),
+    ids=["default_input"],
+)
+@pytest.mark.parametrize(
     "num_prompts",
-    ((1),),
+    ((10),),
 )
 @pytest.mark.parametrize(
     "num_inference_steps",
@@ -608,35 +602,3 @@ def run_demo_inference_diffusiondb(
 )
 def test_demo(device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size):
     return run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size)
-
-
-@skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-@pytest.mark.parametrize(
-    "num_prompts",
-    ((1),),
-)
-@pytest.mark.parametrize(
-    "num_inference_steps",
-    ((50),),
-)
-@pytest.mark.parametrize(
-    "image_size",
-    ((512, 512),),
-)
-def test_demo_diffusiondb(device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size):
-    return run_demo_inference_diffusiondb(device, reset_seeds, input_path, num_prompts, num_inference_steps, image_size)
-
-
-@skip_for_grayskull()
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-@pytest.mark.parametrize(
-    "num_inference_steps",
-    ((50),),
-)
-@pytest.mark.parametrize(
-    "image_size",
-    ((512, 512),),
-)
-def test_interactive_demo(device, num_inference_steps, image_size):
-    return run_interactive_demo_inference(device, num_inference_steps, image_size)

--- a/models/demos/wormhole/stable_diffusion/tests/test_demo.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_demo.py
@@ -3,13 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from models.utility_functions import skip_for_grayskull
-from models.demos.wormhole.stable_diffusion.demo.demo import test_demo as demo
-from models.demos.wormhole.stable_diffusion.demo.demo import test_demo_diffusiondb as demo_db
+from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference as demo
+from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference_diffusiondb as demo_db
 
 
 @pytest.mark.timeout(600)
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
     "input_path",
@@ -35,7 +33,6 @@ def test_demo_sd(device, reset_seeds, input_path, num_prompts, num_inference_ste
 
 
 @pytest.mark.timeout(600)
-@skip_for_grayskull()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
     "num_prompts",


### PR DESCRIPTION
### Ticket
#17735

### Problem description
SD 1.4 model perf in README wasn't up to date.

### What's changed
Update SD 1.4 performance on the README.
Add profiler to the demo test to reproduce reported FPS.

Notes:
- We measure time from the input prompt to the VAE decoder output, we skip image postprocessing and saving image on disk which take different time depending on the machine (0.8s +)
- Updated tests to use persistent kernel cache and to avoid saving image on each denoising iteration
- We don't have trace+2cq feature on main yet - I am currently working on lowering VAE decoder on the device; once I am done, I will add trace+2cq and a test on the CI that ensures the FPS is stable for the whole model, we currently only have a perf test for one Unet block iteration

### Checklist
[Demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/14406457125) ✅ (llama and falcon demo failing on main as well)