### PR TITLE
Enable some compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-reorder-ctor>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-self-assign-overloaded>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-self-assign>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wno-self-move>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-shift-op-parentheses>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-lambda-capture>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-local-typedef>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-mismatched-tags>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-missing-braces>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-reorder-ctor>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wno-self-assign-overloaded>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-shift-op-parentheses>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-lambda-capture>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-local-typedef>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-missing-braces>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-reorder-ctor>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-self-assign-overloaded>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wno-self-assign>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-shift-op-parentheses>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-lambda-capture>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-local-typedef>"

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -251,9 +251,10 @@ TEST_F(DispatchFixture, TestAsyncRefCountManager) {
         /*layout=*/std::nullopt,
         *device);
     uint32_t tensor_to_self_assign_address = get_device_buffer_address(tensor_to_self_assign);
-    tensor_to_self_assign = tensor_to_self_assign;
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
 #pragma clang diagnostic ignored "-Wself-move"
+    tensor_to_self_assign = tensor_to_self_assign;
     tensor_to_self_assign = std::move(tensor_to_self_assign);
 #pragma clang diagnostic pop
     EXPECT_EQ(get_device_buffer_address(tensor_to_self_assign), tensor_to_self_assign_address);

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -252,7 +252,10 @@ TEST_F(DispatchFixture, TestAsyncRefCountManager) {
         *device);
     uint32_t tensor_to_self_assign_address = get_device_buffer_address(tensor_to_self_assign);
     tensor_to_self_assign = tensor_to_self_assign;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
     tensor_to_self_assign = std::move(tensor_to_self_assign);
+#pragma clang diagnostic pop
     EXPECT_EQ(get_device_buffer_address(tensor_to_self_assign), tensor_to_self_assign_address);
     auto barrier_tensor = tensor_to_self_assign.cpu();
     device->enable_async(false);

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -251,12 +251,16 @@ TEST_F(DispatchFixture, TestAsyncRefCountManager) {
         /*layout=*/std::nullopt,
         *device);
     uint32_t tensor_to_self_assign_address = get_device_buffer_address(tensor_to_self_assign);
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
 #pragma clang diagnostic ignored "-Wself-move"
+#endif
     tensor_to_self_assign = tensor_to_self_assign;
     tensor_to_self_assign = std::move(tensor_to_self_assign);
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
     EXPECT_EQ(get_device_buffer_address(tensor_to_self_assign), tensor_to_self_assign_address);
     auto barrier_tensor = tensor_to_self_assign.cpu();
     device->enable_async(false);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -585,8 +585,7 @@ std::vector<Tensor> ExecuteBackwardBiasGelu::invoke(
         "Incorrect rounding mode (expected 'none' or 'tanh')",
         "Error");
     Tensor input = ttnn::add(input_tensor, bias);
-    std::vector<std::optional<Tensor>> gelu_result =
-        ttnn::gelu_bw(grad, input, approximate = approximate, output_mem_config);
+    std::vector<std::optional<Tensor>> gelu_result = ttnn::gelu_bw(grad, input, approximate, output_mem_config);
     if (gelu_result[0].has_value()) {
         grad_tensor.push_back(gelu_result[0].value());
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/multi_core/rms_allgather_pf.cpp
@@ -249,7 +249,6 @@ operation::ProgramWithCallbacks frmsnorm_pre_multi_core_sharded(
     uint32_t x_CB_size = in0_block_tiles * single_tile_size;
     uint32_t xmm_CB_size = in0_block_tiles * single_tile_size;
     uint32_t ex_partial_CB_size = in0_block_tiles * single_tile_size / block_wt;
-    ex_partial_CB_size = ex_partial_CB_size;
     uint32_t ex_CB_size = ex_partial_CB_size;
     uint32_t ex_global_CB_size = ex_partial_CB_size;
     uint32_t ex_external_CB_size = tt::div_up(Kt, block_wt) * single_tile_size;
@@ -284,7 +283,6 @@ operation::ProgramWithCallbacks frmsnorm_pre_multi_core_sharded(
     if (use_two_stage_reduce) {
         ex_external_CB_size = (num_blocks_first_stage + num_blocks_second_stage - 1) * single_tile_size;
     }
-    ex_external_CB_size = ex_external_CB_size;
     uint32_t num_none_all_to_all_workers = num_blocks - num_cores_all_to_all;
 
     CoreCoord start_core = {0, 0};
@@ -1093,7 +1091,6 @@ operation::ProgramWithCallbacks frmsnorm_post_multi_core_sharded(
     uint32_t x_CB_size = in0_block_tiles * single_tile_size;
     uint32_t xmm_CB_size = in0_block_tiles * single_tile_size;
     uint32_t ex_partial_CB_size = in0_block_tiles * single_tile_size / block_wt;
-    ex_partial_CB_size = ex_partial_CB_size;
     uint32_t ex_CB_size = ex_partial_CB_size;
     uint32_t ex_global_CB_size = ex_partial_CB_size;
     uint32_t ex_external_CB_size = tt::div_up(Kt, block_wt) * single_tile_size;

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -83,7 +83,7 @@ ttnn::Tensor bound_matmul(
         post_process_bias ? std::nullopt : bias,
         parameters,
         DefaultQueueId,
-        optional_output_tensor = optional_output_tensor);
+        optional_output_tensor);
 
     if (post_process_bias) {
         output_tensor = ttnn::add(output_tensor, bias.value(), std::nullopt, parameters.output_mem_config);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -1487,7 +1487,7 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
             tt::tt_metal::CreateCircularBuffer(program, all_worker_and_storage_cores, output_reshard_cb_config);
     }
 
-    const auto& cores = corerange_to_cores(all_cores, all_cores.num_cores(), row_wise = row_wise);
+    const auto& cores = corerange_to_cores(all_cores, all_cores.num_cores(), row_wise);
 
     // Runtime Args
     std::vector<KernelHandle> writer_kernel_ids;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Compiler warnings are useful.  It's a disservice to disable them.

### What's changed
Addressed a couple warnings.