### PR TITLE
Add CMake option to build UMD with simulation support

### DIFF
--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -21,6 +21,7 @@ option(BUILD_TT_TRAIN "Enables build of tt-train" OFF)
 option(ENABLE_TTNN_SHARED_SUBLIBS "Use shared libraries for ttnn to speed up incremental builds" OFF)
 option(TT_ENABLE_LIGHT_METAL_TRACE "Enable Light Metal Trace" ON)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
+option(TT_UMD_BUILD_SIMULATION "Force UMD to include its simulation harnessing" ON)
 
 ###########################################################################################
 


### PR DESCRIPTION
### What's changed
Preparing for a future where we don't have to support simulation devices directly in tt_metal.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes