### PR TITLE
Add support for a performance mode in DRAM Prefetcher

### DIFF
--- a/models/demos/llama3_subdevices/demo/conftest.py
+++ b/models/demos/llama3_subdevices/demo/conftest.py
@@ -21,3 +21,6 @@ def pytest_addoption(parser):
     parser.addoption(
         "--stop_at_eos", action="store", type=int, help="Whether to stop decoding when the model generates an EoS token"
     )
+    parser.addoption(
+        "--disable_pf_perf_mode", action="store_true", default=False, help="Enable performance mode for prefetcher"
+    )

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -112,6 +112,7 @@ def run_llama3_demo(
     layers,
     stress_test,
     start_pos,
+    enable_prefetcher_performance_mode=True,
 ):
     # Creat batch output file
     benchmark_data = BenchmarkData()
@@ -206,6 +207,7 @@ def run_llama3_demo(
         state_dict=state_dict,
         weight_cache_path=model_args.weight_cache_path(dtype),
         paged_attention_config=paged_attention_config,
+        enable_prefetcher_performance_mode=enable_prefetcher_performance_mode,
     )
     tt_embd = TtLlamaEmbedding(
         mesh_device=mesh_device,
@@ -669,6 +671,7 @@ def test_llama_demo(
     use_program_cache,
     is_ci_env,
     reset_seeds,
+    request,
 ):
     if is_ci_env and ("long" in input_prompts or optimizations == LlamaOptimizations.accuracy):
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
@@ -686,6 +689,8 @@ def test_llama_demo(
         )
     else:
         paged_attention_config = None
+
+    enable_pf_perf_mode = not request.config.getoption("--disable_pf_perf_mode")
 
     return run_llama3_demo(
         user_input=input_prompts,
@@ -705,4 +710,5 @@ def test_llama_demo(
         layers=layers,
         stress_test=stress_test,
         start_pos=start_pos,
+        enable_prefetcher_performance_mode=enable_pf_perf_mode,
     )

--- a/models/demos/llama3_subdevices/tt/llama_model.py
+++ b/models/demos/llama3_subdevices/tt/llama_model.py
@@ -29,6 +29,7 @@ class TtTransformer(LightweightModule):
         weight_cache_path,
         paged_attention_config=None,
         use_paged_kv_cache=False,
+        enable_prefetcher_performance_mode=False,
         mode="decode",
     ):
         super().__init__()
@@ -40,6 +41,7 @@ class TtTransformer(LightweightModule):
         self.dtype = dtype
         self.model_config = args.get_model_config()
         self.grid_size = self.args.max_grid_size
+        self.enable_prefetcher_performance_mode = enable_prefetcher_performance_mode
         state_dict_prefix = args.get_state_dict_prefix("", None)
 
         self.embd = TtLlamaEmbedding(
@@ -506,6 +508,7 @@ class TtTransformer(LightweightModule):
                 self.tt_tensors,
                 num_layers=self.n_layers,
                 global_cb=self.prefetcher_setup.global_circular_buffer,
+                enable_performance_mode=self.enable_prefetcher_performance_mode,
             )
             self.mesh_device.set_sub_device_stall_group([self.prefetcher_setup.worker_sub_device_id])
 

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -260,6 +260,7 @@ def run_prefetcher_mm(
     num_reader_cores,
     dtypes,
     is_functional_test=False,
+    enable_performance_mode=False,
 ):
     logger.info(f"Running test_run_prefetcher with num_tensors={num_tensors}, num_layers={num_layers}")
     assert len(input_shapes) == len(dtypes)
@@ -551,6 +552,7 @@ def run_prefetcher_mm(
             tt_tensors,
             num_layers,
             global_cb=global_circular_buffer,
+            enable_performance_mode=enable_performance_mode,
         )
         device.set_sub_device_stall_group([worker_sub_device_id])
 

--- a/tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
+++ b/tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
@@ -119,4 +119,5 @@ def test_run_prefetcher_llama_perf(
         num_layers,
         num_reader_cores,
         dtypes,
+        enable_performance_mode=True,
     )

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.cpp
@@ -81,7 +81,7 @@ std::vector<ttnn::TensorSpec> DramPrefetcher::compute_output_specs(const std::ve
 tt::tt_metal::operation::ProgramWithCallbacks DramPrefetcher::create_program(
     const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
     auto global_cb = tt::tt_metal::get_global_circular_buffer(*this->global_cb, input_tensors[0].device()->id());
-    return dram_prefetcher_multi_core(input_tensors, this->num_layers, global_cb);
+    return dram_prefetcher_multi_core(input_tensors, this->num_layers, global_cb, this->enable_performance_mode);
 }
 
 }  // namespace ttnn::operations::dram_prefetcher

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op.hpp
@@ -20,11 +20,13 @@ namespace ttnn::operations::dram_prefetcher {
 tt::tt_metal::operation::ProgramWithCallbacks dram_prefetcher_multi_core(
     const std::vector<Tensor>& input_tensors,
     const uint32_t num_layers,
-    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb);
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb,
+    const bool enable_performance_mode = false);
 
 struct DramPrefetcher {
     const std::optional<const tt::tt_metal::DeviceGlobalCircularBuffer> global_cb;
     const uint32_t num_layers;
+    const bool enable_performance_mode;
 
     void validate(const std::vector<Tensor>& input_tensors) const;
     std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/dram_prefetcher_op_multi_core.cpp
@@ -37,7 +37,8 @@ std::pair<uint32_t, uint32_t> get_max_page_size_and_num_pages(
 operation::ProgramWithCallbacks dram_prefetcher_multi_core(
     const std::vector<Tensor>& input_tensors,
     const uint32_t num_layers,
-    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb) {
+    const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb,
+    const bool enable_performance_mode) {
     /* Buffers */
     const Buffer& global_cb_buffer = global_cb.cb_buffer();
     // tensors that with addresses
@@ -171,6 +172,9 @@ operation::ProgramWithCallbacks dram_prefetcher_multi_core(
         tensor_addrs_cb_index,
     };
 
+    // Configs to enable for performance mode
+    reader_ct_args.push_back((uint32_t)enable_performance_mode /* skip_ptr_update */);
+
     auto reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp",
@@ -191,6 +195,9 @@ operation::ProgramWithCallbacks dram_prefetcher_multi_core(
         reader_cb_index,
         remote_cb_index,
     };
+
+    // Configs to enable for performance mode
+    writer_ct_args.push_back((uint32_t)enable_performance_mode /* skip_ptr_update */);
 
     auto writer_kernel_id = CreateKernel(
         program,

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/device/kernels/reader_dram.cpp
@@ -9,8 +9,6 @@
 
 #include "debug/dprint.h"
 
-constexpr bool skip_ptr_update = true;
-
 void kernel_main() {
     // Compile time args
     constexpr uint32_t num_layers = get_compile_time_arg_val(0);
@@ -21,6 +19,7 @@ void kernel_main() {
     constexpr uint32_t max_block_size = get_compile_time_arg_val(5);
     constexpr uint32_t cb_id = get_compile_time_arg_val(6);
     constexpr uint32_t addrs_cb_id = get_compile_time_arg_val(7);
+    constexpr bool skip_ptr_update = get_compile_time_arg_val(8);
 
     // Runtime args
     uint32_t rt_args_idx = 0;

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.cpp
@@ -14,14 +14,16 @@ namespace ttnn::operations::dram_prefetcher {
 Tensor ExecuteDramPrefetcher::invoke(
     std::vector<ttnn::Tensor>& tensors,
     const uint32_t num_layers,
-    const std::optional<const tt::tt_metal::DeviceGlobalCircularBuffer>& global_cb) {
+    const std::optional<const tt::tt_metal::DeviceGlobalCircularBuffer>& global_cb,
+    const bool enable_performance_mode) {
     std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output(tensors))};
     tt::tt_metal::operation::launch_op(
-        [num_layers, global_cb](
+        [num_layers, global_cb, enable_performance_mode](
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            return tt::tt_metal::operation::run(DramPrefetcher{global_cb, num_layers}, input_tensors);
+            return tt::tt_metal::operation::run(
+                DramPrefetcher{global_cb, num_layers, enable_performance_mode}, input_tensors);
         },
         tensors,
         output_tensors);

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.hpp
@@ -17,7 +17,8 @@ struct ExecuteDramPrefetcher {
     static ttnn::Tensor invoke(
         std::vector<ttnn::Tensor>& tensors,
         const uint32_t num_layers,
-        const std::optional<const tt::tt_metal::DeviceGlobalCircularBuffer>& global_cb);
+        const std::optional<const tt::tt_metal::DeviceGlobalCircularBuffer>& global_cb,
+        const bool enable_performance_mode = false);
 };
 
 }  // namespace operations::dram_prefetcher

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher_pybind.cpp
@@ -27,6 +27,8 @@ void bind_dram_prefetcher_operation(py::module& module) {
                     for which tensors need to be pre-fetched.
                 global_cb (GlobalCircularBuffer): A global cb object, used internally to manage data movement
                     across dram reader cores, and downstream consumer cores.
+                enable_performance_mode (bool, optional): If set to true, the operation will be optimized for performance.
+                    May lead to ND behavior on wormhole 4U systems!
 
             Returns:
                 ttnn.Tensor: empty tensor (TODO: Should return None)
@@ -36,6 +38,8 @@ void bind_dram_prefetcher_operation(py::module& module) {
             py::arg("tensors"),
             py::arg("num_layers"),
             py::arg("global_cb"),
+            py::kw_only(),
+            py::arg("enable_performance_mode") = false,
         });
 }
 


### PR DESCRIPTION
### Ticket
- #10673
- #20940
- #20646

### Problem description
Recently, an optimization was merged that restored the performance of the DRAM Prefetcher, thereby achieving DRAM BW of ~240GB/s. However, on 4U systems, there is a known issue that high DRAM BW can lead to bit flips. On 6U systems, this issue is known to be resolved.

Here's a summary of the problem surfaced on 4U systems due to a fast prefetcher BW in the Llama TG model:
- Demo produces ND outputs
  - Enabling 4 link CCLs also leads to ND outputs
- Accuracy test completely fails (TG nightly)
- Decoder ND test fails (currently not in CI)
- Model ND test fails (traced version, soon to be added to CI)
- Prefill + Decode leads to bad outputs

### What's changed
To resolve the issues above, a new parameter is exposed in the `ttnn.dram_prefetcher` op: `enable_performance_mode`. By default, this is set to `False`. When enabled, the prefetcher kernels skips counter updates in the `dataflow_api.h` operations.

Additionally, a `--disable_pf_perf_mode` flag has been added to the `demo_decode.py` file, to allow users to specifically select the performance mode for the PF, allowing users to test for both accuracy, as well as expected performance. The `TtTransformer` class is set up to use the prefetcher in the performance mode, based on a flag passed at `init`.

Example usage: `pytest models/demos/llama3_subdevices/demo/demo_decode.py -k full --disable_pf_perf_mode`.

Finally, all the places that measure performance have been updated to use this new `enable_performance_mode` flag. This is mainly:
- demo
- PF BW test
- decoder device perf (implicitly uses helper function from `demo_decode.py`, so performance mode is enabled by default)

### ⚠️ Note ⚠️ 
**All existing testing infra uses dram prefetcher in a non-performance mode** (unless specified above). This is because most of the CI infrastructure uses 4U systems, where accuracy tests are susceptible to failure.

### Checklist
- [ ] [TG CI](https://github.com/tenstorrent/tt-metal/actions/runs/14595744437/job/40941515399) functionally passes
- [ ] [TG Demo](https://github.com/tenstorrent/tt-metal/actions/runs/14598504748) passes