### PR TITLE
[skip ci] De-inline detect-slow-tests from the YAML

### DIFF
--- a/.github/actions/detect-slow-tests/action.yml
+++ b/.github/actions/detect-slow-tests/action.yml
@@ -1,0 +1,22 @@
+name: "Detect slow tests"
+description: "Scan a test report and fail if any individual test is slower than a given threshold"
+
+inputs:
+  report-dir:
+    description: "Path that contains the test report"
+    required: false
+    default: "/work/test-reports"
+  threshold:
+    description: "Threshold for slow tests in seconds"
+    required: true
+    default: "5.0"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Find changed files
+      id: find-changed-files
+      shell: bash
+      run: |
+        env
+        python3 ${GITHUB_ACTION_PATH}/detect-slow-tests.py ${{ inputs.report-dir }} ${{ inputs.threshold }}

--- a/.github/actions/detect-slow-tests/detect-slow-tests.py
+++ b/.github/actions/detect-slow-tests/detect-slow-tests.py
@@ -1,0 +1,62 @@
+import os
+import xml.etree.ElementTree as ET
+import sys
+
+
+class SlowTestDetectionError(Exception):
+    pass
+
+
+class NoTestReportsFoundError(SlowTestDetectionError):
+    pass
+
+
+class TestReportParsingError(SlowTestDetectionError):
+    pass
+
+
+class SlowTestsExceededError(SlowTestDetectionError):
+    pass
+
+
+def detect_slow_tests(report_dir, timeout):
+    # Find all XML files in the report directory
+    report_files = [
+        os.path.join(root, file) for root, dirs, files in os.walk(report_dir) for file in files if file.endswith(".xml")
+    ]
+    if not report_files:
+        raise NoTestReportsFoundError("No test reports found.")
+
+    slow_tests = []
+
+    for report_file in report_files:
+        try:
+            tree = ET.parse(report_file)
+            root = tree.getroot()
+            for tc in root.findall(".//testcase"):
+                time = float(tc.get("time", 0))
+                if time > timeout:
+                    slow_tests.append(
+                        f"{report_file}: {tc.get('classname', 'Unknown')}.{tc.get('name', 'Unknown')} ({time:.3f}s)"
+                    )
+        except Exception as e:
+            raise TestReportParsingError(f"Error parsing {report_file}: {e}")
+
+    if slow_tests:
+        raise SlowTestsExceededError(f"Some tests exceeded {timeout}s:\n" + "\n".join(slow_tests))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python detect-slow-tests.py <report_dir> <timeout>")
+        sys.exit(1)
+
+    report_dir = sys.argv[1]
+    timeout = float(sys.argv[2])
+
+    try:
+        detect_slow_tests(report_dir, timeout)
+    except SlowTestDetectionError as e:
+        print(e)
+        sys.exit(1)
+    print("No slow tests slower than {timeout}s detected.")

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -85,35 +85,7 @@ jobs:
           path: /work/test-reports/
           prefix: "test_reports_"
 
-      # Arbitrary limit that's higher than we would like, but the JIT build seems inconsistent.
-      # Keep it here as a guardrail to keep Smoke tests fast.  We can adjust as needed.
       - name: Check for slow tests
-        shell: python3 {0}
-        run: |
-          import os
-          import xml.etree.ElementTree as ET
-          import sys
-
-          # Find all XML files in the /work/test-reports directory
-          report_files = [os.path.join(root, file) for root, dirs, files in os.walk("/work/test-reports/") for file in files if file.endswith(".xml")]
-          if not report_files:
-              print("No test reports found.")
-              sys.exit(1)
-
-          slow_tests = []
-
-          for report_file in report_files:
-              try:
-                  tree = ET.parse(report_file)
-                  root = tree.getroot()
-                  for tc in root.findall(".//testcase"):
-                      time = float(tc.get("time", 0))
-                      if time > float(${{ inputs.per-test-timeout }}):
-                          slow_tests.append(f"{report_file}: {tc.get('classname', 'Unknown')}.{tc.get('name', 'Unknown')} ({time:.3f}s)")
-              except Exception as e:
-                  print(f"Error parsing {report_file}: {e}")
-                  sys.exit(2)
-
-          if slow_tests:
-              print("Some tests exceeded float(${{ inputs.per-test-timeout }})s:\n" + "\n".join(slow_tests))
-              sys.exit(3)
+        uses: tenstorrent/tt-metal/.github/actions/detect-slow-tests@afuller/cleanup-script
+        with:
+          threshold: ${{ inputs.per-test-timeout }}

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -85,7 +85,35 @@ jobs:
           path: /work/test-reports/
           prefix: "test_reports_"
 
+      # Arbitrary limit that's higher than we would like, but the JIT build seems inconsistent.
+      # Keep it here as a guardrail to keep Smoke tests fast.  We can adjust as needed.
       - name: Check for slow tests
-        uses: tenstorrent/tt-metal/.github/actions/detect-slow-tests@afuller/cleanup-script
-        with:
-          threshold: ${{ inputs.per-test-timeout }}
+        shell: python3 {0}
+        run: |
+          import os
+          import xml.etree.ElementTree as ET
+          import sys
+
+          # Find all XML files in the /work/test-reports directory
+          report_files = [os.path.join(root, file) for root, dirs, files in os.walk("/work/test-reports/") for file in files if file.endswith(".xml")]
+          if not report_files:
+              print("No test reports found.")
+              sys.exit(1)
+
+          slow_tests = []
+
+          for report_file in report_files:
+              try:
+                  tree = ET.parse(report_file)
+                  root = tree.getroot()
+                  for tc in root.findall(".//testcase"):
+                      time = float(tc.get("time", 0))
+                      if time > float(${{ inputs.per-test-timeout }}):
+                          slow_tests.append(f"{report_file}: {tc.get('classname', 'Unknown')}.{tc.get('name', 'Unknown')} ({time:.3f}s)")
+              except Exception as e:
+                  print(f"Error parsing {report_file}: {e}")
+                  sys.exit(2)
+
+          if slow_tests:
+              print("Some tests exceeded float(${{ inputs.per-test-timeout }})s:\n" + "\n".join(slow_tests))
+              sys.exit(3)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The script is not reusable.  Nor does Black, et al. scan it.

### What's changed
Pull this step out into its own action.