### PR TITLE
#20895: Restrict using zero copy chunking to contiguous outermost dim

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_partition.cpp
@@ -184,13 +184,13 @@ TEST(PartitionTest, ShardSpans) {
         test_data.push_back(i);
     }
 
-    auto chunks = chunk(tt::stl::Span(test_data), ttnn::Shape{1, 1, kNumChunks, kChunkSize}, kNumChunks, 2);
+    auto chunks = chunk(tt::stl::Span(test_data), ttnn::Shape{kNumChunks, kChunkSize}, kNumChunks);
 
     EXPECT_THAT(chunks, SizeIs(kNumChunks));
     for (int i = 0; i < kNumChunks; i++) {
         const auto& [chunk_span, shape] = chunks[i];
         EXPECT_THAT(chunk_span, SizeIs(kChunkSize));
-        EXPECT_EQ(shape, ttnn::Shape({1, 1, 1, kChunkSize}));
+        EXPECT_EQ(shape, ttnn::Shape({1, kChunkSize}));
         for (int j = 0; j < kChunkSize; j++) {
             EXPECT_EQ(chunk_span[j], i * kChunkSize + j);
         }
@@ -237,12 +237,12 @@ TEST(PartitionTest, ChunkDoesNotAccessData) {
     EXPECT_TRUE(segfault_occurred);
 
     if (sigsetjmp(jmp_env, /*savemask=*/1) == 0) {
-        auto chunks = chunk(protected_span, ttnn::Shape({1, 1, 1, total_size}), num_chunks, /*dim=*/3);
+        auto chunks = chunk(protected_span, ttnn::Shape({total_size}), num_chunks);
 
         EXPECT_THAT(chunks, SizeIs(num_chunks));
         for (const auto& [chunk_span, chunk_shape] : chunks) {
             EXPECT_THAT(chunk_span, SizeIs(page_size));
-            EXPECT_EQ(chunk_shape, ttnn::Shape({1, 1, 1, page_size}));
+            EXPECT_EQ(chunk_shape, ttnn::Shape({page_size}));
         }
     } else {
         FAIL() << "segfault occurred when calling `chunk`";

--- a/ttnn/cpp/ttnn/tensor/xtensor/partition.hpp
+++ b/ttnn/cpp/ttnn/tensor/xtensor/partition.hpp
@@ -19,10 +19,10 @@ std::vector<tt::tt_metal::Tensor> chunk(const tt::tt_metal::Tensor& tensor, int 
 template <typename T>
 std::vector<xt::xarray<T>> chunk(const xt::xarray<T>& tensor, int num_chunks, int dim = 0);
 
-// Overload for `tt::stl::Span` that performs zero-copy chunking.
+// Overload for `tt::stl::Span` that performs zero-copy chunking on the outermost dimension (dim = 0).
 template <typename T>
 std::vector<std::pair<tt::stl::Span<T>, ttnn::Shape>> chunk(
-    tt::stl::Span<T> span, const ttnn::Shape& shape, int num_chunks, int dim);
+    tt::stl::Span<T> span, const ttnn::Shape& shape, int num_chunks);
 
 // Concatenates a list of tensors along the specified dimension.
 tt::tt_metal::Tensor concat(const std::vector<tt::tt_metal::Tensor>& tensors, int dim = 0);


### PR DESCRIPTION
### Ticket
#20895 

### Problem description
The existing code has a problem with data that needs to be along non contiguous dimensions.

`tt::stl::Span` doesn't provide a way to express this, so at the moment disabling this until we find a convenient type that will be able to.

### What's changed
Dropped `dim` argument from `chunk` API and updated the tests accordingly.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14602657237)
- [X] New/Existing tests provide coverage for changes