### PR TITLE
Address incessant load_module warnings

### DIFF
--- a/tests/ttnn/sweep_tests/sweeps/__init__.py
+++ b/tests/ttnn/sweep_tests/sweeps/__init__.py
@@ -9,6 +9,7 @@ import sqlite3
 from types import ModuleType
 import zlib
 from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec
 
 import enlighten
 import pandas as pd
@@ -22,7 +23,9 @@ DATABASE_FILE_NAME = SWEEP_RESULTS_DIR / "db.sqlite"
 
 class SweepFileLoader(SourceFileLoader):
     def load_module(self) -> ModuleType:
-        module = super().load_module()
+        spec = self.spec
+        module = module_from_spec(spec)
+        self.exec_module(module)
 
         if not hasattr(module, "skip"):
             setattr(module, "skip", lambda **kwargs: (False, None))

--- a/tests/ttnn/sweep_tests/test_sweeps.py
+++ b/tests/ttnn/sweep_tests/test_sweeps.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec
 from .sweeps import (
     SWEEP_SOURCES_DIR,
     permutations,
@@ -31,7 +32,10 @@ for file_name in sorted(SWEEP_SOURCES_DIR.glob("**/*.py")):
 def create_test_function(file_name):
     base_name = os.path.basename(file_name)
     base_name = os.path.splitext(base_name)[0]
-    sweep_module = SourceFileLoader(f"sweep_module_{base_name}", str(file_name)).load_module()
+    loader = SourceFileLoader(f"sweep_module_{base_name}", str(file_name))
+    spec = loader.spec
+    sweep_module = module_from_spec(spec)
+    loader.exec_module(sweep_module)
     base_name = base_name + ".csv"
     sweep_tests = []
     for sweep_test_index, parameter_list in enumerate(permutations(sweep_module.parameters)):

--- a/ttnn/ttnn/operations/__init__.py
+++ b/ttnn/ttnn/operations/__init__.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pkgutil
+from importlib.util import module_from_spec
 
 __all__ = []
 
 for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
     __all__.append(module_name)
-    _module = loader.find_spec(module_name).loader.load_module(module_name)
+    spec = loader.find_spec(module_name)
+    _module = module_from_spec(spec)
+    spec.loader.exec_module(_module)
     globals()[module_name] = _module

--- a/ttnn/ttnn/operations/__init__.py
+++ b/ttnn/ttnn/operations/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pkgutil
+import sys
 from importlib.util import module_from_spec
 
 __all__ = []
@@ -11,5 +12,7 @@ for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
     __all__.append(module_name)
     spec = loader.find_spec(module_name)
     _module = module_from_spec(spec)
+    # Register the module in sys.modules before executing it
+    sys.modules[f"{__package__}.{module_name}"] = _module
     spec.loader.exec_module(_module)
     globals()[module_name] = _module

--- a/ttnn/ttnn/operations/__init__.py
+++ b/ttnn/ttnn/operations/__init__.py
@@ -13,6 +13,6 @@ for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
     spec = loader.find_spec(module_name)
     _module = module_from_spec(spec)
     # Register the module in sys.modules before executing it
-    sys.modules[f"{__package__}.{module_name}"] = _module
+    sys.modules[f"{module_name}"] = _module
     spec.loader.exec_module(_module)
     globals()[module_name] = _module


### PR DESCRIPTION
### Problem description
I don't want to see this anymore:
```
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
Warning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead
```

### What's changed
Changed some stuff

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14524976347) CI passes
- [x] New/Existing tests provide coverage for changes