### PR TITLE
Avoid pinning matplotlib

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -79,7 +79,7 @@ toolz==0.12.0 # Required for Save environment data step
 # Suff that used to be in pyproject.toml
 # Needed for various tests
 pyyaml>=5.4
-matplotlib==3.7.1
+matplotlib
 Pillow==10.3.0
 jupyterlab==4.2.5
 ipywidgets==8.1.1


### PR DESCRIPTION
### Problem description
The version of matplotlib we are pinned to, does not exist for Python 3.12
24.04 build is failing.

### What's changed
Just don't pin.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14582744545) CI passes
- [x] New/Existing tests provide coverage for changes