### PR TITLE
Changed FAKE_DEVICE envvar to MESH_DEVICE for consistency nomenclature across TG tt-metal and vLLM

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -27,14 +27,14 @@ jobs:
           {
             name: "Llama TG Accuracy Test",
             arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_llama_accuracy.py",
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ MESH_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_llama_accuracy.py",
             timeout: 25,
             owner_id: U071CKL4AFK
           }, # Ammar Vora
           {
             name: "Llama TG Demo Long Generation Test",
             arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k mini-stress-test",
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ MESH_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k mini-stress-test",
             timeout: 40,
             owner_id: U044T8U8DEF
           }, # Johanna Rock

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -543,7 +543,7 @@ def run_llama3_demo(
 # sampling_params (dict): Sampling parameters for decoding (temperature, top_p). If temperature is set to 0, argmax (greedy decode) is used.
 #
 # optimization (LlamaOptimizations): Optimization level to use for the model (performance or accuracy)
-# FAKE_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export FAKE_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
+# MESH_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export MESH_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
 @pytest.mark.parametrize(
     "weights, layers, input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stress_test, start_pos",
     [
@@ -682,7 +682,7 @@ def test_llama_demo(
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
     # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
+    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
     mesh_device.enable_async(True)

--- a/models/demos/llama3_subdevices/demo/demo_performance.py
+++ b/models/demos/llama3_subdevices/demo/demo_performance.py
@@ -426,7 +426,7 @@ def run_llama3_decode_performance(
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,
@@ -465,7 +465,7 @@ def test_llama_decode_performance(
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
     # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
+    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
     mesh_device.enable_async(True)

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -309,7 +309,7 @@ def test_llama_demo(
         pytest.skip("Do not run the 'long-context' or accuracy tests on CI to reduce load")
 
     # TODO: Remove this once all batch sizes are supported on TG
-    if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
+    if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
     mesh_device.enable_async(True)
@@ -478,7 +478,7 @@ def print_dict(input_dict, dict_name):
 
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
+# Run MESH_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
 # Copy the printed kernel_duration_per_instance_averaged_dict and dispatch_duration_per_instance_averaged_dict dictionaries
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?
@@ -742,7 +742,7 @@ def test_llama_TG_perf_device(
 
 @pytest.mark.models_device_performance_bare_metal
 # To update:
-# Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
+# Run MESH_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 TT_METAL_KERNELS_EARLY_RETURN=1  pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch
 # Copy the printed dispatch_duration_per_instance_averaged_dict dictionary
 # Manually compare each entry between old-expected and the new average values
 # - Any perf regressions? Everything as expected?

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -65,7 +65,7 @@ def get_accuracy_thresholds(model_name: str, device_name: str, optimizations: Ll
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -29,7 +29,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -20,7 +20,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_llama_embedding.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_embedding.py
@@ -23,7 +23,7 @@ from models.demos.llama3_subdevices.tt.llama_common import HostEmbedding
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/test_lm_head.py
+++ b/models/demos/llama3_subdevices/tests/test_lm_head.py
@@ -33,7 +33,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -34,7 +34,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
@@ -29,7 +29,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
@@ -29,7 +29,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -25,7 +25,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
@@ -25,7 +25,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
@@ -25,7 +25,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
     "mesh_device",
     [
         {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
-            os.environ.get("FAKE_DEVICE"), len(ttnn.get_device_ids())
+            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
         )
     ],
     indirect=True,

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -177,6 +177,10 @@ class TtModelArgs:
         if self.num_devices == 32:
             self.use_prefetcher = True
 
+        assert not os.getenv(
+            "FAKE_DEVICE"
+        ), "FAKE_DEVICE has been renamed to MESH_DEVICE for consistency with vLLM, please update your environment variables and run again."
+
         # Set up prefetcher stuff
         _, _, _, self.pf_receiver_cores_list, _, _, _, _ = get_core_ranges(12, 2, False)
 

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -13,9 +13,9 @@ run_tg_llama3_tests() {
   # Run all Llama3 tests for 1B, 3B, 8B, 11B and 70B weights
   # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 1000; fail+=$?;
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "repeat" --timeout 1000; fail+=$?;
-    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "long" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 MESH_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 MESH_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "repeat" --timeout 1000; fail+=$?;
+    LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 MESH_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "long" --timeout 1000; fail+=$?;
 
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done

--- a/tests/scripts/tg/run_tg_frequent_tests.sh
+++ b/tests/scripts/tg/run_tg_frequent_tests.sh
@@ -13,8 +13,8 @@ run_tg_llama3_tests() {
   # Run all Llama3 tests for 8B, 1B, and 3B weights
   # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
-    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model_nd.py --timeout=1800 ; fail+=$?
-    LLAMA_DIR=$llama_dir FAKE_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model.py -k full --timeout=1800 ; fail+=$?
+    LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model_nd.py --timeout=1800 ; fail+=$?
+    LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest --timeout 1800 -n auto models/demos/llama3_subdevices/tests/test_llama_model.py -k full --timeout=1800 ; fail+=$?
     echo "LOG_METAL: Llama3 tests for $llama_dir completed"
   done
 

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -36,10 +36,10 @@ run_tg_llama_70b_model_perf_tests() {
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 
   # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
+  TT_METAL_ENABLE_ERISC_IRAM=1 MESH_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
 
   # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
+  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 MESH_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
 
   # # Merge all the generated reports
   # env python3 models/perf/merge_perf_results.py; fail+=$?

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -11,7 +11,7 @@ run_tg_llama3.1-70b_tests() {
   # Llama3.1-70B weights
   llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
 
-  LLAMA_DIR=$llama70b FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/tests/unit_tests ; fail+=$?
+  LLAMA_DIR=$llama70b MESH_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/tests/unit_tests ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)


### PR DESCRIPTION
The TG codebase still uses the old `FAKE_DEVICE=TG` envvar to setup the mesh device to the galaxy system. 
On TT-Transformers and vLLM this has been substituted for `MESH_DEVICE` for a better description.

This change adds consistency and avoids having to import both `FAKE_DEVICE` and `MESH_DEVICE` when running full TG vLLM demos.