### PR TITLE
Move RunTimeOptions and Hal under MetalContext

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -169,7 +169,7 @@ void validate_sems(
         ::tt::tt_metal::detail::ReadFromDeviceL1(device, core, sem_buffer_base, sem_buffer_size, readback_sem_vals);
         uint32_t sem_idx = 0;
         for (uint32_t i = 0; i < readback_sem_vals.size();
-             i += (hal_ref.get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
+             i += (MetalContext::instance().hal().get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
             EXPECT_EQ(readback_sem_vals[i], expected_semaphore_values[sem_idx]);
             sem_idx++;
         }

--- a/tests/tt_metal/test_utils/env_vars.hpp
+++ b/tests/tt_metal/test_utils/env_vars.hpp
@@ -8,7 +8,7 @@
 #include "umd/device/device_api_metal.h"
 #include "umd/device/tt_cluster_descriptor.h"
 #include "umd/device/tt_simulation_device.h"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 
 #include <string>
 
@@ -42,8 +42,8 @@ inline std::string get_env_arch_name() {
 
 inline std::string get_umd_arch_name() {
 
-    if(llrt::RunTimeOptions::get_instance().get_simulator_enabled()) {
-        tt_SimulationDeviceInit init(llrt::RunTimeOptions::get_instance().get_simulator_path());
+    if(tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
+        tt_SimulationDeviceInit init(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
         return tt::arch_to_str(init.get_arch_name());
     }
 

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "rtoptions.hpp"
 #include "impl/context/metal_context.hpp"
 
 namespace tt::tt_fabric {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -75,7 +75,7 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     auto receiver_noc_encoding =
-        tt::tt_metal::hal_ref.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     // test parameters
     uint32_t packet_header_address = 0x25000;
@@ -218,7 +218,7 @@ TEST_F(Fabric1DFixture, TestUnicastConnAPI) {
     CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     auto receiver_noc_encoding =
-        tt::tt_metal::hal_ref.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     // test parameters
     uint32_t packet_header_address = 0x25000;
@@ -348,7 +348,7 @@ TEST_F(Fabric1DFixture, TestMCastConnAPI) {
     CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     auto receiver_noc_encoding =
-        tt::tt_metal::hal_ref.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     // test parameters
     uint32_t packet_header_address = 0x25000;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -201,7 +201,7 @@ void RunAsyncWriteTest(
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_start_device_id);
 
     auto receiver_noc_encoding =
-        tt::tt_metal::hal_ref.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     // Create the sender program
     std::vector<uint32_t> sender_compile_time_args = {
@@ -215,7 +215,7 @@ void RunAsyncWriteTest(
         data_size,
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
-        tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
+        tt_metal::MetalContext::instance().hal().noc_xy_encoding(routers[0].second.x, routers[0].second.y),
         *outbound_eth_channels.begin()};
     std::map<string, string> defines = {};
     if (mode == fabric_mode::PULL) {
@@ -303,7 +303,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_start_device_id);
 
     auto receiver_noc_encoding =
-        tt::tt_metal::hal_ref.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     // Create the sender program
     auto sender_program = tt_metal::CreateProgram();
@@ -323,7 +323,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
         wrap_boundary,
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
-        tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
+        tt_metal::MetalContext::instance().hal().noc_xy_encoding(routers[0].second.x, routers[0].second.y),
         *outbound_eth_channels.begin()};
 
     CreateSenderKernel(
@@ -420,7 +420,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_start_device_id);
 
     auto receiver_noc_encoding =
-        tt::tt_metal::hal_ref.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     // Create the sender program
     auto sender_program = tt_metal::CreateProgram();
@@ -442,7 +442,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
         atomic_inc,
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
-        tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
+        tt_metal::MetalContext::instance().hal().noc_xy_encoding(routers[0].second.x, routers[0].second.y),
         *outbound_eth_channels.begin()};
 
     CreateSenderKernel(
@@ -587,7 +587,7 @@ void RunAsyncWriteMulticastTest(
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_start_device_id);
 
     auto receiver_noc_encoding =
-        tt::tt_metal::hal_ref.noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
     // Create the sender program
     auto sender_program = tt_metal::CreateProgram();
@@ -604,7 +604,8 @@ void RunAsyncWriteMulticastTest(
         auto& sender_virtual_router_coord = routers[0].second;
         sender_router_noc_xys.try_emplace(
             routing_direction,
-            tt_metal::hal_ref.noc_xy_encoding(sender_virtual_router_coord.x, sender_virtual_router_coord.y));
+            tt_metal::MetalContext::instance().hal().noc_xy_encoding(
+                sender_virtual_router_coord.x, sender_virtual_router_coord.y));
     }
 
     // Prepare runtime args based on whether it's multidirectional or not

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -12,7 +12,6 @@
 #include "fabric_fixture.hpp"
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/mesh_coord.hpp>
-#include "rtoptions.hpp"
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_metal.hpp>
 
@@ -21,7 +20,7 @@ namespace fabric_router_tests {
 
 TEST_F(ControlPlaneFixture, TestTGMeshGraphInit) {
     const std::filesystem::path tg_mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto mesh_graph_desc = std::make_unique<MeshGraph>(tg_mesh_graph_desc_path.string());
 }
@@ -29,7 +28,7 @@ TEST_F(ControlPlaneFixture, TestTGMeshGraphInit) {
 TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
     tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path tg_mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
@@ -50,7 +49,7 @@ TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
 TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
     tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path tg_mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
@@ -62,7 +61,7 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
 
 TEST_F(ControlPlaneFixture, TestT3kMeshGraphInit) {
     const std::filesystem::path t3k_mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto mesh_graph_desc = std::make_unique<MeshGraph>(t3k_mesh_graph_desc_path.string());
 }
@@ -70,7 +69,7 @@ TEST_F(ControlPlaneFixture, TestT3kMeshGraphInit) {
 TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
     tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path t3k_mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
@@ -79,7 +78,7 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
 TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
     tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path t3k_mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
@@ -96,7 +95,7 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
 TEST_F(ControlPlaneFixture, TestQuantaGalaxyControlPlaneInit) {
     tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path quanta_galaxy_mesh_graph_desc_path =
-        std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(quanta_galaxy_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();

--- a/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
+++ b/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/logger.hpp>
 
-#include "llrt/rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 
 using namespace tt;
 
@@ -45,18 +45,18 @@ protected:
     }
 
     void setup_kernel_dir(const std::string& orig_kernel_file, const std::string& new_kernel_file) {
-        const std::string& kernel_dir = llrt::RunTimeOptions::get_instance().get_kernel_dir();
+        const std::string& kernel_dir = tt_metal::MetalContext::instance().rtoptions().get_kernel_dir();
         const std::filesystem::path& kernel_file_path_under_kernel_dir(kernel_dir + new_kernel_file);
         const std::filesystem::path& dirs_under_kernel_dir = kernel_file_path_under_kernel_dir.parent_path();
         std::filesystem::create_directories(dirs_under_kernel_dir);
 
-        const std::string& metal_root = llrt::RunTimeOptions::get_instance().get_root_dir();
+        const std::string& metal_root = tt_metal::MetalContext::instance().rtoptions().get_root_dir();
         const std::filesystem::path& kernel_file_path_under_metal_root(metal_root + orig_kernel_file);
         std::filesystem::copy(kernel_file_path_under_metal_root, kernel_file_path_under_kernel_dir);
     }
 
     void cleanup_kernel_dir() {
-        const std::string& kernel_dir = llrt::RunTimeOptions::get_instance().get_kernel_dir();
+        const std::string& kernel_dir = tt_metal::MetalContext::instance().rtoptions().get_kernel_dir();
         for (const std::filesystem::directory_entry& entry : std::filesystem::directory_iterator(kernel_dir)) {
             std::filesystem::remove_all(entry);
         }
@@ -70,11 +70,11 @@ private:
 
     bool are_env_vars_set() {
         bool are_set = true;
-        if (!llrt::RunTimeOptions::get_instance().is_root_dir_specified()) {
+        if (!tt_metal::MetalContext::instance().rtoptions().is_root_dir_specified()) {
             log_info(LogTest, "Skipping test: TT_METAL_HOME must be set");
             are_set = false;
         }
-        if (!llrt::RunTimeOptions::get_instance().is_kernel_dir_specified()) {
+        if (!tt_metal::MetalContext::instance().rtoptions().is_kernel_dir_specified()) {
             log_info(LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be set");
             are_set = false;
         }
@@ -83,7 +83,7 @@ private:
 
     bool is_kernel_dir_valid() {
         bool is_valid = true;
-        const std::string& kernel_dir = llrt::RunTimeOptions::get_instance().get_kernel_dir();
+        const std::string& kernel_dir = tt_metal::MetalContext::instance().rtoptions().get_kernel_dir();
         if (!this->does_path_exist(kernel_dir) || !this->is_path_a_directory(kernel_dir) ||
             !this->is_dir_empty(kernel_dir)) {
             log_info(LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be an existing, empty directory");

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -281,8 +281,9 @@ TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
         .dram_buffer_size = buffer_size,
         .l1_buffer_addr = tt::align(
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED),
-            hal_ref.get_alignment(HalMemType::DRAM)),
+            MetalContext::instance().hal().get_dev_addr(
+                HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED),
+            MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
         .kernel_cfg = tt_metal::EthernetConfig{.eth_mode = Eth::RECEIVER, .noc = tt_metal::NOC::NOC_0},
     };
 
@@ -308,8 +309,9 @@ TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
         .kernel_file = "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy.cpp",
         .dram_buffer_size = buffer_size,
         .l1_buffer_addr = tt::align(
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED),
-            hal_ref.get_alignment(HalMemType::DRAM)),
+            MetalContext::instance().hal().get_dev_addr(
+                HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED),
+            MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
         .kernel_cfg = tt_metal::EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0},
     };
 

--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -49,7 +49,8 @@ TEST_F(DeviceFixture, TensixTestIncompleteKernelBinaryWithPersistentCache) {
         kernel_handle = CreateKernel(program, kernel_file, CoreCoord(0, 0), config);
         detail::CompileProgram(device, program);
 
-        const uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        const uint32_t tensix_core_type =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         const uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
         const int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(config.processor);
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
@@ -95,7 +96,8 @@ TEST_F(DeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentProces
         KernelHandle kernel_handle_riscv_1 = CreateKernel(program, kernel_file, CoreCoord(0, 0), config_riscv_1);
         detail::CompileProgram(device, program);
 
-        const uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        const uint32_t tensix_core_type =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         const uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
         const int riscv_0_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(config_riscv_0.processor);
         const int riscv_1_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(config_riscv_1.processor);

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -349,7 +349,8 @@ TEST_F(DeviceFixture, TensixInlineWriteDedicatedNoc) {
 
     for (tt_metal::IDevice* device : this->devices_) {
         uint32_t first_receiver_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
-        uint32_t second_receiver_addr = first_receiver_addr + hal_ref.get_alignment(HalMemType::L1);
+        uint32_t second_receiver_addr =
+            first_receiver_addr + MetalContext::instance().hal().get_alignment(HalMemType::L1);
         std::vector<uint32_t> readback(32 / sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, first_receiver_addr, readback);
 
@@ -442,7 +443,7 @@ TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
 
     for (tt_metal::IDevice* device : this->devices_) {
         uint32_t receiver_addr0 = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
-        uint32_t receiver_addr2 = receiver_addr0 + (2 * hal_ref.get_alignment(HalMemType::L1));
+        uint32_t receiver_addr2 = receiver_addr0 + (2 * MetalContext::instance().hal().get_alignment(HalMemType::L1));
         std::vector<uint32_t> readback(80 / sizeof(uint32_t), 0);
         tt_metal::detail::WriteToDeviceL1(device, receiver_core, receiver_addr0, readback);
 
@@ -467,7 +468,7 @@ TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
              receiver_addr0,
              value_to_write,
              2,
-             hal_ref.get_alignment(HalMemType::L1)});
+             MetalContext::instance().hal().get_alignment(HalMemType::L1)});
 
         tt_metal::KernelHandle kernel1 = tt_metal::CreateKernel(
             program,
@@ -487,7 +488,7 @@ TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
              receiver_addr2,
              value_to_write + 2,
              2,
-             hal_ref.get_alignment(HalMemType::L1)});
+             MetalContext::instance().hal().get_alignment(HalMemType::L1)});
 
         tt_metal::detail::LaunchProgram(device, program);
 

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -103,8 +103,9 @@ void create_and_read_max_num_semaphores(
             std::vector<uint32_t> res;
             for (uint32_t i = 0; i < tt::tt_metal::NUM_SEMAPHORES; i++) {
                 std::vector<uint32_t> single_val;
-                uint32_t semaphore_addr = program.get_sem_base_addr(device, logical_core, CoreType::WORKER) +
-                                          (tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::L1) * i);
+                uint32_t semaphore_addr =
+                    program.get_sem_base_addr(device, logical_core, CoreType::WORKER) +
+                    (tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1) * i);
                 uint32_t semaphore_size = sizeof(uint32_t);
                 tt_metal::detail::ReadFromDeviceL1(device, logical_core, semaphore_addr, semaphore_size, single_val);
                 ASSERT_TRUE(single_val.size() == 1);

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -190,7 +190,7 @@ TEST_F(DeviceFixtureWithL1Small, TestWidthShardReadWrite) {
 }
 
 TEST_F(DeviceFixture, TestUnorderedHeightShardReadWrite) {
-    if (tt::llrt::RunTimeOptions::get_instance().get_simulator_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
         GTEST_SKIP() << fmt::format("Skipping {} because it is not supported in simulator", __func__);
     }
 

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -14,7 +14,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "llrt.hpp"
 
 namespace tt::tt_metal {
@@ -47,7 +47,8 @@ protected:
 
     void create_device(const size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
         const chip_id_t device_id = 0;
-        const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         this->device_ =
             tt::tt_metal::CreateDevice(device_id, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_config);
     }
@@ -91,7 +92,8 @@ protected:
     }
 
     void create_devices(const std::size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) {
-        const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         const chip_id_t mmio_device_id = 0;
         std::vector<chip_id_t> chip_ids;
         if (tt::tt_metal::MetalContext::instance().get_cluster().get_board_type(0) == BoardType::UBB) {
@@ -156,7 +158,8 @@ protected:
             chip_ids.push_back(id);
         }
 
-        const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         reserved_devices_ = tt::tt_metal::detail::CreateDevices(
             chip_ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
         for (const auto& [id, device] : reserved_devices_) {

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -48,7 +48,8 @@ protected:
     }
 
     void create_devices(const std::vector<chip_id_t>& device_ids) {
-        const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         tt::DevicePool::initialize(device_ids, 1, l1_small_size_, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
         this->devices_ = tt::DevicePool::instance().get_all_active_devices();
         this->num_devices_ = this->devices_.size();

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -84,10 +84,11 @@ protected:
             }
             ids.push_back(id);
         }
-        const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         tt::DevicePool::initialize(
             ids,
-            tt::llrt::RunTimeOptions::get_instance().get_num_hw_cqs(),
+            tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs(),
             l1_small_size_,
             DEFAULT_TRACE_REGION_SIZE,
             dispatch_core_config);

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/device_pool.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "llrt.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/mesh_device.hpp>
 
 #include "dispatch_fixture.hpp"
@@ -45,7 +46,8 @@ protected:
                 ids.push_back(id);
             }
 
-            const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+            const auto& dispatch_core_config =
+                tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
             tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
             this->devices_ = tt::DevicePool::instance().get_all_active_devices();
         } else {
@@ -75,7 +77,8 @@ protected:
                 ids.push_back(id);
             }
 
-            const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+            const auto& dispatch_core_config =
+                tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
             tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
             this->devices_ = tt::DevicePool::instance().get_all_active_devices();
         } else {

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -19,7 +19,7 @@ class DebugToolsFixture : public DispatchFixture {
 
     void TearDown() override {
         DispatchFixture::TearDown();
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_enabled(watcher_previous_enabled);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(watcher_previous_enabled);
     }
 
     template <typename T>
@@ -49,19 +49,19 @@ protected:
         // The core range (virtual) needs to be set >= the set of all cores
         // used by all tests using this fixture, so set dprint enabled for
         // all cores and all devices
-        tt::llrt::RunTimeOptions::get_instance().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, true);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_prepend_device_core_risc(
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
             tt::llrt::RunTimeDebugFeatureDprint, false);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_all_cores(
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassWorker);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_all_cores(
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassWorker);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, true);
         // Send output to a file so the test can check after program is run.
-        tt::llrt::RunTimeOptions::get_instance().set_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint, dprint_file_name);
-        tt::llrt::RunTimeOptions::get_instance().set_test_mode_enabled(true);
-        watcher_previous_enabled = tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled();
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_enabled(false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint, dprint_file_name);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
+        watcher_previous_enabled = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(false);
 
         ExtraSetUp();
 
@@ -77,17 +77,17 @@ protected:
         std::remove(dprint_file_name.c_str());
 
         // Reset DPrint settings
-        tt::llrt::RunTimeOptions::get_instance().set_feature_cores(tt::llrt::RunTimeDebugFeatureDprint, {});
-        tt::llrt::RunTimeOptions::get_instance().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, false);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_all_cores(
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(tt::llrt::RunTimeDebugFeatureDprint, {});
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::WORKER, tt::llrt::RunTimeDebugClassNoneSpecified);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_all_cores(
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_cores(
             tt::llrt::RunTimeDebugFeatureDprint, CoreType::ETH, tt::llrt::RunTimeDebugClassNoneSpecified);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, false);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint, "");
-        tt::llrt::RunTimeOptions::get_instance().set_feature_prepend_device_core_risc(
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint, "");
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
             tt::llrt::RunTimeDebugFeatureDprint, true);
-        tt::llrt::RunTimeOptions::get_instance().set_test_mode_enabled(false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(false);
     }
 
     void RunTestOnDevice(
@@ -109,8 +109,8 @@ class DPrintDisableDevicesFixture : public DPrintFixture {
 protected:
     void ExtraSetUp() override {
         // For this test, mute each devices using the environment variable
-        tt::llrt::RunTimeOptions::get_instance().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, false);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint, {});
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint, false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint, {});
     }
 };
 
@@ -143,20 +143,20 @@ protected:
     bool test_mode_previous;
     void SetUp() override {
         // Enable watcher for this test, save the previous state so we can restore it later.
-        watcher_previous_enabled = tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled();
-        watcher_previous_interval = tt::llrt::RunTimeOptions::get_instance().get_watcher_interval();
-        watcher_previous_dump_all = tt::llrt::RunTimeOptions::get_instance().get_watcher_dump_all();
-        watcher_previous_append = tt::llrt::RunTimeOptions::get_instance().get_watcher_append();
-        watcher_previous_auto_unpause = tt::llrt::RunTimeOptions::get_instance().get_watcher_auto_unpause();
-        watcher_previous_noinline = tt::llrt::RunTimeOptions::get_instance().get_watcher_noinline();
-        test_mode_previous = tt::llrt::RunTimeOptions::get_instance().get_test_mode_enabled();
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_enabled(true);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_interval(interval_ms);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_dump_all(false);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_append(false);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_auto_unpause(true);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_noinline(true);
-        tt::llrt::RunTimeOptions::get_instance().set_test_mode_enabled(true);
+        watcher_previous_enabled = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled();
+        watcher_previous_interval = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_interval();
+        watcher_previous_dump_all = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_dump_all();
+        watcher_previous_append = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_append();
+        watcher_previous_auto_unpause = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_auto_unpause();
+        watcher_previous_noinline = tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline();
+        test_mode_previous = tt::tt_metal::MetalContext::instance().rtoptions().get_test_mode_enabled();
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_interval(interval_ms);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_dump_all(false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_append(false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_auto_unpause(true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noinline(true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(true);
         tt::watcher_clear_log();
 
         // Parent class initializes devices and any necessary flags
@@ -168,12 +168,12 @@ protected:
         DebugToolsFixture::TearDown();
 
         // Reset watcher settings to their previous values
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_interval(watcher_previous_interval);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_dump_all(watcher_previous_dump_all);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_append(watcher_previous_append);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_auto_unpause(watcher_previous_auto_unpause);
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_noinline(watcher_previous_noinline);
-        tt::llrt::RunTimeOptions::get_instance().set_test_mode_enabled(test_mode_previous);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_interval(watcher_previous_interval);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_dump_all(watcher_previous_dump_all);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_append(watcher_previous_append);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_auto_unpause(watcher_previous_auto_unpause);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_noinline(watcher_previous_noinline);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(test_mode_previous);
         tt::watcher_server_set_error_flag(false);
     }
 
@@ -196,19 +196,19 @@ public:
     std::map<CoreType, std::vector<CoreCoord>> delayed_cores;
 
     void SetUp() override {
-        tt::llrt::RunTimeOptions::get_instance().set_watcher_debug_delay(5000000);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_watcher_debug_delay(5000000);
         delayed_cores[CoreType::WORKER] = {{0, 0}, {1, 1}};
 
         // Store the previous state of the watcher features
-        saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay] = tt::llrt::RunTimeOptions::get_instance().get_feature_targets(tt::llrt::RunTimeDebugFeatureReadDebugDelay);
-        saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay] = tt::llrt::RunTimeOptions::get_instance().get_feature_targets(tt::llrt::RunTimeDebugFeatureWriteDebugDelay);
-        saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay] = tt::llrt::RunTimeOptions::get_instance().get_feature_targets(tt::llrt::RunTimeDebugFeatureAtomicDebugDelay);
+        saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay] = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(tt::llrt::RunTimeDebugFeatureReadDebugDelay);
+        saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay] = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(tt::llrt::RunTimeDebugFeatureWriteDebugDelay);
+        saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay] = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_targets(tt::llrt::RunTimeDebugFeatureAtomicDebugDelay);
 
         // Enable read and write debug delay for the test core
-        tt::llrt::RunTimeOptions::get_instance().set_feature_enabled(tt::llrt::RunTimeDebugFeatureReadDebugDelay, true);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_cores(tt::llrt::RunTimeDebugFeatureReadDebugDelay, delayed_cores);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_enabled(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, true);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_cores(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, delayed_cores);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureReadDebugDelay, true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(tt::llrt::RunTimeDebugFeatureReadDebugDelay, delayed_cores);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, delayed_cores);
 
         // Call parent
         WatcherFixture::SetUp();
@@ -219,9 +219,9 @@ public:
         WatcherFixture::TearDown();
 
         // Restore
-        tt::llrt::RunTimeOptions::get_instance().set_feature_targets(tt::llrt::RunTimeDebugFeatureReadDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay]);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_targets(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay]);
-        tt::llrt::RunTimeOptions::get_instance().set_feature_targets(tt::llrt::RunTimeDebugFeatureAtomicDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay]);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(tt::llrt::RunTimeDebugFeatureReadDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureReadDebugDelay]);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(tt::llrt::RunTimeDebugFeatureWriteDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureWriteDebugDelay]);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_targets(tt::llrt::RunTimeDebugFeatureAtomicDebugDelay, saved_target_selection[tt::llrt::RunTimeDebugFeatureAtomicDebugDelay]);
     }
 };
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_invalid_print_core.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_invalid_print_core.cpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include "debug_tools_fixture.hpp"
 #include "gtest/gtest.h"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/tt_core_coordinates.h"
 #include "umd/device/types/xy_pair.h"
 
@@ -27,12 +27,13 @@ TEST_F(DPrintFixture, TensixTestPrintInvalidCore) {
     // device setup, but not the print server should simply ignore the invalid cores.
     std::map<CoreType, std::vector<CoreCoord>> dprint_cores;
     dprint_cores[CoreType::WORKER] = {{0, 0}, {1, 1}, {100, 100}};
-    tt::llrt::RunTimeOptions::get_instance().set_feature_cores(tt::llrt::RunTimeDebugFeatureDprint, dprint_cores);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_cores(
+        tt::llrt::RunTimeDebugFeatureDprint, dprint_cores);
 
     // We expect that even though illegal worker cores were requested, device setup did not hang.
     // So just make sure that device setup worked and then close the device.
     for (IDevice* device : this->devices_) {
         EXPECT_TRUE(device != nullptr);
     }
-    tt::llrt::RunTimeOptions::get_instance().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint, false);
 }

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
@@ -21,7 +21,7 @@
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt {
@@ -182,19 +182,19 @@ static void RunTest(DPrintFixture* fixture, IDevice* device) {
     // failing test cases, although all three kernels simply print.
     KernelHandle brisc_print_kernel_id = CreateKernel(
         program,
-        llrt::RunTimeOptions::get_instance().get_root_dir() +
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
             "tests/tt_metal/tt_metal/test_kernels/misc/brisc_print.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
     KernelHandle ncrisc_print_kernel_id = CreateKernel(
         program,
-        llrt::RunTimeOptions::get_instance().get_root_dir() +
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
             "tests/tt_metal/tt_metal/test_kernels/misc/ncrisc_print.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
     KernelHandle trisc_print_kernel_id = CreateKernel(
         program,
-        llrt::RunTimeOptions::get_instance().get_root_dir() +
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
             "tests/tt_metal/tt_metal/test_kernels/misc/trisc_print.cpp",
         core,
         ComputeConfig{});

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -22,7 +22,7 @@
 #include "gtest/gtest.h"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 
@@ -100,18 +100,18 @@ static void RunTest(DPrintFixture* fixture, IDevice* device, const bool add_acti
 }  // namespace
 
 TEST_F(DPrintFixture, TensixTestPrintPrependDeviceCoreRisc) {
-    tt::llrt::RunTimeOptions::get_instance().set_feature_prepend_device_core_risc(
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, true);
     for (IDevice* device : this->devices_) {
         this->RunTestOnDevice(
             [](DPrintFixture* fixture, IDevice* device) { CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, device); }, device);
     }
-    tt::llrt::RunTimeOptions::get_instance().set_feature_prepend_device_core_risc(
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, false);
 }
 
 TEST_F(DPrintFixture, TensixActiveEthTestPrintPrependDeviceCoreRisc) {
-    tt::llrt::RunTimeOptions::get_instance().set_feature_prepend_device_core_risc(
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, true);
     for (IDevice* device : this->devices_) {
         if (device->get_active_ethernet_cores(true).empty()) {
@@ -122,6 +122,6 @@ TEST_F(DPrintFixture, TensixActiveEthTestPrintPrependDeviceCoreRisc) {
             [](DPrintFixture* fixture, IDevice* device) { CMAKE_UNIQUE_NAMESPACE::RunTest(fixture, device, true); },
             device);
     }
-    tt::llrt::RunTimeOptions::get_instance().set_feature_prepend_device_core_risc(
+    tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, false);
 }

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
@@ -29,8 +29,8 @@
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/util.hpp>
@@ -245,19 +245,19 @@ static void RunTest(DPrintFixture* fixture, IDevice* device, tt::DataFormat data
     // Create kernels on device
     KernelHandle brisc_print_kernel_id = CreateKernel(
         program,
-        llrt::RunTimeOptions::get_instance().get_root_dir() +
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
             "tests/tt_metal/tt_metal/test_kernels/misc/print_tile_brisc.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
     KernelHandle ncrisc_print_kernel_id = CreateKernel(
         program,
-        llrt::RunTimeOptions::get_instance().get_root_dir() +
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
             "tests/tt_metal/tt_metal/test_kernels/misc/print_tile_ncrisc.cpp",
         core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
     KernelHandle trisc_print_kernel_id = CreateKernel(
         program,
-        llrt::RunTimeOptions::get_instance().get_root_dir() +
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() +
             "tests/tt_metal/tt_metal/test_kernels/misc/print_tile_trisc.cpp",
         core,
         ComputeConfig{});

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -31,7 +31,7 @@
 #include "llrt.hpp"
 // Do we really want to expose Hal like this?
 // This looks like an API level test
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
@@ -78,7 +78,8 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     // For ethernet core, need to have smaller buffer at a different address
     if (is_eth_core) {
         l1_buffer_size = 1024;
-        l1_buffer_addr = hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
+        l1_buffer_addr = MetalContext::instance().hal().get_dev_addr(
+            HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     }
 
     tt_metal::InterleavedBufferConfig l1_config{
@@ -148,10 +149,13 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
             // This is illegal because we'd be writing to the mailbox memory
             if (is_eth_core) {
                 l1_buffer_addr = std::min(
-                    hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::MAILBOX),
-                    hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::MAILBOX));
+                    MetalContext::instance().hal().get_dev_addr(
+                        HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::MAILBOX),
+                    MetalContext::instance().hal().get_dev_addr(
+                        HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::MAILBOX));
             } else {
-                l1_buffer_addr = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::MAILBOX);
+                l1_buffer_addr = MetalContext::instance().hal().get_dev_addr(
+                    HalProgrammableCoreType::TENSIX, HalL1MemAddrType::MAILBOX);
             }
             break;
         default:

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -276,17 +276,17 @@ TEST_F(DeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
     EXPECT_TRUE(device->is_mmio_capable());
     CoreCoord logical_core(0, 0);
 
-    uint32_t base_l1_src_address =
-        device->allocator()->get_base_allocator_addr(HalMemType::L1) + hal_ref.get_alignment(HalMemType::L1);
+    uint32_t base_l1_src_address = device->allocator()->get_base_allocator_addr(HalMemType::L1) +
+                                   MetalContext::instance().hal().get_alignment(HalMemType::L1);
     // This is a slow dispatch test dispatch core type is needed to query DispatchMemMap
     uint32_t base_pcie_dst_address =
         DispatchMemMap::get(CoreType::WORKER).get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED) +
-        hal_ref.get_alignment(HalMemType::L1);
+        MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
     uint32_t size_bytes = 2048 * 128;
     std::vector<uint32_t> src = generate_uniform_random_vector<uint32_t>(0, UINT32_MAX, size_bytes / sizeof(uint32_t));
-    EXPECT_EQ(hal_ref.get_alignment(HalMemType::L1), 16);
-    uint32_t num_16b_writes = size_bytes / hal_ref.get_alignment(HalMemType::L1);
+    EXPECT_EQ(MetalContext::instance().hal().get_alignment(HalMemType::L1), 16);
+    uint32_t num_16b_writes = size_bytes / MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
     tt_metal::detail::WriteToDeviceL1(device, logical_core, base_l1_src_address, src);
 

--- a/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_init_and_teardown.cpp
@@ -17,7 +17,7 @@
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/env_vars.hpp"
@@ -94,7 +94,7 @@ TEST_P(DeviceParamFixture, DeviceInitializeAndTeardown) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {
@@ -113,7 +113,7 @@ TEST_P(DeviceParamFixture, TensixDeviceLoadBlankKernels) {
     for (unsigned int id = 0; id < num_devices; id++) {
         ids.push_back(id);
     }
-    const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
     for (auto device : devices) {

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/allocator_types.hpp>
 #include <tt-metalium/device.hpp>
 #include "hostdevcommon/common_values.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 
 namespace tt::tt_metal {
@@ -23,7 +23,7 @@ TEST(DevicePool, DevicePoolOpenClose) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    const auto& dispatch_core_config = llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
@@ -52,7 +52,7 @@ TEST(DevicePool, DevicePoolReconfigDevices) {
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
     int worker_l1_size = 0;
-    const auto& dispatch_core_config = llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
@@ -90,7 +90,7 @@ TEST(DevicePool, DevicePoolAddDevices) {
     std::vector<chip_id_t> device_ids{0};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    const auto& dispatch_core_config = llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {
@@ -124,7 +124,7 @@ TEST(DevicePool, DevicePoolReduceDevices) {
     std::vector<chip_id_t> device_ids{0, 1, 2, 3};
     int num_hw_cqs = 1;
     int l1_small_size = 1024;
-    const auto& dispatch_core_config = llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     DevicePool::initialize(device_ids, num_hw_cqs, l1_small_size, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = DevicePool::instance().get_all_active_devices();
     for (const auto& dev : devices) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -24,7 +24,6 @@
 #include "gtest/gtest.h"
 #include "impl/debug/watcher_server.hpp"
 #include <tt-metalium/logger.hpp>
-#include "rtoptions.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
@@ -146,7 +145,8 @@ TEST_F(CommandQueueEventFixture, TestEventsEnqueueRecordEventAndSynchronize) {
 // Negative test. Host syncing on a future event that isn't actually issued.
 // Ensure that expected hang is seen, which indicates event sync feature is working properly.
 TEST_F(CommandQueueEventFixture, TestEventsEnqueueRecordEventAndSynchronizeHang) {
-    tt::llrt::RunTimeOptions::get_instance().set_test_mode_enabled(true);  // Required for finish hang breakout.
+    tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(
+        true);  // Required for finish hang breakout.
 
     auto future_event = std::make_shared<Event>();
     EnqueueRecordEvent(this->device_->command_queue(), future_event);
@@ -177,7 +177,8 @@ TEST_F(CommandQueueEventFixture, TestEventsEnqueueRecordEventAndSynchronizeHang)
 TEST_F(CommandQueueEventFixture, TestEventsQueueWaitForEventHang) {
     // Skip this test until #7216 is implemented.
     GTEST_SKIP();
-    tt::llrt::RunTimeOptions::get_instance().set_test_mode_enabled(true);  // Required for finish hang breakout.
+    tt::tt_metal::MetalContext::instance().rtoptions().set_test_mode_enabled(
+        true);  // Required for finish hang breakout.
 
     auto future_event = std::make_shared<Event>();
     EnqueueRecordEvent(this->device_->command_queue(), future_event);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -39,7 +39,6 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include "llrt.hpp"
-#include "llrt/hal.hpp"
 #include <tt-metalium/logger.hpp>
 #include "multi_command_queue_fixture.hpp"
 #include <tt-metalium/program.hpp>
@@ -231,7 +230,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args(IDevice* device, const CoreCoor
     auto eth_noc_xy = device->ethernet_core_from_logical_core(eth_core_coord);
 
     constexpr uint32_t num_runtime_args0 = 9;
-    uint32_t rta_base0 = hal_ref.get_dev_addr(
+    uint32_t rta_base0 = MetalContext::instance().hal().get_dev_addr(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
     std::map<string, string> dummy_defines0 = {
         {"DATA_MOVEMENT", "1"},
@@ -254,7 +253,7 @@ bool test_dummy_EnqueueProgram_with_runtime_args(IDevice* device, const CoreCoor
     vector<uint32_t> dummy_kernel0_args_readback = tt::llrt::read_hex_vec_from_core(
         device->id(),
         eth_noc_xy,
-        hal_ref.get_dev_addr(
+        MetalContext::instance().hal().get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED),
         dummy_kernel0_args.size() * sizeof(uint32_t));
 
@@ -324,12 +323,13 @@ bool test_dummy_EnqueueProgram_with_sems(
         for (const CoreCoord& core_coord : core_range) {
             vector<uint32_t> semaphore_vals;
             uint32_t expected_semaphore_vals_for_core_idx = 0;
-            const uint32_t semaphore_buffer_size = program_config.num_sems * hal_ref.get_alignment(HalMemType::L1);
+            const uint32_t semaphore_buffer_size =
+                program_config.num_sems * MetalContext::instance().hal().get_alignment(HalMemType::L1);
             uint32_t semaphore_base = program.get_sem_base_addr(device, core_coord, CoreType::WORKER);
             tt::tt_metal::detail::ReadFromDeviceL1(
                 device, core_coord, semaphore_base, semaphore_buffer_size, semaphore_vals);
             for (uint32_t i = 0; i < semaphore_vals.size();
-                 i += (hal_ref.get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
+                 i += (MetalContext::instance().hal().get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
                 const bool is_semaphore_value_correct =
                     semaphore_vals[i] == expected_semaphore_vals_for_core[expected_semaphore_vals_for_core_idx];
                 expected_semaphore_vals_for_core_idx++;
@@ -821,7 +821,7 @@ std::pair<uint32_t, uint32_t> get_args_addr(const IDevice* device, const tt::RIS
         case tt::RISCV::ERISC: {
             HalProgrammableCoreType eth_core_type =
                 idle_eth ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
-            unique_args_addr = hal_ref.get_dev_addr(eth_core_type, HalL1MemAddrType::UNRESERVED);
+            unique_args_addr = MetalContext::instance().hal().get_dev_addr(eth_core_type, HalL1MemAddrType::UNRESERVED);
             common_args_addr = unique_args_addr + 1 * 256 * sizeof(uint32_t);
             break;
         } break;

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -23,7 +23,6 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include "llrt/hal.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
@@ -90,7 +89,7 @@ static void test_sems_across_core_types(
 
             // Set up args
             vector<uint32_t> eth_rtas = {
-                tt::tt_metal::hal_ref.noc_xy_encoding(phys_tensix_core.x, phys_tensix_core.y),
+                tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_tensix_core.x, phys_tensix_core.y),
                 eth_sem_id,
                 tensix_sem_id,
                 eth_sem_init_val,
@@ -106,7 +105,7 @@ static void test_sems_across_core_types(
             SetRuntimeArgs(program, eth_kernel, eth_core, eth_rtas);
 
             vector<uint32_t> tensix_rtas = {
-                tt::tt_metal::hal_ref.noc_xy_encoding(phys_eth_core.x, phys_eth_core.y),
+                tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_eth_core.x, phys_eth_core.y),
                 tensix_sem_id,
                 eth_sem_id,
                 tensix_sem_init_val,

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -26,8 +26,8 @@
 #include "llrt/hal.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "umd/device/tt_core_coordinates.h"
@@ -293,12 +293,12 @@ TEST_F(DispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
 
 class EarlyReturnFixture : public DispatchFixture {
     void SetUp() override {
-        tt::llrt::RunTimeOptions::get_instance().set_kernels_early_return(true);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_early_return(true);
         DispatchFixture::SetUp();
     }
     void TearDown() override {
         DispatchFixture::TearDown();
-        tt::llrt::RunTimeOptions::get_instance().set_kernels_early_return(false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_early_return(false);
     }
 };
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
@@ -96,7 +96,8 @@ std::shared_ptr<Program> create_program_multi_core_rta(
     uint32_t rta_base_dm1 = rta_base_dm0 + 1024 * sizeof(uint32_t);
     uint32_t rta_base_compute = rta_base_dm1 + 2048 * sizeof(uint32_t);
 
-    uint32_t coord_base_dm0 = tt::align(base_addr + 4096 * sizeof(uint32_t), hal_ref.get_alignment(HalMemType::L1));
+    uint32_t coord_base_dm0 =
+        tt::align(base_addr + 4096 * sizeof(uint32_t), MetalContext::instance().hal().get_alignment(HalMemType::L1));
     uint32_t coord_base_dm1 = coord_base_dm0 + 1024 * sizeof(uint32_t);
 
     std::map<string, string> dm_defines0 = {
@@ -221,9 +222,10 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
     uint32_t rta_base_compute = rta_base_dm1 + 2048 * sizeof(uint32_t);
 
     // Put the coordinates way above the maximum RTAs
-    uint32_t coord_base_dm0 = tt::align(rta_base_addr + 4096 * sizeof(uint32_t), hal_ref.get_alignment(HalMemType::L1));
+    uint32_t coord_base_dm0 = tt::align(
+        rta_base_addr + 4096 * sizeof(uint32_t), MetalContext::instance().hal().get_alignment(HalMemType::L1));
     uint32_t coord_base_dm1 = coord_base_dm0 + 1024 * sizeof(uint32_t);
-    uint32_t semaphore_buffer_size = dummy_sems.size() * hal_ref.get_alignment(HalMemType::L1);
+    uint32_t semaphore_buffer_size = dummy_sems.size() * MetalContext::instance().hal().get_alignment(HalMemType::L1);
     uint32_t cb_config_buffer_size =
         NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     for (auto device : devices_) {
@@ -308,7 +310,7 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
             uint32_t sem_base_addr = program->get_sem_base_addr(devices_[0], core_coord, CoreType::WORKER);
             detail::ReadFromDeviceL1(device, core_coord, sem_base_addr, semaphore_buffer_size, semaphore_vals);
             for (uint32_t i = 0; i < semaphore_vals.size();
-                 i += (hal_ref.get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
+                 i += (MetalContext::instance().hal().get_alignment(HalMemType::L1) / sizeof(uint32_t))) {
                 EXPECT_EQ(semaphore_vals[i], dummy_sems[expected_sem_idx]) << expected_sem_idx;
                 expected_sem_idx++;
             }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -13,7 +13,6 @@
 
 #include "gtest/gtest.h"
 #include <tt-metalium/hal_types.hpp>
-#include "llrt/hal.hpp"
 #include "impl/context/metal_context.hpp"
 #include "umd/device/tt_core_coordinates.h"
 
@@ -25,8 +24,8 @@ void ForEachCoreTypeXHWCQs(const std::function<void(const CoreType& core_type, c
     const auto num_hw_cqs_to_test = std::array<uint32_t, 2>{1, 2};
 
     for (const auto& core_type : core_types_to_test) {
-        if (core_type == CoreType::ETH &&
-            hal_ref.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
+        if (core_type == CoreType::ETH && MetalContext::instance().hal().get_programmable_core_type_index(
+                                              tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
             // This device does not have the eth core
             tt::log_info(tt::LogTest, "IDLE_ETH core type is not on this device");
             continue;
@@ -117,7 +116,8 @@ TEST(DispatchSettingsTest, TestDispatchSettingsSetTunnelerBuffer) {
 }
 
 TEST(DispatchSettingsTest, TestDispatchSettingsMutations) {
-    if (hal_ref.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
+    if (MetalContext::instance().hal().get_programmable_core_type_index(
+            tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
         // This device does not have the eth core
         tt::log_info(tt::LogTest, "Test not supported on this device");
         return;

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -15,7 +15,7 @@
 #include "tt_metal/test_utils/env_vars.hpp"
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 
@@ -24,7 +24,7 @@ protected:
     void SetUp() override {
         this->validate_dispatch_mode();
 
-        this->num_cqs_ = tt::llrt::RunTimeOptions::get_instance().get_num_hw_cqs();
+        this->num_cqs_ = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
         if (this->num_cqs_ != 2) {
             tt::log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
@@ -90,7 +90,7 @@ protected:
     void SetUp() override {
         this->validate_dispatch_mode();
 
-        this->num_cqs_ = tt::llrt::RunTimeOptions::get_instance().get_num_hw_cqs();
+        this->num_cqs_ = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
         if (this->num_cqs_ != 2) {
             tt::log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
@@ -120,7 +120,7 @@ protected:
             GTEST_SKIP();
         }
 
-        auto num_cqs = tt::llrt::RunTimeOptions::get_instance().get_num_hw_cqs();
+        auto num_cqs = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
         if (num_cqs != 2) {
             tt::log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -8,7 +8,6 @@
 #include "dispatch_fixture.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include <tt-metalium/device_impl.hpp>
-#include "llrt/hal.hpp"
 #include "umd/device/types/cluster_descriptor_types.h"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -7,12 +7,12 @@
 #include "command_queue_fixture.hpp"
 #include "env_lib.hpp"
 #include <tt-metalium/device_impl.hpp>
-#include "llrt/hal.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/circular_buffer_constants.h>
 #include <tt-metalium/kernel.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include "impl/context/metal_context.hpp"
 #include "dispatch_test_utils.hpp"
 
 namespace tt::tt_metal {

--- a/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
@@ -6,7 +6,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/global_semaphore.hpp>
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 
@@ -102,7 +102,7 @@ inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_eth_s
         syncer_core_physical.y,
         tensix_waiter_core_physical.x,
         tensix_waiter_core_physical.y,
-        hal_ref.get_dev_addr(tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED)
+        MetalContext::instance().hal().get_dev_addr(tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED)
     };
     SetRuntimeArgs(waiter_program, waiter_kernel, waiter_core, waiter_rt_args);
 

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -402,7 +402,8 @@ TEST_F(N300DeviceFixture, ActiveEthKernelsNocWriteNoReceive) {
 // TODO #14640: Run this on WH when i$ flush issue is addressed
 TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc0) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
-    uint32_t eth_l1_address = hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
+    uint32_t eth_l1_address =
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
     tt_metal::EthernetConfig noc0_ethernet_config{
         .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = tt_metal::DataMovementProcessor::RISCV_0};
     tt_metal::EthernetConfig noc1_ethernet_config{
@@ -442,7 +443,8 @@ TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc0) {
 
 TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc1) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
-    uint32_t eth_l1_address = hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
+    uint32_t eth_l1_address =
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
     tt_metal::EthernetConfig noc0_ethernet_config{
         .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = tt_metal::DataMovementProcessor::RISCV_1};
     tt_metal::EthernetConfig noc1_ethernet_config{
@@ -483,7 +485,8 @@ TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnIdleErisc1) {
 TEST_F(BlackholeSingleCardFixture, IdleEthKernelOnBothIdleEriscs) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     uint32_t read_write_size_bytes = WORD_SIZE * 2048;
-    uint32_t reader_dst_address = hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
+    uint32_t reader_dst_address =
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED);
     uint32_t writer_src_address = reader_dst_address + read_write_size_bytes;
     tt_metal::EthernetConfig erisc0_ethernet_config{
         .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .processor = tt_metal::DataMovementProcessor::RISCV_0};

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -249,8 +249,8 @@ bool send_over_eth(
         receiver_device->id(), receiver_core, args_1, eth_l1_mem::address_map::ERISC_APP_SYNC_INFO_BASE);
 
     // TODO: this should be updated to use kernel api
-    uint32_t active_eth_index =
-        tt_metal::hal_ref.get_programmable_core_type_index(tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
+    uint32_t active_eth_index = tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
+        tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
     auto sender_firmware_path = tt_metal::BuildEnvManager::get_instance()
                                     .get_firmware_build_state(sender_device->build_id(), active_eth_index, 0, 0)
                                     .get_target_out_path("");

--- a/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
+++ b/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
@@ -7,7 +7,7 @@
 #include "dispatch_fixture.hpp"
 #include "env_lib.hpp"
 #include <tt-metalium/device_impl.hpp>
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <circular_buffer_constants.h>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -36,7 +36,7 @@
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
-#include "get_platform_architecture.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/logger.hpp>
@@ -525,7 +525,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         int device_id = 0;
         tt_metal::DispatchCoreConfig dispatch_core_config;
-        if (tt::tt_metal::get_platform_architecture() == tt::ARCH::GRAYSKULL) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().arch() == tt::ARCH::GRAYSKULL) {
             dispatch_core_config =
                 tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER, tt_metal::DispatchCoreAxis::ROW};
         } else {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/common/util.hpp
@@ -11,7 +11,7 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/host_api.hpp>
 #include "hostdevcommon/dprint_common.h"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "llrt.hpp"
 
 inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, const tt::tt_metal::Program& program) {
@@ -20,12 +20,12 @@ inline uint64_t get_t0_to_any_riscfw_end_cycle(tt::tt_metal::IDevice* device, co
     enum BufferIndex { BUFFER_END_INDEX, DROPPED_MARKER_COUNTER, MARKER_DATA_START };
     enum TimerDataIndex { TIMER_ID, TIMER_VAL_L, TIMER_VAL_H, TIMER_DATA_UINT32_SIZE };
     auto worker_cores_used_in_program = device->worker_cores_from_logical_cores(
-        program.logical_cores()[tt::tt_metal::hal_ref.get_programmable_core_type_index(
+        program.logical_cores()[tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
             tt::tt_metal::HalProgrammableCoreType::TENSIX)]);
     auto device_id = device->id();
     uint64_t min_cycle = -1;
     uint64_t max_cycle = 0;
-    dprint_buf_msg_t* dprint_msg = tt::tt_metal::hal_ref.get_dev_addr<dprint_buf_msg_t*>(
+    dprint_buf_msg_t* dprint_msg = tt::tt_metal::MetalContext::instance().hal().get_dev_addr<dprint_buf_msg_t*>(
         tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DPRINT);
 
     // This works for tensix only, will need to be updated for eth

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -37,7 +37,6 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
@@ -725,7 +724,7 @@ int main(int argc, char** argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "test_dispatcher.cpp - Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/semaphore.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/system_memory_manager.hpp>
@@ -385,7 +385,7 @@ static int pgm_dispatch(T& state, TestInfo info) {
         }
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(true);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(true);
 
     bool pass = true;
     try {
@@ -470,7 +470,7 @@ static int pgm_dispatch(T& state, TestInfo info) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -46,7 +46,6 @@
 #include <tt-metalium/logger.hpp>
 #include "noc/noc_parameters.h"
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
@@ -3775,7 +3774,7 @@ int main(int argc, char** argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "test_prefetcher.cpp - Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -42,7 +42,6 @@
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "llrt.hpp"
-#include "llrt/hal.hpp"
 #include <tt-metalium/logger.hpp>
 #include "noc/noc_parameters.h"
 #include <tt-metalium/program.hpp>
@@ -57,7 +56,8 @@
 #include "umd/device/types/xy_pair.h"
 #include <tt-metalium/utils.hpp>
 
-#define CQ_PREFETCH_CMD_BARE_MIN_SIZE tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST)
+#define CQ_PREFETCH_CMD_BARE_MIN_SIZE \
+    tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST)
 
 constexpr uint32_t DEFAULT_TEST_TYPE = 0;
 constexpr uint32_t DEVICE_DATA_SIZE = 768 * 1024;
@@ -268,7 +268,7 @@ void dirty_host_completion_buffer(uint32_t* host_hugepage_completion_buffer) {
 }
 
 uint32_t round_cmd_size_up(uint32_t size) {
-    uint32_t align_mask = hal_ref.get_alignment(HalMemType::HOST) - 1;
+    uint32_t align_mask = MetalContext::instance().hal().get_alignment(HalMemType::HOST) - 1;
 
     return (size + align_mask) & ~align_mask;
 }
@@ -515,7 +515,7 @@ void gen_dram_packed_read_cmd(
     int count = 0;
     for (auto length : lengths) {
         TT_ASSERT(length <= num_dram_banks_g * page_size);
-        TT_ASSERT((length & (hal_ref.get_alignment(HalMemType::DRAM) - 1)) == 0);
+        TT_ASSERT((length & (MetalContext::instance().hal().get_alignment(HalMemType::DRAM) - 1)) == 0);
         CQPrefetchRelayPagedPackedSubCmd sub_cmd;
         sub_cmd.start_page = 0;  // TODO: randomize?
         sub_cmd.log_page_size = log_page_size;
@@ -684,7 +684,7 @@ void gen_linear_read_cmd(
     for (uint32_t i = 0; i < length_words; i++) {
         device_data.push_one(worker_core, device_data.at(worker_core, bank_id, offset + i));
     }
-    device_data.pad(worker_core, bank_id, hal_ref.get_alignment(HalMemType::L1));
+    device_data.pad(worker_core, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
 }
 
 void gen_dispatcher_delay_cmd(
@@ -897,7 +897,7 @@ void gen_rnd_dram_paged_cmd(
     CoreCoord worker_core) {
     vector<uint32_t> dispatch_cmds;
 
-    const uint32_t dram_alignment = hal_ref.get_alignment(HalMemType::DRAM);
+    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
     uint32_t start_page = std::rand() % num_dram_banks_g;
     uint32_t max_page_size = big_g ? MAX_PAGE_SIZE : 4096;
     uint32_t page_size = (std::rand() % (max_page_size + 1)) & ~(dram_alignment - 1);
@@ -995,7 +995,7 @@ void gen_packed_read_test(
         uint32_t n_sub_cmds =
             relay_max_packed_paged_submcds ? CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS : (std::rand() % 7) + 1;
         uint32_t max_read_size = (1 << packed_read_page_size) * num_dram_banks_g;
-        auto dram_alignment = hal_ref.get_alignment(HalMemType::DRAM);
+        auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
         vector<uint32_t> lengths;
         uint32_t total_length = 0;
         for (uint32_t i = 0; i < n_sub_cmds; i++) {
@@ -1147,7 +1147,7 @@ void gen_ringbuffer_read_test(
     while (!done) {
         uint32_t ringbuffer_read_page_size_log2 = std::rand() % 3 + 9;  // log2 values. i.e., 512, 1024, 2048
         uint32_t max_read_size = (1 << ringbuffer_read_page_size_log2) * num_dram_banks_g;
-        auto dram_alignment = hal_ref.get_alignment(HalMemType::DRAM);
+        auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
         // arbitrary.
         uint32_t n_sub_cmds = (std::rand() % 7) + 1;
         vector<uint32_t> lengths;
@@ -1273,7 +1273,7 @@ void gen_smoke_test(
     CoreCoord another_worker_core) {
     vector<uint32_t> empty_payload;  // don't give me grief, it is just a test
     vector<uint32_t> dispatch_cmds;
-    const uint32_t dram_alignment = hal_ref.get_alignment(HalMemType::DRAM);
+    const uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
 
     if (!use_dram_exec_buf_g) {
         add_prefetcher_cmd(prefetch_cmds, cmd_sizes, CQ_PREFETCH_CMD_DEBUG, empty_payload);
@@ -1929,12 +1929,12 @@ void configure_for_single_chip(
     uint32_t dispatch_buffer_base = l1_buf_base_g;
     uint32_t prefetch_d_buffer_base = l1_buf_base_g;
     uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
-    dispatch_wait_addr_g = l1_unreserved_base_aligned + hal_ref.get_alignment(HalMemType::L1);
+    dispatch_wait_addr_g = l1_unreserved_base_aligned + MetalContext::instance().hal().get_alignment(HalMemType::L1);
     vector<uint32_t> zero_data(0);
     llrt::write_hex_vec_to_core(device->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 
     uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type);
-    uint32_t noc_read_alignment = hal_ref.get_alignment(HalMemType::HOST);
+    uint32_t noc_read_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
     uint32_t cmddat_q_base =
         prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
 
@@ -2659,12 +2659,12 @@ void configure_for_multi_chip(
     uint32_t prefetch_d_buffer_pages = prefetch_d_buffer_size_g >> DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
     prefetch_q_base = l1_buf_base_g;
     prefetch_q_rd_ptr_addr = l1_unreserved_base_aligned;
-    dispatch_wait_addr_g = l1_unreserved_base_aligned + hal_ref.get_alignment(HalMemType::L1);
+    dispatch_wait_addr_g = l1_unreserved_base_aligned + MetalContext::instance().hal().get_alignment(HalMemType::L1);
     vector<uint32_t> zero_data(0);
     llrt::write_hex_vec_to_core(device_r->id(), phys_dispatch_core, zero_data, dispatch_wait_addr_g);
 
     uint32_t prefetch_q_size = prefetch_q_entries_g * sizeof(DispatchSettings::prefetch_q_entry_type);
-    uint32_t noc_read_alignment = hal_ref.get_alignment(HalMemType::HOST);
+    uint32_t noc_read_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
     uint32_t cmddat_q_base =
         prefetch_q_base + ((prefetch_q_size + noc_read_alignment - 1) / noc_read_alignment * noc_read_alignment);
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -125,7 +125,8 @@ public:
         std::vector<chip_id_t> ids(this->num_devices, 0);
         std::iota(ids.begin(), ids.end(), 0);
 
-        const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+        const auto& dispatch_core_config =
+            tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
         tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
         this->devices = tt::DevicePool::instance().get_all_active_devices();
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -33,7 +33,6 @@
 
 #include <tt-metalium/persistent_kernel_cache.hpp>
 #include <thread>
-#include "llrt/hal.hpp"
 #include "impl/context/metal_context.hpp"
 
 #include "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/eth_ubenchmark_types.hpp"
@@ -295,7 +294,7 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
 
     // eth core rt args
     std::vector<uint32_t> eth_receiver_rt_args = {
-        tt_metal::hal_ref.get_dev_addr(
+        tt_metal::MetalContext::instance().hal().get_dev_addr(
             tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::UNRESERVED),
         static_cast<uint32_t>(params.num_packets),
         static_cast<uint32_t>(params.packet_size),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -29,7 +29,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -602,7 +602,7 @@ int main(int argc, char **argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -23,7 +23,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -614,7 +614,7 @@ int main(int argc, char **argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -40,7 +40,6 @@
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
-#include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_interface.h"
 // #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -36,8 +36,8 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
 
     try {
         const std::filesystem::path tg_mesh_graph_desc_path =
-            std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+            std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
             "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
         auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(tg_mesh_graph_desc_path.string());
         control_plane->write_routing_tables_to_all_chips();
@@ -647,7 +647,7 @@ int main(int argc, char** argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -377,7 +377,8 @@ int main(int argc, char** argv) {
             device_router_map[device.first] = device_router_phys_cores;
 
             gk_phys_core = (device.second->worker_core_from_logical_core(gk_core));
-            uint32_t gk_noc_offset = tt_metal::hal_ref.noc_xy_encoding(gk_phys_core.x, gk_phys_core.y);
+            uint32_t gk_noc_offset =
+                tt_metal::MetalContext::instance().hal().noc_xy_encoding(gk_phys_core.x, gk_phys_core.y);
 
             std::vector<uint32_t> router_compile_args = {
                 (tunneler_queue_size_bytes >> 4),  // 0: rx_queue_size_words
@@ -476,7 +477,8 @@ int main(int argc, char** argv) {
             };
 
             // setup runtime args
-            uint32_t tx_gk_noc_offset = tt_metal::hal_ref.noc_xy_encoding(tx_gk_phys_core.x, tx_gk_phys_core.y);
+            uint32_t tx_gk_noc_offset =
+                tt_metal::MetalContext::instance().hal().noc_xy_encoding(tx_gk_phys_core.x, tx_gk_phys_core.y);
             std::vector<uint32_t> runtime_args = {
                 time_seed,                                                              // 0: time based seed
                 (device_map[test_device_id_l]->id() << 8) + src_endpoint_start_id + i,  // 1: src_endpoint_id

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -650,7 +650,7 @@ typedef struct test_device {
 
     inline uint32_t get_noc_offset(CoreCoord& logical_core) {
         CoreCoord phys_core = device_handle->worker_core_from_logical_core(logical_core);
-        return tt_metal::hal_ref.noc_xy_encoding(phys_core.x, phys_core.y);
+        return tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_core.x, phys_core.y);
     }
 
     void get_available_router_cores(
@@ -920,7 +920,7 @@ typedef struct test_traffic {
         test_results_address = test_results_address_;
 
         {
-            uint32_t mcast_encoding = tt::tt_metal::hal_ref.noc_multicast_encoding(
+            uint32_t mcast_encoding = tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
                 tx_device->core_range_start_virtual.x,
                 tx_device->core_range_start_virtual.y,
                 tx_device->core_range_end_virtual.x,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -45,7 +45,6 @@
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
@@ -227,7 +226,7 @@ typedef struct test_board {
     void _init_control_plane(const std::string& mesh_graph_descriptor) {
         try {
             const std::filesystem::path mesh_graph_desc_path =
-                std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+                std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
                 "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
             cp_owning_ptr = std::make_unique<tt::tt_fabric::ControlPlane>(mesh_graph_desc_path.string());
             control_plane = cp_owning_ptr.get();
@@ -1852,7 +1851,7 @@ int main(int argc, char **argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -36,7 +36,6 @@
 #include <tt-metalium/metal_soc_descriptor.h>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
 #include <tt-metalium/system_memory_manager.hpp>
 #include "test_common.hpp"
@@ -263,7 +262,7 @@ int main(int argc, char** argv) {
 
     try {
         const std::filesystem::path tg_mesh_graph_desc_path =
-            std::filesystem::path(tt::llrt::RunTimeOptions::get_instance().get_root_dir()) /
+            std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
             "tt_fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
         auto control_plane = std::make_unique<tt::tt_fabric::ControlPlane>(tg_mesh_graph_desc_path.string());
 
@@ -682,7 +681,7 @@ int main(int argc, char** argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -380,7 +380,8 @@ int main(int argc, char** argv) {
             device_router_map[device.first] = device_router_phys_cores;
 
             gk_phys_core = (device.second->worker_core_from_logical_core(gk_core));
-            uint32_t gk_noc_offset = tt_metal::hal_ref.noc_xy_encoding(gk_phys_core.x, gk_phys_core.y);
+            uint32_t gk_noc_offset =
+                tt_metal::MetalContext::instance().hal().noc_xy_encoding(gk_phys_core.x, gk_phys_core.y);
 
             std::vector<uint32_t> router_compile_args = {
                 (tunneler_queue_size_bytes >> 4),  // 0: rx_queue_size_words

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
@@ -27,7 +27,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include <tt-metalium/utils.hpp>
@@ -265,7 +265,7 @@ int main(int argc, char **argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -1432,7 +1432,7 @@ int main(int argc, char** argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -1570,7 +1570,7 @@ int main(int argc, char** argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -1036,7 +1036,7 @@ int main(int argc, char **argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
@@ -29,7 +29,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -643,7 +643,7 @@ int main(int argc, char **argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
@@ -31,7 +31,7 @@
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include "routing_test_common.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "test_common.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include "umd/device/types/xy_pair.h"
@@ -838,7 +838,7 @@ int main(int argc, char **argv) {
         log_fatal(e.what());
     }
 
-    tt::llrt::RunTimeOptions::get_instance().set_kernels_nullified(false);
+    tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
         log_info(LogTest, "Test Passed");

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -26,8 +26,8 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/system_memory_manager.hpp>
 
 namespace tt {
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
         ids.push_back(id);
     }
 
-    const auto& dispatch_core_config = tt::llrt::RunTimeOptions::get_instance().get_dispatch_core_config();
+    const auto& dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
     tt::DevicePool::initialize(ids, 1, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, dispatch_core_config);
     const auto devices = tt::DevicePool::instance().get_all_active_devices();
 

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
             std::distance(std::filesystem::directory_iterator(binary_path), std::filesystem::directory_iterator{});
         TT_FATAL(num_built_kernels == 2, "Expected compute kernel test_compile_args to be compiled twice!");
 
-        if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
             // Test that the kernel_args.csv file was generated for both kernels
             log_info(LogTest, "Test kernel args logging");
             auto kernel_args_path = binary_path.parent_path() / "kernel_args.csv";

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -42,7 +42,7 @@
 #include "jit_build/build.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include "llrt.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -175,7 +175,8 @@ int main(int argc, char** argv) {
             ////////////////////////////////////////////////////////////////////////////
             // Check that binary memory objects in the kernel match the ones obtained from the persistent cache
             uint32_t programmable_core_index =
-                tt_metal::hal_ref.get_programmable_core_type_index(tt_metal::HalProgrammableCoreType::TENSIX);
+                tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
+                    tt_metal::HalProgrammableCoreType::TENSIX);
             const tt_metal::KernelGroup* kernel_group = program.kernels_on_core(core, programmable_core_index);
             TT_FATAL(
                 kernel_group != nullptr && kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].has_value() and
@@ -235,8 +236,9 @@ int main(int argc, char** argv) {
                                             .get_device_build_env(device->build_id())
                                             .build_key;
                         tt_metal::detail::CompileProgram(device, program);
-                        uint32_t programmable_core_index = tt_metal::hal_ref.get_programmable_core_type_index(
-                            tt_metal::HalProgrammableCoreType::TENSIX);
+                        uint32_t programmable_core_index =
+                            tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
+                                tt_metal::HalProgrammableCoreType::TENSIX);
                         const tt_metal::KernelGroup* kernel_group =
                             program.kernels_on_core(core, programmable_core_index);
                         auto compute_kernel = tt_metal::detail::GetKernel(

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -35,7 +35,7 @@
 #include <tt-metalium/hal_types.hpp>
 #include "hostdevcommon/kernel_structs.h"
 #include <tt-metalium/kernel_types.hpp>
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
@@ -96,7 +96,7 @@ void check_semaphores_are_initialized(
                     res);
                 std::vector<uint32_t> filtered_res;
                 static uint32_t num_u32_to_skip =
-                    tt_metal::hal_ref.get_alignment(tt_metal::HalMemType::L1) / sizeof(uint32_t);
+                    tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1) / sizeof(uint32_t);
                 for (int i = 0; i < res.size(); i += num_u32_to_skip) {
                     filtered_res.push_back(res.at(i));
                 }

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -28,7 +28,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/kernel_types.hpp>
-#include "llrt/hal.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
@@ -144,7 +143,7 @@ int main(int argc, char** argv) {
     }
 
     CoreCoord mcast_end = device->worker_core_from_logical_core(workers_logical.end_coord);
-    bool virtualization_enabled = tt::tt_metal::hal_ref.is_coordinate_virtualization_enabled();
+    bool virtualization_enabled = tt::tt_metal::MetalContext::instance().hal().is_coordinate_virtualization_enabled();
     uint32_t num_dests = workers_logical.size();
     CoreCoord virtual_offset = virtualization_enabled
                                    ? device->worker_core_from_logical_core({0, 0})
@@ -165,9 +164,9 @@ int main(int argc, char** argv) {
         N_RANDS,
         rnd_delay_g,
         device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
-        mcast_from_eth_g
-            ? tt::tt_metal::hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED)
-            : device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
+        mcast_from_eth_g ? tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+                               HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::UNRESERVED)
+                         : device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
     };
 
     KernelHandle ucast_kernel = tt_metal::CreateKernel(

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -37,7 +37,7 @@ enum DispatchWorkerType : uint32_t {
 
 enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };
 
-enum class DispatchCoreAxis { ROW, COL, COUNT };
+enum class DispatchCoreAxis { ROW, COL, COUNT, DEFAULT };
 
 class DispatchCoreConfig {
 private:
@@ -47,9 +47,9 @@ private:
     static DispatchCoreAxis get_default_axis();
 
 public:
-    DispatchCoreConfig() : type_(DispatchCoreType::WORKER), axis_(get_default_axis()) {}
+    DispatchCoreConfig() : type_(DispatchCoreType::WORKER), axis_(DispatchCoreAxis::DEFAULT) {}
 
-    DispatchCoreConfig(DispatchCoreType type) : type_(type), axis_(get_default_axis()) {}
+    DispatchCoreConfig(DispatchCoreType type) : type_(type), axis_(DispatchCoreAxis::DEFAULT) {}
 
     DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type_(type), axis_(axis) {}
 
@@ -68,7 +68,13 @@ public:
 
     void set_dispatch_core_type(DispatchCoreType new_type) { type_ = new_type; }
 
-    DispatchCoreAxis get_dispatch_core_axis() const { return axis_; }
+    DispatchCoreAxis get_dispatch_core_axis() const {
+        if (axis_ == DispatchCoreAxis::DEFAULT) {
+            return get_default_axis();
+        } else {
+            return axis_;
+        }
+    }
 
     void set_dispatch_core_axis(DispatchCoreAxis new_axis) { axis_ = new_axis; }
 

--- a/tt_metal/api/tt-metalium/dispatch_core_common.hpp
+++ b/tt_metal/api/tt-metalium/dispatch_core_common.hpp
@@ -37,19 +37,19 @@ enum DispatchWorkerType : uint32_t {
 
 enum class DispatchCoreType : uint32_t { WORKER, ETH, COUNT };
 
-enum class DispatchCoreAxis { ROW, COL, COUNT, DEFAULT };
+enum class DispatchCoreAxis { ROW, COL, COUNT };
 
 class DispatchCoreConfig {
 private:
     DispatchCoreType type_;
-    DispatchCoreAxis axis_;
+    std::optional<DispatchCoreAxis> axis_;
 
     static DispatchCoreAxis get_default_axis();
 
 public:
-    DispatchCoreConfig() : type_(DispatchCoreType::WORKER), axis_(DispatchCoreAxis::DEFAULT) {}
+    DispatchCoreConfig() : type_(DispatchCoreType::WORKER) {}
 
-    DispatchCoreConfig(DispatchCoreType type) : type_(type), axis_(DispatchCoreAxis::DEFAULT) {}
+    DispatchCoreConfig(DispatchCoreType type) : type_(type) {}
 
     DispatchCoreConfig(DispatchCoreType type, DispatchCoreAxis axis) : type_(type), axis_(axis) {}
 
@@ -68,13 +68,7 @@ public:
 
     void set_dispatch_core_type(DispatchCoreType new_type) { type_ = new_type; }
 
-    DispatchCoreAxis get_dispatch_core_axis() const {
-        if (axis_ == DispatchCoreAxis::DEFAULT) {
-            return get_default_axis();
-        } else {
-            return axis_;
-        }
-    }
+    DispatchCoreAxis get_dispatch_core_axis() const { return axis_.value_or(get_default_axis()); }
 
     void set_dispatch_core_axis(DispatchCoreAxis new_axis) { axis_ = new_axis; }
 

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -107,7 +107,7 @@ void MeshTraceDescriptor::assemble_dispatch_commands(
     MeshCoordinateRange bcast_device_range(mesh_device->shape());
     std::vector<uint32_t> exec_buf_end = {};
 
-    DeviceCommand command_sequence(hal_ref.get_alignment(HalMemType::HOST));
+    DeviceCommand command_sequence(MetalContext::instance().hal().get_alignment(HalMemType::HOST));
     command_sequence.add_prefetch_exec_buf_end();
 
     for (int i = 0; i < command_sequence.size_bytes() / sizeof(uint32_t); i++) {

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -60,8 +60,8 @@ std::optional<MeshCoordinateRange> find_intersection(
 MeshWorkload::MeshWorkload() {
     // A MeshWorkload tracks maintains its own handles to kernels across all
     // encapsulated programs
-    kernel_groups_.resize(hal_ref.get_programmable_core_type_count());
-    kernels_.resize(hal_ref.get_programmable_core_type_count());
+    kernel_groups_.resize(MetalContext::instance().hal().get_programmable_core_type_count());
+    kernels_.resize(MetalContext::instance().hal().get_programmable_core_type_count());
 }
 
 void MeshWorkload::add_program(const MeshCoordinateRange& device_range, Program&& program) {
@@ -300,7 +300,9 @@ uint32_t MeshWorkload::get_sem_base_addr(
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);
-    return base_addr + get_program_config(hal_ref.get_programmable_core_type_index(programmable_core_type)).sem_offset;
+    return base_addr +
+           get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
+               .sem_offset;
 }
 
 uint32_t MeshWorkload::get_sem_size(
@@ -323,7 +325,9 @@ uint32_t MeshWorkload::get_cb_base_addr(
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, mesh_device.get(), programmable_core_type);
-    return base_addr + get_program_config(hal_ref.get_programmable_core_type_index(programmable_core_type)).cb_offset;
+    return base_addr +
+           get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
+               .cb_offset;
 }
 
 uint32_t MeshWorkload::get_cb_size(

--- a/tt_metal/distributed/mesh_workload_utils.cpp
+++ b/tt_metal/distributed/mesh_workload_utils.cpp
@@ -33,9 +33,9 @@ void write_go_signal(
     bool send_mcast,
     bool send_unicasts,
     int num_unicast_txns) {
-    uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
-    uint32_t cmd_sequence_sizeB =
-        align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) + hal_ref.get_alignment(HalMemType::HOST);
+    uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    uint32_t cmd_sequence_sizeB = align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) +
+                                  MetalContext::instance().hal().get_alignment(HalMemType::HOST);
 
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, cq_id);
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -27,7 +27,6 @@
 #include "core_coord.hpp"
 #include "fabric_host_interface.h"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
 #include "logger.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_graph.hpp"
@@ -670,7 +669,7 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
                     physical_chip_id, eth_chan);
 
             TT_ASSERT(
-                tt_metal::hal_ref.get_dev_size(
+                tt_metal::MetalContext::instance().hal().get_dev_size(
                     tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::FABRIC_ROUTER_CONFIG) ==
                     sizeof(tt::tt_fabric::fabric_router_l1_config_t),
                 "ControlPlane: Fabric router config size mismatch");
@@ -684,7 +683,7 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
                 (void*)&fabric_router_config,
                 sizeof(tt::tt_fabric::fabric_router_l1_config_t),
                 tt_cxy_pair(physical_chip_id, virtual_eth_core),
-                tt_metal::hal_ref.get_dev_addr(
+                tt_metal::MetalContext::instance().hal().get_dev_addr(
                     tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::FABRIC_ROUTER_CONFIG),
                 false);
         }

--- a/tt_metal/hal.cpp
+++ b/tt_metal/hal.cpp
@@ -9,34 +9,34 @@
 #include <string>
 
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 
 using tt::tt_metal::HalL1MemAddrType;
 using tt::tt_metal::HalMemType;
 using tt::tt_metal::HalProgrammableCoreType;
-using tt::tt_metal::HalSingleton;
 
 namespace tt::tt_metal::hal {
 
-tt::ARCH get_arch() { return HalSingleton::getInstance().get_arch(); }
+tt::ARCH get_arch() { return tt::tt_metal::MetalContext::instance().hal().get_arch(); }
 
 std::string get_arch_name() {
-    auto arch_enum = HalSingleton::getInstance().get_arch();
+    auto arch_enum = tt::tt_metal::MetalContext::instance().hal().get_arch();
     return tt::get_string_lowercase(arch_enum);
 }
 
 uint32_t get_l1_size() {
-    return HalSingleton::getInstance().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
+    return tt::tt_metal::MetalContext::instance().hal().get_dev_size(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
 }
 
-uint32_t get_dram_alignment() { return HalSingleton::getInstance().get_alignment(HalMemType::DRAM); }
+uint32_t get_dram_alignment() { return tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::DRAM); }
 
-uint32_t get_l1_alignment() { return HalSingleton::getInstance().get_alignment(HalMemType::L1); }
+uint32_t get_l1_alignment() { return tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1); }
 
-uint32_t get_pcie_alignment() { return HalSingleton::getInstance().get_alignment(HalMemType::HOST); }
+uint32_t get_pcie_alignment() { return tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST); }
 
 uint32_t get_erisc_l1_unreserved_base() {
-    auto& hal_ref = HalSingleton::getInstance();
+    auto& hal_ref = tt::tt_metal::MetalContext::instance().hal();
     if (hal_ref.get_arch() != tt::ARCH::GRAYSKULL) {
         return hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     }
@@ -44,7 +44,7 @@ uint32_t get_erisc_l1_unreserved_base() {
 }
 
 uint32_t get_erisc_l1_unreserved_size() {
-    auto& hal_ref = HalSingleton::getInstance();
+    auto& hal_ref = tt::tt_metal::MetalContext::instance().hal();
     if (hal_ref.get_arch() != tt::ARCH::GRAYSKULL) {
         return hal_ref.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
     }
@@ -52,16 +52,16 @@ uint32_t get_erisc_l1_unreserved_size() {
 }
 
 uint32_t get_max_worker_l1_unreserved_size() {
-    auto& hal_ref = HalSingleton::getInstance();
+    auto& hal_ref = tt::tt_metal::MetalContext::instance().hal();
     size_t l1_end = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
                     hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE);
     return l1_end - hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
 }
 
-float get_eps() { return HalSingleton::getInstance().get_eps(); }
+float get_eps() { return tt::tt_metal::MetalContext::instance().hal().get_eps(); }
 
-float get_nan() { return HalSingleton::getInstance().get_nan(); }
+float get_nan() { return tt::tt_metal::MetalContext::instance().hal().get_nan(); }
 
-float get_inf() { return HalSingleton::getInstance().get_inf(); }
+float get_inf() { return tt::tt_metal::MetalContext::instance().hal().get_inf(); }
 
 }  // namespace tt::tt_metal::hal

--- a/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
+++ b/tt_metal/impl/allocator/algorithms/allocator_algorithm.hpp
@@ -9,8 +9,9 @@
 #include <vector>
 #include "hostdevcommon/common_values.hpp"
 
+#include <assert.hpp>
+#include <hal_types.hpp>
 #include <allocator_types.hpp>
-#include "llrt/hal.hpp"
 
 namespace tt {
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -14,7 +14,7 @@
 #include "allocator_types.hpp"
 #include "assert.hpp"
 #include "buffer_constants.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "logger.hpp"
 #include "tt_metal/impl/allocator/algorithms/free_list_opt.hpp"
 
@@ -60,7 +60,7 @@ BankManager::BankManager(
     }
     interleaved_address_limit_ = 0;
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
-    this->init_allocator(size_bytes, hal_ref.get_alignment(HalMemType::DRAM), alloc_offset);
+    this->init_allocator(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
 }
 
 BankManager::BankManager(
@@ -76,7 +76,7 @@ BankManager::BankManager(
     interleaved_address_limit_(interleaved_address_limit),
     alignment_bytes_(alignment_bytes) {
     validate_num_banks(bank_id_to_bank_offset_.size(), buffer_type_, disable_interleaved);
-    this->init_allocator(size_bytes, hal_ref.get_alignment(HalMemType::DRAM), alloc_offset);
+    this->init_allocator(size_bytes, MetalContext::instance().hal().get_alignment(HalMemType::DRAM), alloc_offset);
 }
 
 uint32_t BankManager::num_banks() const { return bank_id_to_bank_offset_.size(); }

--- a/tt_metal/impl/allocator/l1_banking_allocator.cpp
+++ b/tt_metal/impl/allocator/l1_banking_allocator.cpp
@@ -22,7 +22,7 @@
 
 #include "bank_manager.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.h>
 
 namespace tt {
@@ -174,7 +174,8 @@ void Allocator::init_compute_and_storage_l1_bank_manager() {
         num_banks.total);
 
     // Storage only cores only need to reserve mailbox space to hold barriers
-    uint32_t mem_mailbox_base = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::MAILBOX);
+    uint32_t mem_mailbox_base =
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::MAILBOX);
     uint32_t storage_core_unreserved_base =
         ((mem_mailbox_base + config_.l1_alignment - 1) / config_.l1_alignment) * config_.l1_alignment;
 

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -22,8 +22,8 @@
 
 #include "fmt/base.h"
 #include "lightmetal/host_api_capture_helpers.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/strong_type.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_align.hpp"
 #include "util.hpp"
@@ -415,7 +415,7 @@ void Buffer::allocate_impl() {
         TT_ASSERT(address_ <= std::numeric_limits<uint32_t>::max());
 
 #if defined(TRACY_ENABLE)
-        if (tt::llrt::RunTimeOptions::get_instance().get_profiler_buffer_usage_enabled()) {
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_buffer_usage_enabled()) {
             TracyAllocN(
                 reinterpret_cast<const void*>(address_), size_, get_buffer_location_name(buffer_type_, device_->id()));
         }
@@ -463,7 +463,7 @@ void Buffer::deallocate_impl() {
         GraphTracker::instance().track_deallocate(this);
         if (not GraphTracker::instance().hook_deallocate(this)) {
 #if defined(TRACY_ENABLE)
-            if (tt::llrt::RunTimeOptions::get_instance().get_profiler_buffer_usage_enabled()) {
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_buffer_usage_enabled()) {
                 TracyFreeN(
                     reinterpret_cast<const void*>(address()), get_buffer_location_name(buffer_type_, device_->id()));
             }

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -268,7 +268,7 @@ int32_t calculate_num_pages_available_in_cq(
 
 uint32_t calculate_max_data_size(const CoreType& dispatch_core_type) {
     return DispatchMemMap::get(dispatch_core_type).max_prefetch_command_size() -
-           (hal_ref.get_alignment(HalMemType::HOST) * 2);  // * 2 to account for issue
+           (MetalContext::instance().hal().get_alignment(HalMemType::HOST) * 2);  // * 2 to account for issue
 }
 
 bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer) {
@@ -292,7 +292,7 @@ BufferDispatchConstants generate_buffer_dispatch_constants(
 void update_offset_on_issue_wait_cmd(uint32_t& byte_offset, bool issue_wait, uint32_t num_sub_devices) {
     if (issue_wait) {
         // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
-        byte_offset += (hal_ref.get_alignment(HalMemType::HOST) * num_sub_devices);
+        byte_offset += (MetalContext::instance().hal().get_alignment(HalMemType::HOST) * num_sub_devices);
     }
 }
 
@@ -328,7 +328,8 @@ ShardedBufferWriteDispatchParams initialize_sharded_buf_dispatch_params(
 uint32_t calculate_partial_page_size(const Buffer& buffer) {
     const HalMemType buffer_mem_type = buffer.memory_type();
     const uint32_t partial_page_size = tt::align(
-        DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH, hal_ref.get_common_alignment_with_pcie(buffer_mem_type));
+        DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH,
+        MetalContext::instance().hal().get_common_alignment_with_pcie(buffer_mem_type));
     return partial_page_size;
 }
 
@@ -528,9 +529,9 @@ void write_interleaved_buffer_to_device(
     const BufferDispatchConstants& buf_dispatch_constants,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     CoreType dispatch_core_type) {
-    uint32_t byte_offset_in_cq =
-        hal_ref.get_alignment(HalMemType::HOST);  // data appended after CQ_PREFETCH_CMD_RELAY_INLINE
-                                                  // + CQ_DISPATCH_CMD_WRITE_PAGED
+    uint32_t byte_offset_in_cq = MetalContext::instance().hal().get_alignment(
+        HalMemType::HOST);  // data appended after CQ_PREFETCH_CMD_RELAY_INLINE
+                            // + CQ_DISPATCH_CMD_WRITE_PAGED
     while (dispatch_params.total_pages_to_write > 0) {
         dispatch_params.calculate_issue_wait();
 

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -23,7 +23,6 @@
 
 #include "distributed.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
 #include "mesh_buffer.hpp"
 #include "mesh_device.hpp"
 #include <tt_stl/reflection.hpp>
@@ -78,7 +77,7 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
     };
     cb_buffer_ = distributed::AnyBuffer::create(cb_buffer_shard_config);
 
-    auto l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     // is_sender, receiver_val, fifo_start_addr, fifo_size, fifo_ptr, noc_xy coords, and pages_sent
     constexpr uint32_t num_config_elements = 7;
     uint32_t num_noc_xy_words = 2 * max_num_receivers_per_sender;

--- a/tt_metal/impl/buffers/semaphore.cpp
+++ b/tt_metal/impl/buffers/semaphore.cpp
@@ -6,7 +6,7 @@
 #include <stdint.h>
 
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 
 namespace tt {
@@ -52,7 +52,7 @@ bool Semaphore::initialized_on_logical_core(const CoreCoord& logical_core) const
 }
 
 uint32_t Semaphore::offset() const {
-    uint32_t offset = hal_ref.get_alignment(HalMemType::L1) * id_;
+    uint32_t offset = MetalContext::instance().hal().get_alignment(HalMemType::L1) * id_;
     return offset;
 }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -59,7 +59,14 @@ Cluster& MetalContext::get_cluster() {
     return *cluster_;
 }
 
-Hal& MetalContext::hal() {
+const llrt::RunTimeOptions& MetalContext::rtoptions() const { return rtoptions_; }
+
+const Cluster& MetalContext::get_cluster() const {
+    TT_FATAL(cluster_, "Trying to get cluster before intializing it.");
+    return *cluster_;
+}
+
+const Hal& MetalContext::hal() const {
     TT_FATAL(hal_, "Trying to get hal before intializing it.");
     return *hal_;
 }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -36,7 +36,7 @@ void MetalContext::initialize(
     // Initialize dispatch state
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
     dispatch_query_manager_ = std::make_unique<DispatchQueryManager>(num_hw_cqs);
-    tt_metal::DispatchSettings::initialize(cluster_);
+    tt_metal::DispatchSettings::initialize(*cluster_);
 
     // TODO: Move FW, fabric, dispatch init here
 }
@@ -46,9 +46,14 @@ MetalContext& MetalContext::instance() {
     return inst.get();
 }
 
-MetalContext::MetalContext() = default;
+MetalContext::MetalContext() { cluster_ = std::make_unique<Cluster>(rtoptions_); }
 
-Cluster& MetalContext::get_cluster() { return cluster_; }
+llrt::RunTimeOptions& MetalContext::rtoptions() { return rtoptions_; }
+
+Cluster& MetalContext::get_cluster() {
+    TT_FATAL(cluster_, "Trying to get cluster before intializing it.");
+    return *cluster_;
+}
 
 dispatch_core_manager& MetalContext::get_dispatch_core_manager() {
     TT_FATAL(dispatch_core_manager_, "Trying to get dispatch_core_manager before intializing it.");

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -6,7 +6,6 @@
 #include <tt-metalium/dispatch_settings.hpp>
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
-#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -13,6 +13,7 @@
 #include "tt_metal/impl/debug/debug_helpers.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/llrt/llrt.hpp"
+#include "tt_metal/llrt/get_platform_architecture.hpp"
 
 namespace tt::tt_metal {
 
@@ -46,13 +47,21 @@ MetalContext& MetalContext::instance() {
     return inst.get();
 }
 
-MetalContext::MetalContext() { cluster_ = std::make_unique<Cluster>(rtoptions_); }
+MetalContext::MetalContext() {
+    hal_ = std::make_unique<Hal>(get_platform_architecture(rtoptions_));
+    cluster_ = std::make_unique<Cluster>(rtoptions_, *hal_);
+}
 
 llrt::RunTimeOptions& MetalContext::rtoptions() { return rtoptions_; }
 
 Cluster& MetalContext::get_cluster() {
     TT_FATAL(cluster_, "Trying to get cluster before intializing it.");
     return *cluster_;
+}
+
+Hal& MetalContext::hal() {
+    TT_FATAL(hal_, "Trying to get hal before intializing it.");
+    return *hal_;
 }
 
 dispatch_core_manager& MetalContext::get_dispatch_core_manager() {

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/dev_msgs.h>
 #include <tt-metalium/allocator_types.hpp>
 #include <llrt/tt_cluster.hpp>
+#include <llrt/rtoptions.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <impl/dispatch/dispatch_query_manager.hpp>
 
@@ -33,6 +34,7 @@ public:
     static MetalContext& instance();
 
     Cluster& get_cluster();
+    llrt::RunTimeOptions& rtoptions();
     dispatch_core_manager& get_dispatch_core_manager();
     DispatchQueryManager& get_dispatch_query_manager();
 
@@ -50,7 +52,8 @@ private:
     BankMapping l1_bank_remap_;
     DispatchCoreConfig dispatch_core_config_;
 
-    Cluster cluster_;
+    llrt::RunTimeOptions rtoptions_;
+    std::unique_ptr<Cluster> cluster_;
     std::unique_ptr<dispatch_core_manager> dispatch_core_manager_;
     std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;
 };

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -36,7 +36,9 @@ public:
 
     Cluster& get_cluster();
     llrt::RunTimeOptions& rtoptions();
-    Hal& hal();
+    const Cluster& get_cluster() const;
+    const llrt::RunTimeOptions& rtoptions() const;
+    const Hal& hal() const;
     dispatch_core_manager& get_dispatch_core_manager();
     DispatchQueryManager& get_dispatch_query_manager();
 

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/dev_msgs.h>
 #include <tt-metalium/allocator_types.hpp>
 #include <llrt/tt_cluster.hpp>
+#include <llrt/hal.hpp>
 #include <llrt/rtoptions.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <impl/dispatch/dispatch_query_manager.hpp>
@@ -35,6 +36,7 @@ public:
 
     Cluster& get_cluster();
     llrt::RunTimeOptions& rtoptions();
+    Hal& hal();
     dispatch_core_manager& get_dispatch_core_manager();
     DispatchQueryManager& get_dispatch_query_manager();
 
@@ -54,6 +56,7 @@ private:
 
     llrt::RunTimeOptions rtoptions_;
     std::unique_ptr<Cluster> cluster_;
+    std::unique_ptr<Hal> hal_;
     std::unique_ptr<dispatch_core_manager> dispatch_core_manager_;
     std::unique_ptr<DispatchQueryManager> dispatch_query_manager_;
 };

--- a/tt_metal/impl/data_format/bfloat4.cpp
+++ b/tt_metal/impl/data_format/bfloat4.cpp
@@ -15,7 +15,7 @@
 #include "blockfloat_common.hpp"
 #include "constants.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tile.hpp"
 #include "tracy/Tracy.hpp"
@@ -36,7 +36,7 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
     const std::optional<tt::tt_metal::Tile>& tile) {
     ZoneScoped;
 
-    uint32_t l1_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::L1);
+    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 
     auto tile_H = tile.has_value() ? tile->get_tile_shape()[0] : tt::constants::TILE_HEIGHT;
     auto tile_W = tile.has_value() ? tile->get_tile_shape()[1] : tt::constants::TILE_WIDTH;

--- a/tt_metal/impl/data_format/bfloat8.cpp
+++ b/tt_metal/impl/data_format/bfloat8.cpp
@@ -14,7 +14,7 @@
 #include "blockfloat_common.hpp"
 #include "constants.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tile.hpp"
 #include "tracy/Tracy.hpp"
@@ -35,7 +35,7 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
     const std::optional<tt::tt_metal::Tile>& tile) {
     ZoneScoped;
 
-    uint32_t l1_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::L1);
+    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 
     auto tile_H = tile.has_value() ? tile->get_tile_shape()[0] : tt::constants::TILE_HEIGHT;
     auto tile_W = tile.has_value() ? tile->get_tile_shape()[1] : tt::constants::TILE_WIDTH;

--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -11,7 +11,7 @@
 #include "assert.hpp"
 #include "constants.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tile.hpp"
 #include "tracy/Tracy.hpp"
@@ -328,7 +328,7 @@ std::vector<uint32_t> pack_fp32_vec_as_bfp_tiles(
     auto subtile_rows = face_H;
     auto subtile_cols = face_W;
 
-    uint32_t l1_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::L1);
+    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
     bool exponent_padding = (subtile_rows * subtiles_in_tile_col * subtiles_in_tile_row) < l1_alignment;
 
     int num_float_in_tile = tile_HW;

--- a/tt_metal/impl/data_format/tile.cpp
+++ b/tt_metal/impl/data_format/tile.cpp
@@ -8,7 +8,7 @@
 
 #include "assert.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tt_backend_api_types.hpp"
 
@@ -49,7 +49,7 @@ Tile::Tile(std::array<uint32_t, 2> tile_shape, bool transpose_tile) : tile_shape
 }
 
 uint32_t Tile::get_tile_size(const DataFormat& format) const {
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     uint32_t aligned_exp_size = tt::round_up(face_shape[0] * num_faces, l1_alignment);
     switch (format) {
         case DataFormat::Bfp2:

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -84,7 +84,7 @@ static tt::tt_metal::HalProgrammableCoreType get_programmable_core_type(CoreCoor
 }
 
 inline uint64_t GetDprintBufAddr(chip_id_t device_id, const CoreCoord& virtual_core, int risc_id) {
-    dprint_buf_msg_t* buf = tt::tt_metal::hal_ref.get_dev_addr<dprint_buf_msg_t*>(
+    dprint_buf_msg_t* buf = tt::tt_metal::MetalContext::instance().hal().get_dev_addr<dprint_buf_msg_t*>(
         get_programmable_core_type(virtual_core, device_id), tt::tt_metal::HalL1MemAddrType::DPRINT);
     return reinterpret_cast<uint64_t>(&(buf->data[risc_id]));
 }

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/core_descriptor.hpp>
 #include "hostdevcommon/dprint_common.h"
 #include "impl/context/metal_context.hpp"
-#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -513,13 +513,10 @@ DebugPrintServerContext::DebugPrintServerContext() {
     inst = this;
 
     // Read risc mask + log file from rtoptions
-    string file_name =
-        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
-    bool one_file_per_risc = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_one_file_per_risc(
-        tt::llrt::RunTimeDebugFeatureDprint);
-    bool prepend_device_core_risc =
-        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_prepend_device_core_risc(
-            tt::llrt::RunTimeDebugFeatureDprint);
+    auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    string file_name = rtoptions.get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
+    bool one_file_per_risc = rtoptions.get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint);
+    bool prepend_device_core_risc = rtoptions.get_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint);
 
     // One file per risc auto-generates the output files and ignores the env var for it. Print a warning if both are
     // specified just in case.
@@ -533,12 +530,11 @@ DebugPrintServerContext::DebugPrintServerContext() {
         log_warning(
             "Both TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC and TT_METAL_DPRINT_ONE_FILE_PER_RISC are specified. "
             "TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC will be disabled.");
-        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
-            tt::llrt::RunTimeDebugFeatureDprint, false);
+        rtoptions.set_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint, false);
     }
 
     // Set the output stream according to RTOptions, either a file name or stdout if none specified.
-    std::filesystem::path output_dir(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path);
+    std::filesystem::path output_dir(rtoptions.get_root_dir() + logfile_path);
     std::filesystem::create_directories(output_dir);
     if (file_name != "" && !one_file_per_risc) {
         outfile_ = new ofstream(file_name);
@@ -624,10 +620,9 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
 
     // If RTOptions doesn't enable DPRINT on this device, return here and don't actually attach it
     // to the server.
-    std::vector<chip_id_t> chip_ids =
-        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
-    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_chips(
-            tt::llrt::RunTimeDebugFeatureDprint)) {
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    std::vector<chip_id_t> chip_ids = rtoptions.get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
+    if (!rtoptions.get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
         if (std::find(chip_ids.begin(), chip_ids.end(), device_id) == chip_ids.end()) {
             return;
         }
@@ -636,8 +631,8 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
     // Core range depends on whether dprint_all_cores flag is set.
     std::vector<CoreDescriptor> print_cores_sanitized;
     for (CoreType core_type : {CoreType::WORKER, CoreType::ETH}) {
-        if (tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_cores(
-                tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassAll) {
+        if (rtoptions.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
+            tt::llrt::RunTimeDebugClassAll) {
             // Print from all cores of the given type, cores returned here are guaranteed to be valid.
             for (CoreDescriptor logical_core : all_cores) {
                 if (logical_core.type == core_type) {
@@ -650,8 +645,8 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                 device_id,
                 tt::tt_metal::get_core_type_name(core_type));
         } else if (
-            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_cores(
-                tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassDispatch) {
+            rtoptions.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
+            tt::llrt::RunTimeDebugClassDispatch) {
             for (CoreDescriptor logical_core : dispatch_cores) {
                 if (logical_core.type == core_type) {
                     print_cores_sanitized.push_back(logical_core);
@@ -663,8 +658,8 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                 device_id,
                 tt::tt_metal::get_core_type_name(core_type));
         } else if (
-            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_cores(
-                tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassWorker) {
+            rtoptions.get_feature_all_cores(tt::llrt::RunTimeDebugFeatureDprint, core_type) ==
+            tt::llrt::RunTimeDebugClassWorker) {
             // For worker cores, take all cores and remove dispatch cores.
             for (CoreDescriptor logical_core : all_cores) {
                 if (dispatch_cores.find(logical_core) == dispatch_cores.end()) {
@@ -680,8 +675,8 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                 tt::tt_metal::get_core_type_name(core_type));
         } else {
             // No "all cores" option provided, which means print from the cores specified by the user
-            std::vector<CoreCoord>& print_cores = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_cores(
-                tt::llrt::RunTimeDebugFeatureDprint)[core_type];
+            const std::vector<CoreCoord>& print_cores =
+                rtoptions.get_feature_cores(tt::llrt::RunTimeDebugFeatureDprint).at(core_type);
 
             // We should also validate that the cores the user specified are valid worker cores.
             for (auto& logical_core : print_cores) {
@@ -754,10 +749,9 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
 
 void DebugPrintServerContext::DetachDevice(chip_id_t device_id) {
     // Don't detach the device if it's disabled by env vars - in this case it wasn't attached.
-    std::vector<chip_id_t> chip_ids =
-        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
-    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_chips(
-            tt::llrt::RunTimeDebugFeatureDprint)) {
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    std::vector<chip_id_t> chip_ids = rtoptions.get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
+    if (!rtoptions.get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
         if (std::find(chip_ids.begin(), chip_ids.end(), device_id) == chip_ids.end()) {
             return;
         }
@@ -1179,6 +1173,7 @@ void DebugPrintServerContext::PollPrintData() {
 
     // Main print loop, go through all chips/cores/riscs on the device and poll for any print data
     // written.
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
     while (true) {
         if (stop_print_server_) {
             // If the stop signal was received, exit the print server thread, but wait for any
@@ -1216,7 +1211,7 @@ void DebugPrintServerContext::PollPrintData() {
                         } catch (std::runtime_error& e) {
                             // Depending on if test mode is enabled, catch and stop server, or
                             // re-throw the exception.
-                            if (tt::tt_metal::MetalContext::instance().rtoptions().get_test_mode_enabled()) {
+                            if (rtoptions.get_test_mode_enabled()) {
                                 server_killed_due_to_hang_ = true;
                                 device_to_core_range_lock_.unlock();
                                 return;  // Stop the print loop
@@ -1291,13 +1286,13 @@ string DebugPrintServerContext::GetDataToOutput(const HartKey& risc_key, const o
 
 ostream* DebugPrintServerContext::GetOutputStream(const HartKey& risc_key) {
     ostream* output_stream = stream_;
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_feature_one_file_per_risc(
-            tt::llrt::RunTimeDebugFeatureDprint)) {
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    if (rtoptions.get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint)) {
         if (!risc_to_file_stream_[risc_key]) {
             const chip_id_t chip_id = get<0>(risc_key);
             const CoreDescriptor& logical_core = get<1>(risc_key);
             const int risc_id = get<2>(risc_key);
-            string filename = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path;
+            string filename = rtoptions.get_root_dir() + logfile_path;
             filename += fmt::format(
                 "device-{}_{}-core-{}-{}_{}.txt",
                 chip_id,

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -5,7 +5,6 @@
 #include <logger.hpp>
 #include <math.h>
 #include <pthread.h>
-#include <rtoptions.hpp>
 #include <tt-metalium/blockfloat_common.hpp>
 #include <algorithm>
 #include <atomic>
@@ -103,7 +102,7 @@ static void AssertSize(uint8_t sz, uint8_t expected_sz) {
 
 inline bool RiscEnabled(const CoreDescriptor& core, int risc_index) {
     uint32_t risc_mask =
-        tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDprint);
+        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDprint);
     if (core.type == CoreType::ETH) {
         // For ethernet cores, need to adjust the index up since the mask flags are successive. TODO(#17275): move this
         // logic into HAL?
@@ -515,11 +514,12 @@ DebugPrintServerContext::DebugPrintServerContext() {
 
     // Read risc mask + log file from rtoptions
     string file_name =
-        tt::llrt::RunTimeOptions::get_instance().get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
-    bool one_file_per_risc =
-        tt::llrt::RunTimeOptions::get_instance().get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint);
+        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
+    bool one_file_per_risc = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_one_file_per_risc(
+        tt::llrt::RunTimeDebugFeatureDprint);
     bool prepend_device_core_risc =
-        tt::llrt::RunTimeOptions::get_instance().get_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint);
+        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_prepend_device_core_risc(
+            tt::llrt::RunTimeDebugFeatureDprint);
 
     // One file per risc auto-generates the output files and ignores the env var for it. Print a warning if both are
     // specified just in case.
@@ -533,11 +533,12 @@ DebugPrintServerContext::DebugPrintServerContext() {
         log_warning(
             "Both TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC and TT_METAL_DPRINT_ONE_FILE_PER_RISC are specified. "
             "TT_METAL_DPRINT_PREPEND_DEVICE_CORE_RISC will be disabled.");
-        tt::llrt::RunTimeOptions::get_instance().set_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint, false);
+        tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
+            tt::llrt::RunTimeDebugFeatureDprint, false);
     }
 
     // Set the output stream according to RTOptions, either a file name or stdout if none specified.
-    std::filesystem::path output_dir(tt::llrt::RunTimeOptions::get_instance().get_root_dir() + logfile_path);
+    std::filesystem::path output_dir(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path);
     std::filesystem::create_directories(output_dir);
     if (file_name != "" && !one_file_per_risc) {
         outfile_ = new ofstream(file_name);
@@ -624,8 +625,9 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
     // If RTOptions doesn't enable DPRINT on this device, return here and don't actually attach it
     // to the server.
     std::vector<chip_id_t> chip_ids =
-        tt::llrt::RunTimeOptions::get_instance().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
-    if (!tt::llrt::RunTimeOptions::get_instance().get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
+        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_chips(
+            tt::llrt::RunTimeDebugFeatureDprint)) {
         if (std::find(chip_ids.begin(), chip_ids.end(), device_id) == chip_ids.end()) {
             return;
         }
@@ -634,7 +636,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
     // Core range depends on whether dprint_all_cores flag is set.
     std::vector<CoreDescriptor> print_cores_sanitized;
     for (CoreType core_type : {CoreType::WORKER, CoreType::ETH}) {
-        if (tt::llrt::RunTimeOptions::get_instance().get_feature_all_cores(
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_cores(
                 tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassAll) {
             // Print from all cores of the given type, cores returned here are guaranteed to be valid.
             for (CoreDescriptor logical_core : all_cores) {
@@ -648,7 +650,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                 device_id,
                 tt::tt_metal::get_core_type_name(core_type));
         } else if (
-            tt::llrt::RunTimeOptions::get_instance().get_feature_all_cores(
+            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_cores(
                 tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassDispatch) {
             for (CoreDescriptor logical_core : dispatch_cores) {
                 if (logical_core.type == core_type) {
@@ -661,7 +663,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                 device_id,
                 tt::tt_metal::get_core_type_name(core_type));
         } else if (
-            tt::llrt::RunTimeOptions::get_instance().get_feature_all_cores(
+            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_cores(
                 tt::llrt::RunTimeDebugFeatureDprint, core_type) == tt::llrt::RunTimeDebugClassWorker) {
             // For worker cores, take all cores and remove dispatch cores.
             for (CoreDescriptor logical_core : all_cores) {
@@ -678,7 +680,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                 tt::tt_metal::get_core_type_name(core_type));
         } else {
             // No "all cores" option provided, which means print from the cores specified by the user
-            std::vector<CoreCoord>& print_cores = tt::llrt::RunTimeOptions::get_instance().get_feature_cores(
+            std::vector<CoreCoord>& print_cores = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_cores(
                 tt::llrt::RunTimeDebugFeatureDprint)[core_type];
 
             // We should also validate that the cores the user specified are valid worker cores.
@@ -753,8 +755,9 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
 void DebugPrintServerContext::DetachDevice(chip_id_t device_id) {
     // Don't detach the device if it's disabled by env vars - in this case it wasn't attached.
     std::vector<chip_id_t> chip_ids =
-        tt::llrt::RunTimeOptions::get_instance().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
-    if (!tt::llrt::RunTimeOptions::get_instance().get_feature_all_chips(tt::llrt::RunTimeDebugFeatureDprint)) {
+        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_chip_ids(tt::llrt::RunTimeDebugFeatureDprint);
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_feature_all_chips(
+            tt::llrt::RunTimeDebugFeatureDprint)) {
         if (std::find(chip_ids.begin(), chip_ids.end(), device_id) == chip_ids.end()) {
             return;
         }
@@ -850,8 +853,8 @@ void DebugPrintServerContext::ClearLogFile() {
         outfile_->close();
         delete outfile_;
 
-        string file_name =
-            tt::llrt::RunTimeOptions::get_instance().get_feature_file_name(tt::llrt::RunTimeDebugFeatureDprint);
+        string file_name = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_file_name(
+            tt::llrt::RunTimeDebugFeatureDprint);
         outfile_ = new ofstream(file_name);
         stream_ = outfile_ ? outfile_ : &cout;
     }
@@ -1213,7 +1216,7 @@ void DebugPrintServerContext::PollPrintData() {
                         } catch (std::runtime_error& e) {
                             // Depending on if test mode is enabled, catch and stop server, or
                             // re-throw the exception.
-                            if (tt::llrt::RunTimeOptions::get_instance().get_test_mode_enabled()) {
+                            if (tt::tt_metal::MetalContext::instance().rtoptions().get_test_mode_enabled()) {
                                 server_killed_due_to_hang_ = true;
                                 device_to_core_range_lock_.unlock();
                                 return;  // Stop the print loop
@@ -1264,7 +1267,8 @@ void DebugPrintServerContext::TransferToAndFlushOutputStream(
 string DebugPrintServerContext::GetDataToOutput(const HartKey& risc_key, const ostringstream* stream) {
     string output;
     const bool prepend_device_core_risc =
-        tt::llrt::RunTimeOptions::get_instance().get_feature_prepend_device_core_risc(tt::llrt::RunTimeDebugFeatureDprint);
+        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_prepend_device_core_risc(
+            tt::llrt::RunTimeDebugFeatureDprint);
     if (prepend_device_core_risc) {
         const chip_id_t device_id = get<0>(risc_key);
         const CoreDescriptor& core_desc = get<1>(risc_key);
@@ -1287,12 +1291,13 @@ string DebugPrintServerContext::GetDataToOutput(const HartKey& risc_key, const o
 
 ostream* DebugPrintServerContext::GetOutputStream(const HartKey& risc_key) {
     ostream* output_stream = stream_;
-    if (tt::llrt::RunTimeOptions::get_instance().get_feature_one_file_per_risc(tt::llrt::RunTimeDebugFeatureDprint)) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_feature_one_file_per_risc(
+            tt::llrt::RunTimeDebugFeatureDprint)) {
         if (!risc_to_file_stream_[risc_key]) {
             const chip_id_t chip_id = get<0>(risc_key);
             const CoreDescriptor& logical_core = get<1>(risc_key);
             const int risc_id = get<2>(risc_key);
-            string filename = tt::llrt::RunTimeOptions::get_instance().get_root_dir() + logfile_path;
+            string filename = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path;
             filename += fmt::format(
                 "device-{}_{}-core-{}-{}_{}.txt",
                 chip_id,
@@ -1322,7 +1327,7 @@ namespace tt::tt_metal {
 
 void DprintServerAttach(chip_id_t device_id) {
     // Skip if DPRINT not enabled, and make sure profiler is not running.
-    if (!tt::llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         return;
     }
     TT_FATAL(

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -19,7 +19,6 @@
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
 #include "logger.hpp"
-#include "rtoptions.hpp"
 #include <umd/device/tt_soc_descriptor.h>
 #include "utils.hpp"
 
@@ -33,9 +32,9 @@ namespace tt {
 
 static string logfile_path = "generated/noc_data/";
 void PrintNocData(noc_data_t noc_data, const string& file_name) {
-    std::filesystem::path output_dir(tt::llrt::RunTimeOptions::get_instance().get_root_dir() + logfile_path);
+    std::filesystem::path output_dir(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path);
     std::filesystem::create_directories(output_dir);
-    std::string filename = tt::llrt::RunTimeOptions::get_instance().get_root_dir() + logfile_path + file_name;
+    std::string filename = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path + file_name;
     std::ofstream outfile(filename);
 
     for (uint32_t idx = 0; idx < NOC_DATA_SIZE; idx++) {
@@ -82,7 +81,7 @@ void DumpDeviceNocData(chip_id_t device_id, noc_data_t& noc_data, noc_data_t& di
 
 void DumpNocData(const std::vector<chip_id_t>& devices) {
     // Skip if feature is not enabled
-    if (!tt::llrt::RunTimeOptions::get_instance().get_record_noc_transfers()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_record_noc_transfers()) {
         return;
     }
 
@@ -98,13 +97,14 @@ void DumpNocData(const std::vector<chip_id_t>& devices) {
 
 void ClearNocData(chip_id_t device_id) {
     // Skip if feature is not enabled
-    if (!tt::llrt::RunTimeOptions::get_instance().get_record_noc_transfers()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_record_noc_transfers()) {
         return;
     }
 
     // This feature is incomatible with dprint since they share memory space
     TT_FATAL(
-        tt::llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) == false,
+        tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint) ==
+            false,
         "NOC transfer recording is incompatible with DPRINT");
 
     CoreDescriptorSet all_cores = GetAllCores(device_id);

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -32,9 +32,10 @@ namespace tt {
 
 static string logfile_path = "generated/noc_data/";
 void PrintNocData(noc_data_t noc_data, const string& file_name) {
-    std::filesystem::path output_dir(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path);
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    std::filesystem::path output_dir(rtoptions.get_root_dir() + logfile_path);
     std::filesystem::create_directories(output_dir);
-    std::string filename = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + logfile_path + file_name;
+    std::string filename = rtoptions.get_root_dir() + logfile_path + file_name;
     std::ofstream outfile(filename);
 
     for (uint32_t idx = 0; idx < NOC_DATA_SIZE; idx++) {

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -17,7 +17,6 @@
 #include <utility>
 #include <vector>
 
-#include "llrt/hal.hpp"
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -29,7 +29,6 @@
 #include "debug_helpers.hpp"
 #include "hal_types.hpp"
 #include "llrt.hpp"
-#include "llrt/hal.hpp"
 #include "logger.hpp"
 #include "metal_soc_descriptor.h"
 #include <tt_stl/span.hpp>
@@ -46,12 +45,14 @@ using namespace tt::tt_metal;
 namespace tt {
 namespace watcher {
 
-#define GET_WATCHER_TENSIX_DEV_ADDR() hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::WATCHER)
+#define GET_WATCHER_TENSIX_DEV_ADDR() \
+    MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::WATCHER)
 
 #define GET_WATCHER_ERISC_DEV_ADDR() \
-    hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::WATCHER)
+    MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::WATCHER)
 
-#define GET_WATCHER_IERISC_DEV_ADDR() hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::WATCHER)
+#define GET_WATCHER_IERISC_DEV_ADDR() \
+    MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::WATCHER)
 
 static std::atomic<bool> enabled = false;
 static std::atomic<bool> server_running = false;
@@ -242,7 +243,7 @@ void watcher_init(chip_id_t device_id) {
     }
 
     // Initialize debug sanity L1/NOC addresses to sentinel "all ok"
-    const auto NUM_NOCS = tt::tt_metal::hal_ref.get_num_nocs();
+    const auto NUM_NOCS = tt::tt_metal::MetalContext::instance().hal().get_num_nocs();
     for (int i = 0; i < NUM_NOCS; i++) {
         data->sanitize_noc[i].noc_addr = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_64;
         data->sanitize_noc[i].l1_addr = watcher::DEBUG_SANITIZE_NOC_SENTINEL_OK_32;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -472,6 +472,7 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
     uint32_t processor_class_count = MetalContext::instance().hal().get_processor_classes_count(core_type);
     auto jit_build_config = MetalContext::instance().hal().get_jit_build_config(
         core_type_idx, 0, 0);  // Only the first risc needs to be programmed
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
 
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
@@ -490,7 +491,7 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                     }
                     log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, fw_size);
 
-                    if (not tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+                    if (not rtoptions.get_skip_loading_fw()) {
                         llrt::test_load_write_read_risc_binary(
                             binary_mem, this->id(), virtual_core, core_type_idx, processor_class, riscv_id);
                     }
@@ -531,7 +532,7 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                 tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
                     tt_cxy_pair(this->id(), virtual_core), reset_val);
             }
-            if (not tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
+            if (not rtoptions.get_skip_loading_fw()) {
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                     auto num_build_states =
                         MetalContext::instance().hal().get_processor_types_count(core_type_idx, processor_class);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -55,7 +55,6 @@
 #include "launch_message_ring_buffer_state.hpp"
 #include "lightmetal/lightmetal_capture.hpp"
 #include "llrt.hpp"
-#include "llrt/hal.hpp"
 #include "logger.hpp"
 #include "metal_soc_descriptor.h"
 #include "multi_producer_single_consumer_queue.hpp"
@@ -88,7 +87,7 @@ enum class ARCH;
 namespace tt_metal {
 
 uint64_t IDevice::get_dev_addr(CoreCoord virtual_core, HalL1MemAddrType addr_type) const {
-    return hal_ref.get_dev_addr(this->get_programmable_core_type(virtual_core), addr_type);
+    return MetalContext::instance().hal().get_dev_addr(this->get_programmable_core_type(virtual_core), addr_type);
 }
 
 Device::Device(Device&& other) = default;
@@ -373,15 +372,16 @@ std::unique_ptr<Allocator> Device::initialize_allocator(
         {.num_dram_channels = static_cast<size_t>(soc_desc.get_num_dram_views()),
          .dram_bank_size = soc_desc.dram_view_size,
          .dram_bank_offsets = {},
-         .dram_unreserved_base = hal_ref.get_dev_addr(HalDramMemAddrType::DRAM_BARRIER) +
-                                 hal_ref.get_dev_size(HalDramMemAddrType::DRAM_BARRIER),
-         .dram_alignment = hal_ref.get_alignment(HalMemType::DRAM),
-         .l1_unreserved_base = align(worker_l1_unreserved_start, hal_ref.get_alignment(HalMemType::DRAM)),
+         .dram_unreserved_base = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::DRAM_BARRIER) +
+                                 MetalContext::instance().hal().get_dev_size(HalDramMemAddrType::DRAM_BARRIER),
+         .dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM),
+         .l1_unreserved_base =
+             align(worker_l1_unreserved_start, MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
          .worker_grid = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(logical_size.x - 1, logical_size.y - 1))),
          .worker_l1_size = static_cast<size_t>(soc_desc.worker_l1_size),
          .storage_core_bank_size = get_storage_core_bank_size(id_, num_hw_cqs_, dispatch_core_config),
-         .l1_small_size = align(l1_small_size, hal_ref.get_alignment(HalMemType::DRAM)),
-         .trace_region_size = align(trace_region_size, hal_ref.get_alignment(HalMemType::DRAM)),
+         .l1_small_size = align(l1_small_size, MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
+         .trace_region_size = align(trace_region_size, MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
          .core_type_from_noc_coord_table = {},  // Populated later
          .worker_log_to_virtual_routing_x =
              tt::tt_metal::MetalContext::instance().get_cluster().get_worker_logical_to_virtual_x(this->id()),
@@ -389,7 +389,7 @@ std::unique_ptr<Allocator> Device::initialize_allocator(
              tt::tt_metal::MetalContext::instance().get_cluster().get_worker_logical_to_virtual_y(this->id()),
          .l1_bank_remap = {l1_bank_remap.begin(), l1_bank_remap.end()},
          .compute_grid = CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(compute_size.x - 1, compute_size.y - 1))),
-         .l1_alignment = hal_ref.get_alignment(HalMemType::L1),
+         .l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1),
          .disable_interleaved = false});
     TT_FATAL(config.l1_small_size < (config.storage_core_bank_size.has_value() ? config.storage_core_bank_size.value() : config.worker_l1_size - config.l1_unreserved_base),
             "Reserved size must be less than bank size");
@@ -442,8 +442,10 @@ void Device::initialize_device_bank_to_noc_tables(const HalProgrammableCoreType 
     const uint32_t dram_offset_sz_in_bytes = dram_bank_offset_map_.size() * sizeof(int32_t);
     const uint32_t l1_offset_sz_in_bytes = l1_bank_offset_map_.size() * sizeof(int32_t);
 
-    const uint64_t mem_bank_to_noc_addr = hal_ref.get_dev_addr(core_type, HalL1MemAddrType::BANK_TO_NOC_SCRATCH);
-    const uint32_t mem_bank_to_noc_size = hal_ref.get_dev_size(core_type, HalL1MemAddrType::BANK_TO_NOC_SCRATCH);
+    const uint64_t mem_bank_to_noc_addr =
+        MetalContext::instance().hal().get_dev_addr(core_type, HalL1MemAddrType::BANK_TO_NOC_SCRATCH);
+    const uint32_t mem_bank_to_noc_size =
+        MetalContext::instance().hal().get_dev_size(core_type, HalL1MemAddrType::BANK_TO_NOC_SCRATCH);
 
     TT_ASSERT((dram_to_noc_sz_in_bytes + l1_to_noc_sz_in_bytes + dram_offset_sz_in_bytes + l1_offset_sz_in_bytes) <= mem_bank_to_noc_size,
         "Size of bank_to_noc table is greater than available space");
@@ -466,10 +468,10 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
     ZoneScoped;
 
     this->initialize_device_bank_to_noc_tables(core_type, virtual_core);
-    uint32_t core_type_idx = hal_ref.get_programmable_core_type_index(core_type);
-    uint32_t processor_class_count = hal_ref.get_processor_classes_count(core_type);
-    auto jit_build_config =
-        hal_ref.get_jit_build_config(core_type_idx, 0, 0);  // Only the first risc needs to be programmed
+    uint32_t core_type_idx = MetalContext::instance().hal().get_programmable_core_type_index(core_type);
+    uint32_t processor_class_count = MetalContext::instance().hal().get_processor_classes_count(core_type);
+    auto jit_build_config = MetalContext::instance().hal().get_jit_build_config(
+        core_type_idx, 0, 0);  // Only the first risc needs to be programmed
 
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
@@ -525,13 +527,14 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                     reset_val & static_cast<TensixSoftResetOptions>(
                                     ~std::underlying_type<TensixSoftResetOptions>::type(TensixSoftResetOptions::BRISC));
             }
-            if (is_idle_eth or !hal_ref.get_eth_fw_is_cooperative()) {
+            if (is_idle_eth or !MetalContext::instance().hal().get_eth_fw_is_cooperative()) {
                 tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
                     tt_cxy_pair(this->id(), virtual_core), reset_val);
             }
             if (not tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                    auto num_build_states = hal_ref.get_processor_types_count(core_type_idx, processor_class);
+                    auto num_build_states =
+                        MetalContext::instance().hal().get_processor_types_count(core_type_idx, processor_class);
                     for (uint32_t eriscv_id = 0; eriscv_id < num_build_states; eriscv_id++) {
                         auto fw_path = BuildEnvManager::get_instance()
                                            .get_firmware_build_state(id_, core_type_idx, processor_class, eriscv_id)
@@ -599,9 +602,10 @@ void Device::reset_cores() {
             (this->arch() == ARCH::WORMHOLE_B0) and
                 (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, this->id())),
             "Invalid core type for context switch check");
-        auto core_type_idx = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+        auto core_type_idx =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
         std::uint32_t launch_erisc_addr =
-            tt::tt_metal::hal_ref.get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr;
+            tt::tt_metal::MetalContext::instance().hal().get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr;
         auto data =
             tt::llrt::read_hex_vec_from_core(this->id(), virtual_core, launch_erisc_addr, sizeof(std::uint32_t));
         return (data[0] != 0);
@@ -612,13 +616,13 @@ void Device::reset_cores() {
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> dispatch_cores, other_dispatch_cores, device_to_early_exit_cores;
     go_msg_t go_msg;
     std::memset(&go_msg, 0, sizeof(go_msg_t));
-    if (hal_ref.get_eth_fw_is_cooperative()) {
+    if (MetalContext::instance().hal().get_eth_fw_is_cooperative()) {
         for (const auto& eth_core : this->get_active_ethernet_cores()) {
             CoreCoord virtual_core = this->ethernet_core_from_logical_core(eth_core);
             if (erisc_app_still_running(virtual_core)) {
                 std::vector<uint32_t> data(sizeof(launch_msg_t) / sizeof(uint32_t));
-                DeviceAddr launch_addr =
-                    hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH);
+                DeviceAddr launch_addr = MetalContext::instance().hal().get_dev_addr(
+                    HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH);
 
                 data = tt::llrt::read_hex_vec_from_core(this->id(), virtual_core, launch_addr, sizeof(launch_msg_t));
                 launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
@@ -634,9 +638,12 @@ void Device::reset_cores() {
                 device_to_early_exit_cores[this->id()].insert(virtual_core);
 
                 // Clear launch erisc flag
-                auto core_type_idx = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
-                std::uint32_t launch_erisc_addr =
-                    tt::tt_metal::hal_ref.get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr;
+                auto core_type_idx = MetalContext::instance().hal().get_programmable_core_type_index(
+                    HalProgrammableCoreType::ACTIVE_ETH);
+                std::uint32_t launch_erisc_addr = tt::tt_metal::MetalContext::instance()
+                                                      .hal()
+                                                      .get_jit_build_config(core_type_idx, 0, 0)
+                                                      .fw_launch_addr;
                 std::vector<uint32_t> clear_flag_data = {0};
                 tt::llrt::write_hex_vec_to_core(this->id(), virtual_core, clear_flag_data, launch_erisc_addr);
             }
@@ -665,8 +672,8 @@ void Device::reset_cores() {
                         virtual_core.str(),
                         id_and_cores.first);
                     std::vector<uint32_t> data(sizeof(launch_msg_t) / sizeof(uint32_t));
-                    DeviceAddr launch_addr =
-                        hal_ref.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::LAUNCH);
+                    DeviceAddr launch_addr = MetalContext::instance().hal().get_dev_addr(
+                        HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::LAUNCH);
                     data = tt::llrt::read_hex_vec_from_core(
                         id_and_cores.first, virtual_core, launch_addr, sizeof(launch_msg_t));
                     launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
@@ -767,7 +774,7 @@ void Device::initialize_and_launch_firmware() {
     for (const tt::umd::CoreCoord& core : eth_cores) {
         core_info->non_worker_cores[non_worker_cores_idx++] = {core.x, core.y, AddressableCoreType::ETH};
     }
-    if (hal_ref.is_coordinate_virtualization_enabled()) {
+    if (MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // Track Virtual Non Worker Cores (In this case only Eth) separately
         uint32_t virtual_non_worker_cores_idx = 0;
         for (const tt::umd::CoreCoord& core : eth_cores) {
@@ -793,10 +800,10 @@ void Device::initialize_and_launch_firmware() {
         core_info->harvested_y[idx] = (idx < harvested_rows.size()) ? harvested_rows[idx] : CORE_COORD_INVALID;
         // Populate harvested rows in virtual coordinate space if virtualization is supported by HW.
         // Harvested rows in the virtual space are placed at the end of the worker grid,
-        if (hal_ref.is_coordinate_virtualization_enabled() and idx < harvested_rows.size()) {
+        if (MetalContext::instance().hal().is_coordinate_virtualization_enabled() and idx < harvested_rows.size()) {
             core_info->virtual_harvested_y[idx] =
-                (hal_ref.get_virtual_worker_start_y() + this->logical_grid_size().y + harvested_rows.size() -
-                 (idx + 1));
+                (MetalContext::instance().hal().get_virtual_worker_start_y() + this->logical_grid_size().y +
+                 harvested_rows.size() - (idx + 1));
         } else {
             core_info->virtual_harvested_y[idx] = CORE_COORD_INVALID;
         }
@@ -834,7 +841,8 @@ void Device::initialize_and_launch_firmware() {
     // Clear erisc sync info
     for (const auto &eth_core : this->get_active_ethernet_cores()) {
         static std::vector<uint32_t> zero_vec_erisc_init(
-            hal_ref.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::APP_SYNC_INFO) /
+            MetalContext::instance().hal().get_dev_size(
+                HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::APP_SYNC_INFO) /
                 sizeof(uint32_t),
             0);
 
@@ -844,7 +852,8 @@ void Device::initialize_and_launch_firmware() {
             this->id(),
             virtual_core,
             zero_vec_erisc_init,
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::APP_SYNC_INFO));
+            MetalContext::instance().hal().get_dev_addr(
+                HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::APP_SYNC_INFO));
     }
 
     // Load erisc app base FW to eth cores on WH and active_erisc FW on second risc of BH active eth cores
@@ -856,7 +865,7 @@ void Device::initialize_and_launch_firmware() {
         tt::llrt::write_hex_vec_to_core(
             this->id(), phys_eth_core, core_info_vec, this->get_dev_addr(phys_eth_core, HalL1MemAddrType::CORE_INFO));
         this->initialize_firmware(HalProgrammableCoreType::ACTIVE_ETH, phys_eth_core, &launch_msg, &go_msg);
-        if (!hal_ref.get_eth_fw_is_cooperative()) {
+        if (!MetalContext::instance().hal().get_eth_fw_is_cooperative()) {
             active_eth_cores.insert(phys_eth_core);
             not_done_cores.insert(phys_eth_core);
         }
@@ -920,14 +929,14 @@ void Device::clear_l1_state() {
     // between TILE_HEADER_BUFFER_BASE to COMMAND_Q_BASE
     // Clear erisc sync info
     for (const auto& eth_core : this->get_active_ethernet_cores()) {
-        static const uint32_t max_l1_loading_size =
-            hal_ref.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
+        static const uint32_t max_l1_loading_size = MetalContext::instance().hal().get_dev_size(
+            HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
 
         static uint32_t zero_vec_size = max_l1_loading_size;
         auto zero_vec_addr = HalL1MemAddrType::UNRESERVED;
-        if (hal_ref.get_eth_fw_is_cooperative()) {
-            zero_vec_size -=
-                hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::TILE_HEADER_BUFFER);
+        if (MetalContext::instance().hal().get_eth_fw_is_cooperative()) {
+            zero_vec_size -= MetalContext::instance().hal().get_dev_addr(
+                HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::TILE_HEADER_BUFFER);
             zero_vec_addr = HalL1MemAddrType::TILE_HEADER_BUFFER;
         }
 
@@ -939,7 +948,7 @@ void Device::clear_l1_state() {
             this->id(),
             virtual_core,
             zero_vec,
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, zero_vec_addr));
+            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, zero_vec_addr));
     }
     // TODO: clear idle eriscs as well
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(this->id());
@@ -1062,9 +1071,9 @@ void Device::init_command_queue_device() {
 
     // TODO: should get a const ref
     std::vector<std::vector<CoreCoord>>logical_cores = command_queue_program.logical_cores();
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
         const auto& logical_dispatch_cores = logical_cores[index];
-        CoreType core_type = hal_ref.get_core_type(index);
+        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
         for (const CoreCoord &logical_dispatch_core : logical_dispatch_cores) {
             launch_msg_t msg = command_queue_program.kernels_on_core(logical_dispatch_core, index)->launch_msg;
             go_msg_t go_msg = command_queue_program.kernels_on_core(logical_dispatch_core, index)->go_msg;
@@ -1099,7 +1108,7 @@ void Device::init_fabric() {
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->logical_cores();
     for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
-        CoreType core_type = hal_ref.get_core_type(programmable_core_type_index);
+        CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
         for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
             launch_msg_t* msg =
                 &fabric_program_->kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
@@ -1129,12 +1138,14 @@ bool Device::initialize(
     // However, I honestly don't understand it
     this->num_hw_cqs_ = num_hw_cqs;
     if (worker_l1_size == 0) {
-        worker_l1_size = hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+        worker_l1_size = MetalContext::instance().hal().get_dev_size(
+            HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     }
 
-    size_t max_worker_l1_size = hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
-                                hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) -
-                                hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+    size_t max_worker_l1_size =
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
+        MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) -
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
 
     TT_FATAL(
         worker_l1_size <= max_worker_l1_size,
@@ -1142,11 +1153,13 @@ bool Device::initialize(
         worker_l1_size,
         max_worker_l1_size);
     log_debug(tt::LogMetal, "Worker L1 size: {} Max: {}", worker_l1_size, max_worker_l1_size);
-    std::uint32_t max_alignment =
-        std::max(hal_ref.get_alignment(HalMemType::DRAM), hal_ref.get_alignment(HalMemType::L1));
+    std::uint32_t max_alignment = std::max(
+        MetalContext::instance().hal().get_alignment(HalMemType::DRAM),
+        MetalContext::instance().hal().get_alignment(HalMemType::L1));
     uint32_t worker_l1_unreserved_start = tt::align(
-        hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
-            hal_ref.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - worker_l1_size,
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
+            MetalContext::instance().hal().get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) -
+            worker_l1_size,
         max_alignment);
     BuildEnvManager::get_instance().add_build_env(this->id(), this->num_hw_cqs());
     this->initialize_cluster();
@@ -1224,7 +1237,7 @@ bool Device::close() {
         }
     }
 
-    if (!hal_ref.get_eth_fw_is_cooperative()) {
+    if (!MetalContext::instance().hal().get_eth_fw_is_cooperative()) {
         for (const auto& eth_core : this->get_active_ethernet_cores()) {
             CoreCoord virtual_eth_core = this->ethernet_core_from_logical_core(eth_core);
             TensixSoftResetOptions reset_val =
@@ -1310,8 +1323,8 @@ CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) co
         coord = this->virtual_core_from_physical_core(coord);
         // Derive virtual coord in noc_index space.
         CoreCoord virtual_coord = {
-            hal_ref.noc_coordinate(noc_index, grid_size.x, coord.x),
-            hal_ref.noc_coordinate(noc_index, grid_size.y, coord.y)};
+            MetalContext::instance().hal().noc_coordinate(noc_index, grid_size.x, coord.x),
+            MetalContext::instance().hal().noc_coordinate(noc_index, grid_size.y, coord.y)};
         return virtual_coord;
     }
 }
@@ -1362,7 +1375,7 @@ CoreCoord Device::logical_core_from_ethernet_core(const CoreCoord &ethernet_core
 
 uint32_t Device::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
     auto virtual_noc_coord = this->virtual_noc0_coordinate(noc_index, core);
-    return tt::tt_metal::hal_ref.noc_xy_encoding(virtual_noc_coord.x, virtual_noc_coord.y);
+    return tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(virtual_noc_coord.x, virtual_noc_coord.y);
 }
 
 uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const {
@@ -1371,10 +1384,10 @@ uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& 
 
     // NOC 1 mcasts from bottom left to top right, so we need to reverse the coords
     if (noc_index == 0) {
-        return tt::tt_metal::hal_ref.noc_multicast_encoding(
+        return tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
             virtual_noc_start.x, virtual_noc_start.y, virtual_noc_end.x, virtual_noc_end.y);
     } else {
-        return tt::tt_metal::hal_ref.noc_multicast_encoding(
+        return tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
             virtual_noc_end.x, virtual_noc_end.y, virtual_noc_start.x, virtual_noc_start.y);
     }
 }
@@ -1633,28 +1646,30 @@ void Device::generate_device_bank_to_noc_tables()
     const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(this->id());
 
     dram_bank_to_noc_xy_.clear();
-    dram_bank_to_noc_xy_.reserve(tt::tt_metal::hal_ref.get_num_nocs() * dram_noc_coord_per_bank.size());
-    for (unsigned int noc = 0; noc < tt::tt_metal::hal_ref.get_num_nocs(); noc++) {
+    dram_bank_to_noc_xy_.reserve(
+        tt::tt_metal::MetalContext::instance().hal().get_num_nocs() * dram_noc_coord_per_bank.size());
+    for (unsigned int noc = 0; noc < tt::tt_metal::MetalContext::instance().hal().get_num_nocs(); noc++) {
         for (unsigned int bank_id = 0; bank_id < dram_noc_coord_per_bank.size(); bank_id++) {
-            uint16_t noc_x =
-                tt::tt_metal::hal_ref.noc_coordinate(noc, soc_d.grid_size.x, dram_noc_coord_per_bank[bank_id].x);
-            uint16_t noc_y =
-                tt::tt_metal::hal_ref.noc_coordinate(noc, soc_d.grid_size.y, dram_noc_coord_per_bank[bank_id].y);
-            uint16_t xy = ((noc_y << tt::tt_metal::hal_ref.get_noc_addr_node_id_bits()) | noc_x)
-                          << tt::tt_metal::hal_ref.get_noc_coord_reg_offset();
+            uint16_t noc_x = tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                noc, soc_d.grid_size.x, dram_noc_coord_per_bank[bank_id].x);
+            uint16_t noc_y = tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                noc, soc_d.grid_size.y, dram_noc_coord_per_bank[bank_id].y);
+            uint16_t xy = ((noc_y << tt::tt_metal::MetalContext::instance().hal().get_noc_addr_node_id_bits()) | noc_x)
+                          << tt::tt_metal::MetalContext::instance().hal().get_noc_coord_reg_offset();
             dram_bank_to_noc_xy_.push_back(xy);
         }
     }
 
     l1_bank_to_noc_xy_.clear();
-    l1_bank_to_noc_xy_.reserve(tt::tt_metal::hal_ref.get_num_nocs() * l1_noc_coord_per_bank.size());
-    for (unsigned int noc = 0; noc < tt::tt_metal::hal_ref.get_num_nocs(); noc++) {
+    l1_bank_to_noc_xy_.reserve(
+        tt::tt_metal::MetalContext::instance().hal().get_num_nocs() * l1_noc_coord_per_bank.size());
+    for (unsigned int noc = 0; noc < tt::tt_metal::MetalContext::instance().hal().get_num_nocs(); noc++) {
         for (unsigned int bank_id = 0; bank_id < l1_noc_coord_per_bank.size(); bank_id++) {
             auto l1_noc_coords = this->virtual_noc0_coordinate(noc, l1_noc_coord_per_bank[bank_id]);
             uint16_t noc_x = l1_noc_coords.x;
             uint16_t noc_y = l1_noc_coords.y;
-            uint16_t xy = ((noc_y << tt::tt_metal::hal_ref.get_noc_addr_node_id_bits()) | noc_x)
-                          << tt::tt_metal::hal_ref.get_noc_coord_reg_offset();
+            uint16_t xy = ((noc_y << tt::tt_metal::MetalContext::instance().hal().get_noc_addr_node_id_bits()) | noc_x)
+                          << tt::tt_metal::MetalContext::instance().hal().get_noc_coord_reg_offset();
             l1_bank_to_noc_xy_.push_back(xy);
         }
     }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -62,7 +62,6 @@
 #include "profiler_types.hpp"
 #include "program_device_map.hpp"
 #include "tt-metalium/program.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
 #include "trace_buffer.hpp"
@@ -323,7 +322,7 @@ void Device::get_associated_dispatch_virtual_cores(
 
 void Device::initialize_cluster() {
     ZoneScoped;
-    if (llrt::RunTimeOptions::get_instance().get_clear_l1()) {
+    if (tt_metal::MetalContext::instance().rtoptions().get_clear_l1()) {
         this->clear_l1_state();
     }
     int ai_clk = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(this->id_);
@@ -489,7 +488,7 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                     }
                     log_debug(LogDevice, "RISC {} fw binary size: {} in bytes", riscv_id, fw_size);
 
-                    if (not llrt::RunTimeOptions::get_instance().get_skip_loading_fw())  {
+                    if (not tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
                         llrt::test_load_write_read_risc_binary(
                             binary_mem, this->id(), virtual_core, core_type_idx, processor_class, riscv_id);
                     }
@@ -530,7 +529,7 @@ void Device::initialize_firmware(const HalProgrammableCoreType &core_type, CoreC
                 tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
                     tt_cxy_pair(this->id(), virtual_core), reset_val);
             }
-            if (not llrt::RunTimeOptions::get_instance().get_skip_loading_fw()) {
+            if (not tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                     auto num_build_states = hal_ref.get_processor_types_count(core_type_idx, processor_class);
                     for (uint32_t eriscv_id = 0; eriscv_id < num_build_states; eriscv_id++) {
@@ -1049,7 +1048,7 @@ void Device::init_command_queue_host() {
 }
 
 void Device::init_command_queue_device() {
-    if (llrt::RunTimeOptions::get_instance().get_skip_loading_fw()) {
+    if (tt_metal::MetalContext::instance().rtoptions().get_skip_loading_fw()) {
         detail::EnablePersistentKernelCache();
         this->compile_command_queue_programs();
         detail::DisablePersistentKernelCache();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -29,7 +29,6 @@
 #include "host_api.hpp"
 #include "logger.hpp"
 #include "profiler_types.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/fabric/fabric_host_utils.hpp"
@@ -289,7 +288,7 @@ void DevicePool::initialize_host(IDevice* dev) const {
     watcher_init(dev->id());
 
     // TODO: as optimization, investigate removing all this call for already initialized devivces
-    if (!llrt::RunTimeOptions::get_instance().get_skip_reset_cores_on_init()) {
+    if (!tt_metal::MetalContext::instance().rtoptions().get_skip_reset_cores_on_init()) {
         dev->reset_cores();
     }
     dev->initialize_and_launch_firmware();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -515,8 +515,8 @@ void DevicePool::wait_for_fabric_router_sync() const {
             }
         }
     } else if (tt_fabric::is_2d_fabric_config(fabric_config)) {
-        auto fabric_router_sync_sem_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
+        auto fabric_router_sync_sem_addr = MetalContext::instance().hal().get_dev_addr(
+            HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
 
         std::vector<std::uint32_t> master_router_status{0};
         for (const auto& dev : this->get_all_active_devices()) {
@@ -768,8 +768,8 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
         }
     } else if (tt_fabric::is_2d_fabric_config(fabric_config)) {
         std::vector<uint32_t> master_router_terminate(1, 0);
-        auto fabric_router_sync_sem_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
+        auto fabric_router_sync_sem_addr = MetalContext::instance().hal().get_dev_addr(
+            HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
         for (const auto& dev : this->get_all_active_devices()) {
             auto fabric_ethernet_channels =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -7,7 +7,6 @@
 #include <core_coord.hpp>
 #include <kernel.hpp>
 #include <magic_enum/magic_enum.hpp>
-#include <rtoptions.hpp>
 #include <algorithm>
 #include <array>
 #include <cstdlib>
@@ -23,6 +22,7 @@
 #include "dev_msgs.h"
 #include "tt-metalium/program.hpp"
 #include <umd/device/tt_core_coordinates.h>
+#include "impl/context/metal_context.hpp"
 #include "utils.hpp"
 
 using namespace tt;
@@ -271,7 +271,7 @@ namespace tt {
 
 void RecordDispatchData(Program& program, data_collector_t type, uint32_t transaction_size, RISCV riscv) {
     // Do nothing if we're not enabling data collection.
-    if (!tt::llrt::RunTimeOptions::get_instance().get_dispatch_data_collection_enabled()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
 
@@ -281,7 +281,7 @@ void RecordDispatchData(Program& program, data_collector_t type, uint32_t transa
 
 void RecordKernelGroups(Program& program, CoreType core_type, std::vector<KernelGroup>& kernel_groups) {
     // Do nothing if we're not enabling data collection.
-    if (!tt::llrt::RunTimeOptions::get_instance().get_dispatch_data_collection_enabled()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
 
@@ -291,7 +291,7 @@ void RecordKernelGroups(Program& program, CoreType core_type, std::vector<Kernel
 
 void RecordProgramRun(Program& program) {
     // Do nothing if we're not enabling data collection.
-    if (!tt::llrt::RunTimeOptions::get_instance().get_dispatch_data_collection_enabled()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
 

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -438,6 +438,7 @@ void dump_issue_queue_entries(
         first_page_addr + DispatchSettings::TRANSFER_PAGE_SIZE - 1;  // To track offset of latest page read out
     tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(
         read_data.data(), read_data.size(), first_page_addr, mmio_device_id, channel);
+    const auto& hal = MetalContext::instance().hal();
     for (uint32_t offset = 0; offset < issue_q_bytes;) {  // offset increments at end of loop
         uint32_t curr_addr = issue_q_base_addr + offset;
         uint32_t page_offset = curr_addr % DispatchSettings::TRANSFER_PAGE_SIZE;
@@ -454,21 +455,21 @@ void dump_issue_queue_entries(
         CQPrefetchCmd* cmd = (CQPrefetchCmd*)(read_data.data() + page_offset);
         if (cmd->base.cmd_id < CQ_PREFETCH_CMD_MAX_COUNT && cmd->base.cmd_id != CQ_PREFETCH_CMD_ILLEGAL) {
             if (last_span_invalid) {
-                if (curr_addr == last_span_start + MetalContext::instance().hal().get_alignment(HalMemType::HOST)) {
+                if (curr_addr == last_span_start + hal.get_alignment(HalMemType::HOST)) {
                     iq_file << fmt::format("{:#010x}: No valid prefetch command detected.", last_span_start);
                 } else {
                     iq_file << fmt::format(
                         "{:#010x}-{:#010x}: No valid prefetch commands detected.",
                         last_span_start,
-                        curr_addr - MetalContext::instance().hal().get_alignment(HalMemType::HOST));
+                        curr_addr - hal.get_alignment(HalMemType::HOST));
                 }
                 last_span_invalid = false;
                 if (last_span_start <= (issue_write_ptr) &&
-                    curr_addr - MetalContext::instance().hal().get_alignment(HalMemType::HOST) >= (issue_write_ptr)) {
+                    curr_addr - hal.get_alignment(HalMemType::HOST) >= (issue_write_ptr)) {
                     iq_file << fmt::format(" << write_ptr (0x{:08x})", issue_write_ptr);
                 }
                 if (last_span_start <= (issue_read_ptr) &&
-                    curr_addr - MetalContext::instance().hal().get_alignment(HalMemType::HOST) >= (issue_read_ptr)) {
+                    curr_addr - hal.get_alignment(HalMemType::HOST) >= (issue_read_ptr)) {
                     iq_file << fmt::format(" << read_ptr (0x{:08x})", issue_read_ptr);
                 }
                 iq_file << std::endl;
@@ -478,8 +479,8 @@ void dump_issue_queue_entries(
 
             // Check for a bad stride (happen to have a valid cmd_id, overwritten values, etc.)
             if (cmd_stride + offset >= issue_q_bytes || cmd_stride == 0 ||
-                cmd_stride % MetalContext::instance().hal().get_alignment(HalMemType::HOST) != 0) {
-                cmd_stride = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+                cmd_stride % hal.get_alignment(HalMemType::HOST) != 0) {
+                cmd_stride = hal.get_alignment(HalMemType::HOST);
                 iq_file << " (bad stride)";
             }
 
@@ -494,7 +495,7 @@ void dump_issue_queue_entries(
             // If it's a RELAY_INLINE command, then the data inside is dispatch commands, show them.
             if ((cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE ||
                  cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH) &&
-                cmd_stride > MetalContext::instance().hal().get_alignment(HalMemType::HOST)) {
+                cmd_stride > hal.get_alignment(HalMemType::HOST)) {
                 uint32_t dispatch_offset = offset + sizeof(CQPrefetchCmd);
                 uint32_t dispatch_curr_addr = issue_q_base_addr + dispatch_offset;
                 while (dispatch_offset < offset + cmd_stride) {
@@ -530,7 +531,7 @@ void dump_issue_queue_entries(
                 last_span_start = curr_addr;
             }
             last_span_invalid = true;
-            offset += MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+            offset += hal.get_alignment(HalMemType::HOST);
         }
         print_progress_bar((float)offset / issue_q_bytes + 0.005);
     }

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -223,7 +223,8 @@ uint32_t dump_dispatch_cmd(CQDispatchCmd* cmd, uint32_t cmd_addr, std::ofstream&
 
 // Returns the number of bytes taken up by this prefetch command (including header).
 uint32_t dump_prefetch_cmd(CQPrefetchCmd* cmd, uint32_t cmd_addr, std::ofstream& iq_file) {
-    uint32_t stride = hal_ref.get_alignment(HalMemType::HOST);  // Default stride matches alignment.
+    uint32_t stride =
+        MetalContext::instance().hal().get_alignment(HalMemType::HOST);  // Default stride matches alignment.
     CQPrefetchCmdId cmd_id = cmd->base.cmd_id;
 
     if (cmd_id < CQ_PREFETCH_CMD_MAX_COUNT) {
@@ -453,21 +454,21 @@ void dump_issue_queue_entries(
         CQPrefetchCmd* cmd = (CQPrefetchCmd*)(read_data.data() + page_offset);
         if (cmd->base.cmd_id < CQ_PREFETCH_CMD_MAX_COUNT && cmd->base.cmd_id != CQ_PREFETCH_CMD_ILLEGAL) {
             if (last_span_invalid) {
-                if (curr_addr == last_span_start + hal_ref.get_alignment(HalMemType::HOST)) {
+                if (curr_addr == last_span_start + MetalContext::instance().hal().get_alignment(HalMemType::HOST)) {
                     iq_file << fmt::format("{:#010x}: No valid prefetch command detected.", last_span_start);
                 } else {
                     iq_file << fmt::format(
                         "{:#010x}-{:#010x}: No valid prefetch commands detected.",
                         last_span_start,
-                        curr_addr - hal_ref.get_alignment(HalMemType::HOST));
+                        curr_addr - MetalContext::instance().hal().get_alignment(HalMemType::HOST));
                 }
                 last_span_invalid = false;
                 if (last_span_start <= (issue_write_ptr) &&
-                    curr_addr - hal_ref.get_alignment(HalMemType::HOST) >= (issue_write_ptr)) {
+                    curr_addr - MetalContext::instance().hal().get_alignment(HalMemType::HOST) >= (issue_write_ptr)) {
                     iq_file << fmt::format(" << write_ptr (0x{:08x})", issue_write_ptr);
                 }
                 if (last_span_start <= (issue_read_ptr) &&
-                    curr_addr - hal_ref.get_alignment(HalMemType::HOST) >= (issue_read_ptr)) {
+                    curr_addr - MetalContext::instance().hal().get_alignment(HalMemType::HOST) >= (issue_read_ptr)) {
                     iq_file << fmt::format(" << read_ptr (0x{:08x})", issue_read_ptr);
                 }
                 iq_file << std::endl;
@@ -477,8 +478,8 @@ void dump_issue_queue_entries(
 
             // Check for a bad stride (happen to have a valid cmd_id, overwritten values, etc.)
             if (cmd_stride + offset >= issue_q_bytes || cmd_stride == 0 ||
-                cmd_stride % hal_ref.get_alignment(HalMemType::HOST) != 0) {
-                cmd_stride = hal_ref.get_alignment(HalMemType::HOST);
+                cmd_stride % MetalContext::instance().hal().get_alignment(HalMemType::HOST) != 0) {
+                cmd_stride = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
                 iq_file << " (bad stride)";
             }
 
@@ -493,7 +494,7 @@ void dump_issue_queue_entries(
             // If it's a RELAY_INLINE command, then the data inside is dispatch commands, show them.
             if ((cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE ||
                  cmd->base.cmd_id == CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH) &&
-                cmd_stride > hal_ref.get_alignment(HalMemType::HOST)) {
+                cmd_stride > MetalContext::instance().hal().get_alignment(HalMemType::HOST)) {
                 uint32_t dispatch_offset = offset + sizeof(CQPrefetchCmd);
                 uint32_t dispatch_curr_addr = issue_q_base_addr + dispatch_offset;
                 while (dispatch_offset < offset + cmd_stride) {
@@ -529,7 +530,7 @@ void dump_issue_queue_entries(
                 last_span_start = curr_addr;
             }
             last_span_invalid = true;
-            offset += hal_ref.get_alignment(HalMemType::HOST);
+            offset += MetalContext::instance().hal().get_alignment(HalMemType::HOST);
         }
         print_progress_bar((float)offset / issue_q_bytes + 0.005);
     }

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -17,7 +17,7 @@
 #include "command_queue_interface.hpp"
 #include "env_lib.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "memcpy.hpp"
 #include <tt_stl/span.hpp>
 #include "tt_align.hpp"
@@ -227,8 +227,9 @@ private:
     uint32_t cmd_sequence_sizeB = 0;
     void* cmd_region = nullptr;
     uint32_t cmd_write_offsetB = 0;
-    uint32_t pcie_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST);
-    uint32_t l1_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::L1);
+    uint32_t pcie_alignment =
+        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 
     vector_aligned<uint32_t> cmd_region_vector;
 };

--- a/tt_metal/impl/dispatch/device_command_calculator.cpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.cpp
@@ -50,7 +50,7 @@ void DeviceCommandCalculator::insert_write_packed_payloads(
     const uint32_t max_prefetch_command_size,
     const uint32_t packed_write_max_unicast_sub_cmds,
     std::vector<std::pair<uint32_t, uint32_t>>& packed_cmd_payloads) {
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     const uint32_t aligned_sub_cmd_sizeB = tt::align(sub_cmd_sizeB, l1_alignment);
     const uint32_t max_packed_sub_cmds_per_cmd = get_max_write_packed_sub_cmds<PackedSubCmd>(
         aligned_sub_cmd_sizeB, max_prefetch_command_size, packed_write_max_unicast_sub_cmds, false);

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -9,7 +9,7 @@
 
 #include "assert.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "tt_align.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 
@@ -221,7 +221,8 @@ public:
 private:
     void add_prefetch_relay_inline() { this->cmd_write_offsetB += sizeof(CQPrefetchCmd); }
     uint32_t cmd_write_offsetB = 0;
-    uint32_t pcie_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST);
-    uint32_t l1_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::L1);
+    uint32_t pcie_alignment =
+        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+    uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 };
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -4,7 +4,6 @@
 
 #include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
-#include "get_platform_architecture.hpp"
 #include <umd/device/types/arch.h>
 
 enum class CoreType;
@@ -12,8 +11,8 @@ enum class CoreType;
 namespace tt::tt_metal {
 
 DispatchCoreAxis DispatchCoreConfig::get_default_axis() {
-    return (tt::tt_metal::get_platform_architecture() == tt::ARCH::BLACKHOLE) ? DispatchCoreAxis::COL
-                                                                              : DispatchCoreAxis::ROW;
+    return (MetalContext::instance().get_cluster().arch() == tt::ARCH::BLACKHOLE) ? DispatchCoreAxis::COL
+                                                                                  : DispatchCoreAxis::ROW;
 }
 
 DispatchCoreConfig get_dispatch_core_config() {

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -13,7 +13,6 @@
 #include "dispatch_settings.hpp"
 #include "hal_types.hpp"
 #include <tt_stl/indestructible.hpp>
-#include "llrt/hal.hpp"
 #include "impl/context/metal_context.hpp"
 #include "utils.hpp"
 
@@ -79,21 +78,24 @@ uint32_t DispatchMemMap::get_device_command_queue_addr(const CommandQueueDeviceA
 
 uint32_t DispatchMemMap::get_host_command_queue_addr(const CommandQueueHostAddrType& host_addr) const {
     return tt::utils::underlying_type<CommandQueueHostAddrType>(host_addr) *
-           tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST);
+           tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
 }
 
 uint32_t DispatchMemMap::get_sync_offset(uint32_t index) const {
     TT_ASSERT(index < tt::tt_metal::DispatchSettings::DISPATCH_MESSAGE_ENTRIES);
-    uint32_t offset = index * hal_ref.get_alignment(HalMemType::L1);
+    uint32_t offset = index * MetalContext::instance().hal().get_alignment(HalMemType::L1);
     return offset;
 }
 
 uint32_t DispatchMemMap::get_dispatch_message_addr_start() const {
     // Address of the first dispatch message entry. Remaining entries are each offset by
     // get_noc_stream_reg_space_size() bytes.
-    return tt::tt_metal::hal_ref.get_noc_overlay_start_addr() +
-           tt::tt_metal::hal_ref.get_noc_stream_reg_space_size() * get_dispatch_stream_index(0) +
-           tt::tt_metal::hal_ref.get_noc_stream_remote_dest_buf_space_available_update_reg_index() * sizeof(uint32_t);
+    return tt::tt_metal::MetalContext::instance().hal().get_noc_overlay_start_addr() +
+           tt::tt_metal::MetalContext::instance().hal().get_noc_stream_reg_space_size() * get_dispatch_stream_index(0) +
+           tt::tt_metal::MetalContext::instance()
+                   .hal()
+                   .get_noc_stream_remote_dest_buf_space_available_update_reg_index() *
+               sizeof(uint32_t);
 }
 
 uint32_t DispatchMemMap::get_dispatch_stream_index(uint32_t index) const {
@@ -127,8 +129,9 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
 
     const auto dispatch_buffer_block_size = settings.dispatch_size_;
     const auto [l1_base, l1_size] = get_device_l1_info(settings.core_type_);
-    const auto pcie_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST);
-    const auto l1_alignment = tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::L1);
+    const auto pcie_alignment =
+        tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+    const auto l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 
     TT_ASSERT(settings.prefetch_cmddat_q_size_ >= 2 * settings.prefetch_max_cmd_size_);
     TT_ASSERT(settings.prefetch_scratch_db_size_ % 2 == 0);
@@ -188,15 +191,15 @@ std::pair<uint32_t, uint32_t> DispatchMemMap::get_device_l1_info(const CoreType&
     uint32_t l1_base;
     uint32_t l1_size;
     if (core_type == CoreType::WORKER) {
-        l1_base = hal_ref.get_dev_addr(
+        l1_base = MetalContext::instance().hal().get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::DEFAULT_UNRESERVED);
-        l1_size =
-            hal_ref.get_dev_size(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE);
+        l1_size = MetalContext::instance().hal().get_dev_size(
+            tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE);
     } else if (core_type == CoreType::ETH) {
-        l1_base = hal_ref.get_dev_addr(
+        l1_base = MetalContext::instance().hal().get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::UNRESERVED);
-        l1_size =
-            hal_ref.get_dev_size(tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE);
+        l1_size = MetalContext::instance().hal().get_dev_size(
+            tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE);
     } else {
         TT_THROW("get_base_device_command_queue_addr not implemented for core type");
     }

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -14,7 +14,7 @@
 #include "hal_types.hpp"
 #include <tt_stl/indestructible.hpp>
 #include "llrt/hal.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "utils.hpp"
 
 namespace tt::tt_metal {
@@ -149,7 +149,7 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
         } else if (dev_addr_type == CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM) {
             device_cq_addr_sizes_[dev_addr_idx] = settings.dispatch_s_sync_sem_;
         } else if (dev_addr_type == CommandQueueDeviceAddrType::FABRIC_INTERFACE) {
-            if (llrt::RunTimeOptions::get_instance().get_fd_fabric()) {
+            if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
                 device_cq_addr_sizes_[dev_addr_idx] = tt_fabric::PACKET_HEADER_SIZE_BYTES;
             } else {
                 device_cq_addr_sizes_[dev_addr_idx] = 0;

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -32,7 +32,6 @@
 #include "hal_types.hpp"
 #include "logger.hpp"
 #include "program_device_map.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
@@ -329,7 +328,7 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     program.set_last_used_command_queue_for_testing(this);
 
 #ifdef DEBUG
-    if (tt::llrt::RunTimeOptions::get_instance().get_validate_kernel_binaries()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_validate_kernel_binaries()) {
         TT_FATAL(!this->manager_.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
         if (const auto buffer = program.get_kernels_buffer(device_)) {
             std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
@@ -394,7 +393,7 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     this->enqueue_command(command, blocking, sub_device_ids);
 
 #ifdef DEBUG
-    if (tt::llrt::RunTimeOptions::get_instance().get_validate_kernel_binaries()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_validate_kernel_binaries()) {
         TT_FATAL(!this->manager_.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
         if (const auto buffer = program.get_kernels_buffer(device_)) {
             std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
@@ -552,7 +551,7 @@ void HWCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids) {
     tt::log_debug(tt::LogDispatch, "Finish for command queue {}", this->id_);
     std::shared_ptr<Event> event = std::make_shared<Event>();
     this->enqueue_record_event(event, sub_device_ids);
-    if (tt::llrt::RunTimeOptions::get_instance().get_test_mode_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_test_mode_enabled()) {
         while (this->num_entries_in_completion_q_ > this->num_completed_completion_q_reads_) {
             if (DPrintServerHangDetected()) {
                 // DPrint Server hang, early exit. We're in test mode, so main thread will assert.

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -596,7 +596,7 @@ void HWCommandQueue::record_end() {
     auto& trace_data = this->trace_ctx_->data;
     trace_data = std::move(this->manager_.get_bypass_data());
     // Add trace end command to terminate the trace buffer
-    DeviceCommand command_sequence(hal_ref.get_alignment(HalMemType::HOST));
+    DeviceCommand command_sequence(MetalContext::instance().hal().get_alignment(HalMemType::HOST));
     command_sequence.add_prefetch_exec_buf_end();
     for (int i = 0; i < command_sequence.size_bytes() / sizeof(uint32_t); i++) {
         trace_data.push_back(((uint32_t*)command_sequence.data())[i]);

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -31,7 +31,6 @@
 #include "lightmetal/host_api_capture_helpers.hpp"
 #include "llrt/hal.hpp"
 #include "tt-metalium/program.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
 #include "system_memory_manager.hpp"
 #include "tracy/Tracy.hpp"
@@ -318,7 +317,7 @@ void EventSynchronize(const std::shared_ptr<Event>& event) {
         event->event_id);
 
     while (event->device->sysmem_manager().get_last_completed_event(event->cq_id) < event->event_id) {
-        if (tt::llrt::RunTimeOptions::get_instance().get_test_mode_enabled() &&
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_test_mode_enabled() &&
             tt::watcher_server_killed_due_to_error()) {
             TT_FATAL(
                 false,

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -29,7 +29,6 @@
 #include "dprint_server.hpp"
 #include "hal_types.hpp"
 #include "lightmetal/host_api_capture_helpers.hpp"
-#include "llrt/hal.hpp"
 #include "tt-metalium/program.hpp"
 #include <tt_stl/span.hpp>
 #include "system_memory_manager.hpp"
@@ -179,7 +178,7 @@ EnqueueTerminateCommand::EnqueueTerminateCommand(
 void EnqueueTerminateCommand::process() {
     // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_TERMINATE
     // CQ_PREFETCH_CMD_TERMINATE
-    uint32_t cmd_sequence_sizeB = hal_ref.get_alignment(HalMemType::HOST);
+    uint32_t cmd_sequence_sizeB = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
 
     // dispatch and prefetch terminate commands each needs to be a separate fetch queue entry
     void* cmd_region = this->manager.issue_queue_reserve(cmd_sequence_sizeB, this->command_queue_id);

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -176,32 +176,18 @@ void DemuxKernel::CreateKernel() {
     tt_cxy_pair my_virtual_core =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
             logical_core_, GetCoreType());
-    std::map<string, string> defines = {// All of these unused, remove later
-                                        {"MY_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-                                        {"MY_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-                                        {"UPSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.x, 0))},
-                                        {"UPSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"SKIP_NOC_LOGGING", "1"}};
+    const auto& hal = MetalContext::instance().hal();
+    std::map<string, string> defines = {
+        // All of these unused, remove later
+        {"MY_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+        {"MY_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+        {"UPSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
+        {"UPSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[DEMUX], compile_args, defines, false, false, false);
 }

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -176,25 +176,32 @@ void DemuxKernel::CreateKernel() {
     tt_cxy_pair my_virtual_core =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
             logical_core_, GetCoreType());
-    std::map<string, string> defines = {
-        // All of these unused, remove later
-        {"MY_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-        {"MY_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-        {"UPSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
-        {"UPSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"SKIP_NOC_LOGGING", "1"}};
+    std::map<string, string> defines = {// All of these unused, remove later
+                                        {"MY_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+                                        {"MY_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+                                        {"UPSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.x, 0))},
+                                        {"UPSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[DEMUX], compile_args, defines, false, false, false);
 }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -161,7 +161,7 @@ void DispatchKernel::GenerateStaticConfigs() {
             my_dispatch_constants.mux_buffer_pages(device_->num_hw_cqs()),
             GetCoreType());  // Apparently unused
 
-        if (tt::llrt::RunTimeOptions::get_instance().get_fd_fabric()) {
+        if (MetalContext::instance().rtoptions().get_fd_fabric()) {
             static_config_.split_dispatch_page_preamble_size = 0;
         } else {
             static_config_.split_dispatch_page_preamble_size = sizeof(tt::packet_queue::dispatch_packet_header_t);

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -23,7 +23,6 @@
 #include "dispatch_mem_map.hpp"
 #include "dispatch_s.hpp"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
 #include "mux.hpp"
 #include "prefetch.hpp"
 #include "impl/context/metal_context.hpp"
@@ -71,10 +70,11 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
         static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         static_config_.mcast_go_signal_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
         static_config_.unicast_go_signal_addr =
-            (hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-                ? hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+            (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+                ? MetalContext::instance().hal().get_dev_addr(
+                      HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
         static_config_.distributed_dispatcher =
             MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
@@ -175,10 +175,11 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
         static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
         static_config_.mcast_go_signal_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
         static_config_.unicast_go_signal_addr =
-            (hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-                ? hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+            (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+                ? MetalContext::instance().hal().get_dev_addr(
+                      HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
                 : 0;
         static_config_.distributed_dispatcher =
             MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();
@@ -212,7 +213,7 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.prefetch_h_local_downstream_sem_addr = 0;
         } else {
             dependent_config_.split_prefetch = true;
-            dependent_config_.prefetch_h_noc_xy = tt::tt_metal::hal_ref.noc_xy_encoding(
+            dependent_config_.prefetch_h_noc_xy = tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(
                 prefetch_kernel->GetVirtualCore().x, prefetch_kernel->GetVirtualCore().y);
             dependent_config_.prefetch_h_local_downstream_sem_addr =
                 prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id.value();
@@ -261,7 +262,7 @@ void DispatchKernel::GenerateDependentConfigs() {
         dependent_config_.downstream_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
         dependent_config_.split_prefetch = true;
-        dependent_config_.prefetch_h_noc_xy = tt::tt_metal::hal_ref.noc_xy_encoding(
+        dependent_config_.prefetch_h_noc_xy = tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(
             prefetch_h_kernel->GetVirtualCore().x, prefetch_h_kernel->GetVirtualCore().y);
         dependent_config_.prefetch_h_local_downstream_sem_addr =
             prefetch_h_kernel->GetStaticConfig().my_downstream_cb_sem_id;
@@ -284,7 +285,7 @@ void DispatchKernel::GenerateDependentConfigs() {
             dependent_config_.prefetch_h_local_downstream_sem_addr = 0;
         } else {
             dependent_config_.split_prefetch = true;
-            dependent_config_.prefetch_h_noc_xy = tt::tt_metal::hal_ref.noc_xy_encoding(
+            dependent_config_.prefetch_h_noc_xy = tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(
                 prefetch_kernel->GetVirtualCore().x, prefetch_kernel->GetVirtualCore().y);
             dependent_config_.prefetch_h_local_downstream_sem_addr =
                 prefetch_kernel->GetStaticConfig().my_downstream_cb_sem_id.value();
@@ -459,7 +460,7 @@ void DispatchKernel::UpdateArgsForFabric(
     tt::tt_fabric::mesh_id_t downstream_mesh_id,
     chip_id_t downstream_dev_id) {
     dependent_config_.fabric_router_noc_xy =
-        tt::tt_metal::hal_ref.noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
     dependent_config_.upstream_mesh_id = upstream_mesh_id;
     dependent_config_.upstream_dev_id = upstream_dev_id;
     dependent_config_.downstream_mesh_id = downstream_mesh_id;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -9,7 +9,6 @@
 
 #include "assert.hpp"
 #include "core_coord.hpp"
-#include "impl/context/metal_context.hpp"
 #include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
 #include "system_memory_manager.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -58,10 +58,10 @@ void DispatchSKernel::GenerateStaticConfigs() {
     // used by dispatch_d to signal that dispatch_s can send go signal
 
     static_config_.mcast_go_signal_addr =
-        hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
     static_config_.unicast_go_signal_addr =
-        (hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
-            ? hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
+        (MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1)
+            ? MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::GO_MSG)
             : 0;
     static_config_.distributed_dispatcher =
         MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher();

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <optional>
 
-#include "impl/context/metal_context.hpp"
 #include "fd_kernel.hpp"
 #include "system_memory_manager.hpp"
 #include "impl/context/metal_context.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -291,25 +291,32 @@ void EthRouterKernel::CreateKernel() {
     }
     TT_ASSERT(compile_args.size() == 36);
     const auto& grid_size = device_->grid_size();
-    std::map<string, string> defines = {
-        // All of these unused, remove later
-        {"MY_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-        {"MY_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-        {"UPSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
-        {"UPSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"SKIP_NOC_LOGGING", "1"}};
+    std::map<string, string> defines = {// All of these unused, remove later
+                                        {"MY_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+                                        {"MY_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+                                        {"UPSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.x, 0))},
+                                        {"UPSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[PACKET_ROUTER_MUX], compile_args, defines, false, false, false);
 }

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -291,32 +291,18 @@ void EthRouterKernel::CreateKernel() {
     }
     TT_ASSERT(compile_args.size() == 36);
     const auto& grid_size = device_->grid_size();
-    std::map<string, string> defines = {// All of these unused, remove later
-                                        {"MY_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-                                        {"MY_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-                                        {"UPSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.x, 0))},
-                                        {"UPSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"SKIP_NOC_LOGGING", "1"}};
+    const auto& hal = MetalContext::instance().hal();
+    std::map<string, string> defines = {
+        // All of these unused, remove later
+        {"MY_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+        {"MY_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+        {"UPSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
+        {"UPSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[PACKET_ROUTER_MUX], compile_args, defines, false, false, false);
 }

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -325,26 +325,33 @@ void EthTunnelerKernel::CreateKernel() {
     }
     TT_ASSERT(compile_args.size() == 48);
     const auto& grid_size = device_->grid_size();
-    std::map<string, string> defines = {
-        // All of these unused, remove later
-        {"MY_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-        {"MY_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-        {"UPSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
-        {"UPSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"SKIP_NOC_LOGGING", "1"}};
+    std::map<string, string> defines = {// All of these unused, remove later
+                                        {"MY_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+                                        {"MY_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+                                        {"UPSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.x, 0))},
+                                        {"UPSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(
         dispatch_kernel_file_names[is_remote_ ? US_TUNNELER_REMOTE : US_TUNNELER_LOCAL],
         compile_args,

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -325,33 +325,19 @@ void EthTunnelerKernel::CreateKernel() {
     }
     TT_ASSERT(compile_args.size() == 48);
     const auto& grid_size = device_->grid_size();
-    std::map<string, string> defines = {// All of these unused, remove later
-                                        {"MY_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-                                        {"MY_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-                                        {"UPSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.x, 0))},
-                                        {"UPSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"SKIP_NOC_LOGGING", "1"}};
+    const auto& hal = MetalContext::instance().hal();
+    std::map<string, string> defines = {
+        // All of these unused, remove later
+        {"MY_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+        {"MY_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+        {"UPSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
+        {"UPSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(
         dispatch_kernel_file_names[is_remote_ ? US_TUNNELER_REMOTE : US_TUNNELER_LOCAL],
         compile_args,

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -24,9 +24,7 @@
 #include "kernel_types.hpp"
 #include "mux.hpp"
 #include "prefetch.hpp"
-#include "rtoptions.hpp"
 #include "impl/context/metal_context.hpp"
-#include "tt_cluster.hpp"
 #include <umd/device/tt_core_coordinates.h>
 
 using namespace tt::tt_metal;
@@ -138,7 +136,7 @@ void FDKernel::configure_kernel_variant(
     if (force_watcher_no_inline) {
         defines.insert({"WATCHER_NOINLINE", std::to_string(force_watcher_no_inline)});
     }
-    auto& rt_options = tt::llrt::RunTimeOptions::get_instance();
+    auto& rt_options = tt::tt_metal::MetalContext::instance().rtoptions();
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -125,9 +125,11 @@ void FDKernel::configure_kernel_variant(
     KernelBuildOptLevel opt_level) {
     // TODO: just pass in the programmable index
     uint32_t programmable_core_type_index =
-        (GetCoreType() == CoreType::WORKER) ? hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)
-        : is_active_eth_core ? hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)
-                             : hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
+        (GetCoreType() == CoreType::WORKER)
+            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)
+        : is_active_eth_core
+            ? MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)
+            : MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::IDLE_ETH);
 
     std::map<string, string> defines = {
         {"DISPATCH_KERNEL", "1"},

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -15,7 +15,6 @@
 #include "mesh_graph.hpp"
 #include "system_memory_manager.hpp"
 #include "impl/context/metal_context.hpp"
-#include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/packet_queue_ctrl.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include "utils.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -145,32 +145,18 @@ void MuxKernel::CreateKernel() {
     }
     TT_ASSERT(compile_args.size() == 25);
     const auto& grid_size = device_->grid_size();
-    std::map<string, string> defines = {// All of these unused, remove later
-                                        {"MY_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-                                        {"MY_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-                                        {"UPSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.x, 0))},
-                                        {"UPSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.upstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_X",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.x, 0))},
-                                        {"DOWNSTREAM_SLAVE_NOC_Y",
-                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
-                                             noc_selection_.downstream_noc, grid_size.y, 0))},
-                                        {"SKIP_NOC_LOGGING", "1"}};
+    const auto& hal = MetalContext::instance().hal();
+    std::map<string, string> defines = {
+        // All of these unused, remove later
+        {"MY_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+        {"MY_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+        {"UPSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
+        {"UPSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_X", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
+        {"DOWNSTREAM_SLAVE_NOC_Y", std::to_string(hal.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
+        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[MUX_D], compile_args, defines, false, false, false);
 }

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -145,25 +145,32 @@ void MuxKernel::CreateKernel() {
     }
     TT_ASSERT(compile_args.size() == 25);
     const auto& grid_size = device_->grid_size();
-    std::map<string, string> defines = {
-        // All of these unused, remove later
-        {"MY_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.x, 0))},
-        {"MY_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.non_dispatch_noc, grid_size.y, 0))},
-        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
-        {"UPSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.x, 0))},
-        {"UPSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.upstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_X",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.x, 0))},
-        {"DOWNSTREAM_SLAVE_NOC_Y",
-         std::to_string(tt::tt_metal::hal_ref.noc_coordinate(noc_selection_.downstream_noc, grid_size.y, 0))},
-        {"SKIP_NOC_LOGGING", "1"}};
+    std::map<string, string> defines = {// All of these unused, remove later
+                                        {"MY_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.x, 0))},
+                                        {"MY_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.non_dispatch_noc, grid_size.y, 0))},
+                                        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},
+                                        {"UPSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.x, 0))},
+                                        {"UPSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.upstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_X",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.x, 0))},
+                                        {"DOWNSTREAM_SLAVE_NOC_Y",
+                                         std::to_string(tt::tt_metal::MetalContext::instance().hal().noc_coordinate(
+                                             noc_selection_.downstream_noc, grid_size.y, 0))},
+                                        {"SKIP_NOC_LOGGING", "1"}};
     configure_kernel_variant(dispatch_kernel_file_names[MUX_D], compile_args, defines, false, false, false);
 }

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -24,7 +24,6 @@
 #include "eth_router.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
-#include "rtoptions.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/xy_pair.h>
@@ -432,8 +431,8 @@ void PrefetchKernel::CreateKernel() {
         true,
         // TEMP: Disable function inlining on Prefetcher when watcher is enabled but no_inline is not specified to
         // respect code space
-        tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled() &&
-            (not tt::llrt::RunTimeOptions::get_instance().get_watcher_noinline()),
+        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() &&
+            (not tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline()),
         optimization_level);
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -159,7 +159,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.cmddat_q_base = my_dispatch_constants.dispatch_buffer_base();
         static_config_.cmddat_q_size = my_dispatch_constants.prefetch_d_buffer_size();
 
-        uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
+        uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
         static_config_.scratch_db_base = (my_dispatch_constants.dispatch_buffer_base() +
                                           my_dispatch_constants.prefetch_d_buffer_size() + pcie_alignment - 1) &
                                          (~(pcie_alignment - 1));
@@ -479,7 +479,7 @@ void PrefetchKernel::UpdateArgsForFabric(
     tt::tt_fabric::mesh_id_t downstream_mesh_id,
     chip_id_t downstream_dev_id) {
     dependent_config_.fabric_router_noc_xy =
-        tt::tt_metal::hal_ref.noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(fabric_router_virtual.x, fabric_router_virtual.y);
     dependent_config_.upstream_mesh_id = upstream_mesh_id;
     dependent_config_.upstream_dev_id = upstream_dev_id;
     dependent_config_.downstream_mesh_id = downstream_mesh_id;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -8,7 +8,6 @@
 #include <optional>
 
 #include "core_coord.hpp"
-#include "impl/context/metal_context.hpp"
 #include "fd_kernel.hpp"
 #include "mesh_graph.hpp"
 #include "system_memory_manager.hpp"

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -7,7 +7,7 @@
 #include <tt-metalium/system_memory_cq_interface.hpp>
 
 #include "assert.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 
@@ -24,10 +24,10 @@ SystemMemoryCQInterface::SystemMemoryCQInterface(uint16_t channel, uint8_t cq_id
     offset(get_absolute_cq_offset(channel, cq_id, cq_size)),
     id(cq_id) {
     TT_ASSERT(
-        this->command_completion_region_size % hal_ref.get_alignment(HalMemType::HOST) == 0 and
-            this->command_issue_region_size % hal_ref.get_alignment(HalMemType::HOST) == 0,
+        this->command_completion_region_size % MetalContext::instance().hal().get_alignment(HalMemType::HOST) == 0 and
+            this->command_issue_region_size % MetalContext::instance().hal().get_alignment(HalMemType::HOST) == 0,
         "Issue queue and completion queue need to be {}B aligned!",
-        hal_ref.get_alignment(HalMemType::HOST));
+        MetalContext::instance().hal().get_alignment(HalMemType::HOST));
     TT_ASSERT(this->issue_fifo_limit != 0, "Cannot have a 0 fifo limit");
     // Currently read / write pointers on host and device assumes contiguous ranges for each channel
     // Device needs absolute offset of a hugepage to access the region of sysmem that holds a particular command

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -245,7 +245,10 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
     uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
 
     const uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
-    if (issue_q_write_ptr + align(cmd_size_B, tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST)) >
+    if (issue_q_write_ptr +
+            align(
+                cmd_size_B,
+                tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST)) >
         command_issue_limit) {
         this->wrap_issue_queue_wr_ptr(cq_id);
         issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
@@ -293,7 +296,9 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
 
     // All data needs to be PCIE_ALIGNMENT aligned
     uint32_t push_size_16B =
-        align(push_size_B, tt::tt_metal::hal_ref.get_alignment(tt::tt_metal::HalMemType::HOST)) >> 4;
+        align(
+            push_size_B, tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST)) >>
+        4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     CoreType core_type = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -41,7 +41,6 @@
 #include "kernel_types.hpp"
 #include "metal_soc_descriptor.h"
 #include "tt-metalium/program.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
 #include "tt_metal/fabric/fabric_host_utils.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -596,7 +595,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
                 "N300/T3K expects devices in mmio/remote pairs.");
             std::vector<DispatchKernelNode> nodes_for_one_mmio;
             // TODO: Put this in a better place
-            if (llrt::RunTimeOptions::get_instance().get_fd_fabric()) {
+            if (tt_metal::MetalContext::instance().rtoptions().get_fd_fabric()) {
                 TT_FATAL(num_hw_cqs == 1, "Only 1 CQ is supported at this time for FD on Fabric");
                 // Must call tt::tt_metal::detail::InitializeFabricConfig upstream
                 nodes_for_one_mmio = two_chip_arch_1cq_fabric;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1002,8 +1002,8 @@ void configure_2d_fabric_cores(IDevice* device) {
                 device->id(), router_chan);
         auto router_logical_core = device->logical_core_from_ethernet_core(virtual_eth_core);
         // initialize the semaphore
-        auto fabric_router_sync_sem_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
+        auto fabric_router_sync_sem_addr = MetalContext::instance().hal().get_dev_addr(
+            HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
         detail::WriteToDeviceL1(
             device, router_logical_core, fabric_router_sync_sem_addr, router_zero_buf, CoreType::ETH);
     }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -997,13 +997,14 @@ void configure_2d_fabric_cores(IDevice* device) {
 
     auto router_chans = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(device->id());
     for (const auto& router_chan : router_chans) {
+        const auto& hal = MetalContext::instance().hal();
         CoreCoord virtual_eth_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                 device->id(), router_chan);
         auto router_logical_core = device->logical_core_from_ethernet_core(virtual_eth_core);
         // initialize the semaphore
-        auto fabric_router_sync_sem_addr = MetalContext::instance().hal().get_dev_addr(
-            HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
+        auto fabric_router_sync_sem_addr =
+            hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
         detail::WriteToDeviceL1(
             device, router_logical_core, fabric_router_sync_sem_addr, router_zero_buf, CoreType::ETH);
     }

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -6,7 +6,6 @@
 #include <limits.h>
 #include <tt-metalium/dev_msgs.h>
 #include <tt-metalium/dispatch_settings.hpp>
-#include "impl/context/metal_context.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <functional>

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -17,7 +17,7 @@
 #include "assert.hpp"
 #include "fmt/base.h"
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 #include "magic_enum/magic_enum.hpp"
 #include "size_literals.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
@@ -83,7 +83,7 @@ DispatchSettings DispatchSettings::worker_defaults(const tt::Cluster& cluster, c
         .dispatch_size(512_KB)
         .dispatch_s_buffer_size(32_KB)
 
-        .with_alignment(hal_ref.get_alignment(HalMemType::L1))
+        .with_alignment(MetalContext::instance().hal().get_alignment(HalMemType::L1))
 
         .tunneling_buffer_size(256_KB)  // same as prefetch_d_buffer_size
 
@@ -105,7 +105,7 @@ DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& /*cluster*/, 
 
         .tunneling_buffer_size(128_KB)  // same as prefetch_d_buffer_size
 
-        .with_alignment(hal_ref.get_alignment(HalMemType::L1))
+        .with_alignment(MetalContext::instance().hal().get_alignment(HalMemType::L1))
 
         .build();
 }

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -52,7 +52,7 @@ void issue_record_event_commands(
     std::vector<uint32_t> event_payload(DispatchSettings::EVENT_PADDED_SIZE / sizeof(uint32_t), 0);
     event_payload[0] = event_id;
 
-    const uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    const uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     const uint32_t num_worker_counters = sub_device_ids.size();
     const uint32_t packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(device);
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -25,8 +25,8 @@
 #include "jit_build_options.hpp"
 #include "llrt.hpp"
 #include "logger.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
+#include "impl/context/metal_context.hpp"
 #include "tt_memory.h"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
@@ -485,7 +485,8 @@ void EthernetKernel::read_binaries(IDevice* device) {
     ll_api::memory const& binary_mem = llrt::get_risc_binary(
         build_state.get_target_out_path(this->kernel_full_name_),
         load_type);
-    if (tt::llrt::RunTimeOptions::get_instance().get_erisc_iram_enabled() && this->config_.eth_mode != Eth::IDLE) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
+        this->config_.eth_mode != Eth::IDLE) {
         // text_addr and some of span's addr point to IRAM base address.
         // However it need to be placed L1 kernel base address for FW to copy it to IRAM then kick off
         // The kernel can run with IRAM base address once it started.

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -268,12 +268,12 @@ RuntimeArgsData &Kernel::common_runtime_args_data() { return this->common_runtim
 void Kernel::validate_runtime_args_size(
     size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord &logical_core) {
     uint32_t total_rt_args = (num_unique_rt_args + num_common_rt_args);
-    auto arch = hal_ref.get_arch();
+    auto arch = MetalContext::instance().hal().get_arch();
     uint32_t idle_eth_max_runtime_args =
-        (arch == tt::ARCH::GRAYSKULL)
-            ? 0
-            : hal_ref.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) /
-                  sizeof(uint32_t);
+        (arch == tt::ARCH::GRAYSKULL) ? 0
+                                      : MetalContext::instance().hal().get_dev_size(
+                                            HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) /
+                                            sizeof(uint32_t);
     uint32_t max_rt_args = is_idle_eth() ? idle_eth_max_runtime_args : max_runtime_args;
 
     if (total_rt_args > max_rt_args) {
@@ -379,7 +379,8 @@ void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
 void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_kernel_include(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
-    uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     jit_build(
@@ -391,7 +392,8 @@ void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions& /*b
 void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_kernel_include(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
-    uint32_t erisc_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t erisc_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
     jit_build(
@@ -403,7 +405,8 @@ void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build
 void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_triscs_src(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
-    uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     JitBuildStateSubset build_states = BuildEnvManager::get_instance().get_kernel_build_states(
         device->build_id(), tensix_core_type, compute_class_idx);
@@ -422,7 +425,7 @@ void Kernel::set_binaries(uint32_t build_key, std::vector<ll_api::memory const*>
 
 bool DataMovementKernel::binaries_exist_on_disk(const IDevice* device) const {
     const uint32_t tensix_core_type =
-        hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     const int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
@@ -438,7 +441,8 @@ void DataMovementKernel::read_binaries(IDevice* device) {
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indicies
     // TODO(pgk): consolidate read_binaries where possible
-    uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
@@ -460,7 +464,7 @@ void DataMovementKernel::read_binaries(IDevice* device) {
 
 bool EthernetKernel::binaries_exist_on_disk(const IDevice* device) const {
     const uint32_t erisc_core_type =
-        hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     const int erisc_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
@@ -474,7 +478,8 @@ void EthernetKernel::read_binaries(IDevice* device) {
     // untested
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<ll_api::memory const*> binaries;
-    uint32_t erisc_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t erisc_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
@@ -491,9 +496,10 @@ void EthernetKernel::read_binaries(IDevice* device) {
         // However it need to be placed L1 kernel base address for FW to copy it to IRAM then kick off
         // The kernel can run with IRAM base address once it started.
         const_cast<ll_api::memory&>(binary_mem)
-            .set_text_addr(tt::tt_metal::hal_ref.erisc_iram_relocate_dev_addr((uint64_t)binary_mem.get_text_addr()));
+            .set_text_addr(tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(
+                (uint64_t)binary_mem.get_text_addr()));
         std::function<void(uint64_t& addr)> update_callback = [](uint64_t& addr) {
-            addr = tt::tt_metal::hal_ref.erisc_iram_relocate_dev_addr(addr);
+            addr = tt::tt_metal::MetalContext::instance().hal().erisc_iram_relocate_dev_addr(addr);
         };
         const_cast<ll_api::memory&>(binary_mem).update_spans(update_callback);
     }
@@ -506,7 +512,7 @@ void EthernetKernel::read_binaries(IDevice* device) {
 
 bool ComputeKernel::binaries_exist_on_disk(const IDevice* device) const {
     const uint32_t tensix_core_type =
-        hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     const JitBuildStateSubset& build_states = BuildEnvManager::get_instance().get_kernel_build_states(
         device->build_id(), tensix_core_type, compute_class_idx);
@@ -524,7 +530,8 @@ bool ComputeKernel::binaries_exist_on_disk(const IDevice* device) const {
 void ComputeKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
     std::vector<ll_api::memory const*> binaries;
-    uint32_t tensix_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t tensix_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
@@ -576,7 +583,8 @@ bool EthernetKernel::configure(IDevice* device, const CoreCoord &logical_core, u
         uint32_t offset_idx = magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
         llrt::write_binary_to_address(binary_mem, device_id, ethernet_core, base_address + offsets[offset_idx]);
     } else {
-        uint32_t erisc_core_type = hal_ref.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+        uint32_t erisc_core_type =
+            MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
         uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
         int erisc_id = magic_enum::enum_integer(this->config_.processor);
         tt::llrt::test_load_write_read_risc_binary(binary_mem, device_id, ethernet_core, erisc_core_type, dm_class_idx, erisc_id);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -7,7 +7,6 @@
 #include <host_api.hpp>
 #include <magic_enum/magic_enum.hpp>
 #include <nlohmann/json.hpp>
-#include <rtoptions.hpp>
 #include <tracy/TracyTTDevice.hpp>
 #include <tt_metal.hpp>
 #include <algorithm>
@@ -739,7 +738,7 @@ void DeviceProfiler::dumpResults(
         const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
         if (USE_FAST_DISPATCH) {
             if (state == ProfilerDumpState::LAST_CLOSE_DEVICE) {
-                if (tt::llrt::RunTimeOptions::get_instance().get_profiler_do_dispatch_cores()) {
+                if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
                     tt_metal::detail::ReadFromBuffer(output_dram_buffer, profile_buffer);
                 }
             } else {
@@ -751,7 +750,7 @@ void DeviceProfiler::dumpResults(
             }
         }
 
-        if (tt::llrt::RunTimeOptions::get_instance().get_profiler_noc_events_enabled()) {
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
             log_warning("Profiler NoC events are enabled; this can add 1-15% cycle overhead to typical operations!");
         }
 
@@ -778,12 +777,12 @@ void DeviceProfiler::dumpResults(
             }
 
             // if defined, used profiler_noc_events_report_path to write json log. otherwise use output_dir
-            auto rpt_path = tt::llrt::RunTimeOptions::get_instance().get_profiler_noc_events_report_path();
+            auto rpt_path = tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_report_path();
             if (rpt_path.empty()) {
                 rpt_path = output_dir;
             }
 
-            if (tt::llrt::RunTimeOptions::get_instance().get_profiler_noc_events_enabled()) {
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
                 serializeJsonNocTraces(noc_trace_json_log, rpt_path, device_id);
             }
         }
@@ -868,7 +867,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
 #endif
 }
 
-bool getDeviceProfilerState() { return tt::llrt::RunTimeOptions::get_instance().get_profiler_enabled(); }
+bool getDeviceProfilerState() { return tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled(); }
 
 }  // namespace tt_metal
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -71,7 +71,8 @@ void DeviceProfiler::readRiscProfilerResults(
 
         riscCount = 1;
     }
-    profiler_msg_t* profiler_msg = hal_ref.get_dev_addr<profiler_msg_t*>(CoreType, HalL1MemAddrType::PROFILER);
+    profiler_msg_t* profiler_msg =
+        MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(CoreType, HalL1MemAddrType::PROFILER);
 
     uint32_t coreFlatID =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_routing_to_profiler_flat_id(device_id).at(
@@ -634,8 +635,8 @@ void DeviceProfiler::serializeJsonNocTraces(
 }
 
 CoreCoord DeviceProfiler::getPhysicalAddressFromVirtual(chip_id_t device_id, const CoreCoord& c) const {
-    bool coord_is_translated =
-        c.x >= hal_ref.get_virtual_worker_start_x() && c.y >= hal_ref.get_virtual_worker_start_y();
+    bool coord_is_translated = c.x >= MetalContext::instance().hal().get_virtual_worker_start_x() &&
+                               c.y >= MetalContext::instance().hal().get_virtual_worker_start_y();
     if (device_architecture == tt::ARCH::WORMHOLE_B0 && coord_is_translated) {
         const metal_SocDescriptor& soc_desc =
             tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -731,6 +731,7 @@ void DeviceProfiler::dumpResults(
     ZoneScoped;
 
     auto device_id = device->id();
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     device_core_frequency = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device_id);
 
     generateZoneSourceLocationsHashes();
@@ -739,7 +740,7 @@ void DeviceProfiler::dumpResults(
         const auto USE_FAST_DISPATCH = std::getenv("TT_METAL_SLOW_DISPATCH_MODE") == nullptr;
         if (USE_FAST_DISPATCH) {
             if (state == ProfilerDumpState::LAST_CLOSE_DEVICE) {
-                if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
+                if (rtoptions.get_profiler_do_dispatch_cores()) {
                     tt_metal::detail::ReadFromBuffer(output_dram_buffer, profile_buffer);
                 }
             } else {
@@ -751,7 +752,7 @@ void DeviceProfiler::dumpResults(
             }
         }
 
-        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
+        if (rtoptions.get_profiler_noc_events_enabled()) {
             log_warning("Profiler NoC events are enabled; this can add 1-15% cycle overhead to typical operations!");
         }
 
@@ -778,12 +779,12 @@ void DeviceProfiler::dumpResults(
             }
 
             // if defined, used profiler_noc_events_report_path to write json log. otherwise use output_dir
-            auto rpt_path = tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_report_path();
+            auto rpt_path = rtoptions.get_profiler_noc_events_report_path();
             if (rpt_path.empty()) {
                 rpt_path = output_dir;
             }
 
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
+            if (rtoptions.get_profiler_noc_events_enabled()) {
                 serializeJsonNocTraces(noc_trace_json_log, rpt_path, device_id);
             }
         }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -54,7 +54,7 @@
 #include "profiler_state.hpp"
 #include "profiler_types.hpp"
 #include "tt-metalium/program.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include "system_memory_manager.hpp"
 #include "tracy/Tracy.hpp"
 #include "tracy/TracyTTDevice.hpp"
@@ -146,7 +146,7 @@ void setControlBuffer(chip_id_t device_id, std::vector<uint32_t>& control_buffer
 
 void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     ZoneScopedC(tracy::Color::Tomato3);
-    if (!tt::llrt::RunTimeOptions::get_instance().get_profiler_sync_enabled()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_sync_enabled()) {
         return;
     }
     auto device_id = device->id();
@@ -370,7 +370,7 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
     ZoneScopedC(tracy::Color::Tomato4);
     std::string zoneName = fmt::format("sync_device_device_{}->{}", device_id_sender, device_id_receiver);
     ZoneName(zoneName.c_str(), zoneName.size());
-    if (!tt::llrt::RunTimeOptions::get_instance().get_profiler_sync_enabled()) {
+    if (!tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_sync_enabled()) {
         return;
     }
 
@@ -714,7 +714,7 @@ void DumpDeviceProfileResults(IDevice* device, std::vector<CoreCoord>& worker_co
     std::scoped_lock<std::mutex> lock(device_mutex);
     const auto& dispatch_core_config = get_dispatch_core_config();
     auto dispatch_core_type = dispatch_core_config.get_core_type();
-    if (tt::llrt::RunTimeOptions::get_instance().get_profiler_do_dispatch_cores()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
         auto device_id = device->id();
         auto device_num_hw_cqs = device->num_hw_cqs();
         for (const CoreCoord& core :
@@ -730,7 +730,7 @@ void DumpDeviceProfileResults(IDevice* device, std::vector<CoreCoord>& worker_co
                 Finish(device->command_queue());
             }
         } else {
-            if (tt::llrt::RunTimeOptions::get_instance().get_profiler_do_dispatch_cores()) {
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
                 auto device_id = device->id();
                 constexpr uint8_t maxLoopCount = 10;
                 constexpr uint32_t loopDuration_us = 10000;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -280,7 +280,8 @@ uint32_t finalize_kernel_bins(
     uint32_t base_offset,
     uint32_t& kernel_text_offset,
     uint32_t& kernel_text_size) {
-    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const auto& hal = MetalContext::instance().hal();
+    uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
     uint32_t max_offset = 0;
     for (auto& kg : kernel_groups) {
@@ -294,7 +295,7 @@ uint32_t finalize_kernel_bins(
                     BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index ==
-                    MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
+                    hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
                     uint32_t binary_packed_size = kernel->get_binary_packed_size(device, 0);
 
                     if (class_id == DISPATCH_CLASS_TENSIX_DM0) {
@@ -330,7 +331,7 @@ uint32_t finalize_kernel_bins(
                     kg->kernel_bin_sizes[class_id] = binary_packed_size;
 
                     // No kernel config buffer on active eth yet
-                    if (MetalContext::instance().hal().get_programmable_core_type(kg->programmable_core_type_index) ==
+                    if (hal.get_programmable_core_type(kg->programmable_core_type_index) ==
                         HalProgrammableCoreType::IDLE_ETH) {
                         kg->kernel_text_offsets[class_id] = offset;
                         kg->launch_msg.kernel_config.kernel_text_offset[class_id] = offset;
@@ -397,10 +398,11 @@ void finalize_program_offsets(T& workload, IDevice* device) {
         program.get_program_config_sizes()[index] = offset;
     };
 
+    const auto& hal = MetalContext::instance().hal();
     auto set_program_attrs_across_core_types = [&](Program& program) {
-        program.get_program_config_sizes()[MetalContext::instance().hal().get_programmable_core_type_count()] =
+        program.get_program_config_sizes()[hal.get_programmable_core_type_count()] =
             workload.runs_on_noc_multicast_only_cores();
-        program.get_program_config_sizes()[MetalContext::instance().hal().get_programmable_core_type_count() + 1] =
+        program.get_program_config_sizes()[hal.get_programmable_core_type_count() + 1] =
             workload.runs_on_noc_unicast_only_cores();
         program.set_launch_msg_sem_offsets();
         // TODO: This check is wrong - it populates dispatch data for dispatch kernels
@@ -409,9 +411,8 @@ void finalize_program_offsets(T& workload, IDevice* device) {
         }
     };
 
-    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
-        HalProgrammableCoreType programmable_core_type =
-            MetalContext::instance().hal().get_programmable_core_type(index);
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        HalProgrammableCoreType programmable_core_type = hal.get_programmable_core_type(index);
         offset = finalize_rt_args(
             workload.get_kernels(index),
             workload.get_kernel_groups(index),
@@ -421,15 +422,15 @@ void finalize_program_offsets(T& workload, IDevice* device) {
             crta_offsets,
             crta_sizes);
 
-        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, hal.get_alignment(HalMemType::L1)));
 
         offset = finalize_sems(index, offset, workload.semaphores(), sem_offset, sem_size);
 
-        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, hal.get_alignment(HalMemType::L1)));
 
         offset = finalize_cbs(index, workload.get_kernel_groups(index), offset, cb_offset, cb_size, local_cb_size);
 
-        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, hal.get_alignment(HalMemType::L1)));
 
         offset = finalize_kernel_bins(
             device,
@@ -440,7 +441,7 @@ void finalize_program_offsets(T& workload, IDevice* device) {
             kernel_text_offset,
             kernel_text_size);
 
-        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, hal.get_alignment(HalMemType::L1)));
 
         size_t max_size = get_ringbuffer_size(device, programmable_core_type);
 
@@ -674,11 +675,11 @@ BatchedTransfers assemble_runtime_args_commands(
     const DeviceCommandCalculator calculator;
 
     // Unique RTAs
+    const auto& hal = MetalContext::instance().hal();
     for (uint32_t programmable_core_type_index = 0;
-         programmable_core_type_index < MetalContext::instance().hal().get_programmable_core_type_count();
+         programmable_core_type_index < hal.get_programmable_core_type_count();
          programmable_core_type_index++) {
-        if (MetalContext::instance().hal().get_programmable_core_type(programmable_core_type_index) ==
-            HalProgrammableCoreType::IDLE_ETH) {
+        if (hal.get_programmable_core_type(programmable_core_type_index) == HalProgrammableCoreType::IDLE_ETH) {
             // Fast dispatch not supported on IDLE_ETH yet
             continue;
         }
@@ -716,8 +717,7 @@ BatchedTransfers assemble_runtime_args_commands(
     // CRTA writes with CB and semaphore writes.
     uint32_t kernel_group_crta_multicast_count = 0;
     {
-        uint32_t index =
-            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         for (auto& kg : program.get_kernel_groups(index)) {
             bool has_crtas = false;
             for (auto kernel_id : kg->kernel_ids) {
@@ -749,8 +749,7 @@ BatchedTransfers assemble_runtime_args_commands(
         if ((programmable_core_type == HalProgrammableCoreType::TENSIX) && use_kernel_group_crta_multicast) {
             continue;
         }
-        uint32_t programmable_core_type_index =
-            MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
+        uint32_t programmable_core_type_index = hal.get_programmable_core_type_index(programmable_core_type);
         uint32_t common_size =
             program.get_program_config(programmable_core_type_index).crta_sizes[kernel->dispatch_class()];
         if (common_size != 0) {
@@ -758,7 +757,7 @@ BatchedTransfers assemble_runtime_args_commands(
             const auto& common_rt_args = kernel->common_runtime_args();
 
             if (common_rt_args.size() > 0) {
-                CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
+                CoreType core_type = hal.get_core_type(programmable_core_type_index);
                 if (core_type == CoreType::ETH) {
                     uint32_t num_sub_cmds = kernel->logical_cores().size();
                     uint32_t max_packed_cmds =
@@ -779,8 +778,7 @@ BatchedTransfers assemble_runtime_args_commands(
     program_command_sequence.runtime_args_command_sequences.reserve(command_count);
 
     if (use_kernel_group_crta_multicast) {
-        uint32_t index =
-            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         for (auto& kg : program.get_kernel_groups(index)) {
             for (auto kernel_id : kg->kernel_ids) {
                 if (kernel_id) {
@@ -810,14 +808,14 @@ BatchedTransfers assemble_runtime_args_commands(
         }
     }
 
-    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
-        if (MetalContext::instance().hal().get_programmable_core_type(index) == HalProgrammableCoreType::IDLE_ETH) {
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        if (hal.get_programmable_core_type(index) == HalProgrammableCoreType::IDLE_ETH) {
             // Fast dispatch not supported on IDLE_ETH yet
             // TODO: can't just loop here as code below confuses ACTIVE/IDLE
             continue;
         }
-        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
-        uint32_t processor_classes = MetalContext::instance().hal().get_processor_classes_count(index);
+        CoreType core_type = hal.get_core_type(index);
+        uint32_t processor_classes = hal.get_processor_classes_count(index);
 
         // Unique RTAs - Unicast
         // Set by the user based on the kernel and core coord
@@ -1037,12 +1035,12 @@ static void size_semaphore_commands(
     semaphore_data.reserve(program.semaphores().size());
 
     // Unicast/Multicast Semaphores
+    const auto& hal = MetalContext::instance().hal();
     for (const Semaphore& semaphore : program.semaphores()) {
         semaphore_data.push_back(semaphore.initial_value());
 
         if (semaphore.core_type() == CoreType::WORKER) {
-            uint32_t index =
-                MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+            uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
             std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
                 device->extract_dst_noc_multicast_info(semaphore.core_range_set().ranges(), CoreType::WORKER);
             for (const auto& dst_noc_info : dst_noc_multicast_info) {
@@ -1059,8 +1057,7 @@ static void size_semaphore_commands(
             unicast_semaphore_cmds.push_back({.dst = semaphore.offset(), .size = sizeof(uint32_t)});
             auto& unicast_cmds = unicast_semaphore_cmds.back();
             // TODO: we only fast dispatch to active eth...
-            uint32_t index =
-                MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+            uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
             std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info =
                 extract_dst_noc_unicast_info(semaphore.core_range_set().ranges(), CoreType::ETH);
             for (const auto& dst_noc_info : dst_noc_unicast_info) {
@@ -1134,7 +1131,8 @@ void assemble_device_commands(
         unicast_semaphore_cmds,
         batched_transfers);
 
-    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    const auto& hal = MetalContext::instance().hal();
+    uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
     const auto& circular_buffers_unique_coreranges = program.circular_buffers_unique_coreranges();
     const uint16_t num_multicast_cb_sub_cmds = circular_buffers_unique_coreranges.size();
@@ -1145,7 +1143,7 @@ void assemble_device_commands(
         uint32_t i = 0;
         uint32_t max_overall_index = 0;
         uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
-        auto index = MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        auto index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         for (const CoreRange& core_range : circular_buffers_unique_coreranges) {
             const CoreCoord& virtual_start =
                 device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
@@ -1194,7 +1192,7 @@ void assemble_device_commands(
     std::vector<std::vector<Transfer>> batched_cmd_data;
     std::vector<std::vector<CQDispatchWritePackedLargeSubCmd>> batched_dispatch_subcmds;
     {
-        uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+        uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
         // Optimize transfers by combining adjacent or nearly adjacent transfers.
         for (auto& transfer_set : batched_transfers) {
             for (auto it = transfer_set.second.begin(); it != transfer_set.second.end();) {
@@ -1248,7 +1246,7 @@ void assemble_device_commands(
                 }
             }
         }
-        uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+        uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
         for (size_t i = 0; i < batched_dispatch_subcmds.size(); i++) {
             calculator.add_dispatch_write_packed_large(
                 batched_dispatch_subcmds[i].size(),
@@ -1289,8 +1287,7 @@ void assemble_device_commands(
             cores);
         for (uint32_t kernel_idx = 0; kernel_idx < kg_transfer_info.dst_base_addrs.size(); kernel_idx++) {
             if (write_linear) {
-                kernel_bins_unicast_cmds.emplace_back(
-                    2 * MetalContext::instance().hal().get_alignment(HalMemType::HOST));
+                kernel_bins_unicast_cmds.emplace_back(2 * hal.get_alignment(HalMemType::HOST));
                 constexpr bool flush_prefetch = false;
                 calculator.add_dispatch_write_linear<flush_prefetch>(0);
                 kernel_bins_unicast_cmds.back().add_dispatch_write_linear<flush_prefetch>(
@@ -1334,9 +1331,8 @@ void assemble_device_commands(
 
                 // TODO: pack all these writes into 1 linear write
                 uint32_t kernel_config_buffer_offset = kg_transfer_info.dst_base_addrs[kernel_idx];
-                uint32_t aligned_length = tt::align(
-                    kg_transfer_info.lengths[kernel_idx],
-                    MetalContext::instance().hal().get_alignment(HalMemType::DRAM));
+                uint32_t aligned_length =
+                    tt::align(kg_transfer_info.lengths[kernel_idx], hal.get_alignment(HalMemType::DRAM));
                 uint32_t padding = aligned_length - kg_transfer_info.lengths[kernel_idx];
                 while (aligned_length != 0) {
                     if (kernel_bins_dispatch_subcmds.empty() ||
@@ -1389,7 +1385,7 @@ void assemble_device_commands(
             subcmd_list.back().flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
         }
     }
-    uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
     for (uint32_t i = 0; i < kernel_bins_dispatch_subcmds.size(); ++i) {
         calculator.add_dispatch_write_packed_large(kernel_bins_dispatch_subcmds[i].size());
         calculator.add_prefetch_relay_paged_packed(kernel_bins_prefetch_subcmds[i].size());
@@ -1401,8 +1397,7 @@ void assemble_device_commands(
     std::vector<std::pair<uint32_t, uint32_t>> multicast_go_signals_payload;
     std::vector<std::pair<uint32_t, uint32_t>> unicast_go_signals_payload;
     constexpr uint32_t go_signal_sizeB = sizeof(launch_msg_t);
-    uint32_t aligned_go_signal_sizeB =
-        tt::align(go_signal_sizeB, MetalContext::instance().hal().get_alignment(HalMemType::L1));
+    uint32_t aligned_go_signal_sizeB = tt::align(go_signal_sizeB, hal.get_alignment(HalMemType::L1));
     uint32_t go_signal_size_words = aligned_go_signal_sizeB / sizeof(uint32_t);
 
     // TODO: eventually the code below could be structured to loop over programmable_indices
@@ -1413,8 +1408,7 @@ void assemble_device_commands(
      *******************
      */
     // and check for mcast/unicast
-    uint32_t programmable_core_index =
-        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     for (auto& kernel_group : program.get_kernel_groups(programmable_core_index)) {
         kernel_group->launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
         kernel_group->launch_msg.kernel_config.preload = DISPATCH_ENABLE_FLAG_PRELOAD;
@@ -1455,8 +1449,7 @@ void assemble_device_commands(
      *
      *******************
      */
-    programmable_core_index =
-        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+    programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
     // TODO: ugly, can be fixed by looping over indices w/ some work
     if (programmable_core_index != -1) {
         for (auto& kernel_group : program.get_kernel_groups(programmable_core_index)) {
@@ -1521,7 +1514,7 @@ void assemble_device_commands(
 
     auto& device_command_sequence = program_command_sequence.device_command_sequence;
 
-    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
     const std::vector<uint8_t> fill_data(l1_alignment, 0);
 
@@ -1589,7 +1582,7 @@ void assemble_device_commands(
         device_command_sequence.add_data(
             kernel_bins_unicast_cmd.data(), kernel_bins_unicast_cmd.size_bytes(), kernel_bins_unicast_cmd.size_bytes());
     }
-    uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
+    uint32_t dram_alignment = hal.get_alignment(HalMemType::DRAM);
     for (uint32_t i = 0; i < kernel_bins_dispatch_subcmds.size(); ++i) {
         device_command_sequence.add_dispatch_write_packed_large(
             CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_PROGRAM_BINARIES,
@@ -1716,24 +1709,19 @@ void assemble_device_commands(
 }
 
 void initialize_worker_config_buf_mgr(WorkerConfigBufferMgr& config_buffer_mgr, uint32_t worker_l1_unreserved_start) {
-    for (uint32_t index = 0; index < tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_count();
-         index++) {
+    const auto& hal = MetalContext::instance().hal();
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         uint32_t ringbuffer_size;
-        if (tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index) ==
-            tt::tt_metal::HalProgrammableCoreType::TENSIX) {
-            ringbuffer_size = worker_l1_unreserved_start -
-                              tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
-                                  tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index),
-                                  tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
+        if (hal.get_programmable_core_type(index) == tt::tt_metal::HalProgrammableCoreType::TENSIX) {
+            ringbuffer_size =
+                worker_l1_unreserved_start -
+                hal.get_dev_addr(hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
         } else {
-            ringbuffer_size = tt::tt_metal::MetalContext::instance().hal().get_dev_size(
-                tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index),
-                tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
+            ringbuffer_size =
+                hal.get_dev_size(hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
         }
         config_buffer_mgr.init_add_buffer(
-            tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
-                tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index),
-                tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
+            hal.get_dev_addr(hal.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
             ringbuffer_size);
     }
     // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the
@@ -1846,10 +1834,10 @@ void update_program_dispatch_commands(
         wait_count_offset, &(dispatch_md.sync_count), sizeof(uint32_t));
 
     // Update preamble based on kernel config ring buffer slot
+    const auto& hal = MetalContext::instance().hal();
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         tensix_l1_write_offset_offset,
-        &dispatch_md.kernel_config_addrs[MetalContext::instance().hal().get_programmable_core_type_index(
-            HalProgrammableCoreType::TENSIX)],
+        &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
         sizeof(uint32_t));
     // May truncate to fit the space.
     static_assert(
@@ -1858,16 +1846,15 @@ void update_program_dispatch_commands(
     uint16_t runtime_id = program.get_runtime_id();
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         program_host_id_offset, &runtime_id, sizeof(runtime_id));
-    if (MetalContext::instance().hal().get_programmable_core_type_count() >= 2) {
+    if (hal.get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
             eth_l1_write_offset_offset,
-            &dispatch_md.kernel_config_addrs[MetalContext::instance().hal().get_programmable_core_type_index(
-                HalProgrammableCoreType::ACTIVE_ETH)],
+            &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)],
             sizeof(uint32_t));
     }
 
     // Update CB Configs
-    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
     for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
         uint32_t* cb_config_payload = cached_program_command_sequence.cb_configs_payloads[i];
@@ -1907,14 +1894,14 @@ void update_program_dispatch_commands(
     }
     // Update launch message addresses to reflect new launch_msg slot in ring buffer
     uint32_t multicast_cores_launch_msg_addr =
-        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::LAUNCH) +
+        hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::LAUNCH) +
         multicast_cores_launch_message_wptr * sizeof(launch_msg_t);
     for (auto launch_msg_cmd_ptr : cached_program_command_sequence.launch_msg_write_packed_cmd_ptrs) {
         launch_msg_cmd_ptr->addr = multicast_cores_launch_msg_addr;
     }
     if (cached_program_command_sequence.unicast_launch_msg_write_packed_cmd_ptrs.size()) {
         uint32_t unicast_cores_launch_message_addr =
-            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH) +
+            hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH) +
             unicast_cores_launch_message_wptr * sizeof(launch_msg_t);
         for (auto launch_msg_cmd_ptr : cached_program_command_sequence.unicast_launch_msg_write_packed_cmd_ptrs) {
             launch_msg_cmd_ptr->addr = unicast_cores_launch_message_addr;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -43,7 +43,6 @@
 #include "dispatch_mem_map.hpp"
 #include "hal_types.hpp"
 #include "kernel.hpp"
-#include "llrt/hal.hpp"
 #include "math.hpp"
 #include "program_device_map.hpp"
 #include "tt-metalium/program.hpp"
@@ -87,9 +86,10 @@ CoreCoord get_sub_device_worker_origin(
 size_t get_ringbuffer_size(IDevice* device, HalProgrammableCoreType programmable_core_type) {
     if (programmable_core_type == HalProgrammableCoreType::TENSIX) {
         return device->allocator()->get_config().l1_unreserved_base -
-               hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
+               MetalContext::instance().hal().get_dev_addr(
+                   HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG);
     } else {
-        return hal_ref.get_dev_size(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
+        return MetalContext::instance().hal().get_dev_size(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
     }
 }
 };  // namespace
@@ -105,10 +105,11 @@ uint32_t configure_rta_offsets_for_kernel_groups(
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& kernels,
     std::vector<std::shared_ptr<KernelGroup>>& kernel_groups,
     uint32_t base_offset) {
-    uint32_t processor_classes = hal_ref.get_processor_classes_count(programmable_core_type_index);
+    uint32_t processor_classes =
+        MetalContext::instance().hal().get_processor_classes_count(programmable_core_type_index);
     std::vector<uint32_t> max_rtas(processor_classes);
     uint32_t max_unique_rta_size = 0;
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
     for (auto& kg : kernel_groups) {
         for (std::size_t dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
@@ -154,7 +155,8 @@ uint32_t configure_crta_offsets_for_kernel_groups(
     uint32_t crta_base_offset,
     std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_offsets,
     std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_sizes) {
-    uint32_t processor_classes = hal_ref.get_processor_classes_count(programmable_core_type_index);
+    uint32_t processor_classes =
+        MetalContext::instance().hal().get_processor_classes_count(programmable_core_type_index);
     std::vector<uint32_t> max_crtas(processor_classes);
 
     for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
@@ -169,7 +171,7 @@ uint32_t configure_crta_offsets_for_kernel_groups(
 
     // Derive crta offsets and sizes per dispatch class
     uint32_t offset = 0;
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     for (int dispatch_class = 0; dispatch_class < processor_classes; dispatch_class++) {
         uint32_t size = max_crtas[dispatch_class] * sizeof(uint32_t);
         crta_offsets[dispatch_class] = crta_base_offset + offset;
@@ -202,8 +204,9 @@ uint32_t finalize_rt_args(
     uint32_t& rta_offset,
     std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_offsets,
     std::array<uint32_t, DISPATCH_CLASS_MAX>& crta_sizes) {
-    CoreType core_type = hal_ref.get_core_type(programmable_core_type_index);
-    HalProgrammableCoreType programmable_core_type = hal_ref.get_programmable_core_type(programmable_core_type_index);
+    CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
+    HalProgrammableCoreType programmable_core_type =
+        MetalContext::instance().hal().get_programmable_core_type(programmable_core_type_index);
 
     uint32_t max_unique_rta_size = program_dispatch::configure_rta_offsets_for_kernel_groups(
         programmable_core_type_index, kernels, kernel_groups, base_offset);
@@ -224,13 +227,13 @@ uint32_t finalize_sems(
     uint32_t& semaphore_offset,
     uint32_t& semaphore_size) {
     int max_id = -1;
-    CoreType core_type = hal_ref.get_core_type(programmable_core_type_index);
+    CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
     for (const auto& sem : semaphores) {
         if (sem.core_type() == core_type && (int)sem.id() > max_id) {
             max_id = sem.id();
         }
     }
-    uint32_t sem_size = (max_id + 1) * hal_ref.get_alignment(HalMemType::L1);
+    uint32_t sem_size = (max_id + 1) * MetalContext::instance().hal().get_alignment(HalMemType::L1);
     semaphore_offset = sem_base_offset;
     semaphore_size = sem_size;
     return sem_base_offset + sem_size;
@@ -266,7 +269,7 @@ uint32_t finalize_cbs(
     cb_offset = base_offset;
     cb_size = total_cb_size;
 
-    return tt::align(base_offset + total_cb_size, hal_ref.get_alignment(HalMemType::L1));
+    return tt::align(base_offset + total_cb_size, MetalContext::instance().hal().get_alignment(HalMemType::L1));
 }
 
 uint32_t finalize_kernel_bins(
@@ -277,7 +280,7 @@ uint32_t finalize_kernel_bins(
     uint32_t base_offset,
     uint32_t& kernel_text_offset,
     uint32_t& kernel_text_size) {
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
     uint32_t max_offset = 0;
     for (auto& kg : kernel_groups) {
@@ -291,7 +294,7 @@ uint32_t finalize_kernel_bins(
                     BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
                 // TODO: this is really ugly, save me future-HAL!
                 if (programmable_core_type_index ==
-                    hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
+                    MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
                     uint32_t binary_packed_size = kernel->get_binary_packed_size(device, 0);
 
                     if (class_id == DISPATCH_CLASS_TENSIX_DM0) {
@@ -327,7 +330,7 @@ uint32_t finalize_kernel_bins(
                     kg->kernel_bin_sizes[class_id] = binary_packed_size;
 
                     // No kernel config buffer on active eth yet
-                    if (hal_ref.get_programmable_core_type(kg->programmable_core_type_index) ==
+                    if (MetalContext::instance().hal().get_programmable_core_type(kg->programmable_core_type_index) ==
                         HalProgrammableCoreType::IDLE_ETH) {
                         kg->kernel_text_offsets[class_id] = offset;
                         kg->launch_msg.kernel_config.kernel_text_offset[class_id] = offset;
@@ -395,9 +398,9 @@ void finalize_program_offsets(T& workload, IDevice* device) {
     };
 
     auto set_program_attrs_across_core_types = [&](Program& program) {
-        program.get_program_config_sizes()[hal_ref.get_programmable_core_type_count()] =
+        program.get_program_config_sizes()[MetalContext::instance().hal().get_programmable_core_type_count()] =
             workload.runs_on_noc_multicast_only_cores();
-        program.get_program_config_sizes()[hal_ref.get_programmable_core_type_count() + 1] =
+        program.get_program_config_sizes()[MetalContext::instance().hal().get_programmable_core_type_count() + 1] =
             workload.runs_on_noc_unicast_only_cores();
         program.set_launch_msg_sem_offsets();
         // TODO: This check is wrong - it populates dispatch data for dispatch kernels
@@ -406,8 +409,9 @@ void finalize_program_offsets(T& workload, IDevice* device) {
         }
     };
 
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
-        HalProgrammableCoreType programmable_core_type = hal_ref.get_programmable_core_type(index);
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
+        HalProgrammableCoreType programmable_core_type =
+            MetalContext::instance().hal().get_programmable_core_type(index);
         offset = finalize_rt_args(
             workload.get_kernels(index),
             workload.get_kernel_groups(index),
@@ -417,15 +421,15 @@ void finalize_program_offsets(T& workload, IDevice* device) {
             crta_offsets,
             crta_sizes);
 
-        TT_ASSERT(offset == tt::align(offset, hal_ref.get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
 
         offset = finalize_sems(index, offset, workload.semaphores(), sem_offset, sem_size);
 
-        TT_ASSERT(offset == tt::align(offset, hal_ref.get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
 
         offset = finalize_cbs(index, workload.get_kernel_groups(index), offset, cb_offset, cb_size, local_cb_size);
 
-        TT_ASSERT(offset == tt::align(offset, hal_ref.get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
 
         offset = finalize_kernel_bins(
             device,
@@ -436,7 +440,7 @@ void finalize_program_offsets(T& workload, IDevice* device) {
             kernel_text_offset,
             kernel_text_size);
 
-        TT_ASSERT(offset == tt::align(offset, hal_ref.get_alignment(HalMemType::L1)));
+        TT_ASSERT(offset == tt::align(offset, MetalContext::instance().hal().get_alignment(HalMemType::L1)));
 
         size_t max_size = get_ringbuffer_size(device, programmable_core_type);
 
@@ -532,7 +536,7 @@ void generate_runtime_args_cmds(
 
     thread_local static auto get_runtime_payload_sizeB =
         [](uint32_t num_packed_cmds, uint32_t runtime_args_len, bool is_unicast, bool no_stride) {
-            uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+            uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
             uint32_t sub_cmd_sizeB =
                 is_unicast ? sizeof(CQDispatchWritePackedUnicastSubCmd) : sizeof(CQDispatchWritePackedMulticastSubCmd);
             uint32_t dispatch_cmd_sizeB =
@@ -543,7 +547,7 @@ void generate_runtime_args_cmds(
         };
     thread_local static auto get_runtime_args_data_offset =
         [](uint32_t num_packed_cmds, uint32_t /*runtime_args_len*/, bool is_unicast) {
-            uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+            uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
             uint32_t sub_cmd_sizeB =
                 is_unicast ? sizeof(CQDispatchWritePackedUnicastSubCmd) : sizeof(CQDispatchWritePackedMulticastSubCmd);
             uint32_t dispatch_cmd_sizeB =
@@ -565,8 +569,8 @@ void generate_runtime_args_cmds(
             num_packed_cmds_in_seq,
             max_packed_cmds);
     }
-    uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
     while (num_packed_cmds_in_seq != 0) {
         // Generate the device command
         uint32_t num_packed_cmds = std::min(num_packed_cmds_in_seq, max_packed_cmds);
@@ -671,9 +675,10 @@ BatchedTransfers assemble_runtime_args_commands(
 
     // Unique RTAs
     for (uint32_t programmable_core_type_index = 0;
-         programmable_core_type_index < hal_ref.get_programmable_core_type_count();
+         programmable_core_type_index < MetalContext::instance().hal().get_programmable_core_type_count();
          programmable_core_type_index++) {
-        if (hal_ref.get_programmable_core_type(programmable_core_type_index) == HalProgrammableCoreType::IDLE_ETH) {
+        if (MetalContext::instance().hal().get_programmable_core_type(programmable_core_type_index) ==
+            HalProgrammableCoreType::IDLE_ETH) {
             // Fast dispatch not supported on IDLE_ETH yet
             continue;
         }
@@ -711,7 +716,8 @@ BatchedTransfers assemble_runtime_args_commands(
     // CRTA writes with CB and semaphore writes.
     uint32_t kernel_group_crta_multicast_count = 0;
     {
-        uint32_t index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        uint32_t index =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         for (auto& kg : program.get_kernel_groups(index)) {
             bool has_crtas = false;
             for (auto kernel_id : kg->kernel_ids) {
@@ -743,7 +749,8 @@ BatchedTransfers assemble_runtime_args_commands(
         if ((programmable_core_type == HalProgrammableCoreType::TENSIX) && use_kernel_group_crta_multicast) {
             continue;
         }
-        uint32_t programmable_core_type_index = hal_ref.get_programmable_core_type_index(programmable_core_type);
+        uint32_t programmable_core_type_index =
+            MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
         uint32_t common_size =
             program.get_program_config(programmable_core_type_index).crta_sizes[kernel->dispatch_class()];
         if (common_size != 0) {
@@ -751,7 +758,7 @@ BatchedTransfers assemble_runtime_args_commands(
             const auto& common_rt_args = kernel->common_runtime_args();
 
             if (common_rt_args.size() > 0) {
-                CoreType core_type = hal_ref.get_core_type(programmable_core_type_index);
+                CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
                 if (core_type == CoreType::ETH) {
                     uint32_t num_sub_cmds = kernel->logical_cores().size();
                     uint32_t max_packed_cmds =
@@ -772,7 +779,8 @@ BatchedTransfers assemble_runtime_args_commands(
     program_command_sequence.runtime_args_command_sequences.reserve(command_count);
 
     if (use_kernel_group_crta_multicast) {
-        uint32_t index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        uint32_t index =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         for (auto& kg : program.get_kernel_groups(index)) {
             for (auto kernel_id : kg->kernel_ids) {
                 if (kernel_id) {
@@ -802,14 +810,14 @@ BatchedTransfers assemble_runtime_args_commands(
         }
     }
 
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
-        if (hal_ref.get_programmable_core_type(index) == HalProgrammableCoreType::IDLE_ETH) {
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
+        if (MetalContext::instance().hal().get_programmable_core_type(index) == HalProgrammableCoreType::IDLE_ETH) {
             // Fast dispatch not supported on IDLE_ETH yet
             // TODO: can't just loop here as code below confuses ACTIVE/IDLE
             continue;
         }
-        CoreType core_type = hal_ref.get_core_type(index);
-        uint32_t processor_classes = hal_ref.get_processor_classes_count(index);
+        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
+        uint32_t processor_classes = MetalContext::instance().hal().get_processor_classes_count(index);
 
         // Unique RTAs - Unicast
         // Set by the user based on the kernel and core coord
@@ -1033,7 +1041,8 @@ static void size_semaphore_commands(
         semaphore_data.push_back(semaphore.initial_value());
 
         if (semaphore.core_type() == CoreType::WORKER) {
-            uint32_t index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+            uint32_t index =
+                MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
             std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
                 device->extract_dst_noc_multicast_info(semaphore.core_range_set().ranges(), CoreType::WORKER);
             for (const auto& dst_noc_info : dst_noc_multicast_info) {
@@ -1050,7 +1059,8 @@ static void size_semaphore_commands(
             unicast_semaphore_cmds.push_back({.dst = semaphore.offset(), .size = sizeof(uint32_t)});
             auto& unicast_cmds = unicast_semaphore_cmds.back();
             // TODO: we only fast dispatch to active eth...
-            uint32_t index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+            uint32_t index =
+                MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
             std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_unicast_info =
                 extract_dst_noc_unicast_info(semaphore.core_range_set().ranges(), CoreType::ETH);
             for (const auto& dst_noc_info : dst_noc_unicast_info) {
@@ -1075,7 +1085,8 @@ static void assemble_unicast_semaphore_commands(
     const std::vector<UnicastSemaphoreData>& unicast_semaphore_cmds,
     uint32_t packed_write_max_unicast_sub_cmds) {
     // Unicast Semaphore Cmd
-    uint32_t index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+    uint32_t index =
+        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
     for (auto& cmds : unicast_semaphore_cmds) {
         uint32_t curr_sub_cmd_idx = 0;
         for (const auto& [num_sub_cmds_in_cmd, unicast_sem_payload_sizeB] : cmds.payload) {
@@ -1123,7 +1134,7 @@ void assemble_device_commands(
         unicast_semaphore_cmds,
         batched_transfers);
 
-    uint32_t index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
 
     const auto& circular_buffers_unique_coreranges = program.circular_buffers_unique_coreranges();
     const uint16_t num_multicast_cb_sub_cmds = circular_buffers_unique_coreranges.size();
@@ -1134,7 +1145,7 @@ void assemble_device_commands(
         uint32_t i = 0;
         uint32_t max_overall_index = 0;
         uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
-        auto index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        auto index = MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         for (const CoreRange& core_range : circular_buffers_unique_coreranges) {
             const CoreCoord& virtual_start =
                 device->virtual_core_from_logical_core(core_range.start_coord, CoreType::WORKER);
@@ -1183,7 +1194,7 @@ void assemble_device_commands(
     std::vector<std::vector<Transfer>> batched_cmd_data;
     std::vector<std::vector<CQDispatchWritePackedLargeSubCmd>> batched_dispatch_subcmds;
     {
-        uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+        uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
         // Optimize transfers by combining adjacent or nearly adjacent transfers.
         for (auto& transfer_set : batched_transfers) {
             for (auto it = transfer_set.second.begin(); it != transfer_set.second.end();) {
@@ -1237,7 +1248,7 @@ void assemble_device_commands(
                 }
             }
         }
-        uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
+        uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
         for (size_t i = 0; i < batched_dispatch_subcmds.size(); i++) {
             calculator.add_dispatch_write_packed_large(
                 batched_dispatch_subcmds[i].size(),
@@ -1278,7 +1289,8 @@ void assemble_device_commands(
             cores);
         for (uint32_t kernel_idx = 0; kernel_idx < kg_transfer_info.dst_base_addrs.size(); kernel_idx++) {
             if (write_linear) {
-                kernel_bins_unicast_cmds.emplace_back(2 * hal_ref.get_alignment(HalMemType::HOST));
+                kernel_bins_unicast_cmds.emplace_back(
+                    2 * MetalContext::instance().hal().get_alignment(HalMemType::HOST));
                 constexpr bool flush_prefetch = false;
                 calculator.add_dispatch_write_linear<flush_prefetch>(0);
                 kernel_bins_unicast_cmds.back().add_dispatch_write_linear<flush_prefetch>(
@@ -1322,8 +1334,9 @@ void assemble_device_commands(
 
                 // TODO: pack all these writes into 1 linear write
                 uint32_t kernel_config_buffer_offset = kg_transfer_info.dst_base_addrs[kernel_idx];
-                uint32_t aligned_length =
-                    tt::align(kg_transfer_info.lengths[kernel_idx], hal_ref.get_alignment(HalMemType::DRAM));
+                uint32_t aligned_length = tt::align(
+                    kg_transfer_info.lengths[kernel_idx],
+                    MetalContext::instance().hal().get_alignment(HalMemType::DRAM));
                 uint32_t padding = aligned_length - kg_transfer_info.lengths[kernel_idx];
                 while (aligned_length != 0) {
                     if (kernel_bins_dispatch_subcmds.empty() ||
@@ -1376,7 +1389,7 @@ void assemble_device_commands(
             subcmd_list.back().flags |= CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_FLAG_UNLINK;
         }
     }
-    uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
+    uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
     for (uint32_t i = 0; i < kernel_bins_dispatch_subcmds.size(); ++i) {
         calculator.add_dispatch_write_packed_large(kernel_bins_dispatch_subcmds[i].size());
         calculator.add_prefetch_relay_paged_packed(kernel_bins_prefetch_subcmds[i].size());
@@ -1388,7 +1401,8 @@ void assemble_device_commands(
     std::vector<std::pair<uint32_t, uint32_t>> multicast_go_signals_payload;
     std::vector<std::pair<uint32_t, uint32_t>> unicast_go_signals_payload;
     constexpr uint32_t go_signal_sizeB = sizeof(launch_msg_t);
-    uint32_t aligned_go_signal_sizeB = tt::align(go_signal_sizeB, hal_ref.get_alignment(HalMemType::L1));
+    uint32_t aligned_go_signal_sizeB =
+        tt::align(go_signal_sizeB, MetalContext::instance().hal().get_alignment(HalMemType::L1));
     uint32_t go_signal_size_words = aligned_go_signal_sizeB / sizeof(uint32_t);
 
     // TODO: eventually the code below could be structured to loop over programmable_indices
@@ -1399,7 +1413,8 @@ void assemble_device_commands(
      *******************
      */
     // and check for mcast/unicast
-    uint32_t programmable_core_index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t programmable_core_index =
+        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     for (auto& kernel_group : program.get_kernel_groups(programmable_core_index)) {
         kernel_group->launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
         kernel_group->launch_msg.kernel_config.preload = DISPATCH_ENABLE_FLAG_PRELOAD;
@@ -1440,7 +1455,8 @@ void assemble_device_commands(
      *
      *******************
      */
-    programmable_core_index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+    programmable_core_index =
+        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
     // TODO: ugly, can be fixed by looping over indices w/ some work
     if (programmable_core_index != -1) {
         for (auto& kernel_group : program.get_kernel_groups(programmable_core_index)) {
@@ -1505,7 +1521,7 @@ void assemble_device_commands(
 
     auto& device_command_sequence = program_command_sequence.device_command_sequence;
 
-    uint32_t l1_alignment = hal_ref.get_alignment(HalMemType::L1);
+    uint32_t l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
 
     const std::vector<uint8_t> fill_data(l1_alignment, 0);
 
@@ -1573,7 +1589,7 @@ void assemble_device_commands(
         device_command_sequence.add_data(
             kernel_bins_unicast_cmd.data(), kernel_bins_unicast_cmd.size_bytes(), kernel_bins_unicast_cmd.size_bytes());
     }
-    uint32_t dram_alignment = hal_ref.get_alignment(HalMemType::DRAM);
+    uint32_t dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
     for (uint32_t i = 0; i < kernel_bins_dispatch_subcmds.size(); ++i) {
         device_command_sequence.add_dispatch_write_packed_large(
             CQ_DISPATCH_CMD_PACKED_WRITE_LARGE_TYPE_PROGRAM_BINARIES,
@@ -1700,19 +1716,24 @@ void assemble_device_commands(
 }
 
 void initialize_worker_config_buf_mgr(WorkerConfigBufferMgr& config_buffer_mgr, uint32_t worker_l1_unreserved_start) {
-    for (uint32_t index = 0; index < tt::tt_metal::hal_ref.get_programmable_core_type_count(); index++) {
+    for (uint32_t index = 0; index < tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type_count();
+         index++) {
         uint32_t ringbuffer_size;
-        if (tt::tt_metal::hal_ref.get_programmable_core_type(index) == tt::tt_metal::HalProgrammableCoreType::TENSIX) {
-            ringbuffer_size = worker_l1_unreserved_start - tt::tt_metal::hal_ref.get_dev_addr(
-                                                               tt::tt_metal::hal_ref.get_programmable_core_type(index),
-                                                               tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
+        if (tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index) ==
+            tt::tt_metal::HalProgrammableCoreType::TENSIX) {
+            ringbuffer_size = worker_l1_unreserved_start -
+                              tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+                                  tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index),
+                                  tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
         } else {
-            ringbuffer_size = tt::tt_metal::hal_ref.get_dev_size(
-                tt::tt_metal::hal_ref.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
+            ringbuffer_size = tt::tt_metal::MetalContext::instance().hal().get_dev_size(
+                tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index),
+                tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG);
         }
         config_buffer_mgr.init_add_buffer(
-            tt::tt_metal::hal_ref.get_dev_addr(
-                tt::tt_metal::hal_ref.get_programmable_core_type(index), tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
+            tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
+                tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(index),
+                tt::tt_metal::HalL1MemAddrType::KERNEL_CONFIG),
             ringbuffer_size);
     }
     // Subtract 1 from the number of entries, so the watcher can read information (e.g. fired asserts) from the
@@ -1827,7 +1848,8 @@ void update_program_dispatch_commands(
     // Update preamble based on kernel config ring buffer slot
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         tensix_l1_write_offset_offset,
-        &dispatch_md.kernel_config_addrs[hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
+        &dispatch_md.kernel_config_addrs[MetalContext::instance().hal().get_programmable_core_type_index(
+            HalProgrammableCoreType::TENSIX)],
         sizeof(uint32_t));
     // May truncate to fit the space.
     static_assert(
@@ -1836,16 +1858,16 @@ void update_program_dispatch_commands(
     uint16_t runtime_id = program.get_runtime_id();
     cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
         program_host_id_offset, &runtime_id, sizeof(runtime_id));
-    if (hal_ref.get_programmable_core_type_count() >= 2) {
+    if (MetalContext::instance().hal().get_programmable_core_type_count() >= 2) {
         cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
             eth_l1_write_offset_offset,
-            &dispatch_md
-                 .kernel_config_addrs[hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)],
+            &dispatch_md.kernel_config_addrs[MetalContext::instance().hal().get_programmable_core_type_index(
+                HalProgrammableCoreType::ACTIVE_ETH)],
             sizeof(uint32_t));
     }
 
     // Update CB Configs
-    uint32_t index = hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
     uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
     for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
         uint32_t* cb_config_payload = cached_program_command_sequence.cb_configs_payloads[i];
@@ -1885,14 +1907,14 @@ void update_program_dispatch_commands(
     }
     // Update launch message addresses to reflect new launch_msg slot in ring buffer
     uint32_t multicast_cores_launch_msg_addr =
-        hal_ref.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::LAUNCH) +
+        MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::LAUNCH) +
         multicast_cores_launch_message_wptr * sizeof(launch_msg_t);
     for (auto launch_msg_cmd_ptr : cached_program_command_sequence.launch_msg_write_packed_cmd_ptrs) {
         launch_msg_cmd_ptr->addr = multicast_cores_launch_msg_addr;
     }
     if (cached_program_command_sequence.unicast_launch_msg_write_packed_cmd_ptrs.size()) {
         uint32_t unicast_cores_launch_message_addr =
-            hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH) +
+            MetalContext::instance().hal().get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH) +
             unicast_cores_launch_message_wptr * sizeof(launch_msg_t);
         for (auto launch_msg_cmd_ptr : cached_program_command_sequence.unicast_launch_msg_write_packed_cmd_ptrs) {
             launch_msg_cmd_ptr->addr = unicast_cores_launch_message_addr;
@@ -2086,7 +2108,7 @@ KernelHandle get_device_local_kernel_handle(KernelHandle kernel_handle) {
 template <typename WorkloadType, typename DeviceType>
 uint32_t program_base_addr_on_core(
     WorkloadType& workload, DeviceType generic_device, HalProgrammableCoreType programmable_core_type) {
-    uint32_t index = hal_ref.get_programmable_core_type_index(programmable_core_type);
+    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
     const auto& sub_device_ids = workload.determine_sub_device_ids(generic_device);
     // TODO: This restriction can be lifted once this function is changed to return a vector of addresses
     // Addresses are not the same across sub-devices
@@ -2095,7 +2117,7 @@ uint32_t program_base_addr_on_core(
     auto sub_device_index = **sub_device_ids.begin();
     auto cq = workload.get_last_used_command_queue();
     return cq ? (cq->get_config_buffer_mgr(sub_device_index).get_last_slot_addr(programmable_core_type))
-              : hal_ref.get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
+              : MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
 }
 
 void reset_config_buf_mgrs_and_expected_workers(
@@ -2120,7 +2142,7 @@ void reset_worker_dispatch_state_on_device(
     auto num_sub_devices = device->num_sub_devices();
     uint32_t go_signals_cmd_size = 0;
     if (reset_launch_msg_state) {
-        uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
+        uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
         go_signals_cmd_size = align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) * num_sub_devices;
     }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -191,7 +191,7 @@ detail::ProgramImpl::ProgramImpl() :
     local_circular_buffer_allocation_needed_(false),
     finalized_(false),
     cached_device_hash_(std::nullopt) {
-    uint32_t programmable_core_count = hal_ref.get_programmable_core_type_count();
+    uint32_t programmable_core_count = MetalContext::instance().hal().get_programmable_core_type_count();
     for (uint32_t i = 0; i < programmable_core_count; i++) {
         kernels_.push_back({});
         grid_extent_.push_back({});
@@ -212,7 +212,7 @@ KernelHandle detail::ProgramImpl::add_kernel(const std::shared_ptr<Kernel>& kern
     TT_FATAL(this->compiled_.empty(), "Cannot add kernel to an already compiled program {}", this->id);
     // Id is unique across all kernels on all core types
     KernelHandle id = this->num_kernels();
-    uint32_t index = hal_ref.get_programmable_core_type_index(programmable_core_type);
+    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
     kernels_[index].insert({id, kernel});
     kernel_groups_[index].resize(0);
     core_to_kernel_group_index_table_[index].clear();
@@ -255,12 +255,13 @@ KernelGroup::KernelGroup(
 
     // Slow dispatch uses fixed addresses for the kernel config, configured here statically
     // Fast dispatch kernel config mangement happens under the CQ and will re-program the base
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
         this->launch_msg.kernel_config.kernel_config_base[index] =
-            hal_ref.get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
+            MetalContext::instance().hal().get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
     }
 
-    uint32_t processor_classes = hal_ref.get_processor_classes_count(programmable_core_type_index);
+    uint32_t processor_classes =
+        MetalContext::instance().hal().get_processor_classes_count(programmable_core_type_index);
     std::set<NOC_MODE> noc_modes;
     for (int class_id = 0; class_id < processor_classes; class_id++) {
         auto& optional_id = kernel_ids[class_id];
@@ -270,7 +271,7 @@ KernelGroup::KernelGroup(
             this->launch_msg.kernel_config.enables |= 1 << class_id;
 
             if (programmable_core_type_index ==
-                hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
+                MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)) {
                 // The code below sets the brisc_noc_id for use by the device firmware
                 // Use 0 if neither brisc nor ncrisc specify a noc
                 if (class_id == utils::underlying_type<DataMovementProcessor>(DataMovementProcessor::RISCV_0)) {
@@ -309,7 +310,9 @@ KernelGroup::KernelGroup(
     this->go_msg.signal = RUN_MSG_GO;
 }
 
-CoreType KernelGroup::get_core_type() const { return hal_ref.get_core_type(this->programmable_core_type_index); };
+CoreType KernelGroup::get_core_type() const {
+    return MetalContext::instance().hal().get_core_type(this->programmable_core_type_index);
+};
 
 std::vector<std::shared_ptr<KernelGroup>> &detail::ProgramImpl::get_kernel_groups(uint32_t programmable_core_type_index) {
     update_kernel_groups(programmable_core_type_index);
@@ -435,7 +438,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                     for (auto x = range.start_coord.x; x <= range.end_coord.x; x++) {
                         core_to_kernel_group_index_table_[programmable_core_type_index][y * grid_extent_[programmable_core_type_index].x + x] = index;
 
-                        if (not hal_ref.get_supports_cbs(programmable_core_type_index)) {
+                        if (not MetalContext::instance().hal().get_supports_cbs(programmable_core_type_index)) {
                             continue;
                         }
                         auto core = CoreCoord({x, y});
@@ -475,7 +478,8 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                                         // This code should be modified to log the core type index if it isn't obvious.
                                         TT_ASSERT(
                                             programmable_core_type_index ==
-                                            hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
+                                            MetalContext::instance().hal().get_programmable_core_type_index(
+                                                HalProgrammableCoreType::TENSIX));
 
                                         std::string cb_ids;
                                         for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
@@ -794,9 +798,10 @@ size_t detail::ProgramImpl::num_semaphores() const { return semaphores_.size(); 
 size_t Program::num_semaphores() const { return pimpl_->num_semaphores(); }
 
 void detail::ProgramImpl::init_semaphores(const IDevice &device, const CoreCoord &logical_core, uint32_t programmable_core_type_index) const {
-    uint64_t kernel_config_base = hal_ref.get_dev_addr(programmable_core_type_index, HalL1MemAddrType::KERNEL_CONFIG);
+    uint64_t kernel_config_base =
+        MetalContext::instance().hal().get_dev_addr(programmable_core_type_index, HalL1MemAddrType::KERNEL_CONFIG);
     uint64_t addr = kernel_config_base + this->program_configs_[programmable_core_type_index].sem_offset;
-    CoreType core_type = hal_ref.get_core_type(programmable_core_type_index);
+    CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
     auto semaphores_on_core = this->semaphores_on_core(logical_core, core_type);
     for (auto semaphore : semaphores_on_core) {
         llrt::write_hex_vec_to_core(
@@ -1012,8 +1017,8 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
     }
 
     std::uint32_t num_active_cores = 0;
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
-        CoreType core_type = hal_ref.get_core_type(index);
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
+        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
         for (const auto& kernel_group : this->get_kernel_groups(index)) {
             // TODO: add a bit in the hal that says if this core type is unicast/multicast
             if (core_type == CoreType::WORKER) {
@@ -1077,9 +1082,11 @@ ProgramConfig& Program::get_program_config(uint32_t programmable_core_type_index
 }
 
 void detail::ProgramImpl::set_launch_msg_sem_offsets() {
-    for (uint32_t kg_type_index = 0; kg_type_index < hal_ref.get_programmable_core_type_count(); kg_type_index++) {
+    for (uint32_t kg_type_index = 0; kg_type_index < MetalContext::instance().hal().get_programmable_core_type_count();
+         kg_type_index++) {
         for (auto& kg : this->get_kernel_groups(kg_type_index)) {
-            for (uint32_t sem_type_index = 0; sem_type_index < hal_ref.get_programmable_core_type_count();
+            for (uint32_t sem_type_index = 0;
+                 sem_type_index < MetalContext::instance().hal().get_programmable_core_type_count();
                  sem_type_index++) {
                 kg->launch_msg.kernel_config.sem_offset[sem_type_index] =
                     this->program_configs_[sem_type_index].sem_offset;
@@ -1107,11 +1114,12 @@ const std::vector<SubDeviceId> &detail::ProgramImpl::determine_sub_device_ids(co
         } else {
             std::unordered_set<SubDeviceId> used_sub_device_ids;
             auto find_sub_device_ids = [&](HalProgrammableCoreType core_type) {
-                auto core_type_index = hal_ref.get_programmable_core_type_index(core_type);
+                auto core_type_index = MetalContext::instance().hal().get_programmable_core_type_index(core_type);
                 if (core_type_index == -1) {
                     return;
                 }
-                const auto& program_kgs = this->get_kernel_groups(hal_ref.get_programmable_core_type_index(core_type));
+                const auto& program_kgs =
+                    this->get_kernel_groups(MetalContext::instance().hal().get_programmable_core_type_index(core_type));
                 uint32_t num_intersections = 0;
                 uint32_t num_cores = 0;
                 for (const auto& kg : program_kgs) {
@@ -1157,7 +1165,7 @@ void Program::generate_dispatch_commands(IDevice* device) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
     uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
-    if (not hal_ref.is_coordinate_virtualization_enabled()) {
+    if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // When coordinate virtualization is not enabled, explicitly encode the device
         // id into the device hash, to always assert on programs being reused across devices.
         device_hash = (device_hash << 32) | (device->id());
@@ -1312,13 +1320,17 @@ void Program::set_runtime_id(uint64_t id) { pimpl_->set_runtime_id(id); }
 uint32_t Program::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
-    return base_addr + get_program_config(hal_ref.get_programmable_core_type_index(programmable_core_type)).sem_offset;
+    return base_addr +
+           get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
+               .sem_offset;
 }
 
 uint32_t Program::get_cb_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
-    return base_addr + get_program_config(hal_ref.get_programmable_core_type_index(programmable_core_type)).cb_offset;
+    return base_addr +
+           get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
+               .cb_offset;
 }
 
 void detail::ProgramImpl::set_last_used_command_queue_for_testing(CommandQueue* queue) {
@@ -1338,7 +1350,7 @@ CommandQueue* Program::get_last_used_command_queue() const { return pimpl_->get_
 uint32_t detail::ProgramImpl::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
     HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(virtual_core);
-    uint32_t index = hal_ref.get_programmable_core_type_index(programmable_core_type);
+    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
 
     return this->program_configs_[index].sem_size;
 }
@@ -1351,7 +1363,7 @@ uint32_t detail::ProgramImpl::get_cb_size(IDevice* device, CoreCoord logical_cor
 
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
     HalProgrammableCoreType programmable_core_type = device->get_programmable_core_type(virtual_core);
-    uint32_t index = hal_ref.get_programmable_core_type_index(programmable_core_type);
+    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
 
     return this->program_configs_[index].cb_size;
 }
@@ -1363,8 +1375,9 @@ uint32_t Program::get_cb_size(IDevice* device, CoreCoord logical_core, CoreType 
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
 bool detail::ProgramImpl::runs_on_noc_unicast_only_cores() {
     return (
-        hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1 and
-        not this->get_kernel_groups(hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH))
+        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1 and
+        not this->get_kernel_groups(MetalContext::instance().hal().get_programmable_core_type_index(
+                                        HalProgrammableCoreType::ACTIVE_ETH))
                 .empty());
 }
 
@@ -1373,8 +1386,10 @@ bool Program::runs_on_noc_unicast_only_cores() { return pimpl_->runs_on_noc_unic
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
 bool detail::ProgramImpl::runs_on_noc_multicast_only_cores() {
     return (
-        hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX) != -1 and
-        not this->get_kernel_groups(hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)).empty());
+        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX) != -1 and
+        not this->get_kernel_groups(
+                    MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX))
+                .empty());
 }
 
 bool Program::runs_on_noc_multicast_only_cores() { return pimpl_->runs_on_noc_multicast_only_cores(); }
@@ -1383,8 +1398,9 @@ bool detail::ProgramImpl::kernel_binary_always_stored_in_ringbuffer() {
     // Active ethernet cores use a fixed address for the kernel binary, because they don't have enough memory to have
     // that big of a ringbuffer.
     return !(
-        hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1 and
-        not this->get_kernel_groups(hal_ref.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH))
+        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1 and
+        not this->get_kernel_groups(MetalContext::instance().hal().get_programmable_core_type_index(
+                                        HalProgrammableCoreType::ACTIVE_ETH))
                 .empty());
 }
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -63,7 +63,6 @@
 #include "program_device_map.hpp"
 #include "program_impl.hpp"
 #include "tt-metalium/program.hpp"
-#include "rtoptions.hpp"
 #include <tt_stl/span.hpp>
 #include <tt_stl/strong_type.hpp>
 #include "sub_device_types.hpp"
@@ -128,11 +127,12 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions&
         build_key,
         std::to_string(std::hash<tt_hlk_desc>{}(build_options.hlk_desc)),
         kernel->compute_hash(),
-        tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled());
+        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled());
 
     for (int i = 0; i < llrt::RunTimeDebugFeatureCount; i++) {
         compile_hash_str += "_";
-        compile_hash_str += tt::llrt::RunTimeOptions::get_instance().get_feature_hash_string((llrt::RunTimeDebugFeatures)i);
+        compile_hash_str +=
+            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_hash_string((llrt::RunTimeDebugFeatures)i);
     }
     size_t compile_hash = std::hash<std::string>{}(compile_hash_str);
 

--- a/tt_metal/impl/sub_device/sub_device.cpp
+++ b/tt_metal/impl/sub_device/sub_device.cpp
@@ -12,7 +12,7 @@
 #include <utility>
 
 #include "hal_types.hpp"
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt::tt_metal {
 
@@ -31,7 +31,7 @@ SubDevice::SubDevice(std::array<CoreRangeSet, NumHalProgrammableCoreTypes>&& cor
 }
 
 void SubDevice::validate() const {
-    auto num_core_types = hal_ref.get_programmable_core_type_count();
+    auto num_core_types = MetalContext::instance().hal().get_programmable_core_type_count();
     for (uint32_t i = num_core_types; i < NumHalProgrammableCoreTypes; ++i) {
         TT_FATAL(
             this->cores_[i].empty(),

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -48,7 +48,7 @@ SubDeviceManager::SubDeviceManager(
     tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size, IDevice* device) :
     id_(next_sub_device_manager_id_++),
     sub_devices_(sub_devices.begin(), sub_devices.end()),
-    local_l1_size_(tt::align(local_l1_size, hal_ref.get_alignment(HalMemType::L1))),
+    local_l1_size_(tt::align(local_l1_size, MetalContext::instance().hal().get_alignment(HalMemType::L1))),
     device_(device) {
     TT_ASSERT(device != nullptr, "Device must not be null");
     this->validate_sub_devices();

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -176,25 +176,26 @@ void issue_trace_commands(
 }
 
 uint32_t compute_trace_cmd_size(uint32_t num_sub_devices) {
-    uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    const auto& hal = MetalContext::instance().hal();
+    uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
     uint32_t go_signals_cmd_size =
         align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) * num_sub_devices;
 
     uint32_t cmd_sequence_sizeB =
         MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() *
-            MetalContext::instance().hal().get_alignment(
+            hal.get_alignment(
                 HalMemType::HOST) +  // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
         go_signals_cmd_size +        // go signal cmd
-        (MetalContext::instance().hal().get_alignment(
+        (hal.get_alignment(
              HalMemType::HOST) +  // wait to ensure that reset go signal was processed (dispatch_d)
                                   // when dispatch_s and dispatch_d are running on 2 cores, workers update dispatch_s.
                                   // dispatch_s is responsible for resetting worker count and giving dispatch_d the
                                   // latest worker state. This is encapsulated in the dispatch_s wait command (only to
                                   // be sent when dispatch is distributed on 2 cores)
          (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) *
-             MetalContext::instance().hal().get_alignment(HalMemType::HOST)) *
+             hal.get_alignment(HalMemType::HOST)) *
             num_sub_devices +
-        MetalContext::instance().hal().get_alignment(HalMemType::HOST);  // CQ_PREFETCH_CMD_EXEC_BUF
+        hal.get_alignment(HalMemType::HOST);  // CQ_PREFETCH_CMD_EXEC_BUF
 
     return cmd_sequence_sizeB;
 }

--- a/tt_metal/impl/trace/dispatch.cpp
+++ b/tt_metal/impl/trace/dispatch.cpp
@@ -176,25 +176,25 @@ void issue_trace_commands(
 }
 
 uint32_t compute_trace_cmd_size(uint32_t num_sub_devices) {
-    uint32_t pcie_alignment = hal_ref.get_alignment(HalMemType::HOST);
+    uint32_t pcie_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
     uint32_t go_signals_cmd_size =
         align(sizeof(CQPrefetchCmd) + sizeof(CQDispatchCmd), pcie_alignment) * num_sub_devices;
 
     uint32_t cmd_sequence_sizeB =
         MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled() *
-            hal_ref.get_alignment(
+            MetalContext::instance().hal().get_alignment(
                 HalMemType::HOST) +  // dispatch_d -> dispatch_s sem update (send only if dispatch_s is running)
         go_signals_cmd_size +        // go signal cmd
-        (hal_ref.get_alignment(
+        (MetalContext::instance().hal().get_alignment(
              HalMemType::HOST) +  // wait to ensure that reset go signal was processed (dispatch_d)
                                   // when dispatch_s and dispatch_d are running on 2 cores, workers update dispatch_s.
                                   // dispatch_s is responsible for resetting worker count and giving dispatch_d the
                                   // latest worker state. This is encapsulated in the dispatch_s wait command (only to
                                   // be sent when dispatch is distributed on 2 cores)
          (MetalContext::instance().get_dispatch_query_manager().distributed_dispatcher()) *
-             hal_ref.get_alignment(HalMemType::HOST)) *
+             MetalContext::instance().hal().get_alignment(HalMemType::HOST)) *
             num_sub_devices +
-        hal_ref.get_alignment(HalMemType::HOST);  // CQ_PREFETCH_CMD_EXEC_BUF
+        MetalContext::instance().hal().get_alignment(HalMemType::HOST);  // CQ_PREFETCH_CMD_EXEC_BUF
 
     return cmd_sequence_sizeB;
 }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -25,7 +25,6 @@
 #include "impl/context/metal_context.hpp"
 #include "jit_build/kernel_args.hpp"
 #include "jit_build_settings.hpp"
-#include "llrt/hal.hpp"
 #include "logger.hpp"
 #include "profiler_paths.hpp"
 #include "profiler_state.hpp"

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -95,10 +95,9 @@ JitBuildEnv::JitBuildEnv() = default;
 void JitBuildEnv::init(
     uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines) {
     // Paths
-    this->root_ = tt_metal::MetalContext::instance().rtoptions().get_root_dir();
-    this->out_root_ = tt_metal::MetalContext::instance().rtoptions().is_cache_dir_specified()
-                          ? tt_metal::MetalContext::instance().rtoptions().get_cache_dir()
-                          : get_default_root_path();
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    this->root_ = rtoptions.get_root_dir();
+    this->out_root_ = rtoptions.is_cache_dir_specified() ? rtoptions.get_cache_dir() : get_default_root_path();
 
     this->arch_ = arch;
     this->arch_name_ = get_string_lowercase(arch);
@@ -111,8 +110,7 @@ void JitBuildEnv::init(
 
     std::filesystem::path git_hash_path(this->out_root_ + git_hash);
     std::filesystem::path root_path(this->out_root_);
-    if ((not tt_metal::MetalContext::instance().rtoptions().get_skip_deleting_built_cache()) &&
-        std::filesystem::exists(root_path)) {
+    if ((not rtoptions.get_skip_deleting_built_cache()) && std::filesystem::exists(root_path)) {
         std::ranges::for_each(
             std::filesystem::directory_iterator{root_path},
             [&git_hash_path](const auto& dir_entry) { check_built_dir(dir_entry.path(), git_hash_path); });
@@ -167,7 +165,7 @@ void JitBuildEnv::init(
     }
     common_flags += "-std=c++17 -flto -ffast-math ";
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_riscv_debug_info_enabled()) {
+    if (rtoptions.get_riscv_debug_info_enabled()) {
         common_flags += "-g ";
     }
 
@@ -193,14 +191,14 @@ void JitBuildEnv::init(
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
 
     if (tt::tt_metal::getDeviceProfilerState()) {
-        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
+        if (rtoptions.get_profiler_do_dispatch_cores()) {
             // TODO(MO): Standard bit mask for device side profiler options
             this->defines_ += "-DPROFILE_KERNEL=2 ";
         } else {
             this->defines_ += "-DPROFILE_KERNEL=1 ";
         }
     }
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
+    if (rtoptions.get_profiler_noc_events_enabled()) {
         // force profiler on if noc events are being profiled
         if (not tt::tt_metal::getDeviceProfilerState()) {
             this->defines_ += "-DPROFILE_KERNEL=1 ";
@@ -208,38 +206,37 @@ void JitBuildEnv::init(
         this->defines_ += "-DPROFILE_NOC_EVENTS=1 ";
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
+    if (rtoptions.get_watcher_enabled()) {
         this->defines_ += "-DWATCHER_ENABLED ";
     }
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline()) {
+    if (rtoptions.get_watcher_noinline()) {
         this->defines_ += "-DWATCHER_NOINLINE ";
     }
-    for (auto& feature : tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_disabled_features()) {
+    for (auto& feature : rtoptions.get_watcher_disabled_features()) {
         this->defines_ += "-DWATCHER_DISABLE_" + feature + " ";
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+    if (rtoptions.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         this->defines_ += "-DDEBUG_PRINT_ENABLED ";
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_record_noc_transfers()) {
+    if (rtoptions.get_record_noc_transfers()) {
         this->defines_ += "-DNOC_LOGGING_ENABLED ";
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_kernels_nullified()) {
+    if (rtoptions.get_kernels_nullified()) {
         this->defines_ += "-DDEBUG_NULL_KERNELS ";
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_kernels_early_return()) {
+    if (rtoptions.get_kernels_early_return()) {
         this->defines_ += "-DDEBUG_EARLY_RETURN_KERNELS ";
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_debug_delay()) {
-        this->defines_ += "-DWATCHER_DEBUG_DELAY=" +
-                          to_string(tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_debug_delay()) + " ";
+    if (rtoptions.get_watcher_debug_delay()) {
+        this->defines_ += "-DWATCHER_DEBUG_DELAY=" + to_string(rtoptions.get_watcher_debug_delay()) + " ";
     }
 
-    if (tt::tt_metal::MetalContext::instance().rtoptions().get_hw_cache_invalidation_enabled()) {
+    if (rtoptions.get_hw_cache_invalidation_enabled()) {
         this->defines_ += "-DENABLE_HW_CACHE_INVALIDATION ";
     }
 
@@ -517,6 +514,7 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
 JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const JitBuiltStateConfig& build_config) :
     JitBuildState(env, build_config) {
     TT_ASSERT(this->core_id_ >= 0 && this->core_id_ < 1, "Invalid active ethernet processor");
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     this->lflags_ = env.lflags_;
     this->cflags_ = env.cflags_;
     this->default_compile_opt_level_ = "Os";
@@ -531,8 +529,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
     // clang-format on
 
     this->defines_ = env_.defines_;
-    uint32_t l1_cache_disable_mask = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_riscv_mask(
-        tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
+    uint32_t l1_cache_disable_mask = rtoptions.get_feature_riscv_mask(tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
     uint32_t erisc_mask = (tt::llrt::DebugHartFlags::RISCV_ER0 | tt::llrt::DebugHartFlags::RISCV_ER1);
     if ((l1_cache_disable_mask & erisc_mask) == erisc_mask) {
         this->defines_ += "-DDISABLE_L1_DATA_CACHE ";
@@ -574,7 +571,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
             this->target_name_ = "erisc";
             this->cflags_ = env_.cflags_ + " -fno-delete-null-pointer-checks ";
 
-            if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled()) {
+            if (rtoptions.get_erisc_iram_enabled()) {
                 this->defines_ += "-DENABLE_IRAM ";
             }
             this->defines_ +=
@@ -594,13 +591,13 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
 
             string linker_str;
             if (this->is_fw_) {
-                if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled()) {
+                if (rtoptions.get_erisc_iram_enabled()) {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-app_iram.ld ";
                 } else {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-app.ld ";
                 }
             } else {
-                if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled()) {
+                if (rtoptions.get_erisc_iram_enabled()) {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-kernel_iram.ld ";
                 } else {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-kernel.ld ";

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -22,13 +22,13 @@
 #include "env_lib.hpp"
 #include "fmt/base.h"
 #include "hal_types.hpp"
+#include "impl/context/metal_context.hpp"
 #include "jit_build/kernel_args.hpp"
 #include "jit_build_settings.hpp"
 #include "llrt/hal.hpp"
 #include "logger.hpp"
 #include "profiler_paths.hpp"
 #include "profiler_state.hpp"
-#include "rtoptions.hpp"
 #include "tt_backend_api_types.hpp"
 #include "tt_metal/llrt/tt_elffile.hpp"
 #include <umd/device/types/arch.h>
@@ -96,9 +96,9 @@ JitBuildEnv::JitBuildEnv() = default;
 void JitBuildEnv::init(
     uint32_t build_key, tt::ARCH arch, const std::map<std::string, std::string>& device_kernel_defines) {
     // Paths
-    this->root_ = llrt::RunTimeOptions::get_instance().get_root_dir();
-    this->out_root_ = llrt::RunTimeOptions::get_instance().is_cache_dir_specified()
-                          ? llrt::RunTimeOptions::get_instance().get_cache_dir()
+    this->root_ = tt_metal::MetalContext::instance().rtoptions().get_root_dir();
+    this->out_root_ = tt_metal::MetalContext::instance().rtoptions().is_cache_dir_specified()
+                          ? tt_metal::MetalContext::instance().rtoptions().get_cache_dir()
                           : get_default_root_path();
 
     this->arch_ = arch;
@@ -112,7 +112,7 @@ void JitBuildEnv::init(
 
     std::filesystem::path git_hash_path(this->out_root_ + git_hash);
     std::filesystem::path root_path(this->out_root_);
-    if ((not llrt::RunTimeOptions::get_instance().get_skip_deleting_built_cache()) &&
+    if ((not tt_metal::MetalContext::instance().rtoptions().get_skip_deleting_built_cache()) &&
         std::filesystem::exists(root_path)) {
         std::ranges::for_each(
             std::filesystem::directory_iterator{root_path},
@@ -168,7 +168,7 @@ void JitBuildEnv::init(
     }
     common_flags += "-std=c++17 -flto -ffast-math ";
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_riscv_debug_info_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_riscv_debug_info_enabled()) {
         common_flags += "-g ";
     }
 
@@ -194,14 +194,14 @@ void JitBuildEnv::init(
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
 
     if (tt::tt_metal::getDeviceProfilerState()) {
-        if (tt::llrt::RunTimeOptions::get_instance().get_profiler_do_dispatch_cores()) {
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_do_dispatch_cores()) {
             // TODO(MO): Standard bit mask for device side profiler options
             this->defines_ += "-DPROFILE_KERNEL=2 ";
         } else {
             this->defines_ += "-DPROFILE_KERNEL=1 ";
         }
     }
-    if (tt::llrt::RunTimeOptions::get_instance().get_profiler_noc_events_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_noc_events_enabled()) {
         // force profiler on if noc events are being profiled
         if (not tt::tt_metal::getDeviceProfilerState()) {
             this->defines_ += "-DPROFILE_KERNEL=1 ";
@@ -209,39 +209,38 @@ void JitBuildEnv::init(
         this->defines_ += "-DPROFILE_NOC_EVENTS=1 ";
     }
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
         this->defines_ += "-DWATCHER_ENABLED ";
     }
-    if (tt::llrt::RunTimeOptions::get_instance().get_watcher_noinline()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_noinline()) {
         this->defines_ += "-DWATCHER_NOINLINE ";
     }
-    for (auto& feature : tt::llrt::RunTimeOptions::get_instance().get_watcher_disabled_features()) {
+    for (auto& feature : tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_disabled_features()) {
         this->defines_ += "-DWATCHER_DISABLE_" + feature + " ";
     }
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
         this->defines_ += "-DDEBUG_PRINT_ENABLED ";
     }
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_record_noc_transfers()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_record_noc_transfers()) {
         this->defines_ += "-DNOC_LOGGING_ENABLED ";
     }
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_kernels_nullified()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_kernels_nullified()) {
         this->defines_ += "-DDEBUG_NULL_KERNELS ";
     }
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_kernels_early_return()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_kernels_early_return()) {
         this->defines_ += "-DDEBUG_EARLY_RETURN_KERNELS ";
     }
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_watcher_debug_delay()) {
-        this->defines_ +=
-            "-DWATCHER_DEBUG_DELAY=" + to_string(tt::llrt::RunTimeOptions::get_instance().get_watcher_debug_delay()) +
-            " ";
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_debug_delay()) {
+        this->defines_ += "-DWATCHER_DEBUG_DELAY=" +
+                          to_string(tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_debug_delay()) + " ";
     }
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_hw_cache_invalidation_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_hw_cache_invalidation_enabled()) {
         this->defines_ += "-DENABLE_HW_CACHE_INVALIDATION ";
     }
 
@@ -315,7 +314,7 @@ void JitBuildState::finish_init() {
 
     // Append hw build objects compiled offline
     std::string build_dir =
-        llrt::RunTimeOptions::get_instance().get_root_dir() + "runtime/hw/lib/" + get_alias(env_.arch_) + "/";
+        tt_metal::MetalContext::instance().rtoptions().get_root_dir() + "runtime/hw/lib/" + get_alias(env_.arch_) + "/";
     if (this->is_fw_) {
         if (this->target_name_ != "erisc") {
             this->link_objs_ += build_dir + "tmu-crt0.o ";
@@ -365,7 +364,7 @@ JitBuildDataMovement::JitBuildDataMovement(const JitBuildEnv& env, const JitBuil
 
     this->defines_ = env_.defines_;
 
-    uint32_t l1_cache_disable_mask = tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(
+    uint32_t l1_cache_disable_mask = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_riscv_mask(
         tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
 
     switch (this->core_id_) {
@@ -432,7 +431,7 @@ JitBuildCompute::JitBuildCompute(const JitBuildEnv& env, const JitBuiltStateConf
     this->out_path_ = this->is_fw_ ? env_.out_firmware_root_ : env_.out_kernel_root_;
 
     this->defines_ = env_.defines_;
-    uint32_t l1_cache_disable_mask = tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(
+    uint32_t l1_cache_disable_mask = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_riscv_mask(
         tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
     uint32_t debug_compute_mask =
         (tt::llrt::DebugHartFlags::RISCV_TR0 | tt::llrt::DebugHartFlags::RISCV_TR1 |
@@ -533,7 +532,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
     // clang-format on
 
     this->defines_ = env_.defines_;
-    uint32_t l1_cache_disable_mask = tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(
+    uint32_t l1_cache_disable_mask = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_riscv_mask(
         tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
     uint32_t erisc_mask = (tt::llrt::DebugHartFlags::RISCV_ER0 | tt::llrt::DebugHartFlags::RISCV_ER1);
     if ((l1_cache_disable_mask & erisc_mask) == erisc_mask) {
@@ -576,7 +575,7 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
             this->target_name_ = "erisc";
             this->cflags_ = env_.cflags_ + " -fno-delete-null-pointer-checks ";
 
-            if (tt::llrt::RunTimeOptions::get_instance().get_erisc_iram_enabled()) {
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled()) {
                 this->defines_ += "-DENABLE_IRAM ";
             }
             this->defines_ +=
@@ -596,13 +595,13 @@ JitBuildActiveEthernet::JitBuildActiveEthernet(const JitBuildEnv& env, const Jit
 
             string linker_str;
             if (this->is_fw_) {
-                if (tt::llrt::RunTimeOptions::get_instance().get_erisc_iram_enabled()) {
+                if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled()) {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-app_iram.ld ";
                 } else {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-app.ld ";
                 }
             } else {
-                if (tt::llrt::RunTimeOptions::get_instance().get_erisc_iram_enabled()) {
+                if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled()) {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-kernel_iram.ld ";
                 } else {
                     linker_str = "runtime/hw/toolchain/" + get_alias(env_.arch_) + "/erisc-b0-kernel.ld ";
@@ -642,7 +641,7 @@ JitBuildIdleEthernet::JitBuildIdleEthernet(const JitBuildEnv& env, const JitBuil
     // clang-format on
 
     this->defines_ = env_.defines_;
-    uint32_t l1_cache_disable_mask = tt::llrt::RunTimeOptions::get_instance().get_feature_riscv_mask(
+    uint32_t l1_cache_disable_mask = tt::tt_metal::MetalContext::instance().rtoptions().get_feature_riscv_mask(
         tt::llrt::RunTimeDebugFeatureDisableL1DataCache);
     uint32_t erisc_mask = (tt::llrt::DebugHartFlags::RISCV_ER0 | tt::llrt::DebugHartFlags::RISCV_ER1);
     if ((l1_cache_disable_mask & erisc_mask) == erisc_mask) {
@@ -753,7 +752,7 @@ void JitBuildState::compile_one(
 
     log_debug(tt::LogBuildKernels, "    g++ compile cmd: {}", cmd);
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled() && settings) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() && settings) {
         log_kernel_defines_and_args(out_dir, settings->get_full_kernel_name(), defines);
     }
 
@@ -775,7 +774,7 @@ void JitBuildState::compile(const string& log_file, const string& out_dir, const
 
     sync_events(events);
 
-    if (tt::llrt::RunTimeOptions::get_instance().get_watcher_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
         dump_kernel_defines_and_args(env_.get_out_kernel_root_path());
     }
 }
@@ -784,7 +783,7 @@ void JitBuildState::link(const string& log_file, const string& out_dir, const Ji
     // ZoneScoped;
     string cmd{"cd " + out_dir + " && " + env_.gpp_};
     string lflags = this->lflags_;
-    if (tt::llrt::RunTimeOptions::get_instance().get_build_map_enabled()) {
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_build_map_enabled()) {
         lflags += "-Wl,-Map=" + out_dir + "linker.map ";
     }
 

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -18,7 +18,6 @@
 #include "data_format.hpp"
 #include "hostdevcommon/common_values.hpp"
 #include "jit_build_options.hpp"
-#include "rtoptions.hpp"
 #include "tracy/Tracy.hpp"
 #include "tt_backend_api_types.hpp"
 #include "utils.hpp"

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -40,13 +40,14 @@ BuildEnvManager& BuildEnvManager::get_instance() {
 BuildEnvManager::BuildEnvManager() {
     // Initialize build_state_indices_
     uint32_t index = 0;
-    uint32_t programmable_core_type_count = hal_ref.get_programmable_core_type_count();
+    uint32_t programmable_core_type_count = MetalContext::instance().hal().get_programmable_core_type_count();
     build_state_indices_.resize(programmable_core_type_count);
     for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
-        uint32_t processor_class_count = hal_ref.get_processor_classes_count(programmable_core);
+        uint32_t processor_class_count = MetalContext::instance().hal().get_processor_classes_count(programmable_core);
         build_state_indices_[programmable_core].resize(processor_class_count);
         for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-            uint32_t processor_types_count = hal_ref.get_processor_types_count(programmable_core, processor_class);
+            uint32_t processor_types_count =
+                MetalContext::instance().hal().get_processor_types_count(programmable_core, processor_class);
             build_state_indices_[programmable_core][processor_class] = {index, processor_types_count};
             index += processor_types_count;
         }
@@ -124,7 +125,7 @@ uint32_t compute_build_key(chip_id_t device_id, uint8_t num_hw_cqs) {
                 (static_cast<uint32_t>(dispatch_core_config.get_dispatch_core_axis())
                  << (harvesting_map_bits + num_hw_cq_bits)) |
                 (static_cast<uint32_t>(num_hw_cqs) << harvesting_map_bits);
-    if (not hal_ref.is_coordinate_virtualization_enabled()) {
+    if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // Coordinate virtualization is not enabled. For a single program, its associated binaries will vary across
         // devices with different cores harvested.
         build_key |= tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
@@ -145,7 +146,7 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_i
         DispatchMemMap::get(dispatch_core_type, num_hw_cqs).get_dispatch_message_addr_start();
 
     // Prepare the container for build states
-    uint32_t num_build_states = hal_ref.get_num_risc_processors();
+    uint32_t num_build_states = MetalContext::instance().hal().get_num_risc_processors();
     std::vector<std::shared_ptr<JitBuildState>> build_states(num_build_states);
 
     // Helper lambda to create a build state based on the core type and processor info.
@@ -182,7 +183,7 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_i
                         .processor_id = processor_class,
                         .is_fw = is_fw,
                         .dispatch_message_addr = dispatch_message_addr,
-                        .is_cooperative = hal_ref.get_eth_fw_is_cooperative()});
+                        .is_cooperative = MetalContext::instance().hal().get_eth_fw_is_cooperative()});
                 break;
             }
             case HalProgrammableCoreType::IDLE_ETH: {
@@ -203,15 +204,16 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_i
 
     // Loop through programmable core types and their processor classes/types.
     uint32_t index = 0;
-    uint32_t programmable_core_type_count = hal_ref.get_programmable_core_type_count();
+    uint32_t programmable_core_type_count = MetalContext::instance().hal().get_programmable_core_type_count();
     for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
         HalProgrammableCoreType core_type = magic_enum::enum_value<HalProgrammableCoreType>(programmable_core);
-        uint32_t processor_class_count = hal_ref.get_processor_classes_count(programmable_core);
+        uint32_t processor_class_count = MetalContext::instance().hal().get_processor_classes_count(programmable_core);
         for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
             auto compute_proc_class = magic_enum::enum_cast<HalProcessorClassType>(processor_class);
             bool is_compute_processor =
                 compute_proc_class.has_value() and compute_proc_class.value() == HalProcessorClassType::COMPUTE;
-            uint32_t processor_types_count = hal_ref.get_processor_types_count(programmable_core, processor_class);
+            uint32_t processor_types_count =
+                MetalContext::instance().hal().get_processor_types_count(programmable_core, processor_class);
             for (uint32_t processor_type = 0; processor_type < processor_types_count; processor_type++) {
                 build_states[index++] =
                     create_jit_build_state(core_type, processor_class, processor_type, is_compute_processor);

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -40,14 +40,14 @@ BuildEnvManager& BuildEnvManager::get_instance() {
 BuildEnvManager::BuildEnvManager() {
     // Initialize build_state_indices_
     uint32_t index = 0;
-    uint32_t programmable_core_type_count = MetalContext::instance().hal().get_programmable_core_type_count();
+    const auto& hal = MetalContext::instance().hal();
+    uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
     build_state_indices_.resize(programmable_core_type_count);
     for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
-        uint32_t processor_class_count = MetalContext::instance().hal().get_processor_classes_count(programmable_core);
+        uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
         build_state_indices_[programmable_core].resize(processor_class_count);
         for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-            uint32_t processor_types_count =
-                MetalContext::instance().hal().get_processor_types_count(programmable_core, processor_class);
+            uint32_t processor_types_count = hal.get_processor_types_count(programmable_core, processor_class);
             build_state_indices_[programmable_core][processor_class] = {index, processor_types_count};
             index += processor_types_count;
         }
@@ -146,7 +146,8 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_i
         DispatchMemMap::get(dispatch_core_type, num_hw_cqs).get_dispatch_message_addr_start();
 
     // Prepare the container for build states
-    uint32_t num_build_states = MetalContext::instance().hal().get_num_risc_processors();
+    const auto& hal = MetalContext::instance().hal();
+    uint32_t num_build_states = hal.get_num_risc_processors();
     std::vector<std::shared_ptr<JitBuildState>> build_states(num_build_states);
 
     // Helper lambda to create a build state based on the core type and processor info.
@@ -183,7 +184,7 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_i
                         .processor_id = processor_class,
                         .is_fw = is_fw,
                         .dispatch_message_addr = dispatch_message_addr,
-                        .is_cooperative = MetalContext::instance().hal().get_eth_fw_is_cooperative()});
+                        .is_cooperative = hal.get_eth_fw_is_cooperative()});
                 break;
             }
             case HalProgrammableCoreType::IDLE_ETH: {
@@ -204,16 +205,15 @@ JitBuildStateSet create_build_state(JitBuildEnv& build_env, chip_id_t /*device_i
 
     // Loop through programmable core types and their processor classes/types.
     uint32_t index = 0;
-    uint32_t programmable_core_type_count = MetalContext::instance().hal().get_programmable_core_type_count();
+    uint32_t programmable_core_type_count = hal.get_programmable_core_type_count();
     for (uint32_t programmable_core = 0; programmable_core < programmable_core_type_count; programmable_core++) {
         HalProgrammableCoreType core_type = magic_enum::enum_value<HalProgrammableCoreType>(programmable_core);
-        uint32_t processor_class_count = MetalContext::instance().hal().get_processor_classes_count(programmable_core);
+        uint32_t processor_class_count = hal.get_processor_classes_count(programmable_core);
         for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
             auto compute_proc_class = magic_enum::enum_cast<HalProcessorClassType>(processor_class);
             bool is_compute_processor =
                 compute_proc_class.has_value() and compute_proc_class.value() == HalProcessorClassType::COMPUTE;
-            uint32_t processor_types_count =
-                MetalContext::instance().hal().get_processor_types_count(programmable_core, processor_class);
+            uint32_t processor_types_count = hal.get_processor_types_count(programmable_core, processor_class);
             for (uint32_t processor_type = 0; processor_type < processor_types_count; processor_type++) {
                 build_states[index++] =
                     create_jit_build_state(core_type, processor_class, processor_type, is_compute_processor);

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -65,15 +65,13 @@ static fs::path get_file_path_relative_to_dir(const string& dir, const fs::path&
 static fs::path get_relative_file_path_from_config(const fs::path& file_path) {
     fs::path file_path_relative_to_dir;
 
-    if (tt_metal::MetalContext::instance().rtoptions().is_root_dir_specified()) {
-        file_path_relative_to_dir =
-            get_file_path_relative_to_dir(tt_metal::MetalContext::instance().rtoptions().get_root_dir(), file_path);
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    if (rtoptions.is_root_dir_specified()) {
+        file_path_relative_to_dir = get_file_path_relative_to_dir(rtoptions.get_root_dir(), file_path);
     }
 
-    if (!fs::exists(file_path_relative_to_dir) &&
-        tt_metal::MetalContext::instance().rtoptions().is_kernel_dir_specified()) {
-        file_path_relative_to_dir =
-            get_file_path_relative_to_dir(tt_metal::MetalContext::instance().rtoptions().get_kernel_dir(), file_path);
+    if (!fs::exists(file_path_relative_to_dir) && rtoptions.is_kernel_dir_specified()) {
+        file_path_relative_to_dir = get_file_path_relative_to_dir(rtoptions.get_kernel_dir(), file_path);
     }
 
     return file_path_relative_to_dir;

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -27,7 +27,7 @@
 #include "jit_build_settings.hpp"
 #include "kernel.hpp"
 #include "logger.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 
 enum class UnpackToDestMode : uint8_t;
 namespace tt {
@@ -65,12 +65,15 @@ static fs::path get_file_path_relative_to_dir(const string& dir, const fs::path&
 static fs::path get_relative_file_path_from_config(const fs::path& file_path) {
     fs::path file_path_relative_to_dir;
 
-    if (llrt::RunTimeOptions::get_instance().is_root_dir_specified()) {
-        file_path_relative_to_dir = get_file_path_relative_to_dir(llrt::RunTimeOptions::get_instance().get_root_dir(), file_path);
+    if (tt_metal::MetalContext::instance().rtoptions().is_root_dir_specified()) {
+        file_path_relative_to_dir =
+            get_file_path_relative_to_dir(tt_metal::MetalContext::instance().rtoptions().get_root_dir(), file_path);
     }
 
-    if (!fs::exists(file_path_relative_to_dir) && llrt::RunTimeOptions::get_instance().is_kernel_dir_specified()) {
-        file_path_relative_to_dir = get_file_path_relative_to_dir(llrt::RunTimeOptions::get_instance().get_kernel_dir(), file_path);
+    if (!fs::exists(file_path_relative_to_dir) &&
+        tt_metal::MetalContext::instance().rtoptions().is_kernel_dir_specified()) {
+        file_path_relative_to_dir =
+            get_file_path_relative_to_dir(tt_metal::MetalContext::instance().rtoptions().get_kernel_dir(), file_path);
     }
 
     return file_path_relative_to_dir;

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -269,9 +269,11 @@ std::optional<uint32_t> get_storage_core_bank_size(
     const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
     if (core_desc.storage_core_bank_size.has_value()) {
         TT_FATAL(
-            core_desc.storage_core_bank_size.value() % tt_metal::hal_ref.get_alignment(tt_metal::HalMemType::L1) == 0,
+            core_desc.storage_core_bank_size.value() %
+                    tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1) ==
+                0,
             "Storage core bank size must be {} B aligned",
-            tt_metal::hal_ref.get_alignment(tt_metal::HalMemType::L1));
+            tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::L1));
     }
     return core_desc.storage_core_bank_size;
 }

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -18,7 +18,6 @@
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "metal_soc_descriptor.h"
-#include "rtoptions.hpp"
 #include "tt_backend_api_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -43,7 +42,7 @@ inline std::string get_core_descriptor_file(
     }
     core_desc_dir += "tt_metal/core_descriptors/";
 
-    bool targeting_sim = llrt::RunTimeOptions::get_instance().get_simulator_enabled();
+    bool targeting_sim = tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled();
     if (targeting_sim) {
         switch (arch) {
             case tt::ARCH::Invalid:
@@ -195,7 +194,7 @@ const core_descriptor_t& get_core_descriptor_config(
         dispatch_cores.push_back(coord);
     }
     TT_ASSERT(
-        dispatch_cores.size() || llrt::RunTimeOptions::get_instance().get_simulator_enabled(),
+        dispatch_cores.size() || tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled(),
         "Dispatch cores size must be positive");
 
     std::vector<CoreCoord> logical_compute_cores;

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -8,7 +8,7 @@
 
 #include "tt_backend_api_types.hpp"
 #include "assert.hpp"
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 #include <umd/device/pci_device.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/tt_simulation_device.h>
@@ -50,8 +50,8 @@ namespace tt::tt_metal {
  */
 inline tt::ARCH get_platform_architecture() {
     auto arch = tt::ARCH::Invalid;
-    if (llrt::RunTimeOptions::get_instance().get_simulator_enabled()) {
-        tt_SimulationDeviceInit init(llrt::RunTimeOptions::get_instance().get_simulator_path());
+    if (tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
+        tt_SimulationDeviceInit init(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
         arch = init.get_arch_name();
     } else {
         // Issue tt_umd#361: tt_ClusterDescriptor::create() won't work here.

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -8,7 +8,7 @@
 
 #include "tt_backend_api_types.hpp"
 #include "assert.hpp"
-#include "impl/context/metal_context.hpp"
+#include "llrt/rtoptions.hpp"
 #include <umd/device/pci_device.hpp>
 #include <umd/device/tt_soc_descriptor.h>
 #include <umd/device/tt_simulation_device.h>
@@ -48,10 +48,10 @@ namespace tt::tt_metal {
  * @see tt::get_arch_from_string
  * @see PCIDevice::enumerate_devices_info
  */
-inline tt::ARCH get_platform_architecture() {
+inline tt::ARCH get_platform_architecture(tt::llrt::RunTimeOptions& rtoptions) {
     auto arch = tt::ARCH::Invalid;
-    if (tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
-        tt_SimulationDeviceInit init(tt_metal::MetalContext::instance().rtoptions().get_simulator_path());
+    if (rtoptions.get_simulator_enabled()) {
+        tt_SimulationDeviceInit init(rtoptions.get_simulator_path());
         arch = init.get_arch_name();
     } else {
         // Issue tt_umd#361: tt_ClusterDescriptor::create() won't work here.

--- a/tt_metal/llrt/get_platform_architecture.hpp
+++ b/tt_metal/llrt/get_platform_architecture.hpp
@@ -48,7 +48,7 @@ namespace tt::tt_metal {
  * @see tt::get_arch_from_string
  * @see PCIDevice::enumerate_devices_info
  */
-inline tt::ARCH get_platform_architecture(tt::llrt::RunTimeOptions& rtoptions) {
+inline tt::ARCH get_platform_architecture(const tt::llrt::RunTimeOptions& rtoptions) {
     auto arch = tt::ARCH::Invalid;
     if (rtoptions.get_simulator_enabled()) {
         tt_SimulationDeviceInit init(rtoptions.get_simulator_path());

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -6,7 +6,6 @@
 
 #include <assert.hpp>
 
-#include "get_platform_architecture.hpp"
 #include "hal_types.hpp"
 #include <umd/device/types/arch.h>
 
@@ -16,7 +15,7 @@ namespace tt_metal {
 
 // Hal Constructor determines the platform architecture by using UMD
 // Once it knows the architecture it can self initialize architecture specific memory maps
-Hal::Hal() : arch_(get_platform_architecture()) {
+Hal::Hal(tt::ARCH arch) : arch_(arch) {
     switch (this->arch_) {
         case tt::ARCH::GRAYSKULL: /*TT_THROW("Unsupported arch for HAL")*/; break;
 

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -357,20 +357,20 @@ uint32_t generate_risc_startup_addr(uint32_t firmware_base);  // used by Tensix 
 }  // namespace tt_metal
 }  // namespace tt
 
-#define HAL_MEM_L1_BASE                 \
-    tt::tt_metal::hal_ref.get_dev_addr( \
+#define HAL_MEM_L1_BASE                                        \
+    tt::tt_metal::MetalContext::instance().hal().get_dev_addr( \
         tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE)
-#define HAL_MEM_L1_SIZE                 \
-    tt::tt_metal::hal_ref.get_dev_size( \
+#define HAL_MEM_L1_SIZE                                        \
+    tt::tt_metal::MetalContext::instance().hal().get_dev_size( \
         tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE)
 
-#define HAL_MEM_ETH_BASE                                       \
-    ((tt::tt_metal::hal_ref.get_arch() == tt::ARCH::GRAYSKULL) \
-         ? 0                                                   \
-         : tt::tt_metal::hal_ref.get_dev_addr(                 \
+#define HAL_MEM_ETH_BASE                                                              \
+    ((tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::GRAYSKULL) \
+         ? 0                                                                          \
+         : tt::tt_metal::MetalContext::instance().hal().get_dev_addr(                 \
                tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE))
-#define HAL_MEM_ETH_SIZE                                       \
-    ((tt::tt_metal::hal_ref.get_arch() == tt::ARCH::GRAYSKULL) \
-         ? 0                                                   \
-         : tt::tt_metal::hal_ref.get_dev_size(                 \
+#define HAL_MEM_ETH_SIZE                                                              \
+    ((tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::GRAYSKULL) \
+         ? 0                                                                          \
+         : tt::tt_metal::MetalContext::instance().hal().get_dev_size(                 \
                tt::tt_metal::HalProgrammableCoreType::IDLE_ETH, tt::tt_metal::HalL1MemAddrType::BASE))

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -206,7 +206,6 @@ public:
     uint32_t get_programmable_core_type_index(HalProgrammableCoreType programmable_core_type_index) const;
     CoreType get_core_type(uint32_t programmable_core_type_index) const;
     uint32_t get_processor_classes_count(std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type) const;
-    uint32_t get_processor_class_type_index(HalProcessorClassType processor_class);
     uint32_t get_processor_types_count(
         std::variant<HalProgrammableCoreType, uint32_t> programmable_core_type, uint32_t processor_class_idx) const;
 
@@ -232,15 +231,15 @@ public:
     const HalJitBuildConfig& get_jit_build_config(
         uint32_t programmable_core_type_index, uint32_t processor_class_idx, uint32_t processor_type_idx) const;
 
-    uint64_t relocate_dev_addr(uint64_t addr, uint64_t local_init_addr = 0) {
+    uint64_t relocate_dev_addr(uint64_t addr, uint64_t local_init_addr = 0) const {
         return relocate_func_(addr, local_init_addr);
     }
 
-    uint64_t erisc_iram_relocate_dev_addr(uint64_t addr) { return erisc_iram_relocate_func_(addr); }
+    uint64_t erisc_iram_relocate_dev_addr(uint64_t addr) const { return erisc_iram_relocate_func_(addr); }
 
-    uint32_t valid_reg_addr(uint32_t addr) { return valid_reg_addr_func_(addr); }
+    uint32_t valid_reg_addr(uint32_t addr) const { return valid_reg_addr_func_(addr); }
 
-    uint32_t get_stack_size(uint32_t type) { return stack_size_func_(type); }
+    uint32_t get_stack_size(uint32_t type) const { return stack_size_func_(type); }
 };
 
 inline uint32_t Hal::get_programmable_core_type_count() const { return core_info_.size(); }

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -151,7 +151,7 @@ private:
     StackSizeFunc stack_size_func_;
 
 public:
-    Hal();
+    Hal(tt::ARCH arch);
 
     tt::ARCH get_arch() const { return arch_; }
 
@@ -351,25 +351,6 @@ inline const HalJitBuildConfig& Hal::get_jit_build_config(
     TT_ASSERT(programmable_core_type_index < this->core_info_.size());
     return this->core_info_[programmable_core_type_index].get_jit_build_config(processor_class_idx, processor_type_idx);
 }
-
-class HalSingleton : public Hal {
-private:
-    HalSingleton() = default;
-    HalSingleton(const HalSingleton&) = delete;
-    HalSingleton(HalSingleton&&) = delete;
-    ~HalSingleton() = default;
-
-    HalSingleton& operator=(const HalSingleton&) = delete;
-    HalSingleton& operator=(HalSingleton&&) = delete;
-
-public:
-    static inline HalSingleton& getInstance() {
-        static HalSingleton instance;
-        return instance;
-    }
-};
-
-inline auto& hal_ref = HalSingleton::getInstance();  // inline variable requires C++17
 
 uint32_t generate_risc_startup_addr(uint32_t firmware_base);  // used by Tensix initializers to build HalJitBuildConfig
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -26,7 +26,6 @@
 #include "impl/context/metal_context.hpp"
 #include "hal_types.hpp"
 #include "llrt.hpp"
-#include "llrt/hal.hpp"
 #include "metal_soc_descriptor.h"
 // #include <umd/device/driver_atomics.h> - This should be included as it is used here, but the file is missing include
 // guards
@@ -129,7 +128,7 @@ ll_api::memory read_mem_from_core(chip_id_t chip, const CoreCoord &core, const l
 
     ll_api::memory read_mem;
     read_mem.fill_from_mem_template(mem, [&](std::vector<uint32_t>::iterator mem_ptr, uint64_t addr, uint32_t len) {
-        uint64_t relo_addr = tt::tt_metal::hal_ref.relocate_dev_addr(addr, local_init_addr);
+        uint64_t relo_addr = tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
         tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             &*mem_ptr, len * sizeof(uint32_t), tt_cxy_pair(chip, core), relo_addr);
     });
@@ -147,14 +146,15 @@ bool test_load_write_read_risc_binary(
         tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(core, chip_id) or
         tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(core, chip_id));
 
-    uint64_t local_init_addr =
-        tt::tt_metal::hal_ref.get_jit_build_config(core_type_idx, processor_class_idx, processor_type_idx)
-            .local_init_addr;
-    auto core_type = tt::tt_metal::hal_ref.get_programmable_core_type(core_type_idx);
+    uint64_t local_init_addr = tt::tt_metal::MetalContext::instance()
+                                   .hal()
+                                   .get_jit_build_config(core_type_idx, processor_class_idx, processor_type_idx)
+                                   .local_init_addr;
+    auto core_type = tt::tt_metal::MetalContext::instance().hal().get_programmable_core_type(core_type_idx);
 
     log_debug(tt::LogLLRuntime, "hex_vec size = {}, size_in_bytes = {}", mem.size(), mem.size()*sizeof(uint32_t));
     mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t addr, uint32_t len_words) {
-        uint64_t relo_addr = tt::tt_metal::hal_ref.relocate_dev_addr(addr, local_init_addr);
+        uint64_t relo_addr = tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
 
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
             &*mem_ptr, len_words * sizeof(uint32_t), tt_cxy_pair(chip_id, core), relo_addr);
@@ -207,7 +207,8 @@ static bool check_if_riscs_on_specified_core_done(chip_id_t chip_id, const CoreC
 
     tt_metal::HalProgrammableCoreType dispatch_core_type =  is_active_eth_core ? tt_metal::HalProgrammableCoreType::ACTIVE_ETH :
         is_inactive_eth_core ? tt_metal::HalProgrammableCoreType::IDLE_ETH : tt_metal::HalProgrammableCoreType::TENSIX;
-    uint64_t go_msg_addr = tt_metal::hal_ref.get_dev_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
+    uint64_t go_msg_addr =
+        tt_metal::MetalContext::instance().hal().get_dev_addr(dispatch_core_type, tt_metal::HalL1MemAddrType::GO_MSG);
 
     auto get_mailbox_is_done = [&](uint64_t go_msg_addr) {
         constexpr int RUN_MAILBOX_BOGUS = 3;

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -237,7 +237,8 @@ void wait_until_cores_done(
     // poll the cores until the set of not done cores is empty
     int loop_count = 1;
     auto start = std::chrono::high_resolution_clock::now();
-    bool is_simulator = tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled();
+    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    bool is_simulator = rtoptions.get_simulator_enabled();
 
     if (is_simulator) timeout_ms = 0;
     while (!not_done_phys_cores.empty()) {
@@ -281,8 +282,7 @@ void wait_until_cores_done(
         // Continuously polling cores here can cause other host-driven noc transactions (dprint, watcher) to drastically
         // slow down for remote devices. So when debugging with these features, add a small delay to allow other
         // host-driven transactions through.
-        if (tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() ||
-            tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
+        if (rtoptions.get_watcher_enabled() || rtoptions.get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
         }
     }

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -7,7 +7,6 @@
 #include <fmt/base.h>
 #include <fmt/ranges.h>
 #include <logger.hpp>
-#include <rtoptions.hpp>
 #include <unistd.h>
 #include <cassert>
 #include <chrono>
@@ -24,6 +23,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "impl/context/metal_context.hpp"
 #include "hal_types.hpp"
 #include "llrt.hpp"
 #include "llrt/hal.hpp"
@@ -236,7 +236,7 @@ void wait_until_cores_done(
     // poll the cores until the set of not done cores is empty
     int loop_count = 1;
     auto start = std::chrono::high_resolution_clock::now();
-    bool is_simulator = llrt::RunTimeOptions::get_instance().get_simulator_enabled();
+    bool is_simulator = tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled();
 
     if (is_simulator) timeout_ms = 0;
     while (!not_done_phys_cores.empty()) {
@@ -280,9 +280,10 @@ void wait_until_cores_done(
         // Continuously polling cores here can cause other host-driven noc transactions (dprint, watcher) to drastically
         // slow down for remote devices. So when debugging with these features, add a small delay to allow other
         // host-driven transactions through.
-        if (llrt::RunTimeOptions::get_instance().get_watcher_enabled() ||
-            llrt::RunTimeOptions::get_instance().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint))
+        if (tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() ||
+            tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(tt::llrt::RunTimeDebugFeatureDprint)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
     }
 }
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -179,7 +179,7 @@ RunTimeOptions::RunTimeOptions() {
     }
 }
 
-const std::string& RunTimeOptions::get_root_dir() {
+const std::string& RunTimeOptions::get_root_dir() const {
     if (!this->is_root_dir_specified()) {
         TT_THROW("Env var {} is not set.", TT_METAL_HOME_ENV_VAR);
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -187,7 +187,7 @@ const std::string& RunTimeOptions::get_root_dir() const {
     return root_dir;
 }
 
-const std::string& RunTimeOptions::get_cache_dir() {
+const std::string& RunTimeOptions::get_cache_dir() const {
     if (!this->is_cache_dir_specified()) {
         TT_THROW("Env var {} is not set.", TT_METAL_CACHE_ENV_VAR);
     }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -151,7 +151,7 @@ public:
     RunTimeOptions& operator=(const RunTimeOptions&) = delete;
 
     inline bool is_root_dir_specified() const { return this->is_root_dir_env_var_set; }
-    const std::string& get_root_dir();
+    const std::string& get_root_dir() const;
 
     inline bool is_cache_dir_specified() const { return this->is_cache_dir_env_var_set; }
     const std::string& get_cache_dir();
@@ -159,34 +159,34 @@ public:
     inline bool is_kernel_dir_specified() const { return this->is_kernel_dir_env_var_set; }
     const std::string& get_kernel_dir() const;
 
-    inline bool get_build_map_enabled() { return build_map_enabled; }
+    inline bool get_build_map_enabled() const { return build_map_enabled; }
 
     // Info from watcher environment variables, setters included so that user
     // can override with a SW call.
-    inline bool get_watcher_enabled() { return watcher_enabled; }
+    inline bool get_watcher_enabled() const { return watcher_enabled; }
     inline void set_watcher_enabled(bool enabled) { watcher_enabled = enabled; }
-    inline int get_watcher_interval() { return watcher_interval_ms; }
+    inline int get_watcher_interval() const { return watcher_interval_ms; }
     inline void set_watcher_interval(int interval_ms) { watcher_interval_ms = interval_ms; }
-    inline int get_watcher_dump_all() { return watcher_dump_all; }
+    inline int get_watcher_dump_all() const { return watcher_dump_all; }
     inline void set_watcher_dump_all(bool dump_all) { watcher_dump_all = dump_all; }
-    inline int get_watcher_append() { return watcher_append; }
+    inline int get_watcher_append() const { return watcher_append; }
     inline void set_watcher_append(bool append) { watcher_append = append; }
-    inline int get_watcher_auto_unpause() { return watcher_auto_unpause; }
+    inline int get_watcher_auto_unpause() const { return watcher_auto_unpause; }
     inline void set_watcher_auto_unpause(bool auto_unpause) { watcher_auto_unpause = auto_unpause; }
-    inline int get_watcher_noinline() { return watcher_noinline; }
+    inline int get_watcher_noinline() const { return watcher_noinline; }
     inline void set_watcher_noinline(bool noinline) { watcher_noinline = noinline; }
-    inline int get_watcher_phys_coords() { return watcher_phys_coords; }
+    inline int get_watcher_phys_coords() const { return watcher_phys_coords; }
     inline void set_watcher_phys_coords(bool phys_coords) { watcher_phys_coords = phys_coords; }
-    inline int get_watcher_text_start() { return watcher_text_start; }
+    inline int get_watcher_text_start() const { return watcher_text_start; }
     inline void set_watcher_text_start(bool text_start) { watcher_text_start = text_start; }
-    inline std::set<std::string>& get_watcher_disabled_features() { return watcher_disabled_features; }
-    inline bool watcher_status_disabled() { return watcher_feature_disabled(watcher_waypoint_str); }
-    inline bool watcher_noc_sanitize_disabled() { return watcher_feature_disabled(watcher_noc_sanitize_str); }
-    inline bool watcher_assert_disabled() { return watcher_feature_disabled(watcher_assert_str); }
-    inline bool watcher_pause_disabled() { return watcher_feature_disabled(watcher_pause_str); }
-    inline bool watcher_ring_buffer_disabled() { return watcher_feature_disabled(watcher_ring_buffer_str); }
-    inline bool watcher_stack_usage_disabled() { return watcher_feature_disabled(watcher_stack_usage_str); }
-    inline bool watcher_dispatch_disabled() { return watcher_feature_disabled(watcher_dispatch_str); }
+    inline const std::set<std::string>& get_watcher_disabled_features() const { return watcher_disabled_features; }
+    inline bool watcher_status_disabled() const { return watcher_feature_disabled(watcher_waypoint_str); }
+    inline bool watcher_noc_sanitize_disabled() const { return watcher_feature_disabled(watcher_noc_sanitize_str); }
+    inline bool watcher_assert_disabled() const { return watcher_feature_disabled(watcher_assert_str); }
+    inline bool watcher_pause_disabled() const { return watcher_feature_disabled(watcher_pause_str); }
+    inline bool watcher_ring_buffer_disabled() const { return watcher_feature_disabled(watcher_ring_buffer_str); }
+    inline bool watcher_stack_usage_disabled() const { return watcher_feature_disabled(watcher_stack_usage_str); }
+    inline bool watcher_dispatch_disabled() const { return watcher_feature_disabled(watcher_dispatch_str); }
 
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
@@ -256,10 +256,10 @@ public:
         feature_targets[feature] = targets;
     }
 
-    inline bool get_record_noc_transfers() { return record_noc_transfer_data; }
+    inline bool get_record_noc_transfers() const { return record_noc_transfer_data; }
     inline void set_record_noc_transfers(bool val) { record_noc_transfer_data = val; }
 
-    inline bool get_validate_kernel_binaries() { return validate_kernel_binaries; }
+    inline bool get_validate_kernel_binaries() const { return validate_kernel_binaries; }
     inline void set_validate_kernel_binaries(bool val) { validate_kernel_binaries = val; }
 
     // Returns the string representation for hash computation.
@@ -284,55 +284,55 @@ public:
     // (test mode = false). We need to catch for gtesting, since an unhandled exception will kill
     // the gtest (and can't catch an exception from the server thread in main thread), but by
     // default we should throw so that the user can see the exception as soon as it happens.
-    bool get_test_mode_enabled() { return test_mode_enabled; }
+    bool get_test_mode_enabled() const { return test_mode_enabled; }
     inline void set_test_mode_enabled(bool enable) { test_mode_enabled = enable; }
 
-    inline bool get_profiler_enabled() { return profiler_enabled; }
-    inline bool get_profiler_do_dispatch_cores() { return profile_dispatch_cores; }
-    inline bool get_profiler_sync_enabled() { return profiler_sync_enabled; }
-    inline bool get_profiler_buffer_usage_enabled() { return profiler_buffer_usage_enabled; }
-    inline bool get_profiler_noc_events_enabled() { return profiler_noc_events_enabled; }
-    inline std::string get_profiler_noc_events_report_path() { return profiler_noc_events_report_path; }
+    inline bool get_profiler_enabled() const { return profiler_enabled; }
+    inline bool get_profiler_do_dispatch_cores() const { return profile_dispatch_cores; }
+    inline bool get_profiler_sync_enabled() const { return profiler_sync_enabled; }
+    inline bool get_profiler_buffer_usage_enabled() const { return profiler_buffer_usage_enabled; }
+    inline bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }
+    inline std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }
 
     inline void set_kernels_nullified(bool v) { null_kernels = v; }
-    inline bool get_kernels_nullified() { return null_kernels; }
+    inline bool get_kernels_nullified() const { return null_kernels; }
 
     inline void set_kernels_early_return(bool v) { kernels_early_return = v; }
-    inline bool get_kernels_early_return() { return kernels_early_return; }
+    inline bool get_kernels_early_return() const { return kernels_early_return; }
 
-    inline bool get_clear_l1() { return clear_l1; }
+    inline bool get_clear_l1() const { return clear_l1; }
     inline void set_clear_l1(bool clear) { clear_l1 = clear; }
 
-    inline bool get_skip_loading_fw() { return skip_loading_fw; }
-    inline bool get_skip_reset_cores_on_init() { return skip_reset_cores_on_init; }
+    inline bool get_skip_loading_fw() const { return skip_loading_fw; }
+    inline bool get_skip_reset_cores_on_init() const { return skip_reset_cores_on_init; }
 
     // Whether to compile with -g to include DWARF debug info in the binary.
-    inline bool get_riscv_debug_info_enabled() { return riscv_debug_info_enabled; }
+    inline bool get_riscv_debug_info_enabled() const { return riscv_debug_info_enabled; }
     inline void set_riscv_debug_info_enabled(bool enable) { riscv_debug_info_enabled = enable; }
 
-    inline unsigned get_num_hw_cqs() { return num_hw_cqs; }
+    inline unsigned get_num_hw_cqs() const { return num_hw_cqs; }
     inline void set_num_hw_cqs(unsigned num) { num_hw_cqs = num; }
 
     inline bool get_fd_fabric() const { return fb_fabric_en; }
 
-    inline uint32_t get_watcher_debug_delay() { return watcher_debug_delay; }
+    inline uint32_t get_watcher_debug_delay() const { return watcher_debug_delay; }
     inline void set_watcher_debug_delay(uint32_t delay) { watcher_debug_delay = delay; }
 
-    inline bool get_dispatch_data_collection_enabled() { return enable_dispatch_data_collection; }
+    inline bool get_dispatch_data_collection_enabled() const { return enable_dispatch_data_collection; }
     inline void set_dispatch_data_collection_enabled(bool enable) { enable_dispatch_data_collection = enable; }
 
     inline bool get_hw_cache_invalidation_enabled() const { return this->enable_hw_cache_invalidation; }
 
     tt_metal::DispatchCoreConfig get_dispatch_core_config() const;
 
-    inline bool get_skip_deleting_built_cache() { return skip_deleting_built_cache; }
+    inline bool get_skip_deleting_built_cache() const { return skip_deleting_built_cache; }
 
-    inline bool get_simulator_enabled() { return simulator_enabled; }
-    inline const std::filesystem::path& get_simulator_path() { return simulator_path; }
+    inline bool get_simulator_enabled() const { return simulator_enabled; }
+    inline const std::filesystem::path& get_simulator_path() const { return simulator_path; }
 
-    inline bool get_erisc_iram_enabled() { return erisc_iram_enabled; }
+    inline bool get_erisc_iram_enabled() const { return erisc_iram_enabled; }
 
-    inline bool get_skip_eth_cores_with_retrain() { return skip_eth_cores_with_retrain; }
+    inline bool get_skip_eth_cores_with_retrain() const { return skip_eth_cores_with_retrain; }
 
 private:
     // Helper functions to parse feature-specific environment vaiables.
@@ -357,7 +357,7 @@ private:
     const std::string watcher_stack_usage_str = "STACK_USAGE";
     const std::string watcher_dispatch_str = "DISPATCH";
     std::set<std::string> watcher_disabled_features;
-    bool watcher_feature_disabled(const std::string& name) {
+    bool watcher_feature_disabled(const std::string& name) const {
         return watcher_disabled_features.find(name) != watcher_disabled_features.end();
     }
 };

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -154,7 +154,7 @@ public:
     const std::string& get_root_dir() const;
 
     inline bool is_cache_dir_specified() const { return this->is_cache_dir_env_var_set; }
-    const std::string& get_cache_dir();
+    const std::string& get_cache_dir() const;
 
     inline bool is_kernel_dir_specified() const { return this->is_kernel_dir_env_var_set; }
     const std::string& get_kernel_dir() const;
@@ -190,12 +190,12 @@ public:
 
     // Info from DPrint environment variables, setters included so that user can
     // override with a SW call.
-    inline bool get_feature_enabled(RunTimeDebugFeatures feature) { return feature_targets[feature].enabled; }
+    inline bool get_feature_enabled(RunTimeDebugFeatures feature) const { return feature_targets[feature].enabled; }
     inline void set_feature_enabled(RunTimeDebugFeatures feature, bool enabled) {
         feature_targets[feature].enabled = enabled;
     }
     // Note: dprint cores are logical
-    inline std::map<CoreType, std::vector<CoreCoord>>& get_feature_cores(RunTimeDebugFeatures feature) {
+    inline const std::map<CoreType, std::vector<CoreCoord>>& get_feature_cores(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].cores;
     }
     inline void set_feature_cores(RunTimeDebugFeatures feature, std::map<CoreType, std::vector<CoreCoord>> cores) {
@@ -205,8 +205,8 @@ public:
     inline void set_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type, int all_cores) {
         feature_targets[feature].all_cores[core_type] = all_cores;
     }
-    inline int get_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type) {
-        return feature_targets[feature].all_cores[core_type];
+    inline int get_feature_all_cores(RunTimeDebugFeatures feature, CoreType core_type) const {
+        return feature_targets[feature].all_cores.at(core_type);
     }
     // Note: core range is inclusive
     inline void set_feature_core_range(
@@ -218,7 +218,7 @@ public:
             }
         }
     }
-    inline std::vector<int>& get_feature_chip_ids(RunTimeDebugFeatures feature) {
+    inline const std::vector<int>& get_feature_chip_ids(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].chip_ids;
     }
     inline void set_feature_chip_ids(RunTimeDebugFeatures feature, std::vector<int> chip_ids) {
@@ -228,30 +228,32 @@ public:
     inline void set_feature_all_chips(RunTimeDebugFeatures feature, bool all_chips) {
         feature_targets[feature].all_chips = all_chips;
     }
-    inline bool get_feature_all_chips(RunTimeDebugFeatures feature) { return feature_targets[feature].all_chips; }
-    inline uint32_t get_feature_riscv_mask(RunTimeDebugFeatures feature) { return feature_targets[feature].riscv_mask; }
+    inline bool get_feature_all_chips(RunTimeDebugFeatures feature) const { return feature_targets[feature].all_chips; }
+    inline uint32_t get_feature_riscv_mask(RunTimeDebugFeatures feature) const {
+        return feature_targets[feature].riscv_mask;
+    }
     inline void set_feature_riscv_mask(RunTimeDebugFeatures feature, uint32_t riscv_mask) {
         feature_targets[feature].riscv_mask = riscv_mask;
     }
-    inline std::string get_feature_file_name(RunTimeDebugFeatures feature) {
+    inline std::string get_feature_file_name(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].file_name;
     }
     inline void set_feature_file_name(RunTimeDebugFeatures feature, std::string file_name) {
         feature_targets[feature].file_name = file_name;
     }
-    inline bool get_feature_one_file_per_risc(RunTimeDebugFeatures feature) {
+    inline bool get_feature_one_file_per_risc(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].one_file_per_risc;
     }
     inline void set_feature_one_file_per_risc(RunTimeDebugFeatures feature, bool one_file_per_risc) {
         feature_targets[feature].one_file_per_risc = one_file_per_risc;
     }
-    inline bool get_feature_prepend_device_core_risc(RunTimeDebugFeatures feature) {
+    inline bool get_feature_prepend_device_core_risc(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].prepend_device_core_risc;
     }
     inline void set_feature_prepend_device_core_risc(RunTimeDebugFeatures feature, bool prepend_device_core_risc) {
         feature_targets[feature].prepend_device_core_risc = prepend_device_core_risc;
     }
-    inline TargetSelection get_feature_targets(RunTimeDebugFeatures feature) { return feature_targets[feature]; }
+    inline TargetSelection get_feature_targets(RunTimeDebugFeatures feature) const { return feature_targets[feature]; }
     inline void set_feature_targets(RunTimeDebugFeatures feature, TargetSelection targets) {
         feature_targets[feature] = targets;
     }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -145,14 +145,8 @@ class RunTimeOptions {
 
     bool skip_eth_cores_with_retrain = false;
 
-    RunTimeOptions();
-
 public:
-    static RunTimeOptions& get_instance() {
-        static RunTimeOptions instance;
-        return instance;
-    }
-
+    RunTimeOptions();
     RunTimeOptions(const RunTimeOptions&) = delete;
     RunTimeOptions& operator=(const RunTimeOptions&) = delete;
 

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -6,14 +6,14 @@
 
 #include <cstdint>
 
-#include "llrt/hal.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace tt {
 
 // Host MMIO reads/writes don't have alignment restrictions, so no need to check alignment here.
 #define DEBUG_VALID_L1_ADDR(a, l) (((a) >= HAL_MEM_L1_BASE) && ((a) + (l) <= HAL_MEM_L1_BASE + HAL_MEM_L1_SIZE))
 
-#define DEBUG_VALID_REG_ADDR(a) tt::tt_metal::hal_ref.valid_reg_addr(a)
+#define DEBUG_VALID_REG_ADDR(a) tt::tt_metal::MetalContext::instance().hal().valid_reg_addr(a)
 #define DEBUG_VALID_WORKER_ADDR(a, l) (DEBUG_VALID_L1_ADDR(a, l) || (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
 #define DEBUG_VALID_DRAM_ADDR(a, l, b, e) (((a) >= b) && ((a) + (l) <= e))
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -8,7 +8,6 @@
 #include <dev_msgs.h>
 #include <logger.hpp>
 #include <metal_soc_descriptor.h>
-#include <rtoptions.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
@@ -31,6 +30,7 @@
 #include "fabric_types.hpp"
 #include "fmt/base.h"
 #include "hal_types.hpp"
+#include "impl/context/metal_context.hpp"
 #include "llrt/hal.hpp"
 #include "sanitize_noc_host.hpp"
 #include "tracy/Tracy.hpp"

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -29,6 +29,7 @@
 #include "fabric_host_interface.h"
 #include "fabric_types.hpp"
 #include "fmt/base.h"
+#include "get_platform_architecture.hpp"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
 #include "llrt/hal.hpp"
@@ -87,7 +88,7 @@ inline std::string get_soc_description_file(
 }  // namespace
 namespace tt {
 
-Cluster::Cluster(llrt::RunTimeOptions& rtoptions) : rtoptions_(rtoptions) {
+Cluster::Cluster(llrt::RunTimeOptions& rtoptions, Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
     ZoneScoped;
     log_info(tt::LogDevice, "Opening user mode device driver");
 
@@ -114,7 +115,7 @@ Cluster::Cluster(llrt::RunTimeOptions& rtoptions) : rtoptions_(rtoptions) {
 void Cluster::detect_arch_and_target() {
     this->target_type_ = (rtoptions_.get_simulator_enabled()) ? TargetDevice::Simulator : TargetDevice::Silicon;
 
-    this->arch_ = get_platform_architecture(rtoptions_);
+    this->arch_ = tt_metal::get_platform_architecture(rtoptions_);
 
     TT_FATAL(
         this->target_type_ == TargetDevice::Silicon or this->target_type_ == TargetDevice::Simulator,

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -88,7 +88,7 @@ inline std::string get_soc_description_file(
 }  // namespace
 namespace tt {
 
-Cluster::Cluster(llrt::RunTimeOptions& rtoptions, tt_metal::Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
+Cluster::Cluster(const llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
     ZoneScoped;
     log_info(tt::LogDevice, "Opening user mode device driver");
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -88,14 +88,14 @@ inline std::string get_soc_description_file(
 }  // namespace
 namespace tt {
 
-Cluster::Cluster(llrt::RunTimeOptions& rtoptions, Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
+Cluster::Cluster(llrt::RunTimeOptions& rtoptions, tt_metal::Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
     ZoneScoped;
     log_info(tt::LogDevice, "Opening user mode device driver");
 
     this->detect_arch_and_target();
 
     if (arch_ != ARCH::GRAYSKULL) {
-        routing_info_addr_ = tt::tt_metal::hal_ref.get_dev_addr(
+        routing_info_addr_ = hal_.get_dev_addr(
             tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::APP_ROUTING_INFO);
     }
 
@@ -311,12 +311,12 @@ void Cluster::open_driver(const bool &skip_driver_allocs) {
 
     barrier_address_params barrier_params;
     barrier_params.tensix_l1_barrier_base =
-        tt_metal::hal_ref.get_dev_addr(tt_metal::HalProgrammableCoreType::TENSIX, tt_metal::HalL1MemAddrType::BARRIER);
-    barrier_params.dram_barrier_base = tt_metal::hal_ref.get_dev_addr(tt_metal::HalDramMemAddrType::DRAM_BARRIER);
+        hal_.get_dev_addr(tt_metal::HalProgrammableCoreType::TENSIX, tt_metal::HalL1MemAddrType::BARRIER);
+    barrier_params.dram_barrier_base = hal_.get_dev_addr(tt_metal::HalDramMemAddrType::DRAM_BARRIER);
 
-    if (tt_metal::hal_ref.get_arch() != tt::ARCH::GRAYSKULL) {
-        barrier_params.eth_l1_barrier_base = tt_metal::hal_ref.get_dev_addr(
-            tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::BARRIER);
+    if (hal_.get_arch() != tt::ARCH::GRAYSKULL) {
+        barrier_params.eth_l1_barrier_base =
+            hal_.get_dev_addr(tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt_metal::HalL1MemAddrType::BARRIER);
     }
     device_driver->set_barrier_address_params(barrier_params);
 
@@ -889,7 +889,7 @@ void Cluster::disable_ethernet_cores_with_retrain() {
                     this->cluster_desc_->get_board_type(chip_id) == BoardType::UBB) {
                     tt_cxy_pair virtual_eth_core(
                         chip_id, get_virtual_coordinate_from_logical_coordinates(chip_id, eth_core, CoreType::ETH));
-                    auto retrain_count_addr = tt::tt_metal::hal_ref.get_dev_addr(
+                    auto retrain_count_addr = hal_.get_dev_addr(
                         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH,
                         tt::tt_metal::HalL1MemAddrType::RETRAIN_COUNT);
                     this->read_core(read_vec, sizeof(uint32_t), virtual_eth_core, retrain_count_addr);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -87,7 +87,7 @@ public:
     Cluster(const Cluster&) = delete;
     Cluster(Cluster&& other) noexcept = delete;
 
-    Cluster(llrt::RunTimeOptions& rtoptions, tt_metal::Hal& hal);
+    Cluster(const llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal);
     ~Cluster();
 
     // For TG Galaxy systems, mmio chips are gateway chips that are only used for dispatch, so user_devices are meant
@@ -400,8 +400,8 @@ private:
 
     // Cluster depends on RunTimeOptions and Hal to set up, but they're all initialized/accessed by MetalContext, so
     // keep a local reference for init.
-    llrt::RunTimeOptions& rtoptions_;
-    tt_metal::Hal& hal_;
+    const llrt::RunTimeOptions& rtoptions_;
+    const tt_metal::Hal& hal_;
 };
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -26,6 +26,7 @@
 #include "assert.hpp"
 #include "core_coord.hpp"
 #include "llrt/hal.hpp"
+#include "llrt/rtoptions.hpp"
 #include <umd/device/cluster.h>
 #include <umd/device/device_api_metal.h>
 #include <umd/device/tt_cluster_descriptor.h>
@@ -86,7 +87,7 @@ public:
     Cluster(const Cluster&) = delete;
     Cluster(Cluster&& other) noexcept = delete;
 
-    Cluster();
+    Cluster(llrt::RunTimeOptions& rtoptions);
     ~Cluster();
 
     // For TG Galaxy systems, mmio chips are gateway chips that are only used for dispatch, so user_devices are meant
@@ -396,6 +397,9 @@ private:
     std::unordered_map<chip_id_t, std::unordered_map<chip_id_t, std::vector<CoreCoord>>> ethernet_sockets_;
 
     uint32_t routing_info_addr_ = 0;
+
+    llrt::RunTimeOptions& rtoptions_;  // Cluster depends on RunTimeOptions to set up, but they're both
+                                       // initialized/accessed by MetalContext, so keep a local reference for init.
 };
 
 }  // namespace tt

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -87,7 +87,7 @@ public:
     Cluster(const Cluster&) = delete;
     Cluster(Cluster&& other) noexcept = delete;
 
-    Cluster(llrt::RunTimeOptions& rtoptions);
+    Cluster(llrt::RunTimeOptions& rtoptions, tt_metal::Hal& hal);
     ~Cluster();
 
     // For TG Galaxy systems, mmio chips are gateway chips that are only used for dispatch, so user_devices are meant
@@ -398,8 +398,10 @@ private:
 
     uint32_t routing_info_addr_ = 0;
 
-    llrt::RunTimeOptions& rtoptions_;  // Cluster depends on RunTimeOptions to set up, but they're both
-                                       // initialized/accessed by MetalContext, so keep a local reference for init.
+    // Cluster depends on RunTimeOptions and Hal to set up, but they're all initialized/accessed by MetalContext, so
+    // keep a local reference for init.
+    llrt::RunTimeOptions& rtoptions_;
+    tt_metal::Hal& hal_;
 };
 
 }  // namespace tt

--- a/tt_metal/llrt/utils.cpp
+++ b/tt_metal/llrt/utils.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include <mutex>
 
-#include "rtoptions.hpp"
+#include "impl/context/metal_context.hpp"
 
 namespace fs = std::filesystem;
 
@@ -50,7 +50,7 @@ void create_file(const string& file_path_str) {
 const std::string& get_reports_dir() {
     static std::string outpath;
     if (outpath == "") {
-        outpath = tt::llrt::RunTimeOptions::get_instance().get_root_dir() + "/generated/reports/";
+        outpath = tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + "/generated/reports/";
     }
     return outpath;
 }

--- a/tt_metal/tools/watcher_dump/watcher_dump.cpp
+++ b/tt_metal/tools/watcher_dump/watcher_dump.cpp
@@ -10,10 +10,10 @@
 
 #include "device.hpp"
 #include "dispatch_core_common.hpp"
+#include "impl/context/metal_context.hpp"
 #include "impl/debug/noc_logging.hpp"
 #include "impl/debug/watcher_server.hpp"
 #include "impl/dispatch/debug_tools.hpp"
-#include "rtoptions.hpp"
 #include "system_memory_manager.hpp"
 
 using namespace tt;
@@ -34,13 +34,14 @@ void dump_data(
     bool eth_dispatch,
     int num_hw_cqs) {
     // Don't clear L1, this way we can dump the state.
-    llrt::RunTimeOptions::get_instance().set_clear_l1(false);
+    tt_metal::MetalContext::instance().rtoptions().set_clear_l1(false);
 
     // Watcher should be disabled for this, so we don't (1) overwrite the kernel_names.txt and (2) do any other dumping
     // than the one we want.
-    llrt::RunTimeOptions::get_instance().set_watcher_enabled(false);
+    tt_metal::MetalContext::instance().rtoptions().set_watcher_enabled(false);
 
-    std::filesystem::path parent_dir(tt::llrt::RunTimeOptions::get_instance().get_root_dir() + output_dir_name);
+    std::filesystem::path parent_dir(
+        tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir() + output_dir_name);
     std::filesystem::path cq_dir(parent_dir.string() + "command_queue_dump/");
     std::filesystem::create_directories(cq_dir);
 
@@ -150,7 +151,7 @@ int main(int argc, char* argv[]) {
         } else if (s == "--dump-cqs-data") {
             dump_cqs_raw_data = true;
         } else if (s == "--dump-noc-transfer-data") {
-            tt::llrt::RunTimeOptions::get_instance().set_record_noc_transfers(true);
+            tt::tt_metal::MetalContext::instance().rtoptions().set_record_noc_transfers(true);
             dump_noc_xfers = true;
         } else if (s == "--eth-dispatch") {
             eth_dispatch = true;

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -117,12 +117,12 @@ DataMovementConfigStatus CheckDataMovementConfig(
         programmable_core == HalProgrammableCoreType::TENSIX ? DISPATCH_CLASS_TENSIX_DM0 : DISPATCH_CLASS_ETH_DM0;
     uint32_t dm1_idx =
         programmable_core == HalProgrammableCoreType::TENSIX ? DISPATCH_CLASS_TENSIX_DM1 : DISPATCH_CLASS_ETH_DM1;
+    const auto& hal = MetalContext::instance().hal();
     for (const auto& core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                const KernelGroup* kernel_group = program.kernels_on_core(
-                    CoreCoord(x, y),
-                    MetalContext::instance().hal().get_programmable_core_type_index(programmable_core));
+                const KernelGroup* kernel_group =
+                    program.kernels_on_core(CoreCoord(x, y), hal.get_programmable_core_type_index(programmable_core));
                 if (kernel_group != nullptr) {
                     bool local_noc0_in_use = false;
                     bool local_noc1_in_use = false;
@@ -723,10 +723,11 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
 
         std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
         std::unordered_set<CoreCoord> not_done_cores;
+        const auto& hal = MetalContext::instance().hal();
         for (uint32_t programmable_core_type_index = 0;
              programmable_core_type_index < logical_cores_used_in_program.size();
              programmable_core_type_index++) {
-            CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
+            CoreType core_type = hal.get_core_type(programmable_core_type_index);
             for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
                 launch_msg_t* msg = &program.kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
                 go_msg_t* go_msg = &program.kernels_on_core(logical_core, programmable_core_type_index)->go_msg;
@@ -756,9 +757,10 @@ void WaitProgramDone(IDevice* device, Program& program) {
     auto device_id = device->id();
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
     std::unordered_set<CoreCoord> not_done_cores;
-    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
+    const auto& hal = MetalContext::instance().hal();
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         const auto& logical_cores = logical_cores_used_in_program[index];
-        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
+        CoreType core_type = hal.get_core_type(index);
         for (const auto& logical_core : logical_cores) {
             auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
             not_done_cores.insert(physical_core);
@@ -784,9 +786,10 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootl
     detail::ValidateCircularBufferRegion(program, device);
 
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
-    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
+    const auto& hal = MetalContext::instance().hal();
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         const auto& logical_cores = logical_cores_used_in_program[index];
-        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
+        CoreType core_type = hal.get_core_type(index);
         for (const auto& logical_core : logical_cores) {
             KernelGroup* kernel_group = program.kernels_on_core(logical_core, index);
             CoreCoord physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
@@ -821,8 +824,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootl
                             circular_buffer_config_vec[base_index + 1] = circular_buffer->page_size(buffer_index);
                         }
                     }  // PROF_END("CBS")
-                    uint64_t kernel_config_base =
-                        MetalContext::instance().hal().get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
+                    uint64_t kernel_config_base = hal.get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
                     uint64_t addr = kernel_config_base + program.get_program_config(index).cb_offset;
                     llrt::write_hex_vec_to_core(device_id, physical_core, circular_buffer_config_vec, addr);
                 }
@@ -839,9 +841,10 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool fd_bootloa
     auto device_id = device->id();
     detail::DispatchStateCheck(fd_bootloader_mode);
 
-    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
-        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
-        uint32_t processor_classes = MetalContext::instance().hal().get_processor_classes_count(index);
+    const auto& hal = MetalContext::instance().hal();
+    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+        CoreType core_type = hal.get_core_type(index);
+        uint32_t processor_classes = hal.get_processor_classes_count(index);
         for (const auto& kg : program.get_kernel_groups(index)) {
             uint32_t kernel_config_base = kg->launch_msg.kernel_config.kernel_config_base[index];
             for (const CoreRange& core_range : kg->core_ranges.ranges()) {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -43,7 +43,6 @@
 #include "lightmetal/lightmetal_capture.hpp"
 #include "lightmetal_binary.hpp"
 #include "llrt.hpp"
-#include "llrt/hal.hpp"
 #include "logger.hpp"
 #include "tt-metalium/program.hpp"
 #include "semaphore.hpp"
@@ -122,7 +121,8 @@ DataMovementConfigStatus CheckDataMovementConfig(
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 const KernelGroup* kernel_group = program.kernels_on_core(
-                    CoreCoord(x, y), hal_ref.get_programmable_core_type_index(programmable_core));
+                    CoreCoord(x, y),
+                    MetalContext::instance().hal().get_programmable_core_type_index(programmable_core));
                 if (kernel_group != nullptr) {
                     bool local_noc0_in_use = false;
                     bool local_noc1_in_use = false;
@@ -158,7 +158,8 @@ void ConfigureKernelGroup(
     const KernelGroup* kernel_group,
     IDevice* device,
     const CoreCoord& logical_core) {
-    uint32_t kernel_config_base = hal_ref.get_dev_addr(programmable_core_type_index, HalL1MemAddrType::KERNEL_CONFIG);
+    uint32_t kernel_config_base =
+        MetalContext::instance().hal().get_dev_addr(programmable_core_type_index, HalL1MemAddrType::KERNEL_CONFIG);
     for (auto& optional_id : kernel_group->kernel_ids) {
         if (optional_id) {
             // Need the individual offsets of each bin
@@ -725,7 +726,7 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
         for (uint32_t programmable_core_type_index = 0;
              programmable_core_type_index < logical_cores_used_in_program.size();
              programmable_core_type_index++) {
-            CoreType core_type = hal_ref.get_core_type(programmable_core_type_index);
+            CoreType core_type = MetalContext::instance().hal().get_core_type(programmable_core_type_index);
             for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
                 launch_msg_t* msg = &program.kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
                 go_msg_t* go_msg = &program.kernels_on_core(logical_core, programmable_core_type_index)->go_msg;
@@ -755,9 +756,9 @@ void WaitProgramDone(IDevice* device, Program& program) {
     auto device_id = device->id();
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
     std::unordered_set<CoreCoord> not_done_cores;
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
         const auto& logical_cores = logical_cores_used_in_program[index];
-        CoreType core_type = hal_ref.get_core_type(index);
+        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
         for (const auto& logical_core : logical_cores) {
             auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
             not_done_cores.insert(physical_core);
@@ -783,9 +784,9 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootl
     detail::ValidateCircularBufferRegion(program, device);
 
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = program.logical_cores();
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
         const auto& logical_cores = logical_cores_used_in_program[index];
-        CoreType core_type = hal_ref.get_core_type(index);
+        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
         for (const auto& logical_core : logical_cores) {
             KernelGroup* kernel_group = program.kernels_on_core(logical_core, index);
             CoreCoord physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
@@ -820,7 +821,8 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool fd_bootl
                             circular_buffer_config_vec[base_index + 1] = circular_buffer->page_size(buffer_index);
                         }
                     }  // PROF_END("CBS")
-                    uint64_t kernel_config_base = hal_ref.get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
+                    uint64_t kernel_config_base =
+                        MetalContext::instance().hal().get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
                     uint64_t addr = kernel_config_base + program.get_program_config(index).cb_offset;
                     llrt::write_hex_vec_to_core(device_id, physical_core, circular_buffer_config_vec, addr);
                 }
@@ -837,9 +839,9 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool fd_bootloa
     auto device_id = device->id();
     detail::DispatchStateCheck(fd_bootloader_mode);
 
-    for (uint32_t index = 0; index < hal_ref.get_programmable_core_type_count(); index++) {
-        CoreType core_type = hal_ref.get_core_type(index);
-        uint32_t processor_classes = hal_ref.get_processor_classes_count(index);
+    for (uint32_t index = 0; index < MetalContext::instance().hal().get_programmable_core_type_count(); index++) {
+        CoreType core_type = MetalContext::instance().hal().get_core_type(index);
+        uint32_t processor_classes = MetalContext::instance().hal().get_processor_classes_count(index);
         for (const auto& kg : program.get_kernel_groups(index)) {
             uint32_t kernel_config_base = kg->launch_msg.kernel_config.kernel_config_base[index];
             for (const CoreRange& core_range : kg->core_ranges.ranges()) {
@@ -1024,13 +1026,13 @@ KernelHandle CreateEthernetKernel(
 
     TT_FATAL(
         utils::underlying_type<DataMovementProcessor>(config.processor) <
-            hal_ref.get_processor_classes_count(eth_core_type),
+            MetalContext::instance().hal().get_processor_classes_count(eth_core_type),
         "EthernetKernel creation failure: {} kernel cannot target processor {} because Ethernet core only has {} "
         "processors. "
         "Update DataMovementProcessor in the config.",
         kernel->name(),
         magic_enum::enum_name(config.processor),
-        hal_ref.get_processor_classes_count(eth_core_type));
+        MetalContext::instance().hal().get_processor_classes_count(eth_core_type));
     TT_FATAL(
         !(are_both_riscv_in_use),
         "EthernetKernel creation failure: Cannot create data movement kernel for {} across specified "


### PR DESCRIPTION
Ongoing work to remove all metal singletons and have them managed by MetalContext, this PR moves RunTimeOptions and Hal. Need to do them together in one PR due to dependencies between RTO/Hal/Cluster.

First and third commits in the PR are the key changes, second and fourth commits are usage fixes.

https://github.com/tenstorrent/tt-metal/actions/runs/14497991229