### PR TITLE
Resnet imagenet change device to mesh_device

### DIFF
--- a/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
@@ -26,7 +26,7 @@ from models.utility_functions import (
 )
 @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
-    device,
+    mesh_device,
     use_program_cache,
     batch_size_per_device,
     iterations,
@@ -36,15 +36,15 @@ def test_run_resnet50_trace_2cqs_inference(
     enable_async_mode,
     model_location_generator,
 ):
-    batch_size = batch_size_per_device * device.get_num_devices()
-    iterations = iterations // device.get_num_devices()
+    batch_size = batch_size_per_device * mesh_device.get_num_devices()
+    iterations = iterations // mesh_device.get_num_devices()
     profiler.clear()
     with torch.no_grad():
         resnet50_trace_2cq = ResNet50Trace2CQ()
 
         profiler.start(f"compile")
         resnet50_trace_2cq.initialize_resnet50_trace_2cqs_inference(
-            device,
+            mesh_device,
             batch_size_per_device,
             act_dtype,
             weight_dtype,
@@ -80,7 +80,7 @@ def test_run_resnet50_trace_2cqs_inference(
                 mesh_mapper=resnet50_trace_2cq.test_infra.inputs_mesh_mapper,
             )
             output = resnet50_trace_2cq.execute_resnet50_trace_2cqs_inference(tt_inputs_host)
-            output = ttnn.to_torch(output, mesh_composer=ttnn.ConcatMeshToTensor(device, dim=0))
+            output = ttnn.to_torch(output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
             prediction = output[:, 0, 0, :].argmax(dim=-1)
             profiler.end(f"run")
             total_inference_time += profiler.get(f"run")


### PR DESCRIPTION
### Problem description
This file cannot be run as a standalone unit test because it initializes `device` rather than `mesh_device`. As a result, the call to `device.get_num_devices()` is invalid in this context. This usage only works correctly when the file is imported and executed in a context where a valid `mesh_device` is passed in externally.

### What's changed
Simple change `device` to `mesh_device`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14578258767) CI passes
- [x] [Model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/14578327219) CI passes
- [x] [Single card model demos](https://github.com/tenstorrent/tt-metal/actions/runs/14578333495) CI fails but also on [main](https://github.com/tenstorrent/tt-metal/actions/runs/14573096099)
- [x] [Single card device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/14578322317) CI passes