### PR TITLE
#20877: Update BN with hash function

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -16,6 +16,7 @@ struct BatchNormOperation {
 
         DataType input_dtype;
         std::optional<DataType> dtype;
+        tt::stl::hash::hash_t to_hash() const;
         DataType get_dtype() const;
     };
 
@@ -61,6 +62,7 @@ struct BatchNormOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input,
         const Tensor& batch_mean,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20877

### Problem description
While enabling program cache for the Pytorch project, `ttnn.batch_norm` gives low PCC while testing followed by `ttnn.floor_divide`

### What's changed
Added the missing hash function solved this and also tested the program that caused the issue

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14663485397) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14663486662) CI passes
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14663487929) CI passes as in main
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14663489433)  CI passes as in main
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/runs/14663491169)  CI passes as in main