### PR TITLE
#20407: SFPI execution test harness

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,9 +52,8 @@ tt_metal/distributed/**/CMakeLists.txt @cfjchu @aliuTT @tt-asaigal @omilyutin-tt
 tests/tt_metal/distributed/ @cfjchu @tt-asaigal @omilyutin-tt
 tests/tt_metal/distributed/**/CMakeLists.txt @cfjchu @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra
 
-# metal - fw, llks, risc-v
+# metal - fw, llks
 tt_metal/hw/ckernels/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
-tt_metal/hw/cmake/sfpi-version.cmake @nathan-TT
 tt_metal/hw/firmware/src/*erisc* @aliuTT @ubcheema
 tt_metal/hw/inc/ethernet/ @aliuTT @ubcheema
 tt_metal/hw/inc/wormhole/eth_l1_address_map.h @aliuTT @ubcheema
@@ -62,6 +61,11 @@ tt_metal/include/compute_kernel_api.h @davorchap @rtawfik01 @rdjogoTT @ttmtrajko
 tt_metal/include/compute_kernel_api/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
 tt_metal/third_party/tt_llk @rtawfik01 @ttmtrajkovic @rdjogoTT @nvelickovicTT
 tests/tt_metal/tt_metal/data_movement @rtawfik01 @vvukomanovicTT @atatuzunerTT
+
+# sfpi
+tt_metal/hw/cmake/sfpi-version.cmake @nathan-TT
+tests/tt_metal/tt_metal/sfpi/ @nathan-TT
+tests/tt_metal/tt_metal/test_kernels/sfpi/ @nathan-TT
 
 # metal - profiler
 tt_metal/**/profiler/ @mo-tenstorrent

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -44,6 +44,7 @@ jobs:
           {name: dispatch, cmd: "./build/test/tt_metal/unit_tests_dispatch"},
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth"},
           {name: llk, cmd: "./build/test/tt_metal/unit_tests_llk"},
+          {name: sfpi, cmd: "./build/test/tt_metal/unit_tests_sfpi"},
           {name: stl, cmd: "./build/test/tt_metal/unit_tests_stl"},
           {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }} --gtest_filter=MeshDeviceSuite.*"},
           {name: FD2, cmd: ./tests/scripts/run_cpp_fd2_tests.sh},

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -44,6 +44,7 @@ jobs:
           {name: device, cmd: "./build/test/tt_metal/unit_tests_device"},
           {name: dispatch, cmd: "./build/test/tt_metal/unit_tests_dispatch"},
           {name: eth, cmd: "./build/test/tt_metal/unit_tests_eth"},
+          {name: sfpi, cmd: "./build/test/tt_metal/unit_tests_sfpi"},
           {name: stl, cmd: "./build/test/tt_metal/unit_tests_stl"},
           {name: distributed, cmd: "./build/test/tt_metal/distributed/distributed_unit_tests_${{ inputs.arch }}"},
           {name: lightmetal, cmd: "./build/test/tt_metal/unit_tests_lightmetal"},

--- a/tests/tt_metal/tt_metal/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/CMakeLists.txt
@@ -73,6 +73,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/benchmark)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/stl)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/noc)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/lightmetal)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/sfpi)
 
 add_custom_target(
     metal_tests
@@ -91,6 +92,7 @@ add_custom_target(
         unit_tests_stl
         unit_tests_noc
         unit_tests_lightmetal
+        unit_tests_sfpi
 )
 
 add_library(metalium_test_files INTERFACE)

--- a/tests/tt_metal/tt_metal/sfpi/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/sfpi/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_executable(unit_tests_sfpi)
+set_target_properties(
+    unit_tests_sfpi
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)
+
+target_sources(unit_tests_sfpi PRIVATE test_sfpi.cpp)
+target_include_directories(
+    unit_tests_sfpi
+    BEFORE
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
+target_link_libraries(unit_tests_sfpi PRIVATE test_metal_common_libs)

--- a/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
+++ b/tests/tt_metal/tt_metal/sfpi/test_sfpi.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Driver to execute sfpi execution tests.
+
+#include "command_queue_fixture.hpp"
+
+#include <tt-metalium/allocator.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel.hpp>
+#include <tt-metalium/kernel_types.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// We recursively scan this directory for kernels named '*.cpp'.
+constexpr std::string_view KernelDir = "tests/tt_metal/tt_metal/test_kernels/sfpi";
+
+bool runTest(tt::tt_metal::IDevice* device, const CoreCoord& coord, const std::string& path, unsigned baseLen) {
+    uint32_t args_addr = device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+
+    std::vector<uint32_t> compile_args{args_addr};
+
+    auto program(tt::tt_metal::CreateProgram());
+    auto kernel = CreateKernel(
+        program,
+        path,
+        coord,
+        tt::tt_metal::ComputeConfig{
+            .compile_args = compile_args,
+        });
+    EnqueueProgram(device->command_queue(), program, false);
+    Finish(device->command_queue());
+
+    tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+    auto noc_xy = device->worker_core_from_logical_core(coord);
+    unsigned expected = 0;
+    // If path ends in -[digits], extract the expected value
+    // If we need more sofphisticate tuning, we should add tags to the
+    // body of the file itself.
+    auto pos = path.find_last_of('.');
+    while (--pos && path[pos] >= '0' && path[pos] <= '9') {
+        continue;
+    }
+    if (path[pos] == '-') {
+        while (path[++pos] != '.') {
+            expected = expected * 10 + (path[pos] - '0');
+        }
+        expected |= 0x4000;
+    }
+    std::vector<uint32_t> args = tt::llrt::read_hex_vec_from_core(device->id(), noc_xy, args_addr, sizeof(uint32_t));
+    unsigned result = args[0];
+    bool pass = result == expected;
+    if (pass) {
+        std::printf("%s: PASSED\n", path.c_str() + baseLen);
+    } else if (expected || (result & 0xc000) != 0x4000) {
+        std::printf("%s: FAILED result %#x\n", path.c_str() + baseLen, result);
+    } else {
+        unsigned line = result & 0x3fff;
+        std::printf("%s: FAILED line %u\n", path.c_str() + baseLen, line);
+    }
+    return pass;
+}
+
+bool runTests(
+    tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord coord, std::string& path, unsigned baseLen) {
+    bool pass = true;
+    std::vector<std::string> files;
+    std::vector<std::string> dirs;
+
+    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+        if (entry.is_directory()) {
+            dirs.push_back(entry.path().filename());
+        } else if (entry.path().filename().extension() == ".cpp") {
+            files.push_back(entry.path().filename());
+        }
+    }
+    std::sort(files.begin(), files.end());
+    std::sort(dirs.begin(), dirs.end());
+
+    path.push_back('/');
+    for (const auto& file : files) {
+        path.append(file);
+        pass &= runTest(device, coord, path, baseLen);
+        path.erase(path.size() - file.size());
+    }
+
+    for (const auto& dir : dirs) {
+        path.append(dir);
+        pass &= runTests(device, coord, path, baseLen);
+        path.erase(path.size() - dir.size());
+    }
+    path.pop_back();
+
+    return pass;
+}
+
+ bool runTestsuite(tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord coord) {
+    std::string path;
+    if (auto* var = std::getenv("TT_METAL_HOME")) {
+        path.append(var);
+        if (!path.empty()) {
+            path.push_back('/');
+        }
+    }
+    path.append(KernelDir);
+    return runTests(device, coord, path, path.find_last_of('/') + 1);
+}
+
+using tt::tt_metal::CommandQueueSingleCardProgramFixture;
+
+TEST_F(CommandQueueSingleCardProgramFixture, TensixSFPI) {
+    CoreCoord core{0, 0};
+    for (auto* device : devices_) {
+        EXPECT_TRUE(runTestsuite(device, core));
+    }
+}
+
+}

--- a/tests/tt_metal/tt_metal/test_kernels/sfpi/00-self-16.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/sfpi/00-self-16.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ckernel.h"
+#include "compute_kernel_api.h"
+#include <sfpi.h>
+
+using namespace sfpi;
+namespace NAMESPACE {
+void MAIN {
+#if COMPILE_FOR_TRISC == 1  // compute
+#include "pre.inc"
+    FAIL_IF(vInt(1) != vInt(1));
+
+    FAIL_IF(vInt(2) != vInt(1));  // This one, line 16
+
+    FAIL_IF(vInt(3) != vInt(1));  // not this one
+#include "post.inc"
+#endif
+}
+}  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/sfpi/01-int-representation.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/sfpi/01-int-representation.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ckernel.h"
+#include "compute_kernel_api.h"
+#include <sfpi.h>
+
+using namespace sfpi;
+namespace NAMESPACE {
+void MAIN {
+#if COMPILE_FOR_TRISC == 1  // compute
+#include "pre.inc"
+
+    {  // Test -1 is all ones
+        vInt minusOne = -1;
+
+        vUInt allOnes = vUInt(0xffff) | vUInt(0xffff) << 16;
+        vUInt not2sComp = minusOne ^ allOnes;
+        // not2sComp should be all bits zero
+        FAIL_IF(not2sComp != 0);
+
+        vUInt signOne = vUInt(1) | vUInt(0x8000) << 16;
+        vUInt notSignMag = minusOne ^ signOne;
+        FAIL_IF(notSignMag == 0);
+    }
+
+    {  // test loading 0x80000001 loads as expected
+        vUInt value = vUInt(1) | vUInt(0x8000) << 16;
+
+        vUInt signOne = setsgn(vUInt(1), 1);
+
+        vUInt notCorrect = value ^ signOne;
+        FAIL_IF(notCorrect != 0);
+    }
+
+    {  // test 0 - 1 in registers results in all ones.
+        vInt zero = 0;
+        vInt one = 1;
+        vInt sub = zero - one;
+
+        vUInt allOnes = vUInt(0xffff) | vUInt(0xffff) << 16;
+        vUInt not2sComp = sub ^ allOnes;
+        // not2sComp should be all bits zero
+        FAIL_IF(not2sComp != 0);
+
+        vUInt signOne = vUInt(1) | vUInt(0x8000) << 16;
+        vUInt notSignMag = sub ^ signOne;
+        // notSignMag will be zero, if sign-mag
+        FAIL_IF(notSignMag == 0);
+    }
+
+    {  // test 0 + -1 in registers results in all ones.
+        vInt zero = 0;
+        vInt minusOne = -1;
+        vInt sub = zero + minusOne;
+
+        vUInt allOnes = vUInt(0xffff) | vUInt(0xffff) << 16;
+        vUInt not2sComp = sub ^ allOnes;
+        // not2sComp should be all bits zero
+        FAIL_IF(not2sComp != 0);
+
+        vUInt signOne = vUInt(1) | vUInt(0x8000) << 16;
+        vUInt notSignMag = sub ^ signOne;
+        // notSignMag will be zero, if sign-mag
+        FAIL_IF(notSignMag == 0);
+    }
+
+    {  // test 0 - 1 as cst results in all ones.
+        vInt zero = 0;
+        vInt sub = zero - 1;
+
+        vUInt allOnes = vUInt(0xffff) | vUInt(0xffff) << 16;
+        vUInt not2sComp = sub ^ allOnes;
+        // not2sComp should be all bits zero
+        FAIL_IF(not2sComp != 0);
+
+        vUInt signOne = vUInt(1) | vUInt(0x8000) << 16;
+        vUInt notSignMag = sub ^ signOne;
+        // notSignMag will be zero, if sign-mag
+        FAIL_IF(notSignMag == 0);
+    }
+
+    {  // test 0 + -1 as cst results in all ones.
+        vInt zero = 0;
+        vInt sub = zero + -1;
+
+        vUInt allOnes = vUInt(0xffff) | vUInt(0xffff) << 16;
+        vUInt not2sComp = sub ^ allOnes;
+        // not2sComp should be all bits zero
+        FAIL_IF(not2sComp != 0);
+
+        vUInt signOne = vUInt(1) | vUInt(0x8000) << 16;
+        vUInt notSignMag = sub ^ signOne;
+        // notSignMag will be zero, if sign-mag
+        FAIL_IF(notSignMag == 0);
+    }
+
+#if __riscv_tt_blackhole
+    {  // test -2 >> 1 is -1
+        vInt minusTwo = -2;
+        vInt shft = minusTwo >> 1;
+
+        vUInt allOnes = vUInt(0xffff) | vUInt(0xffff) << 16;
+        vUInt not2sComp = shft ^ allOnes;
+        // not2sComp should be all bits zero
+        FAIL_IF(not2sComp != 0);
+
+        vUInt signOne = vUInt(1) | vUInt(0x8000) << 16;
+        vUInt notSignMag = shft ^ signOne;
+        // notSignMag will be zero, if sign-mag
+        FAIL_IF(notSignMag == 0);
+    }
+#endif
+
+    {  // test unsigned(-2) >> 1 is mostPos
+        vUInt minusTwo = -2;
+        vUInt shft = minusTwo >> 1;
+
+        vUInt mostPos = vUInt(0xffff) | vUInt(0x7fff) << 16;
+        vUInt not2sComp = vInt(shft) ^ mostPos;
+        // not2sComp should be all bits zero
+        FAIL_IF(not2sComp != 0);
+
+        vUInt smExpected = vUInt(1) | vUInt(0x4000) << 16;
+        vUInt notSignMag = shft ^ smExpected;
+        // notSignMag will be zero, if sign-mag
+        FAIL_IF(notSignMag == 0);
+    }
+
+#include "post.inc"
+#endif
+}
+}  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/test_kernels/sfpi/post.inc
+++ b/tests/tt_metal/tt_metal/test_kernels/sfpi/post.inc
@@ -1,0 +1,6 @@
+    asm volatile("sfpstore 0,%0,6,0" : : "x"(failed.get()));
+
+    uint32_t ary[8];
+    dbg_read_dest_acc_row(0, ary);
+    auto* args = reinterpret_cast<tt_l1_ptr uint32_t*>(get_compile_time_arg_val(0));
+    args[0] = ary[0] & 0xffff;

--- a/tests/tt_metal/tt_metal/test_kernels/sfpi/pre.inc
+++ b/tests/tt_metal/tt_metal/test_kernels/sfpi/pre.inc
@@ -1,0 +1,5 @@
+#define FAIL_IF(expr)                                                  \
+    v_if(failed == 0 && (expr)) { failed = vUInt(0x4000 + __LINE__); } \
+    v_endif
+
+    vUInt failed = vUInt(0);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20407

### Problem description
We lack a set of executable SFPI unit tests.  I have encountered bug reports that would have most probably been found by such a test suite.

### What's changed
* Added a test runner and kernels test directory, along with an a self test to ensure failures are detected and an initial test of integer representation. The runner uses minimal metal infrastructure to get the job done.
* Added to the cpp-post-commit and build-and-unit-tests actions.
* Augmented CODEOWNERS for the new directories.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [YES] New/Existing tests provide coverage for changes