### PR TITLE
Add FORCE_PUSH_TO_TRACY option to DumpDeviceProfileResults

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -6,6 +6,14 @@ source scripts/tools_setup_common.sh
 
 set -eo pipefail
 
+run_mid_run_tracy_push() {
+    remove_default_log_locations
+    mkdir -p $PROFILER_ARTIFACTS_DIR
+    python -m tracy -v -r -p --sync-host-device --push-device-data-mid-run -m pytest tests/ttnn/tracy/test_profiler_sync.py::test_all_devices
+    runDate=$(ls $PROFILER_OUTPUT_DIR/)
+    cat $PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv
+}
+
 run_async_test() {
     #Some tests here do not skip grayskull
     if [ "$ARCH_NAME" == "wormhole_b0" ]; then
@@ -120,6 +128,8 @@ run_profiling_test() {
     run_async_ccl_T3000_test
 
     run_async_tracing_T3000_test
+
+    run_mid_run_tracy_push
 
     TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py
 

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -7,6 +7,7 @@ source scripts/tools_setup_common.sh
 set -eo pipefail
 
 run_mid_run_tracy_push() {
+    echo "Smoke test, checking tracy mid-run device data push for hangs"
     remove_default_log_locations
     mkdir -p $PROFILER_ARTIFACTS_DIR
     python -m tracy -v -r -p --sync-host-device --push-device-data-mid-run -m pytest tests/ttnn/tracy/test_profiler_sync.py::test_all_devices

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -6,7 +6,7 @@
 
 namespace tt::tt_metal {
 
-enum class ProfilerDumpState { NORMAL, CLOSE_DEVICE_SYNC, LAST_CLOSE_DEVICE, FORCE_UMD_READ };
+enum class ProfilerDumpState { NORMAL, CLOSE_DEVICE_SYNC, LAST_CLOSE_DEVICE, FORCE_UMD_READ, FORCE_PUSH_TO_TRACY };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/profiler_types.hpp
+++ b/tt_metal/api/tt-metalium/profiler_types.hpp
@@ -6,7 +6,7 @@
 
 namespace tt::tt_metal {
 
-enum class ProfilerDumpState { NORMAL, CLOSE_DEVICE_SYNC, LAST_CLOSE_DEVICE, FORCE_UMD_READ, FORCE_PUSH_TO_TRACY };
+enum class ProfilerDumpState { NORMAL, CLOSE_DEVICE_SYNC, LAST_CLOSE_DEVICE, FORCE_UMD_READ };
 enum class ProfilerSyncState { INIT, CLOSE_DEVICE };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -721,6 +721,7 @@ DeviceProfiler::DeviceProfiler(const bool new_logs) {
     }
 
     this->current_zone_it = device_events.begin();
+    device_sync_info = std::make_tuple(0.0, 0.0, 0.0);
 #endif
 }
 
@@ -861,9 +862,28 @@ void DeviceProfiler::dumpResults(
 #endif
 }
 
+bool isSyncInfoNewer(std::tuple<double, double, double> old_info, std::tuple<double, double, double> new_info) {
+    double old_cpu_time = get<0>(old_info);
+    double old_device_time = get<1>(old_info);
+    double old_frequency = get<2>(old_info);
+    double new_cpu_time = get<0>(new_info);
+    double new_device_time = get<1>(new_info);
+    double new_frequency = get<2>(new_info);
+    return (old_cpu_time < new_cpu_time && old_device_time / old_frequency < new_device_time / new_frequency);
+}
+
 void DeviceProfiler::pushTracyDeviceResults() {
 #if defined(TRACY_ENABLE)
     ZoneScoped;
+
+    // If this device is root, it may have new sync info updated with syncDeviceHost
+    // called during DumpDeviceProfilerResults
+    for (auto& [core, info] : device_core_sync_info) {
+        if (isSyncInfoNewer(device_sync_info, info)) {
+            setSyncInfo(info);
+        }
+    }
+
     std::set<std::pair<uint32_t, CoreCoord>> device_cores_set;
     std::vector<std::pair<uint32_t, CoreCoord>> device_cores;
     for (auto& event : device_events) {
@@ -874,64 +894,8 @@ void DeviceProfiler::pushTracyDeviceResults() {
         }
     }
 
-    static bool is_sync_info_available = false;
-    static double cpuTime;
-    static double delay;
-    static double frequency;
-
-    if (!is_sync_info_available) {
-        cpuTime = TracyGetCpuTime();
-        delay = smallest_timestamp;
-        frequency = device_core_frequency / 1000.0;
-    }
-
-    for (auto& [core, info] : device_core_sync_info) {
-        double new_cpuTime = get<0>(info);
-        double new_delay = get<1>(info);
-        double new_frequency = get<2>(info);
-
-        if (!is_sync_info_available || (cpuTime < new_cpuTime && delay < new_delay)) {
-            is_sync_info_available = true;
-            cpuTime = new_cpuTime;
-            delay = new_delay;
-            frequency = new_frequency;
-
-            log_info(
-                "Sync info are, frequency {} GHz,  delay {} cycles and, sync point {} seconds",
-                frequency,
-                delay,
-                cpuTime);
-        }
-    }
-
     for (auto& device_core : device_cores) {
-        chip_id_t device_id = device_core.first;
-        CoreCoord worker_core = device_core.second;
-
-        if (device_tracy_contexts.find(device_core) == device_tracy_contexts.end()) {
-            // Create a new tracy context for this device core
-            auto tracyCtx = TracyTTContext();
-            std::string tracyTTCtxName =
-                fmt::format("Device: {}, Core ({},{})", device_id, worker_core.x, worker_core.y);
-
-            TracyTTContextPopulate(tracyCtx, cpuTime, delay, frequency);
-
-            TracyTTContextName(tracyCtx, tracyTTCtxName.c_str(), tracyTTCtxName.size());
-
-            device_tracy_contexts.emplace(device_core, tracyCtx);
-
-            if (!is_sync_info_available) {
-                log_warning(
-                    "For device {}, core {},{} default frequency was used and its zones will be out of sync",
-                    device_id,
-                    worker_core.x,
-                    worker_core.y);
-            }
-        } else if (is_sync_info_available) {
-            // Update the existing tracy context for this device core
-            auto tracyCtx = device_tracy_contexts.at(device_core);
-            TracyTTContextCalibrate(tracyCtx, cpuTime, delay, frequency);
-        }
+        updateTracyContext(device_core);
     }
 
     for (auto event : device_events) {
@@ -945,6 +909,70 @@ void DeviceProfiler::pushTracyDeviceResults() {
     }
     device_events.clear();
 #endif
+}
+
+void DeviceProfiler::setSyncInfo(std::tuple<double, double, double> sync_info) { device_sync_info = sync_info; }
+
+void DeviceProfiler::updateTracyContext(std::pair<uint32_t, CoreCoord> device_core) {
+    chip_id_t device_id = device_core.first;
+    CoreCoord worker_core = device_core.second;
+
+    if (device_tracy_contexts.find(device_core) == device_tracy_contexts.end()) {
+        // Create a new tracy context for this device core
+        auto tracyCtx = TracyTTContext();
+        std::string tracyTTCtxName = fmt::format("Device: {}, Core ({},{})", device_id, worker_core.x, worker_core.y);
+
+        double cpu_time = get<0>(device_sync_info);
+        double device_time = get<1>(device_sync_info);
+        double frequency = get<2>(device_sync_info);
+
+        if (frequency == 0) {
+            cpu_time = TracyGetCpuTime();
+            device_time = smallest_timestamp;
+            frequency = device_core_frequency / 1000.0;
+            device_sync_info = std::make_tuple(cpu_time, device_time, frequency);
+            log_debug(
+                "For device {}, core {},{} default frequency was used and its zones will be out of sync",
+                device_id,
+                worker_core.x,
+                worker_core.y);
+        } else {
+            log_debug(
+                "Device {}, core {},{} sync info are, frequency {} GHz,  delay {} cycles and, sync point {} seconds",
+                device_id,
+                worker_core.x,
+                worker_core.y,
+                frequency,
+                device_time,
+                cpu_time);
+        }
+
+        TracyTTContextPopulate(tracyCtx, cpu_time, device_time, frequency);
+
+        TracyTTContextName(tracyCtx, tracyTTCtxName.c_str(), tracyTTCtxName.size());
+
+        device_tracy_contexts.emplace(device_core, tracyCtx);
+        core_sync_info[worker_core] = std::make_tuple(cpu_time, device_time, frequency);
+    } else {
+        // Update the existing tracy context for this device core
+        if (isSyncInfoNewer(core_sync_info[worker_core], device_sync_info)) {
+            core_sync_info[worker_core] = device_sync_info;
+            double cpu_time = get<0>(device_sync_info);
+            double device_time = get<1>(device_sync_info);
+            double frequency = get<2>(device_sync_info);
+            auto tracyCtx = device_tracy_contexts.at(device_core);
+            TracyTTContextCalibrate(tracyCtx, cpu_time, device_time, frequency);
+            log_debug(
+                "Device {}, core {},{} calibration info are, frequency {} GHz,  delay {} cycles and, sync point {} "
+                "seconds",
+                device_id,
+                worker_core.x,
+                worker_core.y,
+                frequency,
+                device_time,
+                cpu_time);
+        }
+    }
 }
 
 bool getDeviceProfilerState() { return tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled(); }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -914,6 +914,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
 void DeviceProfiler::setSyncInfo(std::tuple<double, double, double> sync_info) { device_sync_info = sync_info; }
 
 void DeviceProfiler::updateTracyContext(std::pair<uint32_t, CoreCoord> device_core) {
+#if defined(TRACY_ENABLE)
     chip_id_t device_id = device_core.first;
     CoreCoord worker_core = device_core.second;
 
@@ -973,6 +974,7 @@ void DeviceProfiler::updateTracyContext(std::pair<uint32_t, CoreCoord> device_co
                 cpu_time);
         }
     }
+#endif
 }
 
 bool getDeviceProfilerState() { return tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled(); }

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -170,9 +170,6 @@ private:
         std::ofstream& log_file_ofs,
         nlohmann::ordered_json& noc_trace_json_log);
 
-    // Push device results to tracy
-    void pushTracyDeviceResults();
-
     // Track the smallest timestamp dumped to file
     void firstTimestamp(uint64_t timestamp);
 
@@ -221,6 +218,9 @@ public:
         const std::vector<CoreCoord>& worker_cores,
         ProfilerDumpState state = ProfilerDumpState::NORMAL,
         const std::optional<ProfilerOptionalMetadata>& metadata = {});
+
+    // Push device results to tracy
+    void pushTracyDeviceResults();
 };
 
 distributed::AnyBuffer get_control_buffer_view(

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -94,6 +94,12 @@ private:
     // Holding current data collected for dispatch command queue zones
     DisptachMetaData current_dispatch_meta_data;
 
+    // (cpu time, device time, frequency) for sync propagated from root device
+    std::tuple<double, double, double> device_sync_info;
+
+    // Per-core sync info used to make tracy context
+    std::map<CoreCoord, std::tuple<double, double, double>> core_sync_info;
+
     // 32bit FNV-1a hashing
     uint32_t hash32CT(const char* str, size_t n, uint32_t basis = UINT32_C(2166136261));
 
@@ -173,6 +179,9 @@ private:
     // Track the smallest timestamp dumped to file
     void firstTimestamp(uint64_t timestamp);
 
+    // Get tracy context for the core
+    void updateTracyContext(std::pair<uint32_t, CoreCoord> device_core);
+
 public:
     DeviceProfiler(const bool new_logs);
 
@@ -221,6 +230,9 @@ public:
 
     // Push device results to tracy
     void pushTracyDeviceResults();
+
+    // Update sync info for this device
+    void setSyncInfo(std::tuple<double, double, double> sync_info);
 };
 
 distributed::AnyBuffer get_control_buffer_view(

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -596,7 +596,7 @@ void syncAllDevices(chip_id_t first_connected_device_id) {
                                (receiverSquareSum * accumulateSampleCount - receiverSum * receiverSum);
 
             uint64_t shift = (double)(senderSum - freqScale * (double)receiverSum) / accumulateSampleCount +
-                             (senderBase - receiverBase);
+                             (senderBase - freqScale * receiverBase);
             deviceDeviceSyncInfo.emplace(sender.first, (std::unordered_map<chip_id_t, std::pair<double, int64_t>>){});
             deviceDeviceSyncInfo.at(sender.first)
                 .emplace(receiver.first, (std::pair<double, int64_t>){freqScale, shift});
@@ -616,6 +616,7 @@ void syncAllDevices(chip_id_t first_connected_device_id) {
     }
 
     // Propagate sync info with DFS through sync tree
+    sync_set_devices.clear();
     setSyncInfo(first_connected_device_id, (std::pair<double, int64_t>){1.0, 0}, root_sync_info, deviceDeviceSyncInfo);
 }
 
@@ -628,7 +629,6 @@ void ProfilerSync(ProfilerSyncState state) {
     static chip_id_t first_connected_device_id = -1;
     if (state == ProfilerSyncState::INIT) {
         do_sync_on_close = true;
-        sync_set_devices.clear();
         auto ethernet_connections = tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_connections();
         std::set<chip_id_t> visited_devices = {};
         constexpr int TOTAL_DEVICE_COUNT = 36;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -378,7 +378,7 @@ void setShift(int device_id, int64_t shift, double scale, std::tuple<double, dou
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {
         log_warning(
             "Note that tracy device data mid-run push is enabled, this means device-device sync is a not as accurate. "
-            "Please do not use tracy mid-run push for sensitive device-device event analysis");
+            "Please do not use tracy mid-run push for sensitive device-device event analysis.");
     }
     if (tt_metal_device_profiler_map.find(device_id) != tt_metal_device_profiler_map.end()) {
         tt_metal_device_profiler_map.at(device_id).shift = shift;
@@ -684,7 +684,6 @@ void ProfilerSync(ProfilerSyncState state) {
 
     if (state == ProfilerSyncState::CLOSE_DEVICE and do_sync_on_close) {
         do_sync_on_close = false;
-        syncDeviceHost(tt::DevicePool::instance().get_active_device(first_connected_device_id), SYNC_CORE, false);
         syncAllDevices(first_connected_device_id);
     }
 #endif

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -881,6 +881,9 @@ void DumpDeviceProfileResults(
             } else {
                 InitDeviceProfiler(device);
             }
+            if (state == ProfilerDumpState::FORCE_PUSH_TO_TRACY) {
+                tt_metal_device_profiler_map.at(device_id).pushTracyDeviceResults();
+            }
         }
     }
 #endif

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -375,6 +375,11 @@ void setShift(int device_id, int64_t shift, double scale, std::tuple<double, dou
         return;
     }
     log_info("Device sync data for device: {}, delay: {} ns, freq scale: {}", device_id, shift, scale);
+    if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {
+        log_warning(
+            "Note that tracy device data mid-run push is enabled, this means device-device sync is a not as accurate. "
+            "Please do not use tracy mid-run push for sensitive device-device event analysis");
+    }
     if (tt_metal_device_profiler_map.find(device_id) != tt_metal_device_profiler_map.end()) {
         tt_metal_device_profiler_map.at(device_id).shift = shift;
         tt_metal_device_profiler_map.at(device_id).freqScale = scale;
@@ -903,7 +908,7 @@ void DumpDeviceProfileResults(
             } else {
                 InitDeviceProfiler(device);
             }
-            if (state == ProfilerDumpState::FORCE_PUSH_TO_TRACY) {
+            if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {
                 tt_metal_device_profiler_map.at(device_id).pushTracyDeviceResults();
             }
         }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -174,8 +174,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
     const metal_SocDescriptor& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
     auto phys_core = soc_desc.translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::PHYSICAL);
 
-    deviceHostTimePair.emplace(device_id, (std::vector<std::pair<uint64_t, uint64_t>>){});
-    smallestHostime.emplace(device_id, 0);
+    deviceHostTimePair[device_id] = std::vector<std::pair<uint64_t, uint64_t>>{};
+    smallestHostime[device_id] = 0;
 
     constexpr uint16_t sampleCount = 249;
     // TODO(MO): Always recreate a new program until subdevice
@@ -364,8 +364,8 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         delay,
         frequencyFit);
 
-    tt_metal_device_profiler_map.at(device_id).device_core_sync_info.emplace(
-        phys_core, std::make_tuple(smallestHostime[device_id], delay, frequencyFit));
+    tt_metal_device_profiler_map.at(device_id).device_core_sync_info[phys_core] =
+        std::make_tuple(smallestHostime[device_id], delay, frequencyFit);
 }
 void setShift(int device_id, int64_t shift, double scale) {
     if (std::isnan(scale)) {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -72,6 +72,7 @@ RunTimeOptions::RunTimeOptions() {
     profiler_enabled = false;
     profile_dispatch_cores = false;
     profiler_sync_enabled = false;
+    profiler_mid_run_tracy_push = false;
     profiler_buffer_usage_enabled = false;
 #if defined(TRACY_ENABLE)
     const char* profiler_enabled_str = std::getenv("TT_METAL_DEVICE_PROFILER");
@@ -84,6 +85,11 @@ RunTimeOptions::RunTimeOptions() {
         const char* profiler_sync_enabled_str = std::getenv("TT_METAL_PROFILER_SYNC");
         if (profiler_enabled && profiler_sync_enabled_str != nullptr && profiler_sync_enabled_str[0] == '1') {
             profiler_sync_enabled = true;
+        }
+        const char* profiler_force_push_enabled_str = std::getenv("TT_METAL_TRACY_MID_RUN_PUSH");
+        if (profiler_enabled && profiler_force_push_enabled_str != nullptr &&
+            profiler_force_push_enabled_str[0] == '1') {
+            profiler_mid_run_tracy_push = true;
         }
     }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -106,6 +106,7 @@ class RunTimeOptions {
     bool profiler_enabled = false;
     bool profile_dispatch_cores = false;
     bool profiler_sync_enabled = false;
+    bool profiler_mid_run_tracy_push = false;
     bool profiler_buffer_usage_enabled = false;
     bool profiler_noc_events_enabled = false;
     std::string profiler_noc_events_report_path;
@@ -292,6 +293,7 @@ public:
     inline bool get_profiler_enabled() const { return profiler_enabled; }
     inline bool get_profiler_do_dispatch_cores() const { return profile_dispatch_cores; }
     inline bool get_profiler_sync_enabled() const { return profiler_sync_enabled; }
+    inline bool get_profiler_tracy_mid_run_push() const { return profiler_mid_run_tracy_push; }
     inline bool get_profiler_buffer_usage_enabled() const { return profiler_buffer_usage_enabled; }
     inline bool get_profiler_noc_events_enabled() const { return profiler_noc_events_enabled; }
     inline std::string get_profiler_noc_events_report_path() const { return profiler_noc_events_report_path; }

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -554,20 +554,20 @@ def get_device_data_generate_report(
             coreOpToOps = {}
             opToOps = []
             for core in allCores:
-                coreSeries = deviceData["devices"][device]["cores"][core]["riscs"]["TENSIX"]["analysis"]["op2op"][
-                    "series"
-                ]
-                for op2op in coreSeries:
-                    if op2op["end_iter_mark"][1] != op2op["start_iter_mark"][1]:
-                        startMarker, endMarker = op2op["duration_type"]
-                        op2opID = (startMarker["run_host_id"], endMarker["run_host_id"])
-                        op2opDuration = op2op["duration_cycles"]
-                        op2opStart = op2op["start_cycle"]
-                        opToOps.append((op2opStart, op2opID, op2opDuration, core))
-                        if core in coreOpToOps:
-                            coreOpToOps[core].append((op2opStart, op2opID, op2opDuration, core))
-                        else:
-                            coreOpToOps[core] = deque([(op2opStart, op2opID, op2opDuration, core)])
+                deviceDataDict = deviceData["devices"][device]["cores"][core]["riscs"]["TENSIX"]
+                if "analysis" in deviceDataDict:
+                    coreSeries = deviceDataDict["analysis"]["op2op"]["series"]
+                    for op2op in coreSeries:
+                        if op2op["end_iter_mark"][1] != op2op["start_iter_mark"][1]:
+                            startMarker, endMarker = op2op["duration_type"]
+                            op2opID = (startMarker["run_host_id"], endMarker["run_host_id"])
+                            op2opDuration = op2op["duration_cycles"]
+                            op2opStart = op2op["start_cycle"]
+                            opToOps.append((op2opStart, op2opID, op2opDuration, core))
+                            if core in coreOpToOps:
+                                coreOpToOps[core].append((op2opStart, op2opID, op2opDuration, core))
+                            else:
+                                coreOpToOps[core] = deque([(op2opStart, op2opID, op2opDuration, core)])
             opToOps.sort()
 
             pickedOps = set()

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -64,6 +64,20 @@ def main():
         default=False,
     )
     parser.add_option(
+        "--sync-host-device",
+        dest="sync_host_device",
+        action="store_true",
+        help="Sync host with all devices",
+        default=False,
+    )
+    parser.add_option(
+        "--push-device-data-mid-run",
+        dest="mid_run_device_data",
+        action="store_true",
+        help="Push collected device data to Tracy GUI mid-run",
+        default=False,
+    )
+    parser.add_option(
         "--collect-noc-traces",
         dest="collect_noc_traces",
         action="store_true",
@@ -106,6 +120,12 @@ def main():
 
     if options.profile_dispatch_cores:
         os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "1"
+
+    if options.mid_run_device_data:
+        os.environ["TT_METAL_TRACY_MID_RUN_PUSH"] = "1"
+
+    if options.sync_host_device:
+        os.environ["TT_METAL_PROFILER_SYNC"] = "1"
 
     if options.collect_noc_traces:
         os.environ["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"


### PR DESCRIPTION
### Ticket
#20689 

### Problem description
Currently, there is no way to manually push dumped device profile results to tracy server. The results are pushed only when the process exits normally and dtor for the object holding data is properly called. If the process is stopped by a signal(for example, SIGINT by ^C) and there is no signal handler registered, data is lost.

### What's changed
This PR adds an option to trigger push.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes