### PR TITLE
Deduplicate llama's custom implementations of `ShardTensor2dMesh` / `ConcatMesh2DToTensor`

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_rope.py
+++ b/models/demos/llama3_subdevices/tt/llama_rope.py
@@ -185,7 +185,7 @@ class TtLlamaRotarySetup(LightweightModule):
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=None if on_host else self.device,
             memory_config=None if on_host else ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(
+            mesh_mapper=ttnn.ShardTensor2dMesh(
                 self.device,
                 dims=(None, 0) if (self.num_devices == 32 and batch > 1) else (None, None),
                 mesh_shape=list(self.device.shape),

--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -28,56 +28,6 @@ UNIT_TEST_N_LAYER = 1
 UNIT_TEST_LAYER_NUM = 0
 UNIT_TEST_START_POS = 0
 UNIT_TEST_GENERATION_LENGTH = 20
-from ttnn import MeshToTensor, TensorToMesh
-
-
-class ShardTensor2dMesh(TensorToMesh):
-    def __init__(self, mesh_device, dims, cluster_shape):
-        super().__init__(mesh_device)
-        self.dims = dims
-        self.cluster_shape = cluster_shape
-
-    def map(self, tensor: torch.tensor):
-        # Returns list of tensors to map to row-major ordering of chips in cluster
-        tensors_grid_y = None
-        if self.dims[1] == None:
-            tensors_grid_y = [tensor.clone() for _ in range(self.cluster_shape[1])]
-        else:
-            tensors_grid_y = torch.chunk(tensor, self.cluster_shape[1], dim=self.dims[1])
-
-        tensors_grid_all = None
-        if self.dims[0] == None:
-            tensors_grid_all = [t.clone() for t in tensors_grid_y for _ in range(self.cluster_shape[0])]
-        else:
-            tensors_grid_all = [
-                tt for t in tensors_grid_y for tt in torch.chunk(t, self.cluster_shape[0], dim=self.dims[0])
-            ]
-
-        return list(tensors_grid_all)
-
-    def config(self):
-        return {
-            "strategy": "shard",
-            "shard_dim": f"{self.dims[0] if self.dims[0] else self.dims[1]}",
-        }
-
-
-class ConcatMesh2DToTensor(MeshToTensor):
-    def __init__(self, mesh_device, dims, cluster_shape):
-        self.dims = dims
-        self.cluster_shape = cluster_shape
-        self.mesh_device = mesh_device
-
-    def compose(self, tensor: ttnn.Tensor) -> torch.Tensor:
-        tt_shards = [ttnn.to_torch(tt_input_tensor) for tt_input_tensor in ttnn.get_device_tensors(tensor)]
-
-        row_concat = []
-        for cluster_row in range(self.cluster_shape[1]):
-            start = cluster_row * self.cluster_shape[0]
-            end = start + self.cluster_shape[0]
-            row_concat.append(torch.cat(tt_shards[start:end], dim=self.dims[0]))
-        all_concat = torch.cat(row_concat, dim=self.dims[1])
-        return all_concat
 
 
 def load_llama_state_dict(ckpt_dir, n_layers, start_layer_idx=0):

--- a/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_decoder_galaxy.py
@@ -19,8 +19,6 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
     UNIT_TEST_LAYER_NUM,
     UNIT_TEST_N_LAYER,
     UNIT_TEST_START_POS,
-    ConcatMesh2DToTensor,
-    ShardTensor2dMesh,
     check_kv_cache,
     check_mesh_device,
     comp_pcc,
@@ -130,8 +128,10 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos, mode):
             layout=ttnn.TILE_LAYOUT,
             device=llama_decoder_model.mesh_device,
             memory_config=ACT_MEMCFG,
-            mesh_mapper=ShardTensor2dMesh(
-                llama_decoder_model.mesh_device, dims=(3, None), cluster_shape=llama_decoder_model.cluster_shape
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                llama_decoder_model.mesh_device,
+                mesh_shape=tuple(reversed(llama_decoder_model.cluster_shape)),
+                dims=(None, 3),
             ),
         )
 
@@ -174,8 +174,10 @@ def tt_llama_decoder_prepare_inputs(llama_decoder_model, x, start_pos, mode):
             layout=ttnn.TILE_LAYOUT,
             device=llama_decoder_model.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(
-                llama_decoder_model.mesh_device, dims=(3, None), cluster_shape=llama_decoder_model.cluster_shape
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                llama_decoder_model.mesh_device,
+                mesh_shape=tuple(reversed(llama_decoder_model.cluster_shape)),
+                dims=(None, 3),
             ),
         )
 
@@ -328,7 +330,10 @@ def run_test_LlamaDecoder_inference(
         tt_out = tt_LlamaDecoder_model(x_input, rot_mat, start_pos, attn_mask, mode=mode)
 
         tt_out = ttnn.to_torch(
-            tt_out, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(3, 1), cluster_shape=cluster_shape)
+            tt_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(
+                mesh_device, mesh_shape=tuple(reversed(cluster_shape)), dims=(1, 3)
+            ),
         )
 
         tt_out = tt_out[:, 0:1, :, :]
@@ -362,9 +367,12 @@ def run_test_LlamaDecoder_inference(
 
     tt_layer_present_all = [ttnn.from_device(lp) for lp in tt_LlamaDecoder_model.attention.layer_past]
     tt_layer_present_all = [
-        ttnn.to_torch(lp, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(0, 1), cluster_shape=cluster_shape))[
-            :batch, ...
-        ]
+        ttnn.to_torch(
+            lp,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(
+                mesh_device, mesh_shape=tuple(reversed(cluster_shape)), dims=(1, 0)
+            ),
+        )[:batch, ...]
         for lp in tt_layer_present_all
     ]
 

--- a/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
@@ -59,8 +59,8 @@ def tt_llama_mlp_prepare_inputs(llama_mlp_model, x, mode):
             layout=ttnn.TILE_LAYOUT,
             device=llama_mlp_model.mesh_device,
             memory_config=act_mem_config,
-            mesh_mapper=ShardTensor2dMesh(
-                llama_mlp_model.mesh_device, dims=(3, None), cluster_shape=llama_mlp_model.cluster_shape
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                llama_mlp_model.mesh_device, mesh_shape=tuple(reversed(llama_mlp_model.cluster_shape)), dims=(None, 3)
             ),
         )
     elif mode == "prefill":
@@ -70,8 +70,8 @@ def tt_llama_mlp_prepare_inputs(llama_mlp_model, x, mode):
             layout=ttnn.TILE_LAYOUT,
             device=llama_mlp_model.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(
-                llama_mlp_model.mesh_device, dims=(3, None), cluster_shape=llama_mlp_model.cluster_shape
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                llama_mlp_model.mesh_device, mesh_shape=tuple(reversed(llama_mlp_model.cluster_shape)), dims=(None, 3)
             ),
         )
 
@@ -141,7 +141,8 @@ def run_test_LlamaMLP_inference(
     tt_out = tt_LlamaMLP_model(tt_mlp_input, mode=mode)
 
     tt_out = ttnn.to_torch(
-        tt_out, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(3, 1), cluster_shape=cluster_shape)
+        tt_out,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=tuple(reversed(cluster_shape)), dims=(1, 3)),
     )
     tt_out = tt_out[:, 0:1, :, :]
 

--- a/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_mlp_galaxy.py
@@ -15,8 +15,6 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
     MAX_SEQ_LEN,
     UNIT_TEST_LAYER_NUM,
     UNIT_TEST_N_LAYER,
-    ConcatMesh2DToTensor,
-    ShardTensor2dMesh,
     check_mesh_device,
     comp_pcc,
     should_skip_model_load,

--- a/models/demos/tg/llama3_70b/tests/test_llama_perf.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_perf.py
@@ -10,7 +10,6 @@ import ttnn
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     BASE_URL,
-    ConcatMesh2DToTensor,
     check_mesh_device,
     should_skip_model_load,
 )
@@ -138,7 +137,10 @@ def run_test_LlamaModel_end_to_end(
         tt_out = tt_model(tt_inp_emb, rot_mat, start_pos, attn_mask, mode=mode)
         # Retrieve output from device
         tt_out_cpu = ttnn.to_torch(
-            tt_out, mesh_composer=ConcatMesh2DToTensor(mesh_device, dims=(1, 3), cluster_shape=cluster_shape)
+            tt_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(
+                mesh_device, mesh_shape=tuple(reversed(cluster_shape)), dims=(3, 1)
+            ),
         )
 
         profiler.end(f"prefill_iteration_{iter_idx}")

--- a/models/demos/tg/llama3_70b/tests/test_llama_perf.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_perf.py
@@ -8,11 +8,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.t3000.llama2_70b.reference.llama.llama import Llama
-from models.demos.t3000.llama2_70b.tt.llama_common import (
-    BASE_URL,
-    check_mesh_device,
-    should_skip_model_load,
-)
+from models.demos.t3000.llama2_70b.tt.llama_common import BASE_URL, check_mesh_device, should_skip_model_load
 from models.demos.tg.llama3_70b.tt.llama_common import PytorchLlamaModel, setup_llama_env
 from models.demos.tg.llama3_70b.tt.llama_model_galaxy import TtLlamaModel_galaxy
 from models.utility_functions import enable_persistent_kernel_cache, profiler, skip_for_grayskull

--- a/models/demos/tg/llama3_70b/tt/llama_attention_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_attention_galaxy.py
@@ -7,7 +7,6 @@ import math
 import torch
 
 import ttnn
-from models.demos.t3000.llama2_70b.tt.llama_common import ShardTensor2dMesh
 from models.demos.tg.llama3_70b.tt.llama_common import (
     tt_all_reduce,
     tt_composite_sharded_all_reduce,
@@ -198,7 +197,9 @@ class TtLlamaAttention_galaxy:
             layout=ttnn.TILE_LAYOUT,
             device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(2, 3), cluster_shape=self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(3, 2)
+            ),
             cache_file_name=self.cache_path / wqkv_cache_str,
         )
 
@@ -208,7 +209,9 @@ class TtLlamaAttention_galaxy:
             layout=ttnn.TILE_LAYOUT,
             device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(3, 2), cluster_shape=self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(2, 3)
+            ),
             cache_file_name=self.cache_path / wo_cache_str,
         )
 

--- a/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
@@ -5,10 +5,12 @@
 from typing import List
 
 import ttnn
-from models.demos.t3000.llama2_70b.tt.llama_common import ShardTensor2dMesh
 from models.demos.tg.llama3_70b.tt.llama_attention_galaxy import TtLlamaAttention_galaxy
-from models.demos.tg.llama3_70b.tt.llama_common import tt_distributed_rmsnorm, tt_sharded_distributed_rmsnorm
 from models.demos.tg.llama3_70b.tt.llama_mlp_galaxy import TtLlamaMLP_galaxy
+from models.demos.tg.llama3_70b.tt.llama_common import (
+    tt_sharded_distributed_rmsnorm,
+    tt_distributed_rmsnorm,
+)
 
 
 class TtLlamaDecoder_galaxy:
@@ -107,7 +109,9 @@ class TtLlamaDecoder_galaxy:
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, (2, None), self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(None, 2)
+            ),
             cache_file_name=self.cache_path / attn_norm_sharded_str,
         )
 
@@ -117,7 +121,9 @@ class TtLlamaDecoder_galaxy:
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, (2, None), self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(None, 2)
+            ),
             cache_file_name=self.cache_path / ffn_norm_sharded_str,
         )
 

--- a/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_decoder_galaxy.py
@@ -6,11 +6,8 @@ from typing import List
 
 import ttnn
 from models.demos.tg.llama3_70b.tt.llama_attention_galaxy import TtLlamaAttention_galaxy
+from models.demos.tg.llama3_70b.tt.llama_common import tt_distributed_rmsnorm, tt_sharded_distributed_rmsnorm
 from models.demos.tg.llama3_70b.tt.llama_mlp_galaxy import TtLlamaMLP_galaxy
-from models.demos.tg.llama3_70b.tt.llama_common import (
-    tt_sharded_distributed_rmsnorm,
-    tt_distributed_rmsnorm,
-)
 
 
 class TtLlamaDecoder_galaxy:

--- a/models/demos/tg/llama3_70b/tt/llama_embedding_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_embedding_galaxy.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-from models.demos.t3000.llama2_70b.tt.llama_common import ShardTensor2dMesh
 
 
 class TtLlamaEmbedding_galaxy:
@@ -28,7 +27,9 @@ class TtLlamaEmbedding_galaxy:
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(3, None), cluster_shape=self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(None, 3)
+            ),
             cache_file_name=cache_path / embedding_cache_name,
         )
 

--- a/models/demos/tg/llama3_70b/tt/llama_generation_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_generation_galaxy.py
@@ -8,7 +8,8 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.t3000.llama2_70b.tt.llama_common import BASE_URL, ConcatMesh2DToTensor
+from models.demos.tg.llama3_70b.tt.llama_model_galaxy import TtLlamaModel_galaxy as TtLlamaModel
+from models.demos.t3000.llama2_70b.tt.llama_common import BASE_URL
 from models.demos.tg.llama3_70b.tt.llama_common import upper_pad_sequence_length
 from models.demos.tg.llama3_70b.tt.llama_model_galaxy import TtLlamaModel_galaxy as TtLlamaModel
 from models.demos.tg.llama3_70b.tt.model_config import get_model_config
@@ -127,6 +128,8 @@ class TtLlamaModelForGeneration:
     def _process_logits(self, tt_logits):
         logits = ttnn.to_torch(
             tt_logits,
-            mesh_composer=ConcatMesh2DToTensor(self.mesh_device, dims=(1, 3), cluster_shape=self.cluster_shape),
+            mesh_composer=ttnn.ConcatMesh2dToTensor(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(3, 1)
+            ),
         )
         return logits[:, 0:1, :, : self.params.vocab_size].float()

--- a/models/demos/tg/llama3_70b/tt/llama_generation_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_generation_galaxy.py
@@ -8,7 +8,6 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.tg.llama3_70b.tt.llama_model_galaxy import TtLlamaModel_galaxy as TtLlamaModel
 from models.demos.t3000.llama2_70b.tt.llama_common import BASE_URL
 from models.demos.tg.llama3_70b.tt.llama_common import upper_pad_sequence_length
 from models.demos.tg.llama3_70b.tt.llama_model_galaxy import TtLlamaModel_galaxy as TtLlamaModel

--- a/models/demos/tg/llama3_70b/tt/llama_mlp_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_mlp_galaxy.py
@@ -5,7 +5,6 @@
 from typing import List
 
 import ttnn
-from models.demos.t3000.llama2_70b.tt.llama_common import ShardTensor2dMesh
 from models.demos.tg.llama3_70b.tt.llama_common import tt_all_reduce, tt_composite_sharded_all_reduce
 
 
@@ -76,7 +75,9 @@ class TtLlamaMLP_galaxy:
             device=self.mesh_device,
             # memory_config=self.w1_mem_config,  # TODO: Reenable when DRAM-SHARDED PCC issues resolves
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(2, 3), cluster_shape=self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(3, 2)
+            ),
             cache_file_name=self.cache_path / w1_cache_str,
         )
 
@@ -87,7 +88,9 @@ class TtLlamaMLP_galaxy:
             device=self.mesh_device,
             # memory_config=self.mlp_config["W1_MEM_CONFIG"](self.mesh_device, self.cluster_shape),  # TODO: Reenable when DRAM-SHARDED PCC issues resolves
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(2, 3), cluster_shape=self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(3, 2)
+            ),
             cache_file_name=self.cache_path / w3_cache_str,
         )
 
@@ -98,7 +101,9 @@ class TtLlamaMLP_galaxy:
             device=self.mesh_device,
             # memory_config=self.mlp_config["W2_MEM_CONFIG"](self.mesh_device),  # TODO: Reenable when DRAM-SHARDED PCC issues resolves
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(3, 2), cluster_shape=self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(2, 3)
+            ),
             cache_file_name=self.cache_path / w2_cache_str,
         )
 

--- a/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
@@ -10,13 +10,12 @@ from tqdm import tqdm
 
 import ttnn
 from models.demos.t3000.llama2_70b.tt.llama_common import (
-    ShardTensor2dMesh,
     freqs_to_rotation_matrix,
-    gather_cos_sin,
-    get_rot_transformation_mat,
     get_rotation_mat,
-    num_to_corerange,
     precompute_freqs,
+    get_rot_transformation_mat,
+    num_to_corerange,
+    gather_cos_sin,
 )
 from models.demos.tg.llama3_70b.tt.llama_common import (
     tt_all_reduce,
@@ -144,7 +143,9 @@ class TtLlamaModel_galaxy:
             layout=ttnn.TILE_LAYOUT,
             device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, dims=(2, 3), cluster_shape=self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(3, 2)
+            ),
             cache_file_name=self.cache_path / lm_head_cache_str,
         )
 
@@ -154,7 +155,9 @@ class TtLlamaModel_galaxy:
             layout=ttnn.ROW_MAJOR_LAYOUT,
             device=self.mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            mesh_mapper=ShardTensor2dMesh(self.mesh_device, (2, None), self.cluster_shape),
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device, mesh_shape=tuple(reversed(self.cluster_shape)), dims=(None, 2)
+            ),
             cache_file_name=self.cache_path / norm_sharded_cache_str,
         )
 

--- a/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
+++ b/models/demos/tg/llama3_70b/tt/llama_model_galaxy.py
@@ -11,11 +11,11 @@ from tqdm import tqdm
 import ttnn
 from models.demos.t3000.llama2_70b.tt.llama_common import (
     freqs_to_rotation_matrix,
-    get_rotation_mat,
-    precompute_freqs,
-    get_rot_transformation_mat,
-    num_to_corerange,
     gather_cos_sin,
+    get_rot_transformation_mat,
+    get_rotation_mat,
+    num_to_corerange,
+    precompute_freqs,
 )
 from models.demos.tg.llama3_70b.tt.llama_common import (
     tt_all_reduce,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
llama_common.py defines custom `ShardTensor2dMesh` / `ConcatMesh2DToTensor` that works on `cluster_shape` that is just reversed shape of the device.

### What's changed
Delete custom functions, and migrate the user code.

Confirmed in REPL that:
* `mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=(x, y), dims=(a, b))` is equivalent to `mesh_mapper=llama_common.ShardTensor2dMesh(mesh_device, cluster_shape=(y, x), dims=(b, a))`
* `mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, mesh_shape=(x, y), dims=(a, b))` is equivalent to `mesh_composer=llama_common.ConcatMesh2DToTensor(mesh_device, cluster_shape=(y, x), dims=(b, a))`

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14526702233)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14526699948)
- [x] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15444982582)
