### PR TITLE
Demote Circular buffer indices are not contiguous starting  to debug log

### DIFF
--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -490,7 +490,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                                                 cb_ids += std::to_string(i);
                                             }
                                         }
-                                        log_warning(
+                                        log_debug(
                                             tt::LogMetal,
                                             "Circular buffer indices are not contiguous starting at 0. This will hurt "
                                             "dispatch performance. Non-contiguous indices: {}. "


### PR DESCRIPTION
Demote Circular buffer indices are not contiguous starting  to debug log.
This warning is to spammy and is "hiding" other warnings when running models/integration tests.
It's been around for 3 months and people didn't take it seriously, so it's doing more bad than good.