### PR TITLE
#20241: Implement binary minimum

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -111,26 +111,6 @@ def test_binary_isclose_ttnn(input_shapes, atol, rtol, equal_nan, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-def test_binary_minimum_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)
-
-    output_tensor = ttnn.minimum(input_tensor1, input_tensor2)
-    golden_function = ttnn.get_golden_function(ttnn.minimum)
-    golden_tensor = golden_function(in_data1, in_data2)
-
-    comp_pass = compare_pcc([output_tensor], [golden_tensor])
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([1, 3, 320, 384])),
-    ),
-)
 def test_binary_atan2_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 150, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import ttnn
+from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_equal
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([5, 8, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
+    ],
+)
+def test_binary_min_fp32(input_shapes, low_a, high_a, low_b, high_b, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.float32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_a_val, input_b_val",
+    [
+        (0.36719, 0.5),
+        (0, 0.06719),
+        (0, 0.002),
+        (3.4 * 10**38, 1),
+        (-1, -3.4 * 10**38),
+        (3.4 * 10**38, -3.4 * 10**38),
+        (float("inf"), 1),
+        (1, -float("inf")),
+        (3.4 * 10**38, float("inf")),
+        (-3.4 * 10**38, -float("inf")),
+        (11, 1),
+    ],
+)
+def test_binary_min_fill_val_fp32(input_shapes, input_a_val, input_b_val, device):
+    torch_input_a = torch.ones(input_shapes, dtype=torch.float32) * input_a_val
+    torch_input_b = torch.ones(input_shapes, dtype=torch.float32) * input_b_val
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b)
+
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_a_val, input_b_val",
+    [
+        (0.36719, 0.5),
+        (0.0034, 0.0023),
+        (0, 0.06719),
+        (0, 0.002),
+        (3.4 * 10**38, 1),
+        (-1, -3.4 * 10**38),
+        (3.4 * 10**38, -3.4 * 10**38),
+        (float("inf"), 1),
+        (1, -float("inf")),
+        (3.4 * 10**38, float("inf")),
+        (-3.4 * 10**38, -float("inf")),
+        (11, 1),
+    ],
+)
+def test_binary_min_fill_val_bf16(input_shapes, input_a_val, input_b_val, device):
+    torch_input_a = torch.ones(input_shapes, dtype=torch.bfloat16) * input_a_val
+    torch_input_b = torch.ones(input_shapes, dtype=torch.bfloat16) * input_b_val
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b)
+
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([5, 8, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-3.0 * 10**38, 3.0 * 10**38, -3.3 * 10**38, 3.3 * 10**38),
+    ],
+)
+def test_binary_min_bf16(input_shapes, low_a, high_a, low_b, high_b, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.bfloat16)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shapes).nan_to_num(0.0)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b)
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shape_a, input_shape_b",
+    [
+        (torch.Size([1, 2, 32]), torch.Size([1, 2, 32])),
+        (torch.Size([1]), torch.Size([1, 5, 12])),
+        (torch.Size([1, 2, 32, 64, 125]), torch.Size([1, 2, 32, 1, 1])),
+        (torch.Size([]), torch.Size([])),
+        (torch.Size([5]), torch.Size([1])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
+    ],
+)
+def test_binary_min_fp32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
+
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_b)).item()), 1)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.float32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shape_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=False)
+    comp_pass = compare_equal([tt_result], [golden])
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shape_a, input_shape_b",
+    [
+        (torch.Size([1, 2, 32]), torch.Size([1, 2, 32])),
+        (torch.Size([1]), torch.Size([1, 5, 12])),
+        (torch.Size([1, 2, 32, 64, 125]), torch.Size([1, 2, 32, 1, 1])),
+        (torch.Size([]), torch.Size([])),
+        (torch.Size([5]), torch.Size([1])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
+    ],
+)
+def test_binary_min_bf16_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.bfloat16)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a).nan_to_num(0.0)
+
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_b)).item()), 1)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.bfloat16)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shape_b).nan_to_num(0.0)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=False)
+    result = ttnn.to_torch(tt_result)
+    assert_with_pcc(golden, result, 0.999)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([5, 10, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
+    ],
+)
+def test_binary_min_fp32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.float32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.float32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    output_tensor = torch.zeros(input_shapes, dtype=torch.float32)
+
+    cq_id = 0
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_out = ttnn.from_torch(
+        output_tensor,
+        dtype=ttnn.float32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn.minimum(tt_in_a, tt_in_b, output_tensor=tt_out, queue_id=cq_id)
+    comp_pass = compare_equal([tt_out], [golden])
+    assert comp_pass

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -6,15 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
 
-template <int ITERATIONS = 8>
-inline void calculate_binary_max(const uint dst_offset) {
+template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min(const uint dst_offset) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
@@ -22,10 +21,15 @@ inline void calculate_binary_max(const uint dst_offset) {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);                          // a
         TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, dst_offset * dst_tile_size);  // b
 
+        // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         TTI_SFPNOP;
 
-        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
+        if constexpr (IS_MAX_OP) {
+            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+        }
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -6,7 +6,7 @@
 
 #include "llk_math_eltwise_binary_sfpu_init.h"
 #include "llk_math_eltwise_binary_sfpu_params.h"
-#include "ckernel_sfpu_binary_max.h"
+#include "ckernel_sfpu_binary_max_min.h"
 
 namespace ckernel {
 
@@ -22,7 +22,20 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, vector_mode);
+}
+
+// Binary minimum
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -6,15 +6,14 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 
 using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
 
-template <int ITERATIONS = 8>
-inline void calculate_binary_max(const uint dst_offset) {
+template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min(const uint dst_offset) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
@@ -22,10 +21,15 @@ inline void calculate_binary_max(const uint dst_offset) {
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);                          // a
         TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, dst_offset * dst_tile_size);  // b
 
+        // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         TTI_SFPNOP;
 
-        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
+        if constexpr (IS_MAX_OP) {
+            TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
+        }
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -6,7 +6,7 @@
 
 #include "llk_math_eltwise_binary_sfpu_init.h"
 #include "llk_math_eltwise_binary_sfpu_params.h"
-#include "ckernel_sfpu_binary_max.h"
+#include "ckernel_sfpu_binary_max_min.h"
 
 namespace ckernel {
 
@@ -22,7 +22,20 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, vector_mode);
+}
+
+// Binary minimum
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/binary_max_min.h
+++ b/tt_metal/include/compute_kernel_api/binary_max_min.h
@@ -6,7 +6,7 @@
 
 #include "compute_kernel_api/common_globals.h"
 #ifdef TRISC_MATH
-#include "llk_math_eltwise_binary_sfpu_binary_max.h"
+#include "llk_math_eltwise_binary_sfpu_binary_max_min.h"
 #define MAIN math_main()
 #define MATH(x) x
 #else
@@ -41,5 +41,32 @@ ALWI void binary_max_tile(uint32_t idst0, uint32_t idst1) {
  * Please refer to documentation.
  */
 ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max_init<APPROX>())); }
+
+// clang-format off
+/**
+ * Performs an elementwise minimum operation on inputs at idst0, idst1: y = x0 < x1.
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void binary_min_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binary_min<APPROX>(idst0, idst1)));
+}
+
+/**
+ * Please refer to documentation.
+ */
+ALWI void binary_min_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_min_init<APPROX>())); }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/binary_max_min.h
+++ b/tt_metal/include/compute_kernel_api/binary_max_min.h
@@ -17,7 +17,7 @@ namespace ckernel {
 
 // clang-format off
 /**
- * Performs an elementwise maximum operation on inputs at idst0, idst1: y = x0 > x1.
+ * Performs an elementwise maximum operation on inputs at idst0, idst1: y = max(x0, x1).
  * Output overwrites first operand in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
@@ -44,7 +44,7 @@ ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max
 
 // clang-format off
 /**
- * Performs an elementwise minimum operation on inputs at idst0, idst1: y = x0 < x1.
+ * Performs an elementwise minimum operation on inputs at idst0, idst1: y = min(x0, x1).
  * Output overwrites first operand in DST.
  *
  * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -26,7 +26,8 @@ namespace detail {
 constexpr bool is_associative(BinaryOpType op) {
     return op == BinaryOpType::ADD || op == BinaryOpType::MUL || op == BinaryOpType::EQ || op == BinaryOpType::NE ||
            op == BinaryOpType::LOGICAL_AND || op == BinaryOpType::LOGICAL_OR || op == BinaryOpType::LOGADDEXP ||
-           op == BinaryOpType::LOGADDEXP2 || op == BinaryOpType::LOGICAL_XOR || op == BinaryOpType::MAXIMUM;
+           op == BinaryOpType::LOGADDEXP2 || op == BinaryOpType::LOGICAL_XOR || op == BinaryOpType::MAXIMUM ||
+           op == BinaryOpType::MINIMUM;
 }
 
 // Tensor - Scalar
@@ -551,5 +552,6 @@ template struct BinaryOperationSfpu<BinaryOpType::BITWISE_OR>;
 template struct BinaryOperationSfpu<BinaryOpType::LEFT_SHIFT>;
 template struct BinaryOperationSfpu<BinaryOpType::RIGHT_SHIFT>;
 template struct BinaryOperationSfpu<BinaryOpType::MAXIMUM>;
+template struct BinaryOperationSfpu<BinaryOpType::MINIMUM>;
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -298,12 +298,28 @@ struct ExecuteMaximum {
 
 struct ExecuteMinimum {
     static Tensor invoke(
+        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        std::optional<bool> use_legacy = std::nullopt);
 
     static Tensor invoke(
-        const Tensor& input_tensor, float scalar, const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        QueueId queue_id,
+        const Tensor& input_a,
+        const float value,
+        const std::optional<const DataType>& output_dtype = std::nullopt,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
+        tt::stl::Span<const unary::UnaryWithParam> post_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> lhs_activations = {},
+        tt::stl::Span<const unary::UnaryWithParam> rhs_activations = {},
+        std::optional<bool> use_legacy = std::nullopt);
 };
 
 struct ExecutePrelu {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1939,11 +1939,10 @@ void py_module(py::module& module) {
         )doc",
         R"doc(BFLOAT16, BFLOAT8_B)doc");
 
-    detail::bind_binary_composite_overload(
+    detail::bind_binary_unary_max_operation(
         module,
         ttnn::minimum,
-        R"doc(Computes minimum for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(Computes minimum for :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc");
 
     detail::bind_binary_composite(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -36,6 +36,7 @@ enum class BinaryOpType {
     REQUANT,
     DEQUANT,
     MAXIMUM,
+    MINIMUM,
 };
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -234,6 +234,10 @@ std::map<std::string, std::string> get_defines_fp32(
             new_defines.insert({"BINOP_INIT", fmt::format("binary_max_tile_init();")});
             op_name = "binary_max_tile";
             break;
+        case BinaryOpType::MINIMUM:
+            new_defines.insert({"BINOP_INIT", fmt::format("binary_min_tile_init();")});
+            op_name = "binary_min_tile";
+            break;
         case BinaryOpType::LOGADDEXP:
             // PRE_IN0_0 ===> Applies prescaling for first input
             // PRE_IN1_0 ====> Applies prescaling for second input

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -107,18 +107,43 @@ Tensor _isclose(
     return result;
 }
 
-// minimum(a,b) = a - (a - b > 0 )*(a-b)
 Tensor ExecuteMinimum::invoke(
-    const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    Tensor t_diff = ttnn::subtract(input_a, input_b, std::nullopt, output_mem_config);
-    Tensor result = ttnn::where(t_diff, input_b, input_a);
-    return result;
+    QueueId queue_id,
+    const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    tt::stl::Span<const unary::UnaryWithParam> post_activations,
+    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    std::optional<bool> use_legacy) {
+    return BinaryOperationSfpu<operations::binary::BinaryOpType::MINIMUM>::invoke(
+        queue_id,
+        input_tensor_a,
+        input_tensor_b,
+        std::nullopt,
+        memory_config,
+        optional_output_tensor,
+        post_activations,
+        lhs_activations,
+        rhs_activations,
+        use_legacy);
 }
 
 Tensor ExecuteMinimum::invoke(
-    const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
-    return ttnn::operations::unary::ExecuteUnaryWithFloatParameter<
-        ttnn::operations::unary::UnaryOpType::MINIMUM>::invoke(ttnn::DefaultQueueId, input_a, value, output_mem_config);
+    QueueId queue_id,
+    const Tensor& input_a,
+    const float value,
+    const std::optional<const DataType>& output_dtype,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<Tensor>& optional_output_tensor,
+    tt::stl::Span<const unary::UnaryWithParam> post_activations,
+    tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
+    tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
+    std::optional<bool> use_legacy) {
+    return ttnn::operations::unary::ExecuteUnaryWithFloatParameter<ttnn::operations::unary::UnaryOpType::MINIMUM>::
+        invoke(ttnn::DefaultQueueId, input_a, value, memory_config, optional_output_tensor);
 }
 
 Tensor ExecuteMaximum::invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -45,6 +45,7 @@ namespace utils {
         case BinaryOpType::BITWISE_AND:
         case BinaryOpType::BITWISE_OR: return (a == DataType::INT32 && b == DataType::INT32);
         case BinaryOpType::MAXIMUM:
+        case BinaryOpType::MINIMUM:
         case BinaryOpType::POWER: return true;
         default: return false;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -14,7 +14,7 @@
 #include "compute_kernel_api/binary_shift.h"
 #include "compute_kernel_api/add_int32_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
-#include "compute_kernel_api/binary_max.h"
+#include "compute_kernel_api/binary_max_min.h"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -41,6 +41,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case REQUANT:
         case DEQUANT:
         case MAXIMUM:
+        case MINIMUM:
         case POWER: return true;
         default: return false;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -272,6 +272,13 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>) : b
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::MINIMUM:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::MINIMUM;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         default: TT_THROW("Unsupported binary op {}", binary_op_type);
     }
 }
@@ -301,6 +308,7 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case BITWISE_OR: return {"binary_bitwise_tile_init();", "or_binary_tile"};
         case BITWISE_XOR: return {"binary_bitwise_tile_init();", "xor_binary_tile"};
         case MAXIMUM: return {"binary_max_tile_init();", "binary_max_tile"};
+        case MINIMUM: return {"binary_min_tile_init();", "binary_min_tile"};
         case QUANT: return {"quant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "quant_tile"};
         case REQUANT:
             return {"requant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "requant_tile"};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -58,7 +58,8 @@ struct OpConfig {
         QUANT,
         REQUANT,
         DEQUANT,
-        MAXIMUM
+        MAXIMUM,
+        MINIMUM
     };
 
     template <class EnumT>

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -13,7 +13,7 @@
 #include "compute_kernel_api/add_int32_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
-#include "compute_kernel_api/binary_max.h"
+#include "compute_kernel_api/binary_max_min.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -13,7 +13,7 @@
 #include "compute_kernel_api/add_int32_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
 #include "compute_kernel_api/quantization.h"
-#include "compute_kernel_api/binary_max.h"
+#include "compute_kernel_api/binary_max_min.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -493,7 +493,7 @@ Tensor ExecuteUnaryCompositeClamp::invoke(
     } else if (min.value() > max.value()) {
         return full_like(a, max.value());
     }
-    Tensor a_max = ttnn::minimum(a, max.value(), output_memory_config);
+    Tensor a_max = ttnn::minimum(ttnn::DefaultQueueId, a, max.value(), std::nullopt, output_memory_config);
     if (min.value() == 0.0f) {
         return ttnn::relu(a_max, output_memory_config);
     } else {
@@ -515,7 +515,7 @@ Tensor ExecuteUnaryCompositeClamp::invoke(
         return ttnn::where(
             ttnn::le(a, max.value(), std::nullopt, output_memory_config), a, max.value(), output_memory_config);
     }
-    Tensor a_max = ttnn::minimum(a, max.value(), output_memory_config);
+    Tensor a_max = ttnn::minimum(ttnn::DefaultQueueId, a, max.value(), std::nullopt, output_memory_config);
     Tensor temp = ttnn::where(
         ttnn::eq(min.value(), 0.0f, std::nullopt, output_memory_config),
         ttnn::relu(a_max, output_memory_config),
@@ -555,7 +555,7 @@ Tensor _selu(
     Tensor x_Exp_minus_1 = ttnn::expm1(x);
     Tensor result_t2_ = ttnn::multiply(x_Exp_minus_1, alpha, std::nullopt, output_mem_config);
     x_Exp_minus_1.deallocate();
-    Tensor result_term2 = ttnn::minimum(result_t2_, 0.0f, output_mem_config);
+    Tensor result_term2 = ttnn::minimum(ttnn::DefaultQueueId, result_t2_, 0.0f, std::nullopt, output_mem_config);
     result_t2_.deallocate();
 
     // term 1


### PR DESCRIPTION
### Ticket
#20241

### Problem description
Implement Tensor-Tensor version of minimum

### What's changed
Implemented Tensor-Tensor version is minimum

- Used TTI_ instructions
- Supports bcast using `use_legacy=False`
- Tested in WH, BH
- Removed existing GS support
- Added test for bug mentioned in #18556
- Performance improvement on moving from composite 
   - Current implementation is **81.01%** faster than the older implementation.
---> Composite Op : [main.csv](https://github.com/user-attachments/files/19774802/main.csv)
 ---> SFPU Op : [Updated_version.csv](https://github.com/user-attachments/files/19774431/Updated_version.csv)

<img width="372" alt="Screenshot 2025-04-16 at 3 25 28 PM" src="https://github.com/user-attachments/assets/d6e6e4ee-7f0c-4f3e-b528-7d61e4a96f3d" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14490271437) CI Passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14490389491) CI Passes
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14490273890) CI Passes
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14490275374) CI Passes as in main
- [x] [C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/14490277226) CI Passes
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14490279746) CI Passes as in main
- [x] [new models tests](https://github.com/tenstorrent/tt-metal/actions/runs/14490281699/job/40697763599) - passes as in main