### PR TITLE
[skip ci] Move profiler regressions over to CIv2

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   metalium-basic:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner) }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -49,10 +49,11 @@ jobs:
           {name: FD2, cmd: ./tests/scripts/run_cpp_fd2_tests.sh},
         ]
     name: ${{ inputs.arch }} ${{ inputs.runner-label }} ${{ matrix.test-group.name }}
-    runs-on:
-      - ${{ inputs.runner-label }}
-      - cloud-virtual-machine
-      - in-service
+    runs-on: >-
+      ${{
+        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+      }}
     container:
       image: ${{ inputs.docker-image }}
       env:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "tt-beta-ubuntu-2204-n300-large-stable",
+          "N300",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "tt-beta-ubuntu-2204-n150-large-stable",
+          "N150",
         ]
     uses: ./.github/workflows/basic.yaml
     with:

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [
-          "tt-beta-ubuntu-2204-n150-large-stable",
+          "N150",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{
-        (inputs.runner-label == 'N150' || inputs.runner-label == 'N300' && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        ((inputs.runner-label == 'N150' || inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -65,11 +65,7 @@ jobs:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
       fail-fast: false
-    runs-on: >-
-      ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
-      }}
+    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label) }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -65,7 +65,11 @@ jobs:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
       fail-fast: false
-    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label) }}
+    runs-on: >-
+      ${{
+        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+      }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
     runs-on: >-
       ${{
-        github.event.pull_request.head.repo.fork == true && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label)
+        (inputs.runner-label == 'N150' || inputs.runner-label == 'N300' && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
         || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
       }}
     container:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -19,11 +19,7 @@ on:
 
 jobs:
   metalium-smoke:
-    runs-on: >-
-      ${{
-        startsWith(inputs.runner, 'tt-beta-ubuntu') && fromJSON(format('["{0}"]', inputs.runner))
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner))
-      }}
+    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner) }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:


### PR DESCRIPTION
### Ticket
[#20770](https://github.com/tenstorrent/tt-metal/issues/20770)

### Problem description
We wish to move to CIv2.  We do not wish to overload it.  So migrate incrementally and monitor the demand.

### What's changed
Moved one job.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14501915126)
- [x] BH post commit [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14501579641) 