### PR TITLE
Update xtensor stack and fix includes.

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -144,7 +144,7 @@ RUN mkdir -p /tmp/taskflow \
     && make -C /tmp/taskflow/build install \
     && rm -rf /tmp/taskflow
 
-ARG XTENSOR_XTL_VERSION=0.7.7
+ARG XTENSOR_XTL_VERSION=0.8.0
 RUN mkdir -p /tmp/xtensor_xtl \
     && wget -O /tmp/xtensor_xtl/xtensor_xtl-${XTENSOR_XTL_VERSION}.tar.gz "https://github.com/xtensor-stack/xtl/archive/refs/tags/${XTENSOR_XTL_VERSION}.tar.gz" \
     && tar -xzf /tmp/xtensor_xtl/xtensor_xtl-${XTENSOR_XTL_VERSION}.tar.gz -C /tmp/xtensor_xtl --strip-components=1 \
@@ -157,7 +157,7 @@ RUN mkdir -p /tmp/xtensor_xtl \
     && rm -rf /tmp/xtensor_xtl
 
 # xtensor problematic
-#ARG XTENSOR_VERSION=0.25.0
+#ARG XTENSOR_VERSION=0.26.0
 #RUN mkdir -p /tmp/xtensor \
 #    && wget -O /tmp/xtensor/xtensor-${XTENSOR_VERSION}.tar.gz "https://github.com/xtensor-stack/xtensor/archive/refs/tags/${XTENSOR_VERSION}.tar.gz" \
 #    && tar -xzf /tmp/xtensor/xtensor-${XTENSOR_VERSION}.tar.gz -C /tmp/xtensor --strip-components=1 \
@@ -170,7 +170,7 @@ RUN mkdir -p /tmp/xtensor_xtl \
 #    && rm -rf /tmp/xtensor
 
 # Issue arises - No blas
-#ARG XTENSOR_BLAS_VERSION=0.21.0
+#ARG XTENSOR_BLAS_VERSION=0.22.0
 #RUN mkdir -p /tmp/xtensor_blas \
 #    && wget -O /tmp/xtensor_blas/xtensor_blas-${XTENSOR_BLAS_VERSION}.tar.gz "https://github.com/xtensor-stack/xtensor-blas/archive/refs/tags/${XTENSOR_BLAS_VERSION}.tar.gz" \
 #    && tar -xzf /tmp/xtensor_blas/xtensor_blas-${XTENSOR_BLAS_VERSION}.tar.gz -C /tmp/xtensor_blas --strip-components=1 \

--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -3,18 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/utils/xexception.hpp>
+#include <xtensor/core/xiterator.hpp>
+#include <xtensor/core/xlayout.hpp>
+#include <xtensor/core/xmath.hpp>
+#include <xtensor/containers/xstorage.hpp>
+#include <xtensor/core/xtensor_forward.hpp>
+#include <xtensor/utils/xtensor_simd.hpp>
+#include <xtensor/utils/xutils.hpp>
 
 #include <cstdint>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xexception.hpp>
-#include <xtensor/xiterator.hpp>
-#include <xtensor/xlayout.hpp>
-#include <xtensor/xmath.hpp>
-#include <xtensor/xstorage.hpp>
-#include <xtensor/xtensor_forward.hpp>
-#include <xtensor/xtensor_simd.hpp>
-#include <xtensor/xutils.hpp>
 #include <tuple>
 #include <vector>
 #include <sys/mman.h>

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -5,10 +5,10 @@
 #include <boost/move/utility_core.hpp>
 #include <gtest/gtest.h>
 #include <tt-metalium/bfloat16.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xiterator.hpp>
-#include <xtensor/xlayout.hpp>
-#include <xtensor/xtensor_simd.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/core/xiterator.hpp>
+#include <xtensor/core/xlayout.hpp>
+#include <xtensor/utils/xtensor_simd.hpp>
 #include <xtl/xiterator_base.hpp>
 #include <algorithm>
 #include <cstdint>

--- a/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_xtensor_conversion.cpp
@@ -4,16 +4,16 @@
 
 #include <boost/container/vector.hpp>
 #include <gtest/gtest.h>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xcontainer.hpp>
-#include <xtensor/xiterator.hpp>
-#include <xtensor/xlayout.hpp>
-#include <xtensor/xmath.hpp>
-#include <xtensor/xshape.hpp>
-#include <xtensor/xstorage.hpp>
-#include <xtensor/xtensor_forward.hpp>
-#include <xtensor/xtensor_simd.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/containers/xcontainer.hpp>
+#include <xtensor/core/xiterator.hpp>
+#include <xtensor/core/xlayout.hpp>
+#include <xtensor/core/xmath.hpp>
+#include <xtensor/core/xshape.hpp>
+#include <xtensor/containers/xstorage.hpp>
+#include <xtensor/core/xtensor_forward.hpp>
+#include <xtensor/utils/xtensor_simd.hpp>
 #include <cstddef>
 #include <tuple>
 #include <vector>

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -165,7 +165,9 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${DEFAULT_COMPONENT_NAME})
 CPMAddPackage(
     NAME xtl
     GITHUB_REPOSITORY xtensor-stack/xtl
-    GIT_TAG 0.7.7
+    GIT_TAG 0.8.0
+    PATCHES
+        xtl.patch
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "XTL_ENABLE_TESTS OFF"
@@ -173,7 +175,9 @@ CPMAddPackage(
 CPMAddPackage(
     NAME xtensor
     GITHUB_REPOSITORY xtensor-stack/xtensor
-    GIT_TAG 0.25.0
+    GIT_TAG 0.26.0
+    PATCHES
+        xtensor.patch
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "XTENSOR_ENABLE_TESTS OFF"
@@ -181,7 +185,9 @@ CPMAddPackage(
 CPMAddPackage(
     NAME xtensor-blas
     GITHUB_REPOSITORY xtensor-stack/xtensor-blas
-    GIT_TAG 0.21.0
+    GIT_TAG 0.22.0
+    PATCHES
+        xtensor-blas.patch
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "XTENSOR_ENABLE_TESTS OFF"

--- a/third_party/xtensor-blas.patch
+++ b/third_party/xtensor-blas.patch
@@ -1,0 +1,70 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8886cda..8e1333b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+ project(xtensor-blas)
+
+ set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+ set(XTENSOR_BLAS_INCLUDE_DIR ${INCLUDE_DIR})
+
+diff --git a/benchmark/CMakeLists.txt b/benchmark/CMakeLists.txt
+index 1b66d74..8aeb775 100644
+--- a/benchmark/CMakeLists.txt
++++ b/benchmark/CMakeLists.txt
+@@ -4,11 +4,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtensor-benchmark)
+
+     find_package(xtensor REQUIRED CONFIG)
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 025233f..72fd0e6 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtensor-blas-test)
+
+     enable_testing()
+diff --git a/test/downloadGTest.cmake.in b/test/downloadGTest.cmake.in
+index e06bb06..b315e46 100644
+--- a/test/downloadGTest.cmake.in
++++ b/test/downloadGTest.cmake.in
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ project(googletest-download NONE)
+
+ include(ExternalProject)
+ ExternalProject_Add(googletest
+--
+2.49.0

--- a/third_party/xtensor.patch
+++ b/third_party/xtensor.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c7ec920..5228c30 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+ project(xtensor CXX)
+
+ set(XTENSOR_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+ # Versionning
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index cc2f928..8e84e39 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtensor-test CXX)
+
+     enable_testing()
+--
+2.49.0

--- a/third_party/xtl.patch
+++ b/third_party/xtl.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 796dc46..d6ce609 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+ project(xtl)
+
+ set(XTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+ # Versioning
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index ee6ce9c..ac56750 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -5,11 +5,11 @@
+ # Distributed under the terms of the BSD 3-Clause License.                 #
+ #                                                                          #
+ # The full license is in the file LICENSE, distributed with this software. #
+ ############################################################################
+
+-cmake_minimum_required(VERSION 3.29)
++cmake_minimum_required(VERSION 3.15..3.30)
+
+ find_package(doctest            REQUIRED)
+
+ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+     project(xtl-test)
+--
+2.49.0

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -72,14 +72,14 @@ CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.
 
 CPMAddPackage(NAME nlohmann_json GITHUB_REPOSITORY nlohmann/json GIT_TAG v3.11.3 OPTIONS "JSON_BuildTests OFF")
 
-CPMAddPackage(NAME xtl GITHUB_REPOSITORY xtensor-stack/xtl GIT_TAG 0.7.7 OPTIONS "XTL_ENABLE_TESTS OFF")
+CPMAddPackage(NAME xtl GITHUB_REPOSITORY xtensor-stack/xtl GIT_TAG 0.8.0 OPTIONS "XTL_ENABLE_TESTS OFF")
 
-CPMAddPackage(NAME xtensor GITHUB_REPOSITORY xtensor-stack/xtensor GIT_TAG 0.25.0 OPTIONS "XTENSOR_ENABLE_TESTS OFF")
+CPMAddPackage(NAME xtensor GITHUB_REPOSITORY xtensor-stack/xtensor GIT_TAG 0.26.0 OPTIONS "XTENSOR_ENABLE_TESTS OFF")
 
 CPMAddPackage(
     NAME xtensor-blas
     GITHUB_REPOSITORY xtensor-stack/xtensor-blas
-    GIT_TAG 0.21.0
+    GIT_TAG 0.22.0
     OPTIONS
         "XTENSOR_ENABLE_TESTS OFF"
 )

--- a/tt-train/tests/core/clip_grad_norm_test.cpp
+++ b/tt-train/tests/core/clip_grad_norm_test.cpp
@@ -7,8 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <core/ttnn_all_includes.hpp>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/views/xview.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "autograd/tensor.hpp"

--- a/ttnn/cpp/ttnn/tensor/xtensor/partition.cpp
+++ b/ttnn/cpp/ttnn/tensor/xtensor/partition.cpp
@@ -9,11 +9,11 @@
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/tensor/xtensor/conversion_utils.hpp"
 #include <type_traits>
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xdynamic_view.hpp>
-#include <xtensor/xstorage.hpp>
-#include <xtensor/xtensor_forward.hpp>
-#include <xtensor/xview.hpp>
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/views/xdynamic_view.hpp>
+#include <xtensor/containers/xstorage.hpp>
+#include <xtensor/core/xtensor_forward.hpp>
+#include <xtensor/views/xview.hpp>
 
 namespace ttnn::experimental::xtensor {
 namespace {

--- a/ttnn/cpp/ttnn/tensor/xtensor/xtensor_all_includes.hpp
+++ b/ttnn/cpp/ttnn/tensor/xtensor/xtensor_all_includes.hpp
@@ -4,16 +4,16 @@
 
 #pragma once
 
-#include <xtensor/xadapt.hpp>
-#include <xtensor/xarray.hpp>
-#include <xtensor/xbuffer_adaptor.hpp>
-#include <xtensor/xbuilder.hpp>
-#include <xtensor/xexpression.hpp>
-#include <xtensor/xio.hpp>
-#include <xtensor/xrandom.hpp>
-#include <xtensor/xslice.hpp>
-#include <xtensor/xstrided_view.hpp>
-#include <xtensor/xtensor.hpp>
-#include <xtensor/xview.hpp>
-#include <xtensor/xmanipulation.hpp>
-#include <xtensor/xtensor_forward.hpp>
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/containers/xbuffer_adaptor.hpp>
+#include <xtensor/generators/xbuilder.hpp>
+#include <xtensor/core/xexpression.hpp>
+#include <xtensor/io/xio.hpp>
+#include <xtensor/generators/xrandom.hpp>
+#include <xtensor/views/xslice.hpp>
+#include <xtensor/views/xstrided_view.hpp>
+#include <xtensor/containers/xtensor.hpp>
+#include <xtensor/views/xview.hpp>
+#include <xtensor/misc/xmanipulation.hpp>
+#include <xtensor/core/xtensor_forward.hpp>


### PR DESCRIPTION
### Ticket
#20732

### Problem description
* Clang 19/20 ran into issues with the xtensor stack that were fixed in newer releases
* xtensor 0.26.0 changed the directory structure, so those changes had to be propagated.

### What's changed
* xtensor 0.26.0
* xtl 0.8.0
* xtensor-blas 0.22.0

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes