### PR TITLE
Enable aarch64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "loguru>=0.6.0",
   "networkx>=3.1",
   "graphviz>=0.20.3",
-  "torch==2.2.1+cpu",
+  "torch==2.2.1+cpu ; platform_machine == 'x86_64'",
+  "torch==2.2.1 ; platform_machine == 'aarch64'",
 ]
 requires-python = ">=3.10"
 description = "General compute framework for Tenstorrent devices"

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -42,9 +42,11 @@ pytest-xdist==3.6.1
 pytest-benchmark==4.0.0
 jsbeautifier==1.14.7
 datasets==2.9.0
-torch==2.2.1.0+cpu
+torch==2.2.1.0+cpu ; platform_machine == 'x86_64'
+torch==2.2.1.0 ; platform_machine == 'aarch64'
 networkx==3.1
-torchvision==0.17.1+cpu
+torchvision==0.17.1+cpu ; platform_machine == 'x86_64'
+torchvision==0.17.1 ; platform_machine == 'aarch64'
 torchmetrics==1.3.1
 torch-fidelity==0.3.0
 transformers==4.38.0


### PR DESCRIPTION
### Ticket
Link to Github Issue [#15570](https://github.com/tenstorrent/tt-metal/issues/15570)


### Problem description
Initial enablement of a Wormhole n300s on a Ampere Altra server (AADP-64)

### What's changed
Minor changes:
* CMakeLists.txt - verify platform, unchanged for x86/amd64 but added aarch64 - manual way for now
* venv - use platform_machine to request the correct package depending the arch

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes