### PR TITLE
Add reset function

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -90,6 +90,55 @@ struct WorkerToFabricEdmSenderImpl {
             write_at_cmd_buf);
     }
 
+    FORCE_INLINE void reset(
+        bool connected_to_persistent_fabric,
+        uint8_t edm_worker_x,
+        uint8_t edm_worker_y,
+        std::size_t edm_buffer_base_addr,
+        uint8_t num_buffers_per_channel,
+        size_t edm_l1_sem_id,  // may also be an address
+        std::size_t edm_connection_handshake_l1_id,
+        std::size_t edm_worker_location_info_addr,  // The EDM's location for `EDMChannelWorkerLocationInfo`
+        uint16_t buffer_size_bytes,
+        size_t edm_buffer_index_id,
+        volatile uint32_t* const from_remote_buffer_slot_rdptr_ptr,
+        volatile uint32_t* const worker_teardown_addr,
+        uint32_t local_buffer_index_addr,
+        uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        this->edm_buffer_addr = edm_buffer_base_addr;
+        this->edm_buffer_slot_wrptr_addr = connected_to_persistent_fabric
+                                               ? edm_l1_sem_id
+                                               : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_l1_sem_id);
+        this->edm_connection_handshake_l1_addr =
+            connected_to_persistent_fabric
+                ? edm_connection_handshake_l1_id
+                : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_connection_handshake_l1_id);
+        this->edm_worker_location_info_addr = edm_worker_location_info_addr;
+        this->edm_buffer_index_addr = connected_to_persistent_fabric
+                                          ? edm_buffer_index_id
+                                          : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_buffer_index_id);
+        this->from_remote_buffer_slot_rdptr_ptr = from_remote_buffer_slot_rdptr_ptr;
+        this->worker_teardown_addr = worker_teardown_addr;
+        this->edm_buffer_base_addr = edm_buffer_base_addr;
+        this->buffer_slot_wrptr_ptr = reinterpret_cast<tt_l1_ptr size_t*>(local_buffer_index_addr);
+        this->buffer_size_bytes = buffer_size_bytes;
+        this->num_buffers_per_channel = num_buffers_per_channel;
+        this->last_buffer_index = num_buffers_per_channel - 1;
+        this->edm_noc_x = edm_worker_x;
+        this->edm_noc_y = edm_worker_y;
+        this->data_noc_cmd_buf = data_noc_cmd_buf;
+        this->sync_noc_cmd_buf = sync_noc_cmd_buf;
+        setup_edm_noc_cmd_buf(data_noc_cmd_buf, sync_noc_cmd_buf);
+        ASSERT(buffer_size_bytes > 0);
+        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
+            ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
+            for (size_t i = 0; i < EDM_NUM_BUFFER_SLOTS; ++i) {
+                edm_buffer_slot_addrs[i] = edm_buffer_base_addr + (i * buffer_size_bytes);
+            }
+        }
+    }
+
     WorkerToFabricEdmSenderImpl(
         bool connected_to_persistent_fabric,
         uint8_t edm_worker_x,
@@ -105,38 +154,23 @@ struct WorkerToFabricEdmSenderImpl {
         volatile uint32_t* const worker_teardown_addr,
         uint32_t local_buffer_index_addr,
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) :
-        edm_buffer_addr(edm_buffer_base_addr),
-        edm_buffer_slot_wrptr_addr(
-            connected_to_persistent_fabric ? edm_l1_sem_id
-                                           : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_l1_sem_id)),
-        edm_connection_handshake_l1_addr(
-            connected_to_persistent_fabric
-                ? edm_connection_handshake_l1_id
-                : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_connection_handshake_l1_id)),
-        edm_worker_location_info_addr(edm_worker_location_info_addr),
-        edm_buffer_index_addr(
-            connected_to_persistent_fabric ? edm_buffer_index_id
-                                           : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_buffer_index_id)),
-        from_remote_buffer_slot_rdptr_ptr(from_remote_buffer_slot_rdptr_ptr),
-        worker_teardown_addr(worker_teardown_addr),
-        edm_buffer_base_addr(edm_buffer_base_addr),
-        buffer_slot_wrptr_ptr(reinterpret_cast<tt_l1_ptr size_t*>(local_buffer_index_addr)),
-        buffer_size_bytes(buffer_size_bytes),
-        num_buffers_per_channel(num_buffers_per_channel),
-        last_buffer_index(num_buffers_per_channel - 1),
-        edm_noc_x(edm_worker_x),
-        edm_noc_y(edm_worker_y),
-        data_noc_cmd_buf(data_noc_cmd_buf),
-        sync_noc_cmd_buf(sync_noc_cmd_buf) {
-        setup_edm_noc_cmd_buf(data_noc_cmd_buf, sync_noc_cmd_buf);
-        ASSERT(buffer_size_bytes > 0);
-        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
-            ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
-            for (size_t i = 0; i < EDM_NUM_BUFFER_SLOTS; ++i) {
-                edm_buffer_slot_addrs[i] = edm_buffer_base_addr + (i * buffer_size_bytes);
-            }
-        }
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        reset(
+            connected_to_persistent_fabric,
+            edm_worker_x,
+            edm_worker_y,
+            edm_buffer_base_addr,
+            num_buffers_per_channel,
+            edm_l1_sem_id,
+            edm_connection_handshake_l1_id,
+            edm_worker_location_info_addr,
+            buffer_size_bytes,
+            edm_buffer_index_id,
+            from_remote_buffer_slot_rdptr_ptr,
+            worker_teardown_addr,
+            local_buffer_index_addr,
+            data_noc_cmd_buf,
+            sync_noc_cmd_buf);
     }
 
     FORCE_INLINE void setup_edm_noc_cmd_buf(uint8_t data_cmd_buf, uint8_t sync_cmd_buf) const {


### PR DESCRIPTION
### Ticket
#18726

### Problem description
There isn't a way to initialize the `WorkerToFabricEdmSenderImpl` when it's not allocated on the stack

### What's changed
Add a reset function so this class can be allocated in L1 or static memory and then initialized in `kernel_main` by calling reset.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes