### PR TITLE
Split launch message from device command sequence

### DIFF
--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -31,6 +31,7 @@ struct ProgramCommandSequence {
     std::vector<HostMemDeviceCommand> runtime_args_command_sequences;
     uint32_t runtime_args_fetch_size_bytes;
     HostMemDeviceCommand device_command_sequence;
+    HostMemDeviceCommand launch_msg_command_sequence;
     HostMemDeviceCommand go_msg_command_sequence;
     std::vector<uint32_t*> cb_configs_payloads;
     std::vector<std::vector<std::shared_ptr<CircularBuffer>>> circular_buffers_on_core_ranges;
@@ -38,6 +39,7 @@ struct ProgramCommandSequence {
     // sequence. They won't be listed in rta_updates.
     std::vector<RtaUpdate> rta_updates;
     std::vector<launch_msg_t*> go_signals;
+    // Includes batched transfers (CB, RTA, CRTA), semaphores, and program binary
     uint32_t program_config_buffer_data_size_bytes;
     std::vector<CQDispatchWritePackedCmd*> launch_msg_write_packed_cmd_ptrs;
     std::vector<CQDispatchWritePackedCmd*> unicast_launch_msg_write_packed_cmd_ptrs;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Taking apart the monolithic `device_command_sequence` into smaller pieces

### What's changed
Split the launch message out of the device command sequence
No impact to test_pgm_dispatch results

### Checklist
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14669038260
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14669037352
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14651457945
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14669037543
Single Card TTNN and Model
https://github.com/tenstorrent/tt-metal/actions/runs/14669038011
