### PR TITLE
Only define default ctor for forward AnyIterator

### DIFF
--- a/tt_stl/tt_stl/any_range.hpp
+++ b/tt_stl/tt_stl/any_range.hpp
@@ -361,8 +361,6 @@ private:
     }
 
 public:
-    AnyIterator() = delete;
-
     AnyIterator(const AnyIterator& other) { other.iterator_adaptor().uninitialized_copy_to(bytes); }
 
     AnyIterator(AnyIterator&& other) noexcept { other.iterator_adaptor().uninitialized_move_to(bytes); }
@@ -457,6 +455,9 @@ private:
         : std::enable_if<std::is_base_of_v<std::forward_iterator_tag, iterator_category>, enable_if_forward> {};
 
 public:
+    template <class TEnable = enable_if_forward, class = typename TEnable::type>
+    AnyIterator() noexcept : AnyIterator(static_cast<std::add_pointer_t<reference>>(nullptr)) {}
+
     template <class TEnable = enable_if_forward, class = typename TEnable::type>
     [[nodiscard]] AnyIterator operator++(int) {
         static_assert(std::is_same_v<TEnable, enable_if_forward>);


### PR DESCRIPTION
### Ticket
#20785

### Problem description
libstdc++ for GCC 15/Clang 20 rejects deleted `AnyIterator` default constructor when iterator category is at least forward.

### What's changed
Conditionally define the default constructor to type-erase `nullptr` if the iterator category is at least forward.

Previously failing: https://godbolt.org/z/Wv6oWxb81
Now passing: https://godbolt.org/z/hfraYKE6T

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14503313708) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes