### PR TITLE
Bump Timeout for TG Nightly CCL tests

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "TG CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 70, owner_id: ULMEPM2MA}, # Sean Nijjar
+          { name: "TG CCL tests", arch: wormhole_b0, cmd: "pytest tests/nightly/tg/ccl", timeout: 120, owner_id: ULMEPM2MA}, # Sean Nijjar
           {
             name: "Llama TG Accuracy Test",
             arch: wormhole_b0,


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
TG Nightly CCL tests timing out on main after device init based 1D Fabric was integrated with CCLs, since this takes longer to initialize.

### What's changed
Bump timeout for nightly tests to 2 hours.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes