### PR TITLE
#18191: Optimize mish for sharded config

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_composite.py
@@ -12,8 +12,6 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-from models.utility_functions import skip_for_grayskull, is_wormhole_b0, is_blackhole
-
 
 @pytest.mark.parametrize(
     "input_shapes",
@@ -358,7 +356,6 @@ def test_unary_composite_lgamma_ttnn(input_shapes, device):
     assert comp_pass
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -378,42 +375,40 @@ def test_unary_composite_mish_ttnn(input_shapes, device):
     assert comp_pass
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "input_shapes",
-    ((torch.Size([1, 1, 102400, 32])),),
+    (
+        torch.Size([1, 1, 89600, 32]),
+        torch.Size([1, 1, 89600, 128]),
+    ),
 )
 def test_unary_composite_mish_sharded_ttnn(input_shapes, device):
-    in_data1 = torch.Tensor(size=input_shapes).uniform_(-20, 100).to(torch.bfloat16)
+    in_data = torch.Tensor(size=input_shapes).uniform_(-20, 100).to(torch.bfloat16)
     shard_grid = ttnn.CoreRangeSet(
         {
             ttnn.CoreRange(
                 ttnn.CoreCoord(0, 0),
-                ttnn.CoreCoord(7, 7),
+                ttnn.CoreCoord(7, 6),
             ),
         }
     )
-    n_cores = 64
-    N, H, W, C = in_data1.shape
-    shard_spec = ttnn.ShardSpec(shard_grid, [N * H * W // n_cores, C], ttnn.ShardOrientation.ROW_MAJOR)
+    n_cores = 56
+    N, C, H, W = in_data.shape
+    shard_spec = ttnn.ShardSpec(shard_grid, [N * C * H // n_cores, W], ttnn.ShardOrientation.ROW_MAJOR)
     input_mem_config = ttnn.MemoryConfig(
         ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
     )
-    input_tensor1 = ttnn.from_torch(
-        in_data1,
+    input_tensor = ttnn.from_torch(
+        in_data,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
         device=device,
         memory_config=input_mem_config,
     )
 
-    output_tensor = ttnn.mish(input_tensor1)
+    output_tensor = ttnn.mish(input_tensor)
     golden_function = ttnn.get_golden_function(ttnn.mish)
-    golden_tensor = golden_function(in_data1)
-    output_tensor_tt = ttnn.to_torch(output_tensor)
-    diff = torch.abs(golden_tensor - output_tensor_tt)
-    max_atol = torch.max(diff)
-    print(f"Max absolute tolerance (atol): {max_atol.item()}")
+    golden_tensor = golden_function(in_data)
     comp_pass = compare_pcc([output_tensor], [golden_tensor])
     assert comp_pass
 
@@ -628,7 +623,6 @@ def test_unary_composite_triu_ttnn(input_shapes, device):
     assert comp_pass
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -648,7 +642,6 @@ def test_unary_composite_trunc_ttnn(input_shapes, device):
     assert comp_pass
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -755,7 +748,6 @@ def test_unary_logical_not_ttnn(input_shapes, device):
     assert comp_pass
 
 
-@skip_for_grayskull("Not supported for Grayskull")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -890,7 +882,6 @@ def test_unary_celu(input_shapes, param, device):
     assert comp_pass
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -22,8 +22,6 @@ void MAIN {
     constexpr auto cb_output = tt::CBIndex::c_2;
     init_sfpu(cb_input, cb_output);
 
-    log1p_tile_init();
-
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
         cb_reserve_back(cb_output, per_core_block_dim);
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
@@ -36,6 +34,7 @@ void MAIN {
 
             exp_tile_init<1u>();
             exp_tile<1u>(0);
+            log1p_tile_init();
             log1p_tile(0);
             tanh_tile_init();
             tanh_tile(0);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/compute/mish_kernel.cpp
@@ -10,6 +10,7 @@
 #include "compute_kernel_api/eltwise_unary/sfpu_split_includes.h"
 #include "compute_kernel_api/eltwise_unary/binop_with_scalar.h"
 #include "compute_kernel_api/eltwise_unary/exp.h"
+#include "compute_kernel_api/eltwise_unary/log1p.h"
 #include "compute_kernel_api.h"
 
 namespace NAMESPACE {
@@ -19,8 +20,9 @@ void MAIN {
 
     constexpr auto cb_input = tt::CBIndex::c_0;
     constexpr auto cb_output = tt::CBIndex::c_2;
-    constexpr uint32_t one = 0x3f800000u;  // Represents 1.0f
     init_sfpu(cb_input, cb_output);
+
+    log1p_tile_init();
 
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
         cb_reserve_back(cb_output, per_core_block_dim);
@@ -34,12 +36,8 @@ void MAIN {
 
             exp_tile_init<1u>();
             exp_tile<1u>(0);
-            binop_with_scalar_tile_init();
-            add_unary_tile(0, one);
-            log_tile_init();
-            log_tile(0);
+            log1p_tile(0);
             tanh_tile_init();
-
             tanh_tile(0);
 
             binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_input);


### PR DESCRIPTION
### Ticket
#18191

### Problem description
The optimized version of mish did not improve the performance of sharded cases.

### What's changed
Reduced no. of tiles using log1p tile instead of unary tile and log tile

### Perf Results

**Shape tested:** torch.Size([1, 1, 102400, 32])
**Sharding:** Height-sharded config
[Results](https://docs.google.com/spreadsheets/d/1-MtwCs-oD1wQt-rJCG03jixw9dcqicmty2RWEyPjuTg/edit?gid=1335324050#gid=1335324050)

<img width="372" alt="Screenshot 2025-04-21 at 12 05 19" src="https://github.com/user-attachments/assets/2c2291d0-4924-4568-9bf0-6ec065ec0853" />

<img width="1612" alt="Screenshot 2025-04-21 at 12 06 34" src="https://github.com/user-attachments/assets/eedb91cd-3931-4821-830a-62f2e69ac2af" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14588161296) - PASSED
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14588169192) - PASSED
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14588173745) - PASSED
- [x] [(Single-card) Fast dispatch frequent tests](https://github.com/tenstorrent/tt-metal/actions/runs/14588186924) - same as main
- [x] [(Single-card) Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/14588203215) - PASSED
- [x] New/Existing tests provide coverage for changes