### PR TITLE
Fix device perf test

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -496,16 +496,6 @@ def run_llama3_demo(
         if iteration >= max_generated_tokens:
             users_decoding = False
 
-    if not stress_test:
-        # print before assertion
-        out_of_targets_msg = f"Throughput is out of targets {tsu_thresholds['min']} - {tsu_thresholds['max']} t/s/u in {tsu_failures} iterations"
-        logger.info(out_of_targets_msg)
-        # Assert at the end of test to check if the throughput recuperated
-        assert tsu_failures <= TSU_PERF_DROP_LIMIT_COUNT, out_of_targets_msg
-
-    # Print out total number of tsu_failures
-    logger.info(f"Total TSU Failures: {tsu_failures} (threshold: {TSU_PERF_DROP_LIMIT_COUNT})")
-
     # Release trace
     ttnn.release_trace(mesh_device, trace_id)
 
@@ -521,6 +511,16 @@ def run_llama3_demo(
             run_type=f"tg-llama-demo-e2e",
             ml_model_name="tg-llama",
         )
+
+    if not stress_test:
+        # print before assertion
+        out_of_targets_msg = f"Throughput is out of targets {tsu_thresholds['min']} - {tsu_thresholds['max']} t/s/u in {tsu_failures} iterations"
+        logger.info(out_of_targets_msg)
+        # Assert at the end of test to check if the throughput recuperated
+        assert tsu_failures <= TSU_PERF_DROP_LIMIT_COUNT, out_of_targets_msg
+
+    # Print out total number of tsu_failures
+    logger.info(f"Total TSU Failures: {tsu_failures} (threshold: {TSU_PERF_DROP_LIMIT_COUNT})")
 
 
 # List of supported Parameters for demo.py

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -399,7 +399,7 @@ def run_llama3_demo(
     users_decoding = True  # reset to handle next batch
     total_decoding_time = 0  # Track total decoding time
     total_tokens_generated = 0  # Track total tokens generated
-    tokens_per_second_per_user_token127 = 0  # Track tokens per second per user at token 128
+    tokens_per_second_per_user_token127 = None  # Track tokens per second per user at token 128
 
     all_outputs = []
 
@@ -503,7 +503,7 @@ def run_llama3_demo(
     profiler.end(profiler_step_name)
     profiler.end("run")
 
-    if is_ci_env:
+    if is_ci_env and tokens_per_second_per_user_token127 is not None:
         benchmark_data.add_measurement(profiler, 0, profiler_step_name, "tsu_e2e", tokens_per_second_per_user_token127)
 
         benchmark_data.save_partial_run_json(

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -16,7 +16,7 @@ THRESHOLD = 0.4
     [
         ("sdpa", 15, 12.9),
         ("binary_mult", 15, 12.54),
-        ("layernorm", 15, 4.87),
+        ("layernorm", 15, 5.4),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
### Ticket
None

### Problem description
Multiple issues for device perf test and uploading e2e perf to superset.

### What's changed
- Fixed device perf test: num tail heads increased to 12 (plus one was added), updated targets, improved logging for easier debug
- Updated AG layernorm target to 5.5 us (before 4.7 us, but test on CI never was that fast)
- Moved decode demo assert to the back so that e2e perf is sent to superset independent of test pass/failure in case the tok/s/u for tok=127 is known

Ran all tests locally, but skipping CI since no model change was done.