### PR TITLE
#20506: Add int32 support for Tensor-Tensor version of maximum

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
@@ -20,6 +20,204 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "low_a, high_a, low_b, high_b",
     [
+        (-5, 5, -10, 10),
+        (-100, 100, -300, 300),
+        (-2147483647, 2147483647, -21474, 21474),
+    ],
+)
+def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.maximum(tt_in_a, tt_in_b)
+    output_tensor = ttnn.to_torch(tt_result)
+    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
+    assert pcc == 1
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_a_val, input_b_val",
+    [
+        (-1, 1),
+        (1, 0),
+        (0, 0),
+        (2147483647, -2147483647),
+        (11, 53),
+    ],
+)
+def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
+    torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
+    torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.maximum(tt_in_a, tt_in_b)
+    output_tensor = ttnn.to_torch(tt_result)
+    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
+    assert pcc == 1
+
+
+@pytest.mark.parametrize(
+    "input_shape_a, input_shape_b",
+    [
+        (torch.Size([1, 2, 32]), torch.Size([1, 2, 32])),
+        (torch.Size([1]), torch.Size([1, 5, 12])),
+        (torch.Size([1, 2, 32, 64, 125]), torch.Size([1, 2, 32, 1, 1])),
+        (torch.Size([]), torch.Size([])),
+        (torch.Size([5]), torch.Size([1])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-2147483647, 2147483647, -21474, 21474),
+    ],
+)
+def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
+
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_b)).item()), 1)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shape_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(tt_result)
+    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
+    assert pcc == 1
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([5, 10, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-2147483647, 2147483647, -21474, 21474),
+    ],
+)
+def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.maximum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    output_tensor = torch.zeros(input_shapes, dtype=torch.int32)
+
+    cq_id = 0
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_out = ttnn.from_torch(
+        output_tensor,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn.maximum(tt_in_a, tt_in_b, output_tensor=tt_out, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(tt_out)
+    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
+    assert pcc == 1
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([5, 8, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
         (-100, 100, -300, 300),
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_minimum.py
@@ -29,7 +29,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         (11, 1),
     ],
 )
-def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
+def test_unary_min_fill_val_fp32(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.float32) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
@@ -70,7 +70,7 @@ def test_unary_max_fill_val_fp32(input_shapes, input_val, scalar, device):
         (11, 1),
     ],
 )
-def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
+def test_unary_min_fill_val_bf16(input_shapes, input_val, scalar, device):
     torch_input = torch.ones(input_shapes, dtype=torch.bfloat16) * input_val
 
     golden_function = ttnn.get_golden_function(ttnn.minimum)
@@ -105,7 +105,7 @@ def test_unary_max_fill_val_bf16(input_shapes, input_val, scalar, device):
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0, 20, 3.4 * 10**38, -3.4 * 10**38])
-def test_unary_max_bf16(input_shapes, low, high, scalar, device):
+def test_unary_min_bf16(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.bfloat16)
     torch_input = torch_input[:num_elements].reshape(input_shapes).nan_to_num(0.0)
@@ -142,7 +142,7 @@ def test_unary_max_bf16(input_shapes, low, high, scalar, device):
     ],
 )
 @pytest.mark.parametrize("scalar", [0.5, 0.1, 0, 1, 10, 3.4 * 10**38, -3.4 * 10**38, -float("inf"), float("inf")])
-def test_unary_max_fp32(input_shapes, low, high, scalar, device):
+def test_unary_min_fp32(input_shapes, low, high, scalar, device):
     num_elements = torch.prod(torch.tensor(input_shapes)).item()
     torch_input = torch.linspace(high, low, num_elements, dtype=torch.float32)
     torch_input = torch_input[:num_elements].reshape(input_shapes)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -25,6 +25,13 @@ inline void llk_math_eltwise_binary_sfpu_binary_max(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_max_int32, dst_index0, dst_index1, vector_mode);
+}
+
 // Binary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_init() {

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -34,5 +34,22 @@ inline void calculate_binary_max_min(const uint dst_offset) {
     }
 }
 
+template <int ITERATIONS = 8>
+inline void calculate_binary_max_int32(const uint dst_offset) {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);                          // a
+        TT_SFPLOAD(p_sfpu::LREG1, 12, ADDR_MOD_3, dst_offset * dst_tile_size);  // b
+
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
+        TTI_SFPNOP;
+
+        TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_3, 0);
+        dst_reg++;
+    }
+}
+
 }  // namespace sfpu
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -25,6 +25,13 @@ inline void llk_math_eltwise_binary_sfpu_binary_max(
         ckernel::sfpu::calculate_binary_max_min<true>, dst_index0, dst_index1, vector_mode);
 }
 
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_max_int32, dst_index0, dst_index1, vector_mode);
+}
+
 // Binary minimum
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_min_init() {

--- a/tt_metal/include/compute_kernel_api/binary_max_min.h
+++ b/tt_metal/include/compute_kernel_api/binary_max_min.h
@@ -17,6 +17,28 @@ namespace ckernel {
 
 // clang-format off
 /**
+ * Performs an elementwise maximum operation on inputs of int32 data type at idst0, idst1: y = max(x0, x1).
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void binary_max_int32_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binary_max_int32<APPROX>(idst0, idst1)));
+}
+
+// clang-format off
+/**
  * Performs an elementwise maximum operation on inputs at idst0, idst1: y = max(x0, x1).
  * Output overwrites first operand in DST.
  *

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -232,7 +232,11 @@ std::map<std::string, std::string> get_defines_fp32(
             break;
         case BinaryOpType::MAXIMUM:
             new_defines.insert({"BINOP_INIT", fmt::format("binary_max_tile_init();")});
-            op_name = "binary_max_tile";
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "binary_max_int32_tile";
+            } else {
+                op_name = "binary_max_tile";
+            }
             break;
         case BinaryOpType::MINIMUM:
             new_defines.insert({"BINOP_INIT", fmt::format("binary_min_tile_init();")});

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -307,7 +307,12 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case BITWISE_AND: return {"binary_bitwise_tile_init();", "and_binary_tile"};
         case BITWISE_OR: return {"binary_bitwise_tile_init();", "or_binary_tile"};
         case BITWISE_XOR: return {"binary_bitwise_tile_init();", "xor_binary_tile"};
-        case MAXIMUM: return {"binary_max_tile_init();", "binary_max_tile"};
+        case MAXIMUM:
+            if (dtype == DataType::INT32) {
+                return {"binary_max_tile_init();", "binary_max_int32_tile"};
+            } else {
+                return {"binary_max_tile_init();", "binary_max_tile"};
+            }
         case MINIMUM: return {"binary_min_tile_init();", "binary_min_tile"};
         case QUANT: return {"quant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "quant_tile"};
         case REQUANT:


### PR DESCRIPTION
### Ticket
#20506, #20977

### Problem description
Implement Tensor-Tensor version of maximum int32

### What's changed
Implemented Tensor-Tensor version of maximum int32

- Used TTI_ instructions : SFPU requires 2's complement format. Hence in BH,
  - Loaded both inputs as signed magnitude using `instr_mod0 = 12`
  - Casted to int32 2’s complement
  - Set sign from input’s bit
- Supports bcast using `use_legacy=False`
- Tested in WH, BH
- Removed existing GS support

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14538278404) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14538279676) 
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14538280980) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14538282112) 
- [x] [C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/14538283655)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14538285054)
- [x] [new models tests](https://github.com/tenstorrent/tt-metal/actions/runs/14538285961)