### PR TITLE
Update names for superset; send perf in ns

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -508,8 +508,8 @@ def run_llama3_demo(
 
         benchmark_data.save_partial_run_json(
             profiler,
-            run_type=f"tg-llama-demo-e2e",
-            ml_model_name="tg-llama",
+            run_type=f"tg_llama_demo_decode",
+            ml_model_name="llama70b-tg",
         )
 
     if not stress_test:

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -61,7 +61,7 @@ perf_targets = {
         "dispatch_duration_relative_margin": 0.1,
     },
     "AllGatherAsync_0": {
-        "op_name": "AllGatherAsync_SDPA_0",
+        "op_name": "AllGatherAsync_SDPA",
         "kernel_duration": 11153.511574074075,
         "op_to_op": 676.4444444444445,
         "non-overlapped-dispatch-time": 2273.2,
@@ -612,30 +612,40 @@ def test_llama_TG_perf_device(
             op_name = perf_targets[op_code_with_id]["op_name"]
             avg_dispatch_duration = dispatch_duration_per_instance_averaged_dict[op_code_with_id]
             # average
-            benchmark_data.add_measurement(profiler, 0, step_name, op_name, avg_kernel_duration)
-            benchmark_data.add_measurement(profiler, 0, step_name, op_name + "_op_to_op", avg_dispatch_duration)
+            benchmark_data.add_measurement(profiler, 0, step_name, op_name + "-model-kernel-avg", avg_kernel_duration)
+            benchmark_data.add_measurement(
+                profiler, 0, step_name, op_name + "-model-op_to_op-avg", avg_dispatch_duration
+            )
 
             # min
             benchmark_data.add_measurement(
-                profiler, 0, step_name, op_name + "_min", kernel_duration_per_instance_min_dict[op_code_with_id]
+                profiler,
+                0,
+                step_name,
+                op_name + "-model-kernel-min",
+                kernel_duration_per_instance_min_dict[op_code_with_id],
             )
             benchmark_data.add_measurement(
                 profiler,
                 0,
                 step_name,
-                op_name + "_op_to_op_min",
+                op_name + "-model-op_to_op-min",
                 dispatch_duration_per_instance_min_dict[op_code_with_id],
             )
 
             # max
             benchmark_data.add_measurement(
-                profiler, 0, step_name, op_name + "_max", kernel_duration_per_instance_max_dict[op_code_with_id]
+                profiler,
+                0,
+                step_name,
+                op_name + "-model-kernel-max",
+                kernel_duration_per_instance_max_dict[op_code_with_id],
             )
             benchmark_data.add_measurement(
                 profiler,
                 0,
                 step_name,
-                op_name + "_op_to_op_max",
+                op_name + "-model-op_to_op-max",
                 dispatch_duration_per_instance_max_dict[op_code_with_id],
             )
 
@@ -719,15 +729,15 @@ def test_llama_TG_perf_device(
     print(f"e2e estimate: {e2e_estimate_80l}")
 
     benchmark_data.add_measurement(profiler, 0, step_name, "e2e_estimate_80l", e2e_estimate_80l)
-    # Estimated T/s/u is 1000000 / (80L-duration + ~1240 lmhead+sampling+embeddings + ~300 python-overhead
+    # Estimated T/s/u is 1000000 / (80L-duration + ~2100 lmhead+sampling+embeddings + ~300 python-overhead
     benchmark_data.add_measurement(
-        profiler, 0, step_name, "tsu_estimate", 1000000 / (e2e_estimate_80l / 1000 + 1240 + 300)
+        profiler, 0, step_name, "tsu_estimate", 1000000 / (e2e_estimate_80l / 1000 + 2100 + 300)
     )
 
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg-llama-demo-device-perf-default",
-        ml_model_name="tg-llama",
+        run_type=f"tg_llama_demo_decode",
+        ml_model_name="llama70b-tg",
     )
 
     assert passing
@@ -796,19 +806,21 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
             expected_time = perf_targets[op_code_with_id]["non-overlapped-dispatch-time"]
             op_name = perf_targets[op_code_with_id]["op_name"]
 
-            benchmark_data.add_measurement(profiler, 0, step_name, op_name + "_dispatch", avg_dispatch_duration)
+            benchmark_data.add_measurement(
+                profiler, 0, step_name, op_name + "-model-dispatch-avg", avg_dispatch_duration
+            )
             benchmark_data.add_measurement(
                 profiler,
                 0,
                 step_name,
-                op_name + "_dispatch_min",
+                op_name + "-model-dispatch-min",
                 dispatch_duration_per_instance_min_dict[op_code_with_id],
             )
             benchmark_data.add_measurement(
                 profiler,
                 0,
                 step_name,
-                op_name + "_dispatch_max",
+                op_name + "-model-dispatch-max",
                 dispatch_duration_per_instance_max_dict[op_code_with_id],
             )
 
@@ -844,8 +856,8 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
 
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"tg-llama-demo-device-perf-non-overlapped-dispatch",
-        ml_model_name="tg-llama",
+        run_type=f"tg_llama_demo_decode",
+        ml_model_name="llama70b-tg",
     )
 
     assert passing

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ccl_async_perf_TG_llama.py
@@ -44,22 +44,23 @@ def test_ag_tg_llama_perf(
     profiler.end("run")
 
     # Get the measured performance
-    measured_min_us = results[cols[0]]["MIN"] / 1000
-    measured_max_us = results[cols[0]]["MAX"] / 1000
-    measured_avg_us = results[cols[0]]["AVG"] / 1000
-    measured_std_us = results[cols[0]]["STD"] / 1000
+    measured_min = results[cols[0]]["MIN"]
+    measured_max = results[cols[0]]["MAX"]
+    measured_avg = results[cols[0]]["AVG"]
+    measured_std = results[cols[0]]["STD"]
+    measured_avg_us = measured_avg / 1000
 
     logger.info(f"Measured performance: {measured_avg_us:.3f} us vs. target: {perf_target_us} us")
 
     # Save the measurement
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ag_type}-min-us", measured_min_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ag_type}-max-us", measured_max_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ag_type}-avg-us", measured_avg_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-{ag_type}-std-us", measured_std_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ag_type}-min", measured_min)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ag_type}-max", measured_max)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ag_type}-avg", measured_avg)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ag_type}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"all_gather",
-        ml_model_name="llama70b-tg-ccl",
+        run_type=f"tg_llama_ops",
+        ml_model_name="llama70b-tg",
     )
 
     assert (
@@ -101,22 +102,23 @@ def test_ar_tg_llama_perf(
     profiler.end("run")
 
     # Get the measured performance
-    measured_min_us = results[cols[0]]["MIN"] / 1000
-    measured_max_us = results[cols[0]]["MAX"] / 1000
-    measured_avg_us = results[cols[0]]["AVG"] / 1000
-    measured_std_us = results[cols[0]]["STD"] / 1000
+    measured_min = results[cols[0]]["MIN"]
+    measured_max = results[cols[0]]["MAX"]
+    measured_avg = results[cols[0]]["AVG"]
+    measured_std = results[cols[0]]["STD"]
+    measured_avg_us = measured_avg / 1000
 
     logger.info(f"Measured performance: {measured_avg_us:.3f} us vs. target: {perf_target_us} us")
 
     # Save the measurement
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_reduce-{ar_type}-min-us", measured_min_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_reduce-{ar_type}-max-us", measured_max_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_reduce-{ar_type}-avg-us", measured_avg_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_reduce-{ar_type}-std-us", measured_std_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ar_type}-min", measured_min)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ar_type}-max", measured_max)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ar_type}-avg", measured_avg)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-{ar_type}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"all_reduce",
-        ml_model_name="llama70b-tg-ccl",
+        run_type=f"tg_llama_ops",
+        ml_model_name="llama70b-tg",
     )
 
     assert (
@@ -153,22 +155,23 @@ def test_rms_perf(
     profiler.end("run")
 
     # Get the measured performance
-    measured_min_us = results[cols[0]]["MIN"] / 1000
-    measured_max_us = results[cols[0]]["MAX"] / 1000
-    measured_avg_us = results[cols[0]]["AVG"] / 1000
-    measured_std_us = results[cols[0]]["STD"] / 1000
+    measured_min = results[cols[0]]["MIN"]
+    measured_max = results[cols[0]]["MAX"]
+    measured_avg = results[cols[0]]["AVG"]
+    measured_std = results[cols[0]]["STD"]
+    measured_avg_us = measured_avg / 1000
 
     logger.info(f"Measured performance: {measured_avg_us:.3f} us vs. target: {perf_target_us} us")
 
     # Save the measurement
-    benchmark_data.add_measurement(profiler, 0, step_name, f"rms-min-us", measured_min_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"rms-max-us", measured_max_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"rms-avg-us", measured_avg_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"rms-std-us", measured_std_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-min", measured_min)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-max", measured_max)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-avg", measured_avg)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"rms_test",
-        ml_model_name="llama70b-tg-ccl",
+        run_type=f"tg_llama_ops",
+        ml_model_name="llama70b-tg",
     )
 
     assert measured_avg_us < perf_target_us, f"Performance target not met: {measured_avg_us} us > {perf_target_us} us"
@@ -202,22 +205,23 @@ def test_fused_all_gather_concat_perf(
     profiler.end("run")
 
     # Get the measured performance
-    measured_min_us = results[cols[0]]["MIN"] / 1000
-    measured_max_us = results[cols[0]]["MAX"] / 1000
-    measured_avg_us = results[cols[0]]["AVG"] / 1000
-    measured_std_us = results[cols[0]]["STD"] / 1000
+    measured_min = results[cols[0]]["MIN"] / 1000
+    measured_max = results[cols[0]]["MAX"] / 1000
+    measured_avg = results[cols[0]]["AVG"] / 1000
+    measured_std = results[cols[0]]["STD"] / 1000
+    measured_avg_us = measured_avg / 1000
 
     logger.info(f"Measured performance: {measured_avg_us:.3f} us vs. target: {perf_target_us} us")
 
     # Save the measurement
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-concat_heads-min-us", measured_min_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-concat_heads-max-us", measured_max_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-concat_heads-avg-us", measured_avg_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"all_gather-concat_heads-std-us", measured_std_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-min", measured_min)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-max", measured_max)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-avg", measured_avg)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"all_gather_concat_heads_fused",
-        ml_model_name="llama70b-tg-ccl",
+        run_type=f"tg_llama_ops",
+        ml_model_name="llama70b-tg",
     )
 
     assert measured_avg_us < perf_target_us, f"Performance target not met: {measured_avg_us} us > {perf_target_us} us"

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_llama_ops_perf_TG_llama.py
@@ -42,15 +42,16 @@ def test_llama_tg_ops_perf_device(op_name, expected_kernel_duration_us, perf_mar
     profiler.end("run")
 
     # Save the measurement
-    measured_avg_us = post_processed_results[f"AVG {inference_time_key}"] / 1e3
-    measured_max_us = post_processed_results[f"MAX {inference_time_key}"] / 1e3
-    measured_min_us = post_processed_results[f"MIN {inference_time_key}"] / 1e3
-    benchmark_data.add_measurement(profiler, 0, step_name, f"Llama-TG-{op_name}-avg-µs", measured_avg_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"Llama-TG-{op_name}-max-µs", measured_max_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"Llama-TG-{op_name}-min-µs", measured_min_us)
+    measured_avg = post_processed_results[f"AVG {inference_time_key}"]
+    measured_max = post_processed_results[f"MAX {inference_time_key}"]
+    measured_min = post_processed_results[f"MIN {inference_time_key}"]
+
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-avg", measured_avg)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-max", measured_max)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"{op_name}-min", measured_min)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"llama-tg-ops",
+        run_type=f"tg_llama_ops",
         ml_model_name="llama70b-tg",
     )
     expected_results = check_device_perf(post_processed_results, perf_margin, expected_perf_cols, assert_on_fail=True)

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_prefetcher_perf_TG.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_prefetcher_perf_TG.py
@@ -67,7 +67,7 @@ def test_dram_prefetcher_perf(
     benchmark_data.save_partial_run_json(
         profiler,
         run_type=f"dram_prefetcher",
-        ml_model_name="llama70b-tg-unit",
+        ml_model_name="llama70b-tg",
     )
 
     assert (

--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ring_matmul_perf_TG_llama.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_ring_matmul_perf_TG_llama.py
@@ -42,22 +42,23 @@ def test_ring_mm_tg_llama_perf(
     profiler.end("run")
 
     # Get the measured performance
-    measured_min_us = results[cols[0]]["MIN"] / 1000
-    measured_max_us = results[cols[0]]["MAX"] / 1000
-    measured_avg_us = results[cols[0]]["AVG"] / 1000
-    measured_std_us = results[cols[0]]["STD"] / 1000
+    measured_min = results[cols[0]]["MIN"]
+    measured_max = results[cols[0]]["MAX"]
+    measured_avg = results[cols[0]]["AVG"]
+    measured_std = results[cols[0]]["STD"]
+    measured_avg_us = measured_avg / 1000
 
     logger.info(f"Measured performance: {measured_avg_us:.3f} us vs. target: {perf_target_us} us")
 
     # Save the measurement
-    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-min-us", measured_min_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-max-us", measured_max_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-avg-us", measured_avg_us)
-    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-std-us", measured_std_us)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-min", measured_min)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-max", measured_max)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-avg", measured_avg)
+    benchmark_data.add_measurement(profiler, 0, step_name, f"ring_matmul-{mm_type}-std", measured_std)
     benchmark_data.save_partial_run_json(
         profiler,
-        run_type=f"ring_matmul",
-        ml_model_name="llama70b-tg-unit",
+        run_type=f"tg_llama_ops",
+        ml_model_name="llama70b-tg",
     )
 
     assert (


### PR DESCRIPTION
### Ticket
None

### Problem description
Naming in different tests for tg llama to upload data to superset is messy.

### What's changed
- Same model name for all tests, same run_type for each test category
- Send all perf durations in ns instead of us
- Update naming

Not running any CI tests since no model change was done and CI is backlogged.