### PR TITLE
tt_transformets/tt/model_config: Fix typo in parse_optimization

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -238,7 +238,7 @@ def parse_optimizations(string):
     model_opt = ModelOptimizations(settings)
 
     def apply_settings(model_args):
-        return DecodersPrecision(model_args.n_layers, model_arg.model_name, model_opt)
+        return DecodersPrecision(model_args.n_layers, model_args.model_name, model_opt)
 
     apply_settings.__name__ = model_opt.__name__
     return apply_settings


### PR DESCRIPTION
### Problem description
In a recent PR that I merged (https://github.com/tenstorrent/tt-metal/pull/20643), there was a typo that affected the `--optimizations` option (and as a consequence also the `pareto` option in the `lt` tool)

### What's changed
This PR fixes this typo