### PR TITLE
[DM] #20834: DRAM directed ideal test

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -5,8 +5,8 @@ This test suite addresses the functionality and performance (i.e. bandwidth) of 
 ## Tests in the Test Suite
 | Name       | ID(s) | Description                                          |
 | ---------- | ----- | ---------------------------------------------------- |
-| DRAM Unary | 0-2   | Transactions between DRAM and a single Tensix core.  |
-| One to One | 3     | Transactions between two Tensix cores.               |
+| DRAM Unary | 0-3   | Transactions between DRAM and a single Tensix core.  |
+| One to One | 4     | Transactions between two Tensix cores.               |
 
 ## Running Tests
 Before running any tests, build the repo with tests: ```./build_metal.sh --build-tests```

--- a/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
+++ b/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
@@ -43,30 +43,36 @@ test_bounds = {
     },
 }
 
-test_bounds = {
-    0: {
-        "riscv_1": {"latency": {"lower": 500, "upper": 1100}, "bandwidth": 0.06},
-        "riscv_0": {"latency": {"lower": 400, "upper": 900}, "bandwidth": 0.07},
-    },
-    1: {
-        "riscv_1": {"latency": {"lower": 400, "upper": 700}, "bandwidth": 0.19},
-        "riscv_0": {"latency": {"lower": 300, "upper": 500}, "bandwidth": 0.29},
-    },
-    2: {
-        "riscv_1": {"latency": {"lower": 500, "upper": 600}, "bandwidth": 0.24},
-        "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
-    },
-    3: {
-        "riscv_1": {"latency": {"lower": 4100, "upper": 4200}, "bandwidth": 0.06},
-        "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.59},
-    },
-}
-
 def run_dm_tests(profile, verbose, gtest_filter, plot, report):
     log_file_path = f"{PROFILER_LOGS_DIR}/{PROFILER_DEVICE_SIDE_LOG}"
 
     # Profile tests
     if profile or not os.path.exists(log_file_path) or gtest_filter:
+        profile_dm_tests(verbose=verbose, gtest_filter=gtest_filter)
+
+    # Gather analysis stats
+    dm_stats = gather_analysis_stats(log_file_path, verbose=verbose)
+
+    # Print stats if explicitly requested
+    if verbose:
+        print_stats(dm_stats)
+
+    # Plot results
+    if plot:
+        plot_dm_stats(dm_stats)
+
+    # Export results to csv
+    if report:
+        export_dm_stats_to_csv(dm_stats)
+
+    # Check performance (TODO: enable assertions)
+    performance_check(dm_stats, verbose=verbose)
+
+    logger.info("Data movement tests completed.")
+
+
+def profile_dm_tests(verbose=False, gtest_filter=None):
+    if verbose:
         profile_dm_tests(verbose=verbose, gtest_filter=gtest_filter)
 
     # Gather analysis stats

--- a/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
+++ b/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
@@ -43,6 +43,24 @@ test_bounds = {
     },
 }
 
+test_bounds = {
+    0: {
+        "riscv_1": {"latency": {"lower": 500, "upper": 1100}, "bandwidth": 0.06},
+        "riscv_0": {"latency": {"lower": 400, "upper": 900}, "bandwidth": 0.07},
+    },
+    1: {
+        "riscv_1": {"latency": {"lower": 400, "upper": 700}, "bandwidth": 0.19},
+        "riscv_0": {"latency": {"lower": 300, "upper": 500}, "bandwidth": 0.29},
+    },
+    2: {
+        "riscv_1": {"latency": {"lower": 500, "upper": 600}, "bandwidth": 0.24},
+        "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
+    },
+    3: {
+        "riscv_1": {"latency": {"lower": 4100, "upper": 4200}, "bandwidth": 0.06},
+        "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.59},
+    },
+}
 
 def run_dm_tests(profile, verbose, gtest_filter, plot, report):
     log_file_path = f"{PROFILER_LOGS_DIR}/{PROFILER_DEVICE_SIDE_LOG}"

--- a/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
+++ b/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
@@ -27,20 +27,20 @@ test_id_to_name = {
 # Correspondng test bounds for each test id
 test_bounds = {
     0: {
-        "riscv_1": {"latency": {"lower": 500, "upper": 1100}, "bandwidth": 0.06},
-        "riscv_0": {"latency": {"lower": 400, "upper": 900}, "bandwidth": 0.07},
+        "riscv_1": {"latency": {"lower": 400, "upper": 8800}, "bandwidth": 0.12},
+        "riscv_0": {"latency": {"lower": 300, "upper": 8000}, "bandwidth": 0.16},
     },
     1: {
-        "riscv_1": {"latency": {"lower": 400, "upper": 700}, "bandwidth": 0.19},
-        "riscv_0": {"latency": {"lower": 300, "upper": 500}, "bandwidth": 0.29},
+        "riscv_1": {"latency": {"lower": 300, "upper": 700}, "bandwidth": 0.09},
+        "riscv_0": {"latency": {"lower": 200, "upper": 500}, "bandwidth": 0.16},
     },
     2: {
-        "riscv_1": {"latency": {"lower": 500, "upper": 600}, "bandwidth": 0.24},
-        "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
+        "riscv_1": {"latency": {"lower": 400, "upper": 600}, "bandwidth": 0.13},
+        "riscv_0": {"latency": {"lower": 300, "upper": 500}, "bandwidth": 0.16},
     },
     3: {
-        "riscv_1": {"latency": {"lower": 149000, "upper": 150000}, "bandwidth": 9},
-        "riscv_0": {"latency": {"lower": 90000, "upper": 91000}, "bandwidth": 16},
+        "riscv_1": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 33},
+        "riscv_0": {"latency": {"lower": 42000, "upper": 43000}, "bandwidth": 34},
     },
     4: {
         "riscv_1": {"latency": {"lower": 4100, "upper": 4200}, "bandwidth": 0.06},

--- a/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
+++ b/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
@@ -48,36 +48,12 @@ test_bounds = {
     },
 }
 
+
 def run_dm_tests(profile, verbose, gtest_filter, plot, report):
     log_file_path = f"{PROFILER_LOGS_DIR}/{PROFILER_DEVICE_SIDE_LOG}"
 
     # Profile tests
     if profile or not os.path.exists(log_file_path) or gtest_filter:
-        profile_dm_tests(verbose=verbose, gtest_filter=gtest_filter)
-
-    # Gather analysis stats
-    dm_stats = gather_analysis_stats(log_file_path, verbose=verbose)
-
-    # Print stats if explicitly requested
-    if verbose:
-        print_stats(dm_stats)
-
-    # Plot results
-    if plot:
-        plot_dm_stats(dm_stats)
-
-    # Export results to csv
-    if report:
-        export_dm_stats_to_csv(dm_stats)
-
-    # Check performance (TODO: enable assertions)
-    performance_check(dm_stats, verbose=verbose)
-
-    logger.info("Data movement tests completed.")
-
-
-def profile_dm_tests(verbose=False, gtest_filter=None):
-    if verbose:
         profile_dm_tests(verbose=verbose, gtest_filter=gtest_filter)
 
     # Gather analysis stats

--- a/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
+++ b/tests/tt_metal/tt_metal/data_movement/data_movement_tests.py
@@ -20,7 +20,8 @@ test_id_to_name = {
     0: "DRAM Interleaved Packet Sizes",
     1: "DRAM Interleaved Core Locations",
     2: "DRAM Sharded",
-    3: "One to One Packet Sizes",
+    3: "DRAM Directed Ideal",
+    4: "One to One Packet Sizes",
 }
 
 # Correspondng test bounds for each test id
@@ -38,6 +39,10 @@ test_bounds = {
         "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
     },
     3: {
+        "riscv_1": {"latency": {"lower": 149000, "upper": 150000}, "bandwidth": 9},
+        "riscv_0": {"latency": {"lower": 90000, "upper": 91000}, "bandwidth": 16},
+    },
+    4: {
         "riscv_1": {"latency": {"lower": 4100, "upper": 4200}, "bandwidth": 0.06},
         "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.59},
     },
@@ -214,7 +219,7 @@ def performance_check(dm_stats, verbose=False):
             results_bounds[test_id]["riscv_0"]["latency"]["upper"], riscv0_cycles
         )
 
-        riscv1_attributes = dm_stats["riscv_1"]["attributes"][test_id]
+        riscv1_attributes = dm_stats["riscv_1"]["attributes"][run_host_id]
         riscv1_bw = (
             riscv1_attributes["Number of transactions"] * riscv1_attributes["Transaction size in bytes"] / riscv1_cycles
         )
@@ -222,7 +227,7 @@ def performance_check(dm_stats, verbose=False):
             results_bounds[test_id]["riscv_1"]["bandwidth"], riscv1_bw
         )
 
-        riscv0_attributes = dm_stats["riscv_0"]["attributes"][test_id]
+        riscv0_attributes = dm_stats["riscv_0"]["attributes"][run_host_id]
         riscv0_bw = (
             riscv0_attributes["Number of transactions"] * riscv0_attributes["Transaction size in bytes"] / riscv0_cycles
         )

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -263,8 +263,35 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMSharded) {
     }
 }
 
-// TODO: Extend sharded DRAM buffer test with (?)
-//  1. different transaction numbers and sizes
-//  2. different core locations
+/* ========== Directed ideal test case; Test id = 3 ========== */
+TEST_F(DeviceFixture, TensixDataMovementDRAMDirectedIdeal) {
+    // Parameters
+    uint32_t num_of_transactions = 180;
+    uint32_t transaction_size_pages = 4 * 32;
+    uint32_t page_size_bytes = 32;  // (=flit size): 32 bytes for WH, 64 for BH
+    if (arch_ == tt::ARCH::BLACKHOLE) {
+        page_size_bytes *= 2;
+    }
+    // Max transaction size = 4 * 32 pages = 128 * 32 bytes = 4096 bytes for WH; 8192 bytes for BH
+    // Max total transaction size = 180 * 8192 bytes = 1474560 bytes = 1.4 MB = L1 capacity
+
+    // Cores
+    CoreRange core_range({0, 0}, {0, 0});
+    CoreRangeSet core_range_set({core_range});
+
+    // Test config
+    unit_tests::dm::dram::DramConfig test_config = {
+        .test_id = 3,
+        .num_of_transactions = num_of_transactions,
+        .transaction_size_pages = transaction_size_pages,
+        .page_size_bytes = page_size_bytes,
+        .l1_data_format = DataFormat::Float16_b,
+        .cores = core_range_set};
+
+    // Run
+    for (unsigned int id = 0; id < num_devices_; id++) {
+        EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+    }
+}
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -97,7 +97,7 @@ bool run_dm(IDevice* device, const DramConfig& test_config) {
     // Create circular buffers
     CircularBufferConfig l1_cb_config =
         CircularBufferConfig(total_size_bytes, {{l1_cb_index, test_config.l1_data_format}})
-            .set_page_size(l1_cb_index, test_config.page_size_bytes);
+            .set_page_size(l1_cb_index, total_size_bytes);
     auto l1_cb = CreateCircularBuffer(program, test_config.cores, l1_cb_config);
 
     // Kernels
@@ -126,6 +126,7 @@ bool run_dm(IDevice* device, const DramConfig& test_config) {
     // Launch program and record outputs
     vector<uint32_t> packed_output;
     detail::WriteToBuffer(input_dram_buffer, packed_input);
+    MetalContext::instance().get_cluster().dram_barrier(device->id());
     detail::LaunchProgram(device, program);
     detail::ReadFromBuffer(output_dram_buffer, packed_output);
 
@@ -232,6 +233,7 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMSharded) {
     // So 1024 * 1024 / 64 = x * x = 128 * 128 => x = 128
 
     // Fails: (when num dram banks isnt 1, 1), possibly due to the noc_addr_from_bank_id function in kernel
+    // TODO: Expand test case to cover multiple dram banks
 
     // Cores
     CoreRange core_range({0, 0}, {0, 0});

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -129,15 +129,19 @@ bool run_dm(IDevice* device, const DramConfig& test_config) {
     detail::LaunchProgram(device, program);
     detail::ReadFromBuffer(output_dram_buffer, packed_output);
 
-    // Print output and golden vectors
-    log_info("Golden vector");
-    print_vector<uint32_t>(packed_golden);
-    log_info("Output vector");
-    print_vector<uint32_t>(packed_output);
-
-    // Return comparison
-    return is_close_packed_vectors<bfloat16, uint32_t>(
+    // Results comparison
+    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
         packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+
+    if (!pcc) {
+        log_error("PCC Check failed");
+        log_info("Golden vector");
+        print_vector<uint32_t>(packed_golden);
+        log_info("Output vector");
+        print_vector<uint32_t>(packed_output);
+    }
+
+    return pcc;
 }
 }  // namespace unit_tests::dm::dram
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/receiver.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/receiver.cpp
@@ -14,7 +14,7 @@ void kernel_main() {
     constexpr uint32_t page_size_bytes = get_compile_time_arg_val(4);
     constexpr uint32_t test_id = get_compile_time_arg_val(5);
 
-    auto sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(0)));
+    auto sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_arg_val<uint32_t>(0)));
 
     constexpr uint32_t transaction_size_bytes = transaction_num_pages * page_size_bytes;
 
@@ -24,6 +24,6 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
-        noc_semaphore_wait(sem_addr, 1);
+        noc_semaphore_wait(sem_ptr, 1);
     }
 }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -142,15 +142,19 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
     detail::LaunchProgram(device, program);
     detail::ReadFromBuffer(slave_l1_buffer, packed_output);
 
-    // Print output and golden vectors
-    log_info("Golden vector");
-    print_vector<uint32_t>(packed_golden);
-    log_info("Output vector");
-    print_vector<uint32_t>(packed_output);
-
-    // Return comparison
-    return is_close_packed_vectors<bfloat16, uint32_t>(
+    // Results comparison
+    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
         packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+
+    if (!pcc) {
+        log_error("PCC Check failed");
+        log_info("Golden vector");
+        print_vector<uint32_t>(packed_golden);
+        log_info("Output vector");
+        print_vector<uint32_t>(packed_output);
+    }
+
+    return pcc;
 }
 }  // namespace unit_tests::dm::core_to_core
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -154,7 +154,7 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
 }
 }  // namespace unit_tests::dm::core_to_core
 
-/* ========== Test case for one to one data movement; Test id = 3 ========== */
+/* ========== Test case for one to one data movement; Test id = 4 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneToOnePacketSizes) {
     // Parameters
     uint32_t max_transactions = 64;
@@ -173,7 +173,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneToOnePacketSizes) {
              transaction_size_pages *= 2) {
             // Test config
             unit_tests::dm::core_to_core::OneToOneConfig test_config = {
-                .test_id = 3,
+                .test_id = 4,
                 .master_core_coord = master_core_coord,
                 .slave_core_coord = slave_core_coord,
                 .num_of_transactions = num_of_transactions,


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20834)

### Problem description
Current DM tests sweep over all transactions sizes, number of transactions, core locations etc. For each DM test suite, we should add directed ideal tests. These tests should be part of the micro-benchmark suites, and can be advertised for other teams to test chip DM performance.

### What's changed
Added DRAM directed ideal test case to the data movement test suite. This tests 180 transactions between DRAM and a single core. Each transaction has a size of 128 flits where flit size depends on architecture (i.e. 32 bytes for WH and 64 bytes for BH), effectively saturating the L1 capacity.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14650115664) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14650122506) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes