### PR TITLE
Update Whisper WH perf target after single card pipeline docker arg changes

### DIFF
--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -483,7 +483,7 @@ def test_demo_for_conditional_generation(
         if is_blackhole():
             expected_perf_metrics = {"prefill_t/s": 7.31, "decode_t/s/u": 67.8}
         else:  # wormhole_b0
-            expected_perf_metrics = {"prefill_t/s": 3.64, "decode_t/s/u": 35.1}
+            expected_perf_metrics = {"prefill_t/s": 3.64, "decode_t/s/u": 40.8}
         expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"]  # Only supporting batch 1
         measurements = {"prefill_t/s": 1 / ttft, "decode_t/s": decode_throughput, "decode_t/s/u": decode_throughput}
         verify_perf(measurements, expected_perf_metrics)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The Whisper WH demo perf went up after the CI docker changes in ac3aa78 but perf target wasn't updated

### What's changed
- Increased the Whisper WH decode perf target

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes