### PR TITLE
Device perf test updates

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -195,15 +195,6 @@ perf_targets = {
         "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.3,
     },
-    # "NLPConcatHeadsDecodeDeviceOperation_0": {
-    #     "op_name": "ConcatHeads",
-    #     "kernel_duration": 7325.777777777777,
-    #     "op_to_op": 697.0,
-    #     "non-overlapped-dispatch-time": 4003.5,
-    #     "kernel_duration_relative_margin": 0.05,
-    #     "op_to_op_duration_relative_margin": 0.2,
-    #     "dispatch_duration_relative_margin": 0.1,
-    # },
     "BinaryDeviceOperation_0": {
         "op_name": "Binary_Residual_0",
         "kernel_duration": 2671.4444444444443,
@@ -830,7 +821,7 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
             if avg_dispatch_duration > upper_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id} op_to_op: {avg_dispatch_duration} ns is larger than target "
+                    f"{op_code_with_id} dispatch: {avg_dispatch_duration} ns is larger than target "
                     f"({expected_time}) ns, difference: "
                     f"{abs(avg_dispatch_duration - upper_limit)} ns, margin: "
                     f"{perf_targets[op_code_with_id]['dispatch_duration_relative_margin']}, "
@@ -840,7 +831,7 @@ def test_llama_TG_perf_device_non_overlapped_dispatch(
             elif avg_dispatch_duration < lower_limit:
                 passing = False
                 logger.info(
-                    f"{op_code_with_id} op_to_op: {avg_dispatch_duration} ns is smaller than target "
+                    f"{op_code_with_id} dispatch: {avg_dispatch_duration} ns is smaller than target "
                     f"({expected_time}) ns, difference: "
                     f"{abs(lower_limit - avg_dispatch_duration)} ns, margin: "
                     f"{perf_targets[op_code_with_id]['dispatch_duration_relative_margin']}, "

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -80,7 +80,7 @@ perf_targets = {
     },
     "Matmul_0": {
         "op_name": "QKV_MM",
-        "kernel_duration": 11928.0,
+        "kernel_duration": 10623,
         "op_to_op": 716.4444444444445,
         "non-overlapped-dispatch-time": 6102.0,
         "kernel_duration_relative_margin": 0.05,
@@ -89,7 +89,7 @@ perf_targets = {
     },
     "Matmul_1": {
         "op_name": "DO_MM",
-        "kernel_duration": 9686.888888888889,
+        "kernel_duration": 8902,
         "op_to_op": 723.0,
         "non-overlapped-dispatch-time": 6412.2,
         "kernel_duration_relative_margin": 0.05,
@@ -98,7 +98,7 @@ perf_targets = {
     },
     "Matmul_2": {
         "op_name": "FF1_MM",
-        "kernel_duration": 11791.888888888889,
+        "kernel_duration": 10829,
         "op_to_op": 711.8888888888889,
         "non-overlapped-dispatch-time": 6109.0,
         "kernel_duration_relative_margin": 0.05,
@@ -107,7 +107,7 @@ perf_targets = {
     },
     "Matmul_3": {
         "op_name": "FF3_MM",
-        "kernel_duration": 11586.555555555555,
+        "kernel_duration": 10848,
         "op_to_op": 688.7777777777778,
         "non-overlapped-dispatch-time": 6144.8,
         "kernel_duration_relative_margin": 0.01,
@@ -179,16 +179,16 @@ perf_targets = {
     },
     "PagedUpdateCacheDeviceOperation_0": {
         "op_name": "PagedUpdateCache",
-        "kernel_duration": 6939.111111111112,
+        "kernel_duration": 5963,
         "op_to_op": 860.2222222222222,
         "non-overlapped-dispatch-time": 5890.0,
-        "kernel_duration_relative_margin": 0.1,
+        "kernel_duration_relative_margin": 0.15,
         "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "ScaledDotProductAttentionDecode_0": {
         "op_name": "SDPA",
-        "kernel_duration": 15960.777777777777,
+        "kernel_duration": 13338,
         "op_to_op": 652.6666666666666,
         "non-overlapped-dispatch-time": 9741.5,
         "kernel_duration_relative_margin": 0.07,
@@ -197,7 +197,7 @@ perf_targets = {
     },
     "BinaryDeviceOperation_0": {
         "op_name": "Binary_Residual_0",
-        "kernel_duration": 2671.4444444444443,
+        "kernel_duration": 1759,
         "op_to_op": 725.6666666666666,
         "non-overlapped-dispatch-time": 6316.8,
         "kernel_duration_relative_margin": 0.1,
@@ -206,7 +206,7 @@ perf_targets = {
     },
     "BinaryDeviceOperation_1": {
         "op_name": "Binary_Mult_Silu",
-        "kernel_duration": 4554.444444444444,
+        "kernel_duration": 2929,
         "op_to_op": 661.0,
         "non-overlapped-dispatch-time": 6111.2,
         "kernel_duration_relative_margin": 0.1,
@@ -215,7 +215,7 @@ perf_targets = {
     },
     "BinaryDeviceOperation_2": {
         "op_name": "Binary_Residual_1",
-        "kernel_duration": 2697.1111111111113,
+        "kernel_duration": 2298,
         "op_to_op": 731.4444444444445,
         "non-overlapped-dispatch-time": 6751.9,
         "kernel_duration_relative_margin": 0.1,

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -30,7 +30,7 @@ perf_targets = {
         "op_to_op": 759.6666666666666,
         "non-overlapped-dispatch-time": 7260,
         "kernel_duration_relative_margin": 0.05,
-        "op_to_op_duration_relative_margin": 0.15,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "RMSAllGather_1": {
@@ -39,7 +39,7 @@ perf_targets = {
         "op_to_op": 634.3333333333334,
         "non-overlapped-dispatch-time": 6301.3,
         "kernel_duration_relative_margin": 0.05,
-        "op_to_op_duration_relative_margin": 0.15,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "RMSAllGather_2": {
@@ -48,7 +48,7 @@ perf_targets = {
         "op_to_op": 748.3333333333334,
         "non-overlapped-dispatch-time": 7326,
         "kernel_duration_relative_margin": 0.05,
-        "op_to_op_duration_relative_margin": 0.15,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "RMSAllGather_3": {
@@ -57,7 +57,7 @@ perf_targets = {
         "op_to_op": 641.0,
         "non-overlapped-dispatch-time": 6431.2,
         "kernel_duration_relative_margin": 0.05,
-        "op_to_op_duration_relative_margin": 0.15,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "AllGatherConcat_0": {
@@ -84,7 +84,7 @@ perf_targets = {
         "op_to_op": 716.4444444444445,
         "non-overlapped-dispatch-time": 6102.0,
         "kernel_duration_relative_margin": 0.05,
-        "op_to_op_duration_relative_margin": 0.1,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_1": {
@@ -92,8 +92,8 @@ perf_targets = {
         "kernel_duration": 9686.888888888889,
         "op_to_op": 723.0,
         "non-overlapped-dispatch-time": 6412.2,
-        "kernel_duration_relative_margin": 0.03,
-        "op_to_op_duration_relative_margin": 0.1,
+        "kernel_duration_relative_margin": 0.05,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_2": {
@@ -101,8 +101,8 @@ perf_targets = {
         "kernel_duration": 11791.888888888889,
         "op_to_op": 711.8888888888889,
         "non-overlapped-dispatch-time": 6109.0,
-        "kernel_duration_relative_margin": 0.01,
-        "op_to_op_duration_relative_margin": 0.1,
+        "kernel_duration_relative_margin": 0.05,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "Matmul_3": {
@@ -111,7 +111,7 @@ perf_targets = {
         "op_to_op": 688.7777777777778,
         "non-overlapped-dispatch-time": 6144.8,
         "kernel_duration_relative_margin": 0.01,
-        "op_to_op_duration_relative_margin": 0.1,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.15,
     },
     "Matmul_4": {
@@ -119,8 +119,8 @@ perf_targets = {
         "kernel_duration": 15891.0,
         "op_to_op": 658.7777777777778,
         "non-overlapped-dispatch-time": 6770.3,
-        "kernel_duration_relative_margin": 0.01,
-        "op_to_op_duration_relative_margin": 0.1,
+        "kernel_duration_relative_margin": 0.05,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.1,
     },
     "AllReduceCreateQkvHeads_0": {
@@ -174,17 +174,17 @@ perf_targets = {
         "op_to_op": 606.1111111111111,
         "non-overlapped-dispatch-time": 2844.3,
         "kernel_duration_relative_margin": 0.1,
-        "op_to_op_duration_relative_margin": 0.15,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.15,
     },
     "PagedUpdateCacheDeviceOperation_0": {
         "op_name": "PagedUpdateCache",
         "kernel_duration": 6939.111111111112,
         "op_to_op": 860.2222222222222,
-        "non-overlapped-dispatch-time": 5006.4,
-        "kernel_duration_relative_margin": 1,
-        "op_to_op_duration_relative_margin": 0.15,
-        "dispatch_duration_relative_margin": 0.15,
+        "non-overlapped-dispatch-time": 5890.0,
+        "kernel_duration_relative_margin": 0.1,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.2,
     },
     "ScaledDotProductAttentionDecode_0": {
         "op_name": "SDPA",
@@ -192,16 +192,25 @@ perf_targets = {
         "op_to_op": 652.6666666666666,
         "non-overlapped-dispatch-time": 9741.5,
         "kernel_duration_relative_margin": 0.07,
-        "op_to_op_duration_relative_margin": 0.1,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.3,
     },
+    # "NLPConcatHeadsDecodeDeviceOperation_0": {
+    #     "op_name": "ConcatHeads",
+    #     "kernel_duration": 7325.777777777777,
+    #     "op_to_op": 697.0,
+    #     "non-overlapped-dispatch-time": 4003.5,
+    #     "kernel_duration_relative_margin": 0.05,
+    #     "op_to_op_duration_relative_margin": 0.2,
+    #     "dispatch_duration_relative_margin": 0.1,
+    # },
     "BinaryDeviceOperation_0": {
         "op_name": "Binary_Residual_0",
         "kernel_duration": 2671.4444444444443,
         "op_to_op": 725.6666666666666,
         "non-overlapped-dispatch-time": 6316.8,
         "kernel_duration_relative_margin": 0.1,
-        "op_to_op_duration_relative_margin": 0.1,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
     "BinaryDeviceOperation_1": {
@@ -219,7 +228,7 @@ perf_targets = {
         "op_to_op": 731.4444444444445,
         "non-overlapped-dispatch-time": 6751.9,
         "kernel_duration_relative_margin": 0.1,
-        "op_to_op_duration_relative_margin": 0.1,
+        "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
     },
 }
@@ -501,52 +510,97 @@ def test_llama_TG_perf_device(
     df = df[df["OP TYPE"].isin(["tt_dnn_device"])]
     df = merge_device_rows(df)
     # Excluding compile run and capture trace entries
-    df_model = df[int(len(df) / 3 * 2) :]
+    df_model_compilation = df[: int(len(df) / 3)]
+    df_model_trace = df[int(len(df) / 3 * 2) :]
 
     # Excluding model embeddings and lmhead+sampling ops
-    df_layers = df_model[DECODE_OP_START_INDEX:DECODE_OP_END_INDEX]
+    df_layers_compilation = df_model_compilation[DECODE_OP_START_INDEX:DECODE_OP_END_INDEX]
+    df_layers_trace = df_model_trace[DECODE_OP_START_INDEX:DECODE_OP_END_INDEX]
     # Use layers 2-9 for verifying against targets for more stability
-    df_first_layer = df_layers[: int(len(df_layers) / num_layers)]
-    df_mid_layers = df_layers[int(len(df_layers) / num_layers) :]
-    mid_layers_raw_dict = df_mid_layers[["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]].to_dict(
-        orient="records"
-    )
-    first_layer_raw_dict = df_first_layer[["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]].to_dict(
-        orient="records"
-    )
+    df_first_layer_compilation = df_layers_compilation[: int(len(df_layers_compilation) / num_layers)]
+    df_first_layer_trace = df_layers_trace[: int(len(df_layers_trace) / num_layers)]
+
+    df_mid_layers_compilation = df_layers_compilation[int(len(df_layers_compilation) / num_layers) :]
+    df_mid_layers_trace = df_layers_trace[int(len(df_layers_trace) / num_layers) :]
+
+    mid_layers_raw_dict_compilation = df_mid_layers_compilation[
+        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+    ].to_dict(orient="records")
+    mid_layers_raw_dict_trace = df_mid_layers_trace[
+        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+    ].to_dict(orient="records")
+    first_layer_raw_dict_compilation = df_first_layer_compilation[
+        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+    ].to_dict(orient="records")
+    first_layer_raw_dict_trace = df_first_layer_trace[
+        ["OP CODE", "DEVICE KERNEL DURATION [ns]", "OP TO OP LATENCY [ns]"]
+    ].to_dict(orient="records")
 
     # Build dicts of op_code to list of durations
-    kernel_duration_dict = build_duration_dict(mid_layers_raw_dict, "DEVICE KERNEL DURATION [ns]")
-    dispatch_duration_dict = build_duration_dict(mid_layers_raw_dict, "OP TO OP LATENCY [ns]")
+    kernel_duration_dict_compilation = build_duration_dict(
+        mid_layers_raw_dict_compilation, "DEVICE KERNEL DURATION [ns]"
+    )
+    kernel_duration_dict_trace = build_duration_dict(mid_layers_raw_dict_trace, "DEVICE KERNEL DURATION [ns]")
+    dispatch_duration_dict = build_duration_dict(mid_layers_raw_dict_trace, "OP TO OP LATENCY [ns]")
 
     # Build dicts of op_code_with_id to list of durations - one list per op instance
-    kernel_duration_per_instance_dict = build_duration_per_instance_dict(kernel_duration_dict, num_layers - 1)
+    kernel_duration_per_instance_dict_compilation = build_duration_per_instance_dict(
+        kernel_duration_dict_compilation, num_layers - 1
+    )
+    kernel_duration_per_instance_dict_trace = build_duration_per_instance_dict(
+        kernel_duration_dict_trace, num_layers - 1
+    )
     dispatch_duration_per_instance_dict = build_duration_per_instance_dict(dispatch_duration_dict, num_layers - 1)
 
     # Average over all iterations of each op instance
-    kernel_duration_per_instance_averaged_dict = average_per_instance_dict(kernel_duration_per_instance_dict)
+    kernel_duration_per_instance_averaged_dict_compilation = average_per_instance_dict(
+        kernel_duration_per_instance_dict_compilation
+    )
+    kernel_duration_per_instance_averaged_dict_trace = average_per_instance_dict(
+        kernel_duration_per_instance_dict_trace
+    )
     dispatch_duration_per_instance_averaged_dict = average_per_instance_dict(dispatch_duration_per_instance_dict)
 
-    kernel_duration_per_instance_min_dict = min_per_instance_dict(kernel_duration_per_instance_dict)
+    kernel_duration_per_instance_min_dict_compilation = min_per_instance_dict(
+        kernel_duration_per_instance_dict_compilation
+    )
+    kernel_duration_per_instance_min_dict_trace = min_per_instance_dict(kernel_duration_per_instance_dict_trace)
     dispatch_duration_per_instance_min_dict = min_per_instance_dict(dispatch_duration_per_instance_dict)
 
-    kernel_duration_per_instance_max_dict = max_per_instance_dict(kernel_duration_per_instance_dict)
+    kernel_duration_per_instance_max_dict_compilation = max_per_instance_dict(
+        kernel_duration_per_instance_dict_compilation
+    )
+    kernel_duration_per_instance_max_dict_trace = max_per_instance_dict(kernel_duration_per_instance_dict_trace)
     dispatch_duration_per_instance_max_dict = max_per_instance_dict(dispatch_duration_per_instance_dict)
 
-    if len(kernel_duration_per_instance_averaged_dict) != len(perf_targets):
+    if len(kernel_duration_per_instance_averaged_dict_compilation) != len(perf_targets):
         print(f"perf_targets: {perf_targets}")
 
-    print_dict(kernel_duration_per_instance_averaged_dict, "kernel_duration_per_instance_averaged_dict")
+    print_dict(
+        kernel_duration_per_instance_averaged_dict_compilation, "kernel_duration_per_instance_averaged_dict_compilation"
+    )
+    print_dict(kernel_duration_per_instance_averaged_dict_trace, "kernel_duration_per_instance_averaged_dict_trace")
     print_dict(dispatch_duration_per_instance_averaged_dict, "dispatch_duration_per_instance_averaged_dict")
 
-    assert len(kernel_duration_per_instance_averaged_dict) == len(
+    assert len(kernel_duration_per_instance_averaged_dict_compilation) == len(
         perf_targets
-    ), f"Expected {len(perf_targets)} operations, got {len(kernel_duration_per_instance_averaged_dict)}. If the number or type of operations changed, expected times must be updated."
+    ), f"Expected {len(perf_targets)} operations, got {len(kernel_duration_per_instance_averaged_dict_compilation)}. If the number or type of operations changed, expected times must be updated."
 
     passing = True
-    for op_code_with_id, avg_kernel_duration in kernel_duration_per_instance_averaged_dict.items():
+    for op_code_with_id in kernel_duration_per_instance_averaged_dict_compilation.keys():
         if op_code_with_id in perf_targets:
             op_name = perf_targets[op_code_with_id]["op_name"]
+
+            # Dependent on the op_name we need to look at compile time or trace time for kernel duration
+            if "AllGather" in op_code_with_id or "ReduceScatter" in op_code_with_id or "AllReduce" in op_code_with_id:
+                avg_kernel_duration = kernel_duration_per_instance_averaged_dict_trace[op_code_with_id]
+                min_kernel_duration = kernel_duration_per_instance_min_dict_trace[op_code_with_id]
+                max_kernel_duration = kernel_duration_per_instance_max_dict_trace[op_code_with_id]
+            else:
+                avg_kernel_duration = kernel_duration_per_instance_averaged_dict_compilation[op_code_with_id]
+                min_kernel_duration = kernel_duration_per_instance_min_dict_compilation[op_code_with_id]
+                max_kernel_duration = kernel_duration_per_instance_max_dict_compilation[op_code_with_id]
+
             avg_dispatch_duration = dispatch_duration_per_instance_averaged_dict[op_code_with_id]
             # average
             benchmark_data.add_measurement(profiler, 0, step_name, op_name + "-model-kernel-avg", avg_kernel_duration)
@@ -560,7 +614,7 @@ def test_llama_TG_perf_device(
                 0,
                 step_name,
                 op_name + "-model-kernel-min",
-                kernel_duration_per_instance_min_dict[op_code_with_id],
+                min_kernel_duration,
             )
             benchmark_data.add_measurement(
                 profiler,
@@ -576,7 +630,7 @@ def test_llama_TG_perf_device(
                 0,
                 step_name,
                 op_name + "-model-kernel-max",
-                kernel_duration_per_instance_max_dict[op_code_with_id],
+                max_kernel_duration,
             )
             benchmark_data.add_measurement(
                 profiler,
@@ -655,11 +709,17 @@ def test_llama_TG_perf_device(
 
     # Calculate e2e performance
     e2e_estimate_80l = 0
-    for entry in first_layer_raw_dict:
+    for entry in first_layer_raw_dict_compilation:
         kernel_duration = entry["DEVICE KERNEL DURATION [ns]"]
+        e2e_estimate_80l += kernel_duration
+    for entry in first_layer_raw_dict_trace:
         dispatch_duration = entry["OP TO OP LATENCY [ns]"]
-        e2e_estimate_80l += kernel_duration + dispatch_duration
-    for op_code_with_id, avg_kernel_duration in kernel_duration_per_instance_averaged_dict.items():
+        e2e_estimate_80l += dispatch_duration
+    for op_code_with_id in kernel_duration_per_instance_averaged_dict_compilation.keys():
+        if "AllGather" in op_code_with_id or "ReduceScatter" in op_code_with_id or "AllReduce" in op_code_with_id:
+            avg_kernel_duration = kernel_duration_per_instance_averaged_dict_trace[op_code_with_id]
+        else:
+            avg_kernel_duration = kernel_duration_per_instance_averaged_dict_compilation[op_code_with_id]
         avg_dispatch_duration = dispatch_duration_per_instance_averaged_dict[op_code_with_id]
         e2e_estimate_80l += (avg_kernel_duration + avg_dispatch_duration) * 79  # weighting avg for 79 layers
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Dispatch skew yields to inaccurate kernel duration for device perf measurements.

### What's changed
Updated all non-ccl ops to use compile time kernel duration instead of traced kernel duration.

### Checklist
- [x] [Perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/14592779304/job/40932164304) updated according to this CI run