### PR TITLE
Update pip version used in create_venv.sh to fix ubuntu 24.04 installation

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -25,7 +25,7 @@ $PYTHON_CMD -m venv $PYTHON_ENV_DIR
 source $PYTHON_ENV_DIR/bin/activate
 
 echo "Forcefully using a version of pip that will work with our view of editable installs"
-pip install --force-reinstall pip==21.2.4
+pip install --force-reinstall pip==24.0
 
 echo "Setting up virtual env"
 python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
### Ticket
N/A

### Problem description
When running create_venv.sh on Ubuntu 24.04 LTS, I get the following error: 
```
+ python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/__main__.py", line 29, in <module>
    from pip._internal.cli.main import main as _main
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_internal/cli/main.py", line 9, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_internal/cli/autocompletion.py", line 10, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_internal/cli/main_parser.py", line 8, in <module>
    from pip._internal.cli import cmdoptions
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_internal/cli/cmdoptions.py", line 23, in <module>
    from pip._internal.cli.parser import ConfigOptionParser
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_internal/cli/parser.py", line 12, in <module>
    from pip._internal.configuration import Configuration, ConfigurationError
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_internal/configuration.py", line 21, in <module>
    from pip._internal.exceptions import (
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_internal/exceptions.py", line 7, in <module>
    from pip._vendor.pkg_resources import Distribution
  File "/home/pasha/projects/tt-metal/python_env/lib/python3.12/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2164, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

It seems like `pkgutil.ImpImporter` is deprecated for python 3.12, which comes as default for Ubuntu 24.04. The fix would be to use a newer pip version. I verified this pip version works fine on Ubuntu 22.04 too.

### What's changed
Changed `pip==21.2.4` => `pip==24.0`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes