### PR TITLE
tt_transformers/tests/test_accuracy: Fix possible out-of-bound bug

### DIFF
--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -433,7 +433,10 @@ def test_tt_model_acc(
         logger.info("\nError Summary (only showing errors where reference top-1 matches true token):")
         logger.info("-" * 120)
         for error in errors:
-            true_token = input_ids[0, error["position"] + 1].item()
+            if error["position"] + 1 < input_ids.shape[1]:
+                true_token = input_ids[0, error["position"] + 1].item()
+            else:
+                true_token = None
             if error["expected_ids"][0] == true_token:
                 sanitize = lambda x: repr(x)[1:-1]  # Use repr() and remove the outer quotes
                 context = sanitize(error["context"])


### PR DESCRIPTION
### Problem description
The accuracy test sometimes shows an out-of-bound error, e.g.
`IndexError: index 33280 is out of bounds for dimension 1 with size 33280`
in cases where there is an error in the last token

### What's changed
The boundary of the token array is checked before accessing

### Checklist
All post commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/14521698424