### PR TITLE
Replace torch adaptive maxpool 2d with ttnn maxpool2d in yolov8s_world model

### DIFF
--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -11,6 +11,7 @@ from models.experimental.yolov8s_world.tt.ttnn_yolov8s_world_utils import (
     concat,
     determine_num_cores_for_upsample,
     get_core_grid_from_num_cores,
+    tt_adaptive_to_max_pool2d,
 )
 
 
@@ -559,11 +560,10 @@ class TtImagePoolingAttn:
                 input_params=input_params[i],
                 is_act_false=True,
                 conv_alone=True,
-                reshape_tensor=True,
             )
             for i, in_channels in enumerate(ch)
         ]
-        self.im_pools = nn.ModuleList([nn.AdaptiveMaxPool2d((k, k)) for _ in range(nf)])
+        self.im_pools = [ttnn.max_pool2d for i in range(nf)]
         self.ec = ec
         self.nh = nh
         self.nf = nf
@@ -576,16 +576,55 @@ class TtImagePoolingAttn:
         assert len(x) == self.nf
         num_patches = self.k**2
 
-        x = [ttnn.permute(proj(x)[0], (0, 3, 1, 2)) for (x, proj) in zip(x, self.projections)]
+        x = [proj(x)[0] for (x, proj) in zip(x, self.projections)]
         x = [
-            ttnn.reshape(
-                ttnn.from_torch(
-                    pool(ttnn.to_torch(x)),
-                    device=self.device,
-                    layout=ttnn.TILE_LAYOUT,
-                    memory_config=ttnn.L1_MEMORY_CONFIG,
+            ttnn.to_layout(
+                ttnn.reshape(
+                    ttnn.permute(
+                        pool(
+                            input_tensor=ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT),
+                            batch_size=1,
+                            input_h=int(math.sqrt(x.shape[2])),
+                            input_w=int(math.sqrt(x.shape[2])),
+                            channels=x.shape[-1],
+                            kernel_size=[
+                                tt_adaptive_to_max_pool2d(
+                                    torch.randn(
+                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                    ),
+                                    (3, 3),
+                                )[0],
+                                tt_adaptive_to_max_pool2d(
+                                    torch.randn(
+                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                    ),
+                                    (3, 3),
+                                )[0],
+                            ],
+                            stride=[
+                                tt_adaptive_to_max_pool2d(
+                                    torch.randn(
+                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                    ),
+                                    (3, 3),
+                                )[1],
+                                tt_adaptive_to_max_pool2d(
+                                    torch.randn(
+                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                    ),
+                                    (3, 3),
+                                )[1],
+                            ],
+                            padding=[0, 0],
+                            dilation=[1, 1],
+                            memory_config=ttnn.L1_MEMORY_CONFIG,
+                            applied_shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+                        ),
+                        (0, 3, 1, 2),
+                    ),
+                    (bs, -1, num_patches),
                 ),
-                (bs, -1, num_patches),
+                layout=ttnn.TILE_LAYOUT,
             )
             for (x, pool) in zip(x, self.im_pools)
         ]

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -580,56 +580,52 @@ class TtImagePoolingAttn:
         x = [
             ttnn.to_layout(
                 ttnn.reshape(
-                    ttnn.permute(
-                        pool(
-                            input_tensor=ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT),
-                            batch_size=1,
-                            input_h=int(math.sqrt(x.shape[2])),
-                            input_w=int(math.sqrt(x.shape[2])),
-                            channels=x.shape[-1],
-                            kernel_size=[
-                                tt_adaptive_to_max_pool2d(
-                                    torch.randn(
-                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                    ),
-                                    (3, 3),
-                                )[0],
-                                tt_adaptive_to_max_pool2d(
-                                    torch.randn(
-                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                    ),
-                                    (3, 3),
-                                )[0],
-                            ],
-                            stride=[
-                                tt_adaptive_to_max_pool2d(
-                                    torch.randn(
-                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                    ),
-                                    (3, 3),
-                                )[1],
-                                tt_adaptive_to_max_pool2d(
-                                    torch.randn(
-                                        x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
-                                    ),
-                                    (3, 3),
-                                )[1],
-                            ],
-                            padding=[0, 0],
-                            dilation=[1, 1],
-                            memory_config=ttnn.L1_MEMORY_CONFIG,
-                            applied_shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-                        ),
-                        (0, 3, 1, 2),
+                    pool(
+                        input_tensor=ttnn.to_layout(x, layout=ttnn.ROW_MAJOR_LAYOUT),
+                        batch_size=1,
+                        input_h=int(math.sqrt(x.shape[2])),
+                        input_w=int(math.sqrt(x.shape[2])),
+                        channels=x.shape[-1],
+                        kernel_size=[
+                            tt_adaptive_to_max_pool2d(
+                                torch.randn(
+                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                ),
+                                (3, 3),
+                            )[0],
+                            tt_adaptive_to_max_pool2d(
+                                torch.randn(
+                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                ),
+                                (3, 3),
+                            )[0],
+                        ],
+                        stride=[
+                            tt_adaptive_to_max_pool2d(
+                                torch.randn(
+                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                ),
+                                (3, 3),
+                            )[1],
+                            tt_adaptive_to_max_pool2d(
+                                torch.randn(
+                                    x.shape[0], int(math.sqrt(x.shape[2])), int(math.sqrt(x.shape[2])), x.shape[3]
+                                ),
+                                (3, 3),
+                            )[1],
+                        ],
+                        padding=[0, 0],
+                        dilation=[1, 1],
+                        memory_config=ttnn.L1_MEMORY_CONFIG,
+                        applied_shard_scheme=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
                     ),
-                    (bs, -1, num_patches),
+                    (bs, num_patches, -1),
                 ),
                 layout=ttnn.TILE_LAYOUT,
             )
             for (x, pool) in zip(x, self.im_pools)
         ]
-        x = ttnn.concat(x, dim=-1)
-        x = ttnn.permute(x, (0, 2, 1))
+        x = ttnn.concat(x, dim=1)
         q = ttnn.clone(text)
         for index, module in enumerate(self.query):
             if module == ttnn.linear:

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world_utils.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world_utils.py
@@ -576,3 +576,54 @@ def create_custom_preprocessor(device):
         return parameters
 
     return custom_preprocessor
+
+
+def tt_adaptive_to_max_pool2d(input_tensor, output_size):
+    if isinstance(output_size, int):
+        output_size = (output_size, output_size)
+
+    input_height, input_width = input_tensor.shape[1], input_tensor.shape[2]
+    output_height, output_width = output_size
+
+    # Check if dimensions are valid
+    if input_height < output_height or input_width < output_width:
+        raise ValueError("Output size cannot be larger than input size for max pooling")
+
+    # Calculate stride (might be floating point)
+    stride_h_float = input_height / output_height
+    stride_w_float = input_width / output_width
+
+    # Round down stride to integer
+    stride_h = math.floor(stride_h_float)
+    stride_w = math.floor(stride_w_float)
+
+    # Ensure stride is at least 1
+    stride_h = max(1, stride_h)
+    stride_w = max(1, stride_w)
+
+    # Calculate kernel size
+    kernel_h = input_height - (output_height - 1) * stride_h
+    kernel_w = input_width - (output_width - 1) * stride_w
+
+    # Handle case where kernel size might be too large
+    if kernel_h > input_height:
+        kernel_h = input_height
+    if kernel_w > input_width:
+        kernel_w = input_width
+
+    # Calculate if this is an exact conversion
+    is_exact = (
+        stride_h_float == stride_h
+        and stride_w_float == stride_w
+        and input_height == (output_height - 1) * stride_h + kernel_h
+        and input_width == (output_width - 1) * stride_w + kernel_w
+    )
+
+    message = ""
+    if not is_exact:
+        message = (
+            "Note: This is an approximation. For non-integer stride ratios, "
+            "AdaptiveMaxPool2d uses a more complex logic with varying kernel sizes."
+        )
+
+    return kernel_w, stride_h, 0, message


### PR DESCRIPTION
### Problem description
Currently, In the pipeline of yolov8s_world model torch adaptive maxpool2d is used.

### What's changed
Instead of using torch adaptive maxpool2d operation. The operation is replace with ttnn maxpool2d

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Single-card) Nightly model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes