### PR TITLE
Fix for resnet test CB assert, other issues stemming from `transpose` call from `fold`

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1036,7 +1036,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
 
     if (weights_bias_dtype == DataType::BFLOAT8_B) {
         TT_ASSERT(weight_tensor_.get_dtype() == DataType::FLOAT32);
-        if (has_bias) {
+        if (has_bias && bias_tensor.has_value()) {
             TT_ASSERT(bias_tensor.value().get_dtype() == DataType::FLOAT32);
         }
     } else {

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -109,6 +109,9 @@ Tensor tensor_reshape(
                                 new_logical_shape,
                                 new_padded_shape));
 
+                        auto page_size_bytes = upd_spec.compute_page_size_bytes();
+                        device_buffer->set_page_size(page_size_bytes);
+
                         device_storage.update_specs(upd_spec);
                         return Tensor(std::move(device_storage), upd_spec);
                     }


### PR DESCRIPTION
### Ticket
[19922](https://github.com/tenstorrent/tt-metal/issues/19922)

### Problem description
Test failures due to allocated buffer provided to CB in transpose program factory being inconsistent with program factory logic. This was called in the sharded version of `ttnn::fold` but the problem originated in the logic of `ttnn::experimental::view`

### What's changed
 - ~use `reshape` rather than `view` in `fold` in case of page breaking~
 - Tweak `experimental::reshape::view` so that page size changes are recorded, in the case where the tensor is not height sharded
- Side fix of an annoying issue with an assert in `conv2d`


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14715544299
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml https://github.com/tenstorrent/tt-metal/actions/runs/14715560323
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14715565642
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes