### PR TITLE
[skip ci] Increase timeout in build-docker-artifact.yaml

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -104,7 +104,7 @@ jobs:
     name: "🐳️ Build images"
     needs: check-docker-images
     if: needs.check-docker-images.outputs.dev-exists != 'true'
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: tt-beta-ubuntu-2204-large
     steps:
       - name: ⬇️ Checkout


### PR DESCRIPTION
### Problem description
docker build jobs keep timing out at 30 minutes for Ubuntu 24.04 docker images.

### What's changed
Give more cushion.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes