### PR TITLE
Determine multicast capability from HAL

### DIFF
--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -13,7 +13,6 @@
 #include "core_config.h"
 #include "dev_mem_map.h"
 #include "eth_l1_address_map.h"
-#include "hal_asserts.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -97,7 +96,14 @@ HalCoreInfoType create_active_eth_mem_map() {
         processor_classes[processor_class_idx] = processor_types;
     }
 
-    return {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
+    return {
+        HalProgrammableCoreType::ACTIVE_ETH,
+        CoreType::ETH,
+        processor_classes,
+        mem_map_bases,
+        mem_map_sizes,
+        false,
+        false};
 }
 
 }  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_active_eth.cpp
@@ -102,8 +102,8 @@ HalCoreInfoType create_active_eth_mem_map() {
         processor_classes,
         mem_map_bases,
         mem_map_sizes,
-        false,
-        false};
+        false /*supports_cbs*/,
+        false /*supports_receiving_multicast_cmds*/};
 }
 
 }  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -104,8 +104,8 @@ HalCoreInfoType create_idle_eth_mem_map() {
         processor_classes,
         mem_map_bases,
         mem_map_sizes,
-        false,
-        false};
+        false /*supports_cbs*/,
+        false /*supports_receiving_multicast_cmds*/};
 }
 
 }  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_idle_eth.cpp
@@ -14,7 +14,6 @@
 #include "blackhole/bh_hal.hpp"
 #include "core_config.h"
 #include "dev_mem_map.h"
-#include "hal_asserts.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
@@ -99,7 +98,14 @@ HalCoreInfoType create_idle_eth_mem_map() {
         processor_classes[processor_class_idx] = processor_types;
     }
 
-    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
+    return {
+        HalProgrammableCoreType::IDLE_ETH,
+        CoreType::ETH,
+        processor_classes,
+        mem_map_bases,
+        mem_map_sizes,
+        false,
+        false};
 }
 
 }  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
-#include <string>
 #include <vector>
 
 #include "assert.hpp"
@@ -124,7 +123,8 @@ HalCoreInfoType create_tensix_mem_map() {
         processor_classes[processor_class_idx] = processor_types;
     }
 
-    return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true};
+    return {
+        HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true, true};
 }
 
 }  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -124,7 +124,13 @@ HalCoreInfoType create_tensix_mem_map() {
     }
 
     return {
-        HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true, true};
+        HalProgrammableCoreType::TENSIX,
+        CoreType::WORKER,
+        processor_classes,
+        mem_map_bases,
+        mem_map_sizes,
+        true /*supports_cbs*/,
+        true /*supports_receiving_multicast_cmds*/};
 }
 
 }  // namespace tt::tt_metal::blackhole

--- a/tt_metal/llrt/hal.cpp
+++ b/tt_metal/llrt/hal.cpp
@@ -58,13 +58,15 @@ HalCoreInfoType::HalCoreInfoType(
     const std::vector<std::vector<HalJitBuildConfig>>& processor_classes,
     const std::vector<DeviceAddr>& mem_map_bases,
     const std::vector<uint32_t>& mem_map_sizes,
-    bool supports_cbs) :
+    bool supports_cbs,
+    bool supports_receiving_multicast_cmds) :
     programmable_core_type_(programmable_core_type),
     core_type_(core_type),
     processor_classes_(processor_classes),
     mem_map_bases_(mem_map_bases),
     mem_map_sizes_(mem_map_sizes),
-    supports_cbs_(supports_cbs) {}
+    supports_cbs_(supports_cbs),
+    supports_receiving_multicast_cmds_(supports_receiving_multicast_cmds) {}
 
 uint32_t generate_risc_startup_addr(uint32_t firmware_base) {
     // Options for handling brisc fw not starting at mem[0]:

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -52,6 +52,7 @@ private:
     std::vector<DeviceAddr> mem_map_bases_;
     std::vector<uint32_t> mem_map_sizes_;
     bool supports_cbs_;
+    bool supports_receiving_multicast_cmds_;
 
 public:
     HalCoreInfoType(
@@ -60,7 +61,8 @@ public:
         const std::vector<std::vector<HalJitBuildConfig>>& processor_classes,
         const std::vector<DeviceAddr>& mem_map_bases,
         const std::vector<uint32_t>& mem_map_sizes,
-        bool supports_cbs);
+        bool supports_cbs,
+        bool supports_receiving_multicast_cmds);
 
     template <typename T = DeviceAddr>
     T get_dev_addr(HalL1MemAddrType addr_type) const;
@@ -226,6 +228,8 @@ public:
 
     bool get_supports_cbs(uint32_t programmable_core_type_index) const;
 
+    bool get_supports_receiving_multicasts(uint32_t programmable_core_type_index) const;
+
     uint32_t get_num_risc_processors() const;
 
     const HalJitBuildConfig& get_jit_build_config(
@@ -343,6 +347,10 @@ inline uint32_t Hal::get_common_alignment_with_pcie(HalMemType memory_type) cons
 
 inline bool Hal::get_supports_cbs(uint32_t programmable_core_type_index) const {
     return this->core_info_[programmable_core_type_index].supports_cbs_;
+}
+
+inline bool Hal::get_supports_receiving_multicasts(uint32_t programmable_core_type_index) const {
+    return this->core_info_[programmable_core_type_index].supports_receiving_multicast_cmds_;
 }
 
 inline const HalJitBuildConfig& Hal::get_jit_build_config(

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -51,8 +51,8 @@ private:
     std::vector<std::vector<HalJitBuildConfig>> processor_classes_;
     std::vector<DeviceAddr> mem_map_bases_;
     std::vector<uint32_t> mem_map_sizes_;
-    bool supports_cbs_;
-    bool supports_receiving_multicast_cmds_;
+    bool supports_cbs_ = false;
+    bool supports_receiving_multicast_cmds_ = false;
 
 public:
     HalCoreInfoType(

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -11,7 +11,6 @@
 
 #include "core_config.h"
 #include "eth_l1_address_map.h"
-#include "hal_asserts.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include <umd/device/tt_core_coordinates.h>
@@ -94,7 +93,14 @@ HalCoreInfoType create_active_eth_mem_map() {
         processor_classes[processor_class_idx] = processor_types;
     }
 
-    return {HalProgrammableCoreType::ACTIVE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
+    return {
+        HalProgrammableCoreType::ACTIVE_ETH,
+        CoreType::ETH,
+        processor_classes,
+        mem_map_bases,
+        mem_map_sizes,
+        false,
+        false};
 }
 
 }  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_active_eth.cpp
@@ -99,8 +99,8 @@ HalCoreInfoType create_active_eth_mem_map() {
         processor_classes,
         mem_map_bases,
         mem_map_sizes,
-        false,
-        false};
+        false /*supports_cbs*/,
+        false /*supports_receiving_multicast_cmds*/};
 }
 
 }  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -83,8 +83,8 @@ HalCoreInfoType create_idle_eth_mem_map() {
         processor_classes,
         mem_map_bases,
         mem_map_sizes,
-        false,
-        false};
+        false /*supports_cbs*/,
+        false /*supports_receiving_multicast_cmds*/};
 }
 
 }  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_idle_eth.cpp
@@ -12,7 +12,6 @@
 
 #include "core_config.h"
 #include "dev_mem_map.h"
-#include "hal_asserts.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_parameters.h"
@@ -78,7 +77,14 @@ HalCoreInfoType create_idle_eth_mem_map() {
         processor_classes[processor_class_idx] = processor_types;
     }
 
-    return {HalProgrammableCoreType::IDLE_ETH, CoreType::ETH, processor_classes, mem_map_bases, mem_map_sizes, false};
+    return {
+        HalProgrammableCoreType::IDLE_ETH,
+        CoreType::ETH,
+        processor_classes,
+        mem_map_bases,
+        mem_map_sizes,
+        false,
+        false};
 }
 
 }  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -122,7 +122,13 @@ HalCoreInfoType create_tensix_mem_map() {
     }
 
     return {
-        HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true, true};
+        HalProgrammableCoreType::TENSIX,
+        CoreType::WORKER,
+        processor_classes,
+        mem_map_bases,
+        mem_map_sizes,
+        true /*supports_cbs*/,
+        true /*supports_receiving_multicast_cmds*/};
 }
 
 }  // namespace tt::tt_metal::wormhole

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
-#include <string>
 #include <vector>
 
 #include "assert.hpp"
@@ -122,7 +121,8 @@ HalCoreInfoType create_tensix_mem_map() {
         processor_classes[processor_class_idx] = processor_types;
     }
 
-    return {HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true};
+    return {
+        HalProgrammableCoreType::TENSIX, CoreType::WORKER, processor_classes, mem_map_bases, mem_map_sizes, true, true};
 }
 
 }  // namespace tt::tt_metal::wormhole


### PR DESCRIPTION
### Ticket
Cleanup

### Problem description
Rely on the HAL layer to determine if a core can receive multicast commands to simplify logic and reduce the amount of paths for more core types.

### What's changed
Commit 1: Add `get_supports_receiving_multicasts ` to HAL
Commit 2: Update Program dispatch to use `get_supports_receiving_multicasts ` instead of `if (core_type == CoreType::ETH`

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14508802657
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14501092257
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14519892725
https://github.com/tenstorrent/tt-metal/actions/runs/14519890843