### PR TITLE
add fabric ring latency test

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_1d_fabric_latency.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_1d_fabric_latency.py
@@ -166,21 +166,21 @@ def run_latency_test(
 # 1D All-to-All Multicast
 @pytest.mark.parametrize("line_size", [8])
 @pytest.mark.parametrize(
-    "topology, latency_ping_message_size_bytes,latency_measurement_worker_line_index,enable_fused_payload_with_sync, expected_mean_latency_ns,expected_min_latency_ns,expected_max_latency_ns,expected_avg_hop_latency_ns",
+    "latency_ping_message_size_bytes,latency_measurement_worker_line_index,enable_fused_payload_with_sync, expected_mean_latency_ns,expected_min_latency_ns,expected_max_latency_ns,expected_avg_hop_latency_ns",
     [
-        ("linear", 0, 0, False, 10625, 10300, 11000, 760),
-        ("linear", 0, 1, False, 9000, 8680, 9430, 750),
-        ("linear", 4096, 1, False, 15750, 15500, 16200, 1310),
-        ("linear", 0, 2, False, 7550, 7240, 7840, 755),
-        ("linear", 0, 3, False, 6160, 5850, 6580, 770),
-        ("linear", 0, 4, False, 4680, 4450, 4975, 780),
-        ("linear", 0, 5, False, 3160, 2975, 3470, 790),
-        ("linear", 0, 6, False, 1520, 1420, 1680, 760),
-        ("linear", 16, 6, False, 1520, 1400, 1550, 760),
-        ("linear", 16, 6, True, 1535, 1425, 1700, 770),
-        ("linear", 1024, 6, False, 2000, 1820, 2150, 1000),
-        ("linear", 2048, 6, False, 2240, 2150, 2290, 1120),
-        ("linear", 4096, 6, False, 2600, 2520, 2770, 1300),
+        (0, 0, False, 10625, 10300, 11000, 760),
+        (0, 1, False, 9000, 8680, 9430, 750),
+        (4096, 1, False, 15750, 15500, 16200, 1310),
+        (0, 2, False, 7550, 7240, 7840, 755),
+        (0, 3, False, 6160, 5850, 6580, 770),
+        (0, 4, False, 4680, 4450, 4975, 780),
+        (0, 5, False, 3160, 2975, 3470, 790),
+        (0, 6, False, 1520, 1420, 1680, 760),
+        (16, 6, False, 1520, 1400, 1550, 760),
+        (16, 6, True, 1535, 1425, 1700, 770),
+        (1024, 6, False, 2000, 1820, 2150, 1000),
+        (2048, 6, False, 2240, 2150, 2290, 1120),
+        (4096, 6, False, 2600, 2520, 2770, 1300),
     ],
 )
 @pytest.mark.parametrize("latency_ping_burst_size", [1])
@@ -190,7 +190,6 @@ def run_latency_test(
 @pytest.mark.parametrize("congestion_writers_message_size", [0])
 @pytest.mark.parametrize("congestion_writers_use_mcast", [False])
 def test_1D_line_fabric_latency_on_uncongested_fabric(
-    topology,
     line_size,
     latency_measurement_worker_line_index,
     enable_fused_payload_with_sync,
@@ -207,7 +206,7 @@ def test_1D_line_fabric_latency_on_uncongested_fabric(
     expected_avg_hop_latency_ns,
 ):
     run_latency_test(
-        topology,
+        "linear",
         line_size,
         latency_measurement_worker_line_index,
         latency_ping_message_size_bytes,
@@ -228,14 +227,14 @@ def test_1D_line_fabric_latency_on_uncongested_fabric(
 # 1D All-to-All Multicast
 @pytest.mark.parametrize("line_size", [4])
 @pytest.mark.parametrize(
-    "topology, latency_ping_message_size_bytes,latency_measurement_worker_line_index,enable_fused_payload_with_sync, expected_mean_latency_ns,expected_min_latency_ns,expected_max_latency_ns,expected_avg_hop_latency_ns",
+    "latency_ping_message_size_bytes,latency_measurement_worker_line_index,enable_fused_payload_with_sync, expected_mean_latency_ns,expected_min_latency_ns,expected_max_latency_ns,expected_avg_hop_latency_ns",
     [
-        ("ring", 0, 0, False, 3320, 2880, 3520, 805),
-        ("ring", 16, 0, False, 3130, 2840, 3400, 780),
-        ("ring", 16, 0, True, 3170, 2860, 3420, 790),
-        ("ring", 1024, 0, False, 3920, 3580, 4310, 975),
-        ("ring", 2048, 0, False, 4470, 4220, 4730, 1115),
-        ("ring", 4096, 0, False, 5310, 5050, 5700, 1330),
+        (0, 0, False, 3320, 2880, 3520, 805),
+        (16, 0, False, 3130, 2840, 3400, 780),
+        (16, 0, True, 3170, 2860, 3420, 790),
+        (1024, 0, False, 3920, 3580, 4310, 975),
+        (2048, 0, False, 4470, 4220, 4730, 1115),
+        (4096, 0, False, 5310, 5050, 5700, 1330),
     ],
 )
 @pytest.mark.parametrize("latency_ping_burst_size", [1])
@@ -245,7 +244,6 @@ def test_1D_line_fabric_latency_on_uncongested_fabric(
 @pytest.mark.parametrize("congestion_writers_message_size", [0])
 @pytest.mark.parametrize("congestion_writers_use_mcast", [False])
 def test_1D_ring_fabric_latency_on_uncongested_fabric(
-    topology,
     line_size,
     latency_measurement_worker_line_index,
     enable_fused_payload_with_sync,
@@ -262,7 +260,7 @@ def test_1D_ring_fabric_latency_on_uncongested_fabric(
     expected_avg_hop_latency_ns,
 ):
     run_latency_test(
-        topology,
+        "ring",
         line_size,
         latency_measurement_worker_line_index,
         latency_ping_message_size_bytes,

--- a/tests/tt_metal/microbenchmarks/ethernet/test_1d_fabric_latency.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_1d_fabric_latency.py
@@ -91,7 +91,6 @@ def run_latency_test(
     logger.warning("removing file profile_log_device.csv")
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
 
-    # cmd = f"TT_METAL_ENABLE_ERISC_IRAM=1 \
     cmd = f"TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_DEVICE_PROFILER=1 \
             {os.environ['TT_METAL_HOME']}/build/test/ttnn/unit_tests_ttnn_1d_fabric_latency \
                 {line_size} \

--- a/tests/tt_metal/microbenchmarks/ethernet/test_1d_fabric_latency.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_1d_fabric_latency.py
@@ -72,6 +72,7 @@ def profile_results(
 
 
 def run_latency_test(
+    topology,
     line_size,
     latency_measurement_worker_line_index,
     latency_ping_message_size_bytes,
@@ -90,6 +91,7 @@ def run_latency_test(
     logger.warning("removing file profile_log_device.csv")
     os.system(f"rm -rf {os.environ['TT_METAL_HOME']}/generated/profiler/.logs/profile_log_device.csv")
 
+    # cmd = f"TT_METAL_ENABLE_ERISC_IRAM=1 \
     cmd = f"TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_DEVICE_PROFILER=1 \
             {os.environ['TT_METAL_HOME']}/build/test/ttnn/unit_tests_ttnn_1d_fabric_latency \
                 {line_size} \
@@ -101,7 +103,8 @@ def run_latency_test(
                 {num_downstream_fabric_congestion_writers} \
                 {congestion_writers_message_size} \
                 {int(congestion_writers_use_mcast)} \
-                {int(enable_fused_payload_with_sync)}"
+                {int(enable_fused_payload_with_sync)} \
+                {topology}"
     rc = os.system(cmd)
     if rc != 0:
         if os.WEXITSTATUS(rc) == 1:
@@ -121,7 +124,7 @@ def run_latency_test(
         congestion_writers_message_size,
         congestion_writers_use_mcast,
     )
-    num_hops = (line_size - 1 - latency_measurement_worker_line_index) * 2
+    num_hops = (line_size - 1 - latency_measurement_worker_line_index) * 2 if topology != "ring" else line_size
     avg_hop_latency = latency_avg_ns / num_hops
     logger.info("latency_ns: {} ns", latency_avg_ns)
     allowable_delta = expected_mean_latency_ns * 0.05
@@ -163,30 +166,31 @@ def run_latency_test(
 # 1D All-to-All Multicast
 @pytest.mark.parametrize("line_size", [8])
 @pytest.mark.parametrize(
-    "latency_ping_message_size_bytes,latency_measurement_worker_line_index,enable_fused_payload_with_sync, expected_mean_latency_ns,expected_min_latency_ns,expected_max_latency_ns,expected_avg_hop_latency_ns",
+    "topology, latency_ping_message_size_bytes,latency_measurement_worker_line_index,enable_fused_payload_with_sync, expected_mean_latency_ns,expected_min_latency_ns,expected_max_latency_ns,expected_avg_hop_latency_ns",
     [
-        (0, 0, False, 10625, 10300, 11000, 760),
-        (0, 1, False, 9000, 8680, 9430, 750),
-        (4096, 1, False, 15750, 15500, 16200, 1310),
-        (0, 2, False, 7550, 7240, 7840, 755),
-        (0, 3, False, 6160, 5850, 6580, 770),
-        (0, 4, False, 4680, 4450, 4975, 780),
-        (0, 5, False, 3160, 2975, 3470, 790),
-        (0, 6, False, 1520, 1420, 1680, 760),
-        (16, 6, False, 1520, 1400, 1550, 760),
-        (16, 6, True, 1535, 1425, 1700, 770),
-        (1024, 6, False, 2000, 1820, 2150, 1000),
-        (2048, 6, False, 2240, 2150, 2290, 1120),
-        (4096, 6, False, 2600, 2520, 2770, 1300),
+        ("linear", 0, 0, False, 10625, 10300, 11000, 760),
+        ("linear", 0, 1, False, 9000, 8680, 9430, 750),
+        ("linear", 4096, 1, False, 15750, 15500, 16200, 1310),
+        ("linear", 0, 2, False, 7550, 7240, 7840, 755),
+        ("linear", 0, 3, False, 6160, 5850, 6580, 770),
+        ("linear", 0, 4, False, 4680, 4450, 4975, 780),
+        ("linear", 0, 5, False, 3160, 2975, 3470, 790),
+        ("linear", 0, 6, False, 1520, 1420, 1680, 760),
+        ("linear", 16, 6, False, 1520, 1400, 1550, 760),
+        ("linear", 16, 6, True, 1535, 1425, 1700, 770),
+        ("linear", 1024, 6, False, 2000, 1820, 2150, 1000),
+        ("linear", 2048, 6, False, 2240, 2150, 2290, 1120),
+        ("linear", 4096, 6, False, 2600, 2520, 2770, 1300),
     ],
 )
 @pytest.mark.parametrize("latency_ping_burst_size", [1])
-@pytest.mark.parametrize("latency_ping_burst_count", [62])
+@pytest.mark.parametrize("latency_ping_burst_count", [200])
 @pytest.mark.parametrize("add_upstream_fabric_congestion_writers", [False])
 @pytest.mark.parametrize("num_downstream_fabric_congestion_writers", [0])
 @pytest.mark.parametrize("congestion_writers_message_size", [0])
 @pytest.mark.parametrize("congestion_writers_use_mcast", [False])
-def test_1D_fabric_latency_on_uncongested_fabric_minimal_packet_size(
+def test_1D_line_fabric_latency_on_uncongested_fabric(
+    topology,
     line_size,
     latency_measurement_worker_line_index,
     enable_fused_payload_with_sync,
@@ -203,6 +207,62 @@ def test_1D_fabric_latency_on_uncongested_fabric_minimal_packet_size(
     expected_avg_hop_latency_ns,
 ):
     run_latency_test(
+        topology,
+        line_size,
+        latency_measurement_worker_line_index,
+        latency_ping_message_size_bytes,
+        latency_ping_burst_size,
+        latency_ping_burst_count,
+        add_upstream_fabric_congestion_writers,
+        num_downstream_fabric_congestion_writers,
+        congestion_writers_message_size,
+        congestion_writers_use_mcast,
+        enable_fused_payload_with_sync,
+        expected_mean_latency_ns,
+        expected_min_latency_ns,
+        expected_max_latency_ns,
+        expected_avg_hop_latency_ns,
+    )
+
+
+# 1D All-to-All Multicast
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize(
+    "topology, latency_ping_message_size_bytes,latency_measurement_worker_line_index,enable_fused_payload_with_sync, expected_mean_latency_ns,expected_min_latency_ns,expected_max_latency_ns,expected_avg_hop_latency_ns",
+    [
+        ("ring", 0, 0, False, 3320, 2880, 3520, 805),
+        ("ring", 16, 0, False, 3130, 2840, 3400, 780),
+        ("ring", 16, 0, True, 3170, 2860, 3420, 790),
+        ("ring", 1024, 0, False, 3920, 3580, 4310, 975),
+        ("ring", 2048, 0, False, 4470, 4220, 4730, 1115),
+        ("ring", 4096, 0, False, 5310, 5050, 5700, 1330),
+    ],
+)
+@pytest.mark.parametrize("latency_ping_burst_size", [1])
+@pytest.mark.parametrize("latency_ping_burst_count", [62])
+@pytest.mark.parametrize("add_upstream_fabric_congestion_writers", [False])
+@pytest.mark.parametrize("num_downstream_fabric_congestion_writers", [0])
+@pytest.mark.parametrize("congestion_writers_message_size", [0])
+@pytest.mark.parametrize("congestion_writers_use_mcast", [False])
+def test_1D_ring_fabric_latency_on_uncongested_fabric(
+    topology,
+    line_size,
+    latency_measurement_worker_line_index,
+    enable_fused_payload_with_sync,
+    latency_ping_message_size_bytes,
+    latency_ping_burst_size,
+    latency_ping_burst_count,
+    add_upstream_fabric_congestion_writers,
+    num_downstream_fabric_congestion_writers,
+    congestion_writers_message_size,
+    congestion_writers_use_mcast,
+    expected_mean_latency_ns,
+    expected_min_latency_ns,
+    expected_max_latency_ns,
+    expected_avg_hop_latency_ns,
+):
+    run_latency_test(
+        topology,
         line_size,
         latency_measurement_worker_line_index,
         latency_ping_message_size_bytes,

--- a/tests/ttnn/unit_tests/gtests/ccl/kernels/1D_fabric_loopback_latency_test_writer.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/kernels/1D_fabric_loopback_latency_test_writer.cpp
@@ -139,6 +139,7 @@ void kernel_main() {
             // Wait for the fabric endpoint to have a completely empty sender channel buffer
             if constexpr (!sem_inc_only && !enable_fused_payload_with_sync) {
                 if (burst_size > 1) {
+                    DPRINT << "STUCK\n";
                     while (1);  // invalid config -- hang instead of reporting garbage numbers
                 }
                 // Initialize to i + 1 so we can safely reset to 0 and not invalidate the first
@@ -170,7 +171,6 @@ void kernel_main() {
 
                 {
                     DeviceZoneScopedN("WAIT-FOR-ALL-SEMAPHORES");
-
                     if constexpr (!sem_inc_only && !enable_fused_payload_with_sync) {
                         noc_semaphore_wait_min(payload_l1_ptr, i + 1);
                     } else {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -5,6 +5,7 @@
 #include "tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp"
 #include <cstdint>
 #include <cstddef>
+#include <optional>
 
 // The writer that sends the packets that will have latency measured
 struct LatencyPacketTestWriterSpec {
@@ -25,11 +26,15 @@ struct WriterSpec {
 
 using LatencyTestWriterSpecs = std::vector<std::optional<WriterSpec>>;
 
+template <typename DEVICE_FIXTURE_T>
 inline void RunPersistent1dFabricLatencyTest(
     // Args for the measured writer
-    const LatencyTestWriterSpecs& writer_specs,
+    LatencyTestWriterSpecs writer_specs,
     size_t line_size,
-    bool enable_fused_payload_with_sync) {
+    bool enable_fused_payload_with_sync,
+    ttnn::ccl::Topology topology) {
+    const bool is_ring = topology == ttnn::ccl::Topology::Ring;
+    bool use_device_init_fabric = std::is_same_v<DEVICE_FIXTURE_T, Fabric1DRingDeviceInitFixture>;
     size_t num_links = 1;
 
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
@@ -42,18 +47,27 @@ inline void RunPersistent1dFabricLatencyTest(
     TT_FATAL(writer_specs.size() < line_size, "num_devices_with_workers must be less than or equal to num_links");
     using namespace ttnn::ccl;
 
-    Fabric1DFixture test_fixture;
+    DEVICE_FIXTURE_T test_fixture;
     auto view = test_fixture.mesh_device_->get_view();
 
-    std::vector<IDevice*> devices_ = {
-        view.get_device(MeshCoordinate(0, 0)),
-        view.get_device(MeshCoordinate(0, 1)),
-        view.get_device(MeshCoordinate(0, 2)),
-        view.get_device(MeshCoordinate(0, 3)),
-        view.get_device(MeshCoordinate(1, 3)),
-        view.get_device(MeshCoordinate(1, 2)),
-        view.get_device(MeshCoordinate(1, 1)),
-        view.get_device(MeshCoordinate(1, 0))};
+    std::vector<IDevice*> devices_;
+    if (line_size == 4) {
+        devices_ = {
+            view.get_device(MeshCoordinate(0, 1)),
+            view.get_device(MeshCoordinate(0, 2)),
+            view.get_device(MeshCoordinate(1, 2)),
+            view.get_device(MeshCoordinate(1, 1))};
+    } else {
+        devices_ = {
+            view.get_device(MeshCoordinate(0, 0)),
+            view.get_device(MeshCoordinate(0, 1)),
+            view.get_device(MeshCoordinate(0, 2)),
+            view.get_device(MeshCoordinate(0, 3)),
+            view.get_device(MeshCoordinate(1, 3)),
+            view.get_device(MeshCoordinate(1, 2)),
+            view.get_device(MeshCoordinate(1, 1)),
+            view.get_device(MeshCoordinate(1, 0))};
+    }
     std::vector<IDevice*> devices;
     std::vector<IDevice*> devices_with_workers;
     devices.reserve(line_size);
@@ -108,26 +122,27 @@ inline void RunPersistent1dFabricLatencyTest(
     for (auto d : devices) {
         log_info(tt::LogTest, "Launching fabric on device {}", d->id());
     }
-    std::vector<Program> dummy_worker_programs;
     std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
     std::optional<std::vector<Program>> fabric_programs;
     std::vector<Program*> fabric_program_ptrs;
     std::optional<ttnn::ccl::EdmLineFabricOpInterface> fabric_handle;
-    setup_test_with_persistent_fabric(
-        devices,
-        dummy_worker_programs,
-        subdevice_managers,
-        fabric_programs,
-        fabric_program_ptrs,
-        fabric_handle,
-        enable_persistent_fabric_mode,
-        num_links,
-        ttnn::ccl::Topology::Linear,
-        tt::tt_fabric::FabricEriscDatamoverBuilder::default_firmware_context_switch_interval,
-        true);
-
-    for (IDevice* d : devices) {
-        tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
+    if (!use_device_init_fabric) {
+        std::vector<Program> dummy_worker_programs;
+        setup_test_with_persistent_fabric(
+            devices,
+            dummy_worker_programs,
+            subdevice_managers,
+            fabric_programs,
+            fabric_program_ptrs,
+            fabric_handle,
+            enable_persistent_fabric_mode,
+            num_links,
+            topology,
+            tt::tt_fabric::FabricEriscDatamoverBuilder::default_firmware_context_switch_interval,
+            !is_ring,
+            use_device_init_fabric);
+    } else {
+        subdevice_managers = create_subdevices(devices);
     }
 
     // Other boiler plate setup
@@ -208,18 +223,27 @@ inline void RunPersistent1dFabricLatencyTest(
             log_info(tt::LogTest, "index: {} has datapath busy sender", i);
         }
 
-        IDevice* backward_device = i == 0 ? nullptr : devices.at(i - 1);
-        IDevice* forward_device = i == line_size - 1 ? nullptr : devices.at(i + 1);
+        IDevice* backward_device = i == 0 ? is_ring ? devices.at(line_size - 1) : nullptr : devices.at(i - 1);
+        IDevice* forward_device = i == line_size - 1 ? is_ring ? devices.at(0) : nullptr : devices.at(i + 1);
 
         // Initialize the fabric handle for worker connection
         bool start_of_line = line_index == 0;
         bool end_of_line = line_index == line_size - 1;
-        bool has_forward_connection = !end_of_line;
-        bool has_backward_connection = !start_of_line;
+        bool has_forward_connection = is_ring || !end_of_line;
+        bool has_backward_connection = is_ring || !start_of_line;
 
-        auto local_device_fabric_handle =
-            ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
-                device, forward_device, backward_device, &program, enable_persistent_fabric_mode, num_links);
+        std::optional<ttnn::ccl::EdmLineFabricOpInterface> local_device_fabric_handle;
+        if (!use_device_init_fabric) {
+            local_device_fabric_handle =
+                ttnn::ccl::EdmLineFabricOpInterface::build_program_builder_worker_connection_fabric(
+                    device,
+                    forward_device,
+                    backward_device,
+                    &program,
+                    enable_persistent_fabric_mode,
+                    num_links,
+                    topology);
+        }
 
         // reserve CB
         tt_metal::CircularBufferConfig cb_src0_config =
@@ -229,11 +253,13 @@ inline void RunPersistent1dFabricLatencyTest(
                 .set_page_size(packet_header_cb_index, sizeof(tt::tt_fabric::PacketHeader));
         CBHandle sender_workers_cb = CreateCircularBuffer(program, worker_cores, cb_src0_config);
 
-        TT_FATAL(
-            local_device_fabric_handle.get_num_links() == num_links,
-            "Error in test setup. Expected two links between devices but got {} links for device {}",
-            local_device_fabric_handle.get_num_links(),
-            device->id());
+        if (!use_device_init_fabric) {
+            TT_FATAL(
+                local_device_fabric_handle->get_num_links() == num_links,
+                "Error in test setup. Expected two links between devices but got {} links for device {}",
+                local_device_fabric_handle->get_num_links(),
+                device->id());
+        }
 
         std::vector<uint32_t> worker_ct_args = {};
         std::string kernel_path =
@@ -254,30 +280,49 @@ inline void RunPersistent1dFabricLatencyTest(
             program, kernel_path, worker_cores, tt_metal::WriterDataMovementConfig(worker_ct_args));
         worker_kernel_ids.push_back(worker_kernel_id);
 
-        auto build_connection_args = [&local_device_fabric_handle, device, &program, &worker_core_logical](
+        auto build_connection_args = [is_ring,
+                                      use_device_init_fabric,
+                                      &local_device_fabric_handle,
+                                      device,
+                                      forward_device,
+                                      backward_device,
+                                      &program,
+                                      &worker_core_logical](
                                          bool is_connected_in_direction,
                                          ttnn::ccl::EdmLineFabricOpInterface::Direction direction,
                                          std::vector<uint32_t>& rt_args_out) {
             rt_args_out.push_back(is_connected_in_direction);
-            if (is_connected_in_direction) {
-                const auto connection = local_device_fabric_handle.uniquely_connect_worker(device, direction);
-                const auto new_rt_args = ttnn::ccl::worker_detail::generate_edm_connection_rt_args(
-                    connection, program, {worker_core_logical});
-                log_info(
-                    tt::LogTest,
-                    "On device: {}, connecting to EDM fabric in {} direction. EDM noc_x: {}, noc_y: {}",
-                    device->id(),
-                    direction,
-                    connection.edm_noc_x,
-                    connection.edm_noc_y);
-                std::copy(new_rt_args.begin(), new_rt_args.end(), std::back_inserter(rt_args_out));
+            if (!use_device_init_fabric) {
+                if (is_connected_in_direction) {
+                    const auto connection = local_device_fabric_handle->uniquely_connect_worker(device, direction);
+                    const auto new_rt_args = ttnn::ccl::worker_detail::generate_edm_connection_rt_args(
+                        connection, program, {worker_core_logical});
+                    log_info(
+                        tt::LogTest,
+                        "On device: {}, connecting to EDM fabric in {} direction. EDM noc_x: {}, noc_y: {}",
+                        device->id(),
+                        direction,
+                        connection.edm_noc_x,
+                        connection.edm_noc_y);
+                    std::copy(new_rt_args.begin(), new_rt_args.end(), std::back_inserter(rt_args_out));
+                }
+            } else {
+                if (is_connected_in_direction) {
+                    tt::tt_fabric::append_fabric_connection_rt_args(
+                        device->id(),
+                        direction == ttnn::ccl::EdmLineFabricOpInterface::FORWARD ? forward_device->id()
+                                                                                  : backward_device->id(),
+                        0,
+                        program,
+                        {worker_core_logical},
+                        rt_args_out);
+                }
             }
         };
         // RT ARGS
         std::vector<uint32_t> rt_args = {};
         size_t dest_bank_addr = dest_buffer_addresses.at(i);
-        size_t loopback_distance_to_self = ((line_size - 1) - line_index) * 2;
-        size_t loopback_distance_to_start_of_line = ((line_size - 1) * 2) - line_index;
+        size_t loopback_distance_to_self = is_ring ? line_size : ((line_size - 1) - line_index) * 2;
         if (is_latency_packet_sender) {
             bool in_downstream_writers = false;
             std::vector<size_t> downstream_writer_semaphore_addresses;
@@ -382,10 +427,14 @@ inline void RunPersistent1dFabricLatencyTest(
     wait_for_worker_subdevice_program_completion(devices_with_workers, subdevice_managers);
     log_info(tt::LogTest, "Main op done");
 
-    TT_FATAL(fabric_programs->size() == devices.size(), "Expected fabric programs size to be same as devices size");
+    TT_FATAL(
+        is_ring || fabric_programs->size() == devices.size(),
+        "Expected fabric programs size to be same as devices size");
     log_info(tt::LogTest, "Fabric teardown");
-    persistent_fabric_teardown_sequence(
-        devices, subdevice_managers, fabric_handle.value(), tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE);
+    if (!use_device_init_fabric) {
+        persistent_fabric_teardown_sequence(
+            devices, subdevice_managers, fabric_handle.value(), tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE);
+    }
 
     log_info(tt::LogTest, "Waiting for teardown completion");
     for (IDevice* d : devices) {
@@ -417,16 +466,20 @@ int main(int argc, char** argv) {
     std::size_t congestion_writers_message_size = std::stoi(argv[arg_idx++]);
     bool congestion_writers_use_mcast = std::stoi(argv[arg_idx++]) != 0;
     bool enable_fused_payload_with_sync = std::stoi(argv[arg_idx++]) != 0;
+    std::string topology_str = argv[arg_idx++];
     TT_FATAL(arg_idx == argc, "Read past end of args or didn't read all args");
 
     uint32_t test_expected_num_devices = 8;
-    if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
+    size_t num_devices = tt::tt_metal::GetNumAvailableDevices();
+    bool is_6u = num_devices == 32;
+    if (num_devices < test_expected_num_devices) {
         tt::log_warning("This test can only be run on T3000 devices");
         return 1;
     }
 
-    auto compute_loopback_distance_to_start_of_line = [line_size](std::size_t line_index) {
-        return ((line_size - 1) * 2) - line_index;
+    const bool is_ring = topology_str == "ring";
+    auto compute_loopback_distance_to_start_of_line = [line_size, is_ring](std::size_t line_index) {
+        return is_ring ? line_size - 1 : ((line_size - 1) * 2) - line_index;
     };
 
     LatencyTestWriterSpecs writer_specs(line_size - 1, std::nullopt);
@@ -469,7 +522,8 @@ int main(int argc, char** argv) {
     for (size_t i = 0; i < num_downstream_fabric_congestion_writers; i++) {
         TT_FATAL(congestion_writers_message_size != 0, "downstream congestion writer message size must be non-zero");
         size_t downstream_worker_line_index = latency_measurement_worker_line_index + 1 + i;
-        size_t distance = downstream_worker_line_index - latency_measurement_worker_line_index;
+        size_t distance =
+            is_ring ? line_size - 1 : downstream_worker_line_index - latency_measurement_worker_line_index;
         writer_specs.at(downstream_worker_line_index) = WriterSpec{
             .spec =
                 DatapathBusyDataWriterSpec{
@@ -481,5 +535,28 @@ int main(int argc, char** argv) {
             .message_size_bytes = congestion_writers_message_size};
     }
 
-    RunPersistent1dFabricLatencyTest(writer_specs, line_size, enable_fused_payload_with_sync);
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear;
+    if (topology_str == "linear") {
+        topology = ttnn::ccl::Topology::Linear;
+    } else if (topology_str == "ring") {
+        topology = ttnn::ccl::Topology::Ring;
+    } else if (topology_str == "mesh") {
+        topology = ttnn::ccl::Topology::Mesh;
+        TT_THROW("Topology \"mesh\" is currently unsupported.");
+    } else {
+        TT_THROW("Invalid topology: {}", topology_str);
+    }
+
+    if (is_ring) {
+        if (is_6u) {
+            RunPersistent1dFabricLatencyTest<Fabric1DRingDeviceInitFixture>(
+                writer_specs, line_size, enable_fused_payload_with_sync, topology);
+        } else {
+            RunPersistent1dFabricLatencyTest<Fabric1DFixture>(
+                writer_specs, line_size, enable_fused_payload_with_sync, topology);
+        }
+    } else {
+        RunPersistent1dFabricLatencyTest<Fabric1DFixture>(
+            writer_specs, line_size, enable_fused_payload_with_sync, topology);
+    }
 }


### PR DESCRIPTION
Adds fabric latency tests for ring topology fabric. This is only the initial ring latency test and it does not optimize for worker or ethernet core placement. Therefore, the latency numbers are currently conservative. The latency number includes noc hop latency, erisc router processing time, ethernet link latency, and receiver core router processing time.

Current measured latency numbers are around 780-800ns per hop, which is several 10s of ns more than the line topology. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI: https://github.com/tenstorrent/tt-metal/actions/runs/14564588194
- [x] Metal microbenchmark: https://github.com/tenstorrent/tt-metal/actions/runs/14564589826

closes #20217