### PR TITLE
fix library_tweaks.py: loguru calls fatal error, not fatal

### DIFF
--- a/ttnn/ttnn/library_tweaks.py
+++ b/ttnn/ttnn/library_tweaks.py
@@ -46,7 +46,7 @@ def prepare_dir_as_metal_home(ttnn_package_path, metal_home):
     # Firmware binaries need to be present
     runtime_hw_src = ttnn_package_path / "runtime" / "hw"
     if not runtime_hw_src.is_dir():
-        logger.fatal(
+        logger.error(
             f"{runtime_hw_src} seems to not exist as a directory. This should have been packaged during wheel creation"
         )
         sys.exit(1)
@@ -57,7 +57,7 @@ def prepare_dir_as_metal_home(ttnn_package_path, metal_home):
     runtime_sfpi_dest = metal_home / "runtime" / "sfpi"
     if SFPI_IS_BUNDLED:
         if not runtime_sfpi_src.is_dir():
-            logger.fatal(
+            logger.error(
                 f"{runtime_sfpi_src} seems to not exist as a directory. This should have been packaged during wheel creation"
             )
             sys.exit(1)
@@ -66,7 +66,7 @@ def prepare_dir_as_metal_home(ttnn_package_path, metal_home):
     if SFPI_IS_SYSTEM_PACKAGE:
         system_sfpi_path = Path("/opt/tenstorrent/sfpi")
         if not system_sfpi_path.is_dir():
-            logger.fatal(
+            logger.error(
                 f"SFPI system package not found at {system_sfpi_path}. Please install the SFPI system package."
             )
             sys.exit(1)
@@ -82,7 +82,7 @@ def prepare_dir_as_metal_home(ttnn_package_path, metal_home):
 
         if last_used_version == current_version:
             if not runtime_hw_dest.is_dir():
-                logger.fatal(
+                logger.error(
                     f"A .METAL_VERSION file exists in current working directory, but no {runtime_hw_dest} directory within it. Your installation may be corrupted."
                 )
                 sys.exit(1)


### PR DESCRIPTION
### Ticket

Quick semantic fix

### Problem description

Looks like we called `logger.error` `logger.fatal` by accident.

### What's changed

Quick spelling fixes.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes