### PR TITLE
#0: Fix for ttnn.CreateDevice with multiple N150s

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -167,9 +167,7 @@ void Cluster::generate_cluster_descriptor() {
                     this->cluster_type_ = ClusterType::T3K;
                 }
             } else if (board_type == BoardType::N150) {
-                if (this->cluster_desc_->get_all_chips().size() == 1) {
-                    this->cluster_type_ = ClusterType::N150;
-                }
+                this->cluster_type_ = ClusterType::N150;
             } else if (board_type == BoardType::P100) {
                 if (this->cluster_desc_->get_all_chips().size() == 1) {
                     this->cluster_type_ = ClusterType::P100;

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -161,10 +161,10 @@ void Cluster::generate_cluster_descriptor() {
 
         if (all_same_board) {
             if (board_type == BoardType::N300) {
-                if (this->cluster_desc_->get_all_chips().size() == 2) {
-                    this->cluster_type_ = ClusterType::N300;
-                } else if (this->cluster_desc_->get_all_chips().size() == 8) {
+                if (this->cluster_desc_->get_all_chips().size() == 8) {
                     this->cluster_type_ = ClusterType::T3K;
+                } else {
+                    this->cluster_type_ = ClusterType::N300;
                 }
             } else if (board_type == BoardType::N150) {
                 this->cluster_type_ = ClusterType::N150;


### PR DESCRIPTION
### Problem description
ttnn.CreateDevice fails when there are multiple N150 cards, as cluster type is not set.

```
Unknown cluster type
backtrace:
 --- /localdev/smanoj/metal_5/ttnn/ttnn/_ttnn.so(+0xe9a827) [0x7f4d1c69a827]
 --- tt::Cluster::initialize_control_plane()
 --- tt::Cluster::get_control_plane()
 --- tt::DevicePool::wait_for_fabric_router_sync() const
 --- tt::DevicePool::initialize(std::vector<int, std::allocator<int> > const&, unsigned char, unsigned long, unsigned long, tt::tt_metal::DispatchCoreConfig const&, tt::stl::Span<unsigned int const, 18446744073709551615ul>, unsigned long)
```

### What's changed
Removed check on number of N150 cards. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14601591326)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes