### PR TITLE
#19201: add missing barrier and flushed in sdpa decode and adjust brisc stack size

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -118,7 +118,7 @@
 /////////////
 // Stack info
 // Increasing the stack size comes at the expense of less local memory for globals
-#define MEM_BRISC_STACK_SIZE 768
+#define MEM_BRISC_STACK_SIZE 896
 #define MEM_NCRISC_STACK_SIZE 1040
 #define MEM_TRISC0_STACK_SIZE 640
 #define MEM_TRISC1_STACK_SIZE 512

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -129,6 +129,7 @@ void kernel_main() {
                                           // should not be more than one head per core
         worker_compute<out_chunk_tiles, cb_out_worker, cb_out_m, cb_out_l, cb_intermed_out, PNHt>(
             in0_sender_semaphore_noc_addr, worker_id_for_reduce, reduce_core_noc_x, reduce_core_noc_y);
+        noc_async_atomic_barrier();
         return;
     }
 
@@ -199,6 +200,7 @@ void kernel_main() {
         // Write entire out into its corresponding batch
         uint32_t out_tile_id = out_batch_offset;
         cb_wait_front(cb_out, out_chunk_tiles);
+        noc_async_writes_flushed();
 
         if constexpr (num_kv_heads > 1) {
             // if gqa, we will need to write partial outputs for each head


### PR DESCRIPTION
### Ticket
Link to Github Issue #19201 

### Problem description
- llama-3-8B demo hangs on BH

### What's changed
- the brisc stack is increased by 128 since there is a stack overflow (caught by watcher)
- add in a missing noc_async_atomic_barrier() call (caught by watcher)
- add in a noc_async_writes_flushed() call in between two noc_semaphore_wait() calls. This had to be done earlier in matmul.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14455565919
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A main was broken and all the local testing for this PR was done on BH 
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14455730668 passes except for hugging issue which is on main
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14455732221
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14455721188/job/40539214275 everything green except for other N300 WH B0 which fails in the same as main https://github.com/tenstorrent/tt-metal/actions/runs/14457422279/job/40543780681 with not being able to reach hugging face
- [x] New/Existing tests provide coverage for changes

Testing:
Verified that
```
export max_seq_len=131072

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json" --max_seq_len $max_seq_len

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_256.json" --max_seq_len $max_seq_len

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_long_1k.json" --max_seq_len $max_seq_len

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_long_2k.json" --max_seq_len $max_seq_len

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_long_4k.json" --max_seq_len $max_seq_len

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_long_8k.json" --max_seq_len $max_seq_len

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json" --max_seq_len $max_seq_len
failed with div by 0?? rerunning

LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_long_32k.json" --max_seq_len $max_seq_len
```

did not hang by default (q_chunk_size == k_chunk_size == 128) and modified (q_chunk_size == k_chunk_size == 256)

Nothing hung. Everything passed, except for
```
LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-batch-1" --input_prompts "models/tt_transformers/demo/sample_prompts/input_data_long_16k.json" --max_seq_len $max_seq_len
```
with q_chunk_size == k_chunk_size == 256, which failed in post processing due to a division by zero.