### PR TITLE
#20704: remove unpad_from_tile from fast reduce test

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_fast_reduce_nc.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_fast_reduce_nc.py
@@ -80,7 +80,7 @@ def test_fast_reduce_nc(input_shape, dims, compute_kernel_options, dataformat, d
     tt_output = ttnn.experimental.fast_reduce_nc(
         tt_input, dims=dims, output=None, compute_kernel_config=compute_kernel_config
     )
-    tt_output_cpu = tt_output.cpu().to(cpu_layout).unpad_from_tile(output_shape).to_torch()
+    tt_output_cpu = tt_output.cpu().to(cpu_layout).to_torch()
 
     # test for equivalance
     rtol = atol = 0.12


### PR DESCRIPTION
### Ticket
Link to Github Issue #20704

### Problem description
Nightly Debug APC was reporting an error because of an assert

### What's changed
Remove the call in the test that was causing the assert, which just did some post-processing that seems unnecessary. The test passes without the call. A separate issue has been created to look at the assert separately.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14577443376
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes