### PR TITLE
#17307: Start loading NCRISC asynchronously

### DIFF
--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -57,6 +57,8 @@ constexpr uint32_t RUN_MSG_DONE = 0;
 // 0x80808000 is a micro-optimization, calculated with 1 riscv insn
 constexpr uint32_t RUN_SYNC_MSG_INIT = 0x40;
 constexpr uint32_t RUN_SYNC_MSG_GO = 0x80;
+// NCRISC should reset its copy of the read ptr.
+constexpr uint32_t RUN_SYNC_MSG_RESET_READ_PTR = 0xc0;
 // Trigger loading CBs (and IRAM) before actually running the kernel.
 constexpr uint32_t RUN_SYNC_MSG_LOAD = 0x1;
 constexpr uint32_t RUN_SYNC_MSG_WAITING_FOR_RESET = 0x2;

--- a/tt_metal/hw/inc/grayskull/dev_mem_map.h
+++ b/tt_metal/hw/inc/grayskull/dev_mem_map.h
@@ -51,7 +51,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 624)
+#define MEM_BRISC_FIRMWARE_SIZE (5 * 1024 + 704)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 1824
 #define MEM_TRISC0_FIRMWARE_SIZE (1536 + 128)


### PR DESCRIPTION

### Problem description
Currently the NCRISC waits for BRISC to give it a signal to start loading the next kernel. In the case where BRISC finishes after NCRISC (e.g. NCRISC is the reader and BRISC is the writer) this can cause NCRISC to take longer to start than necessary, potentially hurting throughput.

### What's changed
The NCRISC can attempt to start loading the next kernel immediately after it's done with the previous, without waiting for the BRISC to finish sending its ack to the dispatcher. This requires that NCRISC manage its own copy of the launch_msg_rd_ptr, since the one in the mailbox is managed by BRISC and may be behind.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes