### PR TITLE
#20247: Fix device write with small page

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
@@ -55,6 +55,8 @@ namespace tt::tt_metal {
 TEST_F(DeviceFixture, TestSimpleDramBufferReadOnlyLo) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         size_t lo_address = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+        ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), lo_address, 1));
+        ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), lo_address, 2));
         ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), lo_address, 4));
         ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), lo_address, 8));
         ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), lo_address, 16));
@@ -66,6 +68,8 @@ TEST_F(DeviceFixture, TestSimpleDramBufferReadOnlyLo) {
 TEST_F(DeviceFixture, TestSimpleDramBufferReadOnlyHi) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         size_t hi_address = this->devices_.at(id)->dram_size_per_channel() - (16 * 1024);
+        ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), hi_address, 1));
+        ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), hi_address, 2));
         ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), hi_address, 4));
         ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), hi_address, 8));
         ASSERT_TRUE(SimpleDramReadOnly(this->devices_.at(id), hi_address, 16));
@@ -77,6 +81,8 @@ TEST_F(DeviceFixture, TestSimpleDramBufferReadOnlyHi) {
 TEST_F(DeviceFixture, TestSimpleDramBufferWriteOnlyLo) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         size_t lo_address = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+        ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), lo_address, 1));
+        ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), lo_address, 2));
         ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), lo_address, 4));
         ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), lo_address, 8));
         ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), lo_address, 16));
@@ -88,6 +94,8 @@ TEST_F(DeviceFixture, TestSimpleDramBufferWriteOnlyLo) {
 TEST_F(DeviceFixture, TestSimpleDramBufferWriteOnlyHi) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         size_t hi_address = this->devices_.at(id)->dram_size_per_channel() - (16 * 1024);
+        ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), hi_address, 1));
+        ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), hi_address, 2));
         ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), hi_address, 4));
         ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), hi_address, 8));
         ASSERT_TRUE(SimpleDramWriteOnly(this->devices_.at(id), hi_address, 16));

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -511,7 +511,7 @@ void WriteToDeviceInterleavedContiguous(const Buffer& buffer, tt::stl::Span<cons
     uint32_t bank_index = 0;
     int data_index = 0;
     std::vector<uint32_t> page;
-    page.resize(page_size / sizeof(uint32_t));
+    page.resize(std::max<uint32_t>(page_size / sizeof(uint32_t), 1));
     for (int page_index = 0; page_index < num_pages; page_index++) {
         const DeviceAddr address = CalculateAddressDeviceInterleavedContiguous(buffer, bank_index, page_index);
         std::memcpy(page.data(), host_buffer.data() + data_index, page_size);


### PR DESCRIPTION
### Ticket
#20247

### Problem description
Writing from host to device fails when the page is very small. Page size is 2 bytes. 

### What's changed
Fixed page vector size calc to be a minimum of 1. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes