### PR TITLE
#20937: Add INT32 support and fill_pad and test_fill_pad.py for tt-forge models

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_fill_pad.py
@@ -51,6 +51,7 @@ import ttnn
 ttnn_dtype_to_torch_dtype = {
     ttnn.uint16: torch.int16,
     ttnn.uint32: torch.int32,
+    ttnn.int32: torch.int32,
     ttnn.bfloat16: torch.float32,
     ttnn.bfloat8_b: torch.bfloat16,
 }
@@ -163,7 +164,7 @@ def test_fill_pad_bfloat8_b(
     ],
 )
 @pytest.mark.parametrize("fill_value", [1, 0])
-@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.uint16])
+@pytest.mark.parametrize("dtype", [ttnn.uint32, ttnn.int32, ttnn.uint16])
 @pytest.mark.parametrize("input_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("output_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
 def test_fill_pad_int(
@@ -280,7 +281,7 @@ def test_fill_pad_complex_sharding(device, fill_value, shape, shard_scheme, dtyp
         ttnn.TensorMemoryLayout.BLOCK_SHARDED,
     ],
 )
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint32])
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint32, ttnn.int32])
 def test_fill_pad_sharded(device, fill_value, shape, shard_scheme, dtype):
     torch.manual_seed(1234)
     torch_input_tensor, padded_torch_tensor = create_nd_padded_tiled_tensor(

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/fill_pad_program_factory.hpp
@@ -9,6 +9,7 @@ const std::map<ttnn::DataType, uint32_t> data_type_to_size = {
     {ttnn::DataType::FLOAT32, 4},
     {ttnn::DataType::UINT16, 2},
     {ttnn::DataType::UINT32, 4},
+    {ttnn::DataType::INT32, 4},
     {ttnn::DataType::UINT8, 1},
 };
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20937

### Problem description
 - fill_pad op supports uint32 but not int32, and in tt-forge (4 models affected so far) we end up with this op (through ttnn::max and maybe other paths) attempting to use int32, and so we hit assert.

### What's changed
 - Add int32 support in op to avoid assert
 - extend test_fill_pad.py gtests to cover int32, passing for wormhole_b0

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes. test_fill_pad.py locally passing new cases for wormhole_b0, assert is not hit anymore.