### PR TITLE
Re-enable replay buffer for SFPI and disable gathering on brisc/ncrisc to be consistent with triscs

### DIFF
--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -324,6 +324,11 @@ inline void barrier_remote_cb_interface_setup(uint8_t noc_index, uint32_t end_cb
 }
 
 int main() {
+    // Workaround for tt-metal#16439, making sure gathering multiple instructions issued to Tensix is disabled
+    // Brisc does not issue Tensix instructions but to be consistent for all riscs around Tensix we disable it
+#ifdef ARCH_BLACKHOLE
+    disable_gathering();
+#endif
     configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -97,6 +97,11 @@ void l1_to_ncrisc_iram_copy_wait() {
 #endif
 
 int main(int argc, char *argv[]) {
+    // Workaround for tt-metal#16439, making sure gathering multiple instructions issued to Tensix is disabled
+    // Ncrisc does not issue Tensix instructions but to be consistent for all riscs around Tensix we disable it
+#ifdef ARCH_BLACKHOLE
+    disable_gathering();
+#endif
     configure_l1_data_cache();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -93,7 +93,7 @@ void init_sync_registers() {
 }
 
 int main(int argc, char *argv[]) {
-    // Workaround for tt-metal#16439, making sure gathering is disabled
+    // Workaround for tt-metal#16439, making sure gathering multiple instructions issued to Tensix is disabled
 #ifdef ARCH_BLACKHOLE
     disable_gathering();
 #endif

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -130,3 +130,46 @@ bool is_message_go() {
 #else
 #define EARLY_RETURN_FOR_DEBUG
 #endif
+
+inline __attribute__((always_inline)) void disable_gathering() {
+#if defined(ARCH_BLACKHOLE)
+    // Disable gathering: set bit 18
+    asm(R"ASM(
+        .option push
+        li   t1, 0x2
+        csrrs zero, 0x7c0, t1
+        li   t1, 0x1
+        slli t1, t1, 18
+        fence
+        csrrs zero, 0x7c0, t1
+        li   t1, 0x2
+        csrrc zero, 0x7c0, t1
+        fence
+        .option pop
+         )ASM" ::
+            : "t1");
+#endif
+}
+
+inline __attribute__((always_inline)) void configure_l1_data_cache() {
+#if defined(ARCH_BLACKHOLE)
+#if defined(DISABLE_L1_DATA_CACHE)
+    // Disables Blackhole's L1 cache. Grayskull and Wormhole do not have L1 cache
+    // L1 cache can be disabled by setting `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` env var
+    // export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR*,ER*>
+    asm(R"ASM(
+            li t1, 0x8
+            csrrs zero, 0x7c0, t1
+             )ASM" ::
+            : "t1");
+#elif !defined(ENABLE_HW_CACHE_INVALIDATION)
+    // Disable gathering to stop HW from invalidating the data cache after 128 transactions
+    // This is default enabled
+    asm(R"ASM(
+            lui  t1, 0x40
+            csrrs zero, 0x7c0, t1
+             )ASM" ::
+            : "t1");
+#endif
+#endif
+}

--- a/tt_metal/hw/inc/risc_common.h
+++ b/tt_metal/hw/inc/risc_common.h
@@ -186,29 +186,6 @@ inline __attribute__((always_inline)) void invalidate_l1_cache() {
 #endif
 }
 
-inline __attribute__((always_inline)) void configure_l1_data_cache() {
-#if defined(ARCH_BLACKHOLE)
-#if defined(DISABLE_L1_DATA_CACHE)
-    // Disables Blackhole's L1 cache. Grayskull and Wormhole do not have L1 cache
-    // L1 cache can be disabled by setting `TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS` env var
-    // export TT_METAL_DISABLE_L1_DATA_CACHE_RISCVS=<BR,NC,TR*,ER*>
-    asm(R"ASM(
-        li t1, 0x8
-        csrrs zero, 0x7c0, t1
-         )ASM" ::
-            : "t1");
-#elif !defined(ENABLE_HW_CACHE_INVALIDATION)
-    // Disable gathering to stop HW from invalidating the data cache after 128 transactions
-    // This is default enabled
-    asm(R"ASM(
-        lui  t1, 0x40
-        csrrs zero, 0x7c0, t1
-         )ASM" ::
-            : "t1");
-#endif
-#endif
-}
-
 // Flush i$ on ethernet riscs
 inline __attribute__((always_inline)) void flush_erisc_icache() {
 #ifdef ARCH_BLACKHOLE

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -160,7 +160,7 @@ void JitBuildEnv::init(
     switch (arch) {
         case ARCH::GRAYSKULL: common_flags = "-mcpu=tt-gs "; break;
         case ARCH::WORMHOLE_B0: common_flags = "-mcpu=tt-wh "; break;
-        case ARCH::BLACKHOLE: common_flags = "-mcpu=tt-bh -fno-rvtt-sfpu-replay "; break;
+        case ARCH::BLACKHOLE: common_flags = "-mcpu=tt-bh "; break;
         default: TT_ASSERT(false, "Invalid arch"); break;
     }
     common_flags += "-std=c++17 -flto -ffast-math ";


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Gathering is disabled on triscs but not b/ncrisc. Even though dm riscs don't issue tensix instructions, disable gathering here to be consistent with triscs. 

Also re-enabling replay buffer because gathering is always disabled.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14498317026) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14497295319) CI passes 
