### PR TITLE
Fix SD demo zero division

### DIFF
--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -240,14 +240,15 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
 
     profiler.print()
 
-    # skip first for compile
-    total_time = sum([profiler.get("inference_prompt_" + str(i)) for i in range(2, num_prompts + 1)])
-    avg_time = total_time / (num_prompts - 1)
-    FPS = 1 / avg_time
+    if num_prompts > 1:
+        # skip first for compile
+        total_time = sum([profiler.get("inference_prompt_" + str(i)) for i in range(2, num_prompts + 1)])
+        avg_time = total_time / (num_prompts - 1)
+        FPS = 1 / avg_time
 
-    print(
-        f"Average time per prompt: {avg_time}, FPS: {FPS}",
-    )
+        print(
+            f"Average time per prompt: {avg_time}, FPS: {FPS}",
+        )
 
 
 def run_interactive_demo_inference(device, num_inference_steps, image_size=(256, 256)):

--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -240,6 +240,8 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
 
     profiler.print()
 
+    # we calculate average time per prompt only when there is more than 1 iteration,
+    # since first iteration includes compile time
     if num_prompts > 1:
         # skip first for compile
         total_time = sum([profiler.get("inference_prompt_" + str(i)) for i in range(2, num_prompts + 1)])


### PR DESCRIPTION
### Problem description
Zero division error in SD demo

### What's changed
There wasn't a check for number of input prompts - perf should be calculated from the second prompt on since the first one includes compile time.

### Checklist
Frequent model and ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/14488811433