### PR TITLE
Fix dangling reference in ElfFile::Impl constructor

### DIFF
--- a/tt_metal/api/tt-metalium/tt_memory.h
+++ b/tt_metal/api/tt-metalium/tt_memory.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <string>
+#include <string_view>
 #include <vector>
 
 namespace ll_api {
@@ -35,7 +35,7 @@ private:
 
 public:
     memory();
-    memory(std::string const &path, Loading loading);
+    memory(const std::string_view path, Loading loading);
 
 public:
     // These can be large objects, so ban copying ...

--- a/tt_metal/api/tt-metalium/tt_memory.h
+++ b/tt_metal/api/tt-metalium/tt_memory.h
@@ -35,7 +35,7 @@ private:
 
 public:
     memory();
-    memory(const std::string_view path, Loading loading);
+    memory(std::string_view path, Loading loading);
 
 public:
     // These can be large objects, so ban copying ...

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -40,9 +40,7 @@ using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
 
-ll_api::memory const& get_risc_binary(
-    string const& path,
-    ll_api::memory::Loading loading) {
+const ll_api::memory& get_risc_binary(const std::string_view path, ll_api::memory::Loading loading) {
     static struct {
       std::unordered_map<std::string, std::unique_ptr<ll_api::memory const>> map;
       std::mutex mutex;
@@ -50,7 +48,7 @@ ll_api::memory const& get_risc_binary(
     } cache;
 
     std::unique_lock lock(cache.mutex);
-    auto [slot, inserted] = cache.map.try_emplace(path);
+    auto [slot, inserted] = cache.map.try_emplace(std::string(path));
     ll_api::memory const* ptr = nullptr;
     if (inserted) {
       // We're the first with PATH. Create and insert.

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -40,7 +40,7 @@ using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
 
-const ll_api::memory& get_risc_binary(const std::string_view path, ll_api::memory::Loading loading) {
+const ll_api::memory& get_risc_binary(std::string_view path, ll_api::memory::Loading loading) {
     static struct {
       std::unordered_map<std::string, std::unique_ptr<ll_api::memory const>> map;
       std::mutex mutex;

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
-#include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -59,7 +59,7 @@ using WorkerCores = std::vector<WorkerCore>;
 // Return a reference to a potentially shared binary image.
 // The images are cached by path name.
 const ll_api::memory& get_risc_binary(
-    const string& path, ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE);
+    const std::string_view path, ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE);
 
 // TODO: try using "stop" method from device instead, it's the proper way of asserting reset
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -59,7 +59,7 @@ using WorkerCores = std::vector<WorkerCore>;
 // Return a reference to a potentially shared binary image.
 // The images are cached by path name.
 const ll_api::memory& get_risc_binary(
-    const std::string_view path, ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE);
+    std::string_view path, ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE);
 
 // TODO: try using "stop" method from device instead, it's the proper way of asserting reset
 

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -63,7 +63,7 @@ private:
     class Weakener;
 
 public:
-    Impl(ElfFile& owner, const std::string_view path) : owner_(owner), path_(std::string(path)) {}
+    Impl(ElfFile& owner, std::string_view path) : owner_(owner), path_(std::string(path)) {}
     ~Impl() = default;
 
 public:
@@ -162,7 +162,7 @@ void ElfFile::ReleaseImpl() {
     pimpl_ = nullptr;
 }
 
-void ElfFile::ReadImage(const std::string_view path) {
+void ElfFile::ReadImage(std::string_view path) {
     int fd = open(path.data(), O_RDONLY | O_CLOEXEC);
     struct stat st;
     void* buffer = MAP_FAILED;

--- a/tt_metal/llrt/tt_elffile.cpp
+++ b/tt_metal/llrt/tt_elffile.cpp
@@ -56,14 +56,14 @@ class ElfFile::Impl {
 private:
     std::span<Elf32_Phdr> phdrs_;
     std::span<Elf32_Shdr> shdrs_;
-    std::string const& path_;
+    const std::string path_;
     ElfFile& owner_;
 
 private:
     class Weakener;
 
 public:
-    Impl(ElfFile& owner, std::string const& path) : owner_(owner), path_(path) {}
+    Impl(ElfFile& owner, const std::string_view path) : owner_(owner), path_(std::string(path)) {}
     ~Impl() = default;
 
 public:
@@ -162,8 +162,8 @@ void ElfFile::ReleaseImpl() {
     pimpl_ = nullptr;
 }
 
-void ElfFile::ReadImage(std::string const& path) {
-    int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+void ElfFile::ReadImage(const std::string_view path) {
+    int fd = open(path.data(), O_RDONLY | O_CLOEXEC);
     struct stat st;
     void* buffer = MAP_FAILED;
     if (fd >= 0 && fstat(fd, &st) >= 0) {

--- a/tt_metal/llrt/tt_elffile.hpp
+++ b/tt_metal/llrt/tt_elffile.hpp
@@ -68,7 +68,7 @@ public:
 
     // Read an elf file, populate segments vector.
     // Path must remain live throughout processing.
-    void ReadImage(std::string const& path);
+    void ReadImage(const std::string_view path);
 
     // Write the (now-processed) elf file.
     void WriteImage(std::string const& path);

--- a/tt_metal/llrt/tt_elffile.hpp
+++ b/tt_metal/llrt/tt_elffile.hpp
@@ -68,7 +68,7 @@ public:
 
     // Read an elf file, populate segments vector.
     // Path must remain live throughout processing.
-    void ReadImage(const std::string_view path);
+    void ReadImage(std::string_view path);
 
     // Write the (now-processed) elf file.
     void WriteImage(std::string const& path);

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -21,7 +21,7 @@ memory::memory() {
     link_spans_.reserve(initial_span_space_);
 }
 
-memory::memory(std::string const& path, Loading loading) : loading_(loading) {
+memory::memory(const std::string_view path, Loading loading) : loading_(loading) {
     ElfFile elf;
 
     elf.ReadImage(path);

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -21,7 +21,7 @@ memory::memory() {
     link_spans_.reserve(initial_span_space_);
 }
 
-memory::memory(const std::string_view path, Loading loading) : loading_(loading) {
+memory::memory(std::string_view path, Loading loading) : loading_(loading) {
     ElfFile elf;
 
     elf.ReadImage(path);


### PR DESCRIPTION
### Ticket
#20608 

### What's changed
This PR fixes a dangling reference in the constructor of `ElfFile::Impl` by using `string_view` through the call stack, and then copying the string that the `string_view` points to in the constructor instead of storing a reference to the original string.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14601081896)