### PR TITLE
Use 2 command bufs on Prefetch D/HD

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/pgm_dispatch_golden.json
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/pgm_dispatch_golden.json
@@ -1,38 +1,38 @@
 {
   "context": {
-    "date": "2025-04-20T23:27:21+00:00",
-    "host_name": "tt-metal-ci-vm-33",
+    "date": "2025-04-24T00:56:03+00:00",
+    "host_name": "aus-wh-05-special-nhuang-for-reservation-20335",
     "executable": "./build/test/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch_wormhole_b0",
-    "num_cpus": 14,
-    "mhz_per_cpu": 3000,
+    "num_cpus": 96,
+    "mhz_per_cpu": 2007,
     "cpu_scaling_enabled": false,
     "caches": [
       {
         "type": "Data",
         "level": 1,
         "size": 32768,
-        "num_sharing": 1
+        "num_sharing": 2
       },
       {
         "type": "Instruction",
         "level": 1,
         "size": 32768,
-        "num_sharing": 1
+        "num_sharing": 2
       },
       {
         "type": "Unified",
         "level": 2,
         "size": 524288,
-        "num_sharing": 1
+        "num_sharing": 2
       },
       {
         "type": "Unified",
         "level": 3,
         "size": 16777216,
-        "num_sharing": 1
+        "num_sharing": 6
       }
     ],
-    "load_avg": [3.38721,3.86279,3.72363],
+    "load_avg": [4.26123,4.44189,8.39062],
     "library_version": "v1.9.1",
     "library_build_type": "debug",
     "json_schema_version": 1
@@ -47,12 +47,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.7820427920000006e+07,
-      "cpu_time": 3.2757199999999819e+04,
+      "iterations": 27,
+      "real_time": 2.5813668444444440e+07,
+      "cpu_time": 2.9816296296295524e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7820427920000009e-06
+      "IterationTime": 2.5813668444444445e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/512/manual_time",
@@ -63,12 +63,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.7933343760000002e+07,
-      "cpu_time": 2.8926799999999810e+04,
+      "iterations": 27,
+      "real_time": 2.5830025777777776e+07,
+      "cpu_time": 3.0920370370370303e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7933343759999998e-06
+      "IterationTime": 2.5830025777777774e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/1024/manual_time",
@@ -79,12 +79,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.8185889399999995e+07,
-      "cpu_time": 3.0962800000000625e+04,
+      "iterations": 27,
+      "real_time": 2.6014519666666672e+07,
+      "cpu_time": 3.1089259259260754e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8185889399999997e-06
+      "IterationTime": 2.6014519666666675e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/2048/manual_time",
@@ -95,12 +95,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 24,
-      "real_time": 2.9762228958333332e+07,
-      "cpu_time": 6.9390041666665682e+04,
+      "iterations": 26,
+      "real_time": 2.7336015230769221e+07,
+      "cpu_time": 3.1272692307690799e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9762228958333332e-06
+      "IterationTime": 2.7336015230769221e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/4096/manual_time",
@@ -111,12 +111,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 3.0919389782608695e+07,
-      "cpu_time": 2.4686565217393032e+04,
+      "iterations": 24,
+      "real_time": 2.9800089708333340e+07,
+      "cpu_time": 3.1604583333335231e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0919389782608698e-06
+      "IterationTime": 2.9800089708333339e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/8192/manual_time",
@@ -127,12 +127,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 21,
-      "real_time": 3.3419372904761899e+07,
-      "cpu_time": 2.9733333333331877e+04,
+      "iterations": 22,
+      "real_time": 3.2392008636363637e+07,
+      "cpu_time": 2.8570909090909103e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3419372904761902e-06
+      "IterationTime": 3.2392008636363637e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_only_trace/12288/manual_time",
@@ -143,12 +143,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.6068512947368413e+07,
-      "cpu_time": 2.3471578947366710e+04,
+      "iterations": 20,
+      "real_time": 3.5076805199999996e+07,
+      "cpu_time": 2.7314000000000506e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6068512947368419e-06
+      "IterationTime": 3.5076805199999991e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/256/manual_time",
@@ -159,12 +159,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 24,
-      "real_time": 2.7814319041666672e+07,
-      "cpu_time": 2.2999999999999873e+04,
+      "iterations": 27,
+      "real_time": 2.5799587370370369e+07,
+      "cpu_time": 2.7661481481482067e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7814319041666667e-06
+      "IterationTime": 2.5799587370370374e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/512/manual_time",
@@ -175,12 +175,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.7923910319999997e+07,
-      "cpu_time": 2.2004039999994344e+04,
+      "iterations": 27,
+      "real_time": 2.5822539111111116e+07,
+      "cpu_time": 2.8798185185180606e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7923910319999994e-06
+      "IterationTime": 2.5822539111111113e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/1024/manual_time",
@@ -191,12 +191,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.8196666119999994e+07,
-      "cpu_time": 2.8455999999996708e+04,
+      "iterations": 27,
+      "real_time": 2.6040646629629634e+07,
+      "cpu_time": 1.9057074074075368e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8196666119999990e-06
+      "IterationTime": 2.6040646629629635e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/2048/manual_time",
@@ -207,12 +207,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 24,
-      "real_time": 2.9015754541666672e+07,
-      "cpu_time": 3.0333333333335915e+04,
+      "iterations": 26,
+      "real_time": 2.7448341807692312e+07,
+      "cpu_time": 2.6408115384611257e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9015754541666669e-06
+      "IterationTime": 2.7448341807692307e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/4096/manual_time",
@@ -224,11 +224,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0929972695652179e+07,
-      "cpu_time": 2.8659999999999196e+04,
+      "real_time": 2.9792491000000011e+07,
+      "cpu_time": 2.1563913043469136e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0929972695652179e-06
+      "IterationTime": 2.9792491000000004e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/8192/manual_time",
@@ -239,12 +239,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 21,
-      "real_time": 3.3476686523809519e+07,
-      "cpu_time": 2.9943809523818876e+04,
+      "iterations": 22,
+      "real_time": 3.2435888499999996e+07,
+      "cpu_time": 2.1237727272724074e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3476686523809513e-06
+      "IterationTime": 3.2435888499999993e-06
     },
     {
       "name": "BM_pgm_dispatch/ncrisc_only_trace/12288/manual_time",
@@ -255,12 +255,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.6151918315789483e+07,
-      "cpu_time": 2.9716894736847284e+04,
+      "iterations": 20,
+      "real_time": 3.5110685600000001e+07,
+      "cpu_time": 2.0668499999998425e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6151918315789481e-06
+      "IterationTime": 3.5110685600000004e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/256/manual_time",
@@ -271,12 +271,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 3.0438012826086961e+07,
-      "cpu_time": 7.9724986956521671e+05,
+      "iterations": 24,
+      "real_time": 2.9024518291666672e+07,
+      "cpu_time": 2.9144625000004919e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0438012826086958e-06
+      "IterationTime": 2.9024518291666675e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/512/manual_time",
@@ -287,12 +287,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 2.9911238434782613e+07,
-      "cpu_time": 2.8099130434772916e+04,
+      "iterations": 24,
+      "real_time": 2.9009255416666672e+07,
+      "cpu_time": 2.0698333333337334e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9911238434782617e-06
+      "IterationTime": 2.9009255416666673e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/1024/manual_time",
@@ -303,12 +303,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 3.0588867869565211e+07,
-      "cpu_time": 2.9750913043483695e+04,
+      "iterations": 24,
+      "real_time": 2.9682033374999996e+07,
+      "cpu_time": 2.9745833333335209e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0588867869565210e-06
+      "IterationTime": 2.9682033374999993e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/2048/manual_time",
@@ -320,11 +320,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3856754190476194e+07,
-      "cpu_time": 3.0179571428569034e+04,
+      "real_time": 3.3110337285714280e+07,
+      "cpu_time": 2.8733809523813426e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3856754190476188e-06
+      "IterationTime": 3.3110337285714280e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/4096/manual_time",
@@ -335,12 +335,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.8629394055555552e+07,
-      "cpu_time": 2.6872777777785392e+04,
+      "iterations": 19,
+      "real_time": 3.6896249789473683e+07,
+      "cpu_time": 2.7143157894742544e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8629394055555558e-06
+      "IterationTime": 3.6896249789473682e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/8192/manual_time",
@@ -352,11 +352,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.5038149937500007e+07,
-      "cpu_time": 2.7933124999990345e+04,
+      "real_time": 4.4107300062499993e+07,
+      "cpu_time": 3.0150062500011732e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.5038149937500007e-06
+      "IterationTime": 4.4107300062499998e-06
     },
     {
       "name": "BM_pgm_dispatch/trisc_only_trace/12288/manual_time",
@@ -367,12 +367,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 13,
-      "real_time": 5.2811127153846145e+07,
-      "cpu_time": 2.8704615384622655e+04,
+      "iterations": 14,
+      "real_time": 5.1734998928571425e+07,
+      "cpu_time": 3.0263000000006556e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.2811127153846146e-06
+      "IterationTime": 5.1734998928571428e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/256/manual_time",
@@ -383,12 +383,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 3.1743569173913043e+07,
-      "cpu_time": 8.0132504347825248e+05,
+      "iterations": 24,
+      "real_time": 2.9696292916666668e+07,
+      "cpu_time": 2.9956249999999829e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1743569173913046e-06
+      "IterationTime": 2.9696292916666670e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/512/manual_time",
@@ -400,11 +400,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 23,
-      "real_time": 3.0935454869565211e+07,
-      "cpu_time": 2.5595217391316535e+04,
+      "real_time": 2.9939772739130441e+07,
+      "cpu_time": 2.9272173913048693e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0935454869565214e-06
+      "IterationTime": 2.9939772739130436e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/1024/manual_time",
@@ -415,12 +415,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 21,
-      "real_time": 3.2590755238095231e+07,
-      "cpu_time": 3.1185238095252222e+04,
+      "iterations": 22,
+      "real_time": 3.1697786681818187e+07,
+      "cpu_time": 3.0471863636361006e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2590755238095239e-06
+      "IterationTime": 3.1697786681818188e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/2048/manual_time",
@@ -432,11 +432,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5887916799999997e+07,
-      "cpu_time": 2.5494500000000640e+04,
+      "real_time": 3.5045221799999997e+07,
+      "cpu_time": 2.9483050000012056e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5887916800000002e-06
+      "IterationTime": 3.5045221800000001e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/4096/manual_time",
@@ -447,12 +447,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.1573213647058830e+07,
-      "cpu_time": 1.0829815294117490e+06,
+      "iterations": 18,
+      "real_time": 3.9967144444444448e+07,
+      "cpu_time": 2.9241111111133476e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1573213647058834e-06
+      "IterationTime": 3.9967144444444446e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/8192/manual_time",
@@ -464,11 +464,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 5.0647446714285716e+07,
-      "cpu_time": 2.6511499999992695e+04,
+      "real_time": 4.9729006428571418e+07,
+      "cpu_time": 2.8690000000005813e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.0647446714285706e-06
+      "IterationTime": 4.9729006428571421e-06
     },
     {
       "name": "BM_pgm_dispatch/brisc_trisc_only_trace/12288/manual_time",
@@ -479,12 +479,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 11,
-      "real_time": 6.0966045636363648e+07,
-      "cpu_time": 2.7880909090903893e+04,
+      "iterations": 12,
+      "real_time": 5.9975886583333336e+07,
+      "cpu_time": 2.9730833333315353e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.0966045636363639e-06
+      "IterationTime": 5.9975886583333330e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/256/manual_time",
@@ -495,12 +495,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 22,
-      "real_time": 3.1646197909090903e+07,
-      "cpu_time": 2.7122727272727527e+04,
+      "iterations": 23,
+      "real_time": 3.0842540000000000e+07,
+      "cpu_time": 2.0446956521741093e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1646197909090901e-06
+      "IterationTime": 3.0842539999999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/512/manual_time",
@@ -512,11 +512,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.2251070863636363e+07,
-      "cpu_time": 2.5056363636366543e+04,
+      "real_time": 3.1261707954545449e+07,
+      "cpu_time": 2.0645909090909565e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2251070863636362e-06
+      "IterationTime": 3.1261707954545453e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/1024/manual_time",
@@ -528,11 +528,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.5130178476190470e+07,
-      "cpu_time": 8.8423599999998789e+05,
+      "real_time": 3.3165851380952381e+07,
+      "cpu_time": 2.9743952380941373e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5130178476190474e-06
+      "IterationTime": 3.3165851380952381e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/2048/manual_time",
@@ -544,11 +544,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8655306055555552e+07,
-      "cpu_time": 3.3407222222213582e+04,
+      "real_time": 3.8647580055555552e+07,
+      "cpu_time": 2.9414444444424920e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8655306055555550e-06
+      "IterationTime": 3.8647580055555561e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/4096/manual_time",
@@ -560,11 +560,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.4223447687500007e+07,
-      "cpu_time": 2.6856875000008662e+04,
+      "real_time": 4.3466852000000000e+07,
+      "cpu_time": 2.8159375000003096e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.4223447687500008e-06
+      "IterationTime": 4.3466851999999999e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/8192/manual_time",
@@ -575,12 +575,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 5.6728750583333343e+07,
-      "cpu_time": 2.8485833333332284e+04,
+      "iterations": 13,
+      "real_time": 5.5729855769230776e+07,
+      "cpu_time": 2.7346153846150239e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6728750583333340e-06
+      "IterationTime": 5.5729855769230779e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_trace/12288/manual_time",
@@ -592,11 +592,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 10,
-      "real_time": 6.9373555500000000e+07,
-      "cpu_time": 2.9082999999996413e+04,
+      "real_time": 6.8436018500000015e+07,
+      "cpu_time": 2.7071999999961350e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.9373555499999998e-06
+      "IterationTime": 6.8436018500000006e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/256/manual_time",
@@ -607,12 +607,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 21,
-      "real_time": 3.1634539571428571e+07,
-      "cpu_time": 2.5688095238105667e+04,
+      "iterations": 23,
+      "real_time": 3.0872163391304348e+07,
+      "cpu_time": 2.9778695652190068e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1634539571428572e-06
+      "IterationTime": 3.0872163391304341e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/512/manual_time",
@@ -624,11 +624,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 22,
-      "real_time": 3.2252241772727273e+07,
-      "cpu_time": 2.5726363636351995e+04,
+      "real_time": 3.1278290181818176e+07,
+      "cpu_time": 2.8017727272718188e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2252241772727268e-06
+      "IterationTime": 3.1278290181818181e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/1024/manual_time",
@@ -640,11 +640,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3963626809523806e+07,
-      "cpu_time": 2.9575238095224689e+04,
+      "real_time": 3.3166115190476179e+07,
+      "cpu_time": 2.9893380952383806e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3963626809523805e-06
+      "IterationTime": 3.3166115190476182e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/2048/manual_time",
@@ -656,11 +656,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8657082222222224e+07,
-      "cpu_time": 3.3202277777786039e+04,
+      "real_time": 3.8647772333333336e+07,
+      "cpu_time": 2.8021666666649340e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8657082222222230e-06
+      "IterationTime": 3.8647772333333334e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/4096/manual_time",
@@ -672,11 +672,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 16,
-      "real_time": 4.4603124250000000e+07,
-      "cpu_time": 1.1499829374999881e+06,
+      "real_time": 4.3461517624999993e+07,
+      "cpu_time": 2.9281250000012806e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.4603124250000000e-06
+      "IterationTime": 4.3461517624999994e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/8192/manual_time",
@@ -687,12 +687,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 5.6649950833333321e+07,
-      "cpu_time": 2.8379166666721765e+04,
+      "iterations": 13,
+      "real_time": 5.5678035076923087e+07,
+      "cpu_time": 2.8166923076952888e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6649950833333329e-06
+      "IterationTime": 5.5678035076923092e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_trace/12288/manual_time",
@@ -704,11 +704,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 10,
-      "real_time": 6.9343781000000000e+07,
-      "cpu_time": 2.8451000000018212e+04,
+      "real_time": 6.8392664700000003e+07,
+      "cpu_time": 2.4823000000040451e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.9343781000000007e-06
+      "IterationTime": 6.8392664699999996e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/256/manual_time",
@@ -719,12 +719,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.4832831999999993e+07,
-      "cpu_time": 2.9897499999975709e+04,
+      "iterations": 21,
+      "real_time": 3.3845019809523813e+07,
+      "cpu_time": 2.0568095238072630e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4832831999999998e-06
+      "IterationTime": 3.3845019809523813e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/512/manual_time",
@@ -736,11 +736,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.6449451899999999e+07,
-      "cpu_time": 9.7504840000000037e+05,
+      "real_time": 3.4228751700000003e+07,
+      "cpu_time": 3.2935999999983425e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6449451900000003e-06
+      "IterationTime": 3.4228751699999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/1024/manual_time",
@@ -752,11 +752,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.7350072105263159e+07,
-      "cpu_time": 3.2452631578939796e+04,
+      "real_time": 3.6214824421052627e+07,
+      "cpu_time": 2.7318947368433561e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7350072105263161e-06
+      "IterationTime": 3.6214824421052633e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/2048/manual_time",
@@ -768,11 +768,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1349199000000000e+07,
-      "cpu_time": 3.3047058823519685e+04,
+      "real_time": 4.0400135176470578e+07,
+      "cpu_time": 2.0770588235287298e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1349198999999998e-06
+      "IterationTime": 4.0400135176470587e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/4096/manual_time",
@@ -784,11 +784,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.7423208533333324e+07,
-      "cpu_time": 3.4654218666666737e+06,
+      "real_time": 4.6388238733333327e+07,
+      "cpu_time": 2.9328000000046948e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.7423208533333325e-06
+      "IterationTime": 4.6388238733333321e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb/8192/manual_time",
@@ -800,11 +800,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9620735583333321e+07,
-      "cpu_time": 3.0946666666660978e+04,
+      "real_time": 5.8496497666666664e+07,
+      "cpu_time": 2.8395000000032884e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9620735583333321e-06
+      "IterationTime": 5.8496497666666659e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/256/manual_time",
@@ -815,12 +815,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.4966052399999991e+07,
-      "cpu_time": 2.6245999999963133e+04,
+      "iterations": 21,
+      "real_time": 3.3990628904761903e+07,
+      "cpu_time": 2.0251904761942846e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4966052399999996e-06
+      "IterationTime": 3.3990628904761905e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/512/manual_time",
@@ -832,11 +832,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5434425599999994e+07,
-      "cpu_time": 2.3990000000040367e+04,
+      "real_time": 3.4457520049999997e+07,
+      "cpu_time": 2.7326500000013351e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5434425599999992e-06
+      "IterationTime": 3.4457520050000000e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/1024/manual_time",
@@ -847,12 +847,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.8013000388888881e+07,
-      "cpu_time": 2.5705555555551502e+04,
+      "iterations": 19,
+      "real_time": 3.6387923368421055e+07,
+      "cpu_time": 2.0124210526299630e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8013000388888885e-06
+      "IterationTime": 3.6387923368421044e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/2048/manual_time",
@@ -864,11 +864,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1546207764705881e+07,
-      "cpu_time": 2.8819999999975174e+04,
+      "real_time": 4.0620522764705881e+07,
+      "cpu_time": 2.8557058823535230e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1546207764705886e-06
+      "IterationTime": 4.0620522764705883e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/4096/manual_time",
@@ -879,12 +879,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 15,
-      "real_time": 4.8552954599999994e+07,
-      "cpu_time": 1.0424800000000307e+05,
+      "iterations": 14,
+      "real_time": 4.6791401071428582e+07,
+      "cpu_time": 2.8425714285708535e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8552954599999991e-06
+      "IterationTime": 4.6791401071428577e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb/8192/manual_time",
@@ -896,11 +896,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9867292583333336e+07,
-      "cpu_time": 2.8543333333352904e+04,
+      "real_time": 5.8753966000000000e+07,
+      "cpu_time": 2.7790833333337283e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9867292583333336e-06
+      "IterationTime": 5.8753966000000001e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/256/manual_time",
@@ -912,11 +912,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7667274166666664e+07,
-      "cpu_time": 2.7230833333335981e+04,
+      "real_time": 5.9092001666666664e+07,
+      "cpu_time": 2.7093333333357470e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7667274166666655e-06
+      "IterationTime": 5.9092001666666658e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/512/manual_time",
@@ -928,11 +928,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.7947021583333343e+07,
-      "cpu_time": 2.8888333333328595e+04,
+      "real_time": 5.9355805083333336e+07,
+      "cpu_time": 2.6259166666727415e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7947021583333339e-06
+      "IterationTime": 5.9355805083333341e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/1024/manual_time",
@@ -944,11 +944,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.8670988333333336e+07,
-      "cpu_time": 2.7310833333293875e+04,
+      "real_time": 6.0026740583333336e+07,
+      "cpu_time": 2.9049166666720674e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.8670988333333325e-06
+      "IterationTime": 6.0026740583333336e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/2048/manual_time",
@@ -959,12 +959,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 6.0512937916666657e+07,
-      "cpu_time": 3.7064166666711528e+04,
+      "iterations": 11,
+      "real_time": 6.1927710454545453e+07,
+      "cpu_time": 2.9102727272684544e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.0512937916666649e-06
+      "IterationTime": 6.1927710454545451e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/4096/manual_time",
@@ -976,11 +976,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.4148351000000007e+07,
-      "cpu_time": 2.9450909090930367e+04,
+      "real_time": 6.6789990363636374e+07,
+      "cpu_time": 2.8590909090908666e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4148350999999998e-06
+      "IterationTime": 6.6789990363636374e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_8g/8192/manual_time",
@@ -992,11 +992,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 8,
-      "real_time": 8.6298472625000000e+07,
-      "cpu_time": 3.3377499999986961e+04,
+      "real_time": 8.7640193125000000e+07,
+      "cpu_time": 2.9718750000018445e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 8.6298472624999998e-06
+      "IterationTime": 8.7640193125000002e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/256/manual_time",
@@ -1008,11 +1008,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9048151249999993e+07,
-      "cpu_time": 2.6193333333350092e+04,
+      "real_time": 6.0341891333333336e+07,
+      "cpu_time": 2.7046666666604342e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9048151249999986e-06
+      "IterationTime": 6.0341891333333329e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/512/manual_time",
@@ -1024,11 +1024,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9280490000000000e+07,
-      "cpu_time": 2.8445083333291284e+04,
+      "real_time": 6.0591802249999993e+07,
+      "cpu_time": 2.7308333333383081e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9280490000000005e-06
+      "IterationTime": 6.0591802250000001e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/1024/manual_time",
@@ -1039,12 +1039,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 5.9819036750000000e+07,
-      "cpu_time": 1.4756105000000019e+06,
+      "iterations": 11,
+      "real_time": 6.1203778090909094e+07,
+      "cpu_time": 2.8349090909106748e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9819036749999993e-06
+      "IterationTime": 6.1203778090909097e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/2048/manual_time",
@@ -1056,11 +1056,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.1798934818181805e+07,
-      "cpu_time": 2.5863636363739191e+04,
+      "real_time": 6.3216923000000000e+07,
+      "cpu_time": 2.9241818181899052e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.1798934818181816e-06
+      "IterationTime": 6.3216922999999996e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/4096/manual_time",
@@ -1071,12 +1071,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 11,
-      "real_time": 6.5846429090909101e+07,
-      "cpu_time": 2.4610909090873956e+04,
+      "iterations": 10,
+      "real_time": 6.7251829200000003e+07,
+      "cpu_time": 2.8526000000006490e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.5846429090909096e-06
+      "IterationTime": 6.7251829200000003e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32cb_8g/8192/manual_time",
@@ -1088,11 +1088,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 8,
-      "real_time": 8.9349407250000000e+07,
-      "cpu_time": 2.6471249999993062e+04,
+      "real_time": 9.0846122125000000e+07,
+      "cpu_time": 3.6902499999991182e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 8.9349407250000000e-06
+      "IterationTime": 9.0846122124999994e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/256/manual_time",
@@ -1103,12 +1103,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.4795756149999999e+07,
-      "cpu_time": 1.1732548500000383e+06,
+      "iterations": 21,
+      "real_time": 3.3864094952380955e+07,
+      "cpu_time": 3.1617190476227042e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4795756150000003e-06
+      "IterationTime": 3.3864094952380960e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/512/manual_time",
@@ -1120,11 +1120,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5162341100000001e+07,
-      "cpu_time": 2.4719500000003336e+04,
+      "real_time": 3.4240020249999993e+07,
+      "cpu_time": 3.1280500000008258e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5162341100000002e-06
+      "IterationTime": 3.4240020249999989e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/1024/manual_time",
@@ -1136,11 +1136,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.7268231105263166e+07,
-      "cpu_time": 2.3696315789485154e+04,
+      "real_time": 3.6186565578947365e+07,
+      "cpu_time": 3.1152105263200869e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7268231105263164e-06
+      "IterationTime": 3.6186565578947370e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/2048/manual_time",
@@ -1152,11 +1152,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1270990176470585e+07,
-      "cpu_time": 2.5954117647105712e+04,
+      "real_time": 4.0401109941176467e+07,
+      "cpu_time": 2.7919470588307318e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1270990176470595e-06
+      "IterationTime": 4.0401109941176465e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/4096/manual_time",
@@ -1168,11 +1168,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.8162383600000001e+07,
-      "cpu_time": 1.2334897333333336e+06,
+      "real_time": 4.6422498600000001e+07,
+      "cpu_time": 3.1063400000045738e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8162383600000008e-06
+      "IterationTime": 4.6422498599999994e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/8192/manual_time",
@@ -1184,11 +1184,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9658606333333321e+07,
-      "cpu_time": 2.6235833333387858e+04,
+      "real_time": 5.8549516666666664e+07,
+      "cpu_time": 3.0240833333324466e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9658606333333335e-06
+      "IterationTime": 5.8549516666666671e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/256/manual_time",
@@ -1199,12 +1199,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.4825494799999997e+07,
-      "cpu_time": 2.6379999999992520e+04,
+      "iterations": 21,
+      "real_time": 3.3864683095238097e+07,
+      "cpu_time": 3.2318142857148829e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4825494800000000e-06
+      "IterationTime": 3.3864683095238088e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/512/manual_time",
@@ -1216,11 +1216,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5188474299999997e+07,
-      "cpu_time": 2.3397550000048283e+04,
+      "real_time": 3.4227591750000000e+07,
+      "cpu_time": 3.0549050000061583e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5188474299999996e-06
+      "IterationTime": 3.4227591750000003e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/1024/manual_time",
@@ -1232,11 +1232,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.7378225578947365e+07,
-      "cpu_time": 5.2608421052649661e+04,
+      "real_time": 3.6198510789473675e+07,
+      "cpu_time": 2.8494210526244355e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7378225578947362e-06
+      "IterationTime": 3.6198510789473679e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/2048/manual_time",
@@ -1248,11 +1248,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1344890470588244e+07,
-      "cpu_time": 2.9948882352905024e+04,
+      "real_time": 4.0415821588235289e+07,
+      "cpu_time": 3.1804176470666163e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1344890470588245e-06
+      "IterationTime": 4.0415821588235289e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/4096/manual_time",
@@ -1264,11 +1264,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.7359346933333322e+07,
-      "cpu_time": 2.9212733333376189e+04,
+      "real_time": 4.6382336733333334e+07,
+      "cpu_time": 3.1196666666607103e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.7359346933333322e-06
+      "IterationTime": 4.6382336733333333e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_rta/8192/manual_time",
@@ -1280,11 +1280,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9717628916666679e+07,
-      "cpu_time": 3.0156666666651214e+04,
+      "real_time": 5.8602740749999993e+07,
+      "cpu_time": 2.9139333333372266e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9717628916666669e-06
+      "IterationTime": 5.8602740749999997e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/256/manual_time",
@@ -1295,12 +1295,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 13,
-      "real_time": 5.3956387307692319e+07,
-      "cpu_time": 2.7406923076994233e+04,
+      "iterations": 14,
+      "real_time": 5.1645120642857127e+07,
+      "cpu_time": 2.9487142857093881e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.3956387307692314e-06
+      "IterationTime": 5.1645120642857127e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/512/manual_time",
@@ -1311,12 +1311,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 13,
-      "real_time": 5.4030073384615391e+07,
-      "cpu_time": 2.5227000000072054e+04,
+      "iterations": 14,
+      "real_time": 5.1770988857142858e+07,
+      "cpu_time": 2.8950000000043427e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.4030073384615397e-06
+      "IterationTime": 5.1770988857142860e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/1024/manual_time",
@@ -1328,11 +1328,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.4316575153846152e+07,
-      "cpu_time": 3.0006230769293790e+04,
+      "real_time": 5.1989118538461529e+07,
+      "cpu_time": 2.8928538461523945e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.4316575153846150e-06
+      "IterationTime": 5.1989118538461529e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/2048/manual_time",
@@ -1344,11 +1344,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.4852799384615377e+07,
-      "cpu_time": 2.5773846153799041e+04,
+      "real_time": 5.3252906307692319e+07,
+      "cpu_time": 2.8082307692373503e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.4852799384615378e-06
+      "IterationTime": 5.3252906307692319e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/4096/manual_time",
@@ -1359,12 +1359,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 12,
-      "real_time": 5.7041049750000000e+07,
-      "cpu_time": 1.6942230000000317e+06,
+      "iterations": 13,
+      "real_time": 5.5708592769230768e+07,
+      "cpu_time": 2.8253846153894265e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7041049750000001e-06
+      "IterationTime": 5.5708592769230766e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processor_all_cores_128_rta/8192/manual_time",
@@ -1376,11 +1376,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9298484166666679e+07,
-      "cpu_time": 2.7182499999926320e+04,
+      "real_time": 5.8412570500000000e+07,
+      "cpu_time": 2.8698333333299073e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9298484166666673e-06
+      "IterationTime": 5.8412570500000001e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/256/manual_time",
@@ -1392,11 +1392,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5336459049999997e+07,
-      "cpu_time": 2.9798499999955653e+04,
+      "real_time": 3.5541464750000000e+07,
+      "cpu_time": 3.1890500000031352e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5336459049999999e-06
+      "IterationTime": 3.5541464750000001e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/512/manual_time",
@@ -1408,11 +1408,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5405480700000003e+07,
-      "cpu_time": 2.5639500000007589e+04,
+      "real_time": 3.5623195000000007e+07,
+      "cpu_time": 3.1452999999981304e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5405480699999999e-06
+      "IterationTime": 3.5623195000000006e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/1024/manual_time",
@@ -1424,11 +1424,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.6418341100000001e+07,
-      "cpu_time": 9.1884685000005458e+05,
+      "real_time": 3.5792862999999993e+07,
+      "cpu_time": 3.0696550000008931e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6418341100000003e-06
+      "IterationTime": 3.5792862999999996e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/2048/manual_time",
@@ -1440,11 +1440,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.5931190000000000e+07,
-      "cpu_time": 2.5422105263105339e+04,
+      "real_time": 3.6194161315789476e+07,
+      "cpu_time": 3.4957368421061867e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5931189999999998e-06
+      "IterationTime": 3.6194161315789476e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/4096/manual_time",
@@ -1456,11 +1456,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.6671168157894753e+07,
-      "cpu_time": 2.5701052631607457e+04,
+      "real_time": 3.6893655526315793e+07,
+      "cpu_time": 2.9133157894708904e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6671168157894742e-06
+      "IterationTime": 3.6893655526315797e-06
     },
     {
       "name": "BM_pgm_dispatch/one_processors_all_cores_1_rta/8192/manual_time",
@@ -1472,11 +1472,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8652669333333328e+07,
-      "cpu_time": 2.5340555555549334e+04,
+      "real_time": 3.8810312333333336e+07,
+      "cpu_time": 2.9658888888839385e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8652669333333332e-06
+      "IterationTime": 3.8810312333333328e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/256/manual_time",
@@ -1487,12 +1487,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.5134674550000004e+07,
-      "cpu_time": 8.9725779999998421e+05,
+      "iterations": 21,
+      "real_time": 3.3866708333333336e+07,
+      "cpu_time": 3.0717619047577959e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5134674550000001e-06
+      "IterationTime": 3.3866708333333334e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/512/manual_time",
@@ -1504,11 +1504,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5166275700000003e+07,
-      "cpu_time": 2.5960049999973478e+04,
+      "real_time": 3.4241497200000003e+07,
+      "cpu_time": 2.9323500000000280e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5166275700000006e-06
+      "IterationTime": 3.4241497199999999e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/1024/manual_time",
@@ -1520,11 +1520,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 19,
-      "real_time": 3.7266063947368428e+07,
-      "cpu_time": 2.5258421052592137e+04,
+      "real_time": 3.6193861315789469e+07,
+      "cpu_time": 3.0910578947341313e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7266063947368430e-06
+      "IterationTime": 3.6193861315789472e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/2048/manual_time",
@@ -1536,11 +1536,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1266495705882356e+07,
-      "cpu_time": 2.7744705882384704e+04,
+      "real_time": 4.0410576882352941e+07,
+      "cpu_time": 3.5551764705801630e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1266495705882361e-06
+      "IterationTime": 4.0410576882352939e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/4096/manual_time",
@@ -1552,11 +1552,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.7728151800000004e+07,
-      "cpu_time": 1.1947076666667536e+06,
+      "real_time": 4.6411401333333336e+07,
+      "cpu_time": 3.2304666666623423e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.7728151800000007e-06
+      "IterationTime": 4.6411401333333330e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_1_crta/8192/manual_time",
@@ -1568,11 +1568,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9745197083333336e+07,
-      "cpu_time": 2.8655833333335322e+04,
+      "real_time": 5.8625489833333336e+07,
+      "cpu_time": 3.0932583333420640e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9745197083333329e-06
+      "IterationTime": 5.8625489833333334e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/256/manual_time",
@@ -1584,11 +1584,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5839997899999999e+07,
-      "cpu_time": 2.6375499999975458e+04,
+      "real_time": 3.4860300350000001e+07,
+      "cpu_time": 2.9128549999946077e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5839997899999998e-06
+      "IterationTime": 3.4860300350000000e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/512/manual_time",
@@ -1599,12 +1599,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.6332817736842103e+07,
-      "cpu_time": 2.5973157894747757e+04,
+      "iterations": 20,
+      "real_time": 3.5373598799999997e+07,
+      "cpu_time": 3.1261049999997682e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6332817736842102e-06
+      "IterationTime": 3.5373598799999999e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/1024/manual_time",
@@ -1615,12 +1615,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.9345880777777769e+07,
-      "cpu_time": 2.5228888888821170e+04,
+      "iterations": 19,
+      "real_time": 3.7229482947368421e+07,
+      "cpu_time": 3.0598421052580332e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9345880777777781e-06
+      "IterationTime": 3.7229482947368420e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/2048/manual_time",
@@ -1631,12 +1631,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 16,
-      "real_time": 4.2350622187500000e+07,
-      "cpu_time": 2.7529375000057145e+04,
+      "iterations": 17,
+      "real_time": 4.1499934176470585e+07,
+      "cpu_time": 3.1162352941335899e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.2350622187499997e-06
+      "IterationTime": 4.1499934176470589e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/4096/manual_time",
@@ -1647,12 +1647,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 14,
-      "real_time": 4.8948732142857149e+07,
-      "cpu_time": 2.7228642857122868e+04,
+      "iterations": 15,
+      "real_time": 4.7628230733333349e+07,
+      "cpu_time": 3.4658666666587123e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8948732142857152e-06
+      "IterationTime": 4.7628230733333343e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_1_core_128_crta/8192/manual_time",
@@ -1663,12 +1663,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 11,
-      "real_time": 6.0903836363636352e+07,
-      "cpu_time": 3.0542818181670969e+04,
+      "iterations": 12,
+      "real_time": 5.9730907499999993e+07,
+      "cpu_time": 1.8539166666424004e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.0903836363636352e-06
+      "IterationTime": 5.9730907500000002e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/256/manual_time",
@@ -1680,11 +1680,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8045478666666657e+07,
-      "cpu_time": 2.5201166666772362e+04,
+      "real_time": 3.8268248166666672e+07,
+      "cpu_time": 1.9575000000000073e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8045478666666665e-06
+      "IterationTime": 3.8268248166666672e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/512/manual_time",
@@ -1696,11 +1696,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8745316611111112e+07,
-      "cpu_time": 1.0288191666665527e+06,
+      "real_time": 3.8499662444444448e+07,
+      "cpu_time": 1.9167777777834912e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8745316611111116e-06
+      "IterationTime": 3.8499662444444445e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/1024/manual_time",
@@ -1712,11 +1712,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9149596000000000e+07,
-      "cpu_time": 2.4675055555552681e+04,
+      "real_time": 3.9189716944444448e+07,
+      "cpu_time": 1.9982222222165230e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9149595999999998e-06
+      "IterationTime": 3.9189716944444442e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/2048/manual_time",
@@ -1727,12 +1727,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 4.2109640000000000e+07,
-      "cpu_time": 2.5907647058891613e+04,
+      "iterations": 16,
+      "real_time": 4.2561825687500000e+07,
+      "cpu_time": 1.7193749999977470e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.2109639999999999e-06
+      "IterationTime": 4.2561825687499997e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/4096/manual_time",
@@ -1743,12 +1743,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 14,
-      "real_time": 4.8736820428571418e+07,
-      "cpu_time": 2.9681428571594533e+04,
+      "iterations": 15,
+      "real_time": 4.7476169600000001e+07,
+      "cpu_time": 1.9762666666641358e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8736820428571418e-06
+      "IterationTime": 4.7476169599999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_rta/8192/manual_time",
@@ -1760,11 +1760,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6200155181818180e+07,
-      "cpu_time": 1.6496905454546476e+06,
+      "real_time": 6.6501802181818172e+07,
+      "cpu_time": 2.0488181818414185e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6200155181818189e-06
+      "IterationTime": 6.6501802181818176e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/256/manual_time",
@@ -1775,12 +1775,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 13,
-      "real_time": 5.2148696307692304e+07,
-      "cpu_time": 2.8045384615401541e+04,
+      "iterations": 14,
+      "real_time": 5.1083601857142851e+07,
+      "cpu_time": 1.9944285714247810e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.2148696307692304e-06
+      "IterationTime": 5.1083601857142851e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/512/manual_time",
@@ -1791,12 +1791,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 13,
-      "real_time": 5.2593119923076935e+07,
-      "cpu_time": 3.0483076923104589e+04,
+      "iterations": 14,
+      "real_time": 5.1565836714285709e+07,
+      "cpu_time": 1.8222857142749912e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.2593119923076924e-06
+      "IterationTime": 5.1565836714285712e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/1024/manual_time",
@@ -1808,11 +1808,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 13,
-      "real_time": 5.4211064538461529e+07,
-      "cpu_time": 2.9519230769308862e+04,
+      "real_time": 5.3501291307692319e+07,
+      "cpu_time": 1.7564615384858284e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.4211064538461530e-06
+      "IterationTime": 5.3501291307692315e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/2048/manual_time",
@@ -1824,11 +1824,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.8807677250000000e+07,
-      "cpu_time": 6.9125833333257469e+04,
+      "real_time": 5.7789281916666664e+07,
+      "cpu_time": 2.0549166666938847e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.8807677250000002e-06
+      "IterationTime": 5.7789281916666667e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/4096/manual_time",
@@ -1840,11 +1840,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.4885840636363633e+07,
-      "cpu_time": 2.7539090909104143e+04,
+      "real_time": 6.4216733818181820e+07,
+      "cpu_time": 1.9630909090618719e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4885840636363643e-06
+      "IterationTime": 6.4216733818181811e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_rta/8192/manual_time",
@@ -1856,11 +1856,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 9,
-      "real_time": 7.9924001000000000e+07,
-      "cpu_time": 3.0301111111204664e+04,
+      "real_time": 7.8178400111111104e+07,
+      "cpu_time": 2.0764444444567845e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 7.9924000999999999e-06
+      "IterationTime": 7.8178400111111099e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/256/manual_time",
@@ -1872,11 +1872,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0669869800000001e+08,
-      "cpu_time": 1.5846885714308560e+05,
+      "real_time": 1.0355283642857143e+08,
+      "cpu_time": 2.2270142857446928e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0669869800000001e-05
+      "IterationTime": 1.0355283642857143e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/512/manual_time",
@@ -1888,11 +1888,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0522675642857143e+08,
-      "cpu_time": 3.5912999999863714e+04,
+      "real_time": 1.0405704342857142e+08,
+      "cpu_time": 2.1205714285749924e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0522675642857143e-05
+      "IterationTime": 1.0405704342857141e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/1024/manual_time",
@@ -1904,11 +1904,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0841346357142857e+08,
-      "cpu_time": 1.4169000000003556e+05,
+      "real_time": 1.0599473028571428e+08,
+      "cpu_time": 2.2554285714245936e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0841346357142857e-05
+      "IterationTime": 1.0599473028571429e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/2048/manual_time",
@@ -1920,11 +1920,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1169431983333333e+08,
-      "cpu_time": 3.7853333333022951e+04,
+      "real_time": 1.1076896016666667e+08,
+      "cpu_time": 2.1698333333356837e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1169431983333334e-05
+      "IterationTime": 1.1076896016666667e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/4096/manual_time",
@@ -1936,11 +1936,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1698847583333336e+08,
-      "cpu_time": 3.2194999999883104e+04,
+      "real_time": 1.1617562533333333e+08,
+      "cpu_time": 2.2643333333386789e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1698847583333333e-05
+      "IterationTime": 1.1617562533333333e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_rta/8192/manual_time",
@@ -1952,11 +1952,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.3058787080000000e+08,
-      "cpu_time": 3.2895999999738022e+04,
+      "real_time": 1.2946377100000000e+08,
+      "cpu_time": 2.0956000000182939e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.3058787079999999e-05
+      "IterationTime": 1.2946377099999999e-05
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/256/manual_time",
@@ -1967,12 +1967,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.4806070899999991e+07,
-      "cpu_time": 2.6673550000033683e+04,
+      "iterations": 21,
+      "real_time": 3.3841111380952381e+07,
+      "cpu_time": 2.0024285714184556e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.4806070899999994e-06
+      "IterationTime": 3.3841111380952381e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/512/manual_time",
@@ -1984,11 +1984,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5168553449999996e+07,
-      "cpu_time": 2.9328050000110299e+04,
+      "real_time": 3.4211716500000000e+07,
+      "cpu_time": 1.5647050000211491e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5168553449999994e-06
+      "IterationTime": 3.4211716499999998e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/1024/manual_time",
@@ -1999,12 +1999,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.7264981833333328e+07,
-      "cpu_time": 2.2720555555485094e+04,
+      "iterations": 19,
+      "real_time": 3.6160279578947373e+07,
+      "cpu_time": 1.8234736842259736e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7264981833333326e-06
+      "IterationTime": 3.6160279578947373e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/2048/manual_time",
@@ -2016,11 +2016,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1283655176470585e+07,
-      "cpu_time": 2.2221764705885587e+04,
+      "real_time": 4.0379673176470585e+07,
+      "cpu_time": 1.7873529411862339e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1283655176470589e-06
+      "IterationTime": 4.0379673176470587e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/4096/manual_time",
@@ -2032,11 +2032,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.7415461333333336e+07,
-      "cpu_time": 2.4814666666609737e+04,
+      "real_time": 4.6394755000000000e+07,
+      "cpu_time": 1.7712666666606459e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.7415461333333335e-06
+      "IterationTime": 4.6394754999999999e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_1_crta/8192/manual_time",
@@ -2048,11 +2048,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9652587833333336e+07,
-      "cpu_time": 2.7308416666649293e+04,
+      "real_time": 5.8497706333333336e+07,
+      "cpu_time": 2.0804999999531523e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9652587833333341e-06
+      "IterationTime": 5.8497706333333337e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/256/manual_time",
@@ -2063,12 +2063,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 20,
-      "real_time": 3.5574512350000009e+07,
-      "cpu_time": 9.2171625000005984e+05,
+      "iterations": 21,
+      "real_time": 3.3935311095238090e+07,
+      "cpu_time": 1.8279047619021836e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5574512350000005e-06
+      "IterationTime": 3.3935311095238089e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/512/manual_time",
@@ -2080,11 +2080,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5398209599999994e+07,
-      "cpu_time": 2.4563999999926978e+04,
+      "real_time": 3.4378032049999997e+07,
+      "cpu_time": 1.7181500000162941e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5398209600000002e-06
+      "IterationTime": 3.4378032050000004e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/1024/manual_time",
@@ -2095,12 +2095,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.7982745111111119e+07,
-      "cpu_time": 2.3211666666572088e+04,
+      "iterations": 19,
+      "real_time": 3.6331834368421048e+07,
+      "cpu_time": 1.7326842105092055e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7982745111111113e-06
+      "IterationTime": 3.6331834368421048e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/2048/manual_time",
@@ -2112,11 +2112,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 17,
-      "real_time": 4.1492565470588230e+07,
-      "cpu_time": 2.4804705882279919e+04,
+      "real_time": 4.0580876647058815e+07,
+      "cpu_time": 1.9367647058826980e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1492565470588225e-06
+      "IterationTime": 4.0580876647058811e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/4096/manual_time",
@@ -2128,11 +2128,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 15,
-      "real_time": 4.8860645466666676e+07,
-      "cpu_time": 2.3320341333331387e+06,
+      "real_time": 4.6672790133333340e+07,
+      "cpu_time": 1.8376666666597430e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8860645466666671e-06
+      "IterationTime": 4.6672790133333339e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_32_crta/8192/manual_time",
@@ -2144,11 +2144,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.9852331166666657e+07,
-      "cpu_time": 2.4442499999999258e+04,
+      "real_time": 5.8674129083333343e+07,
+      "cpu_time": 1.9472500000006221e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.9852331166666642e-06
+      "IterationTime": 5.8674129083333343e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/256/manual_time",
@@ -2160,11 +2160,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 20,
-      "real_time": 3.5835629700000003e+07,
-      "cpu_time": 2.5630499999884647e+04,
+      "real_time": 3.4882254450000003e+07,
+      "cpu_time": 1.7607500000238473e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.5835629700000000e-06
+      "IterationTime": 3.4882254450000002e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/512/manual_time",
@@ -2175,12 +2175,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.6319369684210517e+07,
-      "cpu_time": 2.3827894736801849e+04,
+      "iterations": 20,
+      "real_time": 3.5464229150000006e+07,
+      "cpu_time": 1.7219500000109634e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6319369684210522e-06
+      "IterationTime": 3.5464229150000003e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/1024/manual_time",
@@ -2191,12 +2191,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 18,
-      "real_time": 3.9999014611111112e+07,
-      "cpu_time": 1.9556556666666423e+06,
+      "iterations": 19,
+      "real_time": 3.7248529368421055e+07,
+      "cpu_time": 3.1024210526341350e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9999014611111110e-06
+      "IterationTime": 3.7248529368421050e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/2048/manual_time",
@@ -2207,12 +2207,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 16,
-      "real_time": 4.2440385687499993e+07,
-      "cpu_time": 2.6978750000017371e+04,
+      "iterations": 17,
+      "real_time": 4.1504011470588230e+07,
+      "cpu_time": 2.9567647058486808e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.2440385687499991e-06
+      "IterationTime": 4.1504011470588223e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/4096/manual_time",
@@ -2223,12 +2223,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 14,
-      "real_time": 4.8956738714285709e+07,
-      "cpu_time": 2.6667857142876575e+04,
+      "iterations": 15,
+      "real_time": 4.7899107000000000e+07,
+      "cpu_time": 3.3021333333257040e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8956738714285717e-06
+      "IterationTime": 4.7899106999999999e-06
     },
     {
       "name": "BM_pgm_dispatch/all_processors_all_cores_128_crta/8192/manual_time",
@@ -2239,12 +2239,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 11,
-      "real_time": 6.0977367636363648e+07,
-      "cpu_time": 2.8860000000140539e+04,
+      "iterations": 12,
+      "real_time": 5.9780587416666664e+07,
+      "cpu_time": 3.0381666666912108e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.0977367636363637e-06
+      "IterationTime": 5.9780587416666672e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/256/manual_time",
@@ -2255,12 +2255,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 3.0989122739130445e+07,
-      "cpu_time": 3.2104347826064033e+04,
+      "iterations": 24,
+      "real_time": 2.9060579583333332e+07,
+      "cpu_time": 3.0393333333359842e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0989122739130448e-06
+      "IterationTime": 2.9060579583333339e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/512/manual_time",
@@ -2271,12 +2271,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 21,
-      "real_time": 3.0993355809523810e+07,
-      "cpu_time": 3.2487142857090272e+04,
+      "iterations": 24,
+      "real_time": 2.9069395416666660e+07,
+      "cpu_time": 3.0360833333335318e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0993355809523806e-06
+      "IterationTime": 2.9069395416666660e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/1024/manual_time",
@@ -2287,12 +2287,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 22,
-      "real_time": 3.1271749136363637e+07,
-      "cpu_time": 2.5788636363670168e+04,
+      "iterations": 24,
+      "real_time": 2.9061216250000004e+07,
+      "cpu_time": 3.0285458333464037e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1271749136363638e-06
+      "IterationTime": 2.9061216250000004e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/2048/manual_time",
@@ -2303,12 +2303,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 22,
-      "real_time": 3.1956641090909090e+07,
-      "cpu_time": 2.6285954545457455e+04,
+      "iterations": 23,
+      "real_time": 3.0361914695652168e+07,
+      "cpu_time": 2.9296086956304385e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1956641090909090e-06
+      "IterationTime": 3.0361914695652172e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/4096/manual_time",
@@ -2320,11 +2320,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3906762047619052e+07,
-      "cpu_time": 2.5758571428555329e+04,
+      "real_time": 3.2791147952380948e+07,
+      "cpu_time": 3.0320000000133838e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3906762047619054e-06
+      "IterationTime": 3.2791147952380947e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_1_core_1_processor_trace/8192/manual_time",
@@ -2335,12 +2335,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.7305000736842103e+07,
-      "cpu_time": 1.0529236315787814e+06,
+      "iterations": 20,
+      "real_time": 3.5466797249999993e+07,
+      "cpu_time": 3.1161000000068383e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.7305000736842102e-06
+      "IterationTime": 3.5466797249999990e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/256/manual_time",
@@ -2351,12 +2351,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 3.0983176347826082e+07,
-      "cpu_time": 2.6347391304210283e+04,
+      "iterations": 24,
+      "real_time": 2.9060010833333332e+07,
+      "cpu_time": 3.0129999999850552e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0983176347826083e-06
+      "IterationTime": 2.9060010833333329e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/512/manual_time",
@@ -2367,12 +2367,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 23,
-      "real_time": 3.0992202695652176e+07,
-      "cpu_time": 3.3684782608605943e+04,
+      "iterations": 24,
+      "real_time": 2.9061130416666660e+07,
+      "cpu_time": 3.0451708333304832e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0992202695652175e-06
+      "IterationTime": 2.9061130416666668e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/1024/manual_time",
@@ -2383,12 +2383,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 22,
-      "real_time": 3.1278339545454547e+07,
-      "cpu_time": 3.2937772727140407e+04,
+      "iterations": 24,
+      "real_time": 2.9061042916666668e+07,
+      "cpu_time": 3.0333791666651658e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1278339545454546e-06
+      "IterationTime": 2.9061042916666670e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/2048/manual_time",
@@ -2399,12 +2399,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 22,
-      "real_time": 3.2652125227272734e+07,
-      "cpu_time": 8.1298022727273952e+05,
+      "iterations": 23,
+      "real_time": 3.0358220304347821e+07,
+      "cpu_time": 3.0822608695695693e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.2652125227272731e-06
+      "IterationTime": 3.0358220304347827e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/4096/manual_time",
@@ -2416,11 +2416,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 21,
-      "real_time": 3.3913582428571433e+07,
-      "cpu_time": 3.5995238094969973e+04,
+      "real_time": 3.2781814142857127e+07,
+      "cpu_time": 3.0508571428743468e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.3913582428571437e-06
+      "IterationTime": 3.2781814142857126e-06
     },
     {
       "name": "BM_pgm_dispatch/sems_all_cores_1_processor_trace/8192/manual_time",
@@ -2431,12 +2431,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 19,
-      "real_time": 3.6582511789473683e+07,
-      "cpu_time": 3.3462631578785069e+04,
+      "iterations": 20,
+      "real_time": 3.5467025650000006e+07,
+      "cpu_time": 3.1112499999963464e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.6582511789473681e-06
+      "IterationTime": 3.5467025650000002e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/256/manual_time",
@@ -2448,11 +2448,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0020547342857142e+08,
-      "cpu_time": 3.0270000000395416e+04,
+      "real_time": 9.8970142000000000e+07,
+      "cpu_time": 3.0828571428490446e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0020547342857141e-05
+      "IterationTime": 9.8970142000000001e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/512/manual_time",
@@ -2464,11 +2464,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0071548014285716e+08,
-      "cpu_time": 3.2394285713824698e+04,
+      "real_time": 9.9462656285714284e+07,
+      "cpu_time": 3.0458571429343399e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0071548014285715e-05
+      "IterationTime": 9.9462656285714298e-06
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/1024/manual_time",
@@ -2480,11 +2480,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0279107714285712e+08,
-      "cpu_time": 2.9144285713909667e+04,
+      "real_time": 1.0157456257142857e+08,
+      "cpu_time": 3.0581428571200115e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0279107714285712e-05
+      "IterationTime": 1.0157456257142859e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/2048/manual_time",
@@ -2496,11 +2496,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0675037814285712e+08,
-      "cpu_time": 3.1885714285806444e+04,
+      "real_time": 1.0597391171428570e+08,
+      "cpu_time": 3.1457142857301991e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0675037814285713e-05
+      "IterationTime": 1.0597391171428571e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/4096/manual_time",
@@ -2512,11 +2512,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1265458533333333e+08,
-      "cpu_time": 3.1283333332983904e+04,
+      "real_time": 1.1180647550000000e+08,
+      "cpu_time": 2.8068333333427141e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1265458533333334e-05
+      "IterationTime": 1.1180647550000000e-05
     },
     {
       "name": "BM_pgm_dispatch/maxed_config_params_trace/8192/manual_time",
@@ -2528,11 +2528,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2578444416666667e+08,
-      "cpu_time": 3.0806666667141748e+04,
+      "real_time": 1.2468095383333333e+08,
+      "cpu_time": 2.9903333333673272e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2578444416666667e-05
+      "IterationTime": 1.2468095383333332e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/256/manual_time",
@@ -2544,11 +2544,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0395088014285715e+08,
-      "cpu_time": 2.8622857142985529e+04,
+      "real_time": 1.0610243999999999e+08,
+      "cpu_time": 3.2308571429138865e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0395088014285714e-05
+      "IterationTime": 1.0610243999999997e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/512/manual_time",
@@ -2560,11 +2560,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0517327500000000e+08,
-      "cpu_time": 3.7858571428525269e+04,
+      "real_time": 1.0743019014285715e+08,
+      "cpu_time": 3.1808571428371124e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0517327500000002e-05
+      "IterationTime": 1.0743019014285714e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/1024/manual_time",
@@ -2576,11 +2576,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0832465750000000e+08,
-      "cpu_time": 3.7063333333975381e+04,
+      "real_time": 1.1059162583333333e+08,
+      "cpu_time": 2.8786666666983743e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0832465749999998e-05
+      "IterationTime": 1.1059162583333334e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/2048/manual_time",
@@ -2592,11 +2592,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.2893315820000002e+08,
-      "cpu_time": 3.7172000000396110e+04,
+      "real_time": 1.2879711520000000e+08,
+      "cpu_time": 3.1776000000149907e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2893315820000003e-05
+      "IterationTime": 1.2879711520000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/4096/manual_time",
@@ -2608,11 +2608,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.8500533949999997e+08,
-      "cpu_time": 4.7988342499998286e+06,
+      "real_time": 1.7875191150000000e+08,
+      "cpu_time": 2.8770000000122309e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.8500533949999997e-05
+      "IterationTime": 1.7875191150000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_trace/8192/manual_time",
@@ -2623,12 +2623,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 2,
-      "real_time": 2.8120871599999994e+08,
-      "cpu_time": 3.5390000000745655e+04,
+      "iterations": 3,
+      "real_time": 2.7806596533333331e+08,
+      "cpu_time": 3.6736666667517660e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8120871600000001e-05
+      "IterationTime": 2.7806596533333334e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/256/manual_time",
@@ -2640,11 +2640,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2407892733333336e+08,
-      "cpu_time": 2.9946666667039302e+04,
+      "real_time": 1.2610369283333333e+08,
+      "cpu_time": 3.7288333333644157e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2407892733333335e-05
+      "IterationTime": 1.2610369283333331e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/512/manual_time",
@@ -2656,11 +2656,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2524062633333333e+08,
-      "cpu_time": 3.1069999999762862e+04,
+      "real_time": 1.2722772266666664e+08,
+      "cpu_time": 3.0970000000962726e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2524062633333332e-05
+      "IterationTime": 1.2722772266666664e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/1024/manual_time",
@@ -2672,11 +2672,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.2798612220000000e+08,
-      "cpu_time": 3.4307999999327876e+04,
+      "real_time": 1.2995550940000001e+08,
+      "cpu_time": 3.3784000000025568e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2798612220000000e-05
+      "IterationTime": 1.2995550940000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/2048/manual_time",
@@ -2688,11 +2688,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.5434513300000000e+08,
-      "cpu_time": 3.7935999999660904e+04,
+      "real_time": 1.5226067439999998e+08,
+      "cpu_time": 3.2199999999704691e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.5434513300000000e-05
+      "IterationTime": 1.5226067439999999e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/4096/manual_time",
@@ -2704,11 +2704,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 3,
-      "real_time": 2.0448539000000000e+08,
-      "cpu_time": 3.7953333335375799e+04,
+      "real_time": 2.0252018266666666e+08,
+      "cpu_time": 3.1379999998174902e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.0448538999999999e-05
+      "IterationTime": 2.0252018266666671e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_rta_trace/8192/manual_time",
@@ -2720,11 +2720,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 3.0579334599999994e+08,
-      "cpu_time": 3.4840000001423730e+04,
+      "real_time": 3.0177375549999994e+08,
+      "cpu_time": 3.1584999998557352e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.0579334599999996e-05
+      "IterationTime": 3.0177375549999995e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/256/manual_time",
@@ -2735,12 +2735,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 6,
-      "real_time": 1.2910258499999999e+08,
-      "cpu_time": 6.1742671666671364e+06,
+      "iterations": 5,
+      "real_time": 1.2771940040000001e+08,
+      "cpu_time": 3.0114000000480701e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2910258499999997e-05
+      "IterationTime": 1.2771940040000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/512/manual_time",
@@ -2751,12 +2751,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 6,
-      "real_time": 1.2712165633333336e+08,
-      "cpu_time": 3.7090000000479980e+04,
+      "iterations": 5,
+      "real_time": 1.2910435020000002e+08,
+      "cpu_time": 2.9400000001089666e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2712165633333336e-05
+      "IterationTime": 1.2910435020000003e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/1024/manual_time",
@@ -2768,11 +2768,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.3009249619999997e+08,
-      "cpu_time": 1.9608000000914672e+04,
+      "real_time": 1.3197805520000000e+08,
+      "cpu_time": 3.1878000000062912e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.3009249619999999e-05
+      "IterationTime": 1.3197805520000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/2048/manual_time",
@@ -2784,11 +2784,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.6807468250000000e+08,
-      "cpu_time": 4.6700000000399203e+04,
+      "real_time": 1.6634992225000000e+08,
+      "cpu_time": 3.1332499998981690e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.6807468249999999e-05
+      "IterationTime": 1.6634992225000002e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/4096/manual_time",
@@ -2800,11 +2800,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 3,
-      "real_time": 2.1897294000000000e+08,
-      "cpu_time": 2.8293333334280152e+04,
+      "real_time": 2.1654962933333334e+08,
+      "cpu_time": 3.0996666666283087e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.1897293999999998e-05
+      "IterationTime": 2.1654962933333334e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_128_rta_trace/8192/manual_time",
@@ -2816,11 +2816,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 3.1992644100000000e+08,
-      "cpu_time": 4.5215000000098371e+04,
+      "real_time": 3.1573346199999994e+08,
+      "cpu_time": 3.1200000002229444e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.1992644100000001e-05
+      "IterationTime": 3.1573346200000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/256/manual_time",
@@ -2831,12 +2831,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 7,
-      "real_time": 1.0693013771428572e+08,
-      "cpu_time": 3.1768571429121752e+04,
+      "iterations": 6,
+      "real_time": 1.0906042383333333e+08,
+      "cpu_time": 4.1004999999927350e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0693013771428573e-05
+      "IterationTime": 1.0906042383333332e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/512/manual_time",
@@ -2848,11 +2848,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0812168533333333e+08,
-      "cpu_time": 3.1434999999172913e+04,
+      "real_time": 1.1043540466666667e+08,
+      "cpu_time": 3.0764999999396041e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0812168533333333e-05
+      "IterationTime": 1.1043540466666666e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/1024/manual_time",
@@ -2864,11 +2864,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1104894750000001e+08,
-      "cpu_time": 3.9051666666030847e+04,
+      "real_time": 1.1327980583333333e+08,
+      "cpu_time": 3.2305000000102762e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1104894750000002e-05
+      "IterationTime": 1.1327980583333333e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/2048/manual_time",
@@ -2880,11 +2880,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.3262566679999998e+08,
-      "cpu_time": 3.8968000001204928e+04,
+      "real_time": 1.3221944259999998e+08,
+      "cpu_time": 3.1902000000627595e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.3262566679999999e-05
+      "IterationTime": 1.3221944259999999e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/4096/manual_time",
@@ -2896,11 +2896,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.8337839050000000e+08,
-      "cpu_time": 4.0167499999910207e+04,
+      "real_time": 1.8155627525000000e+08,
+      "cpu_time": 3.3627500000577013e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.8337839049999998e-05
+      "IterationTime": 1.8155627525000003e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_1_cb_trace/8192/manual_time",
@@ -2912,11 +2912,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 2.8493300050000000e+08,
-      "cpu_time": 4.2964999998673651e+04,
+      "real_time": 2.8173979750000000e+08,
+      "cpu_time": 4.0335000001334716e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8493300049999996e-05
+      "IterationTime": 2.8173979750000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/256/manual_time",
@@ -2927,12 +2927,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 7,
-      "real_time": 1.0706938057142857e+08,
-      "cpu_time": 3.5974285714652462e+04,
+      "iterations": 6,
+      "real_time": 1.0918960016666667e+08,
+      "cpu_time": 3.2868333332676986e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0706938057142858e-05
+      "IterationTime": 1.0918960016666666e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/512/manual_time",
@@ -2944,11 +2944,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0839401566666667e+08,
-      "cpu_time": 3.5845000000496912e+04,
+      "real_time": 1.1062842750000001e+08,
+      "cpu_time": 3.3051666666968529e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0839401566666664e-05
+      "IterationTime": 1.1062842750000002e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/1024/manual_time",
@@ -2960,11 +2960,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1118008766666669e+08,
-      "cpu_time": 3.4850000001066895e+04,
+      "real_time": 1.1339158216666667e+08,
+      "cpu_time": 3.3578500000667569e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1118008766666669e-05
+      "IterationTime": 1.1339158216666667e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/2048/manual_time",
@@ -2976,11 +2976,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.3272633780000000e+08,
-      "cpu_time": 3.5035999999877276e+04,
+      "real_time": 1.3232231799999997e+08,
+      "cpu_time": 2.8674000000705746e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.3272633779999999e-05
+      "IterationTime": 1.3232231799999999e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/4096/manual_time",
@@ -2992,11 +2992,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.8431346175000000e+08,
-      "cpu_time": 3.9974999999969892e+04,
+      "real_time": 1.8173267700000000e+08,
+      "cpu_time": 3.1992500000299628e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.8431346174999999e-05
+      "IterationTime": 1.8173267700000002e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_32_cb_trace/8192/manual_time",
@@ -3008,11 +3008,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 2.8504145000000000e+08,
-      "cpu_time": 8.5591730000018626e+06,
+      "real_time": 2.8126592400000000e+08,
+      "cpu_time": 5.6385000000602755e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8504145000000004e-05
+      "IterationTime": 2.8126592400000001e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/256/manual_time",
@@ -3024,11 +3024,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1681535133333333e+08,
-      "cpu_time": 3.1801666666571768e+04,
+      "real_time": 1.1679317150000001e+08,
+      "cpu_time": 2.2703333333614257e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1681535133333334e-05
+      "IterationTime": 1.1679317150000001e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/512/manual_time",
@@ -3040,11 +3040,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1676174016666667e+08,
-      "cpu_time": 3.6960000000381871e+04,
+      "real_time": 1.1676785500000000e+08,
+      "cpu_time": 5.0581666666715821e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1676174016666666e-05
+      "IterationTime": 1.1676785500000000e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/1024/manual_time",
@@ -3056,11 +3056,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1682643949999999e+08,
-      "cpu_time": 4.0001666666474492e+04,
+      "real_time": 1.1684012983333333e+08,
+      "cpu_time": 4.7326833333490482e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1682643950000000e-05
+      "IterationTime": 1.1684012983333332e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/2048/manual_time",
@@ -3072,11 +3072,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1691816000000000e+08,
-      "cpu_time": 3.0296666666392488e+04,
+      "real_time": 1.1691199300000001e+08,
+      "cpu_time": 3.1710000000610231e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1691815999999997e-05
+      "IterationTime": 1.1691199300000000e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/4096/manual_time",
@@ -3088,11 +3088,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.1722509633333331e+08,
-      "cpu_time": 3.4466666665622368e+04,
+      "real_time": 1.1723572700000000e+08,
+      "cpu_time": 5.4871666666400641e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1722509633333331e-05
+      "IterationTime": 1.1723572699999999e-05
     },
     {
       "name": "BM_pgm_dispatch/10000_kernel_all_cores_all_processors_32_cbs_trace/8192/manual_time",
@@ -3104,11 +3104,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.5718024575000000e+08,
-      "cpu_time": 3.8812500001483844e+04,
+      "real_time": 1.5774183900000000e+08,
+      "cpu_time": 5.6297499998692045e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.5718024575000002e-05
+      "IterationTime": 1.5774183900000000e-05
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/256/manual_time",
@@ -3120,11 +3120,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6074897909090899e+07,
-      "cpu_time": 2.8766454545606477e+04,
+      "real_time": 6.6064957181818195e+07,
+      "cpu_time": 2.9350909090649940e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6074897909090886e-06
+      "IterationTime": 6.6064957181818200e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/512/manual_time",
@@ -3136,11 +3136,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6019053181818180e+07,
-      "cpu_time": 3.3818181818064244e+04,
+      "real_time": 6.6025611818181828e+07,
+      "cpu_time": 4.8680909090654204e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6019053181818176e-06
+      "IterationTime": 6.6025611818181828e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/1024/manual_time",
@@ -3152,11 +3152,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6080409636363633e+07,
-      "cpu_time": 2.7058181818130255e+04,
+      "real_time": 6.6079304454545453e+07,
+      "cpu_time": 3.4977272727458476e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6080409636363637e-06
+      "IterationTime": 6.6079304454545459e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/2048/manual_time",
@@ -3168,11 +3168,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6177555727272727e+07,
-      "cpu_time": 2.7727272727676420e+04,
+      "real_time": 6.6228246727272719e+07,
+      "cpu_time": 3.1561818181687198e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6177555727272724e-06
+      "IterationTime": 6.6228246727272719e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/4096/manual_time",
@@ -3184,11 +3184,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 11,
-      "real_time": 6.6674711454545453e+07,
-      "cpu_time": 3.0993093636365901e+06,
+      "real_time": 6.6476872363636367e+07,
+      "cpu_time": 3.8626363636818824e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.6674711454545449e-06
+      "IterationTime": 6.6476872363636361e-06
     },
     {
       "name": "BM_pgm_dispatch/5000_kernel_all_cores_all_processors_32_cbs_trace/8192/manual_time",
@@ -3200,11 +3200,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 7,
-      "real_time": 1.0731944485714285e+08,
-      "cpu_time": 3.3552857142841014e+04,
+      "real_time": 1.0774948914285716e+08,
+      "cpu_time": 3.3524285714950762e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0731944485714288e-05
+      "IterationTime": 1.0774948914285715e-05
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/0/manual_time",
@@ -3215,12 +3215,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.7819183080000006e+07,
-      "cpu_time": 3.2608399999958241e+04,
+      "iterations": 27,
+      "real_time": 2.5800653074074075e+07,
+      "cpu_time": 3.8286333333322393e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7819183079999999e-06
+      "IterationTime": 2.5800653074074073e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/1000/manual_time",
@@ -3231,12 +3231,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 25,
-      "real_time": 2.7829376480000004e+07,
-      "cpu_time": 3.1957200000078956e+04,
+      "iterations": 27,
+      "real_time": 2.5799754518518519e+07,
+      "cpu_time": 3.0782222222253749e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.7829376480000003e-06
+      "IterationTime": 2.5799754518518520e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/2000/manual_time",
@@ -3248,11 +3248,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 25,
-      "real_time": 2.9115468199999999e+07,
-      "cpu_time": 8.0030063999998895e+05,
+      "real_time": 2.8437292320000000e+07,
+      "cpu_time": 3.0215639999937594e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.9115468200000000e-06
+      "IterationTime": 2.8437292320000001e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/3000/manual_time",
@@ -3264,11 +3264,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.8369763111111104e+07,
-      "cpu_time": 3.3540000000047912e+04,
+      "real_time": 3.8730182833333336e+07,
+      "cpu_time": 4.5516111111254526e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.8369763111111104e-06
+      "IterationTime": 3.8730182833333333e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/4000/manual_time",
@@ -3280,11 +3280,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 14,
-      "real_time": 4.8617472928571418e+07,
-      "cpu_time": 3.3930714285495305e+04,
+      "real_time": 4.8937169142857142e+07,
+      "cpu_time": 3.4513571428870397e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8617472928571419e-06
+      "IterationTime": 4.8937169142857148e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/5000/manual_time",
@@ -3296,11 +3296,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 12,
-      "real_time": 5.8756008166666664e+07,
-      "cpu_time": 3.4389249999951709e+04,
+      "real_time": 5.9064526249999993e+07,
+      "cpu_time": 3.0545000000140968e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.8756008166666663e-06
+      "IterationTime": 5.9064526249999997e-06
     },
     {
       "name": "BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/10000/manual_time",
@@ -3312,11 +3312,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.0960825433333333e+08,
-      "cpu_time": 6.0970271666664174e+06,
+      "real_time": 1.0978792650000000e+08,
+      "cpu_time": 4.5754999999777130e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0960825433333335e-05
+      "IterationTime": 1.0978792650000001e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/256/manual_time",
@@ -3328,11 +3328,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 4.6906806900000000e+08,
-      "cpu_time": 5.6414999999532258e+04,
+      "real_time": 4.7896277150000000e+08,
+      "cpu_time": 3.9930000003352005e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.6906806899999997e-05
+      "IterationTime": 4.7896277149999995e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/512/manual_time",
@@ -3344,11 +3344,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 4.7510786900000000e+08,
-      "cpu_time": 4.6735000001518754e+04,
+      "real_time": 4.8553752100000000e+08,
+      "cpu_time": 4.1919999997475090e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.7510786900000005e-05
+      "IterationTime": 4.8553752100000003e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/1024/manual_time",
@@ -3360,11 +3360,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 4.8742609200000000e+08,
-      "cpu_time": 4.7330499999276297e+04,
+      "real_time": 4.9778333350000006e+08,
+      "cpu_time": 4.0260000002234621e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.8742609199999998e-05
+      "IterationTime": 4.9778333350000005e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/2048/manual_time",
@@ -3376,11 +3376,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.3244618899999994e+08,
-      "cpu_time": 4.6369999999740234e+04,
+      "real_time": 5.3373265700000006e+08,
+      "cpu_time": 3.4870000000353233e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.3244618899999989e-05
+      "IterationTime": 5.3373265699999998e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/4096/manual_time",
@@ -3392,11 +3392,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 7.9592275300000000e+08,
-      "cpu_time": 5.2830000001335975e+04,
+      "real_time": 8.0165213700000000e+08,
+      "cpu_time": 3.7800000001197986e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 7.9592275300000007e-05
+      "IterationTime": 8.0165213700000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_4_shadow/8192/manual_time",
@@ -3408,11 +3408,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.4437069030000000e+09,
-      "cpu_time": 5.1700000000209911e+04,
+      "real_time": 1.4387176740000000e+09,
+      "cpu_time": 4.8519999999996347e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.4437069030000000e-04
+      "IterationTime": 1.4387176740000002e-04
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/256/manual_time",
@@ -3424,11 +3424,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.6260136600000000e+08,
-      "cpu_time": 4.3030000000499058e+04,
+      "real_time": 5.7490134000000000e+08,
+      "cpu_time": 3.6950000001922948e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.6260136599999995e-05
+      "IterationTime": 5.7490134000000000e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/512/manual_time",
@@ -3440,11 +3440,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.7024147100000000e+08,
-      "cpu_time": 4.3930000003911118e+04,
+      "real_time": 5.8252821600000000e+08,
+      "cpu_time": 3.6979999997299732e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.7024147099999995e-05
+      "IterationTime": 5.8252821600000006e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/1024/manual_time",
@@ -3456,11 +3456,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 5.8485421000000000e+08,
-      "cpu_time": 4.3499999996754472e+04,
+      "real_time": 5.9714095100000000e+08,
+      "cpu_time": 3.6449999996079896e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 5.8485421000000005e-05
+      "IterationTime": 5.9714095100000003e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/2048/manual_time",
@@ -3472,11 +3472,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 6.4137597900000000e+08,
-      "cpu_time": 4.3849999997291889e+04,
+      "real_time": 6.4178296300000000e+08,
+      "cpu_time": 4.0840000004038753e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 6.4137597899999990e-05
+      "IterationTime": 6.4178296300000006e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/4096/manual_time",
@@ -3488,11 +3488,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 9.2638885600000000e+08,
-      "cpu_time": 4.5700000001147600e+04,
+      "real_time": 9.3228072300000000e+08,
+      "cpu_time": 3.7599999998860767e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 9.2638885599999994e-05
+      "IterationTime": 9.3228072299999994e-05
     },
     {
       "name": "BM_pgm_dispatch/kernel_groups_5_shadow/8192/manual_time",
@@ -3504,11 +3504,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.6835827900000000e+09,
-      "cpu_time": 4.9181000001397028e+04,
+      "real_time": 1.6735890170000000e+09,
+      "cpu_time": 3.5949999997342275e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.6835827900000001e-04
+      "IterationTime": 1.6735890170000001e-04
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/256/manual_time",
@@ -3519,12 +3519,12 @@
       "repetitions": 1,
       "repetition_index": 0,
       "threads": 1,
-      "iterations": 17,
-      "real_time": 3.9901253588235289e+07,
-      "cpu_time": 3.3157117647169129e+04,
+      "iterations": 18,
+      "real_time": 3.9896256444444448e+07,
+      "cpu_time": 2.9305000000571607e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9901253588235286e-06
+      "IterationTime": 3.9896256444444451e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/512/manual_time",
@@ -3536,11 +3536,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9904250388888896e+07,
-      "cpu_time": 3.5503888888794361e+04,
+      "real_time": 3.9888878166666664e+07,
+      "cpu_time": 2.9495555555709212e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9904250388888894e-06
+      "IterationTime": 3.9888878166666665e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/1024/manual_time",
@@ -3552,11 +3552,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9893135500000000e+07,
-      "cpu_time": 2.7898888888778907e+04,
+      "real_time": 3.9895302000000000e+07,
+      "cpu_time": 2.9689444444455956e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9893135499999995e-06
+      "IterationTime": 3.9895301999999999e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/2048/manual_time",
@@ -3568,11 +3568,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 4.1687979944444448e+07,
-      "cpu_time": 1.1582055555534351e+05,
+      "real_time": 3.9894994222222224e+07,
+      "cpu_time": 2.9724999999795426e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 4.1687979944444449e-06
+      "IterationTime": 3.9894994222222228e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/4096/manual_time",
@@ -3584,11 +3584,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9897498777777776e+07,
-      "cpu_time": 2.7346111111054623e+04,
+      "real_time": 3.9897563722222231e+07,
+      "cpu_time": 3.0073333333133531e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9897498777777775e-06
+      "IterationTime": 3.9897563722222225e-06
     },
     {
       "name": "BM_pgm_dispatch/eth_dispatch/8192/manual_time",
@@ -3600,11 +3600,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 18,
-      "real_time": 3.9900033166666657e+07,
-      "cpu_time": 3.4659444444745051e+04,
+      "real_time": 3.9895881999999993e+07,
+      "cpu_time": 2.9718333333366649e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 3.9900033166666654e-06
+      "IterationTime": 3.9895881999999994e-06
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/256/manual_time",
@@ -3616,11 +3616,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2309639583333333e+08,
-      "cpu_time": 3.6728333333494826e+04,
+      "real_time": 1.2661854800000001e+08,
+      "cpu_time": 3.5085000000378837e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2309639583333334e-05
+      "IterationTime": 1.2661854800000002e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/512/manual_time",
@@ -3632,11 +3632,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 6,
-      "real_time": 1.2491025166666667e+08,
-      "cpu_time": 3.7485000000003762e+04,
+      "real_time": 1.2673097066666667e+08,
+      "cpu_time": 3.3154999999377804e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2491025166666668e-05
+      "IterationTime": 1.2673097066666666e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/1024/manual_time",
@@ -3648,11 +3648,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.2732347760000002e+08,
-      "cpu_time": 4.4163999999113912e+04,
+      "real_time": 1.3283111259999999e+08,
+      "cpu_time": 3.3817999999996573e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.2732347760000002e-05
+      "IterationTime": 1.3283111260000001e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/2048/manual_time",
@@ -3664,11 +3664,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 5,
-      "real_time": 1.4944012780000001e+08,
-      "cpu_time": 3.5585999999909742e+04,
+      "real_time": 1.4865564159999999e+08,
+      "cpu_time": 3.2611999998266583e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.4944012779999999e-05
+      "IterationTime": 1.4865564159999997e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/4096/manual_time",
@@ -3680,11 +3680,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 4,
-      "real_time": 1.9695448400000000e+08,
-      "cpu_time": 2.3387750000125606e+05,
+      "real_time": 1.9484878400000000e+08,
+      "cpu_time": 2.9144999999175525e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.9695448399999999e-05
+      "IterationTime": 1.9484878400000000e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2/8192/manual_time",
@@ -3696,11 +3696,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 2,
-      "real_time": 2.8816356800000000e+08,
-      "cpu_time": 3.7809999998472675e+04,
+      "real_time": 2.8437306400000000e+08,
+      "cpu_time": 4.0290000001164117e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 2.8816356799999997e-05
+      "IterationTime": 2.8437306400000002e-05
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/256/manual_time",
@@ -3712,11 +3712,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 9.9659720800000000e+08,
-      "cpu_time": 4.3070000003808673e+04,
+      "real_time": 1.0166909209999999e+09,
+      "cpu_time": 3.3240000007594972e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 9.9659720799999998e-05
+      "IterationTime": 1.0166909210000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/512/manual_time",
@@ -3728,11 +3728,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.0170174150000000e+09,
-      "cpu_time": 5.1720000001864719e+04,
+      "real_time": 1.0171507200000001e+09,
+      "cpu_time": 3.3979999997768573e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0170174150000000e-04
+      "IterationTime": 1.0171507199999999e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/1024/manual_time",
@@ -3744,11 +3744,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.0209643260000001e+09,
-      "cpu_time": 5.0889999997139057e+04,
+      "real_time": 1.0357760119999999e+09,
+      "cpu_time": 3.2689999997614905e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0209643260000000e-04
+      "IterationTime": 1.0357760120000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/2048/manual_time",
@@ -3760,11 +3760,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.0645734860000000e+09,
-      "cpu_time": 4.4309999999825325e+05,
+      "real_time": 1.0560168590000001e+09,
+      "cpu_time": 4.0070000011382945e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.0645734860000000e-04
+      "IterationTime": 1.0560168590000001e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/4096/manual_time",
@@ -3776,11 +3776,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.1705127430000000e+09,
-      "cpu_time": 5.4239999997207633e+04,
+      "real_time": 1.1712396920000000e+09,
+      "cpu_time": 3.3549999997717350e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.1705127429999999e-04
+      "IterationTime": 1.1712396920000000e-04
     },
     {
       "name": "BM_pgm_dispatch/tensix_eth_2_4_shadow/8192/manual_time",
@@ -3792,11 +3792,11 @@
       "repetition_index": 0,
       "threads": 1,
       "iterations": 1,
-      "real_time": 1.6802131370000000e+09,
-      "cpu_time": 9.4727000001171289e+05,
+      "real_time": 1.6648780940000000e+09,
+      "cpu_time": 4.0889999993964921e+04,
       "time_unit": "ns",
       "Clock": 1.0000000000000000e+03,
-      "IterationTime": 1.6802131370000000e-04
+      "IterationTime": 1.6648780940000001e-04
     }
   ]
 }

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -451,14 +451,14 @@ void debug_throw_on_dram_addr(uint8_t noc_id, uint64_t addr, uint32_t len) {
             ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_TARG_ADDR_LO)),                              \
         NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_RET_ADDR_LO),                                               \
         NOC_CMD_BUF_READ_REG(noc_id, read_cmd_buf, NOC_AT_LEN_BE));
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id)                                                    \
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id, cmd_buf)                                                    \
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(                                                                          \
         noc_id,                                                                                                    \
-        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_MID) << 32) |                      \
-            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_RET_ADDR_LO)),                              \
-        NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_TARG_ADDR_LO),                                             \
-        NOC_CMD_BUF_READ_REG(noc_id, write_cmd_buf, NOC_AT_LEN_BE));
+        ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_COORDINATE) << NOC_ADDR_COORD_SHIFT) | \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_MID) << 32) |                      \
+            ((uint64_t)NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_RET_ADDR_LO)),                              \
+        NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_TARG_ADDR_LO),                                             \
+        NOC_CMD_BUF_READ_REG(noc_id, cmd_buf, NOC_AT_LEN_BE));
 #define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)                                                   \
     DEBUG_SANITIZE_NOC_ADDR(                                                                                  \
         noc_id,                                                                                               \
@@ -558,7 +558,7 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc_id, noc_a_lower, worker_a) \
     LOG_WRITE_LEN_FROM_STATE(noc_id)
 #define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_STATE(noc_id, noc_a_lower, worker_a, l) LOG_LEN(l)
-#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id)
+#define DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_id, cmd_buf)
 #define DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_id, cmd_buf)
 #define DEBUG_INSERT_DELAY(transaction_type)
 #define DEBUG_SANITIZE_NO_DRAM_ADDR(noc_id, addr, l) LOG_LEN(l)

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -129,37 +129,34 @@ template <
     enum CQNocSend send = CQ_NOC_SEND,
     uint32_t cmd_buf = NCRISC_WR_CMD_BUF>
 FORCE_INLINE void cq_noc_async_write_with_state(
-    uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
+    uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1, uint8_t noc = noc_index) {
     if constexpr (wait) {
         WAYPOINT("CNSW");
-        while (!noc_cmd_buf_ready(noc_index, cmd_buf));
+        while (!noc_cmd_buf_ready(noc, cmd_buf));
         WAYPOINT("CNSD");
     }
 
     if constexpr (flags & CQ_NOC_FLAG_SRC) {
-        NOC_CMD_BUF_WRITE_REG(noc_index, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
     }
     if constexpr (flags & CQ_NOC_FLAG_DST) {
-        NOC_CMD_BUF_WRITE_REG(noc_index, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_addr);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_addr);
     }
     if constexpr (flags & CQ_NOC_FLAG_NOC) {
 #ifdef ARCH_BLACKHOLE
         // Handles writing to PCIe
-        NOC_CMD_BUF_WRITE_REG(noc_index, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_addr >> 32) & 0x1000000F);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_addr >> 32) & 0x1000000F);
 #endif
         NOC_CMD_BUF_WRITE_REG(
-            noc_index,
-            cmd_buf,
-            NOC_RET_ADDR_COORDINATE,
-            (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+            noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
     }
     if constexpr (flags & CQ_NOC_FLAG_LEN) {
         ASSERT(size <= NOC_MAX_BURST_SIZE);
-        NOC_CMD_BUF_WRITE_REG(noc_index, cmd_buf, NOC_AT_LEN_BE, size);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
     }
     if constexpr (send) {
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc_index);
-        NOC_CMD_BUF_WRITE_REG(noc_index, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc);
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
 }
 
@@ -167,32 +164,32 @@ FORCE_INLINE void cq_noc_async_write_with_state(
 // (dst_noc, VC..) have been specified.
 template <bool write_last_packet = true, bool update_counters = false, enum CQNocWait wait_first = CQ_NOC_WAIT>
 inline uint32_t cq_noc_async_write_with_state_any_len(
-    uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1) {
+    uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1, uint8_t noc = noc_index) {
     if (size > NOC_MAX_BURST_SIZE) {
         cq_noc_async_write_with_state<CQ_NOC_SnDL, wait_first>(src_addr, dst_addr, NOC_MAX_BURST_SIZE, ndests);
         src_addr += NOC_MAX_BURST_SIZE;
         dst_addr += NOC_MAX_BURST_SIZE;
         size -= NOC_MAX_BURST_SIZE;
         if constexpr (update_counters) {
-            noc_nonposted_writes_num_issued[noc_index] += 1;
-            noc_nonposted_writes_acked[noc_index] += ndests;
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += ndests;
         }
         while (size > NOC_MAX_BURST_SIZE) {
-            cq_noc_async_write_with_state<CQ_NOC_SnDl>(src_addr, dst_addr, NOC_MAX_BURST_SIZE, ndests);
+            cq_noc_async_write_with_state<CQ_NOC_SnDl>(src_addr, dst_addr, NOC_MAX_BURST_SIZE, ndests, noc);
             src_addr += NOC_MAX_BURST_SIZE;
             dst_addr += NOC_MAX_BURST_SIZE;
             size -= NOC_MAX_BURST_SIZE;
             if constexpr (update_counters) {
-                noc_nonposted_writes_num_issued[noc_index] += 1;
-                noc_nonposted_writes_acked[noc_index] += ndests;
+                noc_nonposted_writes_num_issued[noc] += 1;
+                noc_nonposted_writes_acked[noc] += ndests;
             }
         }
     }
     if constexpr (write_last_packet) {
-        cq_noc_async_write_with_state<CQ_NOC_SnDL>(src_addr, dst_addr, size, ndests);
+        cq_noc_async_write_with_state<CQ_NOC_SnDL>(src_addr, dst_addr, size, ndests, noc);
         if constexpr (update_counters) {
-            noc_nonposted_writes_num_issued[noc_index] += 1;
-            noc_nonposted_writes_acked[noc_index] += ndests;
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += ndests;
         }
         return 0;
     } else {
@@ -201,10 +198,11 @@ inline uint32_t cq_noc_async_write_with_state_any_len(
 }
 
 template <enum CQNocFlags flags, bool mcast = false, bool linked = false, uint32_t cmd_buf = NCRISC_WR_CMD_BUF>
-FORCE_INLINE void cq_noc_async_write_init_state(uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0) {
+FORCE_INLINE void cq_noc_async_write_init_state(
+    uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint8_t noc = noc_index) {
     WAYPOINT("CNIW");
     uint32_t heartbeat = 0;
-    while (!noc_cmd_buf_ready(noc_index, cmd_buf)) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf)) {
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
     }
     WAYPOINT("CNID");
@@ -218,32 +216,32 @@ FORCE_INLINE void cq_noc_async_write_init_state(uint32_t src_addr, uint64_t dst_
         (mcast ? ((multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET) : 0x0) |
         (posted ? 0 : NOC_CMD_RESP_MARKED);
 
-    NOC_CMD_BUF_WRITE_REG(noc_index, cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
 
     cq_noc_async_write_with_state<flags, CQ_NOC_wait, CQ_NOC_send, cmd_buf>(src_addr, dst_addr, size);
 }
 
 template <enum CQNocInlineFlags flags, enum CQNocWait wait = CQ_NOC_WAIT, enum CQNocSend send = CQ_NOC_SEND>
-FORCE_INLINE void cq_noc_inline_dw_write_with_state(uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF) {
+FORCE_INLINE void cq_noc_inline_dw_write_with_state(
+    uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF, uint8_t noc = noc_index) {
     if constexpr (wait) {
         WAYPOINT("NISW");
-        while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF));
+        while (!noc_cmd_buf_ready(noc, NCRISC_WR_REG_CMD_BUF));
         WAYPOINT("NISD");
     }
 
     if constexpr (flags & CQ_NOC_INLINE_FLAG_VAL) {
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_DATA, val);
+        NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_AT_DATA, val);
     }
     if constexpr (flags & CQ_NOC_FLAG_DST) {
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, (uint32_t)(dst_addr));
+        NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_LO, (uint32_t)(dst_addr));
     }
     if constexpr (flags & CQ_NOC_FLAG_NOC) {
 #ifdef ARCH_BLACKHOLE
-        NOC_CMD_BUF_WRITE_REG(
-            noc_index, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(dst_addr >> 32) & 0x1000000F);
+        NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_TARG_ADDR_MID, (uint32_t)(dst_addr >> 32) & 0x1000000F);
 #endif
         NOC_CMD_BUF_WRITE_REG(
-            noc_index,
+            noc,
             NCRISC_WR_REG_CMD_BUF,
             NOC_TARG_ADDR_COORDINATE,
             (uint32_t)(dst_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
@@ -252,11 +250,11 @@ FORCE_INLINE void cq_noc_inline_dw_write_with_state(uint64_t dst_addr, uint32_t 
         uint32_t be32 = be;
         uint32_t be_shift = (dst_addr & (NOC_WORD_BYTES - 1));
         be32 = (be32 << be_shift);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE, be32);
+        NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_AT_LEN_BE, be32);
     }
     if constexpr (send) {
-        DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc_index, NCRISC_WR_REG_CMD_BUF);
-        NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+        DEBUG_SANITIZE_NOC_ADDR_FROM_STATE(noc, NCRISC_WR_REG_CMD_BUF);
+        NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
 }
 
@@ -264,10 +262,11 @@ FORCE_INLINE void cq_noc_inline_dw_write_with_state(uint64_t dst_addr, uint32_t 
 // If needed, add templates for setting these
 // TODO: uplift for BH to not do inline write
 template <enum CQNocInlineFlags flags>
-FORCE_INLINE void cq_noc_inline_dw_write_init_state(uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF) {
+FORCE_INLINE void cq_noc_inline_dw_write_init_state(
+    uint64_t dst_addr, uint32_t val = 0, uint8_t be = 0xF, uint8_t noc = noc_index) {
     WAYPOINT("NIIW");
     uint32_t heartbeat = 0;
-    while (!noc_cmd_buf_ready(noc_index, NCRISC_WR_REG_CMD_BUF)) {
+    while (!noc_cmd_buf_ready(noc, NCRISC_WR_REG_CMD_BUF)) {
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
     }
     WAYPOINT("NIID");
@@ -282,7 +281,7 @@ FORCE_INLINE void cq_noc_inline_dw_write_init_state(uint64_t dst_addr, uint32_t 
                                        (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0) |
                                        (posted ? 0x0 : NOC_CMD_RESP_MARKED);
 
-    NOC_CMD_BUF_WRITE_REG(noc_index, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, NCRISC_WR_REG_CMD_BUF, NOC_CTRL, noc_cmd_field);
 
     cq_noc_inline_dw_write_with_state<flags, CQ_NOC_wait, CQ_NOC_send>(dst_addr, val, be);
 }
@@ -357,20 +356,20 @@ cb_acquire_pages(uint32_t cb_fence, uint32_t block_next_start_addr[], uint32_t r
 }
 
 template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_per_block>
-FORCE_INLINE void cb_block_release_pages(uint32_t& block_noc_writes_to_clear) {
+FORCE_INLINE void cb_block_release_pages(uint32_t& block_noc_writes_to_clear, uint8_t noc = noc_index) {
     // Do not release pages on the first call to this function
     // This is because the first call means we don't have a previous block to release
     static bool prev_block = false;
     if (prev_block) {
         WAYPOINT("CBRW");
         uint32_t sem_addr = get_semaphore<fd_core_type>(sem_id);
-        while (!wrap_ge(NOC_STATUS_READ_REG(noc_index, NIU_MST_NONPOSTED_WR_REQ_SENT), block_noc_writes_to_clear));
+        while (!wrap_ge(NOC_STATUS_READ_REG(noc, NIU_MST_NONPOSTED_WR_REQ_SENT), block_noc_writes_to_clear));
         noc_semaphore_inc(get_noc_addr_helper(noc_xy, sem_addr), cb_pages_per_block, noc_idx);
         WAYPOINT("CBRD");
     } else {
         prev_block = true;
     }
-    block_noc_writes_to_clear = noc_nonposted_writes_num_issued[noc_index];
+    block_noc_writes_to_clear = noc_nonposted_writes_num_issued[noc];
 }
 
 template <uint32_t cb_blocks>
@@ -381,8 +380,9 @@ FORCE_INLINE void move_rd_to_next_block(uint32_t& rd_block_idx) {
 }
 
 template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_per_block, uint32_t cb_blocks>
-FORCE_INLINE void move_rd_to_next_block_and_release_pages(uint32_t& block_noc_writes_to_clear, uint32_t& rd_block_idx) {
-    cb_block_release_pages<noc_idx, noc_xy, sem_id, cb_pages_per_block>(block_noc_writes_to_clear);
+FORCE_INLINE void move_rd_to_next_block_and_release_pages(
+    uint32_t& block_noc_writes_to_clear, uint32_t& rd_block_idx, uint8_t noc = noc_index) {
+    cb_block_release_pages<noc_idx, noc_xy, sem_id, cb_pages_per_block>(block_noc_writes_to_clear, noc);
     move_rd_to_next_block<cb_blocks>(rd_block_idx);
 }
 
@@ -401,7 +401,8 @@ FORCE_INLINE uint32_t get_cb_page_and_release_pages(
     uint32_t& block_noc_writes_to_clear,
     uint32_t block_next_start_addr[],
     uint32_t& rd_block_idx,
-    uint32_t& local_count) {
+    uint32_t& local_count,
+    uint8_t noc = noc_index) {
     // Strided past the data that has arrived, get the next page
     if (cb_fence == block_next_start_addr[rd_block_idx]) {
         if (rd_block_idx == cb_blocks - 1) {
@@ -413,7 +414,7 @@ FORCE_INLINE uint32_t get_cb_page_and_release_pages(
             upstream_noc_xy,
             upstream_cb_sem,
             cb_pages_per_block,
-            cb_blocks>(block_noc_writes_to_clear, rd_block_idx);
+            cb_blocks>(block_noc_writes_to_clear, rd_block_idx, noc);
     }
 
     // Wait for dispatcher to supply a page

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -7,8 +7,6 @@
 #include "core_config.h"
 #include "risc_attribs.h"
 #include "dataflow_api.h"
-#include "debug/dprint.h"
-#include "debug/ring_buffer.h"
 #include "cq_helpers.hpp"
 
 // The command queue read interface controls reads from the issue region, host owns the issue region write interface
@@ -155,7 +153,7 @@ FORCE_INLINE void cq_noc_async_write_with_state(
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
     }
     if constexpr (send) {
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc);
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_FROM_STATE(noc, cmd_buf);
         NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     }
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -8,6 +8,13 @@
 //  - uses HostQ for host handshaking, ComDatQ for commands (from host),
 //    double buffered ScratchBuf for out of band data (e.g., from DRAM)
 //  - syncs w/ dispatcher via 2 semaphores, page_ready, page_done
+//
+// Write cmd buf allocation:
+//  - BRISC_WR_CMD_BUF: writes to downstream_noc_xy
+//  - BRISC_WR_REG_CMD_BUF: small writes to dispatch_s_noc_xy. not much traffic on this path.
+//
+//  Using the normal NoC APIs for writes and/or inline_dw_writes are not allowed on this kernel.
+//
 
 #include "dataflow_api.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
@@ -147,6 +154,8 @@ struct DispatchRelayInlineState {
     static constexpr uint32_t downstream_log_page_size = downstream_cb_log_page_size;
     static constexpr uint32_t downstream_cb_base_addr = downstream_cb_base;
     static constexpr uint32_t downstream_cb_end_addr = downstream_cb_end;
+    static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_CMD_BUF;
+    static constexpr uint32_t downstream_noc_index = my_noc_index;
 };
 
 struct DispatchSRelayInlineState {
@@ -157,6 +166,8 @@ struct DispatchSRelayInlineState {
     static constexpr uint32_t downstream_log_page_size = dispatch_s_cb_log_page_size;
     static constexpr uint32_t downstream_cb_base_addr = dispatch_s_buffer_base;
     static constexpr uint32_t downstream_cb_end_addr = dispatch_s_buffer_end;
+    static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_REG_CMD_BUF;
+    static constexpr uint32_t downstream_noc_index = my_noc_index;
 };
 
 typedef struct PrefetchExecBufState {
@@ -192,7 +203,7 @@ bool process_cmd(
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state);
 
-template <uint32_t downstream_cb_base_addr>
+template <uint32_t downstream_cb_base_addr, uint32_t downstream_cmd_buf>
 FORCE_INLINE void write_downstream(
     uint32_t& data_ptr,
     uint32_t& local_downstream_data_ptr,
@@ -202,7 +213,7 @@ FORCE_INLINE void write_downstream(
     uint32_t remaining = downstream_end - local_downstream_data_ptr;
     if (length > remaining) {
         if (remaining > 0) {
-            noc_async_write(
+            cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
                 data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), remaining);
             data_ptr += remaining;
             length -= remaining;
@@ -210,13 +221,13 @@ FORCE_INLINE void write_downstream(
         local_downstream_data_ptr = downstream_cb_base_addr;
     }
 
-    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), length);
+    cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
+        data_ptr, get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr), length);
     local_downstream_data_ptr += length;
 }
 
 // If prefetcher must stall after this fetch, wait for data to come back, and move to stalled state.
-FORCE_INLINE
-void barrier_and_stall(uint32_t& pending_read_size, uint32_t& fence, uint32_t& cmd_ptr) {
+FORCE_INLINE void barrier_and_stall(uint32_t& pending_read_size, uint32_t& fence, uint32_t& cmd_ptr) {
     noc_async_read_barrier();
     if (fence < cmd_ptr) {
         cmd_ptr = fence;
@@ -317,7 +328,8 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
     stall_state = static_cast<StallState>(stall_flag << 1);  // NOT_STALLED -> STALL_NEXT if stall_flag is set
 
     if (fetch_size != 0 && pending_read_size == 0) {
-        pending_read_size = read_from_pcie<preamble_size>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+        pending_read_size = read_from_pcie<preamble_size>(
+            prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
         if (stall_state == STALL_NEXT && pending_read_size != 0) {
             // No pending reads -> stall_state can be set to STALLED, since the read to the cmd
             // that initiated the stall has been issued.
@@ -352,17 +364,19 @@ void fetch_q_get_cmds(uint32_t& fence, uint32_t& cmd_ptr, uint32_t& pcie_read_pt
                     // If the prefetcher state reached here, it is issuing a read to the same "slot", since for exec_buf
                     // commands we will insert a read barrier. Hence, the exec_buf command will be concatenated to a
                     // previous command, and should not be offset by preamble size.
-                    pending_read_size = read_from_pcie<0>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                    pending_read_size = read_from_pcie<0>(
+                        prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
                     if (pending_read_size != 0) {
                         // if pending_read_size == 0 read_from_pcie early exited, due to a wrap, i.e. the exec_buf cmd
                         // is at a wrapped location, and a read to it could not be issued, since there are existing
                         // commands in the cmddat_q. Only move the stall_state to stalled if the read to the cmd that
                         // initiated the stall was issued
-                        barrier_and_stall(pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
+                        barrier_and_stall(
+                            pending_read_size, fence, cmd_ptr);  // STALL_NEXT -> STALLED
                     }
                 } else {
-                    pending_read_size =
-                        read_from_pcie<preamble_size>(prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
+                    pending_read_size = read_from_pcie<preamble_size>(
+                        prefetch_q_rd_ptr, fence, pcie_read_ptr, cmd_ptr, fetch_size);
                 }
             }
         } else {
@@ -401,7 +415,7 @@ static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downs
     uint32_t remaining = cmddat_q_end - data_ptr;
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
-        write_downstream<RelayInlineState::downstream_cb_base_addr>(
+        write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
             data_ptr,
             local_downstream_data_ptr,
             remaining,
@@ -411,7 +425,7 @@ static uint32_t process_relay_inline_cmd(uint32_t cmd_ptr, uint32_t& local_downs
         data_ptr = cmddat_q_base;
     }
 
-    write_downstream<RelayInlineState::downstream_cb_base_addr>(
+    write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
         data_ptr,
         local_downstream_data_ptr,
         length,
@@ -475,13 +489,13 @@ static uint32_t write_pages_to_dispatcher(
     } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
         uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
         noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
-        noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
+        cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, last_chunk_size);
         downstream_data_ptr = downstream_cb_base;
         scratch_write_addr += last_chunk_size;
         amt_to_write -= last_chunk_size;
     }
     noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
-    noc_async_write(scratch_write_addr, noc_addr, amt_to_write);
+    cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, amt_to_write);
     downstream_data_ptr += amt_to_write;
 
     return npages;
@@ -983,7 +997,7 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     uint32_t remaining = exec_buf_state.length - sizeof(CQPrefetchCmd);
     while (length > remaining) {
         // wrap cmddat
-        write_downstream<RelayInlineState::downstream_cb_base_addr>(
+        write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
             data_ptr,
             local_downstream_data_ptr,
             remaining,
@@ -996,20 +1010,20 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
         cmd_ptr = cmddat_q_base;
 
         // fetch more
-        noc_async_writes_flushed();
+        noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
         paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
         noc_async_read_barrier();
     }
-    write_downstream<RelayInlineState::downstream_cb_base_addr>(
+    write_downstream<RelayInlineState::downstream_cb_base_addr, RelayInlineState::downstream_write_cmd_buf>(
         data_ptr,
         local_downstream_data_ptr,
         length,
         RelayInlineState::downstream_cb_end_addr,
         RelayInlineState::downstream_noc_encoding);
     local_downstream_data_ptr = round_up_pow2(local_downstream_data_ptr, RelayInlineState::downstream_page_size);
-    noc_async_writes_flushed();
+    noc_async_writes_flushed(RelayInlineState::downstream_noc_index);
     cb_release_pages<my_noc_index, RelayInlineState::downstream_noc_encoding, RelayInlineState::downstream_cb_sem>(
         npages);
 
@@ -1038,7 +1052,8 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     uint32_t remaining = exec_buf_state.length - sizeof(CQPrefetchCmd);
     while (length > remaining) {
         // wrap cmddat
-        noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+        cq_noc_async_write_with_state_any_len<true, true>(
+            data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
         dispatch_data_ptr += remaining;
         length -= remaining;
         stride -= remaining_stride;
@@ -1053,7 +1068,8 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
     }
-    noc_async_write(data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+    cq_noc_async_write_with_state_any_len<true, true>(
+        data_ptr, get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
     dispatch_data_ptr += length;
 
     return stride;
@@ -1566,6 +1582,12 @@ void kernel_main_d() {
     bool done = false;
     uint32_t heartbeat = 0;
     uint32_t l1_cache[l1_cache_elements_rounded];
+
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0, my_noc_index);
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0, my_noc_index);
+
     while (!done) {
         // cmds come in packed batches based on HostQ reads in prefetch_h
         // once a packed batch ends, we need to jump to the next page
@@ -1618,6 +1640,12 @@ void kernel_main_hd() {
     uint32_t heartbeat = 0;
     uint32_t l1_cache[l1_cache_elements_rounded];
     PrefetchExecBufState exec_buf_state;
+
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0);
+    cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
+        0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0);
+
     while (!done) {
         DeviceZoneScopedN("CQ-PREFETCH");
         constexpr uint32_t preamble_size = 0;


### PR DESCRIPTION
### Ticket
#20243

### Problem description
Saves the register write by using the stateful API.

### What's changed
- Prefetch D/HD is only writing to `downstream_noc_xy` and `dispatch_s_noc_xy`. We can setup 2 command buf's NoC destination to point to those downstream addresses once during init.
- Write cmd buf allocation:
    - BRISC_WR_CMD_BUF: writes to downstream_noc_xy
    - BRISC_WR_REG_CMD_BUF: small writes to dispatch_s_noc_xy. not much traffic on this path.

-  Using the normal NoC APIs for writes and/or inline_dw_writes are not allowed on this kernel because it's using the stateful APIs now.
- Device profiler to save and restore some NoC destination/cmd registers when it's running on a dispatch kernel

Device 0 test_pgm_dispatch (~7% better)
```
Consider adjusting baselines. Test BM_pgm_dispatch/brisc_only_trace/256/manual_time got value 2.58us but expected 2.78us (7.21% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/brisc_only_trace/512/manual_time got value 2.58us but expected 2.79us (7.53% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/brisc_only_trace/1024/manual_time got value 2.60us but expected 2.82us (7.70% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/brisc_only_trace/2048/manual_time got value 2.73us but expected 2.98us (8.15% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/ncrisc_only_trace/256/manual_time got value 2.58us but expected 2.78us (7.24% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/ncrisc_only_trace/512/manual_time got value 2.58us but expected 2.79us (7.53% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/ncrisc_only_trace/1024/manual_time got value 2.60us but expected 2.82us (7.65% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/ncrisc_only_trace/2048/manual_time got value 2.74us but expected 2.90us (5.40% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/brisc_trisc_only_trace/256/manual_time got value 2.97us but expected 3.17us (6.45% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_trace/1024/manual_time got value 3.32us but expected 3.51us (5.59% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_1cb/512/manual_time got value 3.42us but expected 3.64us (6.09% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_1_core_128_crta/1024/manual_time got value 3.72us but expected 3.93us (5.38% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_128_crta/1024/manual_time got value 3.72us but expected 4.00us (6.88% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_1_core_1_processor_trace/256/manual_time got value 2.91us but expected 3.10us (6.22% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_1_core_1_processor_trace/512/manual_time got value 2.91us but expected 3.10us (6.21% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_1_core_1_processor_trace/1024/manual_time got value 2.91us but expected 3.13us (7.07% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_all_cores_1_processor_trace/256/manual_time got value 2.91us but expected 3.10us (6.21% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_all_cores_1_processor_trace/512/manual_time got value 2.91us but expected 3.10us (6.23% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_all_cores_1_processor_trace/1024/manual_time got value 2.91us but expected 3.13us (7.09% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_all_cores_1_processor_trace/2048/manual_time got value 3.04us but expected 3.27us (7.03% better) .
Consider adjusting baselines. Test BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/0/manual_time got value 2.58us but expected 2.78us (7.26% better) .
Consider adjusting baselines. Test BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/1000/manual_time got value 2.58us but expected 2.78us (7.29% better) .
Test successful
```

Device 1 test_pgm_dispatch (5-7% better)
```
Consider adjusting baselines. Test BM_pgm_dispatch/brisc_only_trace/1024/manual_time got value 2.59us but expected 2.74us (5.36% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/brisc_only_trace/2048/manual_time got value 2.74us but expected 2.92us (5.99% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/ncrisc_only_trace/1024/manual_time got value 2.60us but expected 2.78us (6.57% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/ncrisc_only_trace/2048/manual_time got value 2.73us but expected 2.93us (6.70% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/trisc_only_trace/4096/manual_time got value 3.68us but expected 3.89us (5.26% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_trace/256/manual_time got value 3.07us but expected 3.24us (5.36% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_1cb/1024/manual_time got value 3.60us but expected 3.87us (7.16% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_32cb/1024/manual_time got value 3.61us but expected 3.91us (7.59% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/512/manual_time got value 3.40us but expected 3.59us (5.14% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_1cb_1sem/1024/manual_time got value 3.60us but expected 3.87us (7.04% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_1_core_1_rta/1024/manual_time got value 3.62us but expected 3.87us (6.56% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_1_core_1_crta/1024/manual_time got value 3.60us but expected 3.87us (7.06% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_1_core_128_crta/1024/manual_time got value 3.71us but expected 3.94us (5.70% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_1_crta/1024/manual_time got value 3.60us but expected 3.88us (7.18% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_32_crta/1024/manual_time got value 3.60us but expected 3.89us (7.26% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_128_crta/256/manual_time got value 3.46us but expected 3.65us (5.09% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/all_processors_all_cores_128_crta/1024/manual_time got value 3.71us but expected 3.94us (5.69% better) .
Consider adjusting baselines. Test BM_pgm_dispatch/sems_1_core_1_processor_trace/1024/manual_time got value 2.92us but expected 3.08us (5.09% better) .
Consider adjusting baselines. Test BM_pgm_dispatch_vary_slow_cycles/256_bytes_brisc_only_all_processors_trace/1000/manual_time got value 2.60us but expected 2.75us (5.41% better) .
```

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14672544503
https://github.com/tenstorrent/tt-metal/actions/runs/14672543313
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14674087209
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14650127736
test_pgm_dispatch
https://github.com/tenstorrent/tt-metal/actions/runs/14650834834