### PR TITLE
#17138: SD: Reuse conv weights and bias

### DIFF
--- a/models/demos/blackhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py
+++ b/models/demos/blackhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py
@@ -1,1 +1,0 @@
-../../../../wormhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py

--- a/models/demos/blackhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/blackhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -1,0 +1,1 @@
+../../../../wormhole/stable_diffusion/tests/vae/test_vae_upsample.py

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -46,6 +46,8 @@ def test_upsample(
         torch_upsample,
         device,
         input_channels,
+        input_height,
+        input_width,
         out_channels,
         output_height,
         output_width,
@@ -67,6 +69,10 @@ def test_upsample(
     ttnn_output.deallocate(True)
     ttnn_output = ttnn_model(ttnn_input)
 
+    ttnn_output = ttnn.reshape(
+        ttnn_output,
+        [1, output_height, output_width, out_channels],
+    )
     ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
     ttnn_output = ttnn.to_torch(ttnn_output)
 

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_conv_block.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_conv_block.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import ttnn
 
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (
     get_default_compute_config,
@@ -81,8 +80,5 @@ class ConvBlock:
             self.return_weights_and_bias = False
         else:
             hidden_states = conv_result
-
-        if hidden_states.memory_config() != ttnn.DRAM_MEMORY_CONFIG:
-            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
 
         return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_conv_block.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_conv_block.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import ttnn
 
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_conv_block.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_conv_block.py
@@ -1,0 +1,84 @@
+import ttnn
+
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (
+    get_default_compute_config,
+    get_default_conv_config,
+    prepare_split_conv_weights_bias,
+    split_conv_and_run,
+)
+
+
+# Conv op wrapper for weights and bias caching.
+# ConvBlock passes in host weights and bias to conv2d op,
+# and caches returned prepared weights and bias on device for next calls.
+class ConvBlock:
+    def __init__(
+        self,
+        torch_conv,
+        device,
+        in_channels,
+        input_height,
+        input_width,
+        out_channels,
+        conv_in_channel_split_factor,
+        conv_out_channel_split_factor,
+        kernel_size=3,
+        padding=1,
+    ):
+        self.device = device
+        self.in_channels = in_channels
+        self.input_height = input_height
+        self.input_width = input_width
+        self.out_channels = out_channels
+        self.conv_in_channel_split_factor = conv_in_channel_split_factor
+        self.conv_out_channel_split_factor = conv_out_channel_split_factor
+        self.kernel_size = kernel_size
+        self.padding = padding
+
+        self.return_weights_and_bias = True
+        self.compute_config = get_default_compute_config(device)
+        self.conv_config = get_default_conv_config()
+
+        self.conv_weights, self.conv_bias = prepare_split_conv_weights_bias(
+            in_channels,
+            out_channels,
+            conv_in_channel_split_factor,
+            conv_out_channel_split_factor,
+            torch_conv.weight,
+            torch_conv.bias.unsqueeze(0).unsqueeze(0).unsqueeze(0),
+        )
+
+    def __call__(
+        self,
+        hidden_states,
+    ):
+        conv_result = split_conv_and_run(
+            hidden_states,
+            self.conv_weights,
+            self.conv_bias,
+            self.device,
+            self.in_channels,
+            self.input_height,
+            self.input_width,
+            self.out_channels,
+            self.conv_in_channel_split_factor,
+            self.conv_out_channel_split_factor,
+            self.compute_config,
+            self.conv_config,
+            self.kernel_size,
+            self.padding,
+            self.return_weights_and_bias,
+        )
+
+        if self.return_weights_and_bias:
+            # In the first pass, we pass in weights on host,
+            # so we want to keep the weights on device and reuse them
+            hidden_states, self.conv_weights, self.conv_bias = conv_result
+            self.return_weights_and_bias = False
+        else:
+            hidden_states = conv_result
+
+        if hidden_states.memory_config() != ttnn.DRAM_MEMORY_CONFIG:
+            hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+
+        return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upsample.py
@@ -3,12 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (
-    get_default_compute_config,
-    get_default_conv_config,
-    prepare_split_conv_weights_bias,
-    split_conv_and_run,
-)
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_conv_block import ConvBlock
 
 
 class UpsampleBlock:
@@ -17,6 +12,8 @@ class UpsampleBlock:
         torch_upsample,
         device,
         in_channels,
+        input_height,
+        input_width,
         out_channels,
         output_height,
         output_width,
@@ -26,24 +23,19 @@ class UpsampleBlock:
     ):
         self.device = device
         self.in_channels = in_channels
-        self.out_channels = out_channels
-        self.output_height = output_height
-        self.output_width = output_width
-        self.conv_in_channel_split_factor = conv_in_channel_split_factor
-        self.conv_out_channel_split_factor = conv_out_channel_split_factor
+        self.input_height = input_height
+        self.input_width = input_width
         self.scale_factor = scale_factor
-        self.return_weights_and_bias = True
 
-        self.compute_config = get_default_compute_config(device)
-        self.conv_config = get_default_conv_config()
-
-        self.conv_weights, self.conv_bias = prepare_split_conv_weights_bias(
+        self.conv = ConvBlock(
+            torch_upsample.conv,
+            device,
             in_channels,
+            output_height,
+            output_width,
             out_channels,
             conv_in_channel_split_factor,
             conv_out_channel_split_factor,
-            torch_upsample.conv.weight,
-            torch_upsample.conv.bias.unsqueeze(0).unsqueeze(0).unsqueeze(0),
         )
 
     def __call__(self, hidden_states):
@@ -53,30 +45,6 @@ class UpsampleBlock:
 
         hidden_states = ttnn.upsample(hidden_states, self.scale_factor)
 
-        conv_result = split_conv_and_run(
-            hidden_states,
-            self.conv_weights,
-            self.conv_bias,
-            self.device,
-            self.in_channels,
-            self.output_height,
-            self.output_width,
-            self.out_channels,
-            self.conv_in_channel_split_factor,
-            self.conv_out_channel_split_factor,
-            self.compute_config,
-            self.conv_config,
-            return_weights_and_bias=self.return_weights_and_bias,
-        )
+        hidden_states = self.conv(hidden_states)
 
-        if self.return_weights_and_bias:
-            # In the first pass, we pass in weights on host,
-            # so we want to keep the weights on device and reuse them
-            hidden_states, self.conv_weights, self.conv_bias = conv_result
-            self.return_weights_and_bias = False
-        else:
-            hidden_states = conv_result
-
-        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
-        hidden_states = ttnn.reshape(hidden_states, [1, self.output_height, self.output_width, self.out_channels])
         return hidden_states

--- a/tests/nightly/single_card/stable_diffusion/vae/test_vae_decoder_upsample.py
+++ b/tests/nightly/single_card/stable_diffusion/vae/test_vae_decoder_upsample.py
@@ -1,1 +1,0 @@
-../../../../../models/demos/wormhole/stable_diffusion/tests/vae/test_vae_decoder_upsample.py

--- a/tests/nightly/single_card/stable_diffusion/vae/test_vae_upsample.py
+++ b/tests/nightly/single_card/stable_diffusion/vae/test_vae_upsample.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py


### PR DESCRIPTION
### Ticket
#17138

### Problem description
We always pass in host weights to conv2d in VAE upsample, so conv2d always needs to preprocess them.

### What's changed
- Add ConvBlock class that handles weights and bias caching.
- Update VAE upsample to use ConvBlock.
- Fix a bug in split conv - check `conv_out_channel_split_factor` instead of `conv_in_channel_split_factor`
- Deallocate all midresults in split conv
- Renamed test and symlinks pointing to it

### Checklist
[WH] Frequent model and ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/14494284549
[BH] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/14494287604