### PR TITLE
Remove MeshDeviceView::cord_range method

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -56,7 +56,6 @@ public:
     [[nodiscard]] DeviceView get_devices(const MeshShape& submesh_shape) const;
     [[nodiscard]] DeviceView get_devices() const;
     [[nodiscard]] size_t num_devices() const;
-    [[nodiscard]] const MeshCoordinateRange& coord_range() const;
 
     [[nodiscard]] bool empty() const noexcept;
     [[nodiscard]] size_t size() const noexcept;

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -125,8 +125,6 @@ size_t MeshDeviceView::num_cols() const {
 }
 size_t MeshDeviceView::num_devices() const { return devices_.shape().mesh_size(); }
 
-const MeshCoordinateRange& MeshDeviceView::coord_range() const { return devices_.coord_range(); }
-
 bool MeshDeviceView::contains_device(chip_id_t device_id) const {
     return device_coordinates_.find(device_id) != device_coordinates_.end();
 }

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -258,10 +258,13 @@ void GraphProcessor::track_function_end(const std::any& output_tensors) {
 int GraphProcessor::add_tensor(const Tensor& t) {
     auto& storage = t.get_storage();
     std::vector<tt::tt_metal::Buffer*> buffers = std::visit(
-        [&t](auto&& storage) -> std::vector<tt::tt_metal::Buffer*> {
-            using T = std::decay_t<decltype(storage)>;
+        [&t]<typename T>(const T& storage) -> std::vector<tt::tt_metal::Buffer*> {
             if constexpr (std::is_same_v<T, DeviceStorage>) {
                 if (storage.mesh_buffer) {
+                    // `t.buffers()` returns a reference buffer allocated on first device in a mesh.
+                    // It has an ID different from the "backing" buffer that was used to perform the allocation.
+                    // To deduplicate an entry for this buffer, captured during its allocation, use the "backing"
+                    // buffer.
                     return {storage.mesh_buffer->get_backing_buffer()};
                 } else {
                     return t.buffers();


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Remove `MeshDeviceView::cord_range` method

\+ Also add a comment on "backing buffer".

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14479217709)