### PR TITLE
#20743: Update documentation with use_legacy flag

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -241,6 +241,7 @@ void bind_binary_unary_max_operation(
             output_tensor (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
             activations (List[str], optional): list of activation functions to apply to the output tensor{4}Defaults to `None`.
             queue_id (int, optional): command queue id. Defaults to `0`.
+            use_legacy (bool, optional): Set to `False` to support broadcasting when shape of tensors input_tensor_b and input_tensor_a are not same. Defaults to `True`.
 
         Returns:
             ttnn.Tensor: the output tensor.


### PR DESCRIPTION
### Ticket
[Link](https://github.com/tenstorrent/tt-metal/pull/20743#issuecomment-2819595701)

### Problem description
Missing documentation description on use_legacy flag

### What's changed
Added description about the usage of use_legacy flag

<img width="823" alt="Screenshot 2025-04-22 at 7 52 44 AM" src="https://github.com/user-attachments/assets/c9e48bd4-6daa-45b2-aa34-056b32e1f85d" />
<img width="817" alt="Screenshot 2025-04-22 at 7 52 57 AM" src="https://github.com/user-attachments/assets/a3594bdf-9ce0-450c-a283-674857c93198" />

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)