### PR TITLE
Limit scope of xtensor-blas dependency

### DIFF
--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -7,6 +7,7 @@
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/compute_kernel_config.hpp"

--- a/tt-train/tests/modules/distributed/linear_test.cpp
+++ b/tt-train/tests/modules/distributed/linear_test.cpp
@@ -9,6 +9,7 @@
 
 #include <core/ttnn_all_includes.hpp>
 #include <core/xtensor_utils.hpp>
+#include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/distributed_mapping.hpp"

--- a/tt-train/tests/ttnn_fixed/matmuls_test.cpp
+++ b/tt-train/tests/ttnn_fixed/matmuls_test.cpp
@@ -9,6 +9,7 @@
 #include <core/ttnn_all_includes.hpp>
 #include <ttnn/operations/core/compute_kernel/compute_kernel_config.hpp>
 #include <ttnn/operations/reduction/generic/generic_reductions.hpp>
+#include <xtensor-blas/xlinalg.hpp>
 
 #include "autograd/auto_context.hpp"
 #include "core/device.hpp"

--- a/ttnn/cpp/ttnn/tensor/xtensor/xtensor_all_includes.hpp
+++ b/ttnn/cpp/ttnn/tensor/xtensor/xtensor_all_includes.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <xtensor-blas/xlinalg.hpp>
 #include <xtensor/xadapt.hpp>
 #include <xtensor/xarray.hpp>
 #include <xtensor/xbuffer_adaptor.hpp>


### PR DESCRIPTION
### Ticket
Inspired by @marty1885 

### Problem description
Compilation is slow.

### What's changed
xtensor-blas is a header only library used in a very small section of the code base, but it is globally included inside of ttnn/ where it is unused. `rm -rf`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14603496339) CI passes
- [x] New/Existing tests provide coverage for changes