### PR TITLE
Increase Whisper BH demo perf targets

### DIFF
--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -481,7 +481,7 @@ def test_demo_for_conditional_generation(
     )
     if is_ci_env:
         if is_blackhole():
-            expected_perf_metrics = {"prefill_t/s": 7.31, "decode_t/s/u": 67.8}
+            expected_perf_metrics = {"prefill_t/s": 7.67, "decode_t/s/u": 92.9}
         else:  # wormhole_b0
             expected_perf_metrics = {"prefill_t/s": 3.85, "decode_t/s/u": 51.8}
         expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"]  # Only supporting batch 1


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Whisper BH demo perf went up, targets need updating (same reason as https://github.com/tenstorrent/tt-metal/pull/20928, not caught before since BH demo was hanging)

### What's changed
- Updated Whisper BH ci targets

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

Blackhole demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/14604791256