### PR TITLE
Add sanity tests to Merge Gate

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -1,4 +1,4 @@
-name: "zzz Sanity tests"
+name: "zzz Basic tests"
 
 on:
   workflow_call:
@@ -18,7 +18,7 @@ on:
         default: 5.5
 
 jobs:
-  metalium-sanity:
+  metalium-basic:
     runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
@@ -55,7 +55,7 @@ jobs:
           TT_METAL_WATCHER: 5
           TT_METAL_WATCHER_TEST_MODE: 1
         run: |
-          /usr/libexec/tt-metalium/validation/tt-metalium-validation-sanity
+          /usr/libexec/tt-metalium/validation/tt-metalium-validation-basic
 
       - name: workaround
         run: |
@@ -68,7 +68,7 @@ jobs:
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
         with:
-          name: Metalium ${{ matrix.platform }} sanity tests
+          name: Metalium ${{ matrix.platform }} basic tests
           path: /work/test-reports/*.xml
           reporter: jest-junit
           working-directory: /work

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -83,8 +83,7 @@ jobs:
   build-tsan:
     if: ${{ github.ref_name == 'main' ||
             needs.find-changes.outputs.cmake-changed == 'true' ||
-            needs.find-changes.outputs.any-code-changed == 'true' ||
-            needs.find-changes.outputs.docs-changed == 'true'
+            needs.find-changes.outputs.any-code-changed == 'true'
         }}
     needs: find-changes
     uses: ./.github/workflows/build-artifact.yaml
@@ -114,6 +113,39 @@ jobs:
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
       per-test-timeout: 5.5 # TSan can be slow; relax the timeout a bit
+
+  build-asan:
+    if: ${{ github.ref_name == 'main' ||
+            needs.find-changes.outputs.cmake-changed == 'true' ||
+            needs.find-changes.outputs.any-code-changed == 'true'
+        }}
+    needs: find-changes
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      build-type: ASan
+      version: 22.04
+      skip-tt-train: false
+      publish-artifact: false
+
+  sanity-tests:
+    if: ${{ true ||
+        needs.find-changes.outputs.cmake-changed == 'true' ||
+        needs.find-changes.outputs.tt-metalium-changed == 'true' ||
+        needs.find-changes.outputs.tt-metalium-or-tt-nn-tests-changed == 'true'
+      }}
+    needs: [ build-asan, find-changes ]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "tt-beta-ubuntu-2204-n150-large-stable",
+        ]
+    uses: ./.github/workflows/sanity.yaml
+    with:
+      docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
 
   # GitHub has so many design limitations it's not even funny.
   # This job is purely so we can capture the essence of the workflow as a whole in our status checks.

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -128,7 +128,7 @@ jobs:
       skip-tt-train: false
       publish-artifact: false
 
-  sanity-tests:
+  basic-tests:
     if: ${{ true ||
         needs.find-changes.outputs.cmake-changed == 'true' ||
         needs.find-changes.outputs.tt-metalium-changed == 'true' ||
@@ -141,7 +141,7 @@ jobs:
         platform: [
           "tt-beta-ubuntu-2204-n150-large-stable",
         ]
-    uses: ./.github/workflows/sanity.yaml
+    uses: ./.github/workflows/basic.yaml
     with:
       docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-asan.outputs.packages-artifact-name }}

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,0 +1,86 @@
+name: "zzz Sanity tests"
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        required: true
+        type: string
+      package-artifact-name:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      per-test-timeout:
+        required: false
+        type: string
+        default: 5.5
+
+jobs:
+  metalium-sanity:
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
+      env:
+        ASAN_OPTIONS: "color=always"
+        TSAN_OPTIONS: "color=always"
+        UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
+      volumes:
+        - /work
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: --device /dev/tenstorrent
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: ${{ inputs.package-artifact-name || 'packages artifact unresolved!' }}
+          path: /work/pkgs/
+
+      - name: Install packages
+        run: |
+          apt install ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-validation_*.deb
+
+      - name: Run a test
+        id: test
+        timeout-minutes: 30
+        env:
+          GTEST_COLOR: yes
+          GTEST_OUTPUT: xml:/work/test-reports/
+          TT_METAL_HOME: /usr/libexec/tt-metalium # TODO: Need to get away from env vars!
+          TT_METAL_WATCHER: 5
+          TT_METAL_WATCHER_TEST_MODE: 1
+        run: |
+          /usr/libexec/tt-metalium/validation/tt-metalium-validation-sanity
+
+      - name: workaround
+        run: |
+          # The test-reporting action runs git ls-files with no way to opt-out.
+          # Give it a dummy repo so it doesn't fail.
+          git init
+      - name: Test Report
+        # Because of https://github.com/tenstorrent/tt-metal/issues/19413, only run for our repo
+        # for now. No forks!
+        if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
+        with:
+          name: Metalium ${{ matrix.platform }} sanity tests
+          path: /work/test-reports/*.xml
+          reporter: jest-junit
+          working-directory: /work
+
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        if: ${{ !cancelled() }}
+        timeout-minutes: 10
+        with:
+          path: /work/test-reports/
+          prefix: "test_reports_"
+
+      - name: Check for slow tests
+        uses: tenstorrent/tt-metal/.github/actions/detect-slow-tests@main
+        with:
+          threshold: ${{ inputs.per-test-timeout }}

--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -18,7 +18,6 @@ target_sources(
 )
 target_include_directories(
     unit_tests_dispatch_smoke
-    BEFORE
     PRIVATE
         "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
         ${PROJECT_SOURCE_DIR}/tests
@@ -32,17 +31,9 @@ target_link_libraries(unit_tests_dispatch_smoke PRIVATE test_metal_common_libs)
 add_library(unit_tests_dispatch_sanity OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Sanity ALIAS unit_tests_dispatch_sanity)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_sanity)
-target_sources(
-    unit_tests_dispatch_sanity
-    PRIVATE
-        dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
-        dispatch_program/test_EnqueueProgram.cpp
-        dispatch_trace/test_EnqueueTrace.cpp
-        dispatch_trace/test_sub_device.cpp
-)
+target_sources(unit_tests_dispatch_sanity PRIVATE dispatch_trace/test_sub_device.cpp)
 target_include_directories(
     unit_tests_dispatch_sanity
-    BEFORE
     PRIVATE
         "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
         ${PROJECT_SOURCE_DIR}/tests
@@ -51,6 +42,27 @@ target_include_directories(
         ${CMAKE_CURRENT_SOURCE_DIR}/common
 )
 target_link_libraries(unit_tests_dispatch_sanity PRIVATE test_metal_common_libs)
+
+add_library(unit_tests_dispatch_slow OBJECT)
+add_library(TT::Metalium::Test::Dispatch::Slow ALIAS unit_tests_dispatch_slow)
+TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_slow)
+target_sources(
+    unit_tests_dispatch_slow
+    PRIVATE
+        dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp # FIXME: Fix the heap-buffer-overflow in here and see if it's fast enough for Sanity
+        dispatch_program/test_EnqueueProgram.cpp
+        dispatch_trace/test_EnqueueTrace.cpp
+)
+target_include_directories(
+    unit_tests_dispatch_slow
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
+target_link_libraries(unit_tests_dispatch_slow PRIVATE test_metal_common_libs)
 
 # Target for all Dispatch tests regardless of duration
 add_executable(unit_tests_dispatch)
@@ -67,4 +79,5 @@ target_link_libraries(
     PRIVATE
         TT::Metalium::Test::Dispatch::Smoke
         TT::Metalium::Test::Dispatch::Sanity
+        TT::Metalium::Test::Dispatch::Slow
 )

--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -27,13 +27,13 @@ target_include_directories(
 )
 target_link_libraries(unit_tests_dispatch_smoke PRIVATE test_metal_common_libs)
 
-# Sanity tests (too slow for smoke; will run less frequently)
-add_library(unit_tests_dispatch_sanity OBJECT)
-add_library(TT::Metalium::Test::Dispatch::Sanity ALIAS unit_tests_dispatch_sanity)
-TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_sanity)
-target_sources(unit_tests_dispatch_sanity PRIVATE dispatch_trace/test_sub_device.cpp)
+# Basic tests (too slow for smoke; will run less frequently)
+add_library(unit_tests_dispatch_basic OBJECT)
+add_library(TT::Metalium::Test::Dispatch::Basic ALIAS unit_tests_dispatch_basic)
+TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_basic)
+target_sources(unit_tests_dispatch_basic PRIVATE dispatch_trace/test_sub_device.cpp)
 target_include_directories(
-    unit_tests_dispatch_sanity
+    unit_tests_dispatch_basic
     PRIVATE
         "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
         ${PROJECT_SOURCE_DIR}/tests
@@ -41,7 +41,7 @@ target_include_directories(
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/common
 )
-target_link_libraries(unit_tests_dispatch_sanity PRIVATE test_metal_common_libs)
+target_link_libraries(unit_tests_dispatch_basic PRIVATE test_metal_common_libs)
 
 add_library(unit_tests_dispatch_slow OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Slow ALIAS unit_tests_dispatch_slow)
@@ -49,7 +49,7 @@ TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_slow)
 target_sources(
     unit_tests_dispatch_slow
     PRIVATE
-        dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp # FIXME: Fix the heap-buffer-overflow in here and see if it's fast enough for Sanity
+        dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp # FIXME: Fix the heap-buffer-overflow in here and see if it's fast enough for Basic
         dispatch_program/test_EnqueueProgram.cpp
         dispatch_trace/test_EnqueueTrace.cpp
 )
@@ -78,6 +78,6 @@ target_link_libraries(
     unit_tests_dispatch
     PRIVATE
         TT::Metalium::Test::Dispatch::Smoke
-        TT::Metalium::Test::Dispatch::Sanity
+        TT::Metalium::Test::Dispatch::Basic
         TT::Metalium::Test::Dispatch::Slow
 )

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Smoke
 add_executable(tt-metalium-validation-smoke)
 
 target_link_libraries(
@@ -10,6 +11,19 @@ target_link_libraries(
 install(
     TARGETS
         tt-metalium-validation-smoke
+    RUNTIME
+        DESTINATION libexec/tt-metalium/validation
+        COMPONENT metalium-validation
+)
+
+# Sanity
+add_executable(tt-metalium-validation-sanity)
+
+target_link_libraries(tt-metalium-validation-sanity PRIVATE TT::Metalium::Test::Dispatch::Sanity)
+
+install(
+    TARGETS
+        tt-metalium-validation-sanity
     RUNTIME
         DESTINATION libexec/tt-metalium/validation
         COMPONENT metalium-validation

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -16,14 +16,14 @@ install(
         COMPONENT metalium-validation
 )
 
-# Sanity
-add_executable(tt-metalium-validation-sanity)
+# Basic
+add_executable(tt-metalium-validation-basic)
 
-target_link_libraries(tt-metalium-validation-sanity PRIVATE TT::Metalium::Test::Dispatch::Sanity)
+target_link_libraries(tt-metalium-validation-basic PRIVATE TT::Metalium::Test::Dispatch::Basic)
 
 install(
     TARGETS
-        tt-metalium-validation-sanity
+        tt-metalium-validation-basic
     RUNTIME
         DESTINATION libexec/tt-metalium/validation
         COMPONENT metalium-validation


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We don't have a home for tests that are too slow for Smoke, but fast enough we can run them before we let a PR onto main.

### What's changed
* Provide a home for these just-slightly-too-slow-for-Smoke tests.  Call it Sanity.
* Run them with ASan in Merge Gate