### PR TITLE
#20135: Build umd unit tests inside build-artifact step

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -75,6 +75,7 @@ jobs:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
   sd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/build-and-unit-tests.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -47,6 +47,7 @@ jobs:
       build-type: ${{ inputs.build-type || 'Release' }}
       build-wheel: true
       version: "22.04"
+      build-umd-tests: true
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -75,7 +75,7 @@ jobs:
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
   sd-unit-tests:
     needs: build-artifact
     uses: ./.github/workflows/build-and-unit-tests.yaml

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -52,6 +52,11 @@ on:
         type: boolean
         default: false
         description: "Profile the compilation"
+      build-umd-tests:
+        required: false
+        type: boolean
+        default: false
+        description: "Build UMD tests"
     outputs:
       ci-build-docker-image:
         description: "Docker tag for the CI Build Docker image for building TT-Metalium et al"

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -110,6 +110,11 @@ on:
         type: boolean
         default: false
         description: "Profile the compilation"
+      build-umd-tests:
+        required: false
+        type: boolean
+        default: false
+        description: "Build UMD tests"
 
 
 jobs:
@@ -219,6 +224,9 @@ jobs:
           fi
           if [ "${{ inputs.profile }}" = "true" ]; then
             build_command="$build_command --enable-time-trace --disable-unity-builds"
+          fi
+          if [ "${{ inputs.build-umd-tests }}" = "true" ]; then
+            build_command="$build_command --build-umd-tests"
           fi
 
           nice -n 19 $build_command

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -25,3 +25,4 @@ jobs:
       arch: ${{ matrix.test-group.arch }}
       runner-label: ${{ matrix.test-group.runner-label }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/umd-unit-tests-wrapper.yaml
+++ b/.github/workflows/umd-unit-tests-wrapper.yaml
@@ -9,6 +9,7 @@ jobs:
     secrets: inherit
     with:
       version: 22.04
+      build-umd-tests: true
   umd-unit-tests:
     needs: build-artifact
     secrets: inherit

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -64,10 +64,6 @@ jobs:
         with:
           submodules: recursive
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
-      - name: Build UMD device and tests
-        run: |
-          cmake -B build -G Ninja -DTT_UMD_BUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=cmake/x86_64-linux-clang-17-libstdcpp-toolchain.cmake
-          cmake --build build --target umd_tests
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}
         run: build/test/umd/${{ inputs.arch }}/unit_tests

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -16,25 +16,9 @@ on:
       docker-image:
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      arch:
+      build-artifact-name:
         required: true
-        type: choice
-        options:
-          - wormhole_b0
-          - blackhole
-      runner-label:
-        required: true
-        type: choice
-        options:
-          - N150
-          - N300
-          - BH
-      timeout:
-        required: false
-        type: number
-        default: 15
+        type: string
 
 jobs:
   umd-unit-tests:
@@ -59,11 +43,11 @@ jobs:
         shell: bash
         working-directory: /work # https://github.com/actions/runner/issues/878
     steps:
-      - name: ⬇️ Checkout
-        uses: actions/checkout@v4
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
         with:
-          submodules: recursive
-          path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
+          build-artifact-name: ${{ inputs.build-artifact-name }}
       - name: Run UMD unit tests
         timeout-minutes: ${{ inputs.timeout }}
         run: build/test/umd/${{ inputs.arch }}/unit_tests


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/20135

### Problem description
Currently UMD unit tests are built before running the tests as part of the workflow, not as part of build-artifact step

### What's changed
Add `inputs.build-umd-tests` which will add `--build-umd-tests` to the build command.
Add input to workflows that run umd unit tests.
Pass build artifact tarball to umd unit test impl
Remove build step from umd unit test impl.

### Checklist
- [x] UMD unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/14408550514
- [ ] Blackhole post commit: https://github.com/tenstorrent/tt-metal/actions/runs/14408858309