### PR TITLE
#20696: WS ttnn.conv2d runtime arg override fix

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -3205,3 +3205,79 @@ def test_conv2d_vae_sdxl(
             output_mesh_composer=None,
             enable_split_reader=enable_split_reader,
         )
+
+
+@pytest.mark.parametrize(
+    "batch, input_channels, output_channels, input_height, input_width, weights_dtype, activations_dtype, groups, kernel, stride, padding, dilation, auto_shard, use_shallow_conv_variant, act_block_h_override, act_block_w_div, deallocate_activation, math_fidelity, fp32_accum, packer_l1_acc, enable_split_reader",
+    (
+        (1, 1920, 1280, 32, 32, ttnn.bfloat8_b, ttnn.bfloat16, 1, (3, 3), (1, 1), (1, 1), (1, 1), True, False,  0, 1, False, ttnn.MathFidelity.LoFi, False, False, False),
+    ),
+)
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_conv2d_ws_program_cache(
+    device,
+    torch_tensor_map,
+    batch,
+    input_channels,
+    output_channels,
+    input_height,
+    input_width,
+    weights_dtype,
+    activations_dtype,
+    groups,
+    kernel,
+    stride,
+    padding,
+    dilation,
+    auto_shard,
+    use_shallow_conv_variant,
+    act_block_h_override,
+    act_block_w_div,
+    deallocate_activation,
+    math_fidelity,
+    fp32_accum,
+    packer_l1_acc,
+    enable_split_reader,
+    use_program_cache,
+):
+
+    config_override = {}
+    config_override["act_block_h"] = act_block_h_override
+    config_override["act_block_w_div"] = act_block_w_div
+
+    run_conv(
+        device=device,
+        torch_tensor_map=torch_tensor_map,
+        math_fidelity=math_fidelity,
+        activations_dtype=activations_dtype,
+        weights_dtype=weights_dtype,
+        batch_size=batch,
+        output_channels=output_channels,
+        input_channels=input_channels,
+        input_height=input_height,
+        input_width=input_width,
+        filter_height=kernel[0],
+        filter_width=kernel[1],
+        stride_h=stride[0],
+        stride_w=stride[1],
+        padding=padding,
+        config_override=config_override,
+        dilation_h=dilation[0],
+        dilation_w=dilation[1],
+        use_shallow_conv_variant=use_shallow_conv_variant,
+        fp32_accum=fp32_accum,
+        packer_l1_acc=packer_l1_acc,
+        output_layout=ttnn.TILE_LAYOUT,
+        deallocate_activation=deallocate_activation,
+        groups=groups,
+        has_bias=True,
+        shard_layout=None,
+        auto_shard=auto_shard,
+        memory_config=None,
+        input_mesh_mapper=None,
+        weight_mesh_mapper=None,
+        output_mesh_composer=None,
+        enable_split_reader=enable_split_reader,
+        run_twice=True,
+    )

--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -14,7 +14,7 @@ import torch
 @pytest.mark.parametrize(
     "output_channels, input_channels, input_height, input_width, shard_layout, config",
     (
-        (256, 256, 8, 8, WS, None),
+        (353, 384, 8, 8, WS, None),
         (128, 128, 32, 32, BS, None),
         (16, 16, 256, 256, HS, {"act_block_h": 32}),
     ),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -919,7 +919,14 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
 
     // Capture conv_reader_indices_buffer to cache this with the program
     auto override_runtime_arguments_callback =
-        [conv_reader_indices_buffer, cb_input, cb_output, has_bias, full_core_grid, total_num_cores, weights_kernel_id](
+        [conv_reader_indices_buffer,
+         cb_input,
+         cb_output,
+         has_bias,
+         full_core_grid,
+         total_num_cores,
+         weights_kernel_id,
+         total_num_active_cores](
             const void* operation,
             tt::tt_metal::Program& program,
             const std::vector<Tensor>& input_tensors,
@@ -928,26 +935,19 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
             bool src_a_is_sharded = input_tensors[0].is_sharded();
             bool out_sharded = output_tensors[0].is_sharded();
 
-            auto input_num_cores = input_tensors[0].memory_config().shard_spec.value().grid.num_cores();
-            auto output_num_cores = output_tensors[0].memory_config().shard_spec.value().grid.num_cores();
-            auto total_num_active_cores = std::max(input_num_cores, output_num_cores);
-
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
             auto dst_buffer = output_tensors.at(0).buffer();
 
             auto weights_kernel_runtime_args = GetRuntimeArgs(program, weights_kernel_id);
-            for (uint32_t core_index = 0; core_index < total_num_cores; core_index++) {
+            for (uint32_t core_index = 0; core_index < total_num_active_cores; core_index++) {
                 uint32_t core_x = core_index % full_core_grid.x;
                 uint32_t core_y = core_index / full_core_grid.x;
 
-                if (core_index < total_num_active_cores) {
-                    auto this_core_weights_kernel_runtime_args = weights_kernel_runtime_args[core_x][core_y];
-                    this_core_weights_kernel_runtime_args[1] = src_buffer_b->address();
-                    if (has_bias) {
-                        this_core_weights_kernel_runtime_args[2] =
-                            optional_input_tensors.at(0).value().buffer()->address();
-                    }
+                auto this_core_weights_kernel_runtime_args = weights_kernel_runtime_args[core_x][core_y];
+                this_core_weights_kernel_runtime_args[1] = src_buffer_b->address();
+                if (has_bias) {
+                    this_core_weights_kernel_runtime_args[2] = optional_input_tensors.at(0).value().buffer()->address();
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -928,6 +928,10 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
             bool src_a_is_sharded = input_tensors[0].is_sharded();
             bool out_sharded = output_tensors[0].is_sharded();
 
+            auto input_num_cores = input_tensors[0].memory_config().shard_spec.value().grid.num_cores();
+            auto output_num_cores = output_tensors[0].memory_config().shard_spec.value().grid.num_cores();
+            auto total_num_active_cores = std::max(input_num_cores, output_num_cores);
+
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
             auto dst_buffer = output_tensors.at(0).buffer();
@@ -937,10 +941,13 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
                 uint32_t core_x = core_index % full_core_grid.x;
                 uint32_t core_y = core_index / full_core_grid.x;
 
-                auto this_core_weights_kernel_runtime_args = weights_kernel_runtime_args[core_x][core_y];
-                this_core_weights_kernel_runtime_args[1] = src_buffer_b->address();
-                if (has_bias) {
-                    this_core_weights_kernel_runtime_args[2] = optional_input_tensors.at(0).value().buffer()->address();
+                if (core_index < total_num_active_cores) {
+                    auto this_core_weights_kernel_runtime_args = weights_kernel_runtime_args[core_x][core_y];
+                    this_core_weights_kernel_runtime_args[1] = src_buffer_b->address();
+                    if (has_bias) {
+                        this_core_weights_kernel_runtime_args[2] =
+                            optional_input_tensors.at(0).value().buffer()->address();
+                    }
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -919,14 +919,7 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_optimized_conv_width_sh
 
     // Capture conv_reader_indices_buffer to cache this with the program
     auto override_runtime_arguments_callback =
-        [conv_reader_indices_buffer,
-         cb_input,
-         cb_output,
-         has_bias,
-         full_core_grid,
-         total_num_cores,
-         weights_kernel_id,
-         total_num_active_cores](
+        [cb_input, cb_output, has_bias, full_core_grid, weights_kernel_id, total_num_active_cores](
             const void* operation,
             tt::tt_metal::Program& program,
             const std::vector<Tensor>& input_tensors,


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-metal/issues/20696)

### Problem description
Runtime args were specified for active cores only, but later overwritten for each of the cores resulting in error from the issue.

### What's changed
Overwriting of the runtime args is done for active cores only.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14473957673) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14473933795) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14473966404) CI passes (test fail same as main)