### PR TITLE
Start of -dev package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,9 +126,9 @@ endif()
 include(CPM)
 if(CMAKE_VERSION VERSION_LESS 3.25)
     # FIXME(14681): `SYSTEM` was introduced in v3.25; remove this when we can require v3.25
-    add_subdirectory(third_party EXCLUDE_FROM_ALL)
+    add_subdirectory(third_party)
 else()
-    add_subdirectory(third_party EXCLUDE_FROM_ALL SYSTEM)
+    add_subdirectory(third_party SYSTEM)
 endif()
 
 if(WITH_PYTHON_BINDINGS)

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -16,8 +16,10 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
 if(CMAKE_BUILD_TYPE_LOWER STREQUAL "asan" OR CMAKE_BUILD_TYPE_LOWER STREQUAL "tsan")
     set(CPACK_DEBIAN_DEBUGINFO_PACKAGE FALSE)
 else()
-    # set(CPACK_DEBIAN_DEBUGINFO_PACKAGE TRUE)
     set(CPACK_DEBIAN_METALIUM_DEBUGINFO_PACKAGE TRUE)
+    set(CPACK_DEBIAN_METALIUM-VALIDATION_DEBUGINFO_PACKAGE TRUE)
+    set(CPACK_DEBIAN_METALIUM-DEV_DEBUGINFO_PACKAGE TRUE)
+    set(CPACK_DEBIAN_METALIUM-EXAMPLES_DEBUGINFO_PACKAGE TRUE)
     set(CPACK_DEBIAN_JIT-BUILD_DEBUGINFO_PACKAGE FALSE) # Some binaries don't have a Build ID; we cannot split dbgsyms
 endif()
 
@@ -32,13 +34,36 @@ set(CPACK_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
 )
 
 set(CPACK_DEBIAN_ENABLE_COMPONENT_DEPENDS TRUE)
-set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS FALSE)
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS TRUE)
+# jit-build is cross compiling; shlibdeps does not find dependencies on the host; it should be self-contained anyway.
+set(CPACK_DEBIAN_METALIUM-JIT_PACKAGE_SHLIBDEPS FALSE)
+
+# FIXME(afuller): Sucks for Ubuntu 22.04, but I'm not about to start packaging Boost.
+set(CPACK_DEBIAN_METALIUM-DEV_PACKAGE_DEPENDS "libboost-dev (>= 1.78) | libboost1.81-dev")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${PROJECT_BINARY_DIR}/tt-metalium-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/packaging.d/tt-metalium-config.cmake.in
+    ${PROJECT_BINARY_DIR}/tt-metalium-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tt-metalium
+)
+install(
+    FILES
+        ${PROJECT_BINARY_DIR}/tt-metalium-config.cmake
+        ${PROJECT_BINARY_DIR}/tt-metalium-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tt-metalium
+    COMPONENT metalium-dev
+)
 
 get_cmake_property(CPACK_COMPONENTS_ALL COMPONENTS)
 list(
     REMOVE_ITEM
     CPACK_COMPONENTS_ALL
-    umd-dev # FIXME: -dev packages will come later
     tt_pybinds # Wow this one is big!
     tar # TODO: Remove that tarball entirely
     # Deps that define install targets that we can't (or haven't) disabled
@@ -48,13 +73,18 @@ list(
     Unspecified # TODO: audit if there's anything we need to ship here
 )
 
-# Logically we should ship jit-build with metalium-runtime, but jit-build fails to split dbgsyms for now (lacking a Build ID on the binaries)
 cpack_add_component(jit-build GROUP metalium-jit)
 
 cpack_add_component(metalium-runtime GROUP metalium)
 cpack_add_component(umd-runtime GROUP metalium)
-cpack_add_component(dev GROUP metalium) # FIXME: delete this line when we bump UMD submodule
 cpack_add_component_group(metalium)
+
+cpack_add_component(metalium-dev GROUP metalium-dev)
+cpack_add_component(fmt-core GROUP metalium-dev)
+cpack_add_component(json-dev GROUP metalium-dev)
+cpack_add_component(magic-enum-dev GROUP metalium-dev)
+cpack_add_component(umd-dev GROUP metalium-dev)
+cpack_add_component_group(metalium-dev)
 
 cpack_add_component(gtest GROUP metalium-validation)
 cpack_add_component_group(metalium-validation)

--- a/cmake/packaging.d/tt-metalium-config.cmake.in
+++ b/cmake/packaging.d/tt-metalium-config.cmake.in
@@ -1,0 +1,19 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Find all required dependencies
+find_dependency(fmt REQUIRED)
+find_dependency(nlohmann_json REQUIRED)
+find_dependency(umd REQUIRED)
+
+# Set package as found
+set(TT-@PROJECT_NAME@_FOUND TRUE)
+
+# Include the exported targets
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@.cmake")
+
+# Set the directory containing the CMake files for the project
+get_filename_component(@PROJECT_NAME@_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+message(STATUS "Found TT-@PROJECT_NAME@ at ${@PROJECT_NAME@_CMAKE_DIR}")

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -5,7 +5,7 @@ if(NOT ENABLE_TRACY)
     # Stub Tracy::TracyClient to provide the headers which themselves provide stubs
     add_library(TracyClient INTERFACE)
     add_library(Tracy::TracyClient ALIAS TracyClient)
-    target_include_directories(TracyClient SYSTEM INTERFACE ${TRACY_HOME}/public)
+    target_include_directories(TracyClient SYSTEM INTERFACE "$<BUILD_INTERFACE:${TRACY_HOME}/public>")
     return()
 endif()
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -109,20 +109,21 @@ RUN mkdir -p /tmp/json \
     && make -C /tmp/json/build install \
     && rm -rf /tmp/json
 
-ARG MAGIC_ENUM_VERSION=0.9.7
-RUN mkdir -p /tmp/magic_enum \
-    && wget -O /tmp/magic_enum/magic_enum-${MAGIC_ENUM_VERSION}.tar.gz "https://github.com/Neargye/magic_enum/archive/refs/tags/v${MAGIC_ENUM_VERSION}.tar.gz" \
-    && tar -xzf /tmp/magic_enum/magic_enum-${MAGIC_ENUM_VERSION}.tar.gz -C /tmp/magic_enum --strip-components=1 \
-    && cmake \
-         -S /tmp/magic_enum \
-         -B /tmp/magic_enum/build \
-         -DCMAKE_BUILD_TYPE=Release \
-         -DMAGIC_ENUM_OPT_BUILD_TESTS=OFF \
-         -DMAGIC_ENUM_OPT_BUILD_EXAMPLES=OFF \
-         -DMAGIC_ENUM_OPT_INSTALL=ON \
-    && make -C /tmp/magic_enum/build -j$(nproc) \
-    && make -C /tmp/magic_enum/build install \
-    && rm -rf /tmp/magic_enum
+# Problematic with packaging
+# ARG MAGIC_ENUM_VERSION=0.9.7
+# RUN mkdir -p /tmp/magic_enum \
+#     && wget -O /tmp/magic_enum/magic_enum-${MAGIC_ENUM_VERSION}.tar.gz "https://github.com/Neargye/magic_enum/archive/refs/tags/v${MAGIC_ENUM_VERSION}.tar.gz" \
+#     && tar -xzf /tmp/magic_enum/magic_enum-${MAGIC_ENUM_VERSION}.tar.gz -C /tmp/magic_enum --strip-components=1 \
+#     && cmake \
+#          -S /tmp/magic_enum \
+#          -B /tmp/magic_enum/build \
+#          -DCMAKE_BUILD_TYPE=Release \
+#          -DMAGIC_ENUM_OPT_BUILD_TESTS=OFF \
+#          -DMAGIC_ENUM_OPT_BUILD_EXAMPLES=OFF \
+#          -DMAGIC_ENUM_OPT_INSTALL=ON \
+#     && make -C /tmp/magic_enum/build -j$(nproc) \
+#     && make -C /tmp/magic_enum/build install \
+#     && rm -rf /tmp/magic_enum
 
 ARG TAKSFLOW_VERSION=3.7.0
 RUN mkdir -p /tmp/taskflow \

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,6 +3,7 @@
 # their own .clang-tidy within themselves and still not be clean against it <cough>flatbuffers</cough>
 set(CMAKE_C_CLANG_TIDY "")
 set(CMAKE_CXX_CLANG_TIDY "")
+set(DEFAULT_COMPONENT_NAME ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME})
 
 ############################################################################################################################
 # Boost
@@ -40,10 +41,18 @@ ensureboosttarget(smart_ptr)
 ensureboosttarget(interprocess)
 
 add_library(span INTERFACE)
-target_link_libraries(span INTERFACE Boost::core)
+target_link_libraries(
+    span
+    INTERFACE
+        "$<BUILD_INTERFACE:Boost::core>" # FIXME: this is a hack so we do not need to package up Boost
+)
 
 add_library(small_vector INTERFACE)
-target_link_libraries(small_vector INTERFACE Boost::container)
+target_link_libraries(
+    small_vector
+    INTERFACE
+        "$<BUILD_INTERFACE:Boost::container>" # FIXME: this is a hack so we do not need to package up Boost
+)
 
 ############################################################################################################################
 # yaml-cpp
@@ -87,14 +96,25 @@ CPMAddPackage(NAME reflect GITHUB_REPOSITORY boost-ext/reflect GIT_TAG v1.1.1)
 if(reflect_ADDED)
     add_library(reflect INTERFACE)
     add_library(Reflect::Reflect ALIAS reflect)
-    target_include_directories(reflect SYSTEM INTERFACE ${reflect_SOURCE_DIR})
+    target_include_directories(reflect SYSTEM INTERFACE "$<BUILD_INTERFACE:${reflect_SOURCE_DIR}>")
+
+    target_sources(
+        reflect
+        INTERFACE
+            FILE_SET api
+            TYPE HEADERS
+            BASE_DIRS ${reflect_SOURCE_DIR}
+            FILES ${reflect_SOURCE_DIR}/reflect
+    )
 endif()
 
 ############################################################################################################################
 # magic_enum : https://github.com/Neargye/magic_enum
 ############################################################################################################################
 
-CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.7)
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME magic-enum-dev)
+CPMAddPackage(NAME magic_enum GITHUB_REPOSITORY Neargye/magic_enum GIT_TAG v0.9.7 OPTIONS "MAGIC_ENUM_OPT_INSTALL TRUE")
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${DEFAULT_COMPONENT_NAME})
 
 ############################################################################################################################
 # fmt : https://github.com/fmtlib/fmt
@@ -127,13 +147,16 @@ CPMAddPackage(NAME pybind11 GITHUB_REPOSITORY pybind/pybind11 GIT_TAG v2.13.6 OP
 # nlohmann/json : https://github.com/nlohmann/json
 ############################################################################################################################
 
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME json-dev)
 CPMAddPackage(
     NAME nlohmann_json
     GITHUB_REPOSITORY nlohmann/json
     GIT_TAG v3.11.3
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+        "JSON_Install ON"
 )
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${DEFAULT_COMPONENT_NAME})
 
 ############################################################################################################################
 # xtensor : https://github.com/xtensor-stack/xtensor

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -5,7 +5,15 @@ if(ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 
 add_library(tt_metal)
-add_library(Metalium::Metal ALIAS tt_metal)
+add_library(TT::Metalium ALIAS tt_metal)
+add_library(Metalium::Metal ALIAS tt_metal) # For backwards compatibility
+
+set_target_properties(
+    tt_metal
+    PROPERTIES
+        EXPORT_NAME
+            Metalium
+)
 
 target_sources(
     tt_metal
@@ -13,6 +21,87 @@ target_sources(
         tt_metal.cpp
         graph/graph_tracking.cpp
         hal.cpp
+)
+target_sources(
+    tt_metal
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/api
+        FILES
+            api/tt-metalium/allocator.hpp
+            api/tt-metalium/allocator_types.hpp
+            api/tt-metalium/assert.hpp
+            api/tt-metalium/base_types.hpp
+            api/tt-metalium/bfloat16.hpp
+            api/tt-metalium/bfloat4.hpp
+            api/tt-metalium/bfloat8.hpp
+            api/tt-metalium/blockfloat_common.hpp
+            api/tt-metalium/buffer.hpp
+            api/tt-metalium/buffer_types.hpp
+            api/tt-metalium/circular_buffer.hpp
+            api/tt-metalium/circular_buffer_constants.h
+            api/tt-metalium/circular_buffer_types.hpp
+            api/tt-metalium/command_queue.hpp
+            api/tt-metalium/command_queue_common.hpp
+            api/tt-metalium/command_queue_interface.hpp
+            api/tt-metalium/constants.hpp
+            api/tt-metalium/core_coord.hpp
+            api/tt-metalium/core_descriptor.hpp
+            api/tt-metalium/data_format.hpp
+            api/tt-metalium/data_types.hpp
+            api/tt-metalium/dev_msgs.h
+            api/tt-metalium/device.hpp
+            api/tt-metalium/device_impl.hpp
+            api/tt-metalium/device_pool.hpp
+            api/tt-metalium/dispatch_core_common.hpp
+            api/tt-metalium/dispatch_settings.hpp
+            api/tt-metalium/event.hpp
+            api/tt-metalium/fabric_host_interface.h
+            api/tt-metalium/global_circular_buffer.hpp
+            api/tt-metalium/global_circular_buffer_impl.hpp
+            api/tt-metalium/global_semaphore.hpp
+            api/tt-metalium/graph_tracking.hpp
+            api/tt-metalium/hal.hpp
+            api/tt-metalium/hal_types.hpp
+            api/tt-metalium/hlk_desc.hpp
+            api/tt-metalium/host_api.hpp
+            api/tt-metalium/kernel.hpp
+            api/tt-metalium/lightmetal_binary.hpp
+            api/tt-metalium/kernel_types.hpp
+            api/tt-metalium/launch_message_ring_buffer_state.hpp
+            api/tt-metalium/logger.hpp
+            api/tt-metalium/math.hpp
+            api/tt-metalium/memory_reporter.hpp
+            api/tt-metalium/mesh_config.hpp
+            api/tt-metalium/mesh_device.hpp
+            api/tt-metalium/mesh_device_view.hpp
+            api/tt-metalium/metal_soc_descriptor.h
+            api/tt-metalium/persistent_kernel_cache.hpp
+            api/tt-metalium/program.hpp
+            api/tt-metalium/program_cache.hpp
+            api/tt-metalium/program_device_map.hpp
+            api/tt-metalium/runtime_args_data.hpp
+            api/tt-metalium/semaphore.hpp
+            api/tt-metalium/shape.hpp
+            api/tt-metalium/sub_device.hpp
+            api/tt-metalium/sub_device_manager_tracker.hpp
+            api/tt-metalium/sub_device_types.hpp
+            api/tt-metalium/system_mesh.hpp
+            api/tt-metalium/system_memory_manager.hpp
+            api/tt-metalium/system_memory_cq_interface.hpp
+            api/tt-metalium/tile.hpp
+            api/tt-metalium/trace.hpp
+            api/tt-metalium/trace_buffer.hpp
+            api/tt-metalium/tt_align.hpp
+            api/tt-metalium/tt_backend_api_types.hpp
+            api/tt-metalium/tt_memory.h
+            api/tt-metalium/tt_metal.hpp
+            api/tt-metalium/util.hpp
+            api/tt-metalium/utils.hpp
+            api/tt-metalium/work_split.hpp
+            api/tt-metalium/work_executor_types.hpp
+            api/tt-metalium/worker_config_buffer.hpp
 )
 
 # TODO(afuller): this should be self-describing modules.
@@ -284,12 +373,39 @@ endif()
 install(
     TARGETS
         tt_metal
-        jitapi
+    EXPORT Metalium
     LIBRARY
         COMPONENT metalium-runtime
+    FILE_SET
+    api
+        DESTINATION COMPONENT
+        metalium-dev
+)
+install(EXPORT Metalium NAMESPACE TT:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tt-metalium COMPONENT metalium-dev)
+
+install(
+    TARGETS
+        jitapi
     FILE_SET
     jit_api
         DESTINATION
             ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal # FIXME: fix the include paths for jit_build
         COMPONENT metalium-runtime
+)
+
+# 3rd party dependencies we export in our public API.
+# We must ship not only these libraries, but their public headers as well
+# ... or refactor our public API.
+install(
+    TARGETS
+        reflect
+        magic_enum
+        TracyClient
+        span
+        small_vector
+    EXPORT Metalium
+    FILE_SET
+    api
+        COMPONENT metalium-dev
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/metalium-thirdparty
 )

--- a/tt_metal/hostdevcommon/CMakeLists.txt
+++ b/tt_metal/hostdevcommon/CMakeLists.txt
@@ -1,31 +1,39 @@
 add_library(ttmetalium_hostdevcommon INTERFACE)
 add_library(TT::Metalium::HostDevCommon ALIAS ttmetalium_hostdevcommon)
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
-    target_sources(
+target_sources(
+    ttmetalium_hostdevcommon
+    PUBLIC
+        FILE_SET jit_api
+        TYPE HEADERS
+        BASE_DIRS api
+        FILES
+            api/hostdevcommon/common_values.hpp
+            api/hostdevcommon/dprint_common.h
+            api/hostdevcommon/kernel_structs.h
+            api/hostdevcommon/profiler_common.h
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS api
+        FILES
+            api/hostdevcommon/common_values.hpp
+            api/hostdevcommon/dprint_common.h
+            api/hostdevcommon/kernel_structs.h
+            api/hostdevcommon/profiler_common.h
+)
+
+target_include_directories(ttmetalium_hostdevcommon INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api>")
+
+install(
+    TARGETS
         ttmetalium_hostdevcommon
-        PUBLIC
-            FILE_SET jit_api
-            TYPE HEADERS
-            BASE_DIRS api
-            FILES
-                api/hostdevcommon/common_values.hpp
-                api/hostdevcommon/dprint_common.h
-                api/hostdevcommon/kernel_structs.h
-                api/hostdevcommon/profiler_common.h
-    )
-endif()
-
-target_include_directories(ttmetalium_hostdevcommon INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/api)
-
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.23)
-    install(
-        TARGETS
-            ttmetalium_hostdevcommon
-        FILE_SET
-        jit_api
-            DESTINATION
-                ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/hostdevcommon/api # FIXME: fix the include paths for jit_build
-            COMPONENT metalium-runtime
-    )
-endif()
+    EXPORT Metalium
+    FILE_SET
+    jit_api
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal/hostdevcommon/api # FIXME: fix the include paths for jit_build
+        COMPONENT metalium-runtime
+    FILE_SET
+    api
+        COMPONENT metalium-dev
+)

--- a/tt_metal/programming_examples/CMakeLists.txt
+++ b/tt_metal/programming_examples/CMakeLists.txt
@@ -35,3 +35,14 @@ add_custom_target(
         contributed
         ${PROGRAMMING_EXAMPLES_TEST_TARGETS}
 )
+
+install(
+    DIRECTORY
+        hello_world_compute_kernel
+    # DESTINATION ${CMAKE_INSTALL_DOCDIR}/examples
+    # FIXME(afuller): Something funky is happening when installing files into /usr/share/doc on a default Docker image.
+    #                 Speculation: some dependency for magic doc handling is missing.
+    #                 For now keep it out of 'doc'.
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/tt-metalium/examples"
+    COMPONENT metalium-examples
+)

--- a/tt_metal/programming_examples/hello_world_compute_kernel/CMakeLists.txt
+++ b/tt_metal/programming_examples/hello_world_compute_kernel/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.22...3.30)
+project(metal_example_hello_world_compute_kernel)
+
+add_executable(metal_example_hello_world_compute_kernel)
+target_sources(metal_example_hello_world_compute_kernel PRIVATE hello_world_compute_kernel.cpp)
+
+find_package(TT-Metalium REQUIRED)
+target_link_libraries(metal_example_hello_world_compute_kernel PUBLIC TT::Metalium)

--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -1,10 +1,14 @@
 add_library(tt_stl INTERFACE)
 add_library(TT:STL ALIAS tt_stl)
 
+# FIXME: TT-STL should support down to C++17 (so that TT-Metalium can), but we have headers (eg: <reflect>) in our
+#        public API that is pushing C++20 on consumers
+target_compile_features(tt_stl INTERFACE cxx_std_20)
+
 target_sources(
     tt_stl
     INTERFACE
-        FILE_SET tt_stl
+        FILE_SET api
         TYPE HEADERS
         BASE_DIRS .
         FILES
@@ -31,3 +35,5 @@ target_link_libraries(
         magic_enum::magic_enum
         nlohmann_json::nlohmann_json
 )
+
+install(TARGETS tt_stl EXPORT Metalium FILE_SET api COMPONENT metalium-dev)


### PR DESCRIPTION
### Ticket
#7915

### Problem description
We have no easy way for projects to consume TT-Metalium.  TT-NN is lucky that it builds in the same tree.  But customers do not and should not.  Also other external projects like TT-Forge.  Current workarounds are brittle and painful.

### What's changed
The rough-in of a -dev package.

What it does:
* Builds a .deb package for TT-Metalium SDK
* Builds a .deb package for TT-Metalium examples
* Able to build hello_world_compute_kernel in a clean Ubuntu 22.04 container.
What it does not:
* Not yet functional (waiting for https://github.com/tenstorrent/tt-umd/pull/777 ).
* Only tested for _building_ one hello kernel example; have not exercised running it, or building others.  Will expand in follow-ups.
* Exercised this in CI.  Can't do that until the UMD fix reaches TT-Metalium.