### PR TITLE
#18973: Deduplicate ttnn_test_fixtures.hpp code

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -22,8 +22,9 @@
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "hostdevcommon/common_values.hpp"
 
-namespace ttnn {
 using namespace tt::tt_metal;  // For test
+
+namespace ttnn {
 
 class TTNNFixtureWithDevice : public ::testing::Test {
 protected:

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -22,26 +22,22 @@
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "hostdevcommon/common_values.hpp"
 
-using namespace tt::tt_metal;  // For test
-
 namespace ttnn {
+using namespace tt::tt_metal;  // For test
 
 class TTNNFixtureWithDevice : public ::testing::Test {
 protected:
     int trace_region_size_ = DEFAULT_TRACE_REGION_SIZE;
     int l1_small_size_ = DEFAULT_L1_SMALL_SIZE;
 
-    union {
-        tt::tt_metal::IDevice* device_;
-        std::map<chip_id_t, tt::tt_metal::IDevice*> devs;
-    };
+    IDevice* device_;
 
     tt::ARCH arch_ = tt::ARCH::Invalid;
     size_t num_devices_ = 0;
 
     void InitStateEnv() {
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
+        num_devices_ = GetNumAvailableDevices();
     }
 
     void checkSlowDispatch() {
@@ -61,7 +57,7 @@ protected:
             trace_region_size_);
     }
 
-    void TearDown() override { device_->close(); }
+    void TearDown() override { CloseDevice(device_); }
 
 public:
     TTNNFixtureWithDevice() : trace_region_size_(DEFAULT_TRACE_REGION_SIZE), l1_small_size_(DEFAULT_L1_SMALL_SIZE) {}
@@ -98,6 +94,10 @@ protected:
 // TODO: deduplicate the code with `TTNNFixtureWithDevice`.
 class MultiCommandQueueT3KFixture : public TTNNFixtureWithDevice {
 protected:
+    // TODO: I think device_ still shows up here, not sure what to do about that though
+
+    std::map<chip_id_t, tt::tt_metal::IDevice*> devs;
+
     void SetUp() override {
         InitStateEnv();
         checkSlowDispatch();

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -42,7 +42,7 @@ public:
 
 public:
     TTNNFixtureBase() : TTNNFixtureBase(DEFAULT_TRACE_REGION_SIZE, DEFAULT_L1_SMALL_SIZE) { }
-    
+
     TTNNFixtureBase(int trace_region_size, int l1_small_size) :
         trace_region_size_(trace_region_size), l1_small_size_(l1_small_size) {
         std::srand(0);
@@ -108,10 +108,6 @@ protected:
     }
 
     void TearDown() override { tt::tt_metal::detail::CloseDevices(devs); }
-        std::map<chip_id_t, std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devs;
-    tt::ARCH arch_;
-    size_t num_devices_;
-
 };
 
 }  // namespace ttnn

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -41,12 +41,8 @@ public:
     }
 
 public:
-    TTNNFixtureBase() : trace_region_size_(DEFAULT_TRACE_REGION_SIZE), l1_small_size_(DEFAULT_L1_SMALL_SIZE) {
-        std::srand(0);
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        num_devices_ = GetNumAvailableDevices();
-    }
-
+    TTNNFixtureBase() : TTNNFixtureBase(DEFAULT_TRACE_REGION_SIZE, DEFAULT_L1_SMALL_SIZE) { }
+    
     TTNNFixtureBase(int trace_region_size, int l1_small_size) :
         trace_region_size_(trace_region_size), l1_small_size_(l1_small_size) {
         std::srand(0);

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -27,22 +27,38 @@ using namespace tt::tt_metal;  // For test
 namespace ttnn {
 
 class TTNNFixtureWithDevice : public ::testing::Test {
-private:
+protected:
     int trace_region_size_ = DEFAULT_TRACE_REGION_SIZE;
     int l1_small_size_ = DEFAULT_L1_SMALL_SIZE;
 
-protected:
-    tt::tt_metal::distributed::MeshDevice* device_ = nullptr;
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
+    union {
+        tt::tt_metal::IDevice* device_;
+        std::map<chip_id_t, tt::tt_metal::IDevice*> devs;
+    };
+
     tt::ARCH arch_ = tt::ARCH::Invalid;
     size_t num_devices_ = 0;
 
-    void SetUp() override {
-        std::srand(0);
+    void InitStateEnv() {
         arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        device_holder_ = ttnn::open_mesh_device(/*device_id=*/0, l1_small_size_, trace_region_size_);
-        device_ = device_holder_.get();
+    }
+
+    void checkSlowDispatch() {
+        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (slow_dispatch) {
+            GTEST_SKIP() << "Skipping test, since it can only be run in Fast Dispatch Mode.";
+        }
+    }
+
+    void SetUp() override {
+        std::srand(0);
+        InitStateEnv();
+        device_ = tt::tt_metal::CreateDevice(
+            /*device_id=*/0,
+            /*num_hw_cqs=*/1,
+            l1_small_size_,
+            trace_region_size_);
     }
 
     void TearDown() override { device_->close(); }
@@ -55,15 +71,11 @@ public:
 };
 
 // TODO: deduplicate the code with `TTNNFixtureWithDevice`.
-class MultiCommandQueueSingleDeviceFixture : public ::testing::Test {
+class MultiCommandQueueSingleDeviceFixture : public TTNNFixtureWithDevice {
 protected:
     void SetUp() override {
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        if (slow_dispatch) {
-            GTEST_SKIP() << "Skipping Multi CQ test suite, since it can only be run in Fast Dispatch Mode.";
-        }
+        InitStateEnv();
+        checkSlowDispatch();
 
         DispatchCoreType dispatch_core_type = DispatchCoreType::WORKER;
         if (arch_ == tt::ARCH::WORMHOLE_B0 and num_devices_ != 1) {
@@ -71,9 +83,8 @@ protected:
                 tt::LogTest, "Ethernet Dispatch not being explicitly used. Set this configuration in Setup()");
             dispatch_core_type = DispatchCoreType::ETH;
         }
-        device_holder_ = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(
-            0, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 2, DispatchCoreConfig{dispatch_core_type});
-        device_ = device_holder_.get();
+        device_ = tt::tt_metal::CreateDevice(
+            0, 2, trace_region_size_, l1_small_size_, DispatchCoreConfig{dispatch_core_type});
     }
 
     void TearDown() override { device_->close(); }
@@ -85,37 +96,26 @@ protected:
 };
 
 // TODO: deduplicate the code with `TTNNFixtureWithDevice`.
-class MultiCommandQueueT3KFixture : public ::testing::Test {
+class MultiCommandQueueT3KFixture : public TTNNFixtureWithDevice {
 protected:
     void SetUp() override {
-        auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
-        num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        if (slow_dispatch) {
-            GTEST_SKIP() << "Skipping Multi CQ test suite, since it can only be run in Fast Dispatch Mode.";
-        }
+        InitStateEnv();
+        checkSlowDispatch();
+
         if (num_devices_ < 8 or arch_ != tt::ARCH::WORMHOLE_B0) {
             GTEST_SKIP() << "Skipping T3K Multi CQ test suite on non T3K machine.";
         }
+
         // Enable Ethernet Dispatch for Multi-CQ tests.
-
-        devs = tt::tt_metal::distributed::MeshDevice::create_unit_meshes(
-            {0, 1, 2, 3, 4, 5, 6, 7},
-            DEFAULT_L1_SMALL_SIZE,
-            DEFAULT_TRACE_REGION_SIZE,
-            2,
-            DispatchCoreConfig{DispatchCoreType::ETH});
+        devs = tt::tt_metal::detail::CreateDevices(
+            {0, 1, 2, 3, 4, 5, 6, 7}, 2, trace_region_size_, l1_small_size_, DispatchCoreConfig{DispatchCoreType::ETH});
     }
 
-    void TearDown() override {
-        for (auto& [_, dev] : devs) {
-            dev->close();
-        }
-    }
-
-    std::map<chip_id_t, std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devs;
+    void TearDown() override { tt::tt_metal::detail::CloseDevices(devs); }
+        std::map<chip_id_t, std::shared_ptr<tt::tt_metal::distributed::MeshDevice>> devs;
     tt::ARCH arch_;
     size_t num_devices_;
+
 };
 
 }  // namespace ttnn

--- a/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
+++ b/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp
@@ -68,9 +68,13 @@ protected:
     }
 
     void TearDown() override { CloseDevice(device_); }
+
+    TTNNFixtureWithDevice() : TTNNFixtureBase() {}
+
+    TTNNFixtureWithDevice(int trace_region_size, int l1_small_size) :
+        TTNNFixtureBase(trace_region_size, l1_small_size) {}
 };
 
-// TODO: deduplicate the code with `TTNNFixtureWithDevice`.
 class MultiCommandQueueSingleDeviceFixture : public TTNNFixtureBase {
 protected:
     IDevice* device_;
@@ -88,15 +92,9 @@ protected:
             0, 2, trace_region_size_, l1_small_size_, DispatchCoreConfig{dispatch_core_type});
     }
 
-    void TearDown() override { device_->close(); }
-
-    tt::tt_metal::distributed::MeshDevice* device_ = nullptr;
-    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
-    tt::ARCH arch_;
-    size_t num_devices_;
+    void TearDown() override { CloseDevice(device_); }
 };
 
-// TODO: deduplicate the code with `TTNNFixtureWithDevice`.
 class MultiCommandQueueT3KFixture : public TTNNFixtureBase {
 protected:
     std::map<chip_id_t, tt::tt_metal::IDevice*> devs;


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/18973

### Problem description
A lot of similar code is duplicated between the fixtures in the jjiang/tt-metal/tests/ttnn/unit_tests/gtests/ttnn_test_fixtures.hpp file. Moving things into TTNNFixtureWithDevice and making MultiCommandQueueSingleDeviceFixture and MultiCommandQueueT3KFixture inherit from it makes things a bit cleaner. 

### What's changed
Add InitStateEnv(); and checkSlowDispatch(); methods to TTNNFixtureWithDevice, move shared variables into TTNNFixtureWithDevice. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14599336507
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes: tests/ttnn/unit_tests