### PR TITLE
Add support for RM input for all_gather_concat + implicit tilize for its output

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -32,7 +32,7 @@ from models.demos.llama3_subdevices.tt.model_config import LlamaOptimizations
 TSU_PERF_DROP_LIMIT_COUNT = 20
 
 # Constants for TSU thresholds based on the number of layers
-TSU_THRESHOLDS = {1: {"min": 515, "max": 535}, 10: {"min": 230, "max": 250}, 80: {"min": 47, "max": 51}}
+TSU_THRESHOLDS = {1: {"min": 515, "max": 535}, 10: {"min": 230, "max": 250}, 80: {"min": 48, "max": 52}}
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -32,7 +32,7 @@ from models.demos.llama3_subdevices.tt.model_config import LlamaOptimizations
 TSU_PERF_DROP_LIMIT_COUNT = 20
 
 # Constants for TSU thresholds based on the number of layers
-TSU_THRESHOLDS = {1: {"min": 515, "max": 535}, 10: {"min": 230, "max": 250}, 80: {"min": 48, "max": 52}}
+TSU_THRESHOLDS = {1: {"min": 515, "max": 535}, 10: {"min": 230, "max": 250}, 80: {"min": 47, "max": 51}}
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -206,10 +206,10 @@ perf_targets = {
     },
     "Untilize_0": {
         "op_name": "Untilize",
-        "kernel_duration": 2641.3333333333335,
+        "kernel_duration": 1517.3333333333335,
         "op_to_op": 996.8888888888889,
         "non-overlapped-dispatch-time": 3113.6,
-        "kernel_duration_relative_margin": 0.05,
+        "kernel_duration_relative_margin": 0.2,
         "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.5,
     },

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -44,9 +44,9 @@ perf_targets = {
     },
     "AllGatherConcat_0": {
         "op_name": "AllGatherConcat",
-        "kernel_duration": 16953.190972222223,
+        "kernel_duration": 12419.194444444445,
         "op_to_op": 796.8888888888889,
-        "non-overlapped-dispatch-time": 11465.5,
+        "non-overlapped-dispatch-time": 12541.7,
         "kernel_duration_relative_margin": 0.05,
         "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.5,
@@ -203,6 +203,15 @@ perf_targets = {
         "kernel_duration_relative_margin": 0.1,
         "op_to_op_duration_relative_margin": 0.2,
         "dispatch_duration_relative_margin": 0.2,
+    },
+    "Untilize_0": {
+        "op_name": "Untilize",
+        "kernel_duration": 2641.3333333333335,
+        "op_to_op": 996.8888888888889,
+        "non-overlapped-dispatch-time": 3113.6,
+        "kernel_duration_relative_margin": 0.05,
+        "op_to_op_duration_relative_margin": 0.2,
+        "dispatch_duration_relative_margin": 0.5,
     },
 }
 

--- a/models/demos/llama3_subdevices/tt/llama_attention.py
+++ b/models/demos/llama3_subdevices/tt/llama_attention.py
@@ -375,9 +375,12 @@ class TtLlamaAttention(LightweightModule):
         #     attn_output_gathered, self.model_config["GATHER_USERS_MEMCFG"](list(self.mesh_device.shape)[1])
         # )
         # ttnn.deallocate(attn_output_gathered)
-
-        attn_output_cat = self.tt_ccl.all_gather_concat(
+        attn_output_1G4D_sharded_rm = ttnn.untilize(
             attn_output_1G4D_sharded,
+        )
+        ttnn.deallocate(attn_output_1G4D_sharded)
+        attn_output_cat = self.tt_ccl.all_gather_concat(
+            attn_output_1G4D_sharded_rm,
             dim=1,
             cluster_axis=1,
             num_links=3,

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -102,7 +102,7 @@ class TT_CCL:
         tt_intermediate_tensor = ttnn.from_torch(
             intermediate_tensor,
             device=self.mesh_device,
-            layout=ttnn.TILE_LAYOUT,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
             dtype=ttnn.bfloat16,
             memory_config=intermediate_mem_config,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=[0, 1], mesh_shape=[8, 4]),

--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -67,7 +67,7 @@ class TT_CCL:
 
     def get_all_gather_concat_inter_buffer(self):
         intermediate_core_range_set = ttnn.CoreRangeSet(
-            {
+            [
                 ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 4)),
                 ttnn.CoreRange(ttnn.CoreCoord(6, 6), ttnn.CoreCoord(6, 6)),
                 ttnn.CoreRange(ttnn.CoreCoord(6, 7), ttnn.CoreCoord(6, 7)),
@@ -86,7 +86,7 @@ class TT_CCL:
                 ttnn.CoreRange(ttnn.CoreCoord(5, 2), ttnn.CoreCoord(5, 2)),
                 ttnn.CoreRange(ttnn.CoreCoord(5, 4), ttnn.CoreCoord(5, 4)),
                 ttnn.CoreRange(ttnn.CoreCoord(1, 5), ttnn.CoreCoord(1, 5)),
-            }
+            ]
         )
         intermediate_mem_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -485,7 +485,7 @@ def test_rms_fuse(
             4,
             [1, 32, 32, 128],
             1,
-            ttnn.TILE_LAYOUT,
+            ttnn.ROW_MAJOR_LAYOUT,
             (32, 128),
             ttnn.CoreRangeSet(
                 {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.cpp
@@ -43,9 +43,8 @@ void AllGatherConcat::validate(const std::vector<Tensor>& input_tensors) const {
     CoreCoord grid_size = input_tensors[0].device()->compute_with_storage_grid_size();
     TT_FATAL(grid_size.x >= 3 && grid_size.y >= 3, "Input core grid out of bound!");
     TT_FATAL(
-        padded_input_shape[0] == 1 && padded_input_shape[1] == 8 && padded_input_shape[2] == 32 &&
-            padded_input_shape[3] == 128,
-        "Unsupported input shape, should be [1, 8, 32, 128]!");
+        padded_input_shape[0] == 1 && padded_input_shape[1] == 8 && padded_input_shape[3] == 128,
+        "Unsupported input shape, should be [1, 8, 32, 128] or [1, 8, 8, 128]!");
 }
 
 std::vector<ttnn::TensorSpec> AllGatherConcat::compute_output_specs(const std::vector<Tensor>& input_tensors) const {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -315,7 +315,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp",
         q_cores_updated,
-        tt::tt_metal::ComputeConfig{.compile_args = {1, 2}});
+        tt::tt_metal::ComputeConfig{.compile_args = {1, 2, tt::CBIndex::c_17, tt::CBIndex::c_16}});
 
     // KERNEL CREATION
     // Reader

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -138,15 +138,17 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
     auto sender_worker_core_range = CoreRangeSet(CoreRange({1, 0}, {3, 0}));
     auto sender_worker_cores = corerange_to_cores(sender_worker_core_range, 3, true);
     // Tensor Info
-    const auto input_tensor_num_pages = input_tensor.buffer()->num_pages();
+    const uint32_t logical_dim_2 = 8;
+    const auto input_tensor_num_pages =
+        input_tensor.get_logical_shape()[0] * input_tensor.get_logical_shape()[1] * logical_dim_2;
     const auto input_tensor_cores = input_tensor.memory_config().shard_spec->grid;
     const auto input_tensor_shard_shape = input_tensor.memory_config().shard_spec->shape;
-    const auto input_tensor_shard_num_pages = input_tensor_shard_shape[0] * input_tensor_shard_shape[1] / TILE_HW;
+    const auto input_tensor_shard_num_pages = logical_dim_2;
 
     const auto output_interm_tensor_cores = temp_tensor.memory_config().shard_spec->grid;
     const auto output_interm_tensor_shard_shape = temp_tensor.memory_config().shard_spec->shape;
-    const auto output_interm_tensor_shard_num_pages =
-        output_interm_tensor_shard_shape[0] * output_interm_tensor_shard_shape[1] / TILE_HW;
+    const auto output_interm_tensor_shard_num_pages = logical_dim_2;
+    const auto row_size = input_tensor.get_padded_shape()[-1] / 2 * output_tensor.element_size();
 
     tt::log_debug(tt::LogOp, "input_tensor_num_pages: {}", input_tensor_num_pages);
     tt::log_debug(tt::LogOp, "input_tensor_cores: {}", input_tensor_cores);
@@ -212,10 +214,16 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
 
     uint32_t q_output_cb_index = tt::CBIndex::c_16;
     tt::tt_metal::CircularBufferConfig cb_q_output_config =
-        tt::tt_metal::CircularBufferConfig(q_num_tiles * single_tile_size, {{q_output_cb_index, df}})
+        tt::tt_metal::CircularBufferConfig(output_tensor.get_padded_shape()[-2] * row_size, {{q_output_cb_index, df}})
             .set_page_size(q_output_cb_index, single_tile_size)
             .set_globally_allocated_address(*output_tensor.buffer());
     auto cb_q_output = tt::tt_metal::CreateCircularBuffer(program, q_cores, cb_q_output_config);
+
+    uint32_t pre_tilize_cb_index = tt::CBIndex::c_17;
+    tt::tt_metal::CircularBufferConfig cb_pre_tilize_config =
+        tt::tt_metal::CircularBufferConfig(output_tensor.get_padded_shape()[-2] * row_size, {{pre_tilize_cb_index, df}})
+            .set_page_size(pre_tilize_cb_index, single_tile_size);
+    auto cb_pre_tilize = tt::tt_metal::CreateCircularBuffer(program, q_cores, cb_pre_tilize_config);
 
     llama_config llama_configuration;
     std::vector<CoreRange> q_cores_vector;
@@ -261,28 +269,23 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
         noc_y_coords.push_back(mesh_device->worker_core_from_logical_core(in_cores_vec[i]).y);
     }
 
+    auto output_tensor_shard_shape = output_tensor.memory_config().shard_spec->shape;
     // create concat semaphore for each link
     uint32_t concat_semaphore_id = tt::tt_metal::CreateSemaphore(program, sem_cores_updated, 0);
     uint32_t concat_semaphore_id2 = tt::tt_metal::CreateSemaphore(program, sem_cores_updated, 0);
 
     std::vector<uint32_t> concat_reader_ct_args = {
-        (std::uint32_t)element_size,
-        (std::uint32_t)sub_tile_line_bytes,
-        q_output_cb_index,
-        head_size,
-        batch,
-        llama_configuration.num_tiles_reshard,
+        pre_tilize_cb_index,
         first_phase,
         in_num_cores,
-        face_h,
-        face_hw,
         batch_size,
         batch_start_1,
         batch_end_1,
         batch_start_2,
         batch_end_2,
         start_local,
-        tile_size,
+        input_tensor_shard_shape[1] * input_tensor.element_size(),
+        output_tensor_shard_shape[1] * output_tensor.element_size(),
     };
 
     auto concat_reader_kernel_id = tt::tt_metal::CreateKernel(
@@ -295,16 +298,24 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
             .noc = reader_noc,
             .compile_args = concat_reader_ct_args});
 
-    concat_reader_ct_args[6] = second_phase;
-    auto concat_reader_2_kernel_id = tt::tt_metal::CreateKernel(
+    std::vector<uint32_t> tilize_ct_args = {
+        q_output_cb_index,
+    };
+    auto tilize_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/"
-        "llama_concat_reader.cpp",
+        "tilize_writer.cpp",
         q_cores_updated,
         tt::tt_metal::DataMovementConfig{
             .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
             .noc = writer_noc,
-            .compile_args = concat_reader_ct_args});
+            .compile_args = tilize_ct_args});
+
+    auto tilize_compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp",
+        q_cores_updated,
+        tt::tt_metal::ComputeConfig{.compile_args = {1, 2}});
 
     // KERNEL CREATION
     // Reader
@@ -380,8 +391,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
         // construct input and output core x and y
         uint32_t base_pages_per_worker = input_tensor_num_pages / num_links;
         uint32_t remainder = input_tensor_num_pages % num_links;
-        uint32_t input_tile_id_start = link * base_pages_per_worker + std::min(link, remainder);
-        uint32_t input_tile_id_end = (link + 1) * base_pages_per_worker + std::min(link + 1, remainder);
+        bool add_remainder = link == num_links - 1;
+        uint32_t input_tile_id_start = link * base_pages_per_worker;
+        uint32_t input_tile_id_end = (link + 1) * base_pages_per_worker + add_remainder * remainder;
 
         uint32_t worker_num_tiles_to_read = input_tile_id_end - input_tile_id_start;
         uint32_t input_first_core_tile_start_offset = input_tile_id_start % input_tensor_shard_num_pages;
@@ -427,6 +439,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
         std::vector<uint32_t> reader_rt_args = {
             input_tensor.buffer()->address(),  // tensor_address0
             semaphore.address(),
+            input_tensor_shard_num_pages,
             worker_num_tiles_to_read,            // num_tiles_to_read
             input_first_core_tile_start_offset,  // first_core_tile_start_offset
             input_tensor_cores_x.size(),         // num_cores
@@ -445,8 +458,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
         bool reset_global_semaphore = (link == 0) && !enable_async_output_tensor;
         uint32_t out_ready_sem_wait_value = ring_size * num_links;
         std::vector<uint32_t> writer_rt_args = {
-            temp_tensor.buffer()->address(),      // tensor_address0
-            semaphore.address(),                  // out_ready_sem_bank_addr (absolute address)
+            temp_tensor.buffer()->address(),  // tensor_address0
+            semaphore.address(),              // out_ready_sem_bank_addr (absolute address)
+            input_tensor_shard_num_pages,
             worker_num_tiles_to_read,             // num_tiles_to_read
             output_first_core_tile_start_offset,  // first_core_tile_start_offset
             output_tensor_cores_x.size(),         // num_cores
@@ -531,17 +545,14 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
             std::vector<uint32_t> reader_runtime_args;
             reader_runtime_args.reserve(6 + 2 * in_num_cores);
             reader_runtime_args = {
-                in_tile_offset_by_batch,
-                q_start_addr,
-                input_tensor.buffer()->address(),
-                concat_semaphore_id,
-                concat_semaphore_id2};
+                q_start_addr, input_tensor.buffer()->address(), concat_semaphore_id, concat_semaphore_id2};
+
             reader_runtime_args.insert(reader_runtime_args.end(), noc_x_coords.begin(), noc_x_coords.end());
             reader_runtime_args.insert(reader_runtime_args.end(), noc_y_coords.begin(), noc_y_coords.end());
             reader_runtime_args.push_back(second_half_core);
+            reader_runtime_args.push_back(i / 2);
 
             tt::tt_metal::SetRuntimeArgs(program, concat_reader_kernel_id, core, reader_runtime_args);
-            tt::tt_metal::SetRuntimeArgs(program, concat_reader_2_kernel_id, core, reader_runtime_args);
         }
     }
     uint32_t num_concat_worker_cores = llama_configuration.concat_num_cores;
@@ -554,7 +565,6 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
          cb_q_output,
          cores,
          concat_reader_kernel_id,
-         concat_reader_2_kernel_id,
          face_h,
          sub_tile_line_bytes](
             const void* operation,
@@ -593,16 +603,9 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
 
             for (uint32_t i = 0; i < num_concat_worker_cores; ++i) {
                 const auto& core = cores[i];
-                uint32_t in_tile_offset_by_batch = get_tile_offset_by_batch(i, face_h, sub_tile_line_bytes);
                 auto& concat_reader_runtime_args = GetRuntimeArgs(program, concat_reader_kernel_id, core);
-                concat_reader_runtime_args[0] = in_tile_offset_by_batch;
-                concat_reader_runtime_args[1] = q_start_addr;
-                concat_reader_runtime_args[2] = input.buffer()->address();
-
-                auto& concat_reader_2_runtime_args = GetRuntimeArgs(program, concat_reader_2_kernel_id, core);
-                concat_reader_2_runtime_args[0] = in_tile_offset_by_batch;
-                concat_reader_2_runtime_args[1] = q_start_addr;
-                concat_reader_2_runtime_args[2] = input.buffer()->address();
+                concat_reader_runtime_args[0] = q_start_addr;
+                concat_reader_runtime_args[1] = input.buffer()->address();
             }
         };
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -138,7 +138,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
     auto sender_worker_core_range = CoreRangeSet(CoreRange({1, 0}, {3, 0}));
     auto sender_worker_cores = corerange_to_cores(sender_worker_core_range, 3, true);
     // Tensor Info
-    const uint32_t logical_dim_2 = 8;
+    const uint32_t logical_dim_2 = input_tensor.get_logical_shape()[2];
     const auto input_tensor_num_pages =
         input_tensor.get_logical_shape()[0] * input_tensor.get_logical_shape()[1] * logical_dim_2;
     const auto input_tensor_cores = input_tensor.memory_config().shard_spec->grid;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_reader.cpp
@@ -33,7 +33,7 @@ void kernel_main() {
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
     uint32_t out_ready_sem_bank_addr_concat = get_arg_val<uint32_t>(arg_idx++);
-    constexpr uint32_t num_tiles_per_core = 4;  // get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -40,7 +40,7 @@ void kernel_main() {
     // Load the input tensor spec
     address_t tensor_address0 = get_arg_val<address_t>(arg_idx++);
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
-    constexpr uint32_t num_tiles_per_core = 4;  // get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_tiles_per_core = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_tiles_to_read = get_arg_val<uint32_t>(arg_idx++);
     uint32_t first_core_tile_start_offset = get_arg_val<uint32_t>(arg_idx++);
     uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -26,6 +26,7 @@ constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
 constexpr uint32_t num_sem_ranges = get_compile_time_arg_val(8);
+constexpr uint32_t out_ready_sem_wait_value = get_compile_time_arg_val(9);
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -48,7 +49,6 @@ void kernel_main() {
     bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
     constexpr uint8_t out_ready_sem_noc0_x = 19;       // get_arg_val<uint32_t>(arg_idx++);
     constexpr uint8_t out_ready_sem_noc0_y = 18;       // get_arg_val<uint32_t>(arg_idx++);
-    constexpr uint32_t out_ready_sem_wait_value = 12;  // get_arg_val<uint32_t>(arg_idx++);
 
     const uint32_t concat_semaphore_send_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t concat_semaphore_send_addr2 = get_semaphore(get_arg_val<uint32_t>(arg_idx++));

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_concat_reader.cpp
@@ -120,22 +120,23 @@ void kernel_main() {
     ///////////////////////////////////////////////////
     // ARGS
     ///////////////////////////////////////////////////
-
-    uint32_t q_start_addr = get_arg_val<uint32_t>(0);
-    uint32_t tensor_address0 = get_arg_val<uint32_t>(1);
-    const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(2));
-    const uint32_t signal_semaphore_addr2 = get_semaphore(get_arg_val<uint32_t>(3));
+    uint32_t arg_idx = 0;
+    uint32_t q_start_addr = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t tensor_address0 = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t signal_semaphore_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t signal_semaphore_addr2 = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
 
     volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr);
     volatile tt_l1_ptr uint32_t* signal_semaphore_addr_ptr2 =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(signal_semaphore_addr2);
 
-    uint32_t arg_idx = 4 + 2 * in_num_cores;
-    uint32_t second_half_core = get_arg_val<uint32_t>(arg_idx);
-    uint32_t start_row = get_arg_val<uint32_t>(arg_idx + 1);
-    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(4));
-    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(4 + in_num_cores));
+    tt_l1_ptr uint32_t* in0_mcast_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += in_num_cores;
+    tt_l1_ptr uint32_t* in0_mcast_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(arg_idx));
+    arg_idx += in_num_cores;
+    uint32_t second_half_core = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t start_row = get_arg_val<uint32_t>(arg_idx++);
 
     std::array<uint32_t, 8> core_noc_x = {19, 20, 21, 19, 20, 21, 19, 20};
     std::array<uint32_t, 8> core_noc_y = {18, 18, 18, 19, 19, 19, 20, 20};

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp
@@ -12,16 +12,18 @@ namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
     uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
-    tilize_init(tt::CBIndex::c_17, per_core_block_tile_cnt, tt::CBIndex::c_16);
+    uint32_t cb_in_idx = get_compile_time_arg_val(2);
+    uint32_t cb_out_idx = get_compile_time_arg_val(3);
+    tilize_init(cb_in_idx, per_core_block_tile_cnt, cb_out_idx);
 
     for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
-        cb_wait_front(tt::CBIndex::c_17, per_core_block_tile_cnt);
-        cb_reserve_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
+        cb_wait_front(cb_in_idx, per_core_block_tile_cnt);
+        cb_reserve_back(cb_out_idx, per_core_block_tile_cnt);
 
-        tilize_block(tt::CBIndex::c_17, per_core_block_tile_cnt, tt::CBIndex::c_16);
+        tilize_block(cb_in_idx, per_core_block_tile_cnt, cb_out_idx);
 
-        cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
-        cb_pop_front(tt::CBIndex::c_17, per_core_block_tile_cnt);
+        cb_push_back(cb_out_idx, per_core_block_tile_cnt);
+        cb_pop_front(cb_in_idx, per_core_block_tile_cnt);
     }
 }
 }  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_compute.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/tilize.h"
+
+// #include "debug/dprint.h"
+
+namespace NAMESPACE {
+void MAIN {
+    uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
+    uint32_t per_core_block_tile_cnt = get_compile_time_arg_val(1);
+    tilize_init(tt::CBIndex::c_17, per_core_block_tile_cnt, tt::CBIndex::c_16);
+
+    for (uint32_t b = 0; b < per_core_block_cnt; ++b) {
+        cb_wait_front(tt::CBIndex::c_17, per_core_block_tile_cnt);
+        cb_reserve_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
+
+        tilize_block(tt::CBIndex::c_17, per_core_block_tile_cnt, tt::CBIndex::c_16);
+
+        cb_push_back(tt::CBIndex::c_16, per_core_block_tile_cnt);
+        cb_pop_front(tt::CBIndex::c_17, per_core_block_tile_cnt);
+    }
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/tilize_writer.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    cb_wait_front(cb_id_out, 2);
+}


### PR DESCRIPTION
### Ticket
Llama 80tkps project

### Problem description
The input tensor for all_gather_concat op in llama attention is very narrow ([1, 8, 8, 128] per device), which makes all_gather_concat operates mostly on padded values. This PR adds the support for input tensors in row_major layout for all_gather_concat. 

The kernel time in llama model dropped from 16.9us to 12.4us
The tok/s/usr increases by around 1 (range 46-50)

### What's changed
- All gather op reads the input data in row major, which reduces the number of packets per device to a maximum of 2 packets instead of 6
- NLP concat heads processes a whole row at a time which increases the size of a single transaction from 32B to 256B
- Added an implicit tilize op in all_gather concat kernels to return an output in tile layout (for the next operation MM)

The current model integration adds an untilize op before all_gather_concat op. This will be replaced by an RM support for SDPA op

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes