### PR TITLE
Stability script for Resnet50

### DIFF
--- a/.github/workflows/single-card-demo-tests-impl.yaml
+++ b/.github/workflows/single-card-demo-tests-impl.yaml
@@ -58,6 +58,7 @@ jobs:
           { name: "falcon7b", runner-label: "N300", performance: true, cmd: run_falcon7b_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
           { name: "whisper", runner-label: "N300", performance: true, cmd: run_whisper_perf, owner_id: U05RWH3QUPM}, # Salar Hosseini
           { name: "mamba", runner-label: "N300", performance: true, cmd: run_mamba_perf, owner_id: U06ECNVR0EN}, # Evan Smal
+          { name: "resnet", runner-label: "N150", performance: true, cmd: run_resnet_stability, owner_id: U0837MYG788}, # Marko Radosavljevic
           { name: "segformer", runner-label: "N300", performance: false, cmd: run_segformer_func, owner_id: U045U3DEKM4}, # Mohamed Bahnas (vguduruTT)
         ]
     name: ${{ matrix.test-group.name }}-${{ matrix.test-group.runner-label }}-${{ (matrix.test-group.performance && 'perf') || 'func' }}

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_stability.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_stability.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+from models.utility_functions import (
+    run_for_wormhole_b0,
+)
+import time
+from loguru import logger
+from models.demos.wormhole.resnet50.demo.demo import test_demo_trace_with_imagenet
+
+test_demo_trace_with_imagenet.__test__ = False
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 1605632, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size, iterations, act_dtype, weight_dtype",
+    ((16, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize("mesh_device", [1], indirect=True)
+@pytest.mark.parametrize("test_duration_seconds", [24 * 60 * 60, 10], ids=["long", "short"])
+def test_resnet_stability(
+    mesh_device,
+    use_program_cache,
+    batch_size,
+    iterations,
+    imagenet_label_dict,
+    act_dtype,
+    weight_dtype,
+    model_location_generator,
+    test_duration_seconds,
+    enable_async_mode=True,
+):
+    logger.info(f"Running ResNet50 stability test for {test_duration_seconds} seconds")
+
+    start = time.time()
+    iter = 0
+
+    while True:
+        iter += 1
+
+        test_demo_trace_with_imagenet(
+            mesh_device,
+            use_program_cache,
+            batch_size,
+            iterations,
+            imagenet_label_dict,
+            act_dtype,
+            weight_dtype,
+            model_location_generator,
+            enable_async_mode=True,
+        )
+
+        if time.time() - start > test_duration_seconds:
+            break
+
+    logger.info(f"ResNet50 stability test completed after {iter} iterations and {time.time() - start} seconds")

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -84,6 +84,12 @@ run_bert_func() {
 
 }
 
+run_resnet_stability() {
+
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/wormhole/resnet50/tests/test_resnet50_stability.py::test_resnet_stability[wormhole_b0-short-1-16-100-act_dtype0-weight_dtype0-device_params0]
+
+}
+
 run_resnet_func() {
 
   WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/wormhole/resnet50/demo/demo.py

--- a/tests/scripts/single_card/run_single_card_demo_tests.sh
+++ b/tests/scripts/single_card/run_single_card_demo_tests.sh
@@ -86,7 +86,7 @@ run_bert_func() {
 
 run_resnet_stability() {
 
-  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/wormhole/resnet50/tests/test_resnet50_stability.py::test_resnet_stability[wormhole_b0-short-1-16-100-act_dtype0-weight_dtype0-device_params0]
+  WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto --disable-warnings models/demos/wormhole/resnet50/tests/test_resnet50_stability.py -k "short"
 
 }
 


### PR DESCRIPTION
### Problem description
To ensure that ResNet50 is customer complete, we need a stability script that runs inference over an extended period. While the full 24-hour version will be executed in a different repository's CI, this PR includes a minimal version to verify that the setup and inference logic are functioning correctly.

### What's changed
Looped inference on the imagenet-1k dataset.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14590128125) CI passes
- [x] [Single card model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/14591884844) CI passes
- [x] [Single card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/14591903988) CI passes