### PR TITLE
Remove superfluous 'static'

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -171,7 +171,6 @@ Checks: >
   -readability-redundant-string-cstr,
   -readability-redundant-string-init,
   -readability-static-accessed-through-instance,
-  -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -47,7 +47,7 @@ SETW:
 HEX/OCT/DEC:
 1e240361100123456)";
 
-static void RunTest(
+void RunTest(
     DPrintFixture* fixture,
     IDevice* device,
     bool active,

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_device.cpp
@@ -65,7 +65,7 @@ SLICE:
 0.365234375 0.373046875 0.380859375 0.388671875 1.4609375 1.4921875 1.5234375 1.5546875
 <TileSlice data truncated due to exceeding max count (32)>)";
 
-static void RunTest(DPrintFixture* fixture, IDevice* device) {
+void RunTest(DPrintFixture* fixture, IDevice* device) {
     // Set up program and command queue
     constexpr CoreCoord core = {0, 0}; // Print on first core only
     Program program = Program();

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_mute_print_server.cpp
@@ -37,7 +37,7 @@ const std::string golden_output =
 R"(Printing int from arg: 0
 Printing int from arg: 2)";
 
-static void RunTest(DPrintFixture* fixture, IDevice* device) {
+void RunTest(DPrintFixture* fixture, IDevice* device) {
     // Set up program
     Program program = Program();
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_all_harts.cpp
@@ -158,7 +158,7 @@ SLICE:
 <TileSlice data truncated due to exceeding max count (32)>
 Tried printing CBIndex::c_1: Unsupported data format (Bfp2_b))";
 
-static void RunTest(DPrintFixture* fixture, IDevice* device) {
+void RunTest(DPrintFixture* fixture, IDevice* device) {
     // Set up program and command queue
     constexpr CoreCoord core = {0, 0}; // Print on first core only
     Program program = Program();

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
@@ -70,7 +70,7 @@ little mouse learned that bravery and kindness can change the world.",
     "contains several newline characters",
     "and should be displayed over multiple lines."};
 
-static void RunTest(DPrintFixture* fixture, IDevice* device) {
+void RunTest(DPrintFixture* fixture, IDevice* device) {
     std::vector<CoreCoord> cores;
     cores.emplace_back(0, 0);
     cores.emplace_back(0, 1);

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
@@ -40,7 +40,7 @@ const std::string golden_output =
     R"(DPRINT server timed out on Device *, worker core (x=*,y=*), riscv 4, waiting on a RAISE signal: 1
 )";
 
-static void RunTest(DPrintFixture* fixture, IDevice* device) {
+void RunTest(DPrintFixture* fixture, IDevice* device) {
     // Set up program
     Program program = Program();
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -34,7 +34,7 @@ using namespace tt::tt_metal;
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-static void UpdateGoldenOutput(std::vector<string>& golden_output, const IDevice* device, const string& risc) {
+void UpdateGoldenOutput(std::vector<string>& golden_output, const IDevice* device, const string& risc) {
     // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
     // by machine
     const string& device_core_risc = std::to_string(device->id()) + ":(x=*,y=*):" + risc + ": ";
@@ -48,7 +48,7 @@ static void UpdateGoldenOutput(std::vector<string>& golden_output, const IDevice
     }
 }
 
-static void RunTest(DPrintFixture* fixture, IDevice* device, const bool add_active_eth_kernel = false) {
+void RunTest(DPrintFixture* fixture, IDevice* device, const bool add_active_eth_kernel = false) {
     std::vector<string> golden_output;
 
     CoreRange cores({0, 0}, {0, 1});

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_raise_wait.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_raise_wait.cpp
@@ -235,7 +235,7 @@ TestConstCharStrNC{4,4}
 TestStrBR{4,4}
 +++++++++++++++)";
 
-static void RunTest(DPrintFixture* fixture, IDevice* device) {
+void RunTest(DPrintFixture* fixture, IDevice* device) {
     // Set up program and command queue
     Program program = Program();
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -36,7 +36,7 @@ using namespace tt::tt_metal;
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-static void RunTest(WatcherFixture* fixture, IDevice* device) {
+void RunTest(WatcherFixture* fixture, IDevice* device) {
     // Set up program
     Program program = Program();
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -40,7 +40,7 @@ using namespace tt::tt_metal;
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-static void RunTest(WatcherFixture* fixture, IDevice* device) {
+void RunTest(WatcherFixture* fixture, IDevice* device) {
     // Set up program
     Program program = Program();
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -61,16 +61,16 @@ using namespace tt;
 
 namespace {
 
-static string logfile_path = "generated/dprint/";
+string logfile_path = "generated/dprint/";
 
-static inline float bfloat16_to_float(uint16_t bfloat_val) {
+inline float bfloat16_to_float(uint16_t bfloat_val) {
     uint32_t uint32_data = ((uint32_t)bfloat_val) << 16;
     float f;
     std::memcpy(&f, &uint32_data, sizeof(f));
     return f;
 }
 
-static string GetRiscName(CoreType core_type, int risc_id, bool abbreviated = false) {
+string GetRiscName(CoreType core_type, int risc_id, bool abbreviated = false) {
     if (core_type == CoreType::ETH) {
         switch (risc_id) {
             case DPRINT_RISCV_INDEX_ER: return abbreviated ? "ER" : "ERISC";
@@ -92,7 +92,7 @@ static string GetRiscName(CoreType core_type, int risc_id, bool abbreviated = fa
     return fmt::format("UNKNOWN_RISC_ID({})", risc_id);
 }
 
-static void AssertSize(uint8_t sz, uint8_t expected_sz) {
+void AssertSize(uint8_t sz, uint8_t expected_sz) {
     TT_ASSERT(
         sz == expected_sz,
         "DPrint token size ({}) did not match expected ({}), potential data corruption in the DPrint buffer.",
@@ -262,17 +262,17 @@ private:
     char most_recent_setw = 0;
 };
 
-static void ResetStream(ostringstream* stream) {
+void ResetStream(ostringstream* stream) {
     stream->str("");
     stream->clear();
 }  // ResetStream
 
-static bool StreamEndsWithNewlineChar(const ostringstream* stream) {
+bool StreamEndsWithNewlineChar(const ostringstream* stream) {
     const string stream_str = stream->str();
     return !stream_str.empty() && stream_str.back() == '\n';
 }  // StreamEndsWithNewlineChar
 
-static void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
+void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
     TileSliceHostDev<0> ts_copy;  // Make a copy since ptr might not be properly aligned
     std::memcpy(&ts_copy, ptr, sizeof(TileSliceHostDev<0>));
     TileSliceHostDev<0>* ts = &ts_copy;
@@ -391,7 +391,7 @@ static void PrintTileSlice(ostringstream* stream, uint8_t* ptr) {
 // Create a float from a given bit pattern, given the number of bits for the exponent and mantissa.
 // Assumes the following order of bits in the input data:
 //   [sign bit][mantissa bits][exponent bits]
-static float make_float(uint8_t exp_bit_count, uint8_t mantissa_bit_count, uint32_t data) {
+float make_float(uint8_t exp_bit_count, uint8_t mantissa_bit_count, uint32_t data) {
     int sign = (data >> (exp_bit_count + mantissa_bit_count)) & 0x1;
     const int exp_mask = (1 << (exp_bit_count)) - 1;
     int exp_bias = (1 << (exp_bit_count - 1)) - 1;
@@ -407,7 +407,7 @@ static float make_float(uint8_t exp_bit_count, uint8_t mantissa_bit_count, uint3
 }
 
 // Prints a given datum in the array, given the data_format
-static void PrintTensixRegisterData(ostringstream* stream, int setwidth, uint32_t datum, uint16_t data_format) {
+void PrintTensixRegisterData(ostringstream* stream, int setwidth, uint32_t datum, uint16_t data_format) {
     switch (data_format) {
         case static_cast<std::uint8_t>(tt::DataFormat::Float16):
         case static_cast<std::uint8_t>(tt::DataFormat::Bfp8):
@@ -444,7 +444,7 @@ static void PrintTensixRegisterData(ostringstream* stream, int setwidth, uint32_
 // Prints a typed uint32 array given the number of elements including the type.
 // If force_element_type is set to a valid type, it is assumed that the type is not included in the
 // data array, and the type is forced to be the given type.
-static void PrintTypedUint32Array(
+void PrintTypedUint32Array(
     ostringstream* stream,
     int setwidth,
     uint32_t raw_element_count,

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -52,7 +52,7 @@ using std::string;
 namespace {  // Helper functions
 
 // Helper function to get string rep of riscv type
-static const char* get_riscv_name(const CoreCoord& core, uint32_t type) {
+const char* get_riscv_name(const CoreCoord& core, uint32_t type) {
     switch (type) {
         case DebugBrisc: return "brisc";
         case DebugNCrisc: return "ncrisc";
@@ -68,7 +68,7 @@ static const char* get_riscv_name(const CoreCoord& core, uint32_t type) {
 }
 
 // Helper function to get stack size by riscv core type
-static uint32_t get_riscv_stack_size(const CoreDescriptor& core, uint32_t type) {
+uint32_t get_riscv_stack_size(const CoreDescriptor& core, uint32_t type) {
     auto stack_size = MetalContext::instance().hal().get_stack_size(type);
     if (stack_size == 0xdeadbeef) {
         TT_THROW("Watcher data corrupted, unexpected riscv type on core {}: {}", core.coord.str(), type);
@@ -77,7 +77,7 @@ static uint32_t get_riscv_stack_size(const CoreDescriptor& core, uint32_t type) 
 }
 
 // Helper function to determine core type from virtual coord. TODO: Remove this once we fix code types.
-static CoreType core_type_from_virtual_core(chip_id_t device_id, const CoreCoord& virtual_coord) {
+CoreType core_type_from_virtual_core(chip_id_t device_id, const CoreCoord& virtual_coord) {
     if (tt::tt_metal::MetalContext::instance().get_cluster().is_worker_core(virtual_coord, device_id)) {
         return CoreType::WORKER;
     } else if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_coord, device_id)) {
@@ -94,7 +94,7 @@ static CoreType core_type_from_virtual_core(chip_id_t device_id, const CoreCoord
 }
 
 // Helper function to convert noc coord -> virtual coord. TODO: Remove this once we fix code types.
-static CoreCoord virtual_noc_coordinate(chip_id_t device_id, uint8_t noc_index, CoreCoord coord) {
+CoreCoord virtual_noc_coordinate(chip_id_t device_id, uint8_t noc_index, CoreCoord coord) {
     auto grid_size = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id).grid_size;
     if (coord.x >= grid_size.x || coord.y >= grid_size.y) {
         // Coordinate already in virtual space: NOC0 and NOC1 are the same
@@ -112,7 +112,7 @@ static CoreCoord virtual_noc_coordinate(chip_id_t device_id, uint8_t noc_index, 
 }
 
 // Helper function to get string rep of noc target.
-static string get_noc_target_str(
+string get_noc_target_str(
     chip_id_t device_id, CoreDescriptor& core, int noc, const debug_sanitize_noc_addr_msg_t* san) {
     auto get_core_and_mem_type = [](chip_id_t device_id, CoreCoord& noc_coord, int noc) -> std::pair<string, string> {
         // Get the virtual coord from the noc coord

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -28,7 +28,7 @@ ttnn::Shape update_original_shape(const ttnn::Shape& padded_shape, const ttnn::S
     return ttnn::Shape(std::move(updated_shape));
 }
 
-static ttnn::Tensor pad_impl(
+ttnn::Tensor pad_impl(
     QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     std::span<const uint32_t> output_padded_shape,
@@ -164,7 +164,7 @@ static ttnn::Tensor pad_impl(
     }
 }
 
-static ttnn::Tensor pad_impl(
+ttnn::Tensor pad_impl(
     QueueId queue_id,
     const ttnn::Tensor& input_tensor,
     ttnn::SmallVector<PadSpecDim> padding,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp
@@ -19,7 +19,7 @@ namespace ttnn::operations::binary {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-static BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
+BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: return BcastOpMath::ADD;
         case BinaryOpType::SUB: return BcastOpMath::SUB;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_program_factory.cpp
@@ -15,7 +15,7 @@ namespace ttnn::operations::binary {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-static BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
+BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: return BcastOpMath::ADD;
         case BinaryOpType::SUB: return BcastOpMath::SUB;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_multi_core_sharded_optimized_program_factory.cpp
@@ -15,7 +15,7 @@ namespace ttnn::operations::binary {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-static BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
+BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: return BcastOpMath::ADD;
         case BinaryOpType::SUB: return BcastOpMath::SUB;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_width_multi_core_program_factory.cpp
@@ -15,7 +15,7 @@ namespace ttnn::operations::binary {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
-static BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
+BcastOpMath binary_op_type_to_bcast_op_math(const BinaryOpType binary_op_type) {
     switch (binary_op_type) {
         case BinaryOpType::ADD: return BcastOpMath::ADD;
         case BinaryOpType::SUB: return BcastOpMath::SUB;

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -82,7 +82,7 @@ struct LegacyShape {
     }
 };
 
-static constexpr uint64_t SENTINEL_VALUE = std::numeric_limits<uint64_t>::max();
+constexpr uint64_t SENTINEL_VALUE = std::numeric_limits<uint64_t>::max();
 
 void safe_fread(void* buffer, size_t size, size_t count, FILE* file) {
     if (fread(buffer, size, count, file) != count) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`static` is redundant inside anonymous namespaces.

### What's changed
Less is more: rm -rf