### PR TITLE
#0: Remove duplicated error check

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -67,12 +67,6 @@ Tensor dispatch_ops_to_device(IDevice* dev, Tensor input_tensor, QueueId cq_id) 
 }
 
 TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
-    // 8 devices with 2 CQs. Enable this test on T3K only.
-    if (tt::tt_metal::GetNumAvailableDevices() < 8 or
-        tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP();
-    }
-
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -134,12 +128,6 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
 }
 
 TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
-    // 8 devices with 2 CQs. Enable this test on T3K only.
-    if (tt::tt_metal::GetNumAvailableDevices() < 8 or
-        tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP();
-    }
-
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -202,12 +190,6 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
 }
 
 TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
-    // 8 devices with 2 CQs. Enable this test on T3K only.
-    if (tt::tt_metal::GetNumAvailableDevices() < 8 or
-        tt::get_arch_from_string(tt::test_utils::get_umd_arch_name()) != tt::ARCH::WORMHOLE_B0) {
-        GTEST_SKIP();
-    }
-
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,


### PR DESCRIPTION
### Ticket
Link to Github Issue: N/A

### Problem description
There is a set of error checks in tt-metal/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp that aren't needed because the gtest fixture that is used here (MultiCommandQueueT3KFixture from tt-metal/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp) already includes the exact same check. 

### What's changed
Delete the duplicated checks. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14575494023
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes: tt-metal/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp