### PR TITLE
Remove division from cq_dispatch

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -35,9 +35,6 @@ FORCE_INLINE
 uint32_t round_up_pow2(uint32_t v, uint32_t pow2_size) { return (v + (pow2_size - 1)) & ~(pow2_size - 1); }
 
 FORCE_INLINE
-uint32_t div_up(uint32_t n, uint32_t d) { return (n + d - 1) / d; }
-
-FORCE_INLINE
 uint32_t wrap_ge(uint32_t a, uint32_t b) {
     // Careful below: have to take the signed diff for 2s complement to handle the wrap
     // Below relies on taking the diff first then the compare to move the wrap


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Number of writes sent counter

### What's changed
Slight improvements in some test cases compared to main. Everything still within thresholds.
```
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/1024/manual_time got value 3.73us but expected 3.74us (0.50% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_128_rta/8192/manual_time got value 13.05us but expected 13.14us (0.65% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/kernel_groups_1_rta_trace/256/manual_time got value 12.86us but expected 12.96us (0.75% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/kernel_groups_1_rta_trace/512/manual_time got value 12.98us but expected 13.07us (0.73% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/kernel_groups_1_rta_trace/1024/manual_time got value 13.24us but expected 13.33us (0.63% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/kernel_groups_128_rta_trace/256/manual_time got value 13.01us but expected 13.10us (0.66% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/kernel_groups_128_rta_trace/512/manual_time got value 13.15us but expected 13.23us (0.63% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/kernel_groups_128_rta_trace/1024/manual_time got value 13.43us but expected 13.52us (0.66% better) .
Error:Test BM_pgm_dispatch/kernel_groups_32_cb_trace/512/manual_time expected value 11.24us but got 11.32us (0.75% worse) 
Consider adjusting baselines. Test BM_pgm_dispatch/tensix_eth_2/256/manual_time got value 12.78us but expected 12.87us (0.77% better) .
Error:Test BM_pgm_dispatch/tensix_eth_2_4_shadow/2048/manual_time expected value 107.50us but got 108.23us (0.67% worse) 
Consider adjusting baselines. Test BM_pgm_dispatch/tensix_eth_2_4_shadow/4096/manual_time got value 117.61us but expected 118.51us (0.76% better) .
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes