### PR TITLE
Skipping the avg_pool2d sweeps that are failing on blackhole

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
@@ -50,7 +50,7 @@ parameters = {
 }
 
 
-@skip_for_blackhole()
+@skip_for_blackhole("Nigthly CI tests failing, ticket #20492")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("input_spec", parameters["input_specs"])
 def test_ttnn_pytorch_sweep(device, tensor_map, input_spec):

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from tests.ttnn.unit_tests.operations.pool.test_avgpool2d import run_avg_pool2d
+from models.utility_functions import skip_for_blackhole
 
 import pytest
 import ttnn
@@ -49,6 +50,7 @@ parameters = {
 }
 
 
+@skip_for_blackhole()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize("input_spec", parameters["input_specs"])
 def test_ttnn_pytorch_sweep(device, tensor_map, input_spec):

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -7,6 +7,7 @@ import ttnn
 import pytest
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_blackhole
 
 
 @pytest.fixture(scope="module")
@@ -77,6 +78,7 @@ def run_avg_pool2d(
     assert allclose, " Reference and output tensor are not close"
 
 
+@skip_for_blackhole("Nigthly CI tests failing, ticket #20492")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "input_shape",  # NCHW

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -73,7 +73,8 @@ def run_avg_pool2d(
 
     ## Assertion
     assert_with_pcc(torch_output, ttnn_output, 0.99)
-    assert torch.allclose(ttnn_output, torch_output, rtol=0.02)
+    allclose = torch.allclose(ttnn_output, torch_output, rtol=0.02)
+    assert allclose, " Reference and output tensor are not close"
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)


### PR DESCRIPTION
### Ticket
[#20492](https://github.com/tenstorrent/tt-metal/issues/20492)

### Problem description
[L2 Nightly](https://github.com/tenstorrent/tt-metal/actions/runs/14372971922/job/40299739802) are avg_pool2d sweeps are failing on blackhole.

### What's changed
Added skip for blackhole not to fail the CI testing until the problem is solved.
Changed the assert message not to make noice with the blocks of error messages when test fails.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14441442511)