### PR TITLE
#19458:sentenceBERT Perf,trace tests

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -70,6 +70,7 @@ jobs:
           pytest models/demos/squeezebert/tests -m models_device_performance_bare_metal
           pytest models/demos/roberta/tests/ -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/resnet50/tests -m models_device_performance_bare_metal
+          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/sentence_bert/tests -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/functional_unet/tests/test_unet_perf.py -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/wormhole/mamba/tests -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/metal_BERT_large_11/tests -m models_device_performance_bare_metal

--- a/models/experimental/sentence_bert/README.md
+++ b/models/experimental/sentence_bert/README.md
@@ -1,24 +1,42 @@
 # SentenceBERT Model
 
-### Platforms:
+## Platforms:
     WH N300,N150
 
-### Introduction
+## Introduction
 
 **bert-base-turkish-cased-mean-nli-stsb-tr** is a SentenceBERT-based model fine-tuned for semantic textual similarity and natural language inference tasks in Turkish. Built on a cased BERT architecture, it leverages mean pooling to generate dense sentence embeddings, enabling efficient and accurate sentence-level understanding. Optimized for performance in real-world NLP applications such as semantic search, clustering, and question answering.
 
 Resource link - [source](https://huggingface.co/emrecan/bert-base-turkish-cased-mean-nli-stsb-tr)
 
-### Model Details
+## Model Details
+The entry point to the SentenceBERT model is located at:`models/experimental/sentence_bert/ttnn/ttnn_sentence_bert.py`
+- Sequence Length: 384
+-  Batch size: 8
 
-- The entry point to the SentenceBERT is located at:`models/experimental/sentence_bert/ttnn/ttnn_sentence_bert.py`
+## How to Run:
+If running on Wormhole N300 (not required for N150 or Blackhole), the following environment variable needs to be set as the model requires at least 8x8 core grid size:
+```sh
+export WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+```
 
-Export the following command before running pytests:
-
-`WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml`
+### Build Command to Use:
+To obtain the perf reports through profiler, please build with following command:
+```
+./build_metal.sh -p
+```
 
 Use the following command to run the model :
 
-`pytest tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_model.py:test_ttnn_sentence_bert_model`
+```
+pytest --disable-warnings tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_model.py::test_ttnn_sentence_bert_model
+```
 
-Note : The model currently supports a batch size of 8 for a sequence length of 384.
+##  Performant Model with Trace+2CQ
+- end-2-end perf is 403 sentences per second
+
+Use the following command to run the performant Model with Trace+2CQ:
+
+```
+pytest --disable-warnings models/experimental/sentence_bert/tests/test_sentence_bert_e2e_performant.py
+```

--- a/models/experimental/sentence_bert/reference/sentence_bert.py
+++ b/models/experimental/sentence_bert/reference/sentence_bert.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,6 +6,7 @@ import math
 from typing import List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
+from models.experimental.functional_common.attention_mask_functions import get_extended_attention_mask
 
 
 class BaseModelOutputWithPoolingAndCrossAttentions:
@@ -576,10 +577,8 @@ class BertModel(nn.Module):
         )
 
 
-def custom_extended_mask(mask, tgt_len=None, dtype=torch.bfloat16):
-    batch_size, seq_length = mask.shape
-    tgt_len = tgt_len if tgt_len is not None else seq_length
-    expanded_mask = mask[:, None, None, :].expand(batch_size, 1, tgt_len, seq_length).to(dtype)
-    inverted_mask = 1.0 - expanded_mask
-    inverted_mask.masked_fill(inverted_mask.to(torch.bool), torch.finfo(dtype).min)
-    return inverted_mask
+def custom_extended_mask(mask, dtype=torch.float32):
+    attention_mask_extended = get_extended_attention_mask(mask, mask.shape, dtype)
+    attention_mask_extended = attention_mask_extended.expand((mask.shape[0], -1, -1, -1))
+    attention_mask_extended = torch.clamp(attention_mask_extended, min=-100000)
+    return attention_mask_extended

--- a/models/experimental/sentence_bert/tests/sentence_bert_e2e_performant.py
+++ b/models/experimental/sentence_bert/tests/sentence_bert_e2e_performant.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.sentence_bert.tests.sentence_bert_test_infra import create_test_infra
+
+try:
+    pass
+
+    use_signpost = True
+except ModuleNotFoundError:
+    use_signpost = False
+
+
+class SentenceBERTrace2CQ:
+    def __init__(self):
+        ...
+
+    def initialize_sentence_bert_trace_2cqs_inference(
+        self, device, device_batch_size=8, act_dtype=ttnn.bfloat16, weight_dtype=ttnn.bfloat16, sequence_length=384
+    ):
+        self.test_infra = create_test_infra(device, device_batch_size, sequence_length)
+        self.device = device
+        self.tt_inputs_host, self.input_mem_config = self.test_infra.setup_l1_sharded_input(device)
+        self.tt_image_res = self.tt_inputs_host.to(device, ttnn.DRAM_MEMORY_CONFIG)
+        self.op_event = ttnn.record_event(device, 0)
+
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        spec = self.test_infra.input_tensor.spec
+        self.op_event = ttnn.record_event(device, 0)
+        self.test_infra.run()
+        self.test_infra.validate()
+        self.test_infra.output_tensor_1[0].deallocate(force=True)
+
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(device, 0)
+        self.test_infra.run()
+        self.test_infra.validate()
+
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(device, 0)
+        self.test_infra.output_tensor_1[0].deallocate(force=True)
+        trace_input_addr = self.test_infra.input_tensor.buffer_address()
+        self.tid = ttnn.begin_trace_capture(device, cq_id=0)
+        self.test_infra.run()
+        self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
+        ttnn.end_trace_capture(device, self.tid, cq_id=0)
+        assert trace_input_addr == self.input_tensor.buffer_address()
+
+    def execute_sentence_bert_trace_2cqs_inference(self, tt_inputs_host=None):
+        ttnn.wait_for_event(1, self.op_event)
+
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        if self.tt_image_res.is_sharded():
+            self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
+        self.op_event = ttnn.record_event(self.device, 0)
+        ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
+        outputs = ttnn.from_device(self.test_infra.output_tensor_1[0], blocking=True)
+
+        return outputs
+
+    def release_sentence_bert_trace_2cqs_inference(self):
+        ttnn.release_trace(self.device, self.tid)

--- a/models/experimental/sentence_bert/tests/sentence_bert_performant.py
+++ b/models/experimental/sentence_bert/tests/sentence_bert_performant.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import ttnn
+from models.experimental.sentence_bert.tests.sentence_bert_test_infra import create_test_infra
+
+try:
+    from tracy import signpost
+
+    use_signpost = True
+
+except ModuleNotFoundError:
+    use_signpost = False
+
+
+def run_sentence_bert_inference(device, device_batch_size, sequence_length):
+    test_infra = create_test_infra(device, device_batch_size, sequence_length)
+
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+
+    # First run configures convs JIT
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+
+    test_infra.run()
+    test_infra.validate()
+    test_infra.dealloc_output()
+    # Optimized run
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    test_infra.validate()
+    test_infra.dealloc_output()
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    if use_signpost:
+        signpost(header="stop")
+    test_infra.validate()
+    test_infra.dealloc_output()
+
+
+def run_sentence_bert_trace_inference(device, device_batch_size, sequence_length):
+    test_infra = create_test_infra(device, device_batch_size, sequence_length)
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+
+    # First run configures convs JIT
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    spec = test_infra.input_tensor.spec
+    test_infra.run()
+    test_infra.validate()
+    test_infra.dealloc_output()
+
+    # Optimized run
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    test_infra.validate()
+    # Capture
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+
+    test_infra.dealloc_output()
+    trace_input_addr = test_infra.input_tensor.buffer_address()
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    test_infra.run()
+    tt_image_res = ttnn.allocate_tensor_on_device(spec, device)
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert trace_input_addr == tt_image_res.buffer_address()
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+    if use_signpost:
+        signpost(header="stop")
+    test_infra.validate()
+
+    ttnn.release_trace(device, tid)
+    test_infra.dealloc_output()
+
+
+def run_sentence_bert_trace_2cqs_inference(device, device_batch_size, sequence_length):
+    test_infra = create_test_infra(device, device_batch_size, sequence_length)
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+    tt_image_res = tt_inputs_host.to(device, ttnn.DRAM_MEMORY_CONFIG)
+    # Initialize the op event so we can write
+    op_event = ttnn.record_event(device, 0)
+    # First run configures convs JIT
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    write_event = ttnn.record_event(device, 1)
+    ttnn.wait_for_event(0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    spec = test_infra.input_tensor.spec
+    op_event = ttnn.record_event(device, 0)
+    test_infra.run()
+    test_infra.validate()
+    test_infra.dealloc_output()
+    # Optimized run
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    write_event = ttnn.record_event(device, 1)
+    ttnn.wait_for_event(0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    op_event = ttnn.record_event(device, 0)
+    test_infra.run()
+    test_infra.validate()
+    # Capture
+    ttnn.wait_for_event(1, op_event)
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+    write_event = ttnn.record_event(device, 1)
+    ttnn.wait_for_event(0, write_event)
+    test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
+    op_event = ttnn.record_event(device, 0)
+    test_infra.dealloc_output()
+    trace_input_addr = test_infra.input_tensor.buffer_address()
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    test_infra.run()
+    input_tensor = ttnn.allocate_tensor_on_device(spec, device)
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert trace_input_addr == input_tensor.buffer_address()
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    for iter in range(0, 2):
+        ttnn.wait_for_event(1, op_event)
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 1)
+        write_event = ttnn.record_event(device, 1)
+        ttnn.wait_for_event(0, write_event)
+        if tt_image_res.is_sharded():
+            input_tensor = ttnn.reshard(tt_image_res, input_mem_config, input_tensor)
+        op_event = ttnn.record_event(device, 0)
+        ttnn.execute_trace(device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+
+    if use_signpost:
+        signpost(header="stop")
+
+    ttnn.release_trace(device, tid)

--- a/models/experimental/sentence_bert/tests/sentence_bert_test_infra.py
+++ b/models/experimental/sentence_bert/tests/sentence_bert_test_infra.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+from loguru import logger
+import transformers
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import is_wormhole_b0
+from models.experimental.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
+from models.experimental.sentence_bert.ttnn.ttnn_sentence_bert_model import TtnnSentenceBertModel
+from models.experimental.sentence_bert.ttnn.common import custom_preprocessor, preprocess_inputs
+from ttnn.model_preprocessing import preprocess_model_parameters
+
+
+def load_reference_model(config):
+    torch_model = transformers.AutoModel.from_pretrained("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr").eval()
+    reference_model = BertModel(config).to(torch.bfloat16)
+    reference_model.load_state_dict(torch_model.state_dict())
+    return reference_model
+
+
+def load_ttnn_model(device, torch_model, config):
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: torch_model,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    ttnn_model = TtnnSentenceBertModel(parameters=parameters, config=config)
+    return ttnn_model
+
+
+class SentenceBERTTestInfra:
+    def __init__(self, device, batch_size, sequence_length):
+        super().__init__()
+        torch.manual_seed(0)
+        self.pcc_passed = False
+        self.pcc_message = "Did you forget to call validate()?"
+        self.device = device
+        self.batch_size = batch_size
+        self.sequence_length = sequence_length
+        config = transformers.BertConfig.from_pretrained("emrecan/bert-base-turkish-cased-mean-nli-stsb-tr")
+        input_ids = torch.randint(
+            low=0, high=config.vocab_size - 1, size=[self.batch_size, self.sequence_length], dtype=torch.int64
+        )
+        attention_mask = torch.ones(self.batch_size, self.sequence_length)
+        extended_mask = custom_extended_mask(attention_mask, dtype=torch.bfloat16)
+        token_type_ids = torch.zeros([self.batch_size, self.sequence_length], dtype=torch.int64)
+        position_ids = torch.arange(0, self.sequence_length, dtype=torch.int64).unsqueeze(dim=0)
+        self.torch_input_tensor = input_ids
+        reference_model = load_reference_model(config)
+        (
+            self.ttnn_input_ids,
+            self.ttnn_token_type_ids,
+            self.ttnn_position_ids,
+            self.ttnn_attention_mask,
+        ) = preprocess_inputs(input_ids, token_type_ids, position_ids, extended_mask, device)
+        self.ttnn_model = load_ttnn_model(self.device, reference_model, config)
+        torch_out = reference_model(
+            input_ids, attention_mask=extended_mask, token_type_ids=token_type_ids, position_ids=position_ids
+        )
+        self.torch_output_tensor_1, self.torch_output_tensor_2 = torch_out.last_hidden_state, torch_out.pooler_output
+
+    def run(self):
+        self.output_tensor_1 = self.ttnn_model(
+            self.input_tensor,
+            self.ttnn_attention_mask,
+            self.ttnn_token_type_ids,
+            self.ttnn_position_ids,
+            device=self.device,
+        )
+
+    def setup_l1_sharded_input(self, device, torch_input_tensor=None):
+        if is_wormhole_b0():
+            core_grid = ttnn.CoreGrid(y=8, x=8)
+        else:
+            exit("Unsupported device")
+        torch_input_tensor = self.torch_input_tensor if torch_input_tensor is None else torch_input_tensor
+        torch_input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.uint32)
+        input_memory_config = ttnn.create_sharded_memory_config(
+            torch_input_tensor.shape,
+            core_grid=device.core_grid,
+            strategy=ttnn.ShardStrategy.BLOCK,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        )
+
+        return torch_input_tensor, input_memory_config
+
+    def validate(self, output_tensor=None):
+        output_tensor_1 = ttnn.to_torch(self.output_tensor_1[0]).squeeze(dim=1)
+        valid_pcc = 0.98
+        self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output_tensor_1, output_tensor_1, pcc=valid_pcc)
+
+        logger.info(f"sentence bert batch_size={self.batch_size}, PCC={self.pcc_message}")
+
+    def dealloc_output(self):
+        ttnn.deallocate(self.output_tensor_1[0])
+
+
+def create_test_infra(device, batch_size, sequence_length):
+    return SentenceBERTTestInfra(device, batch_size, sequence_length)

--- a/models/experimental/sentence_bert/tests/test_sentence_bert_e2e_performant.py
+++ b/models/experimental/sentence_bert/tests/test_sentence_bert_e2e_performant.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import time
+import torch
+import transformers
+from loguru import logger
+from models.utility_functions import run_for_wormhole_b0
+from models.experimental.sentence_bert.tests.sentence_bert_e2e_performant import SentenceBERTrace2CQ
+from models.experimental.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
+from models.experimental.sentence_bert.ttnn.ttnn_sentence_bert_model import TtnnSentenceBertModel
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.experimental.sentence_bert.ttnn.common import custom_preprocessor, preprocess_inputs
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize("batch_size, sequence_length", [(8, 384)])
+@pytest.mark.parametrize(
+    "inputs",
+    [["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384]]],
+)
+def test_run_sentence_bert_trace_2cqs_inference(
+    device,
+    use_program_cache,
+    batch_size,
+    inputs,
+    sequence_length,
+    model_location_generator,
+):
+    sentence_bert_trace_2cq = SentenceBERTrace2CQ()
+
+    sentence_bert_trace_2cq.initialize_sentence_bert_trace_2cqs_inference(
+        device, sequence_length=sequence_length, device_batch_size=batch_size, weight_dtype=ttnn.bfloat8_b
+    )
+
+    transformers_model = transformers.AutoModel.from_pretrained(inputs[0]).eval()
+    config = transformers.BertConfig.from_pretrained(inputs[0])
+    input_ids = torch.randint(low=0, high=config.vocab_size - 1, size=inputs[1], dtype=torch.int64)
+    attention_mask = torch.randint(0, inputs[1][0], size=inputs[1], dtype=torch.int64)
+    extended_mask = custom_extended_mask(attention_mask, dtype=torch.bfloat16)
+    token_type_ids = torch.zeros(inputs[1], dtype=torch.int64)
+    position_ids = torch.arange(0, inputs[1][1], dtype=torch.int64).unsqueeze(dim=0)
+    reference_module = BertModel(config).to(torch.bfloat16)
+    reference_module.load_state_dict(transformers_model.state_dict())
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: reference_module,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    ttnn_module = TtnnSentenceBertModel(parameters=parameters, config=config)
+    ttnn_input_ids, ttnn_token_type_ids, ttnn_position_ids, ttnn_attention_mask = preprocess_inputs(
+        input_ids, token_type_ids, position_ids, extended_mask, device
+    )
+    ttnn_input_ids = ttnn.from_device(ttnn_input_ids)
+    inference_iter_count = 10
+    inference_time_iter = []
+    for iter in range(0, inference_iter_count):
+        t0 = time.time()
+        output = sentence_bert_trace_2cq.execute_sentence_bert_trace_2cqs_inference(ttnn_input_ids)
+        t1 = time.time()
+        inference_time_iter.append(t1 - t0)
+    sentence_bert_trace_2cq.release_sentence_bert_trace_2cqs_inference()
+    inference_time_avg = round(sum(inference_time_iter) / len(inference_time_iter), 6)
+    logger.info(
+        f"ttnn_sentence_bert inference iteration time (sec): {inference_time_avg}, Sentence per sec: {round(batch_size/inference_time_avg)}"
+    )

--- a/models/experimental/sentence_bert/tests/test_sentence_bert_perf.py
+++ b/models/experimental/sentence_bert/tests/test_sentence_bert_perf.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import time
+import torch
+import transformers
+import pytest
+from loguru import logger
+from models.perf.perf_utils import prep_perf_report
+from models.experimental.sentence_bert.ttnn.ttnn_sentence_bert_model import TtnnSentenceBertModel
+from models.experimental.sentence_bert.reference.sentence_bert import BertModel, custom_extended_mask
+from models.utility_functions import (
+    enable_persistent_kernel_cache,
+    run_for_wormhole_b0,
+    is_wormhole_b0,
+)
+from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.experimental.sentence_bert.ttnn.common import custom_preprocessor, preprocess_inputs
+
+
+def get_expected_times(name):
+    base = {"sentence_bert": (12.1, 0.14)}
+    return base[name]
+
+
+@run_for_wormhole_b0()
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "inputs",
+    [["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384]]],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+def test_ttnn_sentence_bert_perf(device, inputs):
+    transformers_model = transformers.AutoModel.from_pretrained(inputs[0]).eval()
+    config = transformers.BertConfig.from_pretrained(inputs[0])
+    input_ids = torch.randint(low=0, high=config.vocab_size - 1, size=inputs[1], dtype=torch.int64)
+    attention_mask = torch.ones(inputs[1][0], inputs[1][1])
+    extended_mask = custom_extended_mask(attention_mask, dtype=torch.bfloat16)
+    token_type_ids = torch.zeros(inputs[1], dtype=torch.int64)
+    position_ids = torch.arange(0, inputs[1][1], dtype=torch.int64).unsqueeze(dim=0)
+    reference_module = BertModel(config).to(torch.bfloat16)
+    reference_module.load_state_dict(transformers_model.state_dict())
+    parameters = preprocess_model_parameters(
+        initialize_model=lambda: reference_module,
+        custom_preprocessor=custom_preprocessor,
+        device=device,
+    )
+    ttnn_module = TtnnSentenceBertModel(parameters=parameters, config=config)
+    ttnn_input_ids, ttnn_token_type_ids, ttnn_position_ids, ttnn_attention_mask = preprocess_inputs(
+        input_ids, token_type_ids, position_ids, extended_mask, device
+    )
+    durations = []
+    for i in range(2):
+        start = time.time()
+        ttnn_model_output = ttnn_module(
+            ttnn_input_ids, ttnn_attention_mask, ttnn_token_type_ids, ttnn_position_ids, device=device
+        )
+        end = time.time()
+        durations.append(end - start)
+        for outputs in ttnn_model_output:
+            ttnn.deallocate(outputs)
+        enable_persistent_kernel_cache()
+
+    inference_and_compile_time, inference_time, *_ = durations
+
+    expected_compile_time, expected_inference_time = get_expected_times("sentence_bert")
+
+    prep_perf_report(
+        model_name="models/experimental/sentence_bert",
+        batch_size=inputs[1][0],
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="",
+        inference_time_cpu=0.0,
+    )
+
+    logger.info(f"Compile time: {inference_and_compile_time - inference_time}")
+    logger.info(f"Inference time: {inference_time}")
+    logger.info(f"Sentences per second: {1 / inference_time *inputs[1][0] }")  #
+    assert (
+        inference_time < expected_inference_time
+    ), f"Expected inference time: {expected_inference_time} Actual inference time: {inference_time}"
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "batch_size, expected_perf,test",
+    [
+        [8, 456.5, "sentence_bert"],
+    ],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_perf_device_bare_metal_sentence_bert(batch_size, expected_perf, test):
+    subdir = "ttnn_sentence_bert_model"
+    num_iterations = 1
+    margin = 0.03
+    expected_perf = expected_perf if is_wormhole_b0() else 0
+
+    command = f"pytest tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_model.py::test_ttnn_sentence_bert_model"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    expected_perf_cols = {inference_time_key: expected_perf}
+
+    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
+
+    logger.info(f"{expected_results}")
+
+    prep_device_perf_report(
+        model_name=f"ttnn_sentence_bert{batch_size}",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments=test.replace("/", "_"),
+    )

--- a/models/experimental/sentence_bert/tests/test_sentence_bert_performant.py
+++ b/models/experimental/sentence_bert/tests/test_sentence_bert_performant.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from models.experimental.sentence_bert.tests.sentence_bert_performant import (
+    run_sentence_bert_inference,
+    run_sentence_bert_trace_inference,
+    run_sentence_bert_trace_2cqs_inference,
+)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
+@pytest.mark.parametrize("device_batch_size, sequence_length", [(8, 384)])
+def test_run_sentence_bert_inference(
+    device,
+    device_batch_size,
+    sequence_length,
+    use_program_cache,
+):
+    run_sentence_bert_inference(device, device_batch_size, sequence_length)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 3686400}], indirect=True)
+@pytest.mark.parametrize("device_batch_size, sequence_length", [(8, 384)])
+def test_run_sentence_bert_trace_inference(
+    device,
+    device_batch_size,
+    sequence_length,
+    use_program_cache,
+):
+    run_sentence_bert_trace_inference(device, device_batch_size, sequence_length)
+
+
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 6397952, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize("device_batch_size, sequence_length", [(8, 384)])
+def test_run_sentence_bert_trace_2cq_inference(
+    device,
+    device_batch_size,
+    sequence_length,
+    use_program_cache,
+):
+    run_sentence_bert_trace_2cqs_inference(
+        device=device, device_batch_size=device_batch_size, sequence_length=sequence_length
+    )

--- a/models/experimental/sentence_bert/ttnn/common.py
+++ b/models/experimental/sentence_bert/ttnn/common.py
@@ -1,75 +1,107 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
 import torch
-from ttnn.model_preprocessing import (
-    preprocess_linear_bias,
-    preprocess_linear_weight,
-)
 
 layernorm_program_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
-    compute_with_storage_grid_size=(8, 8),
-    subblock_w=3,
+    compute_with_storage_grid_size=(6, 8),
+    subblock_w=4,
     block_h=12,
-    block_w=3,
+    block_w=4,
     inplace=True,
 )
 
 ff1_matmul_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-    compute_with_storage_grid_size=(8, 8),
-    in0_block_w=3,
+    compute_with_storage_grid_size=(6, 8),
+    in0_block_w=4,
     out_subblock_h=1,
     out_subblock_w=8,
     per_core_M=12,
     per_core_N=16,
-    transpose_mcast=True,
+    transpose_mcast=False,
     fused_activation=(ttnn.UnaryOpType.GELU, True),
 )
 
 ff2_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-    compute_with_storage_grid_size=(8, 8),
+    compute_with_storage_grid_size=(6, 8),
     in0_block_w=4,
     out_subblock_h=1,
     out_subblock_w=6,
     per_core_M=12,
     per_core_N=12,
-    transpose_mcast=True,
+    transpose_mcast=False,
     fused_activation=None,
 )
 
 query_key_value_matmul_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-    compute_with_storage_grid_size=(8, 8),
-    in0_block_w=3,
+    compute_with_storage_grid_size=(6, 8),
+    in0_block_w=4,
     out_subblock_h=1,
     out_subblock_w=6,
     per_core_M=12,
     per_core_N=12,
-    transpose_mcast=True,
+    transpose_mcast=False,
     fused_activation=None,
+)
+
+self_out_program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+    compute_with_storage_grid_size=(6, 8),
+    in0_block_w=4,
+    out_subblock_h=2,
+    out_subblock_w=4,
+    per_core_M=12,
+    per_core_N=4,
+    transpose_mcast=False,
+    fused_activation=None,
+)
+pre_softmax_config = ttnn.MatmulMultiCoreReuseProgramConfig(
+    compute_with_storage_grid_size=(6, 8),
+    in0_block_w=2,
+    out_subblock_h=1,
+    out_subblock_w=6,
+    per_core_M=24,
+    per_core_N=12,
+)
+softmax_config = ttnn.SoftmaxShardedMultiCoreProgramConfig(
+    compute_with_storage_grid_size=(6, 8),
+    subblock_w=6,
+    block_h=24,
+    block_w=12,
 )
 
 
 def custom_preprocessor(torch_model, name):
     parameters = {}
     if hasattr(torch_model, "query") and hasattr(torch_model, "key") and hasattr(torch_model, "value"):
-        qkv_weight = torch.cat(
-            [
-                torch_model.query.weight,
-                torch_model.key.weight,
-                torch_model.value.weight,
-            ],
-            dim=0,
-        )
-        qkv_bias = torch.cat(
-            [torch_model.query.bias, torch_model.key.bias, torch_model.value.bias],
-            dim=0,
-        )
+        qw = torch_model.query.weight
+        kw = torch_model.key.weight
+        vw = torch_model.value.weight
+        qb = torch_model.query.bias
+        kb = torch_model.key.bias
+        vb = torch_model.value.bias
+        qw = torch.transpose(qw, -1, -2)
+        kw = torch.transpose(kw, -1, -2)
+        vw = torch.transpose(vw, -1, -2)
+        const_w_dims = qw.shape[:-1]
+        qw = qw.reshape([*const_w_dims, 6, -1])  # nums_attention_heads// 2
+        kw = kw.reshape(qw.shape)
+        vw = vw.reshape(qw.shape)
+        qkv_weight_torch = torch.cat((qw, kw, vw), -1).reshape([*const_w_dims, -1])
+        const_b_dims = qb.shape[:-1]
+        qb = qb.reshape([*const_b_dims, 6, -1])  # nums_attention_heads// 2
+        kb = kb.reshape(qb.shape)
+        vb = vb.reshape(qb.shape)
+        qkv_bias_torch = torch.cat((qb, kb, vb), -1).reshape([*const_b_dims, -1])
 
         parameters = {"query_key_value": {}}
-        parameters["query_key_value"]["weight"] = preprocess_linear_weight(qkv_weight, dtype=ttnn.bfloat16)
-        parameters["query_key_value"]["bias"] = preprocess_linear_bias(qkv_bias, dtype=ttnn.bfloat16)
+        parameters["query_key_value"]["weight"] = ttnn.from_torch(
+            qkv_weight_torch, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT
+        )
+        parameters["query_key_value"]["bias"] = ttnn.from_torch(
+            qkv_bias_torch, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT
+        )
 
     return parameters
 
@@ -91,6 +123,6 @@ def preprocess_inputs(
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
     )
     return input_ids, token_type_ids, position_ids, attention_mask

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentence_bert_model.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentence_bert_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -23,18 +23,6 @@ class TtnnSentenceBertModel:
         device=None,
     ):
         embedding_output = self.embeddings(input_ids, token_type_ids, position_ids, device=device)
-        encoder_input = ttnn.to_memory_config(
-            embedding_output,
-            memory_config=ttnn.create_sharded_memory_config(
-                embedding_output.shape,
-                core_grid=device.core_grid,
-                strategy=ttnn.ShardStrategy.BLOCK,
-                orientation=ttnn.ShardOrientation.COL_MAJOR,
-            ),
-        )
+        sequence_output = self.encoder(embedding_output, attention_mask, device=device)
         ttnn.deallocate(embedding_output)
-        sequence_output = self.encoder(encoder_input, attention_mask, device=device)
-        ttnn.deallocate(encoder_input)
-        sequence_output = ttnn.to_memory_config(sequence_output, ttnn.L1_MEMORY_CONFIG)
-        pooled_output = self.pooler(sequence_output)
-        return (sequence_output, pooled_output)
+        return (sequence_output,)

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_attention.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_attention.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,14 +19,5 @@ class TtnnSentenceBertAttention:
         device=None,
     ):
         self_outputs = self.self(hidden_states, attention_mask, device=device)
-        self_outputs = ttnn.to_memory_config(
-            self_outputs,
-            memory_config=ttnn.create_sharded_memory_config(
-                self_outputs.shape,
-                core_grid=device.core_grid,
-                strategy=ttnn.ShardStrategy.BLOCK,
-                orientation=ttnn.ShardOrientation.COL_MAJOR,
-            ),
-        )
         self_outputs = self.output(self_outputs, hidden_states)
         return self_outputs

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_embeddings.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_embeddings.py
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
+from models.experimental.sentence_bert.ttnn.common import layernorm_program_config
 
 
 class TtnnSentenceBertEmbeddings:
@@ -16,10 +17,12 @@ class TtnnSentenceBertEmbeddings:
 
     def __call__(self, input_ids: ttnn.Tensor, token_type_ids: ttnn.Tensor, position_ids: ttnn.Tensor, device):
         if input_ids.is_sharded():
-            input_ids = ttnn.sharded_to_interleaved(input_ids, ttnn.L1_MEMORY_CONFIG)
-
+            input_ids_interleaved = ttnn.sharded_to_interleaved(input_ids, ttnn.L1_MEMORY_CONFIG)
+            ttnn.deallocate(input_ids)
+        else:
+            input_ids_interleaved = input_ids
         word_embeddings = self.word_embeddings(
-            input_ids,
+            input_ids_interleaved,
             weight=self.parameters.word_embeddings.weight,
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.L1_MEMORY_CONFIG,
@@ -32,7 +35,6 @@ class TtnnSentenceBertEmbeddings:
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
-        embeddings = word_embeddings + token_type_embeddings
 
         position_embeddings = self.position_embeddings(
             position_ids,
@@ -45,13 +47,24 @@ class TtnnSentenceBertEmbeddings:
         ttnn.deallocate(word_embeddings)
         ttnn.deallocate(token_type_embeddings)
         ttnn.deallocate(position_embeddings)
-
+        embeddings = ttnn.unsqueeze(embeddings, dim=1)
+        embeddings = ttnn.to_memory_config(
+            embeddings,
+            memory_config=ttnn.create_sharded_memory_config(
+                embeddings.shape,
+                core_grid=ttnn.CoreGrid(y=8, x=6),
+                strategy=ttnn.ShardStrategy.BLOCK,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+            dtype=ttnn.bfloat8_b,
+        )
         embeddings = self.LayerNorm(
             embeddings,
             weight=self.parameters.LayerNorm.weight,
             bias=self.parameters.LayerNorm.bias,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+            memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
             epsilon=self.config.layer_norm_eps,
             compute_kernel_config=ttnn.WormholeComputeKernelConfig(math_fidelity=ttnn.MathFidelity.HiFi4),
+            program_config=layernorm_program_config,
         )
         return embeddings

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_encoder.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_encoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_intermediate.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_intermediate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -23,5 +23,6 @@ class TtnnSentenceBertIntermediate:
                 math_approx_mode=False,
                 packer_l1_acc=False,
             ),
+            dtype=ttnn.bfloat8_b,
         )
         return out_intermediate

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_layer.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_layer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_output.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_output.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,6 +20,7 @@ class TtnnSentenceBertOutput:
             bias=self.parameters.dense.bias,
             memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
             program_config=ff2_program_config,
+            dtype=ttnn.bfloat8_b,
         )
         bert_output_lin = ttnn.reshard(bert_output_lin, input_tensor.memory_config())
         bert_output_lin = self.LayerNorm(

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_pooler.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_pooler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,13 +12,14 @@ class TtnnSentenceBertPooler:
         self.parameters = parameters
 
     def __call__(self, hidden_states: ttnn.Tensor):
+        hidden_states = ttnn.squeeze(hidden_states, dim=1)
         first_token_tensor = hidden_states[:, 0, :]
         pooled_output = self.dense(
             first_token_tensor,
             self.parameters.dense.weight,
             bias=self.parameters.dense.bias,
             memory_config=ttnn.L1_MEMORY_CONFIG,
-            core_grid=ttnn.CoreGrid(y=first_token_tensor.shape[0], x=8),
+            dtype=ttnn.bfloat8_b,
         )
         pooled_output = self.activation(pooled_output)
         return pooled_output

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_self_attention.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_self_attention.py
@@ -1,9 +1,13 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
-from models.experimental.sentence_bert.ttnn.common import query_key_value_matmul_program_config
+from models.experimental.sentence_bert.ttnn.common import (
+    query_key_value_matmul_program_config,
+    pre_softmax_config,
+    softmax_config,
+)
 
 
 class TtnnSentenceBertSelfAttention:
@@ -21,39 +25,53 @@ class TtnnSentenceBertSelfAttention:
         attention_mask: ttnn.Tensor,
         device=None,
     ):
+        num_heads = self.config.num_attention_heads
+        *_, hidden_size = hidden_states.shape
+        head_size = hidden_size // num_heads
         query_key_value_output = ttnn.linear(
             hidden_states,
             self.parameters.query_key_value.weight,
             bias=self.parameters.query_key_value.bias,
             memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
             program_config=query_key_value_matmul_program_config,
+            dtype=ttnn.bfloat8_b,
         )
-        query_key_value_output_dram = ttnn.to_memory_config(query_key_value_output, ttnn.DRAM_MEMORY_CONFIG)
         (
             query_layer,
             key_layer,
             value_layer,
-        ) = ttnn.transformer.split_query_key_value_and_split_heads(
-            query_key_value_output_dram,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            num_heads=self.config.num_attention_heads,
+        ) = ttnn.experimental.split_query_key_value_and_split_heads(
+            query_key_value_output,
+            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+            num_heads=num_heads,
         )
         ttnn.deallocate(query_key_value_output)
-        ttnn.deallocate(query_key_value_output_dram)
-        key_layer = ttnn.permute(key_layer, (0, 1, 3, 2))
-        attn_output = ttnn.transformer.scaled_dot_product_attention(
+        attention_scores = ttnn.matmul(
             query_layer,
             key_layer,
-            value_layer,
-            attn_mask=attention_mask,
-            is_causal=False,
+            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+            dtype=ttnn.bfloat8_b,
+            program_config=pre_softmax_config,
         )
         ttnn.deallocate(query_layer)
         ttnn.deallocate(key_layer)
-        ttnn.deallocate(value_layer)
-
-        attn_output = ttnn.permute(attn_output, (0, 2, 1, 3))
-        attn_output = ttnn.reshape(
-            attn_output, (attn_output.shape[0], attn_output.shape[1], attn_output.shape[2] * attn_output.shape[3])
+        attention_probabilities = ttnn.transformer.attention_softmax_(
+            attention_scores,
+            attention_mask=attention_mask,
+            head_size=head_size,
+            program_config=softmax_config,
         )
-        return attn_output
+        context_layer = ttnn.matmul(
+            attention_probabilities,
+            value_layer,
+            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+            dtype=ttnn.bfloat8_b,
+        )
+        ttnn.deallocate(attention_probabilities)
+        ttnn.deallocate(value_layer)
+        context_layer = ttnn.experimental.nlp_concat_heads(
+            context_layer,
+            memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
+        )
+        return context_layer

--- a/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_self_output.py
+++ b/models/experimental/sentence_bert/ttnn/ttnn_sentencebert_self_output.py
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
 import ttnn
 from models.experimental.sentence_bert.ttnn.common import (
-    query_key_value_matmul_program_config,
+    self_out_program_config,
     layernorm_program_config,
 )
 
@@ -22,9 +22,10 @@ class TtnnSentenceBertSelfOutput:
             self.parameters.dense.weight,
             bias=self.parameters.dense.bias,
             memory_config=ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG,
-            program_config=query_key_value_matmul_program_config,
+            program_config=self_out_program_config,
+            dtype=ttnn.bfloat8_b,
         )
-        output = ttnn.reshard(output, input_tensor.memory_config())
+        input_tensor = ttnn.reshard(input_tensor, output.memory_config())
         output = self.LayerNorm(
             output,
             residual_input_tensor=input_tensor,

--- a/tests/nightly/single_card/sentence_bert/test_sentence_bert_e2e_performant.py
+++ b/tests/nightly/single_card/sentence_bert/test_sentence_bert_e2e_performant.py
@@ -1,0 +1,1 @@
+../../../../models/experimental/sentence_bert/tests/test_sentence_bert_e2e_performant.py

--- a/tests/nightly/single_card/sentence_bert/test_sentence_bert_performant.py
+++ b/tests/nightly/single_card/sentence_bert/test_sentence_bert_performant.py
@@ -1,0 +1,1 @@
+../../../../models/experimental/sentence_bert/tests/test_sentence_bert_performant.py

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -16,6 +16,8 @@ run_perf_models_other() {
     fi
 
     if [ "$tt_arch" == "wormhole_b0" ]; then
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/sentence_bert/tests -m $test_marker
+
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py -m $test_marker
 
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest models/demos/wormhole/bert_tiny/tests/test_performance.py -m $test_marker

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_attention.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_attention.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ from models.experimental.sentence_bert.ttnn.ttnn_sentencebert_attention import T
 @pytest.mark.parametrize(
     "inputs",
     [
-        ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 384, 384]],
+        ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 1, 384]],
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
@@ -34,14 +34,16 @@ def test_ttnn_sentence_bert_attention(device, inputs):
         device=device,
     )
     ttnn_module = TtnnSentenceBertAttention(parameters=parameters, config=config)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_hidden_states = ttnn.from_torch(
+        hidden_states.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
     sharded_input = ttnn.to_memory_config(
         ttnn_hidden_states,
         memory_config=ttnn.create_sharded_memory_config(
             ttnn_hidden_states.shape,
-            core_grid=device.core_grid,
+            core_grid=ttnn.CoreGrid(y=8, x=6),
             strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
     ttnn_attention_mask = ttnn.from_torch(attention_mask, layout=ttnn.TILE_LAYOUT, device=device)
@@ -50,5 +52,5 @@ def test_ttnn_sentence_bert_attention(device, inputs):
         ttnn_attention_mask,
         device=device,
     )
-    ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out[0], ttnn_out, 0.999)
+    ttnn_out = ttnn.to_torch(ttnn_out).squeeze(dim=1)
+    assert_with_pcc(reference_out[0], ttnn_out, 0.99)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_embeddings.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_embeddings.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -39,17 +39,8 @@ def test_ttnn_sentence_bert_Embeddings(device, inputs):
     ttnn_input_ids, ttnn_token_type_ids, ttnn_position_ids, _ = preprocess_inputs(
         input_ids, token_type_ids, position_ids, attention_mask, device
     )
-    sharded_input = ttnn.to_memory_config(
-        ttnn_input_ids,
-        memory_config=ttnn.create_sharded_memory_config(
-            ttnn_input_ids.shape,
-            core_grid=device.core_grid,
-            strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
-        ),
-    )
     ttnn_out = ttnn_module(
-        input_ids=sharded_input, token_type_ids=ttnn_token_type_ids, position_ids=ttnn_position_ids, device=device
+        input_ids=ttnn_input_ids, token_type_ids=ttnn_token_type_ids, position_ids=ttnn_position_ids, device=device
     )
-    ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out, ttnn_out, 0.9999)
+    ttnn_out = ttnn.to_torch(ttnn_out).squeeze(dim=1)
+    assert_with_pcc(reference_out, ttnn_out, 0.99)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_encoder.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_encoder.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ from models.experimental.sentence_bert.ttnn.ttnn_sentencebert_encoder import Ttn
 @pytest.mark.parametrize(
     "inputs",
     [
-        ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 384, 384]],
+        ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 1, 384]],
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
@@ -37,15 +37,17 @@ def test_ttnn_sentence_bert_encoder(device, inputs):
         device=device,
     )
     ttnn_module = TtnnSentenceBertEncoder(parameters=parameters, config=config)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_hidden_states = ttnn.from_torch(
+        hidden_states.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
     ttnn_attention_mask = ttnn.from_torch(attention_mask, layout=ttnn.TILE_LAYOUT, device=device)
     sharded_input = ttnn.to_memory_config(
         ttnn_hidden_states,
         memory_config=ttnn.create_sharded_memory_config(
             ttnn_hidden_states.shape,
-            core_grid=device.core_grid,
+            core_grid=ttnn.CoreGrid(y=8, x=6),
             strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
     ttnn_out = ttnn_module(
@@ -53,5 +55,5 @@ def test_ttnn_sentence_bert_encoder(device, inputs):
         ttnn_attention_mask,
         device=device,
     )
-    ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out.last_hidden_state, ttnn_out, 0.97)
+    ttnn_out = ttnn.to_torch(ttnn_out).squeeze(dim=1)
+    assert_with_pcc(reference_out.last_hidden_state, ttnn_out, 0.98)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_intermediate.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_intermediate.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -33,16 +33,18 @@ def test_ttnn_sentence_bert_intermediate(device, inputs):
         device=device,
     )
     ttnn_module = TtnnSentenceBertIntermediate(parameters=parameters)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_hidden_states = ttnn.from_torch(
+        hidden_states.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
     sharded_input = ttnn.to_memory_config(
         ttnn_hidden_states,
         memory_config=ttnn.create_sharded_memory_config(
             ttnn_hidden_states.shape,
-            core_grid=device.core_grid,
+            core_grid=ttnn.CoreGrid(y=8, x=6),
             strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
     ttnn_out = ttnn_module(sharded_input)
-    ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out, ttnn_out, 0.9997)
+    ttnn_out = ttnn.to_torch(ttnn_out).squeeze(dim=1)
+    assert_with_pcc(reference_out, ttnn_out, 0.99)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_layer.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_layer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ from models.experimental.sentence_bert.ttnn.ttnn_sentencebert_layer import TtnnS
 @pytest.mark.parametrize(
     "inputs",
     [
-        ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 384, 384]],
+        ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 1, 384]],
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
@@ -37,15 +37,17 @@ def test_ttnn_sentence_bert_layer(device, inputs):
         device=device,
     )
     ttnn_module = TtnnSentenceBertLayer(parameters=parameters, config=config)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_hidden_states = ttnn.from_torch(
+        hidden_states.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
     ttnn_attention_mask = ttnn.from_torch(attention_mask, layout=ttnn.TILE_LAYOUT, device=device)
     sharded_input = ttnn.to_memory_config(
         ttnn_hidden_states,
         memory_config=ttnn.create_sharded_memory_config(
             ttnn_hidden_states.shape,
-            core_grid=device.core_grid,
+            core_grid=ttnn.CoreGrid(y=8, x=6),
             strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
     ttnn_out = ttnn_module(
@@ -53,5 +55,5 @@ def test_ttnn_sentence_bert_layer(device, inputs):
         ttnn_attention_mask,
         device=device,
     )
-    ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out[0], ttnn_out, 0.999)
+    ttnn_out = ttnn.to_torch(ttnn_out).squeeze(dim=1)
+    assert_with_pcc(reference_out[0], ttnn_out, 0.99)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_model.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,14 +15,14 @@ from models.experimental.sentence_bert.ttnn.ttnn_sentence_bert_model import Ttnn
 
 @pytest.mark.parametrize(
     "inputs",
-    [["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384], [8, 1, 384, 384]]],
+    [["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384], [8, 1, 1, 384]]],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_ttnn_sentence_bert_model(device, inputs):
     transformers_model = transformers.AutoModel.from_pretrained(inputs[0]).eval()
     config = transformers.BertConfig.from_pretrained(inputs[0])
     input_ids = torch.randint(low=0, high=config.vocab_size - 1, size=inputs[1], dtype=torch.int64)
-    attention_mask = torch.randint(0, inputs[1][0], size=inputs[1], dtype=torch.int64)
+    attention_mask = torch.ones(inputs[1][0], inputs[1][1])
     extended_mask = custom_extended_mask(attention_mask, dtype=torch.bfloat16)
     token_type_ids = torch.zeros(inputs[1], dtype=torch.int64)
     position_ids = torch.arange(0, inputs[1][1], dtype=torch.int64).unsqueeze(dim=0)
@@ -40,15 +40,6 @@ def test_ttnn_sentence_bert_model(device, inputs):
     ttnn_input_ids, ttnn_token_type_ids, ttnn_position_ids, ttnn_attention_mask = preprocess_inputs(
         input_ids, token_type_ids, position_ids, extended_mask, device
     )
-    sharded_input = ttnn.to_memory_config(
-        ttnn_input_ids,
-        memory_config=ttnn.create_sharded_memory_config(
-            ttnn_input_ids.shape,
-            core_grid=device.core_grid,
-            strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
-        ),
-    )
-    ttnn_out = ttnn_module(sharded_input, ttnn_attention_mask, ttnn_token_type_ids, ttnn_position_ids, device=device)
-    ttnn_out = ttnn.to_torch(ttnn_out[0])
-    assert_with_pcc(reference_out.last_hidden_state, ttnn_out, 0.956)
+    ttnn_out = ttnn_module(ttnn_input_ids, ttnn_attention_mask, ttnn_token_type_ids, ttnn_position_ids, device=device)
+    ttnn_out = ttnn.to_torch(ttnn_out[0]).squeeze(dim=1)
+    assert_with_pcc(reference_out.last_hidden_state, ttnn_out, 0.987)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_pooler.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_pooler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -33,7 +33,9 @@ def test_ttnn_sentence_bert_pooler(device, inputs):
         device=device,
     )
     ttnn_module = TtnnSentenceBertPooler(parameters=parameters)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_hidden_states = ttnn.from_torch(
+        hidden_states.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
     ttnn_out = ttnn_module(ttnn_hidden_states)
     ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out, ttnn_out, 0.998)
+    assert_with_pcc(reference_out, ttnn_out, 0.99)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_self_attention.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_self_attention.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -9,13 +9,13 @@ import pytest
 from ttnn.model_preprocessing import preprocess_model_parameters
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.sentence_bert.ttnn.common import custom_preprocessor
-from models.experimental.sentence_bert.reference.sentence_bert import BertSdpaSelfAttention
+from models.experimental.sentence_bert.reference.sentence_bert import BertSelfAttention
 from models.experimental.sentence_bert.ttnn.ttnn_sentencebert_self_attention import TtnnSentenceBertSelfAttention
 
 
 @pytest.mark.parametrize(
     "inputs",
-    [["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 384, 384]]],
+    [["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr", [8, 384, 768], [8, 1, 1, 384]]],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_ttnn_sentence_bert_self_attention(device, inputs):
@@ -23,7 +23,7 @@ def test_ttnn_sentence_bert_self_attention(device, inputs):
     config = transformers.BertConfig.from_pretrained(inputs[0])
     hidden_states = torch.randn(inputs[1], dtype=torch.bfloat16)
     attention_mask = torch.randn(inputs[2], dtype=torch.bfloat16)
-    reference_module = BertSdpaSelfAttention(config).to(torch.bfloat16)
+    reference_module = BertSelfAttention(config).to(torch.bfloat16)
     reference_module.load_state_dict(transformers_model.state_dict())
     reference_out = reference_module(
         hidden_states,
@@ -35,21 +35,29 @@ def test_ttnn_sentence_bert_self_attention(device, inputs):
         device=device,
     )
     ttnn_module = TtnnSentenceBertSelfAttention(parameters=parameters, config=config)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_hidden_states = ttnn.from_torch(
+        hidden_states.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
     sharded_input = ttnn.to_memory_config(
         ttnn_hidden_states,
         memory_config=ttnn.create_sharded_memory_config(
             ttnn_hidden_states.shape,
-            core_grid=device.core_grid,
+            core_grid=ttnn.CoreGrid(y=8, x=6),
             strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
-    ttnn_attention_mask = ttnn.from_torch(attention_mask, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_attention_mask = ttnn.from_torch(
+        attention_mask,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat8_b,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
     ttnn_out = ttnn_module(
         sharded_input,
         ttnn_attention_mask,
         device=device,
     )
-    ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out[0], ttnn_out, 0.997)
+    ttnn_out = ttnn.to_torch(ttnn_out).squeeze(dim=1)
+    assert_with_pcc(reference_out[0], ttnn_out, 0.99)

--- a/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_self_output.py
+++ b/tests/ttnn/integration_tests/sentence_bert/test_ttnn_sentencebert_self_output.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -34,15 +34,19 @@ def test_ttnn_sentence_bert_self_output(device, inputs):
         device=device,
     )
     ttnn_module = TtnnSentenceBertSelfOutput(parameters=parameters, config=config)
-    ttnn_hidden_states = ttnn.from_torch(hidden_states, layout=ttnn.TILE_LAYOUT, device=device)
-    ttnn_input_tensor = ttnn.from_torch(input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_hidden_states = ttnn.from_torch(
+        hidden_states.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    ttnn_input_tensor = ttnn.from_torch(
+        input_tensor.unsqueeze(dim=1), dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device
+    )
     sharded_hidden_states = ttnn.to_memory_config(
         ttnn_hidden_states,
         memory_config=ttnn.create_sharded_memory_config(
             ttnn_hidden_states.shape,
-            core_grid=ttnn.CoreGrid(y=2, x=8),
+            core_grid=ttnn.CoreGrid(y=8, x=6),
             strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
     sharded_input_tens = ttnn.to_memory_config(
@@ -51,9 +55,9 @@ def test_ttnn_sentence_bert_self_output(device, inputs):
             ttnn_hidden_states.shape,
             core_grid=ttnn.CoreGrid(y=8, x=8),
             strategy=ttnn.ShardStrategy.BLOCK,
-            orientation=ttnn.ShardOrientation.COL_MAJOR,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
         ),
     )
     ttnn_out = ttnn_module(sharded_hidden_states, sharded_input_tens)
-    ttnn_out = ttnn.to_torch(ttnn_out)
-    assert_with_pcc(reference_out, ttnn_out, 0.9998)
+    ttnn_out = ttnn.to_torch(ttnn_out).squeeze(dim=1)
+    assert_with_pcc(reference_out, ttnn_out, 0.99)

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation.cpp
@@ -13,7 +13,6 @@ void SplitFusedQKVAndSplitHeadsDeviceOperation::validate_with_output_tensors(
     const auto& input_tensor = input_tensors.at(0);
     const auto batch_size = input_tensor.get_padded_shape()[0];
     // TODO: See issue #1744
-    TT_FATAL((input_tensor.get_padded_shape() == ttnn::Shape({batch_size, 1, 384, 3072})), "Unsupported input shape");
     TT_FATAL(input_tensor.storage_type() == tt::tt_metal::StorageType::DEVICE, "Operands to TM need to be on device!");
     TT_FATAL(input_tensor.buffer() != nullptr, "Operands to TM need to be allocated in buffers on device!");
     TT_FATAL(


### PR DESCRIPTION
### Ticket

SentenceBERT -  [#19458](https://github.com/tenstorrent/tt-metal/issues/19458)

### Problem description
Add Perf tests for SentenceBERT model.

### What's changed
- Bought up the device perf
- Added e2e, Device performance tests along with trace, trace with e2e perf

### Checklist
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15528040464) (unrelated ones fail) 
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15528044734) (unrelated ones fail)
- [x] [ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15494601261/workflow) 
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) - [Link](https://github.com/tenstorrent/tt-metal/actions/runs/15534012150) (unrelated ones fail)

### Performance Details (BS-8)
- Device perf - ([Sentence_BERT_BS_8_Optimised.csv](https://github.com/user-attachments/files/20441277/Sentence_BERT_BS_8_Optimised.csv))
- Model (e2e) perf with trace+2cqs - 403 sentence per sec
