### PR TITLE
#17138: fix SD VAe upsample pcc and use same blocks for WH and BH

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_sd14_vae_convs.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_sd14_vae_convs.py
@@ -12,7 +12,6 @@ from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_utils import (
     prepare_split_conv_weights_bias,
     split_conv_and_run,
 )
-from models.utility_functions import is_wormhole_b0
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -21,8 +20,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "in_channels, input_height, input_width, out_channels, output_height, output_width, conv_in_channel_split_factor, conv_out_channel_split_factor",
     [
         (512, 128, 128, 512, 128, 128, 1, 1),
-        (512, 256, 256, 512, 256, 256, 8 if is_wormhole_b0() else 2, 1 if is_wormhole_b0() else 2),
-        (256, 512, 512, 256, 512, 512, 8 if is_wormhole_b0() else 4, 2),
+        (512, 256, 256, 512, 256, 256, 2, 2),
+        (256, 512, 512, 256, 512, 512, 4, 2),
     ],
 )
 def test_split_conv(

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -8,7 +8,6 @@ from diffusers import AutoencoderKL
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
-from models.utility_functions import is_wormhole_b0
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -17,8 +16,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "input_channels, input_height, input_width, out_channels, output_height, output_width, conv_in_channel_split_factor, conv_out_channel_split_factor, block_id",
     [
         (512, 64, 64, 512, 128, 128, 1, 1, 0),
-        (512, 128, 128, 512, 256, 256, 8 if is_wormhole_b0() else 2, 1 if is_wormhole_b0() else 2, 1),
-        (256, 256, 256, 256, 512, 512, 8 if is_wormhole_b0() else 4, 2, 2),
+        (512, 128, 128, 512, 256, 256, 2, 2, 1),
+        (256, 256, 256, 256, 512, 512, 4, 2, 2),
     ],
 )
 def test_upsample(
@@ -76,4 +75,4 @@ def test_upsample(
     ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
     ttnn_output = ttnn.to_torch(ttnn_output)
 
-    assert_with_pcc(torch_output, ttnn_output, 0.97)
+    assert_with_pcc(torch_output, ttnn_output, 0.99)


### PR DESCRIPTION
### Ticket
#17138

### What's changed
- Upsample is updated to use same in/out slicing for WH and BH 
- PCC is updated to 0.99 since with less slices we got better PCC

### Checklist
[WH] Frequent model and ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/14513446945
[BH] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/14513449842