### PR TITLE
Add multicore support for argmax for any rank and shape

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -268,7 +268,7 @@ def run_llama3_demo(
 
     # Prepare the encoded prompts for the decode input
     tt_out_tok = ttnn.from_torch(
-        encoded_prompts_tensor_whole_sequence[:, :1].reshape(1, 1, 1, batch_size),
+        encoded_prompts_tensor_whole_sequence[:, :1].reshape(1, 1, batch_size),
         device=mesh_device,
         dtype=ttnn.uint32,
         layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -312,7 +312,7 @@ def run_llama3_demo(
         )
         tt_out_rm = ttnn.untilize(tt_out_gathered, use_multicore=True, sub_core_grids=sub_core_grids)
         tt_out_tok = ttnn.argmax(  # FIXME When ttnn.argmax supports multicore, avoid falling back to host
-            tt_out_rm, dim=3, keepdim=True, use_multicore=True, output_tensor=tt_out_tok, sub_core_grids=sub_core_grids
+            tt_out_rm, dim=3, keepdim=False, use_multicore=True, output_tensor=tt_out_tok, sub_core_grids=sub_core_grids
         )
         logger.info(f"sampling done")
 
@@ -352,7 +352,7 @@ def run_llama3_demo(
     )
     tt_out_rm = ttnn.untilize(tt_out_gathered, use_multicore=True, sub_core_grids=sub_core_grids)
     tt_out_tok = ttnn.argmax(  # FIXME When ttnn.argmax supports multicore, avoid falling back to host
-        tt_out_rm, dim=3, keepdim=True, use_multicore=True, output_tensor=tt_out_tok, sub_core_grids=sub_core_grids
+        tt_out_rm, dim=3, keepdim=False, use_multicore=True, output_tensor=tt_out_tok, sub_core_grids=sub_core_grids
     )
 
     if not stress_test:
@@ -380,7 +380,7 @@ def run_llama3_demo(
     )
 
     tt_out_tok_reset = ttnn.from_torch(
-        encoded_prompts_tensor_whole_sequence[:, :1].reshape(1, 1, 1, batch_size),
+        encoded_prompts_tensor_whole_sequence[:, :1].reshape(1, 1, batch_size),
         dtype=ttnn.uint32,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
@@ -435,15 +435,15 @@ def run_llama3_demo(
             tt_out_tok_cpu,
             mesh_composer=ttnn.ConcatMesh2dToTensor(
                 mesh_device,
-                dims=(3, 1),
+                dims=(2, 1),
                 mesh_shape=model_args.cluster_shape,
             ),
-        )[0, 0, 0, :batch_size]
+        )[0, 0, :batch_size]
         # Append the generated token to the list of outputs
         if iteration in range(len(encoded_prompts[0])):
             all_outputs.append(encoded_prompts[0][iteration])  # Update list of TT outputs
             tt_out_tok_reset = ttnn.from_torch(
-                encoded_prompts_tensor_whole_sequence[:, iteration].reshape(1, 1, 1, batch_size),
+                encoded_prompts_tensor_whole_sequence[:, iteration].reshape(1, 1, batch_size),
                 dtype=ttnn.uint32,
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -311,7 +311,11 @@ def run_llama3_demo(
             tt_out[0], dim=3, num_links=2, cluster_axis=0, memory_config=ttnn.DRAM_MEMORY_CONFIG, buffer_key="SAMPLING"
         )
         tt_out_rm = ttnn.untilize(tt_out_gathered, use_multicore=True, sub_core_grids=sub_core_grids)
-        tt_out_tok = ttnn.argmax(  # FIXME When ttnn.argmax supports multicore, avoid falling back to host
+        # Run argmax only for user0
+        tt_out_rm = ttnn.reshape(
+            tt_out_rm, (1, 1, 1, tt_out_rm.shape[3]), (1, 1, tt_out_rm.shape[2], tt_out_rm.shape[3])
+        )
+        _ = ttnn.argmax(
             tt_out_rm, dim=3, keepdim=False, use_multicore=True, output_tensor=tt_out_tok, sub_core_grids=sub_core_grids
         )
         logger.info(f"sampling done")
@@ -351,7 +355,8 @@ def run_llama3_demo(
         tt_out[0], dim=3, num_links=2, cluster_axis=0, memory_config=ttnn.DRAM_MEMORY_CONFIG, buffer_key="SAMPLING"
     )
     tt_out_rm = ttnn.untilize(tt_out_gathered, use_multicore=True, sub_core_grids=sub_core_grids)
-    tt_out_tok = ttnn.argmax(  # FIXME When ttnn.argmax supports multicore, avoid falling back to host
+    tt_out_rm = ttnn.reshape(tt_out_rm, (1, 1, 1, tt_out_rm.shape[3]), (1, 1, tt_out_rm.shape[2], tt_out_rm.shape[3]))
+    _ = ttnn.argmax(
         tt_out_rm, dim=3, keepdim=False, use_multicore=True, output_tensor=tt_out_tok, sub_core_grids=sub_core_grids
     )
 

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -32,7 +32,7 @@ from models.demos.llama3_subdevices.tt.model_config import LlamaOptimizations
 TSU_PERF_DROP_LIMIT_COUNT = 20
 
 # Constants for TSU thresholds based on the number of layers
-TSU_THRESHOLDS = {1: {"min": 355, "max": 390}, 10: {"min": 195, "max": 215}, 80: {"min": 44, "max": 48}}
+TSU_THRESHOLDS = {1: {"min": 470, "max": 490}, 10: {"min": 195, "max": 215}, 80: {"min": 45, "max": 49}}
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
@@ -79,6 +79,13 @@ void ArgMax::validate_with_output_tensors(
         // TODO: Add support for normalized_dim = 0, 1, 2
         TT_FATAL(normalized_dim == (input_rank - 1), "Only argmax on last dim is supported!");
     }
+
+    if (this->use_multicore && this->sub_core_grids.has_value()) {
+        TT_FATAL(
+            this->sub_core_grids->ranges().size() == 1,
+            "Multicore argmax only supports a single core grid range, but got {} ranges",
+            this->sub_core_grids->ranges().size());
+    }
 }
 
 std::vector<TensorSpec> ArgMax::compute_output_specs(
@@ -110,7 +117,8 @@ operation::ProgramWithCallbacks ArgMax::create_program(
     const auto normalized_dim =
         this->dim.has_value() ? *this->dim + input_tensor.get_padded_shape().rank() * (*this->dim < 0) : this->dim;
     if (this->use_multicore) {
-        return detail::argmax_multi_core(input_tensor, output_tensor, normalized_dim, this->sub_core_grids);
+        return detail::argmax_multi_core(
+            input_tensor, output_tensor, normalized_dim, this->keepdim, this->sub_core_grids);
     }
     return detail::argmax_single_core(input_tensor, output_tensor, normalized_dim, this->keepdim);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp
@@ -82,8 +82,8 @@ void ArgMax::validate_with_output_tensors(
 
     if (this->use_multicore && this->sub_core_grids.has_value()) {
         TT_FATAL(
-            this->sub_core_grids->ranges().size() == 1,
-            "Multicore argmax only supports a single core grid range, but got {} ranges",
+            this->sub_core_grids->ranges().size() <= 2,
+            "Multicore argmax only supports up to 2 core grid ranges, but got {} ranges",
             this->sub_core_grids->ranges().size());
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/math.hpp>
 #include "ttnn/operation.hpp"
 
 using namespace tt::tt_metal;
@@ -118,127 +119,322 @@ operation::ProgramWithCallbacks argmax_single_core(
     return {std::move(program), override_runtime_args_callback};
 }
 
+// NOC xactions need to be 32B aligned.
+// So, for bfloat16 dtype, we need at least 16 units per core to avoid unaligned accesses.
+constexpr uint32_t min_red_dim_units_per_core = 16;
+
+/*
+ * Design of argmax_multi_core:
+ *
+ * The argmax operation is split across multiple cores to handle large tensors efficiently.
+ * Each core processes a portion of the reduction dimension, finding local maxima and their indices.
+ *
+ * Circular Buffers (CBs):
+ * 1. Input CB:
+ *    - Size depends on input tensor shape and number of cores
+ *    - Used for reading input tensor data
+ *
+ * 2. Worker Output CB (indices):
+ *    - Size depends on final output shape and number of worker cores
+ *    - Used by worker cores to store local maxima indices
+ *
+ * 3. Worker Output CB (values):
+ *    - Size depends on final output shape and number of worker cores
+ *    - Used by worker cores to store local maxima values
+ *
+ * 4. Final Output CB:
+ *    - Size depends on final output tensor shape
+ *    - Used only by reduce core to write final global argmax results
+ *
+ * Core Roles:
+ * 1. Worker Cores:
+ *    - Process assigned portion of reduction dimension
+ *    - Find local maxima and their indices
+ *    - Write results to output CB
+ *
+ * 2. Reduce Core:
+ *    - Collects results from all worker cores
+ *    - Performs final reduction to find global maxima
+ *    - Writes final results to DRAM
+ *
+ * Semaphore Usage:
+ * 1. Semaphore 1:
+ *    - Controls output buffer availability for writing results
+ *    - Worker cores wait before writing results
+ *    - Set by reduce core (multicast)
+ *
+ * 2. Semaphore 2:
+ *    - Controls output buffer availability for reading results
+ *    - Worker cores signal completion (increment)
+ *    - Reduce core waits for all workers
+ *
+ * Multicast Design:
+ *
+ * 1. Core Groups:
+ *    - Cores are split into two groups (cores0 and cores1) for balanced workload
+ *    - Each group handles a different portion of the reduction dimension
+ *    - cores0 handles red_dim_units0 elements
+ *    - cores1 handles red_dim_units1 elements
+ *    - Each core gets a minimum of `min_red_dim_units_per_core` elements to process, except the last core
+ *
+ * 2. Core Layout:
+ *    - Cores are arranged in a grid pattern
+ *    - Example for 4x4 grid:
+ *
+ *      +---+---+---+---+
+ *      |R0 |W1 |W2 |W3 |
+ *      +---+---+---+---+
+ *      |W4 |W5 |W6 |W7 |
+ *      +---+---+---+---+
+ *      |W8 |W9 |W10|W11|
+ *      +---+---+---+---+
+ *      |W12|W13|W14|W15|
+ *      +---+---+---+---+
+ *
+ *    Where R0 is reduce core, W* are worker cores
+ *    There may be two grids (based on the number of cores)
+ *
+ *    Refer to the kernel code for info on compile time args and runtime args
+ */
 operation::ProgramWithCallbacks argmax_multi_core(
     const Tensor& input,
     const Tensor& output,
     const std::optional<uint32_t> dim,
+    const bool keepdim,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     tt::tt_metal::Program program{};
 
-    tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
-    uint32_t input_unit_size = input.element_size();
-    tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
-    uint32_t output_unit_size = output.element_size();
-
-    tt::tt_metal::IDevice* device = output.device();
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRangeSet core_grid = CoreRangeSet(std::vector{CoreRange({0, 0}, {num_cores_x - 1, num_cores_y - 1})});
-    uint32_t num_cores = num_cores_x * num_cores_y;
-
-    if (sub_core_grids.has_value()) {
-        core_grid = sub_core_grids.value();
-        num_cores = core_grid.num_cores();
-    }
+    const auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
+    const auto input_unit_size = input.element_size();
+    const auto output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
+    const auto output_unit_size = output.element_size();
 
     const auto& input_shape = input.get_padded_shape();
-    const uint32_t B = input_shape[0];
-    const uint32_t C = input_shape[1];
-    const uint32_t H = input_shape[2];
-    const uint32_t W = input_shape[3];
+    const auto rank = input_shape.size();
+    const bool reduce_all = not dim.has_value();
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t num_input_units = W;
-    uint32_t aligned_input_unit_size = round_up_to_mul32(num_input_units * input_unit_size);
-    tt::tt_metal::CircularBufferConfig cb_src0_config =
-        tt::tt_metal::CircularBufferConfig(aligned_input_unit_size, {{src0_cb_index, input_cb_data_format}})
-            .set_page_size(src0_cb_index, aligned_input_unit_size);
-    auto cb_src0 = tt::tt_metal::CreateCircularBuffer(program, core_grid, cb_src0_config);
+    // Last dimension in input i.e. reduction dimension
+    const auto red_dim_units = input_shape[rank - 1];
 
-    uint32_t intermed0_cb_index = tt::CBIndex::c_1;
-    uint32_t num_intermed0_units = B * C * H;
-    uint32_t aligned_intermed0_unit_size = num_intermed0_units * output_unit_size;
-    tt::tt_metal::CircularBufferConfig intermed0_cb_config =
-        tt::tt_metal::CircularBufferConfig(aligned_intermed0_unit_size, {{intermed0_cb_index, output_cb_data_format}})
-            .set_page_size(intermed0_cb_index, aligned_intermed0_unit_size);  /// page size shouldn't matter here
-    auto cb_intermed0 = tt::tt_metal::CreateCircularBuffer(program, core_grid, intermed0_cb_config);
+    // Last dimension in output i.e. the dim left after reduction
+    const auto output_last_dim = reduce_all or keepdim or (rank < 2) ? 1 : input_shape[rank - 2];
 
-    uint32_t intermed1_cb_index = tt::CBIndex::c_2;
-    uint32_t num_intermed1_units = B * C * H;
-    uint32_t aligned_intermed1_unit_size = round_up_to_mul32(num_intermed1_units * input_unit_size);
-    tt::tt_metal::CircularBufferConfig intermed1_cb_config =
-        tt::tt_metal::CircularBufferConfig(aligned_intermed1_unit_size, {{intermed1_cb_index, input_cb_data_format}})
-            .set_page_size(intermed1_cb_index, aligned_intermed1_unit_size);  /// page size shouldn't matter here
-    auto cb_intermed1 = tt::tt_metal::CreateCircularBuffer(program, core_grid, intermed1_cb_config);
+    const tt::tt_metal::IDevice* device = output.device();
+    CoreRangeSet all_cores, cores0, cores1;
+    uint32_t num_total_cores, num_cores0, num_cores1;
+    uint32_t red_dim_units0, red_dim_units1;
 
-    uint32_t out0_cb_index = tt::CBIndex::c_3;
-    uint32_t num_out0_units = B * C * H;
-    uint32_t aligned_out0_unit_size = num_out0_units * output_unit_size;
-    tt::tt_metal::CircularBufferConfig out0_cb_config =
-        tt::tt_metal::CircularBufferConfig(aligned_out0_unit_size, {{out0_cb_index, output_cb_data_format}})
-            .set_page_size(out0_cb_index, aligned_out0_unit_size);  /// page size shouldn't matter here
-    auto cb_out0 = tt::tt_metal::CreateCircularBuffer(program, core_grid, out0_cb_config);
+    if (sub_core_grids.has_value()) {
+        all_cores = sub_core_grids.value();
+        cores0 = all_cores;
+        cores1 = CoreRangeSet();
+        num_total_cores = all_cores.num_cores();
+        num_cores0 = num_total_cores;
+        num_cores1 = 0;
+        red_dim_units0 = red_dim_units;
+        red_dim_units1 = 0;
+    } else {
+        // We pick as many cores as possible, but each core will read a multiple of min_red_dim_units_per_core
+        const auto core_grid = device->compute_with_storage_grid_size();
+        std::tie(num_total_cores, all_cores, cores0, cores1, red_dim_units0, red_dim_units1) =
+            tt::tt_metal::split_work_to_cores(
+                core_grid, tt::round_up(red_dim_units, min_red_dim_units_per_core) / min_red_dim_units_per_core);
+        red_dim_units0 *= min_red_dim_units_per_core;
+        red_dim_units1 *= min_red_dim_units_per_core;
+        num_cores0 = cores0.num_cores();
+        num_cores1 = cores1.num_cores();
+    }
 
-    auto src_buffer = input.buffer();
-    auto dst_buffer = output.buffer();
-    bool src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
-    bool dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    // Page sizes for input and output tensors based on the ROW_MAJOR layout
+    const auto src_page_size = round_up_to_mul32(red_dim_units * input_unit_size);
+    const auto dst_page_size = round_up_to_mul32(output_last_dim * output_unit_size);
 
-    auto semaphore_addr = tt::tt_metal::CreateSemaphore(program, core_grid, 0);
-    auto cores = corerange_to_cores(core_grid, num_cores, true);
-    CoreCoord final_cores_physical = device->worker_core_from_logical_core(cores.at(0));
-    uint32_t final_cores_physical_x = final_cores_physical.x;
-    uint32_t final_cores_physical_y = final_cores_physical.y;
+    // Create input CB to read reduction dim worth of data at once (split across all cores)
+    const uint32_t src_cb_idx = tt::CBIndex::c_0;
+    const auto src_cb_page_size0 = round_up_to_mul32(red_dim_units0 * input_unit_size);
+    const auto src_cb_config0 =
+        tt::tt_metal::CircularBufferConfig(src_cb_page_size0, {{src_cb_idx, input_cb_data_format}})
+            .set_page_size(src_cb_idx, src_cb_page_size0);
+    const auto src_cb0 = tt::tt_metal::CreateCircularBuffer(program, cores0, src_cb_config0);
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        src0_cb_index,
-        intermed0_cb_index,
-        intermed1_cb_index,
-        out0_cb_index,
+    // We only create the second CB if there are some cores assigned to the second group
+    if (num_cores1 > 0) {
+        const auto src_cb_page_size1 = round_up_to_mul32(red_dim_units1 * input_unit_size);
+        const auto src_cb_config1 =
+            tt::tt_metal::CircularBufferConfig(src_cb_page_size1, {{src_cb_idx, input_cb_data_format}})
+                .set_page_size(src_cb_idx, src_cb_page_size1);
+        const auto src_cb1 = tt::tt_metal::CreateCircularBuffer(program, cores1, src_cb_config1);
+    }
+
+    // Create output CB based on the output shape's last dimension
+    const uint32_t dst_cb_idx = tt::CBIndex::c_1;
+    const auto dst_db_config = tt::tt_metal::CircularBufferConfig(dst_page_size, {{dst_cb_idx, output_cb_data_format}})
+                                   .set_page_size(dst_cb_idx, dst_page_size);
+    const auto dst_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, dst_db_config);
+
+    // Create intermediate CB for indices based on number of cores and output shape's last dimension
+    const uint32_t red_idxs_cb_idx = tt::CBIndex::c_2;
+    const auto red_idxs_page_size = round_up_to_mul32(output_last_dim * output_unit_size) * num_total_cores;
+    const auto red_idxs_db_config =
+        tt::tt_metal::CircularBufferConfig(red_idxs_page_size, {{red_idxs_cb_idx, output_cb_data_format}})
+            .set_page_size(red_idxs_cb_idx, red_idxs_page_size);
+    const auto red_idxs_cb = tt::tt_metal::CreateCircularBuffer(program, all_cores, red_idxs_db_config);
+
+    // Create intermediate CB for values based on number of cores and output shape's last dimension
+    const uint32_t red_vals_cb_idx = tt::CBIndex::c_3;
+    const auto red_vals_page_size = round_up_to_mul32(output_last_dim * input_unit_size) * num_total_cores;
+    const auto red_vals_cb_config =
+        tt::tt_metal::CircularBufferConfig(red_vals_page_size, {{red_vals_cb_idx, input_cb_data_format}})
+            .set_page_size(red_vals_cb_idx, red_vals_page_size);
+    const auto cb_red_vals = tt::tt_metal::CreateCircularBuffer(program, all_cores, red_vals_cb_config);
+
+    const auto src_buffer = input.buffer();
+    const auto dst_buffer = output.buffer();
+    const auto src_is_dram = src_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+    const auto dst_is_dram = dst_buffer->buffer_type() == tt::tt_metal::BufferType::DRAM;
+
+    const auto inner_dim_units = output_last_dim;
+    const auto outer_dim_units = input.get_logical_volume() / inner_dim_units / red_dim_units;
+
+    // Get physical coordinates of the reduce core that collates the intermediate outputs
+    const uint32_t reduce_core_id = 0;  // We can do perf optimization by tuning this in the future
+    const auto cores = corerange_to_cores(all_cores, num_total_cores, true);
+    const auto reduce_core = device->worker_core_from_logical_core(cores.at(reduce_core_id));
+
+    // Get first and last core's coordinates for the at max two groups of cores in all_cores
+    const auto group0 = all_cores.ranges().at(0);
+    const auto group1 = all_cores.size() > 1 ? all_cores.ranges().at(1) : CoreRange(CoreCoord(0, 0), CoreCoord(0, 0));
+
+    const auto start_core0 = device->worker_core_from_logical_core(group0.start_coord);
+    const auto end_core0 = device->worker_core_from_logical_core(group0.end_coord);
+    const auto start_core1 = device->worker_core_from_logical_core(group1.start_coord);
+    const auto end_core1 = device->worker_core_from_logical_core(group1.end_coord);
+
+    const auto num_cores_range0 = group0.size();
+    const auto num_cores_range1 = all_cores.size() > 1 ? group1.size() : 0;
+
+    // Allocate two semaphores for synchronization (cores -> reducer core) and (reducer core -> cores)
+    const auto start_sem_idx = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
+    const auto done_sem_idx = tt::tt_metal::CreateSemaphore(program, all_cores, 0);
+
+    // Byte size of the data to read from the input CB for each core
+    const auto src_read_size0 = red_dim_units0 * input_unit_size;
+    const auto src_read_size1 = red_dim_units1 * input_unit_size;
+
+    // If red_dim_units is not a multiple of min_red_dim_units_per_core, then the last core will read a smaller amount
+    // of data We calculate that number here
+    const int ideal_red_dim_units = num_cores0 * red_dim_units0 + num_cores1 * red_dim_units1;
+
+    uint32_t red_dim_units_last0, red_dim_units_last1;
+    if (num_cores1 > 0) {
+        red_dim_units_last0 = red_dim_units0;
+        red_dim_units_last1 = ideal_red_dim_units == red_dim_units
+                                  ? red_dim_units1
+                                  : red_dim_units1 - (ideal_red_dim_units - red_dim_units);
+    } else {
+        red_dim_units_last0 = ideal_red_dim_units == red_dim_units
+                                  ? red_dim_units0
+                                  : red_dim_units0 - (ideal_red_dim_units - red_dim_units);
+        red_dim_units_last1 = 0;
+    }
+
+    const auto src_read_size_last0 = red_dim_units_last0 * input_unit_size;
+    const auto src_read_size_last1 = red_dim_units_last1 * input_unit_size;
+
+    // Common compile time args for all cores
+    // Refer to the kernel code for explanation of the args
+    std::vector<uint32_t> reader_compile_args = {
+        src_cb_idx,
+        dst_cb_idx,
+        red_idxs_cb_idx,
+        red_vals_cb_idx,
         src_is_dram,
         dst_is_dram,
-        aligned_input_unit_size,
-        aligned_intermed0_unit_size,
-        aligned_out0_unit_size,
-        B,
-        C,
-        H,
-        W / num_cores,
-        num_cores,
-        semaphore_addr,
-        final_cores_physical_x,
-        final_cores_physical_y};
+        src_page_size,
+        dst_page_size,
+        red_idxs_page_size / num_total_cores,
+        red_vals_page_size / num_total_cores,
+        outer_dim_units,
+        inner_dim_units,
+        red_dim_units,
+        (uint32_t)(reduce_all),
+        num_total_cores,
+        reduce_core_id,
+        (uint32_t)reduce_core.x,
+        (uint32_t)reduce_core.y,
+        // end comes before start for NOC1
+        (uint32_t)end_core0.x,
+        (uint32_t)end_core0.y,
+        (uint32_t)start_core0.x,
+        (uint32_t)start_core0.y,
+        (uint32_t)end_core1.x,
+        (uint32_t)end_core1.y,
+        (uint32_t)start_core1.x,
+        (uint32_t)start_core1.y,
+        (uint32_t)num_cores_range0,
+        (uint32_t)num_cores_range1,
+        start_sem_idx,
+        done_sem_idx,
+    };
 
     std::map<string, string> kernel_defines;
-    tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
+    tt::tt_metal::KernelHandle reader_kernel_id0 = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp",
-        core_grid,
+        cores0,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
             .noc = tt::tt_metal::NOC::RISCV_1_default,
-            .compile_args = reader_compile_time_args});
+            .compile_args = reader_compile_args});
 
-    // tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-    //     program,
-    //     "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp",
-    //     all_cores,
-    //     tt::tt_metal::DataMovementConfig{.processor = tt::tt_metal::DataMovementProcessor::RISCV_0, .noc =
-    //     tt::tt_metal::NOC::RISCV_0_default, .compile_args = reader_compile_time_args});
+    tt::tt_metal::KernelHandle reader_kernel_id1 = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp",
+        cores1,
+        tt::tt_metal::DataMovementConfig{
+            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+            .noc = tt::tt_metal::NOC::RISCV_1_default,
+            .compile_args = reader_compile_args});
 
-    for (uint32_t i = 0; i < cores.size(); ++i) {
-        const CoreCoord& core = cores.at(i);
+    const auto cores_coords0 = corerange_to_cores(cores0, num_cores0, true);
+    const auto cores_coords1 = corerange_to_cores(cores1, num_cores1, true);
 
+    // Set runtime args for cores0 and cores1, only offsets (src and red_dim_units) are different
+    // Refer to the kernel code for explanation of the args
+    for (uint32_t i = 0; i < num_cores0; ++i) {
+        const CoreCoord& core = cores_coords0.at(i);
         tt::tt_metal::SetRuntimeArgs(
-            program, reader_kernel_id, core, {src_buffer->address(), dst_buffer->address(), i});
-
-        // tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, {src_buffer->address(), dst_buffer->address(),
-        // 2*i+1});
+            program,
+            reader_kernel_id0,
+            core,
+            {src_buffer->address(),
+             dst_buffer->address(),
+             i,
+             i * src_read_size0,
+             i * red_dim_units0,
+             (i == num_cores0 - 1) ? src_read_size_last0 : src_read_size0,
+             (i == num_cores0 - 1) ? red_dim_units_last0 : red_dim_units0});
     }
 
-    auto override_runtime_args_callback = [reader_kernel_id, cores](
+    const uint32_t src_offset1 = static_cast<uint32_t>(src_read_size0 * num_cores0);
+    const uint32_t red_dim_offset1 = static_cast<uint32_t>(red_dim_units0 * num_cores0);
+
+    for (uint32_t i = 0; i < num_cores1; ++i) {
+        const CoreCoord& core = cores_coords1.at(i);
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            reader_kernel_id1,
+            core,
+            {src_buffer->address(),
+             dst_buffer->address(),
+             static_cast<uint32_t>(num_cores0 + i),
+             src_offset1 + i * src_read_size1,
+             red_dim_offset1 + i * red_dim_units1,
+             (i == num_cores1 - 1) ? src_read_size_last1 : src_read_size1,
+             (i == num_cores1 - 1) ? red_dim_units_last1 : red_dim_units1});
+    }
+
+    auto override_runtime_args_callback = [reader_kernel_id0, reader_kernel_id1, cores_coords0, cores_coords1](
                                               const void* operation,
                                               const Program& program,
                                               const std::vector<Tensor>& input_tensors,
@@ -247,20 +443,18 @@ operation::ProgramWithCallbacks argmax_multi_core(
         auto src_buffer = input_tensors.at(0).buffer();
 
         auto dst_buffer = output_tensors.at(0).buffer();
-        uint32_t core_id = 0;
-        for (const auto& core : cores) {
+        for (const auto& core : cores_coords0) {
             {
-                auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id, core);
+                auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id0, core);
                 reader_runtime_args[0] = src_buffer->address();
                 reader_runtime_args[1] = dst_buffer->address();
-                reader_runtime_args[2] = core_id;
-                core_id++;
-
-                // auto &writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id, core);
-                // writer_runtime_args[0] = src_buffer->address();
-                // writer_runtime_args[1] = dst_buffer->address();
-                // writer_runtime_args[2] = core_id;
-                // core_id++;
+            }
+        }
+        for (const auto& core : cores_coords1) {
+            {
+                auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id1, core);
+                reader_runtime_args[0] = src_buffer->address();
+                reader_runtime_args[1] = dst_buffer->address();
             }
         }
     };

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp
@@ -186,7 +186,7 @@ operation::ProgramWithCallbacks argmax_single_core(
     return {std::move(program), override_runtime_args_callback};
 }
 
-// NOC xactions need to be 32B aligned.
+// NOC transactions need to be 32B aligned.
 // So, for bfloat16 dtype, we need at least 16 units per core to avoid unaligned accesses.
 constexpr uint32_t min_red_dim_units_per_core = 16;
 

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.hpp
@@ -14,6 +14,7 @@ tt::tt_metal::operation::ProgramWithCallbacks argmax_multi_core(
     const Tensor& input,
     const Tensor& output,
     const std::optional<uint32_t> dim,
+    const bool keepdim,
     const std::optional<CoreRangeSet>& sub_core_grids);
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -282,20 +282,20 @@ void kernel_main() {
         }
 
         find_argmax_for_core<src_is_dram, reduce_all>(
-            /*inner_dim_units=*/inner_dim_units,
-            /*k=*/k,
-            /*src_offset=*/src_offset,
-            /*s_src=*/s_src,
-            /*src_cb_addr=*/src_cb_addr,
-            /*src_read_size=*/src_read_size,
-            /*red_dim_offset=*/red_dim_offset,
-            /*red_dim_units_this_core=*/red_dim_units_this_core,
-            /*in_vals=*/in_vals,
-            /*red_dim_units=*/red_dim_units,
-            /*max_idx=*/max_idx,
-            /*max_val=*/max_val,
-            /*red_idxs=*/red_idxs,
-            /*red_vals=*/red_vals);
+            inner_dim_units,
+            k,
+            src_offset,
+            s_src,
+            src_cb_addr,
+            src_read_size,
+            red_dim_offset,
+            red_dim_units_this_core,
+            in_vals,
+            red_dim_units,
+            max_idx,
+            max_val,
+            red_idxs,
+            red_vals);
 
         if constexpr (not reduce_all) {
             // We now write these local values to the equivalent position in the reduction core
@@ -317,11 +317,11 @@ void kernel_main() {
                 // Find argmax from intermediate outputs and write to output
                 for (uint32_t j = 0; j < inner_dim_units; ++j) {
                     out_idxs[j] = find_argmax_from_intermediate_outputs<num_cores>(
-                        /*j=*/j,
-                        /*red_val_cb_local_base_addr=*/red_val_cb_local_base_addr,
-                        /*red_idx_cb_local_base_addr=*/red_idx_cb_local_base_addr,
-                        /*red_val_size_per_core=*/red_val_size_per_core,
-                        /*red_idx_size_per_core=*/red_idx_size_per_core);
+                        j,
+                        red_val_cb_local_base_addr,
+                        red_idx_cb_local_base_addr,
+                        red_val_size_per_core,
+                        red_idx_size_per_core);
                 }
 
                 const uint64_t dst_noc_addr = get_noc_addr(k, s_dst);
@@ -352,11 +352,11 @@ void kernel_main() {
             }
 
             out_idxs[0] = find_argmax_from_intermediate_outputs<num_cores>(
-                /*j=*/0,  // For reduce_all, we only have one inner_dim_unit
-                /*red_val_cb_local_base_addr=*/red_val_cb_local_base_addr,
-                /*red_idx_cb_local_base_addr=*/red_idx_cb_local_base_addr,
-                /*red_val_size_per_core=*/red_val_size_per_core,
-                /*red_idx_size_per_core=*/red_idx_size_per_core);
+                0,  // For reduce_all, we only have one inner_dim_unit
+                red_val_cb_local_base_addr,
+                red_idx_cb_local_base_addr,
+                red_val_size_per_core,
+                red_idx_size_per_core);
 
             const uint64_t dst_noc_addr = get_noc_addr(0, s_dst);
             noc_async_write(dst_cb_addr, dst_noc_addr, dst_page_size);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -264,7 +264,9 @@ void kernel_main() {
             noc_semaphore_set(start_sem_local_ptr, k + 1);
 
             if constexpr (num_cores > 1) {
-                noc_semaphore_set_multicast_loopback_src(start_sem_local_addr, start_sem_noc_addr0, num_cores0);
+                if (k > 0) {
+                    noc_semaphore_set_multicast_loopback_src(start_sem_local_addr, start_sem_noc_addr0, num_cores0);
+                }
 
                 if (num_cores1 > 0) {
                     noc_semaphore_set_multicast(start_sem_local_addr, start_sem_noc_addr1, num_cores1);
@@ -275,7 +277,9 @@ void kernel_main() {
         }
 
         // Wait to start
-        noc_semaphore_wait(start_sem_local_ptr, k + 1);
+        if (k > 0) {
+            noc_semaphore_wait(start_sem_local_ptr, k + 1);
+        }
 
         find_argmax_for_core<src_is_dram, reduce_all>(
             /*inner_dim_units=*/inner_dim_units,

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_interleaved_multicore.cpp
@@ -7,136 +7,356 @@
 #include "dataflow_api.h"
 #include "utils/bfloat16.h"
 
-void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t dst_addr = get_arg_val<uint32_t>(1);
-    uint32_t core_id = get_arg_val<uint32_t>(2);
+/**
+ * @brief Process inner dimension units for argmax reduction
+ *
+ * This function handles the core logic of processing inner dimension units,
+ * including reading data, finding max values and indices, and storing results.
+ *
+ * @tparam src_is_dram Whether source is in DRAM
+ * @tparam reduce_all Whether to reduce across all dimensions
+ * @param inner_dim_units Number of units in the inner dimension
+ * @param outer_idx Current outer dimension index
+ * @param src_offset Source offset for reading data
+ * @param s_src Source stream descriptor
+ * @param src_cb_addr Source circular buffer address
+ * @param src_read_size Size of data to read from source
+ * @param red_dim_offset Reduction dimension offset
+ * @param red_dim_units_this_core Number of reduction units for this core
+ * @param in_vals Input values buffer
+ * @param red_dim_units Total reduction dimension units
+ * @param max_idx Maximum index found (output parameter)
+ * @param max_val Maximum value found (output parameter)
+ * @param red_idxs Buffer for reduction indices
+ * @param red_vals Buffer for reduction values
+ */
+template <bool src_is_dram, bool reduce_all>
+inline void find_argmax_for_core(
+    const uint32_t inner_dim_units,
+    const uint32_t outer_idx,
+    const uint32_t src_offset,
+    const InterleavedAddrGen<src_is_dram>& s_src,
+    const uint32_t src_cb_addr,
+    const uint32_t src_read_size,
+    const uint32_t red_dim_offset,
+    const uint32_t red_dim_units_this_core,
+    volatile tt_l1_ptr uint16_t* in_vals,
+    const uint32_t red_dim_units,
+    uint32_t& max_idx,
+    uint16_t& max_val,
+    volatile tt_l1_ptr uint32_t* red_idxs,
+    volatile tt_l1_ptr uint16_t* red_vals) {
+    for (uint32_t j = 0; j < inner_dim_units; ++j) {
+        noc_async_read(s_src.get_noc_addr(outer_idx * inner_dim_units + j, src_offset), src_cb_addr, src_read_size);
+        noc_async_read_barrier();
 
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_intermed0 = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_id_intermed1 = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(3);
-    constexpr bool src0_is_dram = (bool)get_compile_time_arg_val(4);
-    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(5);
-    constexpr uint32_t in0_stick_size = get_compile_time_arg_val(6);
-    constexpr uint32_t intermed0_stick_size = get_compile_time_arg_val(7);
-    constexpr uint32_t out_stick_size = get_compile_time_arg_val(8);
-    constexpr uint32_t B = get_compile_time_arg_val(9);
-    constexpr uint32_t C = get_compile_time_arg_val(10);
-    constexpr uint32_t H = get_compile_time_arg_val(11);
-    constexpr uint32_t W = get_compile_time_arg_val(12);
-    constexpr uint32_t num_cores = get_compile_time_arg_val(13);
-    uint32_t semaphore_addr_ptr = get_semaphore(get_compile_time_arg_val(14));
-    constexpr uint32_t final_cores_physical_x = get_compile_time_arg_val(15);
-    constexpr uint32_t final_cores_physical_y = get_compile_time_arg_val(16);
-    bool reducer_core = core_id == 0 ? 1 : 0;
-
-    const InterleavedAddrGen<src0_is_dram> s0 = {.bank_base_address = src_addr, .page_size = in0_stick_size};
-    uint64_t src_noc_addr = get_noc_addr(0, s0);
-    // Use cb as L1 scratch memory
-    uint32_t intermed0_addr = get_write_ptr(cb_id_intermed0);
-    volatile tt_l1_ptr uint32_t* max_ids = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(intermed0_addr);
-
-    uint32_t intermed1_addr = get_write_ptr(cb_id_intermed1) + 4 * num_cores;
-    volatile tt_l1_ptr uint16_t* max_vals = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(intermed1_addr);
-
-    // Use cb as L1 scratch memory
-    uint32_t cb_addr = get_write_ptr(cb_id_in0);
-    volatile tt_l1_ptr uint16_t* stick = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb_addr);
-    // DPRINT << cb_id_intermed0 << " "<< cb_id_intermed1 << " " <<intermed0_addr << " " << intermed1_addr <<" " <<
-    // cb_addr<< ENDL();
-
-    uint32_t max_index = 0;
-    uint32_t max_val = 0;
-    uint32_t index_counter = 0;
-    uint32_t core_offset = core_id * W;
-    // uint32_t page_number = core_id; //(core_id*W)/in0_stick_size;
-    // uint32_t page_offset = 0; //(core_id*W)%in0_stick_size;
-    // DPRINT << "core" << core_id << " page_number: " << page_number<< " page_offset: " << page_offset << "page size"
-    // <<  in0_stick_size <<ENDL();
-    noc_async_read(src_noc_addr, cb_addr, (W * num_cores) * 2);
-    // noc_async_read(src_noc_addr + core_id*W*2, cb_addr, (W)*2);
-    // noc_async_read_page(0, s0, cb_addr);
-    noc_async_read_barrier();
-
-    index_counter = core_offset;
-    max_index = index_counter;
-    max_val = stick[0];  //
-    max_val = stick[core_id * W];
-    for (uint32_t i = core_id * W; i < W + core_id * W; i++) {
-        uint16_t val = stick[i];
-        // DPRINT << "W"<< i<< ":"<<val << ENDL();
-        if (bfloat16_greater(val, max_val)) {
-            max_index = index_counter;
-            max_val = val;
+        // Reset max_val for each new output
+        if constexpr (not reduce_all) {
+            max_idx = 0;
+            max_val = NEG_INF_BFLOAT16;
         }
-        index_counter++;
-    }
 
-    // set max_vals for reader and writer kernels
-    max_ids[core_id] = max_index;
-    max_vals[core_id] = max_val;
-
-    // DPRINT << "core" << core_id << " max_index: " << max_ids[0]<< " max_val: " << max_vals[0] << ENDL();
-    // DPRINT << "core" << core_id << max_index << " done" << max_val<< ENDL();
-    // write max_vals to reducer core CB
-    uint64_t dst_cb_addr_0 =
-        get_noc_addr(final_cores_physical_x, final_cores_physical_y, get_write_ptr(cb_id_intermed0));
-    uint64_t dst_cb_addr_1 =
-        get_noc_addr(final_cores_physical_x, final_cores_physical_y, get_write_ptr(cb_id_intermed1)) + 4 * num_cores;
-    // noc_async_write(intermed_addr + (core_id%2)*4, dst_cb_addr + core_id*4, 4);
-    noc_async_write(intermed0_addr + core_id * 4, dst_cb_addr_0 + core_id * 4, 4);
-    noc_async_write_barrier();
-    noc_async_write(intermed1_addr + core_id * 2, dst_cb_addr_1 + core_id * 2, 2);
-    noc_async_write_barrier();
-
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_cb_addr_0);
-    volatile tt_l1_ptr uint16_t* ptr1 = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(dst_cb_addr_1);
-    // DPRINT << dst_cb_addr_0 << " "<< dst_cb_addr_0 + core_id*4 <<" "<< dst_cb_addr_1 << " " <<intermed0_addr << " "
-    // << intermed1_addr <<" " << cb_addr<< ENDL(); DPRINT << ptr[0] <<" "<< ptr[1] << " " <<ptr[2] << " " << ptr[3] <<
-    // " " << ptr[4]<<ENDL(); DPRINT << ptr1[0] <<" "<< ptr1[1] << " " <<ptr1[2] << " " << ptr1[3] << " " <<
-    // ptr1[4]<<ENDL();
-
-    // inc noc semaphore
-    const uint64_t in0_sender_semaphore_noc_addr =
-        get_noc_addr(final_cores_physical_x, final_cores_physical_y, semaphore_addr_ptr);
-    noc_semaphore_inc(in0_sender_semaphore_noc_addr, 1);
-
-    // DPRINT << "core" << core_id << " done" << ENDL();
-
-    if (reducer_core) {
-        // wait for semaphore
-        volatile tt_l1_ptr uint32_t* in0_receiver_semaphore_addr_ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(semaphore_addr_ptr);
-        noc_semaphore_wait(in0_receiver_semaphore_addr_ptr, num_cores);
-        // Use cb as L1 scratch memory
-        uint32_t out_addr = get_write_ptr(cb_id_out0);
-        volatile tt_l1_ptr uint32_t* max_vals_final = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_addr);
-        // re-use intermed cb
-        uint32_t intermed0_re_addr = get_write_ptr(cb_id_intermed0);
-        volatile tt_l1_ptr uint32_t* max_ids_reduce = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(intermed0_re_addr);
-        uint32_t intermed1_re_addr = get_write_ptr(cb_id_intermed1) + 4 * num_cores;
-        volatile tt_l1_ptr uint16_t* max_vals_reduce =
-            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(intermed1_re_addr);
-
-        max_index = max_ids_reduce[0];
-        max_val = max_vals_reduce[0];
-        for (uint32_t i = 0; i < num_cores; i++) {
-            uint32_t index = max_ids_reduce[i];
-            uint16_t val = max_vals_reduce[i];
-            // DPRINT << "core"<< i<< ":"<<index <<" "<< val<< ENDL();
+        for (uint32_t i = red_dim_offset; i < (red_dim_offset + red_dim_units_this_core); ++i) {
+            uint16_t val = in_vals[i - red_dim_offset];
             if (bfloat16_greater(val, max_val)) {
-                max_index = index;
+                auto full_idx = outer_idx * inner_dim_units * red_dim_units + j * red_dim_units + i;
+                max_idx = reduce_all ? full_idx : i;
                 max_val = val;
+            } else if (val == max_val) {
+                auto full_idx = outer_idx * inner_dim_units * red_dim_units + j * red_dim_units + i;
+                max_idx = reduce_all ? min(max_idx, full_idx) : min(max_idx, i);
             }
         }
-        max_vals_final[0] = max_index;
 
-        const InterleavedAddrGen<dst_is_dram> s_out = {.bank_base_address = dst_addr, .page_size = out_stick_size};
-        uint64_t dst_noc_addr = get_noc_addr(0, s_out);
-        noc_async_write(out_addr, dst_noc_addr, out_stick_size);
-        noc_async_write_barrier();
+        if constexpr (not reduce_all) {
+            red_idxs[j] = max_idx;
+            red_vals[j] = max_val;
+        }
     }
+}
 
-    noc_async_atomic_barrier();
+/**
+ * @brief Finds the argmax from intermediate outputs across all cores
+ *
+ * This function processes the intermediate outputs from all cores to find the final
+ * argmax values. It compares values from each core and selects the maximum value,
+ * with ties broken by selecting the smaller index.
+ *
+ * @tparam num_cores Total number of cores participating in the reduction
+ * @param inner_idx Index of the inner dimension unit to find argmax for
+ * @param red_val_cb_local_base_addr Base address of the circular buffer storing intermediate values
+ * @param red_idx_cb_local_base_addr Base address of the circular buffer storing intermediate indices
+ * @param red_val_size_per_core Size of the value buffer per core
+ * @param red_idx_size_per_core Size of the index buffer per core
+ * @param inner_dim_units Number of elements in the inner dimension
+ */
+template <uint32_t num_cores>
+inline uint32_t find_argmax_from_intermediate_outputs(
+    const uint32_t inner_idx,
+    const uint32_t red_val_cb_local_base_addr,
+    const uint32_t red_idx_cb_local_base_addr,
+    const uint32_t red_val_size_per_core,
+    const uint32_t red_idx_size_per_core) {
+    // Reset max_val for each new output
+    uint16_t max_val = NEG_INF_BFLOAT16;
+    uint32_t max_idx = 0;
+
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        volatile tt_l1_ptr auto i_red_vals =
+            reinterpret_cast<volatile tt_l1_ptr uint16_t*>(red_val_cb_local_base_addr + i * red_val_size_per_core);
+        volatile tt_l1_ptr auto i_red_idxs =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_idx_cb_local_base_addr + i * red_idx_size_per_core);
+
+        uint16_t val = i_red_vals[inner_idx];
+
+        if (bfloat16_greater(val, max_val)) {
+            max_idx = i_red_idxs[inner_idx];
+            max_val = val;
+        } else if ((val == max_val) && (i_red_idxs[inner_idx] < max_idx)) {
+            max_idx = i_red_idxs[inner_idx];
+        }
+    }
+    return max_idx;
+}
+
+void kernel_main() {
+    // Runtime args
+    // ------------
+    const uint32_t src_base_addr = get_arg_val<uint32_t>(0);
+    const uint32_t dst_base_addr = get_arg_val<uint32_t>(1);
+    const uint32_t core_id = get_arg_val<uint32_t>(2);
+
+    // The offset of the input CB in the input tensor
+    const uint32_t src_offset = get_arg_val<uint32_t>(3);
+
+    // The offset of the reduction dim in the input CB
+    const uint32_t red_dim_offset = get_arg_val<uint32_t>(4);
+
+    // The bytes to read from the input CB for this core
+    const uint32_t src_read_size = get_arg_val<uint32_t>(5);
+
+    // This is the number of elements in the reduction dim processed by this core
+    const uint32_t red_dim_units_this_core = get_arg_val<uint32_t>(6);
+
+    // Compile time args
+    // -----------------
+    constexpr uint32_t src_cb_idx = get_compile_time_arg_val(0);
+
+    // This CB is only used in the reduction core. It is used to store
+    // final outputs (indices) after reduction of intermediate outputs.
+    constexpr uint32_t dst_cb_idx = get_compile_time_arg_val(1);
+
+    // This CB holds intermediate outputs (indices) in each core
+    constexpr uint32_t red_idxs_cb_idx = get_compile_time_arg_val(2);
+
+    // This CB holds intermediate outputs (values) in each core
+    constexpr uint32_t red_vals_cb_idx = get_compile_time_arg_val(3);
+
+    constexpr bool src_is_dram = (bool)get_compile_time_arg_val(4);
+    constexpr bool dst_is_dram = (bool)get_compile_time_arg_val(5);
+    constexpr uint32_t src_page_size = get_compile_time_arg_val(6);
+    constexpr uint32_t dst_page_size = get_compile_time_arg_val(7);
+    constexpr uint32_t red_idx_size_per_core = get_compile_time_arg_val(8);
+    constexpr uint32_t red_val_size_per_core = get_compile_time_arg_val(9);
+
+    // This is the number of elements in the output, excluding the last two dimensions.
+    // i.e. for an input tensor of shape (.., N, C, H, W), this is (.. * N * C)
+    // It also depends on the `keepdim`
+    constexpr uint32_t outer_dim_units = get_compile_time_arg_val(10);
+
+    // This is the number of elements in the last dimension of the output
+    // i.e. for an input tensor of shape (.., N, C, H, W), this is H.
+    // This dictates the page size in the output cb
+    constexpr uint32_t inner_dim_units = get_compile_time_arg_val(11);
+
+    // This is the number of elements in the input tensor along the reduction dim (W)
+    constexpr uint32_t red_dim_units = get_compile_time_arg_val(12);
+
+    // Boolean to indicate if we reduce across _all_ dimensions or just on the reduction dim (last dim)
+    constexpr bool reduce_all = (bool)get_compile_time_arg_val(13);
+
+    // Total number of cores participating in this op
+    constexpr uint32_t num_cores = get_compile_time_arg_val(14);
+
+    // Pick the core that will collate the intermediate outputs
+    constexpr uint32_t reduce_core_id = (bool)get_compile_time_arg_val(15);
+
+    constexpr uint32_t reduce_core_x = get_compile_time_arg_val(16);
+    constexpr uint32_t reduce_core_y = get_compile_time_arg_val(17);
+
+    // start and end coordinates of the cores that will be used to compute the intermediate outputs
+    // At maximum, there can be two groups of cores (suffix 0 and 1)
+    constexpr uint32_t start_core_x0 = get_compile_time_arg_val(18);
+    constexpr uint32_t start_core_y0 = get_compile_time_arg_val(19);
+    constexpr uint32_t end_core_x0 = get_compile_time_arg_val(20);
+    constexpr uint32_t end_core_y0 = get_compile_time_arg_val(21);
+
+    constexpr uint32_t start_core_x1 = get_compile_time_arg_val(22);
+    constexpr uint32_t start_core_y1 = get_compile_time_arg_val(23);
+    constexpr uint32_t end_core_x1 = get_compile_time_arg_val(24);
+    constexpr uint32_t end_core_y1 = get_compile_time_arg_val(25);
+
+    constexpr uint32_t num_cores0 = get_compile_time_arg_val(26);  // Number of cores in group 0
+    constexpr uint32_t num_cores1 = get_compile_time_arg_val(27);  // Number of cores in group 1
+
+    // Semaphore to fire when intermediate outputs can be started to compute
+    constexpr uint32_t start_sem_idx = get_compile_time_arg_val(28);
+
+    // Semaphore to fire when intermediate outputs for one page are ready
+    constexpr uint32_t done_sem_idx = get_compile_time_arg_val(29);
+
+    //-------------------------------------------------------------------------
+    // Flag to identify if this core will collate intermediate outputs
+    const bool is_reduce_core = (core_id == reduce_core_id);
+
+    const InterleavedAddrGen<src_is_dram> s_src = {.bank_base_address = src_base_addr, .page_size = src_page_size};
+    const InterleavedAddrGen<dst_is_dram> s_dst = {.bank_base_address = dst_base_addr, .page_size = dst_page_size};
+
+    // CB in L1 memory for storing input
+    const uint32_t src_cb_addr = get_write_ptr(src_cb_idx);
+    volatile tt_l1_ptr uint16_t* in_vals = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(src_cb_addr);
+
+    // CB in L1 memory of reducer core for storing output
+    const uint32_t dst_cb_addr = get_write_ptr(dst_cb_idx);
+    volatile tt_l1_ptr uint32_t* out_idxs = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_cb_addr);
+
+    // CB in L1 memory for storing partial idx output
+    const uint32_t red_idx_cb_local_base_addr = get_write_ptr(red_idxs_cb_idx);
+    const uint32_t red_idx_offset = core_id * red_idx_size_per_core;
+
+    const uint32_t red_idx_cb_local_addr = red_idx_cb_local_base_addr + red_idx_offset;
+    volatile tt_l1_ptr uint32_t* red_idxs = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(red_idx_cb_local_addr);
+
+    const uint64_t red_idx_noc_addr = get_noc_addr(reduce_core_x, reduce_core_y, red_idx_cb_local_addr);
+
+    // CB in L1 memory for storing partial val output
+    const uint32_t red_val_cb_local_base_addr = get_write_ptr(red_vals_cb_idx);
+    const uint32_t red_val_offset = core_id * red_val_size_per_core;
+
+    const uint32_t red_val_cb_local_addr = red_val_cb_local_base_addr + red_val_offset;
+    volatile tt_l1_ptr uint16_t* red_vals = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(red_val_cb_local_addr);
+
+    const uint64_t red_val_noc_addr = get_noc_addr(reduce_core_x, reduce_core_y, red_val_cb_local_addr);
+
+    // Semaphore addresses
+    const uint32_t start_sem_local_addr = get_semaphore(start_sem_idx);
+    uint64_t start_sem_noc_addr0 =
+        get_noc_multicast_addr(start_core_x0, start_core_y0, end_core_x0, end_core_y0, start_sem_local_addr);
+    uint64_t start_sem_noc_addr1 =
+        get_noc_multicast_addr(start_core_x1, start_core_y1, end_core_x1, end_core_y1, start_sem_local_addr);
+    volatile tt_l1_ptr uint32_t* start_sem_local_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_sem_local_addr);
+
+    const uint32_t done_sem_local_addr = get_semaphore(done_sem_idx);
+    const uint64_t done_sem_noc_addr = get_noc_addr(reduce_core_x, reduce_core_y, done_sem_local_addr);
+    volatile tt_l1_ptr uint32_t* done_sem_local_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(done_sem_local_addr);
+
+    uint32_t max_idx = 0;
+    uint16_t max_val = NEG_INF_BFLOAT16;
+    noc_semaphore_set(done_sem_local_ptr, 0);
+
+    // -------------------------------------------------------------------------
+    // Main loop - run by all cores
+    for (uint32_t k = 0; k < outer_dim_units; ++k) {
+        if (is_reduce_core) {
+            noc_semaphore_set(done_sem_local_ptr, 0);
+            noc_semaphore_set(start_sem_local_ptr, k + 1);
+
+            if constexpr (num_cores > 1) {
+                noc_semaphore_set_multicast_loopback_src(start_sem_local_addr, start_sem_noc_addr0, num_cores0);
+
+                if (num_cores1 > 0) {
+                    noc_semaphore_set_multicast(start_sem_local_addr, start_sem_noc_addr1, num_cores1);
+                }
+
+                noc_async_atomic_barrier();
+            }
+        }
+
+        // Wait to start
+        noc_semaphore_wait(start_sem_local_ptr, k + 1);
+
+        find_argmax_for_core<src_is_dram, reduce_all>(
+            /*inner_dim_units=*/inner_dim_units,
+            /*k=*/k,
+            /*src_offset=*/src_offset,
+            /*s_src=*/s_src,
+            /*src_cb_addr=*/src_cb_addr,
+            /*src_read_size=*/src_read_size,
+            /*red_dim_offset=*/red_dim_offset,
+            /*red_dim_units_this_core=*/red_dim_units_this_core,
+            /*in_vals=*/in_vals,
+            /*red_dim_units=*/red_dim_units,
+            /*max_idx=*/max_idx,
+            /*max_val=*/max_val,
+            /*red_idxs=*/red_idxs,
+            /*red_vals=*/red_vals);
+
+        if constexpr (not reduce_all) {
+            // We now write these local values to the equivalent position in the reduction core
+            if (core_id != reduce_core_id) {
+                noc_async_write(red_idx_cb_local_addr, red_idx_noc_addr, red_idx_size_per_core);
+                noc_async_write(red_val_cb_local_addr, red_val_noc_addr, red_val_size_per_core);
+                noc_async_write_barrier();
+            }
+
+            noc_semaphore_inc(done_sem_noc_addr, 1);
+            noc_async_atomic_barrier();
+
+            // If this is the reducer core, wait for the semaphore to be set
+            if (is_reduce_core) {
+                if constexpr (num_cores > 1) {
+                    noc_semaphore_wait(done_sem_local_ptr, num_cores);
+                }
+
+                // Find argmax from intermediate outputs and write to output
+                for (uint32_t j = 0; j < inner_dim_units; ++j) {
+                    out_idxs[j] = find_argmax_from_intermediate_outputs<num_cores>(
+                        /*j=*/j,
+                        /*red_val_cb_local_base_addr=*/red_val_cb_local_base_addr,
+                        /*red_idx_cb_local_base_addr=*/red_idx_cb_local_base_addr,
+                        /*red_val_size_per_core=*/red_val_size_per_core,
+                        /*red_idx_size_per_core=*/red_idx_size_per_core);
+                }
+
+                const uint64_t dst_noc_addr = get_noc_addr(k, s_dst);
+                noc_async_write(dst_cb_addr, dst_noc_addr, dst_page_size);
+                noc_async_write_barrier();
+            }
+        }
+    }  // for (uint32_t k = 0; k < outer_dim_units; ++k)
+
+    if constexpr (reduce_all) {
+        red_idxs[0] = max_idx;
+        red_vals[0] = max_val;
+
+        // We now write these local values to the equivalent position in the reduction core
+        if (core_id != reduce_core_id) {
+            noc_async_write(red_idx_cb_local_addr, red_idx_noc_addr, red_idx_size_per_core);
+            noc_async_write(red_val_cb_local_addr, red_val_noc_addr, red_val_size_per_core);
+            noc_async_write_barrier();
+        }
+
+        noc_semaphore_inc(done_sem_noc_addr, 1);
+        noc_async_atomic_barrier();
+
+        // If this is the reducer core, wait for the semaphore to be set
+        if (is_reduce_core) {
+            if constexpr (num_cores > 1) {
+                noc_semaphore_wait(done_sem_local_ptr, num_cores);
+            }
+
+            out_idxs[0] = find_argmax_from_intermediate_outputs<num_cores>(
+                /*j=*/0,  // For reduce_all, we only have one inner_dim_unit
+                /*red_val_cb_local_base_addr=*/red_val_cb_local_base_addr,
+                /*red_idx_cb_local_base_addr=*/red_idx_cb_local_base_addr,
+                /*red_val_size_per_core=*/red_val_size_per_core,
+                /*red_idx_size_per_core=*/red_idx_size_per_core);
+
+            const uint64_t dst_noc_addr = get_noc_addr(0, s_dst);
+            noc_async_write(dst_cb_addr, dst_noc_addr, dst_page_size);
+            noc_async_write_barrier();
+        }
+    }  // if constexpr (reduce_all)
 }


### PR DESCRIPTION
### 🎫 Ticket
This PR addresses the following issues:
- https://github.com/tenstorrent/tt-metal/issues/16719
- https://github.com/tenstorrent/tt-metal/issues/16720
- https://github.com/tenstorrent/tt-metal/issues/18241

### 🔍 Problem Description
Current multicore implementation for argmax is restricted to 1,1,H,W shapes only. This PR replaces the current implementation with a more generic one.

### ✨ What's Changed
1. New argmax multicore factory function that generates compile and runtime parameters for a given input tensor and reduction dim.
2. New device kernel that runs on a maximum of 2 grids on the device with synchronization using multicast and semaphores.
3. Flexible implementation that can be tuned for performance with knobs for number of cores and work per core.
4. Placeholders to use NOC0 and RISC1 cores to double throughput in the future among other performance optimizations.
5. Tailor input CB size based on the data read from DRAM. This increases the maximum reduction dim that can be processed by each core and improves overall SRAM utilization and performance.

More details on the kernel can be [found here.](https://github.com/tenstorrent/tt-metal/blob/696c010cecd4f04ed36711bcf19cc43c1b90b722/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_program_factory.cpp#L127)

### 🎯 Impact
1. ttnn.argmax now works on wider range of inputs.
2. It also supports distributing the work over as many cores as needed to get speedup over single core implementation.

### 📊 Summary

| Rank | All dims supported | Matches Torch? | 0 volume supported | Shape requirement | Multicore support |
|------|-------------------|----------------|-------------------|-------------------|-------------------|
| 0    | ✅                | ✅             | ✅                | -                 | ✅                |
| 1    | ✅                | ✅             | ✅                | -                 | ✅                |
| 3-8  | ❌ (-1, None)      | ✅             | ✅                | -                 | ✅                |

### Checklist
- [x] [All post commit] Passing: https://github.com/tenstorrent/tt-metal/actions/runs/14488520104
- [x] [Blackhole Post commit] Passing: https://github.com/tenstorrent/tt-metal/actions/runs/14484570314
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) Passing: https://github.com/tenstorrent/tt-metal/actions/runs/14544516628
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) Passing: https://github.com/tenstorrent/tt-metal/actions/runs/14544508802
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) Matching main: https://github.com/tenstorrent/tt-metal/actions/runs/14544484899
- [x] New/Existing tests provide coverage for changes - Unit tests updated, sweeps added.
- [x] TG Frequent Tests - Passing: https://github.com/tenstorrent/tt-metal/actions/runs/14546402398
- [x] T3K Frequent Tests - Matching main: https://github.com/tenstorrent/tt-metal/actions/runs/14546395615
- [x] TG Quick - Performance improved: https://github.com/tenstorrent/tt-metal/actions/runs/14610086574