### PR TITLE
amortize some credit passing to producers in fabric

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -225,8 +225,13 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
             to_sender_0_pkts_completed_id, to_sender_1_pkts_completed_id, to_sender_2_pkts_completed_id});
 
 // Miscellaneous configuration
-constexpr uint32_t DEFAULT_ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS = 32;
+// 25 good
+// 24 bad -- 1.4 GB/s/dir drop in 2k packet size line mcast wtf
+constexpr size_t DEFAULT_ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS = 32;
 constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 0;
+
+constexpr bool DO_SENDER_WORKER_ACK_OUTSIDE_OF_LOOP = true;  // + 150 MB/s when true for line mcast (2k packet size)
+constexpr bool DO_RECEIVER_ETH_ACK_OUTSIDE_OF_LOOP = false;
 
 namespace tt::tt_fabric {
 static_assert(

--- a/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/1d_fabric_constants.hpp
@@ -203,9 +203,11 @@ constexpr size_t receiver_channel_base_id = NUM_SENDER_CHANNELS;
 
 // TRANSACTION IDS
 // TODO: Pass this value from host
-constexpr uint8_t NUM_TRANSACTION_IDS = enable_ring_support ? 8 : 4;
+constexpr size_t NUM_TRANSACTION_IDS = enable_ring_support ? 8 : 4;
+constexpr size_t RX_CH0_TRID_START = 0;
+constexpr size_t RX_CH1_TRID_START = NUM_TRANSACTION_IDS;
 
-constexpr std::array<uint8_t, MAX_NUM_RECEIVER_CHANNELS> RX_CH_TRID_STARTS =
+constexpr std::array<size_t, MAX_NUM_RECEIVER_CHANNELS> RX_CH_TRID_STARTS =
     initialize_receiver_channel_trid_starts<MAX_NUM_RECEIVER_CHANNELS, NUM_TRANSACTION_IDS>();
 
 constexpr std::array<uint32_t, MAX_NUM_RECEIVER_CHANNELS> to_receiver_packets_sent_streams =
@@ -230,7 +232,11 @@ constexpr std::array<uint32_t, MAX_NUM_SENDER_CHANNELS> to_sender_packets_comple
 constexpr size_t DEFAULT_ITERATIONS_BETWEEN_CTX_SWITCH_AND_TEARDOWN_CHECKS = 32;
 constexpr size_t DEFAULT_HANDSHAKE_CONTEXT_SWITCH_TIMEOUT = 0;
 
-constexpr bool DO_SENDER_WORKER_ACK_OUTSIDE_OF_LOOP = true;  // + 150 MB/s when true for line mcast (2k packet size)
+// Improves compute bound cases
+constexpr bool DO_SENDER_WORKER_ACK_OUTSIDE_OF_LOOP = true;
+
+// Improves compute bound cases but degrades bandwidth bound cases. With additional buffering, this would be a viable
+// option.
 constexpr bool DO_RECEIVER_ETH_ACK_OUTSIDE_OF_LOOP = false;
 
 namespace tt::tt_fabric {

--- a/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/compile_time_arg_tmp.hpp
@@ -23,8 +23,8 @@
  */
 // clang-format on
 template <size_t NUM_RECEIVER_CHANNELS, size_t NUM_TRANSACTION_IDS_PER_CHANNEL>
-constexpr auto initialize_receiver_channel_trid_starts() -> std::array<uint8_t, NUM_RECEIVER_CHANNELS> {
-    std::array<uint8_t, NUM_RECEIVER_CHANNELS> arr{};
+constexpr auto initialize_receiver_channel_trid_starts() -> std::array<size_t, NUM_RECEIVER_CHANNELS> {
+    std::array<size_t, NUM_RECEIVER_CHANNELS> arr{};
     size_t trid_start = 0;
     for (size_t i = 0; i < NUM_RECEIVER_CHANNELS; i++) {
         arr[i] = trid_start;

--- a/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/fabric_edm_packet_transmission.hpp
@@ -89,8 +89,8 @@ FORCE_INLINE void print_pkt_header(volatile tt::tt_fabric::LowLatencyPacketHeade
 
 FORCE_INLINE void flush_write_to_noc_pipeline(uint8_t rx_channel_id) {
     if constexpr (enable_ring_support) {
-        auto start_trid = RX_CH_TRID_STARTS[rx_channel_id];
-        auto end_trid = start_trid + NUM_TRANSACTION_IDS;
+        int start_trid = RX_CH_TRID_STARTS[rx_channel_id];
+        int end_trid = start_trid + NUM_TRANSACTION_IDS;
         for (int i = start_trid; i < end_trid; i++) {
             if constexpr (tt::tt_fabric::local_chip_noc_equals_downstream_noc) {
                 while (


### PR DESCRIPTION
### Ticket
[#20642](https://github.com/tenstorrent/tt-metal/issues/20642)

### What's changed
As far as buffering lets us latency hide over NoC or the Ethernet line, we delay/amortize credit passing to producers to perform it less frequently. By lowering the frequency of credit passing (but increasing the magnitude), we can improve performance for CPU bound workloads. 

This PR adds tested code paths for amortizing sender and receiver channel credits. However, the feature is only enabled for sender channel 0. For other sender channels, and the receiver channels, we currently do not possess sufficient buffering to mask latency after amortizing credits sent upstream.

When enabled only for sender channel 0, this optimization improves performance by roughly 3% for compute bound workloads. It is expectedly performance neutral for workloads that are more bandwidth bound. 

When enabled for the receiver channel (line fabric) for compute bound workloads, we see a substantial performance uplift of 7%. For ring fabrics, the uplift should be even more substantial. However, for bandwidth bound cases, we lose noticeable performance (> 10%). This is likely because we are bandwidth bound and we may be artificially pushing the workload to become latency bound because we don't have  much excess latency hiding buffering. For this reason, the feature is disabled by default for the time being. However, it's an obvious optimization to enable as more buffering is made available.

Testing of ring fabric on a 6U system with the feature enable for receiver channels is still to be completed.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes