### PR TITLE
[skip ci] Fix Falcon7b demo commands in WH/T3K/TG readmes

### DIFF
--- a/models/demos/t3000/falcon7b/README.md
+++ b/models/demos/t3000/falcon7b/README.md
@@ -13,7 +13,7 @@ export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
 - To run the demo using prewritten prompts for a batch of 256 users split evenly on 8 devices (currently only supports same token-length inputs):
 
 ```sh
-pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[wormhole_b0-True-user_input0-8-True-default_mode_1024_stochastic]
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip -k "default_mode_1024_stochastic and -8-"
 ```
 
 - **Decoding method**: The default decoding method is top-k/top-p (stochastic) sampling, however greedy decoding can also be used by replacing `stochastic` with `greedy` in the command above.
@@ -23,7 +23,7 @@ pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t
 - To measure the performance of generating the `i`'th token while the KV cache is filled with `i-1` rows (where `i` is 128 in the command below):
 
 ```sh
-pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[wormhole_b0-True-user_input0-8-True-perf_mode_128_stochastic]
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t3000/falcon7b/input_data_t3000.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip -k "perf_mode_128_stochastic and not verify and -8-"
 ```
 
 - **Supported sequence lengths**: Currently `i` can only be set to 128, 1024, or 2048 for performance measurement mode.
@@ -33,19 +33,19 @@ pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/t
 - A sample of input prompts for 256 users is provided in `input_data_t3000.json` in demo directory. If you wish you to run the model using a different set of input prompts you can provide a different path, e.g.:
 
 ```sh
-pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[wormhole_b0-True-user_input0-8-True-default_mode_1024_stochastic]
+pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip -k "default_mode_1024_stochastic and -8-"
 ```
 
 ## Running on a different number of devices
 
-- To run the demo on a different number of devices, an input file with the appropriate number of inputs must be prepared (the number of inputs should be (32 x num-devices)). 
+- To run the demo on a different number of devices, an input file with the appropriate number of inputs must be prepared (the number of inputs should be (32 x num-devices)).
 
-- Then, the command above can be modified to replace '8' with the desired number of devices. 
+- Then, the command above can be modified to replace '8' with the desired number of devices.
 
 - For example, to run with 4 devices:
 
 ```sh
-pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip[wormhole_b0-True-user_input0-4-True-default_mode_1024_stochastic]
+pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/t3000/falcon7b/demo_t3000.py::test_demo_multichip -k "default_mode_1024_stochastic and -4-"
 ```
 
 ## Details

--- a/models/demos/tg/falcon7b/README.md
+++ b/models/demos/tg/falcon7b/README.md
@@ -6,7 +6,9 @@
 
 To run the demo using prewritten prompts for a batch of 1024 users split evenly on 32 devices (currently only supports same token-length inputs):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py::test_demo_multichip[wormhole_b0-True-user_input0-32chipTG-True-default_mode_1024_stochastic]`
+```sh
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py::test_demo_multichip -k default_mode_1024_stochastic
+```
 
 - **Decoding method**: The default decoding method is top-k/top-p (stochastic) sampling, however greedy decoding can also be used by replacing `stochastic` with `greedy` in the command above.
 
@@ -14,7 +16,9 @@ To run the demo using prewritten prompts for a batch of 1024 users split evenly 
 
 To measure the performance of generating the `i`'th token while the KV cache is filled with `i-1` rows (where `i` is 128 in the command below):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py::test_demo_multichip[wormhole_b0-True-user_input0-32chipTG-True-perf_mode_128_stochastic]`
+```sh
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/tg/falcon7b/input_data_tg.json' models/demos/tg/falcon7b/demo_tg.py::test_demo_multichip -k "perf_mode_128_stochastic and not verify"
+```
 
 - **Supported sequence lengths**: Currently `i` can only be set to 128, 1024, or 2048 for performance measurement mode.
 
@@ -22,7 +26,9 @@ To measure the performance of generating the `i`'th token while the KV cache is 
 
 A sample of input prompts for 1024 users is provided in `input_data_tg.json` in demo directory. If you wish you to run the model using a different set of input prompts you can provide a different path, e.g.:
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/tg/falcon7b/demo_tg.py::test_demo_multichip[wormhole_b0-True-user_input0-32chipTG-True-default_mode_1024_stochastic]`
+```sh
+pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/tg/falcon7b/demo_tg.py::test_demo_multichip -k default_mode_1024_stochastic
+```
 
 ## Details
 

--- a/models/demos/wormhole/falcon7b/README.md
+++ b/models/demos/wormhole/falcon7b/README.md
@@ -10,11 +10,11 @@ Falcon7b prefill uses 8x8 core grid size, so the following environment variable 
 
 To run the model for a single user you can use the command line input:
 
-`pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[wormhole_b0-True-user_input0-1-default_mode_1024_stochastic]`
+`pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic`
 
 To run the demo using prewritten prompts for a batch of 32 users run (currently only supports same token-length inputs):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[wormhole_b0-True-user_input0-1-default_mode_1024_stochastic]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic`
 
 - **Decoding method**: The default decoding method is top-k/top-p (stochastic) sampling, however greedy decoding can also be used by replacing `stochastic` with `greedy` in the command above.
 
@@ -22,7 +22,7 @@ To run the demo using prewritten prompts for a batch of 32 users run (currently 
 
 To measure the performance of generating the `i`'th token while the KV cache is filled with `i-1` rows (where `i` is 128 in the command below):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[wormhole_b0-True-user_input0-1-perf_mode_128_stochastic]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k perf_mode_128_stochastic`
 
 - **Supported sequence lengths**: Currently `i` can only be set to 128, 1024, or 2048 for performance measurement mode.
 
@@ -30,7 +30,7 @@ To measure the performance of generating the `i`'th token while the KV cache is 
 
 A sample of input prompts for 32 users is provided in `input_data.json` in demo directory. If you wish you to run the model using a different set of input prompts you can provide a different path, e.g.:
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo[wormhole_b0-True-user_input0-1-default_mode_1024_stochastic]`
+`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic`
 
 ## Details
 

--- a/models/demos/wormhole/falcon7b/README.md
+++ b/models/demos/wormhole/falcon7b/README.md
@@ -10,11 +10,15 @@ Falcon7b prefill uses 8x8 core grid size, so the following environment variable 
 
 To run the model for a single user you can use the command line input:
 
-`pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic`
+```sh
+pytest --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!"  models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic
+```
 
 To run the demo using prewritten prompts for a batch of 32 users run (currently only supports same token-length inputs):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic`
+```sh
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic
+```
 
 - **Decoding method**: The default decoding method is top-k/top-p (stochastic) sampling, however greedy decoding can also be used by replacing `stochastic` with `greedy` in the command above.
 
@@ -22,7 +26,9 @@ To run the demo using prewritten prompts for a batch of 32 users run (currently 
 
 To measure the performance of generating the `i`'th token while the KV cache is filled with `i-1` rows (where `i` is 128 in the command below):
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k perf_mode_128_stochastic`
+```sh
+pytest --disable-warnings -q -s --input-method=json --input-path='models/demos/falcon7b_common/demo/input_data.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k "perf_mode_128_stochastic and not verify"
+```
 
 - **Supported sequence lengths**: Currently `i` can only be set to 128, 1024, or 2048 for performance measurement mode.
 
@@ -30,7 +36,9 @@ To measure the performance of generating the `i`'th token while the KV cache is 
 
 A sample of input prompts for 32 users is provided in `input_data.json` in demo directory. If you wish you to run the model using a different set of input prompts you can provide a different path, e.g.:
 
-`pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic`
+```sh
+pytest --disable-warnings -q -s --input-method=json --input-path='path_to_input_prompts.json' models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k default_mode_1024_stochastic
+```
 
 ## Details
 


### PR DESCRIPTION
### Ticket
#20610

### Problem description
- The Falcon7b commands on the readme became incorrect after f39460b modified the mesh_device fixture to remove the wormhole arch

### What's changed
- Updated the Falcon7b WH/T3K/TG demo commands on the readmes

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes