### PR TITLE
#20503: Support prepare weights on device

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -11,60 +11,60 @@ import ttnn
 
 
 @pytest.mark.parametrize(
-    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override",
+    "batch_size, output_channels, input_channels, input_height, input_width, filter_height, filter_width, stride_h, stride_w, pad_h, pad_w, use_1d_systolic_array, config_override, groups",
     (
         # unique convs in rn50 (complete list)
         # first conv post folding and input_channels padding to tile width
         # (8, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, None), HANGS!!
-        (16, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 256}),
-        # (20, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 32}),  Out of Memory!!
+        (16, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 256}, 1),
+        # (20, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 32}, 1),  Out of Memory!!
         # rn50 layer1
-        (8, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
-        (16, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
-        (20, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None),
+        (8, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None, 64),
+        (16, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None, 1),
+        (20, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None, 1),
         # rn50 layer2
-        (8, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None),
-        (16, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None),
-        (20, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, {"act_block_h": 32}),
-        (8, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
-        (16, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
-        (20, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None),
+        (8, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None, 1),
+        (16, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, None, 1),
+        (20, 128, 128, 56, 56, 3, 3, 2, 2, 1, 1, True, {"act_block_h": 32}, 1),
+        (8, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None, 1),
+        (16, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None, 1),
+        (20, 128, 128, 28, 28, 3, 3, 1, 1, 1, 1, True, None, 1),
         # rn50 layer3
-        (8, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
-        (16, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
-        (20, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None),
-        (8, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
-        (16, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
-        (20, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None),
+        (8, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None, 1),
+        (16, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None, 1),
+        (20, 256, 256, 28, 28, 3, 3, 2, 2, 1, 1, False, None, 1),
+        (8, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None, 1),
+        (16, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None, 1),
+        (20, 256, 256, 14, 14, 3, 3, 1, 1, 1, 1, False, None, 1),
         # rn50 layer4
-        (8, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
-        (16, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
-        (20, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None),
-        (8, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
-        (16, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
-        (20, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
+        (8, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None, 1),
+        (16, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None, 1),
+        (20, 512, 512, 14, 14, 3, 3, 2, 2, 1, 1, False, None, 1),
+        (8, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None, 1),
+        (16, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None, 1),
+        (20, 512, 512, 7, 7, 3, 3, 1, 1, 1, 1, False, None, 1),
         ## small test
-        (1, 64, 64, 8, 8, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 2, "grid_size": (2, 2)}),
-        (1, 64, 64, 16, 16, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 4, "grid_size": (2, 4)}),
-        # (1, 160, 160, 7, 7, 3, 3, 1, 1, 1, 1, False, None), sliding_window_op_infra/sliding_window.cpp:341: indices_length_last_core <= indices_length_per_core
-        (8, 256, 256, 7, 7, 3, 3, 1, 1, 1, 1, False, None),
+        (1, 64, 64, 8, 8, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 2, "grid_size": (2, 2)}, 1),
+        (1, 64, 64, 16, 16, 3, 3, 1, 1, 1, 1, False, {"num_cores_nhw": 4, "grid_size": (2, 4)}, 1),
+        # (1, 160, 160, 7, 7, 3, 3, 1, 1, 1, 1, False, None, 1), sliding_window_op_infra/sliding_window.cpp:341: indices_length_last_core <= indices_length_per_core
+        (8, 256, 256, 7, 7, 3, 3, 1, 1, 1, 1, False, None, 1),
         # r50 1x1s2 shapes
-        # Fails with packer_l1_acc = True (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, False, None),  # r50 first bottleneck downsample shape
-        (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, True, None),  # r50 first bottleneck downsample shape
-        # Fails with packer_l1_acc = True (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, False, None),  # r50 second bottleneck downsample shape
-        # (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
-        (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, False, None),  # r50 third bottleneck downsample shape
-        # (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
-        (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, False, None),  # r50 fourth bottleneck downsample shape
-        # (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, True, None), - doesnt fit
-        # (20, 128, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None),  ## L2M1 DS: doesn't fit
+        # Fails with packer_l1_acc = True (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, False, None, 1),  # r50 first bottleneck downsample shape
+        (20, 256, 64, 56, 56, 1, 1, 2, 2, 0, 0, True, None, 1),  # r50 first bottleneck downsample shape
+        # Fails with packer_l1_acc = True (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, False, None, 1),  # r50 second bottleneck downsample shape
+        # (20, 512, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None, 1), - doesnt fit
+        (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, False, None, 1),  # r50 third bottleneck downsample shape
+        # (20, 1024, 512, 28, 28, 1, 1, 2, 2, 0, 0, True, None, 1), - doesnt fit
+        (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, False, None, 1),  # r50 fourth bottleneck downsample shape
+        # (20, 2048, 1024, 14, 14, 1, 1, 2, 2, 0, 0, True, None, 1), - doesnt fit
+        # (20, 128, 256, 56, 56, 1, 1, 2, 2, 0, 0, True, None, 1),  ## L2M1 DS: doesn't fit
         # formerly failing test case in segformer when ntiles_channels not evenly divisible with num_cores_c
-        (1, 640, 640, 32, 32, 3, 3, 1, 1, 1, 1, False, None),
+        (1, 640, 640, 32, 32, 3, 3, 1, 1, 1, 1, False, None, 1),
     ),
 )
 @pytest.mark.parametrize("on_device", [True, False], ids=["on_device", "on_host"])
+@pytest.mark.parametrize("is_owned", [True, False], ids=["owned_storage", "borrowed_storage"])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 2**15}], indirect=True)
-@pytest.mark.parametrize("groups", [1])
 def test_prepare_conv_weights(
     batch_size,
     output_channels,
@@ -82,6 +82,7 @@ def test_prepare_conv_weights(
     on_device,
     device,
     groups,
+    is_owned,
 ):
     if device.core_grid.y == 7:
         pytest.skip("Issue #6992: Statically allocated circular buffers in program clash with L1 buffers on core range")
@@ -91,6 +92,8 @@ def test_prepare_conv_weights(
     ):
         pytest.skip("Skipping test because it won't fit in L1!")
 
+    if groups > 1 and on_device:
+        pytest.skip("Weights Preparation on device is not supported for convs with groups > 1")
     has_bias = True
     inp_shape = (batch_size, input_channels, input_height, input_width)
     conv_weight_shape = (output_channels, input_channels // groups, filter_height, filter_width)
@@ -109,9 +112,17 @@ def test_prepare_conv_weights(
     ).permute(0, 2, 3, 1)
 
     tt_input_tensor = ttnn.from_torch(torch_input_tensor.transpose(-3, -2).transpose(-2, -1), ttnn.bfloat16)
-    tt_weight_tensor = ttnn.from_torch(torch_weight_tensor, ttnn.bfloat16)
-    tt_bias_tensor = ttnn.from_torch(torch_bias_tensor, ttnn.bfloat16) if has_bias else None
-
+    if is_owned:
+        temp_tt_weight_tensor = ttnn.from_torch(torch_weight_tensor, ttnn.bfloat16)
+        temp_tt_bias_tensor = ttnn.from_torch(torch_bias_tensor, ttnn.bfloat16) if has_bias else None
+        tt_weight_tensor = ttnn.zeros(torch_weight_tensor.shape, ttnn.bfloat16)
+        tt_bias_tensor = ttnn.zeros(torch_bias_tensor.shape, ttnn.bfloat16) if has_bias else None
+        tt_weight_tensor = temp_tt_weight_tensor[:, :, :]
+        tt_bias_tensor = temp_tt_bias_tensor[:, :, :] if has_bias else None
+    else:
+        tt_weight_tensor = ttnn.from_torch(torch_weight_tensor, ttnn.bfloat16)
+        tt_bias_tensor = ttnn.from_torch(torch_bias_tensor, ttnn.bfloat16) if has_bias else None
+    print(tt_weight_tensor.storage_type(), tt_bias_tensor.storage_type() if has_bias else None)
     conv_config = ttnn.Conv2dConfig(
         dtype=ttnn.bfloat16,
         weights_dtype=ttnn.bfloat16,

--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -19,7 +19,7 @@ import ttnn
         (16, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 256}, 1),
         # (20, 64, 16, 115, 115, 4, 4, 1, 1, 0, 0, True, {"act_block_h": 32}, 1),  Out of Memory!!
         # rn50 layer1
-        (8, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None, 64),
+        (8, 64, 64, 56, 1, 3, 1, 1, 1, 1, 0, True, None, 64),
         (16, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None, 1),
         (20, 64, 64, 56, 56, 3, 3, 1, 1, 1, 1, True, None, 1),
         # rn50 layer2
@@ -94,7 +94,7 @@ def test_prepare_conv_weights(
 
     if groups > 1 and on_device:
         pytest.skip("Weights Preparation on device is not supported for convs with groups > 1")
-    has_bias = True
+    has_bias = False
     inp_shape = (batch_size, input_channels, input_height, input_width)
     conv_weight_shape = (output_channels, input_channels // groups, filter_height, filter_width)
     torch_weight_tensor = torch.randn(conv_weight_shape, dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -130,6 +130,7 @@ def test_prepare_conv_weights(
         enable_act_double_buffer=False,
         enable_split_reader=False,
         enable_subblock_padding=False,
+        preprocess_weights_on_device=on_device,
     )
     compute_config = ttnn.init_device_compute_kernel_config(device.arch())
     if config_override and "act_block_h" in config_override:

--- a/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_prepare_conv_weights.py
@@ -112,6 +112,7 @@ def test_prepare_conv_weights(
     ).permute(0, 2, 3, 1)
 
     tt_input_tensor = ttnn.from_torch(torch_input_tensor.transpose(-3, -2).transpose(-2, -1), ttnn.bfloat16)
+
     if is_owned:
         temp_tt_weight_tensor = ttnn.from_torch(torch_weight_tensor, ttnn.bfloat16)
         temp_tt_bias_tensor = ttnn.from_torch(torch_bias_tensor, ttnn.bfloat16) if has_bias else None
@@ -122,7 +123,7 @@ def test_prepare_conv_weights(
     else:
         tt_weight_tensor = ttnn.from_torch(torch_weight_tensor, ttnn.bfloat16)
         tt_bias_tensor = ttnn.from_torch(torch_bias_tensor, ttnn.bfloat16) if has_bias else None
-    print(tt_weight_tensor.storage_type(), tt_bias_tensor.storage_type() if has_bias else None)
+
     conv_config = ttnn.Conv2dConfig(
         dtype=ttnn.bfloat16,
         weights_dtype=ttnn.bfloat16,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -461,8 +461,7 @@ Result conv2d_L1(
                 device,
                 groups,
                 opt_conv_op_block_config.act_block_h_ntiles,
-                input_width,
-                true);
+                input_width);
         }
     }
     // if 1x1 conv w/ stride 1, convert input tensor to tile layout if required

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -447,6 +447,7 @@ Result conv2d_L1(
                 groups,
                 opt_conv_op_block_config.act_block_h_ntiles,
                 input_width,
+                bias_tensor.has_value(),
                 true);
         } else {
             tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_on_device(
@@ -461,7 +462,8 @@ Result conv2d_L1(
                 device,
                 groups,
                 opt_conv_op_block_config.act_block_h_ntiles,
-                input_width);
+                input_width,
+                bias_tensor.has_value());
         }
     }
     // if 1x1 conv w/ stride 1, convert input tensor to tile layout if required

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/buffer_constants.hpp>
 #include "tt-metalium/constants.hpp"
 #include <tt-metalium/hal.hpp>
+#include "tt-metalium/logger.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -419,6 +420,7 @@ bool is_1d_deptwise_conv(
     uint32_t image_width,
     bool has_bias) {
     bool is_depthwise_conv = groups == input_channels && groups == output_channels;
+    log_info("has_bias: {}", has_bias);
     return is_depthwise_conv && is_1d_conv(kernel_width, image_width) && !has_bias;
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -420,7 +420,6 @@ bool is_1d_deptwise_conv(
     uint32_t image_width,
     bool has_bias) {
     bool is_depthwise_conv = groups == input_channels && groups == output_channels;
-    log_info("has_bias: {}", has_bias);
     return is_depthwise_conv && is_1d_conv(kernel_width, image_width) && !has_bias;
 }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1164,10 +1164,11 @@ ttnn::Tensor prepare_conv_weights(
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
     if (weight_tensor.is_device_tensor() || conv_config.preprocess_weights_on_device) {
         if (conv_config.preprocess_weights_on_device == false) {
-            log_warning(tt::LogOp,"
-                Conv2D prepare weights was invoked with device tensors, but the conv_config.preprocess_weights_on_device flag was not set to True.
-                This will use the device to prepare weights, which is not fully supported.
-                ");
+            log_warning(
+                tt::LogOp,
+                "Conv2D prepare weights was invoked with device tensors, but the "
+                "conv_config.preprocess_weights_on_device flag was not set to True. \n This will use the device to "
+                "prepare weights, which is not fully supported.");
         }
         if (groups > 1) {
             TT_THROW(
@@ -1290,7 +1291,6 @@ ttnn::Tensor prepare_conv_bias(
     TT_FATAL(bias_tensor_.get_logical_shape()[3] == out_channels, "Bias must have the same length as output channels");
 
     if (bias_tensor_.is_device_tensor()) {
-        log_info(tt::LogOp, "Preparing Bias on Device");
         bias_tensor_ = prepare_bias_on_device(
             bias_tensor_,
             conv_config.weights_dtype,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1173,7 +1173,7 @@ ttnn::Tensor prepare_conv_weights(
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
     if (weight_tensor.is_device_tensor() || conv_config.preprocess_weights_on_device) {
-        if (conv_config.preprocess_weights_on_device == false) {
+        if (!conv_config.preprocess_weights_on_device) {
             log_warning(
                 tt::LogOp,
                 "Conv2D prepare weights was invoked with device tensors, but the "

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
+#include "tt-metalium/logger.hpp"
 #include "tt-metalium/shape.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
@@ -10,6 +11,7 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
@@ -657,6 +659,83 @@ static OptimizedConvBlockConfig get_opt_block_config(
 }
 
 template <typename T>
+ttnn::Tensor prepare_bias_on_device(
+    const ttnn::Tensor& bias_tensor,
+    DataType bias_dtype,
+    uint32_t out_channels,
+    uint32_t weight_block_w_ntiles,
+    const ParallelConfig& input_parallel_config,
+    const ParallelConfig& output_parallel_config,
+    T* device) {
+    uint32_t output_num_cores_channels = get_num_cores_channels_from_parallel_config(output_parallel_config);
+
+    uint32_t out_channels_padded = tt::round_up(out_channels, output_num_cores_channels * tt::constants::TILE_WIDTH);
+    uint32_t out_channel_padding = out_channels_padded - out_channels;
+
+    ttnn::Tensor bias_tensor_ = bias_tensor;
+    bool is_bias_tensor_is_on_device = ttnn::is_tensor_on_device_or_multidevice(bias_tensor_);
+    if (!is_bias_tensor_is_on_device) {
+        bias_tensor_ = ttnn::operations::core::to_device(bias_tensor_, device, std::nullopt);
+    }
+    if (input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
+        auto bias_out_channels = bias_tensor_.get_logical_shape()[3];
+        ttnn::Shape bias_channels_padded_shape({1, 1, 1, out_channels_padded});
+        bias_tensor_ = ttnn::pad(
+            bias_tensor_,
+            bias_channels_padded_shape.to_array_4D(),
+            tt::tt_metal::Array4D{0, 0, 0, 0},
+            0,
+            true,
+            std::nullopt);
+        auto out_channels_per_core = out_channels_padded / output_num_cores_channels;
+        auto rounded_weight_block_width = tt::round_up(out_channels_per_core, constants::TILE_WIDTH);
+
+        auto final_out_channels_padded = rounded_weight_block_width * output_num_cores_channels;
+
+        if (final_out_channels_padded != out_channels_padded) {
+            bias_tensor_ =
+                ttnn::reshape(bias_tensor_, ttnn::Shape({1, 1, output_num_cores_channels, out_channels_per_core}));
+
+            bias_tensor_ = ttnn::pad(
+                bias_tensor_,
+                tt::tt_metal::Array4D({1, 1, output_num_cores_channels, rounded_weight_block_width}),
+                tt::tt_metal::Array4D({0, 0, 0, 0}),
+                0,
+                true,
+                std::nullopt);
+        }
+        bias_tensor_ = ttnn::reshape(bias_tensor_, ttnn::Shape({1, 1, 1, final_out_channels_padded}));
+        bias_tensor_ = ttnn::pad(
+            bias_tensor_,
+            tt::tt_metal::Array4D({1, 1, 32, final_out_channels_padded}),
+            tt::tt_metal::Array4D{0, 0, 0, 0},
+            0,
+            true,
+            std::nullopt);
+    } else {
+        ttnn::Shape bias_channels_padded_shape({1, 1, 32, round_up(out_channels, weight_block_w_ntiles * 32)});
+        bias_tensor_ = ttnn::pad(
+            bias_tensor_,
+            bias_channels_padded_shape.to_array_4D(),
+            tt::tt_metal::Array4D{0, 0, 0, 0},
+            0,
+            true,
+            std::nullopt);
+    }
+    bias_tensor_ = ttnn::tilize(
+        bias_tensor_,
+        ttnn::MemoryConfig(
+            {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+             .buffer_type = tt::tt_metal::BufferType::DRAM}),
+        bias_dtype,
+        true);
+
+    ttnn::Shape bias_target_shape(std::array<uint32_t, 4>{1, 1, 1, out_channels});
+    bias_tensor_ = ttnn::reshape(bias_tensor_, bias_target_shape, bias_tensor_.get_padded_shape());
+    return bias_tensor_;
+}
+
+template <typename T>
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_on_device(
     const ttnn::Tensor& weight_tensor,
     const std::optional<const ttnn::Tensor>& bias_tensor,
@@ -669,8 +748,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     T* device,
     uint32_t groups,
     uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool parameters_on_device) {
+    uint32_t input_width) {
     ttnn::Tensor weight_tensor_ = weight_tensor;  // tensor to return
     Shape weight_shape = weight_tensor.get_logical_shape();
     // In case of 1D convolution and 3D weight tensor, reinterpret it as 4D tensor
@@ -865,68 +943,15 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     weight_tensor_ = ttnn::reshape(weight_tensor_, target_shape, weight_tensor_.get_padded_shape());
 
     if (bias_tensor.has_value()) {
-        bias_tensor_ = bias_tensor.value();
-        bool is_bias_tensor_is_on_device = ttnn::is_tensor_on_device_or_multidevice(bias_tensor_);
-        if (!is_bias_tensor_is_on_device) {
-            bias_tensor_ = ttnn::operations::core::to_device(bias_tensor_, device, std::nullopt);
-        }
-        if (input_parallel_config.shard_scheme == TensorMemoryLayout::BLOCK_SHARDED) {
-            auto bias_out_channels = bias_tensor_.get_logical_shape()[3];
-            ttnn::Shape bias_channels_padded_shape({1, 1, 1, out_channels_padded});
-            bias_tensor_ = ttnn::pad(
-                bias_tensor_,
-                bias_channels_padded_shape.to_array_4D(),
-                tt::tt_metal::Array4D{0, 0, 0, 0},
-                0,
-                true,
-                std::nullopt);
-            auto out_channels_per_core = out_channels_padded / output_num_cores_channels;
-            auto rounded_weight_block_width = tt::round_up(out_channels_per_core, constants::TILE_WIDTH);
-
-            auto final_out_channels_padded = rounded_weight_block_width * output_num_cores_channels;
-
-            if (final_out_channels_padded != out_channels_padded) {
-                bias_tensor_ =
-                    ttnn::reshape(bias_tensor_, ttnn::Shape({1, 1, output_num_cores_channels, out_channels_per_core}));
-
-                bias_tensor_ = ttnn::pad(
-                    bias_tensor_,
-                    tt::tt_metal::Array4D({1, 1, output_num_cores_channels, rounded_weight_block_width}),
-                    tt::tt_metal::Array4D({0, 0, 0, 0}),
-                    0,
-                    true,
-                    std::nullopt);
-            }
-            bias_tensor_ = ttnn::reshape(bias_tensor_, ttnn::Shape({1, 1, 1, final_out_channels_padded}));
-            bias_tensor_ = ttnn::pad(
-                bias_tensor_,
-                tt::tt_metal::Array4D({1, 1, 32, final_out_channels_padded}),
-                tt::tt_metal::Array4D{0, 0, 0, 0},
-                0,
-                true,
-                std::nullopt);
-        } else {
-            ttnn::Shape bias_channels_padded_shape({1, 1, 32, round_up(out_channels, weight_block_w_ntiles * 32)});
-            bias_tensor_ = ttnn::pad(
-                bias_tensor_,
-                bias_channels_padded_shape.to_array_4D(),
-                tt::tt_metal::Array4D{0, 0, 0, 0},
-                0,
-                true,
-                std::nullopt);
-        }
-        bias_tensor_ = ttnn::tilize(
-            bias_tensor_,
-            ttnn::MemoryConfig(
-                {.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
-                 .buffer_type = tt::tt_metal::BufferType::DRAM}),
+        bias_tensor_ = prepare_bias_on_device(
+            bias_tensor.value(),
             weights_bias_dtype,
-            true);
-
-        ttnn::Shape bias_target_shape(std::array<uint32_t, 4>{1, 1, 1, out_channels});
-        bias_tensor_ = ttnn::reshape(bias_tensor_, bias_target_shape, bias_tensor_.get_padded_shape());
+            out_channels,
+            weight_block_w_ntiles,
+            input_parallel_config,
+            output_parallel_config,
+            device);
     }
-
     return {weight_tensor_, bias_tensor.has_value() ? bias_tensor_ : std::optional<ttnn::Tensor>()};
 }
 
@@ -1074,9 +1099,6 @@ ttnn::Tensor prepare_conv_weights(
     T* device,
     const std::optional<const Conv2dConfig>& conv_config_,
     const std::optional<const DeviceComputeKernelConfig>& compute_config_) {
-    TT_FATAL(
-        !ttnn::is_tensor_on_device_or_multidevice(weight_tensor),
-        "Error: weight tensor must be on host for preparation.");
     Conv2dConfig conv_config = conv_config_.value_or(Conv2dConfig());
 
     DeviceComputeKernelConfig compute_config = compute_config_.value_or(get_conv_default_compute_kernel_config(device));
@@ -1140,19 +1162,36 @@ ttnn::Tensor prepare_conv_weights(
     std::optional<const ttnn::Tensor> bias_tensor = std::nullopt;
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
-    tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
-        weight_tensor,
-        bias_tensor,
-        conv_config.input_channels_alignment,
-        conv_config.weights_dtype,
-        opt_conv_op_block_config.act_block_w_ntiles,
-        opt_conv_op_block_config.out_subblock_w_ntiles,
-        parallel_config,
-        output_parallel_config,
-        device,
-        groups,
-        opt_conv_op_block_config.act_block_h_ntiles,
-        input_width);
+    if (weight_tensor.is_device_tensor()) {
+        log_info(tt::LogOp, "Preparing Weights on Device");
+        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_on_device(
+            weight_tensor,
+            bias_tensor,
+            conv_config.input_channels_alignment,
+            conv_config.weights_dtype,
+            opt_conv_op_block_config.act_block_w_ntiles,
+            opt_conv_op_block_config.out_subblock_w_ntiles,
+            parallel_config,
+            output_parallel_config,
+            device,
+            groups,
+            opt_conv_op_block_config.act_block_h_ntiles,
+            input_width);
+    } else {
+        tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
+            weight_tensor,
+            bias_tensor,
+            conv_config.input_channels_alignment,
+            conv_config.weights_dtype,
+            opt_conv_op_block_config.act_block_w_ntiles,
+            opt_conv_op_block_config.out_subblock_w_ntiles,
+            parallel_config,
+            output_parallel_config,
+            device,
+            groups,
+            opt_conv_op_block_config.act_block_h_ntiles,
+            input_width);
+    }
 
     return weight_tensor_on_device;
 }
@@ -1175,9 +1214,6 @@ ttnn::Tensor prepare_conv_bias(
     T* device,
     const std::optional<const Conv2dConfig>& conv_config_,
     const std::optional<const DeviceComputeKernelConfig>& compute_config_) {
-    TT_FATAL(
-        !ttnn::is_tensor_on_device_or_multidevice(bias_tensor), "Error: bias tensor must be on host for preparation.");
-
     Conv2dConfig conv_config = conv_config_.value_or(Conv2dConfig());
 
     std::array<uint32_t, 4> padding_n4 = sliding_window::get_pair_n4_padding(padding);
@@ -1242,14 +1278,26 @@ ttnn::Tensor prepare_conv_bias(
     ttnn::Tensor bias_tensor_ = bias_tensor;
     TT_FATAL(bias_tensor_.get_logical_shape()[3] == out_channels, "Bias must have the same length as output channels");
 
-    bias_tensor_ = conv_bias_layout_convert(
-        bias_tensor_,
-        conv_config.weights_dtype,
-        opt_conv_op_block_config.act_block_h_ntiles,
-        weight_block_w_ntiles,
-        output_parallel_config,
-        device,
-        out_channels);
+    if (bias_tensor_.is_device_tensor()) {
+        log_info(tt::LogOp, "Preparing Bias on Device");
+        bias_tensor_ = prepare_bias_on_device(
+            bias_tensor_,
+            conv_config.weights_dtype,
+            out_channels,
+            weight_block_w_ntiles,
+            parallel_config,
+            output_parallel_config,
+            device);
+    } else {
+        bias_tensor_ = conv_bias_layout_convert(
+            bias_tensor_,
+            conv_config.weights_dtype,
+            opt_conv_op_block_config.act_block_h_ntiles,
+            weight_block_w_ntiles,
+            output_parallel_config,
+            device,
+            out_channels);
+    }
     return bias_tensor_;
 }
 
@@ -1305,8 +1353,7 @@ template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weigh
     IDevice* device,
     uint32_t groups,
     uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool parameters_on_device);
+    uint32_t input_width);
 
 template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_on_device<MeshDevice>(
     const ttnn::Tensor& weight_tensor,
@@ -1320,8 +1367,7 @@ template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weigh
     MeshDevice* device,
     uint32_t groups,
     uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool parameters_on_device);
+    uint32_t input_width);
 
 template std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device<IDevice>(
     const ttnn::Tensor& weight_tensor,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1199,8 +1199,8 @@ ttnn::Tensor prepare_conv_weights(
             device,
             groups,
             opt_conv_op_block_config.act_block_h_ntiles,
-            has_bias,
-            input_width);
+            input_width,
+            has_bias);
     } else {
         tie(weight_tensor_on_device, bias_tensor_on_device) = prepare_conv_weights_biases_and_move_to_device(
             weight_tensor,
@@ -1214,8 +1214,8 @@ ttnn::Tensor prepare_conv_weights(
             device,
             groups,
             opt_conv_op_block_config.act_block_h_ntiles,
-            has_bias,
-            input_width);
+            input_width,
+            has_bias);
     }
 
     return weight_tensor_on_device;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1001,7 +1001,6 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
         original_weights_window_w,
         input_width,
         has_bias);
-    log_info("bias = {} is_conv_1d_depthwise_conv = {}", has_bias, is_conv_1d_depthwise_conv);
     TT_FATAL(
         !is_tensor_on_device_or_multidevice(weight_tensor_),
         "prepare_conv_weights_biases_and_move_to_device is not supported when the weights tensor is on the device");

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -116,7 +116,8 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     T* device,
     uint32_t groups,
     uint32_t act_block_h_ntiles,
-    uint32_t input_width);
+    uint32_t input_width,
+    const bool has_bias);
 
 template <typename T>
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(
@@ -132,6 +133,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     uint32_t groups,
     uint32_t act_block_h_ntiles,
     uint32_t input_width,
+    const bool has_bias,
     const bool parameters_on_device = true);
 
 }  // namespace conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp
@@ -116,8 +116,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
     T* device,
     uint32_t groups,
     uint32_t act_block_h_ntiles,
-    uint32_t input_width,
-    const bool parameters_on_device);
+    uint32_t input_width);
 
 template <typename T>
 std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases_and_move_to_device(

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -294,7 +294,8 @@ Result conv_transpose2d(
             device,
             groups,
             opt_conv_op_block_config.act_block_h_ntiles,
-            input_width);
+            input_width,
+            bias_tensor.has_value());
     }
     if (mm_conv) {
         input_tensor_post_tm = ttnn::to_layout(


### PR DESCRIPTION
### Ticket
#20503

### Problem description
prepare_conv_weights does not support weights located on the device

### What's changed
The prepare conv weights functions will now check the weights/bias tensor's storage type. If it's on device, it will use the device weights preparation path instead.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes