### PR TITLE
Add necessary assert to transpose op

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "transpose_op.hpp"
+#include "tt-metalium/assert.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 
 #include <tt-metalium/constants.hpp>
@@ -177,6 +178,7 @@ std::vector<ttnn::TensorSpec> Transpose::compute_output_specs(const std::vector<
 
     auto output_mem_config = this->output_mem_config;
     if (this->output_mem_config.is_sharded()) {
+        TT_FATAL(input_tensor.is_sharded(), "Sharded output tensor must have a sharded input tensor");
         if (this->dim == TransposeOpDim::WH) {
             const auto& input_padded_shape = input_tensor.get_padded_shape();
             ShardSpec shard_spec = input_tensor.shard_spec().value();


### PR DESCRIPTION
### Ticket
Closes [19856](https://github.com/tenstorrent/tt-metal/issues/19856)

### Problem description
Bad optional access in ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp. This happens when input is interleaved in tile layout and output is sharded.

### What's changed
Added necessary assert before optional access.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes