### PR TITLE
#18811: CLI option for tracy to profile dispatch cores

### DIFF
--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -57,6 +57,13 @@ def main():
         default=False,
     )
     parser.add_option(
+        "--profile-dispatch-cores",
+        dest="profile_dispatch_cores",
+        action="store_true",
+        help="Collect dispatch cores profiling data",
+        default=False,
+    )
+    parser.add_option(
         "--collect-noc-traces",
         dest="collect_noc_traces",
         action="store_true",
@@ -96,6 +103,9 @@ def main():
             del os.environ[opInfoCacheStr]
     else:
         os.environ[opInfoCacheStr] = "1"
+
+    if options.profile_dispatch_cores:
+        os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "1"
 
     if options.collect_noc_traces:
         os.environ["TT_METAL_DEVICE_PROFILER_NOC_EVENTS"] = "1"


### PR DESCRIPTION
### Ticket
#18811 

### Problem description
Avoid exposing the env vars for profiling dispatch cores. 

### What's changed
Wrap the env var `TT_METAL_DEVICE_PROFILER_DISPATCH` in a python -m tracy cli option

### Checklist
- [x] [Profiler regression ](https://github.com/tenstorrent/tt-metal/actions/runs/14579082954)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14579090323)