### PR TITLE
Force larger core grid on Shallow UNet convolution layers

### DIFF
--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-UNET_FULL_MODEL_PCC = 0.99847
+UNET_FULL_MODEL_PCC = 0.99840
 UNET_TRACE_REGION_SIZE = 483328
 
 

--- a/models/experimental/functional_unet/tests/test_unet_output_layer.py
+++ b/models/experimental/functional_unet/tests/test_unet_output_layer.py
@@ -27,8 +27,20 @@ def test_unet_output_layer(batch, groups, device, reset_seeds):
     torch_input, ttnn_input = create_unet_input_tensors(batch, groups, input_channels=16)
     torch_output = model.output_layer(torch_input)
 
-    ttnn_input = ttnn.to_device(ttnn_input, device=device)
-    ttnn_input = ttnn.to_layout(ttnn_input, ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+    # TODO: Either infer these for get them from the model implementation
+    core_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),
+            ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(6, 7)),
+        }
+    )
+    input_shard_shape = (2688, 16 * groups)
+    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+    )
+    ttnn_input = ttnn.to_device(ttnn_input, device=device, memory_config=input_memory_config)
+
     ttnn_output = ttnn_model.output_layer(ttnn_input)
     ttnn_output = ttnn_model.postprocess_output_tensor(ttnn_output)
 

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -19,7 +19,7 @@ from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_S
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1210.0),),
+    ((1, 4, 1277.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -53,7 +53,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1090.0),),
+    ((1, 4, 256, 30.0, 1145.0),),
 )
 def test_unet_trace_perf(
     batch: int,

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -19,7 +19,7 @@ from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_S
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1277.0),),
+    ((1, 4, 1358.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -53,7 +53,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 1145.0),),
+    ((1, 4, 256, 30.0, 1205.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -96,7 +96,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2160.0),)
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2400.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,

--- a/models/experimental/functional_unet/tt/model_preprocessing.py
+++ b/models/experimental/functional_unet/tt/model_preprocessing.py
@@ -57,11 +57,11 @@ def create_unet_model_parameters(
     for key in parameters.keys():
         parameters[key].module = getattr(model, key)
 
-    parameters.c1["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c1["conv_blocking_and_parallelization_config_override"] = None
     parameters.c1["use_split_reader"] = True
     parameters.c1["use_activation_double_buffer"] = True
     parameters.c1["input_channels_alignment"] = 8
-    parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c1_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
     parameters.c1_2["use_split_reader"] = True
     parameters.c1_2["use_activation_double_buffer"] = True
     parameters.c1_2["input_channels_alignment"] = 16
@@ -71,7 +71,6 @@ def create_unet_model_parameters(
     parameters.c2["use_activation_double_buffer"] = True
     parameters.c2["input_channels_alignment"] = 16
     parameters.c2_2["conv_blocking_and_parallelization_config_override"] = None
-    parameters.c2_2["use_activation_double_buffer"] = True
     parameters.c2_2["use_split_reader"] = True
     parameters.c2_2["use_activation_double_buffer"] = True
     parameters.c2_2["input_channels_alignment"] = 16
@@ -93,10 +92,10 @@ def create_unet_model_parameters(
     parameters.c4_2["input_channels_alignment"] = 16
 
     parameters.bnc["conv_blocking_and_parallelization_config_override"] = None
-    parameters.bnc["use_activation_double_buffer"] = True
+    parameters.bnc["use_activation_double_buffer"] = False
     parameters.bnc["input_channels_alignment"] = 16
     parameters.bnc_2["conv_blocking_and_parallelization_config_override"] = None
-    parameters.bnc_2["use_activation_double_buffer"] = True
+    parameters.bnc_2["use_activation_double_buffer"] = False
     parameters.bnc_2["input_channels_alignment"] = 16
 
     parameters.c5["conv_blocking_and_parallelization_config_override"] = None
@@ -122,9 +121,9 @@ def create_unet_model_parameters(
     parameters.c6_3["use_activation_double_buffer"] = True
     parameters.c6_3["input_channels_alignment"] = 16
 
-    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 2 * 32}
+    parameters.c7["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 3 * 32}
     parameters.c7["use_activation_double_buffer"] = True
-    parameters.c7["use_split_reader"] = True
+    parameters.c7["use_split_reader"] = False
     parameters.c7["input_channels_alignment"] = 16
     parameters.c7_2["conv_blocking_and_parallelization_config_override"] = None
     parameters.c7_2["use_split_reader"] = True
@@ -136,21 +135,20 @@ def create_unet_model_parameters(
     parameters.c7_3["input_channels_alignment"] = 16
 
     parameters.c8["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
-    parameters.c8["use_activation_double_buffer"] = False
-    parameters.c8["use_split_reader"] = True
+    parameters.c8["use_activation_double_buffer"] = True
+    parameters.c8["use_split_reader"] = False
     parameters.c8["input_channels_alignment"] = 8
-    parameters.c8["in_place"] = True
-    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 4 * 32}
+    parameters.c8_2["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
     parameters.c8_2["use_activation_double_buffer"] = True
     parameters.c8_2["use_split_reader"] = True
     parameters.c8_2["input_channels_alignment"] = 16
-    parameters.c8_2["in_place"] = False
-    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 8 * 32}
+    parameters.c8_3["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 12 * 32}
+
     parameters.c8_3["use_activation_double_buffer"] = True
     parameters.c8_3["use_split_reader"] = True
     parameters.c8_3["input_channels_alignment"] = 16
 
-    parameters.output_layer["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 16 * 32}
+    parameters.output_layer["conv_blocking_and_parallelization_config_override"] = {"act_block_h": 42 * 32}
     parameters.output_layer["use_activation_double_buffer"] = True
     parameters.output_layer["use_split_reader"] = True
     parameters.output_layer["input_channels_alignment"] = 16

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -132,6 +132,7 @@ class UNetConv2D:
         reshard_if_not_optimal=False,
         mesh_mapper=None,
         reallocate_halo_output=False,
+        override_core_grid=None,
     ):
         assert is_valid_device_for_unet(device), "UNet Shallow requires an 8x8 grid on all devices"
 
@@ -146,7 +147,6 @@ class UNetConv2D:
         self.stride = conv.stride
         self.groups = conv.groups
         self.use_1d_systolic_array = conv.use_1d_systolic_array
-        self.deallocate_activation = True
         self.mesh_mapper = mesh_mapper
 
         shard_layout = (
@@ -158,7 +158,7 @@ class UNetConv2D:
             dtype=activation_dtype,
             weights_dtype=weights_dtype,
             shard_layout=shard_layout,
-            deallocate_activation=self.deallocate_activation,
+            deallocate_activation=True,
             enable_act_double_buffer=(
                 conv.use_activation_double_buffer if "use_activation_double_buffer" in conv else False
             ),
@@ -168,13 +168,17 @@ class UNetConv2D:
             output_layout=output_layout,
             input_channels_alignment=conv.input_channels_alignment if "input_channels_alignment" in conv else 32,
             reshard_if_not_optimal=reshard_if_not_optimal,
-            in_place=(conv.in_place if "in_place" in conv else False),
             reallocate_halo_output=reallocate_halo_output,
         )
+
+        if override_core_grid is not None:
+            self.conv_config.core_grid = get_core_grid_from_num_cores(override_core_grid)
+            self.conv_config.override_sharding_config = True
+
         self.compute_config = ttnn.init_device_compute_kernel_config(
             device.arch(),
             math_fidelity=ttnn.MathFidelity.LoFi,
-            fp32_dest_acc_en=True,
+            fp32_dest_acc_en=False,
             packer_l1_acc=False,
         )
         config_override = conv.conv_blocking_and_parallelization_config_override
@@ -251,8 +255,17 @@ class UNetDownblock:
         pool,
         device,
         mesh_mapper=None,
+        reshard_if_not_optimal=True,
+        override_core_grid=None,
     ):
-        self.conv1 = UNetConv2D(conv1, bn=bn1, device=device, reshard_if_not_optimal=True, mesh_mapper=mesh_mapper)
+        self.conv1 = UNetConv2D(
+            conv1,
+            bn=bn1,
+            device=device,
+            reshard_if_not_optimal=reshard_if_not_optimal,
+            mesh_mapper=mesh_mapper,
+            override_core_grid=override_core_grid,
+        )
         self.conv2 = UNetConv2D(conv2, bn=bn2, device=device, mesh_mapper=mesh_mapper)
         self.pool1 = UNetMaxPool2D(pool, conv2.out_channels, device=device)
 
@@ -266,6 +279,7 @@ class UNetDownblock:
         ], f"Downblock input is shape {list(x.shape)}, expected [1,1,BHW,C]"
         x = self.conv1(x)
         x = self.conv2(x)
+        x = ttnn.move(x)
         residual = x
         x = self.pool1(x)
         return x, residual
@@ -284,6 +298,7 @@ class UNetUpblock:
         mesh_mapper=None,
         reshard=True,
         final_block=False,
+        override_core_grid=None,
     ):
         self.final_block = final_block
         self.device = device
@@ -294,7 +309,8 @@ class UNetUpblock:
             device,
             reshard_if_not_optimal=reshard,
             mesh_mapper=mesh_mapper,
-            reallocate_halo_output=reshard,
+            reallocate_halo_output=True,
+            override_core_grid=override_core_grid,
         )
         self.conv2 = UNetConv2D(conv2, bn2, device, mesh_mapper=mesh_mapper)
         self.conv3 = UNetConv2D(conv3, bn3, device, mesh_mapper=mesh_mapper)
@@ -344,22 +360,13 @@ class UNetUpblock:
         y = concatenate(x_upsampled, residual_rm, dim=-1, final_block=self.final_block)
         ttnn.deallocate(x_upsampled)
         ttnn.deallocate(residual_rm)
-
         if self.final_block:
-            y_rm = ttnn.untilize(y)
-            ttnn.deallocate(y)
+            y = ttnn.move(y)
 
-            out = self.conv1(y_rm)
-            out = self.conv2(out)
-            out = self.conv3(out)
-            return out
-        else:
-            y_re = ttnn.reallocate(y)
-
-            out = self.conv1(y_re)
-            out = self.conv2(out)
-            out = self.conv3(out)
-            return out
+        out = self.conv1(y)
+        out = self.conv2(out)
+        out = self.conv3(out)
+        return out
 
 
 class UNet:
@@ -375,6 +382,7 @@ class UNet:
             parameters.p1,
             device,
             mesh_mapper=mesh_mapper,
+            override_core_grid=63,
         )
         self.downblock2 = UNetDownblock(
             parameters.c2,
@@ -383,6 +391,7 @@ class UNet:
             parameters.b2_2,
             parameters.p2,
             device,
+            reshard_if_not_optimal=False,
             mesh_mapper=mesh_mapper,
         )
         self.downblock3 = UNetDownblock(
@@ -449,6 +458,7 @@ class UNet:
             parameters.b7_3,
             device,
             mesh_mapper=mesh_mapper,
+            override_core_grid=63,
             final_block=False,
         )
         self.upblock4 = UNetUpblock(

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -518,7 +518,7 @@ class UNet:
         output_memory_config = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, output_shard_spec
         )
-        return ttnn.experimental.convert_to_chw(x, memory_config=output_memory_config)
+        return ttnn.experimental.convert_to_chw(x, memory_config=output_memory_config, dtype=ttnn.bfloat16)
 
     def __call__(self, x, move_input_tensor_to_device=True):
         assert len(x.shape) == 4, f"Expected UNet input tensors to be rank 4 (was {len(x.shape)})"


### PR DESCRIPTION
### What's changed
This change improves Shallow UNet performance to 2400 fps end-to-end with the following change:
- Force 63 core grid on some convolution layers
- Disable split reader on compute bound convolutions
- Defragment memory to remove need for in-place halo

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14710699783
- [x] [Model perf regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14710717682
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14707922509
- [x] [Frequent model tests](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14710733466