### PR TITLE
#20658 Update num BH active erisc for timestamp profiler test

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -364,7 +364,7 @@ def test_timestamped_events():
     ZONE_COUNT = 100
     WH_ERISC_COUNTS = [0, 1, 5]
     WH_TENSIX_COUNTS = [72, 64, 56]
-    BH_ERISC_COUNTS = [0, 1, 5]
+    BH_ERISC_COUNTS = [0, 1, 6, 8]
     BH_TENSIX_COUNTS = [130, 120, 110]
 
     WH_COMBO_COUNTS = []

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -113,7 +113,7 @@ int main() {
             // Only include this iteration in the device profile if the launch message is valid. This is because all
             // workers get a go signal regardless of whether they're running a kernel or not. We don't want to profile
             // "invalid" iterations.
-            DeviceZoneScopedMainN("ACTIVE-ERISC-FW");
+            DeviceZoneScopedMainN("ERISC-FW");
             uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
             launch_msg_t* launch_msg_address = &(mailboxes->launch[launch_msg_rd_ptr]);
 

--- a/tt_metal/hw/firmware/src/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/active_erisck.cc
@@ -31,7 +31,7 @@ void kernel_launch(uint32_t kernel_base_addr) {
     noc_local_state_init(NOC_INDEX);
 
     {
-        DeviceZoneScopedMainChildN("ACTIVE-ERISC-KERNEL");
+        DeviceZoneScopedMainChildN("ERISC-KERNEL");
         WAYPOINT("K");
         kernel_main();
         WAYPOINT("KD");


### PR DESCRIPTION
### Ticket
#20658 

### Problem description
Timestamp profiler test was listing the wrong number of BH active eth. This wasn't caught on CI before because P100s don't have any active eth cores. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14499835964) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14499822791) CI passes