### PR TITLE
[skip ci] Don't do pointless work

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -316,6 +316,3 @@ jobs:
           name: ${{ env.build_artifact_name }}
           path: /work/ttm_any.tar
           if-no-files-found: error
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -198,14 +198,6 @@ jobs:
           fetch-tags: true # Need tags for `git describe`
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
 
-      - name: Sanity check
-        run: |
-          set -eu # basic shell hygiene
-          if find . -maxdepth 1 -type d -name 'build*' -print -quit | grep -q .; then
-            echo "!!! ALERT !!! This should never happen, but does explain an issue we've been hunting. Please send a link to this job to Metal Infra.  kthxbye."
-            exit 42
-          fi
-
       - name: Create ccache tmpdir
         run: |
           mkdir -p /tmp/ccache

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -193,6 +193,3 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           ccache -s >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
-        if: always()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Since moving to the ephemeral runners, we no longer need to cleanup after the Docker container.

### What's changed
rm -rf