### PR TITLE
[skip ci] Reduce timeout on TG pipelines

### DIFF
--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         test-group: [
           # Deleting for now - LLM team will put in a new version soon
-          { name: "TG Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 180, owner_id: U044T8U8DEF}, # Johanna Rock
-          { name: "TG Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 120, owner_id: U05RWH3QUPM}, # Salar Hosseini
+          { name: "TG Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 30, owner_id: U044T8U8DEF}, # Johanna Rock
+          { name: "TG Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
         ]
     runs-on:
       - arch-wormhole_b0

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -73,7 +73,7 @@ jobs:
         test-group: [
           { name: "TG unit tests", arch: wormhole_b0, model: unit, timeout: 45, owner_id: XXXXX},  # Add owner
           { name: "TG Fabric tests", arch: wormhole_b0, model: fabric, timeout: 30, owner_id: UJ45FEC7M},  # Allan Liu
-          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 45, owner_id: U044T8U8DEF, mlperf: true}, # Johanna Rock
+          { name: "TG Llama3-70b unit tests", arch: wormhole_b0, model: llama3-70b, timeout: 30, owner_id: U044T8U8DEF, mlperf: true}, # Johanna Rock
           { name: "TG DRAM Prefetcher unit tests", arch: wormhole_b0, model: prefetcher, timeout: 30, owner_id: U071CKL4AFK}, # Ammar Vora, Yu Gao
           { name: "TG distributed ops tests", arch: wormhole_b0, model: distributed-ops, timeout: 15, owner_id: U044T8U8DEF},  # Johanna Rock
           { name: "TG distributed runtime tests", arch: wormhole_b0, model: distributed-runtime, timeout: 45, owner_id: U03NG0A5ND7},  # Aditya Saigal


### PR DESCRIPTION
### Ticket


### Problem description
TG pipelines sometimes fail and hang for a long time. Since CI TG machines are scarce, it is important that we do not waste machine time to reduce queues.

Reducing TG demo llama test 180min -> 30min
Reducing TG demo falcon7b test 120min -> 30min
Normal run under 12 mins. Example: https://github.com/tenstorrent/tt-metal/actions/runs/14369482177/job/40314793312

Reducing TG unit llama test 45min -> 30min
Normal run under 14mins. Example: https://github.com/tenstorrent/tt-metal/actions/runs/14376519193/job/40338008606

### What's changed


### Checklist