### PR TITLE
#17138: Add vae midblock and upblocks

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from diffusers import (
+    AutoencoderKL,
+)
+
+import pytest
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
+    MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
+    MIDBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS,
+)
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_midblock import MidBlock
+from models.utility_functions import skip_for_blackhole
+
+
+@skip_for_blackhole("Blackhole PCC bad until GN issues fixed (#20760)")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "input_channels, input_height, input_width, norm_num_blocks, conv_in_channel_split_factors",
+    [
+        (512, 64, 64, MIDBLOCK_RESNET_NORM_NUM_BLOCKS, MIDBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS),
+    ],
+)
+def test_vae_midblock(
+    device, input_channels, input_height, input_width, norm_num_blocks, conv_in_channel_split_factors, use_program_cache
+):
+    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+
+    torch_midblock = vae.decoder.mid_block
+
+    # Run pytorch model
+    torch_input = torch.randn([1, input_channels, input_height, input_width])
+    torch_output = torch_midblock(torch_input)
+
+    # Initialize ttnn model
+    ttnn_model = MidBlock(
+        torch_midblock,
+        device,
+        input_channels,
+        input_height,
+        input_width,
+        norm_num_blocks,
+        conv_in_channel_split_factors,
+    )
+
+    # Prepare ttnn input
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
+    )
+
+    # Run ttnn model twice to test program cache and weights reuse
+    ttnn_output = ttnn_model(ttnn_input)
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
+    )
+    ttnn_output = ttnn_model(ttnn_input)
+
+    ttnn_output = ttnn.reshape(ttnn_output, [1, input_height, input_width, input_channels])
+    ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
+    result = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, result, 0.99)

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py
@@ -50,13 +50,13 @@ def test_vae_midblock(
 
     # Prepare ttnn input
     ttnn_input = ttnn.from_torch(
-        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b
     )
 
     # Run ttnn model twice to test program cache and weights reuse
     ttnn_output = ttnn_model(ttnn_input)
     ttnn_input = ttnn.from_torch(
-        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b
     )
     ttnn_output = ttnn_model(ttnn_input)
 

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from diffusers import (
+    AutoencoderKL,
+)
+
+import pytest
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
+    UPBLOCK_RESNET_NORM_NUM_BLOCKS,
+    UPBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS,
+    UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS,
+)
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upblock import UpDecoderBlock
+from models.utility_functions import skip_for_blackhole
+
+
+@skip_for_blackhole("Blackhole PCC bad until GN issues fixed (#20760)")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize(
+    "input_channels, input_height, input_width, out_channels, output_height, output_width, resnet_norm_blocks, resnet_conv_in_channel_split_factors, upsample_conv_channel_split_factors, block_id, pcc",
+    [
+        (
+            512,
+            64,
+            64,
+            512,
+            128,
+            128,
+            UPBLOCK_RESNET_NORM_NUM_BLOCKS[0],
+            UPBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS[0],
+            UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS[0],
+            0,
+            0.99,
+        ),
+        (
+            512,
+            128,
+            128,
+            512,
+            256,
+            256,
+            UPBLOCK_RESNET_NORM_NUM_BLOCKS[1],
+            UPBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS[1],
+            UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS[1],
+            1,
+            0.98,  # can we get to 0.99 PCC?
+        ),
+        (
+            512,
+            256,
+            256,
+            256,
+            512,
+            512,
+            UPBLOCK_RESNET_NORM_NUM_BLOCKS[2],
+            UPBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS[2],
+            UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS[2],
+            2,
+            0.99,
+        ),
+        (
+            256,
+            512,
+            512,
+            128,
+            512,
+            512,
+            UPBLOCK_RESNET_NORM_NUM_BLOCKS[3],
+            UPBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS[3],
+            UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS[3],
+            3,
+            0.99,
+        ),
+    ],
+)
+def test_vae_upblock(
+    device,
+    input_channels,
+    input_height,
+    input_width,
+    out_channels,
+    output_height,
+    output_width,
+    resnet_norm_blocks,
+    resnet_conv_in_channel_split_factors,
+    upsample_conv_channel_split_factors,
+    block_id,
+    pcc,
+    use_program_cache,
+):
+    torch.manual_seed(0)
+    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+
+    torch_upblock = vae.decoder.up_blocks[block_id]
+
+    # Run pytorch model
+    torch_input = torch.randn([1, input_channels, input_height, input_width])
+    torch_output = torch_upblock(torch_input)
+
+    # Initialize ttnn model
+    ttnn_model = UpDecoderBlock(
+        torch_upblock,
+        device,
+        input_channels,
+        input_height,
+        input_width,
+        out_channels,
+        output_height,
+        output_width,
+        resnet_norm_blocks,
+        resnet_conv_in_channel_split_factors,
+        upsample_conv_channel_split_factors,
+    )
+
+    # Prepare ttnn input
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b
+    )
+
+    # Run ttnn model twice to test program cache and weights reuse
+    ttnn_output = ttnn_model(ttnn_input)
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b
+    )
+    ttnn_output = ttnn_model(ttnn_input)
+
+    ttnn_output = ttnn.reshape(ttnn_output, [1, output_height, output_width, out_channels])
+    ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_with_pcc(torch_output, ttnn_output, pcc)

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upsample.py
@@ -7,17 +7,20 @@ import torch
 from diffusers import AutoencoderKL
 
 import ttnn
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
+    UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS,
+)
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 @pytest.mark.parametrize(
-    "input_channels, input_height, input_width, out_channels, output_height, output_width, conv_in_channel_split_factor, conv_out_channel_split_factor, block_id",
+    "input_channels, input_height, input_width, out_channels, output_height, output_width, conv_channel_split_factor, block_id",
     [
-        (512, 64, 64, 512, 128, 128, 1, 1, 0),
-        (512, 128, 128, 512, 256, 256, 2, 2, 1),
-        (256, 256, 256, 256, 512, 512, 4, 2, 2),
+        (512, 64, 64, 512, 128, 128, UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS[0], 0),
+        (512, 128, 128, 512, 256, 256, UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS[1], 1),
+        (256, 256, 256, 256, 512, 512, UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS[2], 2),
     ],
 )
 def test_upsample(
@@ -28,8 +31,7 @@ def test_upsample(
     out_channels,
     output_height,
     output_width,
-    conv_in_channel_split_factor,
-    conv_out_channel_split_factor,
+    conv_channel_split_factor,
     block_id,
     use_program_cache,
 ):
@@ -50,8 +52,8 @@ def test_upsample(
         out_channels,
         output_height,
         output_width,
-        conv_in_channel_split_factor,
-        conv_out_channel_split_factor,
+        conv_channel_split_factor[0],
+        conv_channel_split_factor[1],
     )
 
     # Prepare ttnn input

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_configs.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_configs.py
@@ -59,3 +59,10 @@ UPBLOCK_RESNET_CONV_IN_CHANNEL_SPLIT_FACTORS = [
         (4, 4),  # upblock 3, resnet 2
     ],
 ]
+
+UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS = [
+    (1, 1),  # upblock 0
+    (2, 2),  # upblock 1
+    (4, 2),  # upblock 2
+    (1, 1),  # upblock 3 (no upsample here)
+]

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_midblock.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_midblock.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_attention import Attention
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_resnet import ResnetBlock
+
+
+class MidBlock:
+    def __init__(
+        self,
+        torch_midblock,
+        device,
+        in_channels,
+        input_height,
+        input_width,
+        resnet_norm_num_blocks=[(1, 1), (1, 1)],
+        resnet_conv_channel_split_factors=[(1, 1), (1, 1)],
+    ):
+        self.resnets = []
+        self.resnets.append(
+            ResnetBlock(
+                torch_midblock.resnets[0],
+                device,
+                in_channels,
+                input_height,
+                input_width,
+                in_channels,
+                resnet_norm_num_blocks[0][0],
+                resnet_norm_num_blocks[0][1],
+                resnet_conv_channel_split_factors[0][0],
+                resnet_conv_channel_split_factors[0][1],
+            )
+        )
+        self.attention = Attention(
+            torch_midblock.attentions[0],
+            device,
+            in_channels,
+        )
+
+        self.resnets.append(
+            ResnetBlock(
+                torch_midblock.resnets[1],
+                device,
+                in_channels,
+                input_height,
+                input_width,
+                in_channels,
+                resnet_norm_num_blocks[1][0],
+                resnet_norm_num_blocks[1][1],
+                resnet_conv_channel_split_factors[1][0],
+                resnet_conv_channel_split_factors[1][1],
+            )
+        )
+
+    def __call__(self, hidden_states):
+        hidden_states = self.resnets[0](hidden_states)
+        hidden_states = self.attention(hidden_states)
+        hidden_states = self.resnets[1](hidden_states)
+        return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upblock.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upblock.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_upsample import UpsampleBlock
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_resnet import ResnetBlock
+
+
+class UpDecoderBlock:
+    def __init__(
+        self,
+        torch_upblock,
+        device,
+        in_channels,
+        input_height,
+        input_width,
+        out_channels,
+        output_height,
+        output_width,
+        resnet_norm_blocks=[(1, 1), (1, 1), (1, 1)],
+        resnet_conv_in_channel_split_factors=[(1, 1), (1, 1), (1, 1)],
+        upsample_conv_channel_split_factors=((1, 1), (1, 1)),
+    ):
+        self.resnets = []
+        for i in range(3):
+            self.resnets.append(
+                ResnetBlock(
+                    torch_upblock.resnets[i],
+                    device,
+                    in_channels if i == 0 else out_channels,
+                    input_height,
+                    input_width,
+                    out_channels,
+                    resnet_norm_blocks[i][0],
+                    resnet_norm_blocks[i][1],
+                    resnet_conv_in_channel_split_factors[i][0],
+                    resnet_conv_in_channel_split_factors[i][1],
+                )
+            )
+
+        self.upsample = None
+        if torch_upblock.upsamplers:
+            self.upsample = UpsampleBlock(
+                torch_upblock.upsamplers[0],
+                device,
+                out_channels,
+                input_height,
+                input_width,
+                out_channels,
+                output_height,
+                output_width,
+                upsample_conv_channel_split_factors[0],
+                upsample_conv_channel_split_factors[1],
+            )
+
+    def __call__(self, hidden_states):
+        for resnet in self.resnets:
+            hidden_states = resnet(hidden_states)
+
+        if self.upsample:
+            hidden_states = self.upsample(hidden_states)
+
+        return hidden_states

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upsample.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae_upsample.py
@@ -39,9 +39,11 @@ class UpsampleBlock:
         )
 
     def __call__(self, hidden_states):
+        # Prepare upsample op
         if hidden_states.layout == ttnn.TILE_LAYOUT:
-            # Upsample op requires row-major input
             hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
+        if hidden_states.shape[1] == 1:
+            hidden_states = ttnn.reshape(hidden_states, [1, self.input_height, self.input_width, self.in_channels])
 
         hidden_states = ttnn.upsample(hidden_states, self.scale_factor)
 

--- a/tests/nightly/single_card/stable_diffusion/vae/test_vae_midblock.py
+++ b/tests/nightly/single_card/stable_diffusion/vae/test_vae_midblock.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/wormhole/stable_diffusion/tests/vae/test_vae_midblock.py

--- a/tests/nightly/single_card/stable_diffusion/vae/test_vae_upblock.py
+++ b/tests/nightly/single_card/stable_diffusion/vae/test_vae_upblock.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/wormhole/stable_diffusion/tests/vae/test_vae_upblock.py


### PR DESCRIPTION
### Ticket
#17138

### What's changed
Added midblock and upblock components and their tests.
Currently tests added only for WH as BH tests have badd PCC due to  #20760.

Note: one of the upblock components has PCC 0.98. The only missing component is the final decoder, that currently has 0.92 PCC locally. I am debugging this, doesn't seem related to the upblock 0.98 PCC.

### Checklist
[WH] Frequent model and ttnn: https://github.com/tenstorrent/tt-metal/actions/runs/14594742195