### PR TITLE
Add host manager for prefetcher ringbuffer

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(
         dispatch_program/test_global_circular_buffers.cpp
         dispatch_program/test_program_reuse.cpp
         dispatch_trace/test_sub_device.cpp
+        dispatch_util/test_ringbuffer_cache.cpp
 )
 target_include_directories(
     unit_tests_dispatch_basic

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_ringbuffer_cache.cpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include "tt_metal/impl/dispatch/ringbuffer_cache.hpp"
+#include <memory>
+#include <numeric>
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+#include <map>
+#include <random>
+
+namespace tt::tt_metal {
+
+struct CacheTestParams {
+    size_t cache_block_sizeB;
+    size_t cache_size_blocks;
+    size_t initial_manager_size;
+    std::pair<int, int> pgm_ids;
+    std::pair<int, int> pgm_sizes;
+};
+class RingbufferCacheRandomizedTestsFixture : public ::testing::TestWithParam<CacheTestParams> {
+protected:
+    RingbufferCacheRandomizedTestsFixture() = default;
+    ~RingbufferCacheRandomizedTestsFixture() override = default;
+
+    std::unique_ptr<RingbufferCacheManager> rb_cache_;
+
+    // This function is called before each test in this test case.
+    void setup(CacheTestParams& params) {
+        rb_cache_ = std::make_unique<RingbufferCacheManager>(
+            params.cache_block_sizeB, params.cache_size_blocks, params.initial_manager_size);
+    }
+
+    // define accessors to the private members of the RingbufferCacheManager
+    auto get_next_block_offset() const { return rb_cache_->manager_.next_block_offset; }
+    auto get_oldest_block_offset() const { return rb_cache_->manager_.entry[rb_cache_->manager_.oldest_idx].offset; }
+    auto get_oldest_idx() const { return rb_cache_->manager_.oldest_idx; }
+    auto get_next_idx() const { return rb_cache_->manager_.next_idx; }
+    auto get_manager_entry_size() const { return rb_cache_->manager_.entry.size(); }
+    auto get_manager_entry(size_t idx) const { return rb_cache_->manager_.entry[idx]; }
+    auto get_valid_entry(size_t idx) const { return rb_cache_->valid_[idx]; }
+    constexpr static auto invalid_entry_ = RingbufferCacheManager::invalid_cache_entry_;
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    RingbufferCacheRandomSuite,
+    RingbufferCacheRandomizedTestsFixture,
+    testing::Values(
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 1024,
+            .initial_manager_size = 64,
+            .pgm_ids = std::make_pair(0, 1000),
+            .pgm_sizes = std::make_pair(1, 769)},
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 1024,
+            .initial_manager_size = 32,
+            .pgm_ids = std::make_pair(0, 4000),
+            .pgm_sizes = std::make_pair(4, 20)},
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 256,
+            .initial_manager_size = 64,
+            .pgm_ids = std::make_pair(0, 10000),
+            .pgm_sizes = std::make_pair(1, 4)},
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 1024,
+            .initial_manager_size = 2,
+            .pgm_ids = std::make_pair(0, 10000),
+            .pgm_sizes = std::make_pair(1, 100)},
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 512,
+            .initial_manager_size = 4,
+            .pgm_ids = std::make_pair(0, 1000),
+            .pgm_sizes = std::make_pair(1, 10)},
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 1024,
+            .initial_manager_size = 1024,
+            .pgm_ids = std::make_pair(0, 4000),
+            .pgm_sizes = std::make_pair(4, 20)},
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 1024,
+            .initial_manager_size = 2048,
+            .pgm_ids = std::make_pair(0, 4000),
+            .pgm_sizes = std::make_pair(16, 64)},
+        CacheTestParams{// high hits test
+                        .cache_block_sizeB = 4,
+                        .cache_size_blocks = 1024,
+                        .initial_manager_size = 2,
+                        .pgm_ids = std::make_pair(0, 512),
+                        .pgm_sizes = std::make_pair(1, 8)},
+        CacheTestParams{// high hits test
+                        .cache_block_sizeB = 4,
+                        .cache_size_blocks = 4096,
+                        .initial_manager_size = 32,
+                        .pgm_ids = std::make_pair(0, 512),
+                        .pgm_sizes = std::make_pair(4, 24)},
+        CacheTestParams{// high hits test
+                        .cache_block_sizeB = 4,
+                        .cache_size_blocks = 4096,
+                        .initial_manager_size = 16,
+                        .pgm_ids = std::make_pair(0, 256),
+                        .pgm_sizes = std::make_pair(4, 16)},
+        CacheTestParams{
+            .cache_block_sizeB = 4,
+            .cache_size_blocks = 512,
+            .initial_manager_size = 128,
+            .pgm_ids = std::make_pair(0, 4000),
+            .pgm_sizes = std::make_pair(100, 200)}));
+
+TEST_P(RingbufferCacheRandomizedTestsFixture, RandomizedQueries) {
+    CacheTestParams params = GetParam();
+    setup(params);
+    auto pgm_ids = params.pgm_ids;
+    auto pgm_sizes = params.pgm_sizes;
+
+    std::unordered_map<int, int> pgm_id_size_map;
+
+    int hits_count = 0;
+
+    std::random_device rd;
+    uint64_t rd1 = rd(), rd2 = rd();
+    std::mt19937 gen_pgm_id(rd1);
+    std::mt19937 gen_pgm_size(rd2);
+    std::uniform_int_distribution<uint64_t> dist_pgm_id(pgm_ids.first, pgm_ids.second - 1);
+    std::uniform_int_distribution<uint64_t> dist_pgm_size(pgm_sizes.first, pgm_sizes.second - 1);
+    uint64_t pgm_id, pgm_size;
+    constexpr size_t num_iterations = 10'000'000;
+    for (size_t i = 0; i < num_iterations; ++i) {
+        pgm_id = dist_pgm_id(gen_pgm_id);
+        if (pgm_id_size_map.find(pgm_id) != pgm_id_size_map.end()) {
+            pgm_size = pgm_id_size_map[pgm_id];
+        } else {
+            pgm_size = dist_pgm_size(gen_pgm_size);
+            pgm_id_size_map[pgm_id] = pgm_size;
+        }
+    }
+
+    gen_pgm_id.seed(rd1);  // restart from seed
+    auto start_rbcache = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < num_iterations; ++i) {
+        pgm_id = dist_pgm_id(gen_pgm_id);
+        pgm_size = pgm_id_size_map[pgm_id];
+
+        auto result = rb_cache_->get_cache_offset(pgm_id, pgm_size * params.cache_block_sizeB);
+        ASSERT_TRUE(result);
+        ASSERT_GE(result->offset, 0);
+        ASSERT_LT(result->offset, params.cache_size_blocks);
+        if (!result->is_cached) {
+            ASSERT_TRUE((result->offset + pgm_size) % params.cache_size_blocks == get_next_block_offset())
+                << "Failed check (iter:" << i << "): cache size: " << params.cache_size_blocks << ", pgm_id: " << pgm_id
+                << ", pgm_size: " << pgm_size << ", offset: " << result->offset
+                << ", next_block_offset: " << get_next_block_offset() << std::endl;
+        }
+        ASSERT_TRUE(get_manager_entry_size() >= std::min(params.initial_manager_size, params.cache_size_blocks))
+            << "Manager size: " << get_manager_entry_size() << ", cache size: " << params.cache_size_blocks
+            << ", initial manager size: " << params.initial_manager_size << ", oldest_idx: " << get_oldest_idx()
+            << ", next_index: " << get_next_idx() << ", oldest_block_offset: " << get_oldest_block_offset()
+            << ", next_block_offset: " << get_next_block_offset() << std::endl;
+        if (result->is_cached) {
+            ++hits_count;
+        }
+    }
+    auto end_rbcache = std::chrono::high_resolution_clock::now();
+    auto duration_rbcache = std::chrono::duration_cast<std::chrono::milliseconds>(end_rbcache - start_rbcache).count();
+    std::cout << "Ringbuffer cache runtime: " << duration_rbcache << " ms, hits: " << hits_count << std::endl;
+    ASSERT_TRUE(get_manager_entry_size() <= params.cache_size_blocks)
+        << "Manager size: " << get_manager_entry_size() << ", cache size: " << params.cache_size_blocks << std::endl;
+    std::cout << "Cache size: " << params.cache_size_blocks << ", initial manager size: " << params.initial_manager_size
+              << ", final manager size: " << get_manager_entry_size() << std::endl;
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1073,6 +1073,7 @@ void gen_dram_ringbuffer_read_cmd(
         ringbuffer_cmd.log2_page_size = log_page_size;
         ringbuffer_cmd.base_addr = DRAM_DATA_BASE_ADDR + count * page_size;
         ringbuffer_cmd.length = length;
+        ringbuffer_cmd.wp_offset_update = length;
         count++;
 
         update_cmd_sizes(prefetch_cmds, cmd_sizes, [&]() { add_bare_prefetcher_cmd(prefetch_cmds, cmd, true); });

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -109,7 +109,7 @@ public:
 
     void compile(IDevice* device, bool force_slow_dispatch = false);
 
-    void generate_dispatch_commands(IDevice* device);
+    void generate_dispatch_commands(IDevice* device, bool use_prefetcher_cache);
 
     void invalidate_circular_buffer_allocation();
 

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -75,14 +75,23 @@ FDMeshCommandQueue::FDMeshCommandQueue(
     std::shared_ptr<CQSharedState>& cq_shared_state) :
     MeshCommandQueueBase(mesh_device, id, dispatch_thread_pool),
     reader_thread_pool_(reader_thread_pool),
-    cq_shared_state_(cq_shared_state) {
+    cq_shared_state_(cq_shared_state),
+    dispatch_core_type_(MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type()),
+    prefetcher_dram_aligned_block_size_(MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
+    prefetcher_cache_sizeB_(MetalContext::instance().dispatch_mem_map(this->dispatch_core_type_).ringbuffer_size()),
+    prefetcher_dram_aligned_num_blocks_(prefetcher_cache_sizeB_ / prefetcher_dram_aligned_block_size_),
+    prefetcher_cache_manager_size_(
+        1 << (std::bit_width(std::min(1024u, std::max(2u, prefetcher_dram_aligned_num_blocks_ >> 4))) - 1)),
+    prefetcher_cache_manager_(std::make_unique<RingbufferCacheManager>(
+        prefetcher_dram_aligned_block_size_, prefetcher_dram_aligned_num_blocks_, prefetcher_cache_manager_size_)),
+    dummy_prefetcher_cache_manager_(std::make_unique<RingbufferCacheManager>(
+        prefetcher_dram_aligned_block_size_, prefetcher_dram_aligned_num_blocks_, prefetcher_cache_manager_size_)) {
     program_dispatch::reset_config_buf_mgrs_and_expected_workers(
         config_buffer_mgr_,
         expected_num_workers_completed_,
         DispatchSettings::DISPATCH_MESSAGE_ENTRIES,
         mesh_device_->allocator()->get_config().l1_unreserved_base);
     this->populate_virtual_program_dispatch_core();
-    this->populate_dispatch_core_type();
     this->populate_read_descriptor_queue();
     completion_queue_reader_thread_ = std::thread(&FDMeshCommandQueue::read_completion_queue, this);
 }
@@ -132,21 +141,6 @@ void FDMeshCommandQueue::populate_virtual_program_dispatch_core() {
                 "Expected Dispatch Cores to match across devices in a Mesh");
         } else {
             this->dispatch_core_ = device->virtual_program_dispatch_core(this->id_);
-        }
-        device_idx++;
-    }
-}
-
-void FDMeshCommandQueue::populate_dispatch_core_type() {
-    uint32_t device_idx = 0;
-    for (auto device : this->mesh_device_->get_devices()) {
-        if (device_idx) {
-            TT_FATAL(
-                this->dispatch_core_type_ ==
-                    MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type(),
-                "Expected the Dispatch Core Type to match across device in a Mesh");
-        } else {
-            this->dispatch_core_type_ = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
         }
         device_idx++;
     }
@@ -244,11 +238,37 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
 
     std::unordered_set<uint32_t> chip_ids_in_workload = {};
     std::vector<MeshCoordinateRange> active_sub_grids = {};
+
+    auto max_program_kernels_sizeB = mesh_workload.impl().max_program_kernels_sizeB_;
+    bool use_prefetcher_cache = mesh_workload.impl().use_prefetcher_cache_;
+    if (use_prefetcher_cache) {
+        bool is_cached;
+        uint32_t cache_offset;
+        std::tie(is_cached, cache_offset) =
+            this->query_prefetcher_cache(mesh_workload.impl().get_id(), max_program_kernels_sizeB);
+        TT_ASSERT(
+            cache_offset + max_program_kernels_sizeB <= this->prefetcher_cache_sizeB_,
+            "Prefetcher cache offset: {}, max_program_kernels_sizeB: {}, prefetcher_cache_sizeB: {}",
+            cache_offset,
+            max_program_kernels_sizeB,
+            this->prefetcher_cache_sizeB_);
+        dispatch_metadata.prefetcher_cache_info.is_cached = is_cached;
+        dispatch_metadata.prefetcher_cache_info.offset = cache_offset;
+        dispatch_metadata.prefetcher_cache_info.mesh_max_program_kernels_sizeB = max_program_kernels_sizeB;
+    } else {
+        // prefetcher cache will be overwritten, reset for next workload
+        this->reset_prefetcher_cache_manager();
+    }
     // Iterate over all programs. Update dispatch commands per program to reflect
     // current device state. Write the finalized program command sequence to each
     // physical device tied to the program.
     for (auto& [device_range, program] : mesh_workload.get_programs()) {
         auto& program_cmd_seq = mesh_workload.impl().get_dispatch_cmds_for_program(program, command_hash);
+        TT_ASSERT(
+            use_prefetcher_cache == program_cmd_seq.prefetcher_cache_used,
+            "use_prefetcher_cache: {}, program_cmd_seq.prefetcher_cache_used: {}",
+            use_prefetcher_cache,
+            program_cmd_seq.prefetcher_cache_used);
         program_dispatch::update_program_dispatch_commands(
             program.impl(),
             program_cmd_seq,
@@ -283,7 +303,12 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     // Send go signals to devices not running a program to ensure consistent global state
     if (not sysmem_manager.get_bypass_mode()) {
         this->write_go_signal_to_unused_sub_grids(
-            chip_ids_in_workload, sub_device_id, expected_num_workers_completed, mcast_go_signals, unicast_go_signals);
+            chip_ids_in_workload,
+            sub_device_id,
+            expected_num_workers_completed,
+            mcast_go_signals,
+            unicast_go_signals,
+            dispatch_metadata);
     } else {
         MeshCoordinateRangeSet active_sub_grids_set;
         for (const auto& sub_grid : active_sub_grids) {
@@ -295,7 +320,8 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             sub_device_id,
             expected_num_workers_completed,
             mcast_go_signals,
-            unicast_go_signals);
+            unicast_go_signals,
+            dispatch_metadata);
     }
     // Increment Launch Message Buffer Write Pointers
     if (mcast_go_signals) {
@@ -375,6 +401,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
 
     if (size_bytes > 0) {
+        this->reset_prefetcher_cache_manager();
         device_dispatch::CoreReadDispatchParams dispatch_params{
             address.virtual_core_coord,
             address.address,
@@ -440,6 +467,8 @@ void FDMeshCommandQueue::read_shard_from_device(
 
     auto device = shard_view->device();
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
+    // Reading from device would clobber prefetcher cache, so reset it now
+    this->reset_prefetcher_cache_manager();
 
     if (is_sharded(shard_view->buffer_layout())) {
         auto dispatch_params = buffer_dispatch::initialize_sharded_buf_read_dispatch_params(
@@ -745,7 +774,8 @@ void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(
     const SubDeviceId& sub_device_id,
     uint32_t expected_num_workers_completed,
     bool mcast_go_signals,
-    bool unicast_go_signals) {
+    bool unicast_go_signals,
+    const program_dispatch::ProgramDispatchMetadata& dispatch_md) {
     for (auto& device : this->mesh_device_->get_devices()) {
         if (chip_ids_in_workload.find(device->id()) == chip_ids_in_workload.end()) {
             write_go_signal(
@@ -756,7 +786,8 @@ void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(
                 expected_num_workers_completed,
                 this->virtual_program_dispatch_core(),
                 mcast_go_signals,
-                unicast_go_signals);
+                unicast_go_signals,
+                dispatch_md);
         }
     }
 }
@@ -811,7 +842,8 @@ void FDMeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
     const SubDeviceId& sub_device_id,
     uint32_t expected_num_workers_completed,
     bool mcast_go_signals,
-    bool unicast_go_signals) {
+    bool unicast_go_signals,
+    const program_dispatch::ProgramDispatchMetadata& dispatch_md) {
     MeshCoordinateRange full_grid(mesh_device_->shape());
     MeshCoordinateRangeSet unused_grids = subtract(full_grid, active_grid);
     for (const auto& unused_grid : unused_grids.ranges()) {
@@ -825,7 +857,8 @@ void FDMeshCommandQueue::capture_go_signal_trace_on_unused_subgrids(
             expected_num_workers_completed,
             this->virtual_program_dispatch_core(),
             mcast_go_signals,
-            unicast_go_signals);
+            unicast_go_signals,
+            dispatch_md);
         auto mesh_trace_md = MeshTraceStagingMetadata{
             unused_grid,
             unused_grid.start_coord(),
@@ -861,6 +894,11 @@ void FDMeshCommandQueue::enqueue_trace(const MeshTraceId& trace_id, bool blockin
         trace_dispatch::issue_trace_commands(
             mesh_device_, device->sysmem_manager(), dispatch_md, id_, expected_num_workers_completed_, dispatch_core_);
     }
+
+    // Reset the prefetcher cache manager, since trace capture modifies the state on host for subsequent non-trace
+    // programs
+    this->reset_prefetcher_cache_manager();
+
     trace_dispatch::update_worker_state_post_trace_execution(
         trace_inst->desc->descriptors,
         cq_shared_state_->worker_launch_message_buffer_state,
@@ -887,6 +925,8 @@ void FDMeshCommandQueue::record_begin(const MeshTraceId& trace_id, const std::sh
     for (auto device : mesh_device_->get_devices()) {
         device->sysmem_manager().set_bypass_mode(/*enable*/ true, /*clear*/ true);
     }
+
+    swap(this->dummy_prefetcher_cache_manager_, this->prefetcher_cache_manager_);
 }
 
 void FDMeshCommandQueue::record_end() {
@@ -907,6 +947,11 @@ void FDMeshCommandQueue::record_end() {
     for (auto device : mesh_device_->get_devices()) {
         device->sysmem_manager().set_bypass_mode(/*enable*/ false, /*clear*/ true);
     }
+
+    // Trace has modified the prefetcher cache manager so reset it first and then swap to restore the state as before
+    // the recording
+    this->reset_prefetcher_cache_manager();
+    swap(this->dummy_prefetcher_cache_manager_, this->prefetcher_cache_manager_);
 }
 
 SystemMemoryManager& FDMeshCommandQueue::reference_sysmem_manager() {
@@ -921,6 +966,22 @@ void FDMeshCommandQueue::update_launch_messages_for_device_profiler(
             tt_metal::detail::EncodePerDeviceProgramID(program_runtime_id, device->id());
     }
 #endif
+}
+
+std::pair<bool, size_t> FDMeshCommandQueue::query_prefetcher_cache(uint64_t workload_id, uint32_t lengthB) {
+    auto result = prefetcher_cache_manager_->get_cache_offset(workload_id, lengthB);
+    TT_FATAL(
+        result.has_value(),
+        "Prefetcher cache query failed. Cache size: {}, requested: {}",
+        this->prefetcher_cache_manager_->get_cache_sizeB(),
+        lengthB);
+    return std::make_pair(result.value().is_cached, result.value().offset * this->prefetcher_dram_aligned_block_size_);
+}
+
+void FDMeshCommandQueue::reset_prefetcher_cache_manager() { prefetcher_cache_manager_->reset(); }
+
+int FDMeshCommandQueue::get_prefetcher_cache_sizeB() const {
+    return this->prefetcher_cache_manager_->get_cache_sizeB();
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -14,6 +14,8 @@
 #include "dispatch/launch_message_ring_buffer_state.hpp"
 #include "dispatch/worker_config_buffer.hpp"
 #include "mesh_trace.hpp"
+#include "tt_metal/impl/dispatch/ringbuffer_cache.hpp"
+#include "tt_metal/impl/program/dispatch.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -34,7 +36,6 @@ class FDMeshCommandQueue final : public MeshCommandQueueBase {
 private:
     void populate_read_descriptor_queue();
     void populate_virtual_program_dispatch_core();
-    void populate_dispatch_core_type();
     CoreCoord virtual_program_dispatch_core() const;
     CoreType dispatch_core_type() const;
 
@@ -61,7 +62,8 @@ private:
         const SubDeviceId& sub_device_id,
         uint32_t expected_num_workers_completed,
         bool mcast_go_signals,
-        bool unicast_go_signals);
+        bool unicast_go_signals,
+        const program_dispatch::ProgramDispatchMetadata& dispatch_md);
     // Workload dispatch utility functions
     // Write dispatch commands associated with running a program on a Virtual Mesh subgrid
     void write_program_cmds_to_subgrid(
@@ -79,7 +81,8 @@ private:
         const SubDeviceId& sub_device_id,
         uint32_t expected_num_workers_completed,
         bool mcast_go_signals,
-        bool unicast_go_signals);
+        bool unicast_go_signals,
+        const program_dispatch::ProgramDispatchMetadata& dispatch_md);
     // When the device profiler is not enabled, launch messages are identical across all physical devices running the
     // same program, to reduce state managed on host. When the profiler is enabled, the host_assigned_id field in the
     // launch message must be unique across physical devices to accurately capture program execution time on host and
@@ -121,7 +124,7 @@ private:
     std::vector<MeshTraceStagingMetadata> ordered_mesh_trace_md_;
 
     CoreCoord dispatch_core_;
-    CoreType dispatch_core_type_ = CoreType::WORKER;
+    const CoreType dispatch_core_type_;
     // MeshCommandQueues and the MeshDevice share thread-pools for dispatching to and reading from the Mesh
     std::shared_ptr<ThreadPool>
         reader_thread_pool_;  // Thread pool used to read from the Mesh (used by the Completion Queue Reader thread)
@@ -152,6 +155,15 @@ private:
     // Used to Maintain state: Mark/Check if this data structure is being used for dispatch.
     // This is temporary - will not be needed when we MeshCommandQueue is the only dispatch interface.
     std::atomic<bool> in_use_ = false;
+
+    const uint32_t prefetcher_dram_aligned_block_size_;
+    const uint64_t prefetcher_cache_sizeB_;
+    const uint32_t prefetcher_dram_aligned_num_blocks_;
+    const uint32_t prefetcher_cache_manager_size_;
+    // The prefetcher cache manager is used to track the state of the prefetcher cache.
+    std::unique_ptr<RingbufferCacheManager> prefetcher_cache_manager_;
+    // The backup prefetcher cache manager is used to stash away the prefetcher cache state during trace recording.
+    std::unique_ptr<RingbufferCacheManager> dummy_prefetcher_cache_manager_;
 
 protected:
     void write_shard_to_device(
@@ -222,6 +234,11 @@ public:
     void copy_buffer_data_to_user_space(MeshBufferReadDescriptor& read_buffer_descriptor);
     // Helper function - read L1 data from Completion Queue
     void read_l1_data_from_completion_queue(MeshCoreDataReadDescriptor& read_l1_data_descriptor);
+
+    // Prefetcher Cache Manager APIs
+    std::pair<bool, size_t> query_prefetcher_cache(uint64_t workload_id, uint32_t lengthB);
+    void reset_prefetcher_cache_manager();
+    int get_prefetcher_cache_sizeB() const;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -16,6 +16,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <atomic>
 
 #include "assert.hpp"
 #include "buffer.hpp"
@@ -35,6 +36,7 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "util.hpp"
 #include "tracy/Tracy.hpp"
+#include "tt_metal/distributed/fd_mesh_command_queue.hpp"
 
 enum class CoreType;
 namespace tt {
@@ -45,7 +47,13 @@ enum class HalProgrammableCoreType;
 }  // namespace tt_metal
 }  // namespace tt
 
+static uint64_t get_next_counter() {
+    static std::atomic<uint64_t> workload_counter = 0;
+    return workload_counter++;
+}
+
 namespace tt::tt_metal::distributed {
+
 namespace {
 
 // Returns an intersecting range from `programs` if it exists, otherwise returns std::nullopt.
@@ -61,7 +69,7 @@ std::optional<MeshCoordinateRange> find_intersection(
 
 }  // namespace
 
-MeshWorkloadImpl::MeshWorkloadImpl() {
+MeshWorkloadImpl::MeshWorkloadImpl() : id(get_next_counter()) {
     ZoneScoped;
     // A MeshWorkload tracks maintains its own handles to kernels across all
     // encapsulated programs
@@ -197,9 +205,15 @@ void MeshWorkloadImpl::generate_dispatch_commands(MeshCommandQueue& mesh_cq) {
     // These commands will be updated based on MeshDevice state when the
     // workload is enqueued.
     auto mesh_device = mesh_cq.device();
+    auto dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
+    uint32_t prefetcher_cache_sizeB = MetalContext::instance().dispatch_mem_map(dispatch_core_type).ringbuffer_size();
+
+    bool use_prefetcher_cache =
+        this->max_program_kernels_sizeB_ and this->max_program_kernels_sizeB_ <= prefetcher_cache_sizeB;
     for (auto& [device_range, program] : programs_) {
-        program.generate_dispatch_commands(mesh_device);
+        program.generate_dispatch_commands(mesh_device, use_prefetcher_cache);
     }
+    this->use_prefetcher_cache_ = use_prefetcher_cache;
 }
 
 bool MeshWorkloadImpl::runs_on_noc_multicast_only_cores() {
@@ -417,7 +431,7 @@ void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
     }
     tt::stl::Span<tt::tt_metal::detail::ProgramImpl*> programs(program_impls.data(), program_impls.size());
 
-    tt::tt_metal::detail::ProgramImpl::finalize_program_offsets(
+    this->max_program_kernels_sizeB_ = tt::tt_metal::detail::ProgramImpl::finalize_program_offsets(
         mesh_device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
 
     set_finalized();

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -24,6 +24,9 @@ class MeshWorkloadImpl {
     //  - Multi Program Multi Device (Completely Heterogeneous MeshWorkload)
     // Support for configurable runtime arguments will be added in future versions.
 private:
+    uint64_t id;
+
+    uint64_t get_id() const { return id; }
     bool runs_on_noc_multicast_only_cores();
     bool runs_on_noc_unicast_only_cores();
     void compile(MeshDevice* mesh_device);
@@ -59,6 +62,9 @@ private:
     friend void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
     friend FDMeshCommandQueue;
     friend class tt::tt_metal::Program;
+
+    uint32_t max_program_kernels_sizeB_ = 0;
+    bool use_prefetcher_cache_ = false;
 
 public:
     // Main User-Facing API building blocks

--- a/tt_metal/distributed/mesh_workload_utils.hpp
+++ b/tt_metal/distributed/mesh_workload_utils.hpp
@@ -7,6 +7,7 @@
 
 #include "core_coord.hpp"
 #include "sub_device_types.hpp"
+#include "tt_metal/impl/program/dispatch.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -27,6 +28,7 @@ void write_go_signal(
     uint32_t expected_num_workers_completed,
     CoreCoord dispatch_core,
     bool send_mcast,
-    bool send_unicasts);
+    bool send_unicasts,
+    const program_dispatch::ProgramDispatchMetadata& dispatch_md);
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -49,6 +49,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/launch_message_ring_buffer_state.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/worker_config_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/data_collection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/ringbuffer_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/topology.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/fd_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/kernel_config/prefetch.cpp

--- a/tt_metal/impl/dispatch/device_command.cpp
+++ b/tt_metal/impl/dispatch/device_command.cpp
@@ -233,6 +233,70 @@ void DeviceCommand<hugepage_write>::add_prefetch_relay_paged_packed(
 }
 
 template <bool hugepage_write>
+void DeviceCommand<hugepage_write>::add_prefetch_paged_to_ringbuffer(
+    const CQPrefetchPagedToRingbufferCmd& paged_to_ringbuffer_info) {
+    uint32_t increment_sizeB = tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
+    auto initialize_paged_to_ringbuffer_cmd = [&](CQPrefetchCmd* paged_to_ringbuffer_cmd) {
+        paged_to_ringbuffer_cmd->base.cmd_id = CQ_PREFETCH_CMD_PAGED_TO_RINGBUFFER;
+        paged_to_ringbuffer_cmd->paged_to_ringbuffer = paged_to_ringbuffer_info;
+    };
+    CQPrefetchCmd* paged_to_ringbuffer_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+
+    if constexpr (hugepage_write) {
+        alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd paged_to_ringbuffer_cmd;
+        initialize_paged_to_ringbuffer_cmd(&paged_to_ringbuffer_cmd);
+        this->memcpy(paged_to_ringbuffer_cmd_dst, &paged_to_ringbuffer_cmd, sizeof(CQPrefetchCmd));
+    } else {
+        initialize_paged_to_ringbuffer_cmd(paged_to_ringbuffer_cmd_dst);
+    }
+}
+
+template <bool hugepage_write>
+void DeviceCommand<hugepage_write>::add_prefetch_set_ringbuffer_offset(uint32_t offset, bool update_wp) {
+    uint32_t increment_sizeB = tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
+    auto initialize_set_ringbuffer_offset_cmd = [&](CQPrefetchCmd* set_ringbuffer_offset_cmd) {
+        set_ringbuffer_offset_cmd->base.cmd_id = CQ_PREFETCH_CMD_SET_RINGBUFFER_OFFSET;
+        set_ringbuffer_offset_cmd->set_ringbuffer_offset.offset = offset;
+        set_ringbuffer_offset_cmd->set_ringbuffer_offset.update_wp = update_wp;
+    };
+    CQPrefetchCmd* set_ringbuffer_offset_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+
+    if constexpr (hugepage_write) {
+        alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd set_ringbuffer_offset_cmd;
+        initialize_set_ringbuffer_offset_cmd(&set_ringbuffer_offset_cmd);
+        this->memcpy(set_ringbuffer_offset_cmd_dst, &set_ringbuffer_offset_cmd, sizeof(CQPrefetchCmd));
+    } else {
+        initialize_set_ringbuffer_offset_cmd(set_ringbuffer_offset_cmd_dst);
+    }
+}
+
+template <bool hugepage_write>
+void DeviceCommand<hugepage_write>::add_prefetch_relay_ringbuffer(
+    uint32_t num_sub_cmds, const std::vector<CQPrefetchRelayRingbufferSubCmd>& sub_cmds, uint32_t offset_idx) {
+    static_assert(sizeof(CQPrefetchRelayRingbufferSubCmd) % sizeof(uint32_t) == 0);
+
+    uint32_t sub_cmds_sizeB = num_sub_cmds * sizeof(CQPrefetchRelayRingbufferSubCmd);
+    uint32_t increment_sizeB = tt::align(sub_cmds_sizeB + sizeof(CQPrefetchCmd), this->pcie_alignment);
+    auto initialize_relay_ringbuffer_cmd = [&](CQPrefetchCmd* relay_ringbuffer_cmd) {
+        relay_ringbuffer_cmd->base.cmd_id = CQ_PREFETCH_CMD_RELAY_RINGBUFFER;
+        relay_ringbuffer_cmd->relay_ringbuffer.count = num_sub_cmds;
+        relay_ringbuffer_cmd->relay_ringbuffer.stride = increment_sizeB;
+    };
+
+    CQPrefetchCmd* relay_ringbuffer_cmd_dst = this->reserve_space<CQPrefetchCmd*>(increment_sizeB);
+
+    if constexpr (hugepage_write) {
+        alignas(MEMCPY_ALIGNMENT) CQPrefetchCmd relay_ringbuffer_cmd;
+        initialize_relay_ringbuffer_cmd(&relay_ringbuffer_cmd);
+        this->memcpy(relay_ringbuffer_cmd_dst, &relay_ringbuffer_cmd, sizeof(CQPrefetchCmd));
+    } else {
+        initialize_relay_ringbuffer_cmd(relay_ringbuffer_cmd_dst);
+    }
+
+    this->memcpy((char*)relay_ringbuffer_cmd_dst + sizeof(CQPrefetchCmd), &sub_cmds[offset_idx], sub_cmds_sizeB);
+}
+
+template <bool hugepage_write>
 template <bool flush_prefetch, bool inline_data>
 void DeviceCommand<hugepage_write>::add_dispatch_write_linear(
     uint8_t num_mcast_dests,

--- a/tt_metal/impl/dispatch/device_command.hpp
+++ b/tt_metal/impl/dispatch/device_command.hpp
@@ -73,6 +73,13 @@ public:
         uint16_t num_sub_cmds,
         uint32_t offset_idx = 0);
 
+    void add_prefetch_paged_to_ringbuffer(const CQPrefetchPagedToRingbufferCmd& paged_to_ringbuffer_info);
+
+    void add_prefetch_set_ringbuffer_offset(uint32_t offset, bool update_wp = false);
+
+    void add_prefetch_relay_ringbuffer(
+        uint32_t num_sub_cmds, const std::vector<CQPrefetchRelayRingbufferSubCmd>& sub_cmds, uint32_t offset_idx = 0);
+
     template <bool flush_prefetch = true, bool inline_data = false>
     void add_dispatch_write_linear(
         uint8_t num_mcast_dests,

--- a/tt_metal/impl/dispatch/device_command_calculator.hpp
+++ b/tt_metal/impl/dispatch/device_command_calculator.hpp
@@ -129,6 +129,22 @@ public:
         this->cmd_write_offsetB += increment_sizeB;
     }
 
+    void add_prefetch_relay_ringbuffer(uint16_t num_sub_cmds) {
+        static_assert(sizeof(CQPrefetchRelayRingbufferSubCmd) % sizeof(uint32_t) == 0);
+
+        uint32_t sub_cmds_sizeB = num_sub_cmds * sizeof(CQPrefetchRelayRingbufferSubCmd);
+        uint32_t increment_sizeB = tt::align(sub_cmds_sizeB + sizeof(CQPrefetchCmd), this->pcie_alignment);
+        this->cmd_write_offsetB += increment_sizeB;
+    }
+
+    void add_prefetch_set_ringbuffer_offset() {
+        this->cmd_write_offsetB += tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
+    }
+
+    void add_prefetch_paged_to_ringbuffer() {
+        this->cmd_write_offsetB += tt::align(sizeof(CQPrefetchCmd), this->pcie_alignment);
+    }
+
     template <typename PackedSubCmd>
     void add_dispatch_write_packed(
         uint16_t num_sub_cmds,

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -205,4 +205,9 @@ std::pair<uint32_t, uint32_t> DispatchMemMap::get_device_l1_info(const CoreType&
     return {l1_base, l1_size};
 }
 
+uint32_t DispatchMemMap::get_prefetcher_l1_size() const {
+    auto [l1_base, l1_size] = this->get_device_l1_info(this->settings.core_type_);
+    return l1_size;
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -81,6 +81,8 @@ public:
     // Offset to be passed in the go message.
     uint8_t get_dispatch_message_update_offset(uint32_t index) const;
 
+    uint32_t get_prefetcher_l1_size() const;
+
 private:
     // Reset the instance using the settings for the core_type and num_hw_cqs.
     void reset(const CoreType& core_type, const uint32_t num_hw_cqs);

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -40,6 +40,8 @@
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include <umd/device/tt_xy_pair.h>
 #include "data_collection.hpp"
+#include "ringbuffer_cache.hpp"
+#include "program/dispatch.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -82,7 +84,17 @@ HWCommandQueue::HWCommandQueue(
     uint32_t completion_queue_reader_core) :
     manager_(device->sysmem_manager()),
     completion_queue_thread_{},
-    completion_queue_reader_core_(completion_queue_reader_core) {
+    completion_queue_reader_core_(completion_queue_reader_core),
+    prefetcher_dram_aligned_block_size_(MetalContext::instance().hal().get_alignment(HalMemType::DRAM)),
+    prefetcher_cache_sizeB_(
+        MetalContext::instance().dispatch_mem_map(this->get_dispatch_core_type()).ringbuffer_size()),
+    prefetcher_dram_aligned_num_blocks_(prefetcher_cache_sizeB_ / prefetcher_dram_aligned_block_size_),
+    prefetcher_cache_manager_size_(
+        1 << (std::bit_width(std::min(1024u, std::max(2u, prefetcher_dram_aligned_num_blocks_ >> 4))) - 1)),
+    prefetcher_cache_manager_(std::make_unique<RingbufferCacheManager>(
+        prefetcher_dram_aligned_block_size_, prefetcher_dram_aligned_num_blocks_, prefetcher_cache_manager_size_)),
+    dummy_prefetcher_cache_manager_(std::make_unique<RingbufferCacheManager>(
+        prefetcher_dram_aligned_block_size_, prefetcher_dram_aligned_num_blocks_, prefetcher_cache_manager_size_)) {
     ZoneScopedN("CommandQueue_constructor");
     this->device_ = device;
     this->cq_shared_state_ = std::move(cq_shared_state);
@@ -236,6 +248,9 @@ void HWCommandQueue::enqueue_read_buffer(
     ZoneScopedN("HWCommandQueue_read_buffer");
     TT_FATAL(!this->manager_.get_bypass_mode(), "Enqueue Read Buffer cannot be used with tracing");
     Buffer& buffer_obj = get_buffer_object(buffer);
+
+    // Reading from device would clobber prefetcher cache, so reset it now
+    this->reset_prefetcher_cache_manager();
 
     // This is to make sure we block on the same sub_device_ids at the end
     // TODO: enqueue_read_from_core will call select_sub_device_ids every loop which will have minor overhead
@@ -418,11 +433,14 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     // Lower the program to device: Generate dispatch commands.
     // Values in these commands will get updated based on kernel config ring
     // buffer state at runtime.
-    program.generate_dispatch_commands(device_);
+    auto program_sizeB = program.impl().kernel_bins_sizeB;
+    bool use_prefetcher_cache = program_sizeB and program_sizeB <= this->prefetcher_cache_sizeB_;
+    program.generate_dispatch_commands(device_, use_prefetcher_cache);
     program.set_last_used_command_queue_for_testing(this);
 
     if (this->manager_.get_bypass_mode()) {
-        this->trace_nodes_.push_back(program_dispatch::create_trace_node(program.impl(), device_));
+        this->trace_nodes_.push_back(
+            program_dispatch::create_trace_node(program.impl(), device_, use_prefetcher_cache));
         return;
     }
 
@@ -455,6 +473,26 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
 
     auto& worker_launch_message_buffer_state =
         this->cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id];
+
+    // Dispatch metadata contains runtime information based on
+    // the kernel config ring buffer state
+    program_dispatch::ProgramDispatchMetadata dispatch_metadata;
+    if (use_prefetcher_cache) {
+        bool& is_cached = dispatch_metadata.prefetcher_cache_info.is_cached;
+        uint32_t& cache_offset = dispatch_metadata.prefetcher_cache_info.offset;
+        std::tie(is_cached, cache_offset) = this->query_prefetcher_cache(program.get_id(), program_sizeB);
+        TT_ASSERT(
+            cache_offset + program_sizeB <= this->prefetcher_cache_sizeB_,
+            "Prefetcher cache overflow: offset: {}, program size: {}, cache size: {}",
+            cache_offset,
+            program_sizeB,
+            this->prefetcher_cache_sizeB_);
+        dispatch_metadata.prefetcher_cache_info.mesh_max_program_kernels_sizeB = program_sizeB;
+    } else {
+        // prefetcher cache will be overwritten, reset for next program
+        this->reset_prefetcher_cache_manager();
+    }
+
     auto command = EnqueueProgramCommand(
         this->id_,
         this->device_,
@@ -467,7 +505,8 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
         // The assembled program command will encode the location of the launch messages in the ring buffer
         worker_launch_message_buffer_state.get_mcast_wptr(),
         worker_launch_message_buffer_state.get_unicast_wptr(),
-        sub_device_id);
+        sub_device_id,
+        dispatch_metadata);
     // Update wptrs for tensix and eth launch message in the device class
     if (program.runs_on_noc_multicast_only_cores()) {
         worker_launch_message_buffer_state.inc_mcast_wptr(1);
@@ -573,6 +612,10 @@ void HWCommandQueue::enqueue_trace(const uint32_t trace_id, bool blocking) {
         id_,
         this->expected_num_workers_completed_,
         virtual_enqueue_program_dispatch_core_);
+
+    // Reset the prefetcher cache manager, since trace capture modifies the state on host for subsequent non-trace
+    // programs
+    this->reset_prefetcher_cache_manager();
 
     trace_dispatch::update_worker_state_post_trace_execution(
         trace_inst->desc->descriptors,
@@ -705,6 +748,8 @@ void HWCommandQueue::record_begin(const uint32_t tid, const std::shared_ptr<Trac
     this->tid_ = tid;
     this->trace_ctx_ = std::move(ctx);
     this->manager_.set_bypass_mode(true, true);  // start trace capture
+
+    swap(this->dummy_prefetcher_cache_manager_, this->prefetcher_cache_manager_);
 }
 
 // Allocate space for program binaries and other data in the worker config ring buffer.
@@ -775,6 +820,29 @@ void HWCommandQueue::record_end() {
         auto& cached_program_command_sequence = program.get_trace_cached_program_command_sequences().at(command_hash);
         auto& worker_launch_message_buffer_state =
             this->cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id];
+
+        // Dispatch metadata contains runtime information based on
+        // the kernel config ring buffer state
+        auto& dispatch_metadata = node.dispatch_metadata;
+        auto use_prefetcher_cache = cached_program_command_sequence.prefetcher_cache_used;
+        auto program_sizeB = cached_program_command_sequence.kernel_bins_sizeB;
+        if (dispatch_metadata.send_binary) {
+            if (use_prefetcher_cache) {
+                bool& is_cached = dispatch_metadata.prefetcher_cache_info.is_cached;
+                uint32_t& cache_offset = dispatch_metadata.prefetcher_cache_info.offset;
+                std::tie(is_cached, cache_offset) = this->query_prefetcher_cache(program.get_id(), program_sizeB);
+                TT_ASSERT(
+                    cache_offset + program_sizeB <= this->prefetcher_cache_sizeB_,
+                    "Prefetcher cache overflow: offset: {}, program size: {}, cache size: {}",
+                    cache_offset,
+                    program_sizeB,
+                    this->prefetcher_cache_sizeB_);
+                dispatch_metadata.prefetcher_cache_info.mesh_max_program_kernels_sizeB = program_sizeB;
+            } else {
+                // prefetcher cache will be overwritten, reset for next program
+                this->reset_prefetcher_cache_manager();
+            }
+        }
         // Update the generated dispatch commands based on the state of the CQ and the ring buffer
         program_dispatch::update_traced_program_dispatch_commands(
             node,
@@ -838,6 +906,11 @@ void HWCommandQueue::record_end() {
         this->expected_num_workers_completed_reset_,
         this->config_buffer_mgr_reset_);
     this->manager_.set_bypass_mode(false, true);  // stop trace capture
+
+    // Trace has modified the prefetcher cache manager so reset it first and then swap to restore the state as before
+    // the recording
+    this->reset_prefetcher_cache_manager();
+    swap(this->dummy_prefetcher_cache_manager_, this->prefetcher_cache_manager_);
 }
 
 void HWCommandQueue::terminate() {
@@ -849,5 +922,19 @@ void HWCommandQueue::terminate() {
 }
 
 WorkerConfigBufferMgr& HWCommandQueue::get_config_buffer_mgr(uint32_t index) { return config_buffer_mgr_[index]; }
+
+std::pair<bool, size_t> HWCommandQueue::query_prefetcher_cache(uint64_t pgm_id, uint32_t lengthB) {
+    auto result = prefetcher_cache_manager_->get_cache_offset(pgm_id, lengthB);
+    TT_FATAL(
+        result.has_value(),
+        "Prefetcher cache query failed. Cache size: {}, requested: {}",
+        this->prefetcher_cache_manager_->get_cache_sizeB(),
+        lengthB);
+    return std::make_pair(result.value().is_cached, result.value().offset * this->prefetcher_dram_aligned_block_size_);
+}
+
+void HWCommandQueue::reset_prefetcher_cache_manager() { prefetcher_cache_manager_->reset(); }
+
+int HWCommandQueue::get_prefetcher_cache_sizeB() const { return this->prefetcher_cache_manager_->get_cache_sizeB(); }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -98,7 +98,8 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     uint32_t expected_num_workers_completed,
     uint32_t multicast_cores_launch_message_wptr,
     uint32_t unicast_cores_launch_message_wptr,
-    SubDeviceId sub_device_id) :
+    SubDeviceId sub_device_id,
+    program_dispatch::ProgramDispatchMetadata& dispatch_md) :
     command_queue_id(command_queue_id),
     noc_index(noc_index),
     manager(manager),
@@ -108,17 +109,14 @@ EnqueueProgramCommand::EnqueueProgramCommand(
     dispatch_core(dispatch_core),
     multicast_cores_launch_message_wptr(multicast_cores_launch_message_wptr),
     unicast_cores_launch_message_wptr(unicast_cores_launch_message_wptr),
-    sub_device_id(sub_device_id) {
+    sub_device_id(sub_device_id),
+    dispatch_metadata(dispatch_md) {
     this->device = device;
     this->dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     this->packed_write_max_unicast_sub_cmds = get_packed_write_max_unicast_sub_cmds(this->device);
 }
 
 void EnqueueProgramCommand::process() {
-    // Dispatch metadata contains runtime information based on
-    // the kernel config ring buffer state
-    program_dispatch::ProgramDispatchMetadata dispatch_metadata;
-
     // Compute the total number of workers this program uses
     uint32_t num_workers = 0;
     if (program.runs_on_noc_multicast_only_cores()) {

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -26,6 +26,7 @@
 #include "trace/trace_buffer.hpp"
 #include "tt_metal/impl/program/program_command_sequence.hpp"
 #include "worker_config_buffer.hpp"
+#include "program/dispatch.hpp"
 
 enum class CoreType;
 namespace tt {
@@ -84,6 +85,7 @@ private:
     uint32_t unicast_cores_launch_message_wptr = 0;
     // TODO: There will be multiple ids once programs support spanning multiple sub_devices
     SubDeviceId sub_device_id = SubDeviceId{0};
+    program_dispatch::ProgramDispatchMetadata& dispatch_metadata;
 
 public:
     EnqueueProgramCommand(
@@ -97,7 +99,8 @@ public:
         uint32_t expected_num_workers_completed,
         uint32_t multicast_cores_launch_message_wptr,
         uint32_t unicast_cores_launch_message_wptr,
-        SubDeviceId sub_device_id);
+        SubDeviceId sub_device_id,
+        program_dispatch::ProgramDispatchMetadata& dispatch_md);
 
     void process() override;
 

--- a/tt_metal/impl/dispatch/kernels/cq_commands.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_commands.hpp
@@ -142,15 +142,18 @@ constexpr uint32_t CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START = 1;
 // Will always flush writes before reading.
 struct CQPrefetchPagedToRingbufferCmd {
     uint8_t flags;
-    uint8_t pad1;
     uint8_t log2_page_size;
-    uint32_t start_page;
+    uint8_t start_page;
+    uint32_t wp_offset_update;  // set final increment ringbuffer write pointer
     uint32_t base_addr;  // Base address of the interleaved buffer to read from.
     uint32_t length;     // multiple of DRAM alignment
 } __attribute__((packed));
 
 struct CQPrefetchSetRingbufferOffsetCmd {
     uint32_t offset;
+    uint16_t pad1;
+    uint8_t pad2;
+    uint8_t update_wp;  // if set, the ringbuffer write pointer will be updated to the offset
 } __attribute__((packed));
 
 // Current implementation limit is based on size of the l1_cache which stores the sub_cmds

--- a/tt_metal/impl/dispatch/ringbuffer_cache.cpp
+++ b/tt_metal/impl/dispatch/ringbuffer_cache.cpp
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tt_metal/impl/dispatch/ringbuffer_cache.hpp"
+#include "assert.hpp"
+// #include "tt_metal/hw/inc/dataflow_api.h"
+
+namespace tt::tt_metal {
+
+RingbufferCacheManager::RingbufferCacheManager(
+    int cache_block_sizeB, int cache_size_blocks, int manager_entry_initial_size) :
+    cache_block_sizeB_(cache_block_sizeB),
+    cache_size_blocks_(cache_size_blocks),
+    cache_manager_initial_entry_size_{manager_entry_initial_size} {
+    TT_ASSERT(cache_size_blocks > 0, "Ringbuffer cache size must be greater than 0");
+    TT_ASSERT(cache_block_sizeB > 0, "Ringbuffer cache block size must be greater than 0");
+    TT_ASSERT(
+        cache_manager_initial_entry_size_ > 0,
+        "Ringbuffer cache manager initial entry size ({}) must be greater than 0 ({}, {})",
+        cache_manager_initial_entry_size_,
+        cache_block_sizeB,
+        cache_size_blocks_);
+    TT_ASSERT(
+        (cache_manager_initial_entry_size_ & (cache_manager_initial_entry_size_ - 1)) == 0,
+        "Ringbuffer cache manager initial entry size ({}) is not a power of 2 ({}, {})",
+        cache_manager_initial_entry_size_,
+        cache_block_sizeB,
+        cache_size_blocks_);
+}
+
+// this function encapsulates the common code for adding a new entry to the ringbuffer manager
+// also, this function should be called when the cache is empty
+void RingbufferCacheManager::add_manager_entry_no_evict(uint64_t pgm_id, uint32_t offset, uint32_t length) {
+    TT_ASSERT(
+        offset + length <= cache_size_blocks_, "RingbufferCacheManager new allocation: offset + length > cache size");
+
+    auto idx = manager_.next_idx;
+    manager_.entry[idx] = {offset, length, pgm_id};
+
+    TT_ASSERT(pgm_id <= UINT32_MAX, "RingbufferCacheManager new allocation: pgm_id > UINT32_MAX");
+    valid_[pgm_id] = idx;
+
+    manager_.next_block_offset = offset + length == cache_size_blocks_ ? 0 : offset + length;
+    manager_.update_next_idx();
+}
+
+// this function should be called to allocate a new cache entry if the cache is not empty
+void RingbufferCacheManager::add_manager_entry(uint64_t pgm_id, uint32_t offset, uint32_t length) {
+    auto idx = manager_.next_idx;
+    if (idx == manager_.oldest_idx) {
+        // if the next index is the same as the oldest index, then we need to invalidate the oldest entry
+        invalidate_manager_entry();
+    }
+    add_manager_entry_no_evict(pgm_id, offset, length);
+}
+
+// this function will invalidate the oldest entry in the ringbuffer manager
+// caution: oldest entry must be valid
+void RingbufferCacheManager::invalidate_manager_entry() {
+    auto& entry = manager_.entry[manager_.oldest_idx];
+    auto valid_idx = entry.valid_idx;
+    TT_ASSERT(valid_idx < valid_.size(), "RingbufferCacheManager invalidation: pgm_id out of range");
+    TT_ASSERT(
+        valid_[valid_idx] != RingbufferCacheManager::invalid_cache_entry_,
+        "RingbufferCacheManager invalidation: entry not valid (mgr: oldest_idx:{}, next_idx:{}, offset:{}, length:{}, "
+        "valid idx (pgm id):{}, valid[pgm id]:{})",
+        manager_.oldest_idx,
+        manager_.next_idx,
+        entry.offset,
+        entry.length,
+        valid_idx,
+        valid_[valid_idx]);
+    // invalidate the entry
+    valid_[valid_idx] = RingbufferCacheManager::invalid_cache_entry_;
+    manager_.update_oldest_idx();
+}
+
+// this function will invalidate all oldest entries until the cache wraps around
+// caution: should not be called if the cache is empty
+bool RingbufferCacheManager::invalidate_oldest_until_wraparound() {
+    if (manager_.oldest_idx == manager_.next_idx) {
+        invalidate_manager_entry();
+    }
+    while ((manager_.entry[manager_.oldest_idx].offset >= manager_.next_block_offset) and
+           (manager_.oldest_idx != manager_.next_idx)) {
+        invalidate_manager_entry();
+    }
+    // true ==> cache is empty and caller should call add_manager_entry_no_evict
+    return manager_.oldest_idx == manager_.next_idx;
+}
+// this function is used to invalidate the oldest entry until there is sufficient space
+// caution: should not be called if the cache is empty
+bool RingbufferCacheManager::invalidate_sufficient_blocks(int required_space, int offset) {
+    if (manager_.oldest_idx == manager_.next_idx) {
+        invalidate_manager_entry();
+    }
+    int oldest_block_offset = manager_.entry[manager_.oldest_idx].offset;
+    int available_space = oldest_block_offset - offset;
+    while (available_space < required_space and manager_.oldest_idx != manager_.next_idx) {
+        available_space += manager_.entry[manager_.oldest_idx].length;
+        invalidate_manager_entry();  // invalidate oldest entry
+    }
+
+    // true ==> cache is empty and caller should call add_manager_entry_no_evict
+    return manager_.oldest_idx == manager_.next_idx;
+}
+
+std::optional<typename RingbufferCacheManager::CacheOffset> RingbufferCacheManager::get_cache_offset(
+    uint64_t pgm_id, uint32_t lengthB) {
+    uint32_t cache_offset;
+    CacheOffset query_result;
+
+    const int required_space = (lengthB + cache_block_sizeB_ - 1) / cache_block_sizeB_;
+    if (required_space > cache_size_blocks_) [[unlikely]] {
+        return std::nullopt;  // cannot fit in cache
+    } else if (manager_.entry.size() == 0) [[unlikely]] {
+        // first entry, so we can just add it
+        valid_.resize(pgm_id + 1, RingbufferCacheManager::invalid_cache_entry_);
+        manager_.entry.resize(std::min(cache_manager_initial_entry_size_, cache_size_blocks_));
+        add_manager_entry_no_evict(pgm_id, 0, required_space);
+        query_result.is_cached = false;
+        query_result.offset = 0;
+        return query_result;
+    } else if (pgm_id >= valid_.size()) {
+        valid_.resize(
+            std::max((uint64_t)cache_manager_initial_entry_size_, pgm_id + 1),
+            RingbufferCacheManager::invalid_cache_entry_);
+    } else if (valid_[pgm_id] != invalid_cache_entry_) {
+        unsigned mgr_idx = valid_[pgm_id];
+        TT_ASSERT(
+            mgr_idx < manager_.entry.size(),
+            "RingbufferCacheManager invalid cache hit: manager index out of bounds. pgm_id:{}, valid idx:{}, entry "
+            "size:{}",
+            pgm_id,
+            mgr_idx,
+            manager_.entry.size());
+        auto mgr_entry = manager_.entry[mgr_idx];
+        TT_ASSERT(
+            mgr_entry.length * cache_block_sizeB_ >= lengthB,
+            "RingbufferCacheManager invalid cache hit: requested length:{} > entry length:{}, manager idx:{}, cache "
+            "offset:{}, valid_idx/pgm_id requested:{}/{}",
+            lengthB,
+            mgr_entry.length * cache_block_sizeB_,
+            mgr_idx,
+            mgr_entry.offset,
+            mgr_entry.valid_idx,
+            pgm_id);
+        query_result.is_cached = true;
+        query_result.offset = mgr_entry.offset;
+        return query_result;
+    }
+
+    query_result.is_cached = false;
+
+    // find space in RB for new entry, or if full, then invalidate oldest entry(ies)
+    int next_block_offset = manager_.next_block_offset;
+    int oldest_block_offset = manager_.entry[manager_.oldest_idx].offset;
+    int free_space_to_end = cache_size_blocks_ - next_block_offset;
+    bool cache_emptied = false;
+    if (next_block_offset > oldest_block_offset) {
+        if (free_space_to_end < required_space) [[unlikely]] {
+            cache_emptied = invalidate_sufficient_blocks(required_space);  // free up space from beginning
+            cache_offset = 0;
+        } else {
+            cache_offset = next_block_offset;  // cache has space
+        }
+    } else {
+        if (free_space_to_end >= required_space) {
+            cache_emptied = invalidate_sufficient_blocks(required_space, next_block_offset);
+            cache_offset = next_block_offset;
+        } else [[unlikely]] {
+            // cache is not full, but must wraparound for sufficient space
+            cache_emptied = invalidate_oldest_until_wraparound();
+            if (not cache_emptied) {
+                cache_emptied = invalidate_sufficient_blocks(required_space);  // free up space from beginning
+            }
+            cache_offset = 0;
+        }
+    }
+    // made room, now allocate the new entry
+    if (cache_emptied) {
+        add_manager_entry_no_evict(pgm_id, cache_offset, required_space);
+    } else {
+        add_manager_entry(pgm_id, cache_offset, required_space);
+    }
+
+    query_result.offset = cache_offset;
+    return query_result;
+}
+
+void RingbufferCacheManager::reset() {
+    this->manager_.clear();
+    std::vector<RingbufferCacheManagerEntry> temp_entry;
+    this->manager_.entry.swap(temp_entry);
+
+    std::vector<int32_t> temp_valid;
+    this->valid_.swap(temp_valid);
+}
+
+void swap(RingbufferCacheManager& a, RingbufferCacheManager& b) {
+    TT_ASSERT(
+        a.cache_block_sizeB_ == b.cache_block_sizeB_,
+        "Ringbuffer cache block size mismatch: {} != {}",
+        a.cache_block_sizeB_,
+        b.cache_block_sizeB_);
+    TT_ASSERT(
+        a.cache_size_blocks_ == b.cache_size_blocks_,
+        "Ringbuffer cache size mismatch: {} != {}",
+        a.cache_size_blocks_,
+        b.cache_size_blocks_);
+    TT_ASSERT(
+        a.cache_manager_initial_entry_size_ == b.cache_manager_initial_entry_size_,
+        "Ringbuffer cache manager initial entry size mismatch: {} != {}",
+        a.cache_manager_initial_entry_size_,
+        b.cache_manager_initial_entry_size_);
+    using std::swap;
+    a.valid_.swap(b.valid_);
+    a.manager_.swap(b.manager_);
+}
+
+void RingbufferCacheManager::InternalManager::clear() {
+    this->oldest_idx = 0;
+    this->next_idx = 0;
+    this->next_block_offset = 0;
+}
+
+RingbufferCacheManager::InternalManager& RingbufferCacheManager::InternalManager::swap(InternalManager& b) {
+    using std::swap;
+    swap(this->entry, b.entry);
+    swap(this->oldest_idx, b.oldest_idx);
+    swap(this->next_idx, b.next_idx);
+    swap(this->next_block_offset, b.next_block_offset);
+    return *this;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/ringbuffer_cache.hpp
+++ b/tt_metal/impl/dispatch/ringbuffer_cache.hpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ringbuffer cache implementation
+
+#pragma once
+
+#include <cstdint>
+#include <array>
+#include <vector>
+#include <optional>
+#include <climits>
+#include "assert.hpp"
+#include <memory>
+namespace tt::tt_metal {
+
+/*! @brief Ringbuffer cache manager
+ *  This class does recordkeeping for the prefetcher cache, which is implemented as a ringbuffer.
+ *  It keeps track of the entries in the ringbuffer and their offsets. The ringbuffer is divided into blocks of size
+ * cache_block_sizeB. Prefetcher cache justification: The ring buffer prefetcher cache stores data (eg, kernel bins)
+ * read from DRAM in the L1 of the prefetcher. The current implementation of a ring buffer works well for traces where
+ * all the data fits into the cache and gets reuse from locality.
+ */
+class RingbufferCacheManager {
+    friend class RingbufferCacheRandomizedTestsFixture;  // for unit testing purposes
+
+public:
+    RingbufferCacheManager(int cache_block_sizeB, int cache_size_blocks, int manager_entry_initial_size);
+    RingbufferCacheManager() = delete;
+    RingbufferCacheManager(const RingbufferCacheManager&) = delete;
+    RingbufferCacheManager(RingbufferCacheManager&&) = delete;
+    RingbufferCacheManager& operator=(const RingbufferCacheManager&) = delete;
+    RingbufferCacheManager& operator=(RingbufferCacheManager&&) = delete;
+    ~RingbufferCacheManager() = default;
+
+    /*! @brief Reset the cache state */
+    void reset();
+
+    /*! @brief Swap the ringbuffer cache manager.
+     *  We provide this functionality to stash away the cache state for the duration of recording a trace.
+     */
+    friend void swap(RingbufferCacheManager& a, RingbufferCacheManager& b);
+
+    struct CacheOffset {
+        bool is_cached{false};  // true if the program is already cached
+        uint32_t offset{0};     // offset of the program in the ringbuffer
+    };
+    /*! @brief Check if the program is present in the ringbuffer
+     *  Add a new entry to the ringbuffer manager if not present
+     *  @param pgm_id program id
+     *  @param lengthB size of program in bytes
+     *  @return struct {bool, offset}, where bool::false indicates that the program was added
+     */
+    std::optional<CacheOffset> get_cache_offset(uint64_t pgm_id, uint32_t lengthB);
+
+    int get_cache_sizeB() const { return this->cache_size_blocks_ * this->cache_block_sizeB_; }
+
+private:
+    const uint32_t cache_block_sizeB_;
+    const uint32_t cache_size_blocks_;
+
+    /*! @brief cache manager entry */
+    const uint32_t cache_manager_initial_entry_size_;
+    struct RingbufferCacheManagerEntry {
+        uint32_t offset{0};     // offset in ringbuffer
+        uint32_t length{0};     // length of the program in blocks
+        uint32_t valid_idx{0};  // index into the valid_ array
+
+        RingbufferCacheManagerEntry() = default;
+        RingbufferCacheManagerEntry(uint32_t off, uint32_t len, uint32_t val) :
+            offset(off), length(len), valid_idx(val) {}
+    };
+
+    /*! @brief cache manager  */
+    struct InternalManager {
+        std::vector<RingbufferCacheManagerEntry> entry;  // ringbuffer manager entries
+        // the following indexes are for the ringbuffer manager, not the ringbuffer
+        uint32_t oldest_idx{0};
+        uint32_t next_idx{0};
+        // the following is saved for convenience
+        uint32_t next_block_offset{0};  // offset of the next block to allocate in ringbuffer
+
+        void update_oldest_idx() { this->oldest_idx = (this->oldest_idx + 1) & (entry.size() - 1); }
+        void update_next_idx() {
+            auto local_next_idx = this->next_idx + 1;
+            // wraparound next_idx if it is at the end and if cache is full
+            if (local_next_idx >= entry.size() and this->oldest_idx == 0) [[unlikely]] {
+                if (this->next_block_offset != 0) [[likely]] {
+                    // if cache offset of oldest index is 0 and next_block_offset is not 0, then cache is partially
+                    // filled
+                    this->entry.resize(entry.size() * 2);
+                }
+            }
+            this->next_idx = local_next_idx & (entry.size() - 1);
+        }
+        void clear();
+        InternalManager& swap(InternalManager& b);
+    } manager_;
+
+    /*! @brief indexed by program id. Contains index to entry in cache manager if cache hit */
+    std::vector<int32_t> valid_;
+    constexpr static int32_t invalid_cache_entry_ = -1;
+
+    void add_manager_entry(uint64_t pgm_id, uint32_t offset, uint32_t length);
+    void add_manager_entry_no_evict(uint64_t pgm_id, uint32_t offset, uint32_t length);
+    void invalidate_manager_entry();
+    bool invalidate_oldest_until_wraparound();
+    bool invalidate_sufficient_blocks(int required_space, int offset = 0);
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -97,7 +97,7 @@ DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& /*cluster*/, 
         .prefetch_max_cmd_size(32_KB)
         .prefetch_cmddat_q_size(64_KB)
         .prefetch_scratch_db_size(19_KB)
-        .prefetch_ringbuffer_size(90_KB)
+        .prefetch_ringbuffer_size(70_KB)
         .prefetch_d_buffer_size(128_KB)
 
         .dispatch_size(128_KB)

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -63,6 +63,7 @@
 #include "dispatch/worker_config_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_impl.hpp"
 #include "kernels/kernel_impl.hpp"
+#include "tt_metal/impl/dispatch/hardware_command_queue.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -1087,7 +1088,8 @@ public:
         const ProgramTransferInfo& program_transfer_info,
         const std::shared_ptr<Buffer>& kernels_buffer,
         const CommandConstants& constants,
-        DeviceCommandCalculator& calculator) {
+        DeviceCommandCalculator& calculator,
+        bool using_prefetcher_cache) {
         const auto& hal = MetalContext::instance().hal();
         const uint32_t max_length_per_sub_cmd =
             MetalContext::instance().dispatch_mem_map(constants.dispatch_core_type).scratch_db_size() / 2;
@@ -1124,31 +1126,43 @@ public:
                         kg_transfer_info.lengths[kernel_idx],
                         kg_transfer_info.riscvs[kernel_idx]);
                     // Difference between prefetch total relayed pages and dispatch write linear
-                    uint32_t relayed_bytes =
-                        tt::align(kg_transfer_info.lengths[kernel_idx], HostMemDeviceCommand::PROGRAM_PAGE_SIZE);
-                    uint16_t length_adjust = uint16_t(relayed_bytes - kg_transfer_info.lengths[kernel_idx]);
+                    if (not using_prefetcher_cache) {
+                        uint32_t relayed_bytes =
+                            tt::align(kg_transfer_info.lengths[kernel_idx], HostMemDeviceCommand::PROGRAM_PAGE_SIZE);
+                        uint16_t length_adjust = uint16_t(relayed_bytes - kg_transfer_info.lengths[kernel_idx]);
+                        uint32_t base_address, page_offset;
+                        if (kg_transfer_info.page_offsets[kernel_idx] > CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK) {
+                            const uint32_t num_banks =
+                                device->allocator()->get_num_banks(kernels_buffer->buffer_type());
+                            page_offset = kg_transfer_info.page_offsets[kernel_idx] % num_banks;
+                            uint32_t num_full_pages_written_per_bank =
+                                kg_transfer_info.page_offsets[kernel_idx] / num_banks;
+                            base_address = kernels_buffer->address() +
+                                           num_full_pages_written_per_bank * kernels_buffer->page_size();
+                        } else {
+                            base_address = kernels_buffer->address();
+                            page_offset = kg_transfer_info.page_offsets[kernel_idx];
+                        }
 
-                    uint32_t base_address, page_offset;
-                    if (kg_transfer_info.page_offsets[kernel_idx] > CQ_PREFETCH_RELAY_PAGED_START_PAGE_MASK) {
-                        const uint32_t num_banks = device->allocator()->get_num_banks(kernels_buffer->buffer_type());
-                        page_offset = kg_transfer_info.page_offsets[kernel_idx] % num_banks;
-                        uint32_t num_full_pages_written_per_bank =
-                            kg_transfer_info.page_offsets[kernel_idx] / num_banks;
-                        base_address =
-                            kernels_buffer->address() + num_full_pages_written_per_bank * kernels_buffer->page_size();
+                        calculator.add_prefetch_relay_paged();
+                        kernel_bins_unicast_cmds.back().add_prefetch_relay_paged(
+                            true,  // is_dram
+                            page_offset,
+                            base_address,
+                            kernels_buffer->page_size(),
+                            relayed_bytes / kernels_buffer->page_size(),
+                            length_adjust);
                     } else {
-                        base_address = kernels_buffer->address();
-                        page_offset = kg_transfer_info.page_offsets[kernel_idx];
+                        calculator.add_prefetch_relay_ringbuffer(1);
+                        kernel_bins_unicast_cmds.back().add_prefetch_relay_ringbuffer(
+                            1,
+                            std::vector<CQPrefetchRelayRingbufferSubCmd>(
+                                1,
+                                CQPrefetchRelayRingbufferSubCmd(
+                                    {.start = kg_transfer_info.page_offsets[kernel_idx] *
+                                              HostMemDeviceCommand::PROGRAM_PAGE_SIZE,
+                                     .length = kg_transfer_info.lengths[kernel_idx]})));
                     }
-
-                    calculator.add_prefetch_relay_paged();
-                    kernel_bins_unicast_cmds.back().add_prefetch_relay_paged(
-                        true,  // is_dram
-                        page_offset,
-                        base_address,
-                        kernels_buffer->page_size(),
-                        relayed_bytes / kernels_buffer->page_size(),
-                        length_adjust);
                 } else {
                     uint32_t base_address = kernels_buffer->address();
                     uint32_t page_offset = kg_transfer_info.page_offsets[kernel_idx];
@@ -1188,11 +1202,22 @@ public:
                             program.get_id(), DISPATCH_DATA_BINARY, write_length, kg_transfer_info.riscvs[kernel_idx]);
                         kernel_config_buffer_offset += write_length;
 
-                        kernel_bins_cmd.prefetch_subcmds.emplace_back(CQPrefetchRelayPagedPackedSubCmd{
-                            .start_page = (uint16_t)page_offset,
-                            .log_page_size = (uint16_t)HostMemDeviceCommand::LOG2_PROGRAM_PAGE_SIZE,
-                            .base_addr = base_address,
-                            .length = read_length});
+                        if (not using_prefetcher_cache) {
+                            auto& prefetch_subcmds =
+                                kernel_bins_cmd.get_prefetch_subcmds<CQPrefetchRelayPagedPackedSubCmd>();
+                            prefetch_subcmds.emplace_back(CQPrefetchRelayPagedPackedSubCmd{
+                                .start_page = (uint16_t)page_offset,
+                                .log_page_size = (uint16_t)HostMemDeviceCommand::LOG2_PROGRAM_PAGE_SIZE,
+                                .base_addr = base_address,
+                                .length = read_length});
+                        } else {
+                            auto& prefetch_subcmds =
+                                kernel_bins_cmd.get_prefetch_subcmds<CQPrefetchRelayRingbufferSubCmd>();
+                            // start address for kernel bin is aligned with page boundary, consistent with the
+                            // non-cached case
+                            prefetch_subcmds.emplace_back(CQPrefetchRelayRingbufferSubCmd{
+                                .start = page_offset * HostMemDeviceCommand::PROGRAM_PAGE_SIZE, .length = read_length});
+                        }
                         page_offset += read_length / HostMemDeviceCommand::PROGRAM_PAGE_SIZE;
                         aligned_length -= read_length;
                         kernel_bins_cmd.data_aligned_sizeB += read_length;
@@ -1200,14 +1225,24 @@ public:
                 }
             }
         }
-        for (auto& kernel_bins_cmd : kernel_bins_cmds) {
-            calculator.add_dispatch_write_packed_large(kernel_bins_cmd.dispatch_subcmds.size());
-            calculator.add_prefetch_relay_paged_packed(kernel_bins_cmd.prefetch_subcmds.size());
+
+        if (using_prefetcher_cache) {
+            for (auto& kernel_bins_cmd : kernel_bins_cmds) {
+                calculator.add_dispatch_write_packed_large(kernel_bins_cmd.dispatch_subcmds.size());
+                auto& prefetch_subcmds = kernel_bins_cmd.get_prefetch_subcmds<CQPrefetchRelayRingbufferSubCmd>();
+                calculator.add_prefetch_relay_ringbuffer(prefetch_subcmds.size());
+            }
+        } else {
+            for (auto& kernel_bins_cmd : kernel_bins_cmds) {
+                calculator.add_dispatch_write_packed_large(kernel_bins_cmd.dispatch_subcmds.size());
+                auto& prefetch_subcmds = kernel_bins_cmd.get_prefetch_subcmds<CQPrefetchRelayPagedPackedSubCmd>();
+                calculator.add_prefetch_relay_paged_packed(prefetch_subcmds.size());
+            }
         }
     }
 
     // Assemble the program binary commands into the device command sequence.
-    void assemble_commands(HostMemDeviceCommand& device_command_sequence) const {
+    void assemble_commands(HostMemDeviceCommand& device_command_sequence, bool using_prefetcher_cache) const {
         const auto& hal = MetalContext::instance().hal();
         for (const auto& kernel_bins_unicast_cmd : kernel_bins_unicast_cmds) {
             device_command_sequence.add_data(
@@ -1224,19 +1259,34 @@ public:
                 kernel_bins_cmd.dispatch_subcmds,
                 0,
                 DISPATCH_WRITE_OFFSET_TENSIX_BINARY_L1_CONFIG_BASE);
-            device_command_sequence.add_prefetch_relay_paged_packed(
-                kernel_bins_cmd.data_aligned_sizeB,
-                kernel_bins_cmd.prefetch_subcmds,
-                kernel_bins_cmd.prefetch_subcmds.size());
+            if (using_prefetcher_cache) {
+                auto& prefetch_subcmds = kernel_bins_cmd.get_prefetch_subcmds<CQPrefetchRelayRingbufferSubCmd>();
+                device_command_sequence.add_prefetch_relay_ringbuffer(prefetch_subcmds.size(), prefetch_subcmds);
+            } else {
+                auto& prefetch_subcmds = kernel_bins_cmd.get_prefetch_subcmds<CQPrefetchRelayPagedPackedSubCmd>();
+                device_command_sequence.add_prefetch_relay_paged_packed(
+                    kernel_bins_cmd.data_aligned_sizeB, prefetch_subcmds, prefetch_subcmds.size());
+            }
         }
     }
 
 private:
     struct KernelBinsCmds {
-        std::vector<CQPrefetchRelayPagedPackedSubCmd> prefetch_subcmds;
+        std::pair<std::vector<CQPrefetchRelayPagedPackedSubCmd>, std::vector<CQPrefetchRelayRingbufferSubCmd>>
+            prefetch_subcmds;
         std::vector<CQDispatchWritePackedLargeSubCmd> dispatch_subcmds;
         uint32_t data_aligned_sizeB{0};
+
+        template <class T>
+        std::vector<T>& get_prefetch_subcmds() {
+            return std::get<std::vector<T>>(prefetch_subcmds);
+        }
+        template <class T>
+        const std::vector<T>& get_prefetch_subcmds() const {
+            return std::get<std::vector<T>>(prefetch_subcmds);
+        }
     };
+
     std::vector<KernelBinsCmds> kernel_bins_cmds;
     std::vector<HostMemDeviceCommand> kernel_bins_unicast_cmds;
 };
@@ -1639,7 +1689,8 @@ void assemble_device_commands(
     ProgramCommandSequence& program_command_sequence,
     ProgramImpl& program,
     IDevice* device,
-    SubDeviceId sub_device_id) {
+    SubDeviceId sub_device_id,
+    bool use_prefetcher_cache) {
     CommandConstants constants;
     auto dispatch_core_config = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     constants.dispatch_core_type = dispatch_core_config.get_core_type();
@@ -1688,13 +1739,18 @@ void assemble_device_commands(
         program_transfer_info,
         program.get_kernels_buffer(device),
         constants,
-        program_binary_calculator);
+        program_binary_calculator,
+        use_prefetcher_cache);
     program_command_sequence.program_binary_command_sequence =
         HostMemDeviceCommand(program_binary_calculator.write_offset_bytes());
-    program_binary_command_generator.assemble_commands(program_command_sequence.program_binary_command_sequence);
+    program_binary_command_generator.assemble_commands(
+        program_command_sequence.program_binary_command_sequence, use_prefetcher_cache);
     TT_ASSERT(
         program_command_sequence.program_binary_command_sequence.size_bytes() ==
         program_command_sequence.program_binary_command_sequence.write_offset_bytes());
+    if (use_prefetcher_cache) {
+        program_command_sequence.kernel_bins_base_addr = program.get_kernels_buffer(device)->address();
+    }
 
     // Assemble launch message
     LaunchMessageGenerator launch_message_generator;
@@ -1908,6 +1964,42 @@ void update_program_dispatch_commands(
         memcpy(rta_update.dst, rta_update.src, rta_update.size);
     }
 
+    // Update prefetcher cache initialization
+    if (cached_program_command_sequence.prefetcher_cache_used) {
+        // reserve space for cache command
+        uint32_t pcie_alignment =
+            tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+        cached_program_command_sequence.program_binary_setup_prefetcher_cache_command =
+            HostMemDeviceCommand(tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
+
+        auto is_cached = dispatch_md.prefetcher_cache_info.is_cached;
+        auto cache_offset = dispatch_md.prefetcher_cache_info.offset;
+        auto program_sizeB = cached_program_command_sequence.kernel_bins_sizeB;
+        auto max_program_sizeB = dispatch_md.prefetcher_cache_info.mesh_max_program_kernels_sizeB;
+        if (is_cached) {
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command
+                .add_prefetch_set_ringbuffer_offset(cache_offset);
+        } else {
+            TT_FATAL(
+                program_sizeB <= max_program_sizeB,
+                "Kernel binary size exceeds prefetcher cache size ({}, {})",
+                program_sizeB,
+                max_program_sizeB);
+            bool wraparound_flag = cache_offset != 0 ? 0 : CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command
+                .add_prefetch_paged_to_ringbuffer(CQPrefetchPagedToRingbufferCmd{
+                    .flags = uint8_t(wraparound_flag),
+                    .log2_page_size = uint16_t(HostMemDeviceCommand::LOG2_PROGRAM_PAGE_SIZE),
+                    .start_page = 0,
+                    .wp_offset_update = max_program_sizeB,
+                    .base_addr = cached_program_command_sequence.kernel_bins_base_addr,
+                    .length = program_sizeB});
+        }
+        TT_ASSERT(
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command.size_bytes() ==
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command.write_offset_bytes());
+    }
+
     // Update launch messages
     for (auto& [is_multicast, original_launch_msg, launch_msg] : cached_program_command_sequence.launch_messages) {
         for (uint32_t i = 0; i < dispatch_md.kernel_config_addrs.size(); i++) {
@@ -2042,6 +2134,42 @@ void update_traced_program_dispatch_commands(
         std::memcpy(rta_update.dst, trace_node.rta_data[i].data(), rta_update.size);
     }
 
+    // Update prefetcher cache initialization
+    if (dispatch_md.send_binary && cached_program_command_sequence.prefetcher_cache_used) {
+        // reserve space for cache command
+        uint32_t pcie_alignment =
+            tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::HOST);
+        cached_program_command_sequence.program_binary_setup_prefetcher_cache_command =
+            HostMemDeviceCommand(tt::align(sizeof(CQPrefetchCmd), pcie_alignment));
+
+        auto is_cached = dispatch_md.prefetcher_cache_info.is_cached;
+        auto cache_offset = dispatch_md.prefetcher_cache_info.offset;
+        auto program_sizeB = cached_program_command_sequence.kernel_bins_sizeB;
+        auto max_program_sizeB = dispatch_md.prefetcher_cache_info.mesh_max_program_kernels_sizeB;
+        if (is_cached) {
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command
+                .add_prefetch_set_ringbuffer_offset(cache_offset);
+        } else {
+            TT_FATAL(
+                program_sizeB <= max_program_sizeB,
+                "Kernel binary size exceeds prefetcher cache size ({}, {})",
+                program_sizeB,
+                max_program_sizeB);
+            bool wraparound_flag = cache_offset != 0 ? 0 : CQ_PREFETCH_PAGED_TO_RING_BUFFER_FLAG_RESET_TO_START;
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command
+                .add_prefetch_paged_to_ringbuffer(CQPrefetchPagedToRingbufferCmd{
+                    .flags = uint8_t(wraparound_flag),
+                    .log2_page_size = uint16_t(HostMemDeviceCommand::LOG2_PROGRAM_PAGE_SIZE),
+                    .start_page = 0,
+                    .wp_offset_update = max_program_sizeB,
+                    .base_addr = cached_program_command_sequence.kernel_bins_base_addr,
+                    .length = program_sizeB});
+        }
+        TT_ASSERT(
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command.size_bytes() ==
+            cached_program_command_sequence.program_binary_setup_prefetcher_cache_command.write_offset_bytes());
+    }
+
     // Update launch messages
     for (auto& [is_multicast, original_launch_msg, launch_msg] : cached_program_command_sequence.launch_messages) {
         for (uint32_t i = 0; i < dispatch_md.nonbinary_kernel_config_addrs.size(); i++) {
@@ -2165,6 +2293,11 @@ void write_program_command_sequence(
 
     if (send_binary) {
         // Write the program binary
+        if (program_command_sequence.prefetcher_cache_used) {
+            write_data_to_cq(
+                program_command_sequence.program_binary_setup_prefetcher_cache_command.data(),
+                program_command_sequence.program_binary_setup_prefetcher_cache_command.size_bytes());
+        }
         write_data_to_cq(
             program_command_sequence.program_binary_command_sequence.data(),
             program_command_sequence.program_binary_command_sequence.size_bytes());
@@ -2187,9 +2320,9 @@ void write_program_command_sequence(
     }
 }
 
-TraceNode create_trace_node(ProgramImpl& program, IDevice* device) {
+TraceNode create_trace_node(ProgramImpl& program, IDevice* device, bool use_prefetcher_cache) {
     std::vector<SubDeviceId> sub_device_ids{program.determine_sub_device_ids(device)};
-    program.generate_trace_dispatch_commands(device);
+    program.generate_trace_dispatch_commands(device, use_prefetcher_cache);
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
     // By using the traced command sequence, we know the RTA data source-of-truth isn't this command sequence (it's in a

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -45,6 +45,12 @@ struct ProgramDispatchMetadata {
     uint32_t sync_count;
     uint32_t stall_first;
     uint32_t stall_before_program;
+
+    struct {
+        uint32_t mesh_max_program_kernels_sizeB;
+        bool is_cached;
+        uint32_t offset;
+    } prefetcher_cache_info;
 };
 
 uint32_t configure_rta_offsets_for_kernel_groups(
@@ -133,7 +139,7 @@ void update_traced_program_dispatch_commands(
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update = {false, -1});
 
-TraceNode create_trace_node(detail::ProgramImpl& program, IDevice* device);
+TraceNode create_trace_node(detail::ProgramImpl& program, IDevice* device, bool use_prefetcher_cache);
 
 void write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1273,7 +1273,7 @@ void detail::ProgramImpl::allocate_kernel_bin_buf_on_device(IDevice* device) {
     }
 }
 
-void Program::generate_dispatch_commands(IDevice* device) {
+void Program::generate_dispatch_commands(IDevice* device, bool use_prefetcher_cache) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
     uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
@@ -1297,14 +1297,25 @@ void Program::generate_dispatch_commands(IDevice* device) {
         ProgramCommandSequence program_command_sequence;
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id, device);
-        program_dispatch::assemble_device_commands(program_command_sequence, impl(), device, sub_device_id);
+        program_dispatch::assemble_device_commands(
+            program_command_sequence, impl(), device, sub_device_id, use_prefetcher_cache);
+
+        program_command_sequence.kernel_bins_sizeB = this->impl().kernel_bins_sizeB;
+        program_command_sequence.prefetcher_cache_used = use_prefetcher_cache;
+
         // TODO: We currently do not have a mechanism of removing entries in the cache when a manager is removed
         // This means programs will contain stale entries in the cache until the program is deleted
         cached_program_command_sequences.insert({command_hash, std::move(program_command_sequence)});
+    } else {
+        TT_ASSERT(
+            cached_program_command_sequences.at(command_hash).prefetcher_cache_used == use_prefetcher_cache,
+            "Prefetcher cache used mismatch for program {} on device {}",
+            this->get_id(),
+            device->id());
     }
 }
 
-void ProgramImpl::generate_trace_dispatch_commands(IDevice* device) {
+void ProgramImpl::generate_trace_dispatch_commands(IDevice* device, bool use_prefetcher_cache) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
     uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key;
@@ -1328,10 +1339,19 @@ void ProgramImpl::generate_trace_dispatch_commands(IDevice* device) {
         ProgramCommandSequence program_command_sequence;
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id, device);
-        program_dispatch::assemble_device_commands(program_command_sequence, *this, device, sub_device_id);
+        program_dispatch::assemble_device_commands(
+            program_command_sequence, *this, device, sub_device_id, use_prefetcher_cache);
+        program_command_sequence.prefetcher_cache_used = use_prefetcher_cache;
+        program_command_sequence.kernel_bins_sizeB = this->kernel_bins_sizeB;
         // TODO: We currently do not have a mechanism of removing entries in the cache when a manager is removed
         // This means programs will contain stale entries in the cache until the program is deleted
         trace_cached_program_command_sequences.insert({command_hash, std::move(program_command_sequence)});
+    } else {
+        TT_ASSERT(
+            trace_cached_program_command_sequences.at(command_hash).prefetcher_cache_used == use_prefetcher_cache,
+            "Prefetcher cache used mismatch for program {} on device {}",
+            this->get_id(),
+            device->id());
     }
 }
 
@@ -1711,14 +1731,15 @@ void detail::ProgramImpl::finalize_offsets(IDevice* device) {
     std::array<ProgramImpl*, 1> programs_array = {this};
     tt::stl::Span<ProgramImpl*> programs(programs_array);
 
-    ProgramImpl::finalize_program_offsets(device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
+    (void)ProgramImpl::finalize_program_offsets(
+        device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
 
     set_finalized();
 }
 
 // Compute relative offsets (wrt the start of the kernel config ring buffer) and sizes of all
 // program data structures in L1. Will be used when assembling dispatch commands for this program
-void detail::ProgramImpl::finalize_program_offsets(
+uint32_t detail::ProgramImpl::finalize_program_offsets(
     IDevice* device,
     const KernelsGetter& kernels_getter,
     const KernelGroupsGetter& kernel_groups_getter,
@@ -1780,6 +1801,14 @@ void detail::ProgramImpl::finalize_program_offsets(
     for (auto& program : programs) {
         program->set_program_attrs_across_core_types(device);
     }
+
+    // determine max program size across all programs
+    uint32_t max_program_sizeB = 0;
+    for (auto& program : programs) {
+        program->kernel_bins_sizeB = state.kernel_text_size;
+        max_program_sizeB = std::max(max_program_sizeB, state.kernel_text_size);
+    }
+    return max_program_sizeB;
 }
 
 std::unordered_map<uint64_t, ProgramCommandSequence>&

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -38,6 +38,7 @@ struct ProgramCommandSequence {
     HostMemDeviceCommand stall_command_sequences[2];
     std::vector<HostMemDeviceCommand> runtime_args_command_sequences;
     HostMemDeviceCommand program_config_buffer_command_sequence;
+    HostMemDeviceCommand program_binary_setup_prefetcher_cache_command;
     HostMemDeviceCommand program_binary_command_sequence;
     HostMemDeviceCommand launch_msg_command_sequence;
     HostMemDeviceCommand go_msg_command_sequence;
@@ -51,6 +52,10 @@ struct ProgramCommandSequence {
     std::vector<CQDispatchWritePackedCmd*> unicast_launch_msg_write_packed_cmd_ptrs;
     CQDispatchGoSignalMcastCmd* mcast_go_signal_cmd_ptr;
 
+    bool prefetcher_cache_used = false;
+    uint32_t kernel_bins_sizeB = 0;
+    uint32_t kernel_bins_base_addr = 0;
+
     uint32_t get_rt_args_size() const {
         return std::accumulate(
             runtime_args_command_sequences.begin(),
@@ -63,7 +68,10 @@ struct ProgramCommandSequence {
         uint32_t one_shot_fetch_size =
             ((stall_before_program || stall_first) ? stall_command_sequences[current_stall_seq_idx].size_bytes() : 0) +
             preamble_command_sequence.size_bytes() + program_config_buffer_command_sequence.size_bytes() +
-            get_rt_args_size() + (send_binary ? program_binary_command_sequence.size_bytes() : 0) +
+            get_rt_args_size() +
+            (send_binary ? program_binary_command_sequence.size_bytes() +
+                               program_binary_setup_prefetcher_cache_command.size_bytes()
+                         : 0) +
             launch_msg_command_sequence.size_bytes() + go_msg_command_sequence.size_bytes();
         return one_shot_fetch_size;
     }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -54,8 +54,8 @@ void assemble_device_commands(
     ProgramCommandSequence& program_command_sequence,
     detail::ProgramImpl& program,
     IDevice* device,
-    SubDeviceId sub_device_id);
-
+    SubDeviceId sub_device_id,
+    bool use_prefetcher_cache);
 }
 
 using kernel_id_array_t = std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX>;
@@ -186,7 +186,7 @@ public:
     const ProgramConfig& get_program_config(uint32_t programmable_core_type_index) const;
     const std::vector<SubDeviceId>& determine_sub_device_ids(const IDevice* device);
 
-    void generate_trace_dispatch_commands(IDevice* device);
+    void generate_trace_dispatch_commands(IDevice* device, bool use_prefetcher_cache);
     std::unordered_map<uint64_t, ProgramCommandSequence>& get_trace_cached_program_command_sequences() noexcept;
 
     // debug/test
@@ -198,8 +198,10 @@ public:
 
     void finalize_offsets(IDevice* device);
 
-    // Helper function to finalize program offsets with custom getters
-    static void finalize_program_offsets(
+    // Helper function to finalize program offsets with custom getters. Returns the maximum kernel binaries size among
+    // all the programs, to determine whether the mesh workload can fit in the prefetcher cache all of the programs in
+    // it.
+    static uint32_t finalize_program_offsets(
         IDevice* device,
         const KernelsGetter& kernels_getter,
         const KernelGroupsGetter& kernel_groups_getter,
@@ -282,6 +284,8 @@ private:
     // Counts how much space is needed for each core + each launch buffer msg queue.
     std::vector<uint32_t> program_config_sizes_;
 
+    uint32_t kernel_bins_sizeB = 0;
+
     // The rta_updates from one cached command sequence may reference data in another cached command sequence.
     std::unordered_map<uint64_t, ProgramCommandSequence> cached_program_command_sequences_;
     std::unordered_map<uint64_t, ProgramCommandSequence> trace_cached_program_command_sequences_;
@@ -332,7 +336,8 @@ private:
         ProgramCommandSequence& program_command_sequence,
         ProgramImpl& program,
         IDevice* device,
-        SubDeviceId sub_device_id);
+        SubDeviceId sub_device_id,
+        bool use_prefetcher_cache);
 
     friend HWCommandQueue;
     friend EnqueueProgramCommand;

--- a/tt_metal/impl/trace/trace_node.hpp
+++ b/tt_metal/impl/trace/trace_node.hpp
@@ -19,6 +19,12 @@ struct TraceDispatchMetadata {
     uint32_t sync_count = 0;
     uint32_t stall_first = false;
     uint32_t stall_before_program = false;
+
+    struct {
+        uint32_t mesh_max_program_kernels_sizeB;  // TBD: max program size across all programs in a mesh
+        bool is_cached;
+        uint32_t offset;
+    } prefetcher_cache_info;
 };
 
 // This struct contains all the information needed to execute a program on a device.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20718)

### Problem description
The goal is to reduce NOC traffic and dispatch latency by caching kernels in prefetcher L1, i.o. fetching them from DRAM each time

### What's changed
The cache is implemented as a ring buffer as described here: https://docs.google.com/presentation/d/12FPxbl4JbeXCny8I-xg9aKDKp2-pQsbu/edit#slide=id.p4
This PR implements the host manager and integration with hardware CQ, mesh CQ, single program and trace enqueue integration.
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes