### PR TITLE
Update to relative device perf targets

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -26,177 +26,264 @@ DECODE_OP_END_INDEX = -11
 perf_targets = {
     "RMSAllGather_0": {
         "op_name": "PreRMS_0",
-        "kernel_duration": 10670.763888888889,
+        "kernel_duration": 10649.359953703704,
         "op_to_op": 657.6666666666666,
         "non-overlapped-dispatch-time": 7260,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "RMSAllGather_1": {
         "op_name": "PostRMS_0",
-        "kernel_duration": 6131.541666666667,
+        "kernel_duration": 6327.008101851851,
         "op_to_op": 634.3333333333334,
         "non-overlapped-dispatch-time": 6190.6,
+        "kernel_duration_relative_margin": 0.02,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "RMSAllGather_2": {
         "op_name": "PreRMS_1",
-        "kernel_duration": 10528.003472222223,
+        "kernel_duration": 10564.168981481482,
         "op_to_op": 661.4444444444445,
         "non-overlapped-dispatch-time": 7326,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "RMSAllGather_3": {
         "op_name": "PostRMS_1",
-        "kernel_duration": 6083.21875,
+        "kernel_duration": 6091.445601851851,
         "op_to_op": 641.0,
         "non-overlapped-dispatch-time": 6431.2,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "AllGatherAsync_0": {
         "op_name": "AllGatherAsync_SDPA_0",
-        "kernel_duration": 11155.885416666666,
+        "kernel_duration": 11153.511574074075,
         "op_to_op": 676.4444444444445,
         "non-overlapped-dispatch-time": 2273.2,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "AllGatherAsync_1": {
         "op_name": "AllGatherAsync_Binary_Mult",
-        "kernel_duration": 9363.694444444445,
-        "op_to_op": 1698.7777777777778,
+        "kernel_duration": 9631.332175925925,
+        "op_to_op": 796.5555555555555,
         "non-overlapped-dispatch-time": 4351.1,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "ShardedToInterleavedDeviceOperation_0": {
         "op_name": "ShardedToInterleavedDeviceOperation_LN_0",
-        "kernel_duration": 4017.222222222222,
+        "kernel_duration": 4027.444444444445,
         "op_to_op": 2211.6666666666665,
         "non-overlapped-dispatch-time": 1919.0,
+        "kernel_duration_relative_margin": 0.03,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "ShardedToInterleavedDeviceOperation_1": {
         "op_name": "ShardedToInterleavedDeviceOperation_LN_1",
-        "kernel_duration": 3417.4444444444443,
+        "kernel_duration": 3443.111111111111,
         "op_to_op": 2212.222222222222,
         "non-overlapped-dispatch-time": 1910.2,
+        "kernel_duration_relative_margin": 0.03,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "InterleavedToShardedDeviceOperation_0": {
         "op_name": "InterleavedToShardedDeviceOperation_LN_0",
-        "kernel_duration": 2935.4444444444443,
+        "kernel_duration": 2509.555555555555,
         "op_to_op": 631.8888888888889,
         "non-overlapped-dispatch-time": 10347.3,
+        "kernel_duration_relative_margin": 0.02,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "InterleavedToShardedDeviceOperation_1": {
         "op_name": "InterleavedToShardedDeviceOperation_LN_1",
-        "kernel_duration": 2048.222222222222,
+        "kernel_duration": 2077.8888888888887,
         "op_to_op": 637.7777777777778,
         "non-overlapped-dispatch-time": 10736.0,
+        "kernel_duration_relative_margin": 0.06,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "ReshardDeviceOperation_0": {
         "op_name": "ReshardDeviceOperation_LN_0",
-        "kernel_duration": 2272.6666666666665,
+        "kernel_duration": 2003.7777777777776,
         "op_to_op": 655.2222222222222,
         "non-overlapped-dispatch-time": 10074.9,
+        "kernel_duration_relative_margin": 0.05,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_0": {
         "op_name": "QKV_MM",
-        "kernel_duration": 10530.555555555555,
+        "kernel_duration": 11233.851851851852,
         "op_to_op": 610.7777777777778,
         "non-overlapped-dispatch-time": 6102.0,
+        "kernel_duration_relative_margin": 0.03,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_1": {
         "op_name": "DO_MM",
-        "kernel_duration": 8689.888888888889,
+        "kernel_duration": 9392.111111111111,
         "op_to_op": 653.3333333333334,
         "non-overlapped-dispatch-time": 5641.0,
+        "kernel_duration_relative_margin": 0.03,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_2": {
         "op_name": "FF1_MM",
-        "kernel_duration": 10620.333333333334,
+        "kernel_duration": 10572.666666666666,
         "op_to_op": 630.4444444444445,
         "non-overlapped-dispatch-time": 6109.0,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_3": {
         "op_name": "FF3_MM",
-        "kernel_duration": 10802.0,
-        "op_to_op": 737.5555555555555,
+        "kernel_duration": 10356.037037037036,
+        "op_to_op": 610.6666666666666,
         "non-overlapped-dispatch-time": 6144.8,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_4": {
         "op_name": "FF2_MM",
-        "kernel_duration": 16997.444444444445,
+        "kernel_duration": 20528.0,
         "op_to_op": 658.7777777777778,
         "non-overlapped-dispatch-time": 6029.3,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "AllReduceAsync_0": {
         "op_name": "AllReduceAsync_QKV",
-        "kernel_duration": 11032.798611111111,
+        "kernel_duration": 11112.310185185184,
         "op_to_op": 609.0,
         "non-overlapped-dispatch-time": 7349.4,
+        "kernel_duration_relative_margin": 0.03,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "AllReduceAsync_1": {
         "op_name": "AllReduceAsync_DO",
-        "kernel_duration": 19969.913194444445,
+        "kernel_duration": 19827.862268518522,
         "op_to_op": 626.5555555555555,
         "non-overlapped-dispatch-time": 8510.2,
+        "kernel_duration_relative_margin": 0.03,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "AllReduceAsync_2": {
         "op_name": "AllReduceAsync_FF2",
-        "kernel_duration": 20541.538194444445,
+        "kernel_duration": 20396.775462962964,
         "op_to_op": 637.1111111111111,
         "non-overlapped-dispatch-time": 6475.9,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "LlamaReduceScatterDeviceOperation_0": {
         "op_name": "ReduceScatter_FF1",
-        "kernel_duration": 10375.6875,
+        "kernel_duration": 9231.877314814816,
         "op_to_op": 708.1111111111111,
         "non-overlapped-dispatch-time": 8058.9,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "LlamaReduceScatterDeviceOperation_1": {
         "op_name": "ReduceScatter_FF3",
-        "kernel_duration": 10473.902777777777,
-        "op_to_op": 736.1111111111111,
+        "kernel_duration": 8987.451388888889,
+        "op_to_op": 655.1111111111111,
         "non-overlapped-dispatch-time": 7359.9,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "NLPCreateHeadsDecodeDeviceOperation_0": {
         "op_name": "CreateHeads",
-        "kernel_duration": 8238.0,
+        "kernel_duration": 8205.185185185184,
         "op_to_op": 761.1111111111111,
         "non-overlapped-dispatch-time": 8156.7,
+        "kernel_duration_relative_margin": 0.03,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "RotaryEmbeddingLlamaFusedQK_0": {
         "op_name": "RotaryEmbeddingLlamaFusedQK",
-        "kernel_duration": 5026.777777777777,
+        "kernel_duration": 5030.0370370370365,
         "op_to_op": 540.7777777777778,
         "non-overlapped-dispatch-time": 2844.3,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "PagedUpdateCacheDeviceOperation_0": {
         "op_name": "PagedUpdateCache",
-        "kernel_duration": 6057.777777777777,
+        "kernel_duration": 6939.111111111112,
         "op_to_op": 773.8888888888889,
         "non-overlapped-dispatch-time": 4670.5,
+        "kernel_duration_relative_margin": 0.06,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "ScaledDotProductAttentionDecode_0": {
         "op_name": "SDPA",
-        "kernel_duration": 13967.111111111111,
+        "kernel_duration": 14709.481481481482,
         "op_to_op": 585.5555555555555,
         "non-overlapped-dispatch-time": 9741.5,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "NLPConcatHeadsDecodeDeviceOperation_0": {
         "op_name": "ConcatHeads",
-        "kernel_duration": 6599.888888888889,
+        "kernel_duration": 6635.222222222223,
         "op_to_op": 620.5555555555555,
         "non-overlapped-dispatch-time": 3463.5,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "BinaryDeviceOperation_0": {
         "op_name": "Binary_Residual_0",
-        "kernel_duration": 2404.3333333333335,
+        "kernel_duration": 2405.0,
         "op_to_op": 653.6666666666666,
         "non-overlapped-dispatch-time": 5907.6,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "BinaryDeviceOperation_1": {
         "op_name": "Binary_Mult_Silu",
-        "kernel_duration": 4111.666666666667,
+        "kernel_duration": 4106.222222222222,
         "op_to_op": 661.0,
         "non-overlapped-dispatch-time": 6111.2,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.1,
     },
     "BinaryDeviceOperation_2": {
         "op_name": "Binary_Residual_1",
-        "kernel_duration": 2414.777777777778,
+        "kernel_duration": 2423.222222222222,
         "op_to_op": 647.7777777777778,
         "non-overlapped-dispatch-time": 6751.9,
+        "kernel_duration_relative_margin": 0.01,
+        "op_to_op_duration_relative_margin": 0.1,
+        "dispatch_duration_relative_margin": 0.1,
     },
 }
 
@@ -431,30 +518,6 @@ def print_dict(input_dict, dict_name):
     print("}")
 
 
-@pytest.mark.parametrize(
-    "abs_tolerance_ns",
-    (2200,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_all_reduce",
-    (3000,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_reduce_scatter",
-    (2000,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_all_gather",
-    (1700,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_sdpa",
-    (3000,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_op_to_op",
-    (800,),
-)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
 # Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
@@ -466,12 +529,6 @@ def print_dict(input_dict, dict_name):
 # Run at least once again to verify the new expected values are correct and margins hold
 def test_llama_TG_perf_device(
     reset_seeds,
-    abs_tolerance_ns,
-    abs_tolerance_ns_all_reduce,
-    abs_tolerance_ns_reduce_scatter,
-    abs_tolerance_ns_all_gather,
-    abs_tolerance_ns_sdpa,
-    abs_tolerance_ns_op_to_op,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
@@ -540,7 +597,6 @@ def test_llama_TG_perf_device(
     passing = True
     for op_code_with_id, avg_kernel_duration in kernel_duration_per_instance_averaged_dict.items():
         if op_code_with_id in perf_targets:
-            expected_time = perf_targets[op_code_with_id]["kernel_duration"]
             op_name = perf_targets[op_code_with_id]["op_name"]
             avg_dispatch_duration = dispatch_duration_per_instance_averaged_dict[op_code_with_id]
             # average
@@ -572,37 +628,66 @@ def test_llama_TG_perf_device(
             )
 
             # Verify kernel duration is within tolerance
-            if "AllReduceAsync" in op_code_with_id:
-                tolerance = abs_tolerance_ns_all_reduce
-            elif "LlamaReduceScatterDeviceOperation" in op_code_with_id:
-                tolerance = abs_tolerance_ns_reduce_scatter
-            elif "AllGatherAsync" in op_code_with_id:
-                tolerance = abs_tolerance_ns_all_gather
-            elif "ScaledDotProductAttentionDecode" in op_code_with_id:
-                tolerance = abs_tolerance_ns_sdpa
-            else:
-                tolerance = abs_tolerance_ns
-            if avg_kernel_duration > expected_time + tolerance:
+            upper_limit = (
+                perf_targets[op_code_with_id]["kernel_duration"]
+                + perf_targets[op_code_with_id]["kernel_duration_relative_margin"]
+                * perf_targets[op_code_with_id]["kernel_duration"]
+            )
+            lower_limit = (
+                perf_targets[op_code_with_id]["kernel_duration"]
+                - perf_targets[op_code_with_id]["kernel_duration_relative_margin"]
+                * perf_targets[op_code_with_id]["kernel_duration"]
+            )
+            if avg_kernel_duration > upper_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id} kernel: {avg_kernel_duration} ns larger than expected {expected_time} ns by {abs(avg_kernel_duration - expected_time)} ns (tolerance {tolerance} ns)"
+                    f"{op_code_with_id} kernel: {avg_kernel_duration} ns is larger than target "
+                    f"({perf_targets[op_code_with_id]['kernel_duration']}) ns, difference: "
+                    f"{abs(avg_kernel_duration - upper_limit)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['kernel_duration_relative_margin']} ns, "
+                    f"relative margin to pass would be: "
+                    f"{abs(perf_targets[op_code_with_id]['kernel_duration'] - avg_kernel_duration) / perf_targets[op_code_with_id]['kernel_duration']}"
                 )
-            elif avg_kernel_duration < expected_time - tolerance:
+            elif avg_kernel_duration < lower_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id} kernel: {avg_kernel_duration} ns smaller than expected {expected_time} ns by {abs(expected_time - avg_kernel_duration)} ns (tolerance {tolerance} ns)"
+                    f"{op_code_with_id} kernel: {avg_kernel_duration} ns is smaller than target "
+                    f"({perf_targets[op_code_with_id]['kernel_duration']}) ns, difference: "
+                    f"{abs(lower_limit - avg_kernel_duration)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['kernel_duration_relative_margin']} ns, "
+                    f"relative margin to pass would be: "
+                    f"{abs(perf_targets[op_code_with_id]['kernel_duration'] - avg_kernel_duration) / perf_targets[op_code_with_id]['kernel_duration']}"
                 )
             # Verify op_to_op latency is within tolerance
-            expected_time = perf_targets[op_code_with_id]["op_to_op"]
-            if avg_dispatch_duration > expected_time + abs_tolerance_ns_op_to_op:
+            upper_limit = (
+                perf_targets[op_code_with_id]["op_to_op"]
+                + perf_targets[op_code_with_id]["op_to_op_duration_relative_margin"]
+                * perf_targets[op_code_with_id]["op_to_op"]
+            )
+            lower_limit = (
+                perf_targets[op_code_with_id]["op_to_op"]
+                - perf_targets[op_code_with_id]["op_to_op_duration_relative_margin"]
+                * perf_targets[op_code_with_id]["op_to_op"]
+            )
+            if avg_dispatch_duration > upper_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id} dispatch: {avg_dispatch_duration} ns larger than expected {expected_time} ns by {abs(avg_dispatch_duration - expected_time)} ns (tolerance {abs_tolerance_ns_op_to_op} ns)"
+                    f"{op_code_with_id} op_to_op: {avg_dispatch_duration} ns is larger than target "
+                    f"({perf_targets[op_code_with_id]['op_to_op']}) ns, difference: "
+                    f"{abs(avg_dispatch_duration - upper_limit)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['op_to_op_duration_relative_margin']} ns, "
+                    f"relative margin to pass would be: "
+                    f"{abs(perf_targets[op_code_with_id]['op_to_op'] - avg_dispatch_duration) / perf_targets[op_code_with_id]['op_to_op']}"
                 )
-            elif avg_dispatch_duration < expected_time - abs_tolerance_ns_op_to_op:
+            elif avg_dispatch_duration < lower_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id} dispatch: {avg_dispatch_duration} ns smaller than expected {expected_time} ns by {abs(expected_time - avg_dispatch_duration)} ns (tolerance {abs_tolerance_ns_op_to_op} ns)"
+                    f"{op_code_with_id} op_to_op: {avg_dispatch_duration} ns is smaller than target "
+                    f"({perf_targets[op_code_with_id]['op_to_op']}) ns, difference: "
+                    f"{abs(lower_limit - avg_dispatch_duration)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['op_to_op_duration_relative_margin']} ns, "
+                    f"relative margin to pass would be: "
+                    f"{abs(perf_targets[op_code_with_id]['op_to_op'] - avg_dispatch_duration) / perf_targets[op_code_with_id]['op_to_op']}"
                 )
 
         else:
@@ -636,26 +721,6 @@ def test_llama_TG_perf_device(
     assert passing
 
 
-@pytest.mark.parametrize(
-    "abs_tolerance_ns",
-    (1500,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_all_reduce",
-    (1500,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_reduce_scatter",
-    (1500,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_all_gather",
-    (1500,),
-)
-@pytest.mark.parametrize(
-    "abs_tolerance_ns_sdpa",
-    (2000,),
-)
 @pytest.mark.models_device_performance_bare_metal
 # To update:
 # Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
@@ -667,11 +732,6 @@ def test_llama_TG_perf_device(
 # Run at least once again to verify the new expected values are correct and margins hold
 def test_llama_TG_perf_device_non_overlapped_dispatch(
     reset_seeds,
-    abs_tolerance_ns,
-    abs_tolerance_ns_all_reduce,
-    abs_tolerance_ns_reduce_scatter,
-    abs_tolerance_ns_all_gather,
-    abs_tolerance_ns_sdpa,
 ):
     profiler = BenchmarkProfiler()
     benchmark_data = BenchmarkData()
@@ -740,25 +800,33 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
                 dispatch_duration_per_instance_max_dict[op_code_with_id],
             )
 
-            if "AllReduceAsync" in op_code_with_id:
-                tolerance = abs_tolerance_ns_all_reduce
-            elif "LlamaReduceScatterDeviceOperation" in op_code_with_id:
-                tolerance = abs_tolerance_ns_reduce_scatter
-            elif "AllGatherAsync" in op_code_with_id:
-                tolerance = abs_tolerance_ns_all_gather
-            elif "ScaledDotProductAttentionDecode" in op_code_with_id:
-                tolerance = abs_tolerance_ns_sdpa
-            else:
-                tolerance = abs_tolerance_ns
-            if avg_dispatch_duration > expected_time + tolerance:
+            upper_limit = (
+                expected_time
+                + perf_targets[op_code_with_id]["non-overlapped-dispatch-time_duration_relative_margin"] * expected_time
+            )
+            lower_limit = (
+                expected_time
+                - perf_targets[op_code_with_id]["non-overlapped-dispatch-time_duration_relative_margin"] * expected_time
+            )
+            if avg_dispatch_duration > upper_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id}: {avg_dispatch_duration} ns larger than expected {expected_time} ns by {abs(avg_dispatch_duration - expected_time)} ns (tolerance {tolerance} ns)"
+                    f"{op_code_with_id} op_to_op: {avg_dispatch_duration} ns is larger than target "
+                    f"({expected_time}) ns, difference: "
+                    f"{abs(avg_dispatch_duration - upper_limit)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['non-overlapped-dispatch-time_duration_relative_margin']} ns, "
+                    f"relative margin to pass would be: "
+                    f"{abs(expected_time - avg_dispatch_duration) / expected_time}"
                 )
-            elif avg_dispatch_duration < expected_time - tolerance:
+            elif avg_dispatch_duration < lower_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id}: {avg_dispatch_duration} ns smaller than expected {expected_time} ns by {abs(expected_time - avg_dispatch_duration)} ns (tolerance {tolerance} ns)"
+                    f"{op_code_with_id} op_to_op: {avg_dispatch_duration} ns is smaller than target "
+                    f"({expected_time}) ns, difference: "
+                    f"{abs(lower_limit - avg_dispatch_duration)} ns, margin: "
+                    f"{perf_targets[op_code_with_id]['non-overlapped-dispatch-time_duration_relative_margin']} ns, "
+                    f"relative margin to pass would be: "
+                    f"{abs(expected_time - avg_dispatch_duration) / expected_time}"
                 )
         else:
             passing = False


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently we are using targets with absolute margins for device perf tests, this leads to flaky CI tests and false positive failures.

### What's changed
Added relative target margins based on expected value: abs(max-min) / expected_target and rounded up.

Not running CI since everything is backlogged and no ops / model changes.

@avoraTT @yugaoTT  matmul targets are increased by 500 us -4000 us compared to before in order to make the test pass. You'll need to update the targets for the prefetcher fixes.