### PR TITLE
Llama TG: tg-quick test missing flag 

### DIFF
--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
@@ -31,9 +31,7 @@ from models.utility_functions import skip_for_grayskull
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
-        )
+        (8, 4),
     ],
     indirect=True,
 )


### PR DESCRIPTION
1 of the test is missing the FAKE_DEVICE flag