### PR TITLE
#20660: Add support for running 2x2 N300 configuration

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -551,6 +551,7 @@ std::map<FabricNodeId, chip_id_t> ControlPlane::get_physical_chip_mapping_from_m
         mesh_graph_desc_filename == "t3k_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n150_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n300_mesh_graph_descriptor.yaml" ||
+        mesh_graph_desc_filename == "n300_2x2_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "multihost_t3k_mesh_graph_descriptor.yaml") {
         // Pick out the chip with the lowest ethernet coordinate (i.e. NW chip)
         const auto& chip_eth_coords =

--- a/tt_metal/fabric/mesh_graph_descriptors/n300_2x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n300_2x2_mesh_graph_descriptor.yaml
@@ -1,0 +1,28 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+
+Board: [
+  { name: N300_2x2,
+    type: Mesh,
+    topology: [2, 2]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: N300_2x2,
+  host_topology: [1, 1],
+  device_topology: [2, 2],
+  host_ranks: [[0]]}
+]
+
+Graph: [
+]

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -461,6 +461,7 @@ void MetalContext::initialize_control_plane() {
         case tt::ClusterType::P150_X4: mesh_graph_descriptor = "p150_x4_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::SIMULATOR_WORMHOLE_B0: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::SIMULATOR_BLACKHOLE: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::N300_2x2: mesh_graph_descriptor = "n300_2x2_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::INVALID: TT_THROW("Unknown cluster type");
     }
     const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -77,6 +77,7 @@ enum class ClusterType : std::uint8_t {
     P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
     SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
     SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
+    N300_2x2 = 12,               // 2 N300 cards, ethernet connected to form 2x2
 };
 
 enum class EthRouterMode : uint32_t {


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/20660#event-17255188034)

### Problem description
Customer with 2xN300 cards seeing an error on:
```
E       RuntimeError: TT_THROW @ /home/jchu/tt-metal/tt_metal/llrt/tt_cluster.cpp:1278: tt::exception
E       info:
E       Unknown cluster type
E       backtrace:
E        --- /home/jchu/tt-metal/ttnn/ttnn/_ttnn.so(+0xa2d9d8) [0x7f3a63afa9d8]
E        --- tt::Cluster::initialize_control_plane()
E        --- tt::Cluster::get_control_plane()
E        --- /home/jchu/tt-metal/build_Release/lib/libtt_metal.so(+0x3b2ea9) [0x7f3a62a6eea9]
E        --- tt::tt_metal::distributed::get_system_mesh_coordinate_translation_map()
```

### What's changed
Add static configuration YAML and plumbing to support this use-case.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15918813623