### PR TITLE
llama3_subdevices vLLM follow up

### DIFF
--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -13,7 +13,7 @@ import pytest
 import os
 import ttnn
 
-from models.demos.llama3_subdevices.tt.generator import Generator
+from models.demos.llama3_subdevices.tt.generator import Generator, SamplingParams
 from models.demos.llama3_subdevices.tt.model_config import LlamaOptimizations
 from models.tt_transformers.tt.common import (
     preprocess_inputs_prefill,
@@ -469,6 +469,11 @@ def test_demo_text(
         # TODO Argmax on device is only supported for batch_size=1
         argmax_on_device = True  # False if (batch_size > 1 or sampling_params["temperature"] != 0) else True
 
+        if argmax_on_device:
+            device_sampling_params = SamplingParams(temperature=0.0, top_k=-1, top_p=1.0)
+        else:
+            device_sampling_params = None
+
         # Initial positions
         current_pos = torch.tensor([decoding_pos[0] for b in range(batch_size)])
 
@@ -500,7 +505,7 @@ def test_demo_text(
                     enable_trace=enable_trace,
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
-                    argmax_on_device=argmax_on_device,
+                    sampling_params=device_sampling_params,
                 )
             except Exception as e:
                 logger.error(f"Error during decoding: {str(e)}")

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -280,7 +280,14 @@ def create_tt_model(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"trace_region_size": 23887872, "num_command_queues": 1, "dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    [
+        {
+            "trace_region_size": 23887872,
+            "num_command_queues": 1,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+            "worker_l1_size": 1344544,
+        }
+    ],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/llama3_subdevices/tt/generator_vllm.py
+++ b/models/demos/llama3_subdevices/tt/generator_vllm.py
@@ -21,10 +21,10 @@ def generate_submeshes(mesh_device, data_parallel):
     return mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))
 
 
-def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, mesh_device, tt_cache_path, tt_data_parallel=1):
-    submesh_devices = generate_submeshes(mesh_device, tt_data_parallel)
-
+def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: TtTransformer, tt_cache_path):
+    submesh_devices = [model.mesh_device]
     kv_cache = []
+
     for mesh_idx, submesh in enumerate(submesh_devices):
         cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
         kv_tt = []
@@ -133,4 +133,4 @@ class LlamaForCausalLM(Generator):
         return super().decode_forward_text(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
-        return allocate_vllm_kv_cache(*args, **kwargs, tt_cache_path=self.cache_path)
+        return allocate_vllm_kv_cache(*args, **kwargs, model=self.model, tt_cache_path=self.cache_path)

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -305,13 +305,13 @@ class TtTransformer(LightweightModule):
         )[0, 0, last_token_idx, : self.vocab_size]
         return logits
 
-    def process_output_decode(self, tt_out, B, S=1, argmax_on_device=False):
+    def process_output_decode(self, tt_out, B, S=1, is_tokens=False):
         """
-        Input is ttnn device tensor of logits. Output is torch logits tensor or the generated token if argmax on device
+        Input is ttnn device tensor of logits if is_tokens=False, otherwise tokens. Output is the corresponding torch tensor.
         """
         if isinstance(tt_out, list):
             tt_out = tt_out[0]
-        if argmax_on_device:
+        if is_tokens:
             tt_out = ttnn.to_torch(
                 tt_out,  # tt_out.cpu(blocking=True, cq_id=1),
                 mesh_composer=ttnn.ConcatMesh2dToTensor(


### PR DESCRIPTION
### Ticket
n/a

### Problem description
We've updated vLLM interface for the SamplingParams and this was reflected in tt_transformers in https://github.com/tenstorrent/tt-metal/commit/ac2a64c1bf2c91be62d4057f64bf60736c4ea97d

llama3_subdevices need a follow up.

### What's changed
SamplingParams are used, `is_token` replaces `argmax_on_device`

### Checklist
- ✅ All post commit - [29859](https://github.com/tenstorrent/tt-metal/actions/runs/14408484494)
- ✅ (Single-card) Fast dispatch frequent tests - [839](https://github.com/tenstorrent/tt-metal/actions/runs/14408508608)
- ⚠️ (T3K) T3000 unit tests - [3639](https://github.com/tenstorrent/tt-metal/actions/runs/14408514814), failed in the same places as on main, unrelated to my changes. It's been resolved on main since.