### PR TITLE
Associate dispatch cmd CQ activity with op IDs

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -214,11 +214,13 @@ def test_dispatch_cores():
     RISC_COUNT = 1
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
-        "Tensix CQ Dispatch": [153, 246, 365, 1035, 1548, 1634, 2447],
-        "Tensix CQ Prefetch": [410, 484, 529, 1117, 2356, 2447, 3070],
+        "Tensix CQ Dispatch": [250, 1000, 2000],
+        "Tensix CQ Prefetch": [400, 1000, 4000],
+        "dispatch_total_cq_cmd_op_time": [103],
+        "dispatch_go_send_wait_time": [103],
     }
 
-    def verify_stats(devicesData):
+    def verify_stats(devicesData, statTypes, allowedRange):
         verifiedStat = []
         for device, deviceData in devicesData["data"]["devices"].items():
             for ref, counts in REF_COUNT_DICT.items():
@@ -226,16 +228,14 @@ def test_dispatch_cores():
                     verifiedStat.append(ref)
                     res = False
                     readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
-                    allowedRange = 20
                     for count in counts:
-                        if count - allowedRange < readCount < count + allowedRange:
+                        if count - allowedRange <= readCount <= count + allowedRange:
                             res = True
                             break
                     assert (
                         res
-                    ), f"Wrong dispatch zone count, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
+                    ), f"Wrong tensix dispatch zone count for {ref}, read {readCount} which is not within {allowedRange} cycle counts of any of the limits {counts}"
 
-        statTypes = ["Dispatch", "Prefetch"]
         statTypesSet = set(statTypes)
         for statType in statTypes:
             for stat in verifiedStat:
@@ -243,14 +243,20 @@ def test_dispatch_cores():
                     statTypesSet.remove(statType)
         assert len(statTypesSet) == 0
 
-    verify_stats(run_device_profiler_test(setupAutoExtract=True, doDispatchCores=True))
+    verify_stats(
+        run_device_profiler_test(setupAutoExtract=True, doDispatchCores=True),
+        statTypes=["Dispatch", "Prefetch"],
+        allowedRange=150,
+    )
 
     verify_stats(
         run_device_profiler_test(
             testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
             setupAutoExtract=True,
             doDispatchCores=True,
-        )
+        ),
+        statTypes=["Dispatch", "Prefetch"],
+        allowedRange=1000,
     )
 
     verify_stats(
@@ -258,7 +264,19 @@ def test_dispatch_cores():
             testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_all_devices",
             setupAutoExtract=True,
             doDispatchCores=True,
-        )
+        ),
+        statTypes=["Dispatch", "Prefetch"],
+        allowedRange=1000,
+    )
+
+    verify_stats(
+        run_device_profiler_test(
+            testName=f"pytest {TRACY_TESTS_DIR}/test_trace_runs.py",
+            setupAutoExtract=False,
+            doDispatchCores=True,
+        ),
+        statTypes=["dispatch_total_cq_cmd_op_time", "dispatch_go_send_wait_time"],
+        allowedRange=0,  # This test is basically counting ops and should be exact regardless of changes to dispatch code or harvesting.
     )
 
 
@@ -267,8 +285,8 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [632, 830, 2088, 2287],
-        "Ethernet CQ Prefetch": [520, 716, 2398, 2656],
+        "Ethernet CQ Dispatch": [700, 2100],
+        "Ethernet CQ Prefetch": [600, 2500],
     }
     devicesData = run_device_profiler_test(
         testName=f"pytest {TRACY_TESTS_DIR}/test_dispatch_profiler.py::test_with_ops",
@@ -281,7 +299,7 @@ def test_ethernet_dispatch_cores():
             if ref in deviceData["cores"]["DEVICE"]["analysis"].keys():
                 res = False
                 readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
-                allowedRange = 20
+                allowedRange = 200
                 for count in counts:
                     if count - allowedRange < readCount < count + allowedRange:
                         res = True
@@ -301,7 +319,7 @@ def test_ethernet_dispatch_cores():
             if ref in deviceData["cores"]["DEVICE"]["analysis"].keys():
                 res = False
                 readCount = deviceData["cores"]["DEVICE"]["analysis"][ref]["stats"]["Count"]
-                allowedRange = 20
+                allowedRange = 200
                 for count in counts:
                     if count - allowedRange < readCount < count + allowedRange:
                         res = True

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_slave.cpp
@@ -133,7 +133,6 @@ uint32_t stream_wrap_gt(uint32_t a, uint32_t b) {
 
 FORCE_INLINE
 void wait_for_workers(volatile CQDispatchCmd tt_l1_ptr* cmd) {
-    DeviceZoneScopedN("WAIT-FOR-WORKERS");
     volatile uint32_t* worker_sem =
         (volatile uint32_t*)STREAM_REG_ADDR(cmd->mcast.wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
     while (stream_wrap_gt(cmd->mcast.wait_count, *worker_sem)) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1289,7 +1289,6 @@ bool process_cmd(
     uint32_t& stride,
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state) {
-    DeviceZoneScopedN("PROCESS-CMD");
     volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
     bool done = false;
 
@@ -1603,7 +1602,7 @@ void kernel_main_hd() {
     uint32_t l1_cache[l1_cache_elements_rounded];
     PrefetchExecBufState exec_buf_state;
     while (!done) {
-        DeviceZoneScopedN("KERNEL-MAIN-HD");
+        DeviceZoneScopedN("CQ-PREFETCH");
         constexpr uint32_t preamble_size = 0;
         fetch_q_get_cmds<preamble_size>(fence, cmd_ptr, pcie_read_ptr);
 

--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -104,6 +104,18 @@ class default_setup(metaclass=MergeMetaclass):
             "type": "sum",
             "marker": {"risc": "TRISC_2", "zone_name": "CB-COMPUTE-RESERVE-BACK"},
         },
+        "dispatch_total_cq_cmd_op_time": {
+            "across": "dispatch_ops",
+            "type": "op_first_last",
+            "start": {"core": "ANY", "risc": "BRISC", "zone_name": "CQ_DISPATCH_*"},
+            "end": {"core": "ANY", "risc": "BRISC", "zone_name": "CQ_DISPATCH_*"},
+        },
+        "dispatch_go_send_wait_time": {
+            "across": "dispatch_ops",
+            "type": "op_first_last",
+            "start": {"core": "ANY", "risc": "NCRISC", "zone_name": "CQ_DISPATCH_CMD_SEND_GO_SIGNAL"},
+            "end": {"core": "ANY", "risc": "NCRISC", "zone_name": "CQ_DISPATCH_CMD_SEND_GO_SIGNAL"},
+        },
     }
 
     displayStats = ["Count", "Average", "Max", "Median", "Min", "Sum", "Range"]
@@ -246,8 +258,8 @@ class test_dispatch_cores(default_setup):
         "Tensix CQ Prefetch": {
             "across": "core",
             "type": "adjacent",
-            "start": {"risc": "BRISC", "zone_name": "KERNEL-MAIN-HD"},
-            "end": {"risc": "BRISC", "zone_name": "KERNEL-MAIN-HD"},
+            "start": {"risc": "BRISC", "zone_name": "CQ-PREFETCH"},
+            "end": {"risc": "BRISC", "zone_name": "CQ-PREFETCH"},
         },
     }
     detectOps = False

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -43,6 +43,16 @@ extern uint32_t sums[SUM_COUNT];
 extern uint32_t sumIDs[SUM_COUNT];
 
 constexpr uint32_t QUICK_PUSH_MARKER_COUNT = 2;
+constexpr uint32_t DISPATCH_META_DATA_COUNT = 2;
+constexpr uint32_t DISPATCH_META_DATA_UINT32_SIZE = 4;
+constexpr uint32_t DISPATCH_PARENT_ZONE_MARKER_COUNT = 2;
+// Space has to be left in the buffer in order to guarantee
+// that the next dispatch command can make it fully populated
+// with its meta data (op id + command type)
+constexpr uint32_t DISPATCH_HEADROOM_SIZE =
+    PROFILER_L1_MARKER_UINT32_SIZE * (DISPATCH_PARENT_ZONE_MARKER_COUNT + QUICK_PUSH_MARKER_COUNT) +
+    DISPATCH_META_DATA_UINT32_SIZE * DISPATCH_META_DATA_COUNT;
+
 constexpr int WALL_CLOCK_HIGH_INDEX = 1;
 constexpr int WALL_CLOCK_LOW_INDEX = 0;
 
@@ -77,7 +87,7 @@ constexpr uint32_t Hash16_CT(const char (&s)[N]) {
     return ((res & 0xFFFF) ^ ((res & 0xFFFF0000) >> 16)) & 0xFFFF;
 }
 
-enum class DoingDispatch { DISPATCH, NOT_DISPATCH };
+enum class DoingDispatch { DISPATCH, DISPATCH_META, NOT_DISPATCH };
 
 __attribute__((noinline)) void init_profiler(
     uint16_t briscKernelID = 0, uint16_t ncriscKernelID = 0, uint16_t triscsKernelID = 0) {
@@ -125,6 +135,8 @@ template <DoingDispatch dispatch = DoingDispatch::NOT_DISPATCH>
 inline __attribute__((always_inline)) bool bufferHasRoom() {
     bool bufferHasRoom = false;
     if constexpr (dispatch == DoingDispatch::DISPATCH) {
+        bufferHasRoom = wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize - DISPATCH_HEADROOM_SIZE);
+    } else if constexpr (dispatch == DoingDispatch::DISPATCH_META) {
         bufferHasRoom =
             wIndex < (PROFILER_L1_VECTOR_SIZE - stackSize - (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE));
     } else {
@@ -335,11 +347,10 @@ struct profileScope {
             wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
             start_marked = false;
             stackSize -= PROFILER_L1_MARKER_UINT32_SIZE;
-        }
-
-        if constexpr (dispatch == DoingDispatch::DISPATCH) {
-            if (wIndex >= (PROFILER_L1_VECTOR_SIZE - (QUICK_PUSH_MARKER_COUNT * PROFILER_L1_MARKER_UINT32_SIZE))) {
-                quick_push();
+            if constexpr (dispatch == DoingDispatch::DISPATCH) {
+                if (wIndex >= (PROFILER_L1_VECTOR_SIZE - DISPATCH_HEADROOM_SIZE)) {
+                    quick_push();
+                }
             }
         }
     }
@@ -435,11 +446,11 @@ inline __attribute__((always_inline)) void recordEvent(uint16_t event_id) {
     kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH> zone = \
         kernel_profiler::profileScope<hash, kernel_profiler::DoingDispatch::DISPATCH>();
 
-#define DeviceTimestampedData(name, data)                                                       \
-    {                                                                                           \
-        DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                            \
-        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));              \
-        kernel_profiler::timeStampedData<hash, kernel_profiler::DoingDispatch::DISPATCH>(data); \
+#define DeviceTimestampedData(name, data)                                                            \
+    {                                                                                                \
+        DO_PRAGMA(message(PROFILER_MSG_NAME(name)));                                                 \
+        auto constexpr hash = kernel_profiler::Hash16_CT(PROFILER_MSG_NAME(name));                   \
+        kernel_profiler::timeStampedData<hash, kernel_profiler::DoingDispatch::DISPATCH_META>(data); \
     }
 
 #define DeviceRecordEvent(event_id) kernel_profiler::recordEvent<kernel_profiler::DoingDispatch::DISPATCH>(event_id);

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -22,6 +22,8 @@ import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_confi
 
 SUM_MARKER_ID_START = 3000
 
+dispatchCores = set()
+
 
 def coreCompare(core):
     if type(core) == str:
@@ -193,7 +195,6 @@ def extract_device_info(deviceInfo):
 
 def import_device_profile_log(logPath):
     devicesData = {"devices": {}}
-    doOpsDetection = True
     with open(logPath) as csvFile:
         csvReader = csv.reader(csvFile, delimiter=",")
         arch = ""
@@ -209,9 +210,9 @@ def import_device_profile_log(logPath):
                 risc = row[3].strip()
                 timerID = {"id": int(row[4].strip()), "zone_name": "", "type": "", "src_line": "", "src_file": ""}
                 timeData = int(row[5].strip())
-                statData = 0
+                attachedData = 0
                 if len(row) == 14:
-                    statData = int(row[6].strip())
+                    attachedData = int(row[6].strip())
                     timerID["run_id"] = int(row[7].strip())
                     timerID["run_host_id"] = int(row[8].strip())
                     timerID["zone_name"] = row[9].strip()
@@ -224,25 +225,20 @@ def import_device_profile_log(logPath):
                     if core in devicesData["devices"][chipID]["cores"].keys():
                         if risc in devicesData["devices"][chipID]["cores"][core]["riscs"].keys():
                             devicesData["devices"][chipID]["cores"][core]["riscs"][risc]["timeseries"].append(
-                                (timerID, timeData, statData)
+                                (timerID, timeData, attachedData)
                             )
                         else:
                             devicesData["devices"][chipID]["cores"][core]["riscs"][risc] = {
-                                "timeseries": [(timerID, timeData, statData)]
+                                "timeseries": [(timerID, timeData, attachedData)]
                             }
                     else:
                         devicesData["devices"][chipID]["cores"][core] = {
-                            "riscs": {risc: {"timeseries": [(timerID, timeData, statData)]}}
+                            "riscs": {risc: {"timeseries": [(timerID, timeData, attachedData)]}}
                         }
                 else:
                     devicesData["devices"][chipID] = {
-                        "cores": {core: {"riscs": {risc: {"timeseries": [(timerID, timeData, statData)]}}}}
+                        "cores": {core: {"riscs": {risc: {"timeseries": [(timerID, timeData, attachedData)]}}}}
                     }
-                if doOpsDetection and "zone_name" in timerID.keys() and "dispatch" in timerID["zone_name"].lower():
-                    logger.warning(
-                        "Dispatch core data detected: Stats across ops are skipped as op detection cannot work with dispatch data present. Please turn off dispatch core profiling."
-                    )
-                    doOpsDetection = False
 
     def sort_timeseries_and_find_min(devicesData):
         globalMinTS = (1 << 64) - 1
@@ -267,8 +263,13 @@ def import_device_profile_log(logPath):
             for core, coreData in deviceData["cores"].items():
                 for risc, riscData in coreData["riscs"].items():
                     riscData["timeseries"].sort(key=lambda x: x[1])
-                    for marker, timestamp, statData in riscData["timeseries"]:
+                    for marker, timestamp, attachedData in riscData["timeseries"]:
                         shiftedTS = timestamp - globalMinTS
+                        # ERISC dispatch is EOL, some models still use it. Need to check and drop it here until it is fully removed.
+                        if (
+                            "CQ-DISPATCH" in marker["zone_name"] or "CQ-PREFETCH" in marker["zone_name"]
+                        ) and "ERISC" not in risc:
+                            dispatchCores.add((chipID, core, risc))
                     riscData["timeseries"].insert(
                         0,
                         (
@@ -288,7 +289,7 @@ def import_device_profile_log(logPath):
     # Sort all timeseries and find global min timestamp
     sort_timeseries_and_find_min(devicesData)
 
-    return devicesData, doOpsDetection
+    return devicesData
 
 
 def get_ops(timeseries):
@@ -318,7 +319,7 @@ def get_ops(timeseries):
         op.sort(key=lambda ts: ts[1])
         for ts in op:
             if len(ts) == 5:
-                timerID, tsValue, statData, risc, core = ts
+                timerID, tsValue, attachedData, risc, core = ts
                 opCores[core] = None
 
         for ts in op:
@@ -327,7 +328,7 @@ def get_ops(timeseries):
                 continue
             opIsDone = False
             if len(ts) == 5:
-                timerID, tsValue, statData, risc, core = ts
+                timerID, tsValue, attachedData, risc, core = ts
                 if opCores[core]:
                     if (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_START") or (
                         risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_START"
@@ -349,7 +350,7 @@ def get_ops(timeseries):
                     ):
                         opCores[core] = (timerID,)
             if len(ts) == 4:
-                timerID, tsValue, statData, risc = ts
+                timerID, tsValue, attachedData, risc = ts
                 if (risc == "BRISC" and timerID["zone_name"] == "BRISC-FW" and timerID["type"] == "ZONE_END") or (
                     risc == "ERISC" and timerID["zone_name"] == "ERISC-FW" and timerID["type"] == "ZONE_END"
                 ):
@@ -363,7 +364,83 @@ def get_ops(timeseries):
     return ops
 
 
+def get_dispatch_core_ops(timeseries):
+    masterRisc = "BRISC"
+    slaveRisc = "NCRISC"
+    riscData = {
+        masterRisc: {"zone": [], "opID": 0, "cmdType": "", "ops": {}, "orderedOpIDs": [], "opFinished": False},
+        slaveRisc: {"zone": [], "opID": 0, "cmdType": "", "ops": {}, "orderedOpIDs": [], "opFinished": False},
+    }
+    for ts in timeseries:
+        timerID, tsValue, attachedData, risc = ts
+        riscData[risc]["zone"].append(ts)
+
+        if "meta_data" in timerID and "workers_runtime_id" in timerID["meta_data"]:
+            riscData[risc]["opFinished"] = False
+            riscData[risc]["opID"] = eval(timerID["meta_data"])["workers_runtime_id"]
+            # Only record first trace
+            if riscData[risc]["opID"] in riscData[risc]["ops"].keys():
+                riscData[risc]["opID"] = 0
+
+        if "meta_data" in timerID and "dispatch_command_type" in timerID["meta_data"]:
+            riscData[risc]["cmdType"] = eval(timerID["meta_data"])["dispatch_command_type"]
+            if "CQ_DISPATCH_NOTIFY_SLAVE_GO_SIGNAL" in riscData[risc]["cmdType"]:
+                riscData[risc]["opFinished"] = True
+
+            if "CQ_DISPATCH_CMD_SEND_GO_SIGNAL" in riscData[risc]["cmdType"]:
+                riscData[risc]["opID"] += 1
+
+        if "type" in timerID and timerID["type"] == "ZONE_END":
+            riscData[risc]["zone"][0][0]["zone_name"] = riscData[risc]["cmdType"]
+            riscData[risc]["zone"][-1][0]["zone_name"] = riscData[risc]["cmdType"]
+            if riscData[risc]["opID"] not in riscData[risc]["ops"]:
+                riscData[risc]["ops"][riscData[risc]["opID"]] = riscData[risc]["zone"].copy()
+            else:
+                riscData[risc]["ops"][riscData[risc]["opID"]] += riscData[risc]["zone"]
+            riscData[risc]["zone"] = []
+            if riscData[risc]["opFinished"]:
+                riscData[risc]["opID"] = 0
+
+    for risc, data in riscData.items():
+        data["orderedOpIDs"] = list(data["ops"].keys())
+        # sort over timestamps
+        data["orderedOpIDs"].sort(key=lambda x: data["ops"][x][0][1])
+
+    opsDict = {}
+    for masterOpID, slaveOpID in zip(riscData[masterRisc]["orderedOpIDs"], riscData[slaveRisc]["orderedOpIDs"]):
+        opsDict[masterOpID] = riscData[masterRisc]["ops"][masterOpID] + riscData[slaveRisc]["ops"][slaveOpID]
+        opsDict[masterOpID].sort(key=lambda x: x[1])
+
+    ops = []
+    for opID in riscData[masterRisc]["orderedOpIDs"]:
+        # opID of zero is non-associated with any op and should be discarded
+        if opID > 0:
+            ops.append({"timeseries": opsDict[opID]})
+
+    return ops
+
+
+def get_dispatch_core_ops_core_to_device(chipID, deviceData):
+    deviceDispatchCores = set()
+    for chip, core, risc in dispatchCores:
+        if chip == chipID:
+            deviceDispatchCores.add(core)
+
+    ops = []
+    for core in deviceDispatchCores:
+        for op in deviceData["cores"][core]["riscs"]["TENSIX"]["ops"]:
+            ops.append(op)
+
+    ops.sort(key=lambda x: x["timeseries"][0][1])
+
+    return ops
+
+
 def risc_to_core_timeseries(devicesData, detectOps):
+    dispatchCoresNoRisc = set()
+    for chip, core, risc in dispatchCores:
+        dispatchCoresNoRisc.add((chip, core))
+
     for chipID, deviceData in devicesData["devices"].items():
         for core, coreData in deviceData["cores"].items():
             tmpTimeseries = []
@@ -376,7 +453,10 @@ def risc_to_core_timeseries(devicesData, detectOps):
 
             ops = []
             if detectOps:
-                ops = get_ops(tmpTimeseries)
+                if (chipID, core) in dispatchCoresNoRisc:
+                    ops = get_dispatch_core_ops(tmpTimeseries)
+                else:
+                    ops = get_ops(tmpTimeseries)
 
             coreData["riscs"]["TENSIX"] = {"timeseries": tmpTimeseries, "ops": ops}
 
@@ -400,11 +480,15 @@ def core_to_device_timeseries(devicesData, detectOps):
         for risc in tmpTimeseries["riscs"].keys():
             tmpTimeseries["riscs"][risc]["timeseries"].sort(key=lambda x: x[1])
 
-        ops = []
+        tmpTimeseries["riscs"]["TENSIX"]["ops"] = []
+        tmpTimeseries["riscs"]["TENSIX"]["dispatch_ops"] = []
         if detectOps:
-            ops = get_ops(tmpTimeseries["riscs"]["TENSIX"]["timeseries"])
+            dispatchOps = get_dispatch_core_ops_core_to_device(chipID, deviceData)
+            tmpTimeseries["riscs"]["TENSIX"]["dispatch_ops"] = dispatchOps
 
-        tmpTimeseries["riscs"]["TENSIX"]["ops"] = ops
+            ops = get_ops(tmpTimeseries["riscs"]["TENSIX"]["timeseries"])
+            tmpTimeseries["riscs"]["TENSIX"]["ops"] = ops
+
         deviceData["cores"]["DEVICE"] = tmpTimeseries
 
 
@@ -481,22 +565,38 @@ def determine_conditions(timerID, metaData, analysis):
     return currStart, currEnd, desStart, desEnd
 
 
+def currMark_in_desMarks(currMark, desMarks):
+    ret = False
+    currName, *curr_ = currMark
+    for desMark in desMarks:
+        desName, *des_ = desMark
+        if des_ == curr_:
+            if desName == currName:
+                ret = True
+                break
+            elif "*" == desName[-1]:
+                if desName[:-1] in currName:
+                    ret = True
+                    break
+    return ret
+
+
 def first_last_analysis(timeseries, analysis):
     durations = []
     startFound = None
-    for index, (timerID, timestamp, statData, *metaData) in enumerate(timeseries):
+    for index, (timerID, timestamp, attachedData, *metaData) in enumerate(timeseries):
         currStart, currEnd, desStart, desEnd = determine_conditions(timerID, metaData, analysis)
         if not startFound:
-            if currStart in desStart:
+            if currMark_in_desMarks(currStart, desStart):
                 startFound = (index, timerID, timestamp)
                 break
 
     if startFound:
         startIndex, startID, startTS = startFound
         for i in range(len(timeseries) - 1, startIndex, -1):
-            timerID, timestamp, statData, *metaData = timeseries[i]
+            timerID, timestamp, attachedData, *metaData = timeseries[i]
             currStart, currEnd, desStart, desEnd = determine_conditions(timerID, metaData, analysis)
-            if currEnd in desEnd:
+            if currMark_in_desMarks(currEnd, desEnd):
                 durations.append(
                     dict(
                         start_cycle=startTS,
@@ -535,10 +635,10 @@ def op_core_first_last_analysis(riscData, analysis):
 
 def get_duration(riscData, analysis):
     totalDuration = 0
-    for index, (timerID, timestamp, statData, risc, core) in enumerate(riscData["timeseries"]):
+    for index, (timerID, timestamp, attachedData, risc, core) in enumerate(riscData["timeseries"]):
         desMarker = {"risc": risc, "zone_name": timerID["zone_name"]}
         if desMarker == analysis["marker"]:
-            totalDuration += statData
+            totalDuration += attachedData
     if totalDuration:
         return [dict(duration_type=analysis["marker"], duration_cycles=totalDuration)]
     return []
@@ -548,7 +648,7 @@ def adjacent_LF_analysis(riscData, analysis):
     timeseries = riscData["timeseries"]
     durations = []
     startFound = None
-    for timerID, timestamp, statData, *metaData in timeseries:
+    for timerID, timestamp, attachedData, *metaData in timeseries:
         currStart, currEnd, desStart, desEnd = determine_conditions(timerID, metaData, analysis)
         if not startFound:
             if currStart in desStart:
@@ -617,11 +717,11 @@ def timeseries_events(riscData, name, analysis):
         else:
             riscData["events"][name] = []
 
-        for index, (timerID, timestamp, statData, risc, *_) in enumerate(riscData["timeseries"]):
+        for index, (timerID, timestamp, attachedData, risc, *_) in enumerate(riscData["timeseries"]):
             if (timerID["type"] == "TS_EVENT" or timerID["type"] == "TS_DATA") and (
                 risc == analysis["marker"]["risc"] or analysis["marker"]["risc"] == "ANY"
             ):
-                riscData["events"][name].append((timerID, timestamp, statData, risc, *_))
+                riscData["events"][name].append((timerID, timestamp, attachedData, risc, *_))
 
 
 def core_analysis(name, analysis, devicesData):
@@ -646,17 +746,21 @@ def device_analysis(name, analysis, devicesData):
         timeseries_events(riscData, name, analysis)
 
 
-def ops_analysis(name, analysis, devicesData):
+def ops_analysis(name, analysis, devicesData, doDispatch=False):
     for chipID, deviceData in devicesData["devices"].items():
         core = "DEVICE"
         risc = "TENSIX"
         assert core in deviceData["cores"].keys()
         assert risc in deviceData["cores"][core]["riscs"].keys()
         riscData = deviceData["cores"][core]["riscs"][risc]
-        if "ops" in riscData.keys():
+        if not doDispatch and "ops" in riscData.keys():
             for op in riscData["ops"]:
                 timeseries_analysis(op, name, analysis)
                 timeseries_events(op, name, analysis)
+
+        elif doDispatch and "dispatch_ops" in riscData.keys():
+            for op in riscData["dispatch_ops"]:
+                timeseries_analysis(op, name, analysis)
 
 
 def generate_device_level_summary(devicesData):
@@ -673,6 +777,16 @@ def generate_device_level_summary(devicesData):
                 if core == "DEVICE" and risc == "TENSIX":
                     if "ops" in riscData.keys():
                         for op in riscData["ops"]:
+                            if "analysis" in op.keys():
+                                for name, analysis in op["analysis"].items():
+                                    if name in analysisLists.keys():
+                                        analysisLists[name]["statList"].append(analysis["stats"])
+                                    else:
+                                        analysisLists[name] = dict(
+                                            analysis=analysis["analysis"], statList=[analysis["stats"]]
+                                        )
+                    if "dispatch_ops" in riscData.keys():
+                        for op in riscData["dispatch_ops"]:
                             if "analysis" in op.keys():
                                 for name, analysis in op["analysis"].items():
                                     if name in analysisLists.keys():
@@ -715,9 +829,8 @@ def validate_setup(ctx, param, setup):
 
 
 def import_log_run_stats(setup=device_post_proc_config.default_setup()):
-    devicesData, doOpsDetection = import_device_profile_log(setup.deviceInputLog)
-    if not doOpsDetection:
-        setup.detectOps = False
+    devicesData = import_device_profile_log(setup.deviceInputLog)
+
     risc_to_core_timeseries(devicesData, setup.detectOps)
     core_to_device_timeseries(devicesData, setup.detectOps)
 
@@ -728,6 +841,8 @@ def import_log_run_stats(setup=device_post_proc_config.default_setup()):
             device_analysis(name, analysis, devicesData)
         elif analysis["across"] == "ops":
             ops_analysis(name, analysis, devicesData)
+        elif analysis["across"] == "dispatch_ops":
+            ops_analysis(name, analysis, devicesData, doDispatch=True)
 
     generate_device_level_summary(devicesData)
     return devicesData

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -162,8 +162,6 @@ def main():
             testCommand = f"python3 -m tracy {osCmd}"
 
             envVars = dict(os.environ)
-            # No Dispatch cores for op_report
-            envVars["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
             if options.device:
                 envVars["TT_METAL_DEVICE_PROFILER"] = "1"
             else:


### PR DESCRIPTION
### Ticket
#18811 

### Problem description
The opID presented in dispatch command queue is not utilized to determine and present dispatch overhead in op report.

### What's changed
Bring dispatch go signal wait and total CQ time per op to perf report. 


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14471412628)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14526631341)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14526627447)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14453635875)