### PR TITLE
#20717: Generate per core op to op time csv

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -54,6 +54,10 @@ run_async_tracing_T3000_test() {
             LINE_COUNT=3600 # Smoke test to see at least 3600 ops are reported
             res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$LINE_COUNT")
             echo $res
+
+            LINE_COUNT=3600 # Smoke test to see at least 3600 ops are reported
+            res=$(verify_perf_line_count_floor "$PROFILER_OUTPUT_DIR/$runDate/per_core_op_to_op_times_$runDate.csv" "$LINE_COUNT")
+            echo $res
         fi
     fi
 }

--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -24,6 +24,22 @@ class default_setup(metaclass=MergeMetaclass):
     ]
 
     timerAnalysis = {
+        "op2op": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {
+                "core": "ANY",
+                "risc": "ANY",
+                "zone_phase": "ZONE_END",
+                "zone_name": [f"{risc}-KERNEL" for risc in riscTypes],
+            },
+            "end": {
+                "core": "ANY",
+                "risc": "ANY",
+                "zone_phase": "ZONE_START",
+                "zone_name": [f"{risc}-KERNEL" for risc in ["BRISC", "NCRISC"]],
+            },
+        },
         "device_kernel_first_to_last_start": {
             "across": "ops",
             "type": "op_first_last",

--- a/tt_metal/tools/profiler/device_post_proc_config.py
+++ b/tt_metal/tools/profiler/device_post_proc_config.py
@@ -74,6 +74,16 @@ class default_setup(metaclass=MergeMetaclass):
             "start": {"core": "ANY", "risc": "ANY", "zone_name": [f"{risc}-KERNEL" for risc in riscTypes]},
             "end": {"core": "ANY", "risc": "ANY", "zone_name": [f"{risc}-KERNEL" for risc in riscTypes]},
         },
+        "device_kernel_duration_dm_start": {
+            "across": "ops",
+            "type": "op_first_last",
+            "start": {
+                "core": "ANY",
+                "risc": "ANY",
+                "zone_name": [f"{risc}-KERNEL" for risc in ["BRISC", "NCRISC", "ERISC"]],
+            },
+            "end": {"core": "ANY", "risc": "ANY", "zone_name": [f"{risc}-KERNEL" for risc in riscTypes]},
+        },
         "device_brisc_kernel_duration": {
             "across": "ops",
             "type": "op_first_last",

--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -644,15 +644,27 @@ def get_duration(riscData, analysis):
     return []
 
 
+def is_timer_id_iteration_start(timerID):
+    ret = False
+    if timerID["type"] == "ZONE_START" and timerID["zone_name"] == "BRISC-FW":
+        ret = True
+    return ret
+
+
 def adjacent_LF_analysis(riscData, analysis):
     timeseries = riscData["timeseries"]
     durations = []
     startFound = None
+    startIterMark = None
+    iterMark = None
     for timerID, timestamp, attachedData, *metaData in timeseries:
+        if is_timer_id_iteration_start(timerID):
+            iterMark = (timerID, timestamp)
         currStart, currEnd, desStart, desEnd = determine_conditions(timerID, metaData, analysis)
         if not startFound:
             if currStart in desStart:
                 startFound = (timerID, timestamp)
+                startIterMark = iterMark
         else:
             if currEnd in desEnd:
                 startID, startTS = startFound
@@ -662,11 +674,14 @@ def adjacent_LF_analysis(riscData, analysis):
                         end_cycle=timestamp,
                         duration_type=(startID, timerID),
                         duration_cycles=timestamp - startTS,
+                        end_iter_mark=iterMark,
+                        start_iter_mark=startIterMark,
                     )
                 )
                 startFound = None
             elif currStart in desStart:
                 startFound = (timerID, timestamp)
+                startIterMark = iterMark
 
     return durations
 

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -14,6 +14,7 @@ import json
 import yaml
 from datetime import datetime
 import copy
+from collections import deque
 
 import click
 from loguru import logger
@@ -35,6 +36,8 @@ from tt_metal.tools.profiler.common import (
 yaml.SafeDumper.ignore_aliases = lambda *args: True
 
 OUT_NAME = "ops_perf_results"
+PER_CORE_OP_TO_OP_OUT_NAME = "per_core_op_to_op_times"
+PROFILER_OP_TO_OP_OVERHEAD_NANO_SEC = 1500
 
 OPS_CSV_HEADER = [
     "OP CODE",
@@ -432,25 +435,31 @@ def get_device_data_generate_report(
     deviceOps = {}
     i = 0
     rowDicts = []
+    perCoreRowDicts = []
+    perCoreCSVHeader = set()
 
     outFolder = PROFILER_OUTPUT_DIR
     if outputFolder:
         outFolder = outputFolder
 
     name = OUT_NAME
+    perCoreName = PER_CORE_OP_TO_OP_OUT_NAME
     outFolder = os.path.abspath(outFolder)
 
     if nameAppend:
         name += f"_{nameAppend}"
+        perCoreName += f"_{nameAppend}"
         outFolder = os.path.join(outFolder, nameAppend)
 
     if date:
         dateStr = f"{datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}"
         name += f"_{dateStr}"
+        perCoreName += f"_{dateStr}"
         outFolder = os.path.join(outFolder, dateStr)
 
     if export_csv:
         allOpsCSVPath = os.path.join(outFolder, f"{name}.csv")
+        perCoreCSVPath = os.path.join(outFolder, f"{perCoreName}.csv")
         logger.info(f"Copying runtime artifacts")
         os.system(f"rm -rf {outFolder}; mkdir -p {outFolder}")
         if os.path.isfile(f"{logFolder / PROFILER_DEVICE_SIDE_LOG}"):
@@ -518,6 +527,51 @@ def get_device_data_generate_report(
                         devicePreOpTime[device] = analysisData[0]["end_cycle"]
                 rowDicts.append(rowDict)
 
+            def get_core_str_format(core):
+                return f"{core[0]}; {core[1]} [ns]"
+
+            allCores = list(deviceData["devices"][device]["cores"].keys())
+            allCores.remove("DEVICE")
+            allCores.sort()
+            for core in allCores:
+                perCoreCSVHeader.add(get_core_str_format(core))
+
+            coreOpToOps = {}
+            opToOps = []
+            for core in allCores:
+                coreSeries = deviceData["devices"][device]["cores"][core]["riscs"]["TENSIX"]["analysis"]["op2op"][
+                    "series"
+                ]
+                for op2op in coreSeries:
+                    if op2op["end_iter_mark"][1] != op2op["start_iter_mark"][1]:
+                        startMarker, endMarker = op2op["duration_type"]
+                        op2opID = (startMarker["run_host_id"], endMarker["run_host_id"])
+                        op2opDuration = op2op["duration_cycles"]
+                        op2opStart = op2op["start_cycle"]
+                        opToOps.append((op2opStart, op2opID, op2opDuration, core))
+                        if core in coreOpToOps:
+                            coreOpToOps[core].append((op2opStart, op2opID, op2opDuration, core))
+                        else:
+                            coreOpToOps[core] = deque([(op2opStart, op2opID, op2opDuration, core)])
+            opToOps.sort()
+
+            pickedOps = set()
+            for op2op in opToOps:
+                if op2op not in pickedOps:
+                    op2opStart, op2opID, op2opDuration, core = op2op
+                    perCoreRowDict = {
+                        "device ID": device,
+                        "op2op ID": f"{op2opID[0]} -> {op2opID[1]}",
+                    }
+                    for core, series in coreOpToOps.items():
+                        perCoreRowDict[get_core_str_format(core)] = ""
+                        if series and op2opID == series[0][1]:
+                            coreOpToOp = series.popleft()
+                            perCoreRowDict[get_core_str_format(core)] = coreOpToOp[2]
+                            pickedOps.add(coreOpToOp)
+
+                    perCoreRowDicts.append(perCoreRowDict)
+
         rowDictHeaders = set()
         for row in rowDicts:
             for k in row.keys():
@@ -535,6 +589,15 @@ def get_device_data_generate_report(
                         rowDict[field] = str(fieldData).replace(",", ";")
                     writer.writerow(rowDict)
             logger.info(f"Device only OPs csv generated at: {allOpsCSVPath}")
+            with open(perCoreCSVPath, "w") as perCoreCSV:
+                perCoreCSVHeader = ["device ID", "op2op ID"] + [core for core in perCoreCSVHeader]
+
+                writer = csv.DictWriter(perCoreCSV, fieldnames=perCoreCSVHeader)
+                writer.writeheader()
+
+                for rowDict in perCoreRowDicts:
+                    writer.writerow(rowDict)
+            logger.info(f"Device only per core op to op times csv generated at: {perCoreCSVPath}")
 
         if cleanup_device_log:
             os.remove(deviceTimesLog)


### PR DESCRIPTION
### Ticket
#20717 

### Problem description
Need more insight into op 2 op times per core

### What's changed
Generate per core op 2 op times csv

### Checklist
Only python post proc so did not run full APC
- [x] [APC Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14595838371/job/40941828191)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14595844531/job/40941858469)
- [x] [Device Perf](https://github.com/tenstorrent/tt-metal/actions/runs/14603103504/job/40966070037)