### PR TITLE
Clear set tracking device ids in database between test runs

### DIFF
--- a/tests/ttnn/conftest.py
+++ b/tests/ttnn/conftest.py
@@ -53,6 +53,7 @@ def pre_and_post(request):
             if report_path.exists():
                 logger.warning(f"Removing existing log directory: {report_path}")
                 shutil.rmtree(report_path)
+            ttnn.database.DEVICE_IDS_IN_DATABASE.clear()
         yield
 
     if ttnn.database.SQLITE_CONNECTION is not None:


### PR DESCRIPTION
### Problem description

There is a bug that causes the `devices` table in the report db to not have any devices in it. Debugging revealed that the reason the devices were missing from the table in some cases was that the report directory and its files are getting deleted between test runs, but a set in the `ttnn/ttnn/database.py` file that tracks which devices were already put in the database was not getting cleared between test runs.

When running a single test the problem would not occur, because the code using the `ttnn.database.DEVICE_IDS_IN_DATABASE` set to avoid inserting the same device multiple times was working correctly. For a single test this set was successfully being used to put each device record into the db one time, and not do it over again for other operations.

The problem is that there is a pytest fixture, set to be automatically used in each test, that deletes the report directory. The `tests.ttnn.conftest.pre_and_post` fixture wipes out the directory like this:

```
            if report_path.exists():
		logger.warning(f"Removing existing log directory: {report_path}")
                shutil.rmtree(report_path)
```

The problem was that the code in `ttnn/ttnn/database.py` didn't know about the report directory being cleared between tests, and since the device id already appeared in the `DEVICE_IDS_IN_DATABASE` set, it did not put any record in the db created for the next test.

It therefore appeared that no devices were being put in the db, but what was really going on was that they were in fact put in the db the first time, but then the db would get deleted and they were not put back in after the first `db.sqlite` file was deleted.

### What's changed

The `pre_and_post` fixture is being changed to clear the `DEVICE_IDS_IN_DATABASE` set before each test runs. This ensures that the `ttnn.database.insert_devices` function doesn't skip inserting the records on subsequent tests.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes