### PR TITLE
Revert "Fix CP apis to handle Torus connections"

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -207,7 +207,7 @@ void RunAsyncWriteTest(
     std::vector<uint32_t> sender_compile_time_args = {
         (uint32_t)mode, (uint32_t)test_mode::TEST_ASYNC_WRITE, (uint32_t)is_raw_write};
     auto outbound_eth_channels =
-        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
+        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -216,7 +216,7 @@ void RunAsyncWriteTest(
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
         tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
-        outbound_eth_channels.begin()->first};
+        *outbound_eth_channels.begin()};
     std::map<string, string> defines = {};
     if (mode == fabric_mode::PULL) {
         defines["FVC_MODE_PULL"] = "";
@@ -314,7 +314,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     defines["DISABLE_LOW_LATENCY_ROUTING"] = "";
     std::vector<uint32_t> sender_compile_time_args = {(uint32_t)mode, (uint32_t)TEST_ATOMIC_INC, 0};
     auto outbound_eth_channels =
-        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
+        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -324,7 +324,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
         tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
-        outbound_eth_channels.begin()->first};
+        *outbound_eth_channels.begin()};
 
     CreateSenderKernel(
         sender_program,
@@ -432,7 +432,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
     std::vector<uint32_t> sender_compile_time_args = {
         (uint32_t)mode, (uint32_t)TEST_ASYNC_WRITE_ATOMIC_INC, (uint32_t)is_raw_write};
     auto outbound_eth_channels =
-        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
+        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -443,7 +443,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
         tt_metal::hal_ref.noc_xy_encoding(routers[0].second.x, routers[0].second.y),
-        outbound_eth_channels.begin()->first};
+        *outbound_eth_channels.begin()};
 
     CreateSenderKernel(
         sender_program,
@@ -609,7 +609,7 @@ void RunAsyncWriteMulticastTest(
 
     // Prepare runtime args based on whether it's multidirectional or not
     auto outbound_eth_channels =
-        control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
+        tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_start_device_id);
     std::vector<uint32_t> sender_runtime_args;
 
     if (multidirectional) {
@@ -626,7 +626,7 @@ void RunAsyncWriteMulticastTest(
             end_mesh_chip_ids_by_dir[RoutingDirection::W][0].second,
             mcast_hops[RoutingDirection::W],
             sender_router_noc_xys[RoutingDirection::W],
-            outbound_eth_channels.begin()->first};
+            *outbound_eth_channels.begin()};
     } else {
         auto routing_direction = RoutingDirection::E;
         sender_runtime_args = {
@@ -638,7 +638,7 @@ void RunAsyncWriteMulticastTest(
             end_mesh_chip_ids_by_dir[routing_direction][0].second,
             mcast_hops[routing_direction],
             sender_router_noc_xys[routing_direction],
-            outbound_eth_channels.begin()->first};
+            *outbound_eth_channels.begin()};
     }
 
     // Choose the appropriate kernel based on whether it's multidirectional or not

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -501,13 +501,7 @@ typedef struct test_board {
     }
 
     inline eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t eth_chan) {
-        auto active_eth_chans = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
-        for (const auto& [eth_chan_, direction] : active_eth_chans) {
-            if (eth_chan_ == eth_chan) {
-                return direction;
-            }
-        }
-        TT_THROW("Cannot find ethernet channel direction");
+        return control_plane->get_eth_chan_direction(mesh_id, chip_id, eth_chan);
     }
 
     inline void close_devices() { tt::tt_metal::detail::CloseDevices(device_handle_map); }

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -30,15 +30,6 @@ target_sources(
             api/tt-metalium/fabric_host_interface.h
             core_descriptors/blackhole_140_arch.yaml
             core_descriptors/wormhole_b0_80_arch.yaml
-            fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
-            fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
             impl/dispatch/kernels/cq_commands.hpp
             impl/dispatch/kernels/cq_common.hpp
             impl/dispatch/kernels/cq_helpers.hpp

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -61,8 +61,7 @@ public:
     std::set<chan_id_t> get_active_fabric_eth_channels_in_direction(
         mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const;
 
-    std::set<std::pair<chan_id_t, eth_chan_directions>> get_active_fabric_eth_channels(
-        mesh_id_t mesh_id, chip_id_t chip_id) const;
+    eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const;
 
 private:
     std::unique_ptr<RoutingTableGenerator> routing_table_generator_;
@@ -93,7 +92,6 @@ private:
 
     // Takes RoutingTableGenerator table and converts to routing tables for each ethernet port
     void convert_fabric_routing_table_to_chip_routing_table();
-    // TODO: remove this converter, we should consolidate the directions here
     eth_chan_directions routing_direction_to_eth_direction(RoutingDirection direction) const;
 };
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -309,9 +309,6 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
                 get_ethernet_cores_grouped_by_connected_chips(physical_chip_id_from_north);
             bool found_chip = false;
             for (const auto& [connected_chip_id, eth_ports] : eth_links_grouped_by_connected_chips) {
-                if (is_external_ubb_cable(physical_chip_id_from_north, eth_ports[0])) {
-                    continue;
-                }
                 if (visited_physical_chips.find(connected_chip_id) == visited_physical_chips.end() and
                     eth_ports.size() == num_ports_per_side) {
                     physical_chip_ids[i * mesh_ew_size + j] = connected_chip_id;
@@ -541,13 +538,11 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
                                                       RoutingDirection direction) {
         auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
         auto fabric_router_channels_on_chip = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_chip_id);
-        // TODO: get_fabric_ethernet_channels accounts for down links, but we should manage down links in control plane
-        auto chan_id = tt::tt_metal::MetalContext::instance()
-                           .get_cluster()
-                           .get_soc_desc(physical_chip_id)
-                           .logical_eth_core_to_chan_map.at(eth_core);
+        auto chan_id = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
+        // TODO: remove this from Cluster, manage retraining links only in control plane
+        auto active_eth_cores = tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(physical_chip_id, false);
         // TODO: add logic here to disable unsed routers, e.g. Mesh on Torus system
-        if (fabric_router_channels_on_chip.contains(chan_id)) {
+        if (fabric_router_channels_on_chip.contains(chan_id) and active_eth_cores.contains(eth_core)) {
             this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id][direction].push_back(chan_id);
         } else {
             log_debug(
@@ -763,16 +758,16 @@ eth_chan_directions ControlPlane::routing_direction_to_eth_direction(RoutingDire
     return dir;
 }
 
-std::set<std::pair<chan_id_t, eth_chan_directions>> ControlPlane::get_active_fabric_eth_channels(
-    mesh_id_t mesh_id, chip_id_t chip_id) const {
-    std::set<std::pair<chan_id_t, eth_chan_directions>> active_fabric_eth_channels;
+eth_chan_directions ControlPlane::get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const {
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
         for (const auto& eth_chan : eth_chans) {
-            active_fabric_eth_channels.insert({eth_chan, this->routing_direction_to_eth_direction(direction)});
+            if (chan == eth_chan) {
+                return this->routing_direction_to_eth_direction(direction);
+            }
         }
     }
-    return active_fabric_eth_channels;
+    TT_THROW("Cannot Find Ethernet Channel Direction");
 }
 
 std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -463,21 +463,19 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 
 void DevicePool::wait_for_fabric_router_sync() const {
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     if (tt_fabric::is_1d_fabric_config(fabric_config)) {
         const auto edm_config = tt_fabric::get_1d_fabric_config();
         std::vector<uint32_t> signal(1, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
 
         auto wait_for_handshake = [&](IDevice* dev) {
             std::vector<std::uint32_t> master_router_status{0};
-            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
-
-            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
-            if (router_chans_and_direction.empty()) {
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
+            if (fabric_ethernet_channels.empty()) {
                 return;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
+            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);
@@ -522,20 +520,25 @@ void DevicePool::wait_for_fabric_router_sync() const {
 
         std::vector<std::uint32_t> master_router_status{0};
         for (const auto& dev : this->get_all_active_devices()) {
-            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
-
-            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
-            if (router_chans_and_direction.empty()) {
-                return;
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
+            if (fabric_ethernet_channels.empty()) {
+                continue;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
+            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);
             auto fabric_master_router_core = dev->logical_core_from_ethernet_core(virtual_eth_core);
 
-            auto num_routers = router_chans_and_direction.size();
+            auto [mesh_id, chip_id] = tt::tt_metal::MetalContext::instance()
+                                          .get_cluster()
+                                          .get_control_plane()
+                                          ->get_mesh_chip_id_from_physical_chip_id(dev->id());
+            auto num_routers =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane()->get_num_active_fabric_routers(
+                    mesh_id, chip_id);
             while (master_router_status[0] != num_routers) {
                 tt_metal::detail::ReadFromDeviceL1(
                     dev,
@@ -732,7 +735,6 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
 
     // Terminate fabric routers
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     if (tt_fabric::is_1d_fabric_config(fabric_config)) {
         std::vector<uint32_t> signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
         static constexpr std::size_t edm_buffer_size =
@@ -747,15 +749,14 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
                 // 1d fabric is not launched on TG gateways
                 continue;
             }
-            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
 
-            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
-            if (router_chans_and_direction.empty()) {
-                return;
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
+            if (fabric_ethernet_channels.empty()) {
+                continue;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
-
+            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);
@@ -768,14 +769,13 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices) {
         auto fabric_router_sync_sem_addr =
             hal_ref.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::UNRESERVED);
         for (const auto& dev : this->get_all_active_devices()) {
-            auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dev->id());
-
-            auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
-            if (router_chans_and_direction.empty()) {
-                return;
+            auto fabric_ethernet_channels =
+                tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(dev->id());
+            if (fabric_ethernet_channels.empty()) {
+                continue;
             }
 
-            tt_fabric::chan_id_t fabric_master_router_chan = router_chans_and_direction.begin()->first;
+            tt_fabric::chan_id_t fabric_master_router_chan = *(fabric_ethernet_channels.begin());
             CoreCoord virtual_eth_core =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                     dev->id(), fabric_master_router_chan);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1059,10 +1059,12 @@ void Cluster::release_ethernet_cores_for_fabric_routers() {
 
 std::set<tt_fabric::chan_id_t> Cluster::get_fabric_ethernet_channels(chip_id_t chip_id) const {
     std::set<tt_fabric::chan_id_t> fabric_ethernet_channels;
-    const auto& active_eth_cores = this->get_active_ethernet_cores(chip_id, false);
-    for (const auto& eth_core : active_eth_cores) {
-        if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
-            fabric_ethernet_channels.insert(this->get_soc_desc(chip_id).logical_eth_core_to_chan_map.at(eth_core));
+    const auto& connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(chip_id);
+    for (const auto& [other_chip_id, eth_cores] : connected_chips) {
+        for (const auto& eth_core : eth_cores) {
+            if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
+                fabric_ethernet_channels.insert(this->get_soc_desc(chip_id).logical_eth_core_to_chan_map.at(eth_core));
+            }
         }
     }
     return fabric_ethernet_channels;


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#20370

This PR caused a hard consistent failure of:
```
tests/ttnn/unit_tests/operations/ccl/perf/test_ccl_perf.py::test_reduce_scatter_on_tg[silicon_arch_name=wormhole_b0-device_params={'trace_region_size': 10281600}-math_op=ReduceType.Sum-8x4_grid-num_iters=20-enable_async=True-replication_factor=8-buffer_type=BufferType.DRAM-input_dtype=DataType.BFLOAT16-num_devices=4-num_links=2-per_chip_output_shape=[1, 4, 32, 2304]-dim=1-layout=Layout.TILE] SKIPPED (Requested more devices than available. Test not applicable for machine)
terminate called after throwing an instance of 'std::out_of_range'
  what():  unordered_map::at
Fatal Python error: Aborted
```

https://github.com/tenstorrent/tt-metal/actions/runs/14475972304/job/40609138856

Every run after this failed for the past 14 hours.