### PR TITLE
#20682: Remove `total_size = 0` restriction in `CircularBufferConfig`

### DIFF
--- a/tt_metal/impl/buffers/circular_buffer_types.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.cpp
@@ -108,9 +108,6 @@ CircularBufferConfig& CircularBufferConfig::set_total_size(uint32_t total_size) 
 #endif
         }
     }
-    if (total_size == 0) {
-        TT_THROW("Total size for circular buffer must be non-zero!");
-    }
     this->total_size_ = total_size;
     return *this;
 }
@@ -150,9 +147,6 @@ CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address_and_t
                 this->buffer_size_);
         }
 #endif
-    }
-    if (total_size == 0) {
-        TT_THROW("Total size for circular buffer must be non-zero!");
     }
     this->total_size_ = total_size;
     return *this;


### PR DESCRIPTION
### Ticket
#20682 

### Problem description
In contrast to `CreateCB`, which allows `num_tiles == 0`, `UpdateCB` fails with the size check `total_size = 0`

### What's changed
- Remove the `TT_THROW` relating `total_size = 0` inside `circular_buffer_types.cpp`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14532905672
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes