### PR TITLE
Split go message from device command sequence

### DIFF
--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1819,13 +1819,6 @@ void assemble_device_commands(
     LaunchMessageGenerator launch_message_generator;
     launch_message_generator.construct_commands(device, program, calculator, constants, sub_device_id);
 
-    GoSignalGenerator go_signal_generator;
-    DeviceCommandCalculator go_signal_calculator;
-
-    go_signal_generator.size_commands(go_signal_calculator, device, sub_device_id, program_transfer_info);
-
-    // Start assembling commands into the device_command_sequence.
-
     program_command_sequence.device_command_sequence = HostMemDeviceCommand(calculator.write_offset_bytes());
 
     auto& device_command_sequence = program_command_sequence.device_command_sequence;
@@ -1841,6 +1834,9 @@ void assemble_device_commands(
 
     launch_message_generator.assemble_commands(program_command_sequence, device_command_sequence, constants);
 
+    GoSignalGenerator go_signal_generator;
+    DeviceCommandCalculator go_signal_calculator;
+    go_signal_generator.size_commands(go_signal_calculator, device, sub_device_id, program_transfer_info);
     program_command_sequence.go_msg_command_sequence = HostMemDeviceCommand(go_signal_calculator.write_offset_bytes());
     go_signal_generator.assemble_commands(
         program_command_sequence,

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -31,6 +31,7 @@ struct ProgramCommandSequence {
     std::vector<HostMemDeviceCommand> runtime_args_command_sequences;
     uint32_t runtime_args_fetch_size_bytes;
     HostMemDeviceCommand device_command_sequence;
+    HostMemDeviceCommand go_msg_command_sequence;
     std::vector<uint32_t*> cb_configs_payloads;
     std::vector<std::vector<std::shared_ptr<CircularBuffer>>> circular_buffers_on_core_ranges;
     // Note: some RTAs may be have their RuntimeArgsData modified so the source-of-truth of their data is the command


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Taking apart the monolithic `device_command_sequence` into smaller pieces

### What's changed
Split the go message out of the device command sequence
No impact to test_pgm_dispatch results

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14606233338
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14606233399
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14606233728
Single Card Freq
https://github.com/tenstorrent/tt-metal/actions/runs/14606233949
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14606234084
Test pgm dispatch
https://github.com/tenstorrent/tt-metal/actions/runs/14606395310