### PR TITLE
Full Prod - Update Output Shape, Accept Non-4D Inputs

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -56,6 +56,9 @@ class TestProd:
         dst_mem_config,
         device,
     ):
+        if keepdim and all_dimensions:
+            pytest.skip("keepdim=True with all_dimensions=True is not a valid configuration")
+
         datagen_func = [
             generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=1, high=1.5), torch.bfloat16)
         ]

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -976,8 +976,8 @@ def xlogy(x, y, *args, **kwargs):
 
 def prod(x, *args, all_dimensions, dim, **kwargs):
     if all_dimensions:
-        result = torch.prod(x)
-        return result.view(1, 1, 1, 1)
+        return torch.prod(x)
+
     return torch.prod(x, dim, keepdim=kwargs["keepdim"])
 
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1269,10 +1269,8 @@ def prod(
     output_tensor = ttnn.from_device(t1)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)
-    if all_dimensions:
-        return output_tensor[:1, :1, :1, :1]
-    else:
-        return output_tensor
+
+    return output_tensor
 
 
 @setup_host_and_device

--- a/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
@@ -53,15 +53,13 @@ def test_prod(shapes, device):
     torch_output = torch.prod(torch_input)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = (
-        ttnn.prod(tt_input, all_dimensions=True).cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
-    )
-    N, C, H, W = tt_output_cpu.shape
+    tt_output_cpu = ttnn.prod(tt_input, all_dimensions=True).cpu().to(cpu_layout).to_torch()
+    N = tt_output_cpu.shape
     torch.set_printoptions(threshold=10000, precision=5, sci_mode=False)
     logger.info("Input shape")
     logger.info(torch_input.shape)
     logger.info("TT Output")
-    logger.info(tt_output_cpu[0, 0, 0, 0])
+    logger.info(tt_output_cpu)
     logger.info("Torch Output")
     logger.info(torch_output)
 
@@ -69,9 +67,7 @@ def test_prod(shapes, device):
     # TODO(Dongjin) : check while changing rtol after enabling fp32_dest_acc_en
     rtol = atol = 0.12
     # passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    passing, output_pcc = comp_allclose_and_pcc(
-        torch_output, tt_output_cpu[0, 0, 0, 0], pcc=0.999, rtol=rtol, atol=atol
-    )
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu[0], pcc=0.999, rtol=rtol, atol=atol)
 
     logger.info(f"Out passing={passing}")
     logger.info(f"Output pcc={output_pcc}")

--- a/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
@@ -40,6 +40,7 @@ def get_tensors(input_shape, output_shape, device):
         ([1, 1, 32, 32]),
         ([1, 4, 32, 32]),
         ([2, 2, 32, 32]),
+        ([16, 16]),
         # ([6, 4, 32, 32]), #Fails : expected result is inf but the result generated in nan
         # ([1, 1, 320, 320]), #Fails : expected result is inf but the result generated in nan
         # ([1, 3, 320, 64]), #Fails : expected result is inf but the result generated in nan
@@ -67,7 +68,7 @@ def test_prod(shapes, device):
     # TODO(Dongjin) : check while changing rtol after enabling fp32_dest_acc_en
     rtol = atol = 0.12
     # passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
-    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu[0], pcc=0.999, rtol=rtol, atol=atol)
+    passing, output_pcc = comp_allclose_and_pcc(torch_output, tt_output_cpu, pcc=0.999, rtol=rtol, atol=atol)
 
     logger.info(f"Out passing={passing}")
     logger.info(f"Output pcc={output_pcc}")

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_prod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_prod.py
@@ -52,7 +52,7 @@ def test_bw_prod(input_shapes, all_dimensions, dim, device):
     if all_dimensions == False:
         pyt_y = torch.prod(in_data, dim=dim, keepdim=True)
     else:
-        pyt_y = torch.prod(in_data).view(1, 1, 1, 1)
+        pyt_y = torch.prod(in_data)
     tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor, all_dimensions=all_dimensions, dim=dim)
     in_data.retain_grad()
     pyt_y.backward(gradient=grad_data)
@@ -75,7 +75,7 @@ def test_bw_prod(input_shapes, all_dimensions, dim, device):
 def test_bw_prod_default_both(input_shapes, device):
     in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
     grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device)
-    pyt_y = torch.prod(in_data).view(1, 1, 1, 1)
+    pyt_y = torch.prod(in_data)
     tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor)
     in_data.retain_grad()
     pyt_y.backward(gradient=grad_data)
@@ -102,7 +102,7 @@ def test_bw_prod_default_dim(input_shapes, all_dimensions, device):
     if all_dimensions == False:
         pyt_y = torch.prod(in_data, dim=0, keepdim=True)
     else:
-        pyt_y = torch.prod(in_data).view(1, 1, 1, 1)
+        pyt_y = torch.prod(in_data)
     tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor, all_dimensions=all_dimensions)
     in_data.retain_grad()
     pyt_y.backward(gradient=grad_data)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -116,7 +116,7 @@ def data_gen_pt_tt_prod(input_shapes, device, all_dimensions=True, dim=0, requir
         elif dim == 2 or dim == -2:
             pt_tensor_temp[:, :, :1, :] = pt_tensor
     else:
-        shape_Required = torch.Size([1, 1, 1, 1])
+        shape_Required = torch.Size([])
         pt_tensor = torch.randn(shape_Required, requires_grad=required_grad).bfloat16()
         pt_tensor_temp[:1, :1, :1, :1] = pt_tensor
     tt_tensor = ttnn.Tensor(pt_tensor_temp, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1805,7 +1805,8 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
     std::vector<Tensor> grad_tensor;
     auto output_memory_config = output_mem_config.value_or(
         input.memory_config());  // TODO: Remove after ternary forward ops migration is completed
-    Tensor prod_result = ttnn::prod(input, all_dimensions, dim, true, output_memory_config);
+    const bool keepdim = !all_dimensions;
+    Tensor prod_result = ttnn::prod(input, all_dimensions, dim, keepdim, output_memory_config);
     if (prod_result.get_layout() == Layout::ROW_MAJOR && prod_result.storage_type() == StorageType::DEVICE) {
         prod_result = ttnn::operations::unary_backward::change_layout_to_tile(prod_result, output_memory_config);
     }

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -289,54 +289,6 @@ static Tensor fill_first_val_into_tensor(
 }
 
 template <typename T>
-static Tensor prod_result_computation_GS(
-    const Tensor& input_tensor,
-    DataType data_type,
-    const Layout layout,
-    IDevice* device = nullptr,
-    const MemoryConfig& output_mem_config = MemoryConfig{
-        .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
-    const ttnn::Shape& s_a = input_tensor.get_padded_shape();
-    auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(input_tensor.volume());  // ouput
-    auto input_buffer = detail::to_host_buffer<T>(input_tensor);
-    const ttnn::Shape input_tensor_strides = input_tensor.strides();
-    auto result = static_cast<T>(1.0f);
-    for (uint32_t i = s_a[0] - 1; i < s_a[0]; i++) {
-        for (int32_t j = s_a[1] - 1; j < s_a[1]; j++) {
-            for (int32_t k = s_a[2] - 32; k < s_a[2]; k++) {  // access last tile
-                for (int32_t l = s_a[3] - 32; l < s_a[3]; l++) {
-                    auto input_index =
-                        l + input_tensor_strides[2] * k + input_tensor_strides[1] * j + input_tensor_strides[0] * i;
-                    if (k >= s_a[2] - 2 && l >= s_a[3] - 32) {  // to access 2*32 in TILE layout
-                        result = result * static_cast<T>(input_buffer[input_index]);
-                        owned_buffer[input_index] = static_cast<T>(0.0f);
-                    } else {
-                        owned_buffer[input_index] = static_cast<T>(0.0f);
-                    }
-                }
-            }
-        }
-    }
-    owned_buffer[0] = result;  // store the result at the first position of the tensor,and the rest of the values as
-                               // 0.0f
-    auto output = Tensor(
-                      OwnedStorage{owned_buffer},
-                      TensorSpec(
-                          input_tensor.get_logical_shape(),
-                          TensorLayout::fromPaddedShape(
-                              data_type,
-                              Layout::ROW_MAJOR,
-                              MemoryConfig{},
-                              input_tensor.get_logical_shape(),
-                              input_tensor.get_padded_shape())))
-                      .to_layout(layout);
-    if (device != nullptr) {
-        output = output.to_device(device, output_mem_config);
-    }
-    return output;
-}
-
-template <typename T>
 static Tensor prod_result_computation_WH_B0(
     const Tensor& input_tensor,
     DataType data_type,
@@ -344,9 +296,8 @@ static Tensor prod_result_computation_WH_B0(
     IDevice* device = nullptr,
     const MemoryConfig& output_mem_config = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED}) {
-    const auto& s_a = input_tensor.get_padded_shape();
-    auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(1);  // output
-    auto input_buffer = detail::to_host_buffer<T>(input_tensor);
+    auto owned_buffer = tt::tt_metal::owned_buffer::create<T>(tt::constants::TILE_HW);
+    const auto input_buffer = detail::to_host_buffer<T>(input_tensor);
     const ttnn::Shape input_tensor_strides = input_tensor.strides();
     T result = static_cast<T>(1.0f);
 
@@ -354,7 +305,7 @@ static Tensor prod_result_computation_WH_B0(
     for (int i = 0; i < tt::constants::TILE_HW; ++i) {
         result = result * static_cast<T>(input_buffer[i]);
     }
-    owned_buffer[0] = result;  // output will only have one element - the product of the entire tensor
+    owned_buffer[0] = result;
     auto output = Tensor(
                       OwnedStorage{owned_buffer},
                       TensorSpec(
@@ -363,8 +314,9 @@ static Tensor prod_result_computation_WH_B0(
                               data_type,
                               PageConfig(Layout::ROW_MAJOR),
                               MemoryConfig{},
-                              ttnn::Shape({1}),
-                              ttnn::Shape({tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH}))))
+                              /*logical_shape=*/ttnn::Shape({}),
+                              /*padded_shape=*/ttnn::Shape({tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH}))))
+
                       .to_layout(layout);
     if (device != nullptr) {
         output = output.to_device(device, output_mem_config);

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -354,12 +354,11 @@ static Tensor prod_result_computation_WH_B0(
     for (int i = 0; i < tt::constants::TILE_HW; ++i) {
         result = result * static_cast<T>(input_buffer[i]);
     }
-
     owned_buffer[0] = result;  // output will only have one element - the product of the entire tensor
     auto output = Tensor(
                       OwnedStorage{owned_buffer},
                       TensorSpec(
-                          ttnn::Shape({1}),
+                          ttnn::Shape({}),
                           TensorLayout::fromPaddedShape(
                               data_type,
                               PageConfig(Layout::ROW_MAJOR),

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
@@ -37,6 +37,7 @@ void MAIN {
     copy_tile(input_cb, 0, 0);  // copy from c_in[0] to DST[0]
 
     cb_pop_front(input_cb, one_tile);
+    mul_tiles_init(input_cb, partial_prod_cb);
 
     // When we have more than one tile, we can do the tile-wise multiplication of them all to yield one final tile
     for (uint32_t t = 1; t < num_tiles; t++) {
@@ -55,7 +56,6 @@ void MAIN {
 
         tile_regs_acquire();
 
-        mul_tiles_init(input_cb, partial_prod_cb);
         mul_tiles(input_cb, partial_prod_cb, /*tile0=*/0, /*tile1=*/0, /*dst_tile=*/0);
 
         cb_pop_front(input_cb, one_tile);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
@@ -9,60 +9,64 @@
 #include "tt_metal/include/compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 #include "compute_kernel_api/eltwise_unary/negative.h"
-
+#include "tt_metal/include/compute_kernel_api.h"
 #include "tt_metal/hw/inc/debug/dprint_pages.h"
 
 namespace NAMESPACE {
 void MAIN {
+    const tt::CBIndex final_output_cb = tt::CBIndex::c_3;
+    const tt::CBIndex input_cb = tt::CBIndex::c_0;
+    const tt::CBIndex partial_prod_cb = tt::CBIndex::c_2;
+
+    const int one_tile = 1;
     constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
     constexpr uint32_t per_core_block_dim = get_compile_time_arg_val(1);
+    binary_op_init_common(input_cb, partial_prod_cb, final_output_cb);
 
-    binary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_2, tt::CBIndex::c_3);
-    bool last_tile = false;
-    bool once = true;
-    cb_reserve_back(tt::CBIndex::c_3, 1);
-    for (uint32_t t = 0; t < num_tiles; t++) {
-        if (t == (num_tiles - 1)) {
-            last_tile = true;
-        }
+    reconfig_data_format(input_cb, partial_prod_cb);
+    pack_reconfig_data_format(final_output_cb);
 
-        for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
-            cb_wait_front(tt::CBIndex::c_0, 1);
-            // PACK(tt::compute::common::print_full_tile(tt::CBIndex::c_0));
-            if (once) {
-                cb_reserve_back(tt::CBIndex::c_2, 1);
-                tile_regs_acquire();
-                copy_tile_to_dst_init_short(tt::CBIndex::c_0);
-                copy_tile(tt::CBIndex::c_0, 0, 0);  // copy from c_in[0] to DST[0]
-                tile_regs_commit();
-                tile_regs_wait();
-                if constexpr (num_tiles == 1) {
-                    pack_tile(0, tt::CBIndex::c_3);
-                } else {
-                    pack_tile(0, tt::CBIndex::c_2);
-                    cb_push_back(tt::CBIndex::c_2, 1);
-                }
-                tile_regs_release();
-            } else {
-                tile_regs_acquire();
-                mul_tiles_init(tt::CBIndex::c_0, tt::CBIndex::c_2);
-                mul_tiles(tt::CBIndex::c_0, tt::CBIndex::c_2, 0, 0, 0);
-                tile_regs_commit();
-                tile_regs_wait();
-                if (last_tile) {
-                    pack_tile(0, tt::CBIndex::c_3);
-                } else {
-                    cb_pop_front(tt::CBIndex::c_2, 1);
-                    cb_reserve_back(tt::CBIndex::c_2, 1);
-                    pack_tile(0, tt::CBIndex::c_2);
-                    cb_push_back(tt::CBIndex::c_2, 1);
-                }
-                tile_regs_release();
-            }
-            once = false;
-            cb_pop_front(tt::CBIndex::c_0, 1);
-        }
+    // Ultimate goal is to have a single tile in the final output cb
+    cb_reserve_back(final_output_cb, one_tile);
+
+    // Copy the first tile to DST[0]
+    cb_wait_front(input_cb, one_tile);
+    tile_regs_acquire();
+
+    copy_tile_to_dst_init_short(input_cb);
+    copy_tile(input_cb, 0, 0);  // copy from c_in[0] to DST[0]
+
+    cb_pop_front(input_cb, one_tile);
+
+    // When we have more than one tile, we can do the tile-wise multiplication of them all to yield one final tile
+    for (uint32_t t = 1; t < num_tiles; t++) {
+        // Save the current partial prod into CB
+        tile_regs_commit();
+        tile_regs_wait();
+
+        pack_tile(0, partial_prod_cb);
+
+        cb_reserve_back(partial_prod_cb, one_tile);
+        cb_push_back(partial_prod_cb, one_tile);
+        tile_regs_release();
+
+        // Load the next input tile and multiply it with the partial prod
+        cb_wait_front(input_cb, one_tile);
+
+        tile_regs_acquire();
+
+        mul_tiles_init(input_cb, partial_prod_cb);
+        mul_tiles(input_cb, partial_prod_cb, /*tile0=*/0, /*tile1=*/0, /*dst_tile=*/0);
+
+        cb_pop_front(input_cb, one_tile);
+        cb_pop_front(partial_prod_cb, one_tile);
     }
-    cb_push_back(tt::CBIndex::c_3, 1);
+
+    tile_regs_commit();
+    tile_regs_wait();
+
+    pack_tile(0, final_output_cb);
+    cb_push_back(final_output_cb, one_tile);
+    tile_regs_release();
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -26,11 +26,10 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
     // This should allocate a DRAM buffer on the device
     tt_metal::IDevice* device = a.device();
 
-    uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;
     tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{src0_cb_index, cb_data_format}})
-            .set_page_size(src0_cb_index, single_tile_size);
+        tt_metal::CircularBufferConfig(num_input_tiles * single_tile_size, {{tt::CBIndex::c_0, cb_data_format}})
+            .set_page_size(tt::CBIndex::c_0, single_tile_size);
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     tt_metal::CircularBufferConfig cb_inter_config =
@@ -84,7 +83,7 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
 
     SetRuntimeArgs(program, unary_reader_kernel_id, core, {src_buffer->address(), num_tiles, 0});
 
-    SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), num_tiles, 0});
+    SetRuntimeArgs(program, unary_writer_kernel_id, core, {dst_buffer->address(), /*num_tiles=*/1, 0});
 
     auto override_runtime_args_callback = [unary_reader_kernel_id, unary_writer_kernel_id](
                                               const void* operation,
@@ -108,7 +107,6 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_single_core(
             runtime_args[0] = dst_buffer->address();
         }
     };
-
     return {std::move(program), override_runtime_args_callback};
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <optional>
-
 #include "prod_op_all.hpp"
 #include "ttnn/operations/eltwise/unary/unary.hpp"
 #include <tt-metalium/constants.hpp>
@@ -24,14 +23,14 @@ void Prod_op::validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL((input_tensor_a.get_layout() == tt::tt_metal::Layout::TILE), "Input Layout must be tilized");
     TT_FATAL(input_tensor_a.memory_config().memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
-    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Error");
+    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Error - prod requires BFLOAT16");
 }
 
 std::vector<tt::tt_metal::TensorSpec> Prod_op::compute_output_specs(
     const std::vector<tt::tt_metal::Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
     return {tt::tt_metal::TensorSpec(
-        input_tensor.get_logical_shape(),
+        ttnn::Shape({1, 1, 1, TILE_HW}),
         tt::tt_metal::TensorLayout(
             input_tensor.get_dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), output_mem_config))};
 }
@@ -47,13 +46,7 @@ tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_me
     tt::tt_metal::Tensor result = ttnn::tiled_prod(
         tt::tt_metal::operation::run(Prod_op{.output_mem_config = output_mem_config}, {input}).at(0),
         output_mem_config);
-    auto arch_env = tt_ClusterDescriptor::detect_arch((chip_id_t)0);
-    if (arch_env == tt::ARCH::WORMHOLE_B0) {
-        return ttnn::prod_result_computation_WH_B0<bfloat16>(
-            result, result.get_dtype(), result.get_layout(), result.device(), output_mem_config);
-    }
-    // else --> GS Arch
-    return ttnn::prod_result_computation_GS<bfloat16>(
+    return ttnn::prod_result_computation_WH_B0<bfloat16>(
         result, result.get_dtype(), result.get_layout(), result.device(), output_mem_config);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -43,9 +43,8 @@ tt::tt_metal::operation::ProgramWithCallbacks Prod_op::create_program(
 }
 
 tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
-    tt::tt_metal::Tensor result = ttnn::tiled_prod(
-        tt::tt_metal::operation::run(Prod_op{.output_mem_config = output_mem_config}, {input}).at(0),
-        output_mem_config);
+    tt::tt_metal::Tensor result =
+        tt::tt_metal::operation::run(Prod_op{.output_mem_config = output_mem_config}, {input}).at(0);
     return ttnn::prod_result_computation_WH_B0<bfloat16>(
         result, result.get_dtype(), result.get_layout(), result.device(), output_mem_config);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -25,7 +25,7 @@ void Prod_op::validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.memory_config().memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
     TT_FATAL(
         input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16,
-        "Error - unsupported data type for prod, expected BFLOAT16 but got {}",
+        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
         input_tensor_a.get_dtype());
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -23,7 +23,10 @@ void Prod_op::validate(const std::vector<tt::tt_metal::Tensor>& input_tensors) c
     TT_FATAL(input_tensor_a.buffer() != nullptr, "Operands need to be allocated in buffers on device!");
     TT_FATAL((input_tensor_a.get_layout() == tt::tt_metal::Layout::TILE), "Input Layout must be tilized");
     TT_FATAL(input_tensor_a.memory_config().memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED, "Error");
-    TT_FATAL(input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16, "Error - prod requires BFLOAT16");
+    TT_FATAL(
+        input_tensor_a.get_dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "Error - unsupported data type for prod, expected BFLOAT16 but got {}",
+        input_tensor_a.get_dtype());
 }
 
 std::vector<tt::tt_metal::TensorSpec> Prod_op::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -22,8 +22,7 @@ inline Tensor prod_all(const Tensor& input_a, const MemoryConfig& output_mem_con
     auto formatted_input_tensor = input_a;
     if (formatted_input_tensor.get_layout() == Layout::ROW_MAJOR) {
         auto a_pad_shape = AutoFormat::pad_to_tile_shape(input_a.get_padded_shape());
-        auto out_shape = input_a.get_padded_shape();
-        out_shape = ttnn::Shape({out_shape[0], out_shape[1], out_shape[2], out_shape[3]});
+
         if (!AutoFormat::check_input_tensor_format(input_a, a_pad_shape)) {
             formatted_input_tensor =
                 AutoFormat::format_input_tensor(input_a, input_a.device(), a_pad_shape, 1.0, Layout::TILE);
@@ -84,6 +83,7 @@ Tensor ProdOperation::invoke(
         size - 1);
 
     if (all_dimensions) {
+        TT_FATAL(size == 4, "All dimension prod is only supported with input tensor of rank 4");
         return prod_all(input_a, output_mem_config);
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -90,8 +90,8 @@ Tensor ProdOperation::invoke(
     }
     TT_FATAL(
         size && dim >= -size && dim <= size - 1,
-        "Dimension for prod is out of range (expected to be in range of [-{}, {}]",
-        size,
+        "Dimension for prod is out of range (expected to be in range of [{}, {}]",
+        -size,
         size - 1);
 
     // update the dim because we unsqueezed input to 4d


### PR DESCRIPTION
### Ticket
#16915

### Problem description
Full products only supported 4D tensors, and returned an output tensor with the same shape as the original input tensor (with the first element containing the desired product).

### What's changed
Full prod is enhanced to allow for non-4D inputs, and the output is now 0D, matching the Pytorch implementation.
Tests and the prod usage in backwards ops were updated to account for this change in dimension.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14667823841)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14669355806) 
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes