### PR TITLE
Add support for uneven shards in `ttnn.upsample` for mode=`nearest`

### DIFF
--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
-UNET_FULL_MODEL_PCC = 0.99840
+UNET_FULL_MODEL_PCC = 0.99847
 UNET_TRACE_REGION_SIZE = 483328
 
 

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -19,7 +19,7 @@ from models.experimental.functional_unet.tests.common import UNET_TRACE_REGION_S
 @pytest.mark.models_device_performance_bare_metal
 @pytest.mark.parametrize(
     "batch, groups, expected_device_perf_fps",
-    ((1, 4, 1125.0),),
+    ((1, 4, 1210.0),),
 )
 def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: float):
     command = f"pytest models/experimental/functional_unet/tests/test_unet_model.py::test_unet_model[device_params0-{groups}-{batch}]"
@@ -53,7 +53,7 @@ def test_unet_perf_device(batch: int, groups: int, expected_device_perf_fps: flo
 )
 @pytest.mark.parametrize(
     "batch, groups, iterations, expected_compile_time, expected_throughput",
-    ((1, 4, 256, 30.0, 975.0),),
+    ((1, 4, 256, 30.0, 1090.0),),
 )
 def test_unet_trace_perf(
     batch: int,
@@ -99,7 +99,7 @@ def test_unet_trace_perf(
     "batch, groups, iterations, expected_compile_time, expected_throughput, use_async_mode",
     (
         (1, 4, 256, 30.0, 1500.0, True),  # Model using trace+2CQ is slower with async mode enabled (#16985)
-        (1, 4, 256, 30.0, 1920.0, False),
+        (1, 4, 256, 30.0, 2160.0, False),
     ),
 )
 def test_unet_trace_perf_multi_device(

--- a/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
+++ b/models/experimental/functional_unet/tt/unet_shallow_ttnn.py
@@ -313,9 +313,7 @@ class UNetUpblock:
             x.shape, core_grid, ttnn.ShardStrategy.HEIGHT, orientation=ttnn.ShardOrientation.ROW_MAJOR
         )
 
-        if x.is_sharded():
-            x = ttnn.reshard(x, shardspec)
-        else:
+        if not x.is_sharded():
             x = ttnn.interleaved_to_sharded(x, shardspec)
 
         upsampled = ttnn.upsample(x, (2, 2), memory_config=x.memory_config())

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp
@@ -6,20 +6,20 @@
 #include "dataflow_api.h"
 
 void kernel_main() {
-    uint32_t stick_nbytes = get_arg_val<uint32_t>(0);
-    uint32_t in_nsticks_per_core = get_arg_val<uint32_t>(1);
-    uint32_t scale_h = get_arg_val<uint32_t>(2);
-    uint32_t scale_w = get_arg_val<uint32_t>(3);
-
     constexpr uint32_t in_cb_id = get_compile_time_arg_val(0);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t is_reader = get_compile_time_arg_val(2);
     constexpr uint32_t config_cb_id = get_compile_time_arg_val(3);
 
-    uint32_t reader_nsticks_per_core = (in_nsticks_per_core + is_reader) / 2;
-    uint32_t out_nsticks_per_core = reader_nsticks_per_core * scale_h * scale_w;
-    uint32_t image_row_begin = is_reader ? 0 : reader_nsticks_per_core;
-    uint32_t image_row_end = is_reader ? reader_nsticks_per_core : in_nsticks_per_core;
+    constexpr uint32_t stick_nbytes = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nsticks_per_core = get_compile_time_arg_val(5);
+    constexpr uint32_t scale_h = get_compile_time_arg_val(6);
+    constexpr uint32_t scale_w = get_compile_time_arg_val(7);
+
+    constexpr uint32_t reader_nsticks_per_core = (in_nsticks_per_core + is_reader) / 2;
+    constexpr uint32_t out_nsticks_per_core = reader_nsticks_per_core * scale_h * scale_w;
+    constexpr uint32_t image_row_begin = is_reader ? 0 : reader_nsticks_per_core;
+    constexpr uint32_t image_row_end = is_reader ? reader_nsticks_per_core : in_nsticks_per_core;
     uint32_t l1_read_addr = get_read_ptr(in_cb_id);
     uint32_t l1_write_addr = get_write_ptr(out_cb_id) + image_row_begin * scale_h * scale_w * stick_nbytes;
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -2,13 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include <vector>
-
-#include <math.h>
 
 #include "upsample_op.hpp"
 #include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
@@ -58,7 +56,7 @@ static Tensor create_config_tensor(
     }
 
     std::vector<uint16_t> logical_core_to_stick_map;
-    size_t logical_core_to_stick_map_entry_size = 3;
+    const size_t logical_core_to_stick_map_entry_size = 3;
     size_t row_size = logical_core_to_stick_map_entry_size * in_w;
     // Create map of core and respective offsets in input
     for (uint32_t b = 0; b < batch_size; ++b) {
@@ -85,7 +83,31 @@ static Tensor create_config_tensor(
         }
     }
 
+    /* Each entry in config_vector contains 2 elements:
+     * {{core_coords.x, core_coords.y}, stick_offset(in input_cb)}
+     * - core_coords.x: X coordinate of the core
+     * - core_coords.y: Y coordinate of the core
+     * - stick_offset: Offset within the input circular buffer
+     */
     std::vector<uint16_t> config_vector;
+
+    const uint32_t config_buffer_entry_size = 2;
+    const uint32_t elems_per_core = config_buffer_entry_size * scale_factor_h * input_nsticks_per_core;
+
+    // In case last input shard is not full, fill the rest of the config vector with the last two elements
+    const auto pad_uneven_shards = [elems_per_core, config_buffer_entry_size](
+                                       auto& config_vector, size_t slice_begin = 0) {
+        const uint32_t slice_length = config_vector.size() - slice_begin;
+        const uint32_t remainder = (elems_per_core - (slice_length % elems_per_core)) % elems_per_core;
+        if (remainder != 0) {
+            uint16_t before_last = config_vector[config_vector.size() - 2];
+            uint16_t last = config_vector[config_vector.size() - 1];
+            for (int i = 0; i < remainder / config_buffer_entry_size; i++) {
+                config_vector.push_back(before_last);
+                config_vector.push_back(last);
+            }
+        }
+    };
 
     // Based on core calculate physical location of cores
     CoreCoord core_coords;
@@ -94,30 +116,32 @@ static Tensor create_config_tensor(
             core_coords = device->worker_core_from_logical_core(
                 CoreCoord(logical_core_to_stick_map[j], logical_core_to_stick_map[j + 1]));
             // Combine the x and y coordinates of the core into a single 16-bit value.
-            uint16_t cores = (core_coords.x << 8) + core_coords.y;
+            const uint16_t cores = (core_coords.x << 8) + core_coords.y;
             config_vector.push_back(cores);
             config_vector.push_back(logical_core_to_stick_map[j + 2]);
         }
+        pad_uneven_shards(config_vector);
     } else {
         for (size_t i = ch_start_core; i <= ch_end_core; i++) {
+            const size_t chan_slice_begin = config_vector.size();
             for (size_t j = 0; j < logical_core_to_stick_map.size(); j += logical_core_to_stick_map_entry_size) {
                 core_coords = device->worker_core_from_logical_core(CoreCoord(i, logical_core_to_stick_map[j]));
                 // Combine the x and y coordinates of the core into a single 16-bit value.
-                uint16_t cores = (core_coords.x << 8) + core_coords.y;
+                const uint16_t cores = (core_coords.x << 8) + core_coords.y;
                 config_vector.push_back(cores);
                 config_vector.push_back(logical_core_to_stick_map[j + 2]);
             }
+            pad_uneven_shards(config_vector, chan_slice_begin);
         }
     }
-    /* Each entry in config_vector contains 2 elements:
-     * {{core_coords.x, core_coords.y}, stick_offset(in input_cb)}
-     * - core_coords.x: X coordinate of the core
-     * - core_coords.y: Y coordinate of the core
-     * - stick_offset: Offset within the input circular buffer
-     */
-    const uint32_t config_buffer_entry_size = 2;
-    uint32_t elems_per_core = config_buffer_entry_size * scale_factor_h * input_nsticks_per_core;
-    ttnn::Shape config_shape({config_vector.size() / elems_per_core, elems_per_core});
+
+    TT_FATAL(
+        config_vector.size() % elems_per_core == 0,
+        "Config vector size {} should be multiple of {}",
+        config_vector.size(),
+        elems_per_core);
+
+    ttnn::Shape config_shape({tt::div_up(config_vector.size(), elems_per_core), elems_per_core});
     auto config_buffer = owned_buffer::create<uint16_t>(std::move(config_vector));
     return Tensor(OwnedStorage{config_buffer}, config_shape, DataType::UINT16, Layout::ROW_MAJOR);
 }
@@ -130,18 +154,17 @@ operation::ProgramWithCallbacks upsample_multi_core(
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
 
-    // NOTE: input is assumed to have channels last format: {N, H, W, C}, {N, 1, H * W, C}, {1, 1, N * H * W, C}
-    // NOTE: Bfp8_b/TILE is not yet supported
+    TT_FATAL(
+        input.get_logical_shape()[-1] == output.logical_shape()[-1], "Expected input and output channels to match");
+    TT_FATAL(
+        input.get_layout() == tt_metal::Layout::ROW_MAJOR,
+        "Only row-major layout is currently supported in nearest upsample");
 
     uint32_t input_stick_nbytes = input.get_padded_shape()[-1] * input.element_size();
     uint32_t output_stick_nbytes = output.get_padded_shape()[-1] * output.element_size();
     TT_FATAL(input_stick_nbytes == output_stick_nbytes, "Input and output sticks should have same size");
 
-    uint32_t output_nsticks = output.volume() / output.get_padded_shape()[-1];
-    uint32_t input_nsticks = input.volume() / input.get_padded_shape()[-1];
-
     uint32_t in_w = input.get_padded_shape()[2];
-    uint32_t out_w = output.get_padded_shape()[2];
 
     auto shard_spec = input.shard_spec().value();
     auto all_cores = shard_spec.grid;
@@ -156,8 +179,6 @@ operation::ProgramWithCallbacks upsample_multi_core(
         out_shard_spec.num_cores(),
         ncores);
 
-    uint32_t in_nsticks_per_core = shard_spec.shape[0];
-
     if (input.memory_config().memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
         TT_THROW("Unsupported sharding layout");
     }
@@ -170,24 +191,14 @@ operation::ProgramWithCallbacks upsample_multi_core(
         output_stick_nbytes = output_stick_nbytes / ncores_x;
     }
 
-    uint32_t input_nsticks_per_core = div_up(input_nsticks, ncores_nhw);
-    uint32_t output_nsticks_per_core = div_up(output_nsticks, ncores_nhw);
+    const uint32_t input_nsticks_per_core = shard_spec.shape[0];
+    const uint32_t output_nsticks_per_core = input_nsticks_per_core * scale_factor_h * scale_factor_w;
 
-    // TODO: Support non-multiple case
-    TT_FATAL(
-        in_nsticks_per_core == input_nsticks_per_core,
-        "Input sticks per shard {} should be same as input sticks per core {}",
-        in_nsticks_per_core,
-        input_nsticks_per_core);
-
-    // CBs
-
-    uint32_t buffering_factor = 1;  // data is already fully buffered in the CBs since its sharded
     uint32_t next_cb_index = CBIndex::c_0;
-    // input data is in a sharded CB
-    uint32_t aligned_input_stick_nbytes = round_up_to_mul32(input_stick_nbytes);
-    uint32_t in_cb_pagesize = aligned_input_stick_nbytes;
-    uint32_t in_cb_npages = input_nsticks_per_core * buffering_factor;
+    const uint32_t buffering_factor = 1;  // data is already fully buffered in the CBs since its sharded
+    const uint32_t aligned_input_stick_nbytes = round_up_to_mul32(input_stick_nbytes);
+    const uint32_t in_cb_pagesize = aligned_input_stick_nbytes;
+    const uint32_t in_cb_npages = input_nsticks_per_core * buffering_factor;
 
     auto [in_cb_id, cb_src0] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, in_cb_pagesize, in_cb_npages, input_cb_data_format, input.buffer());
@@ -248,71 +259,25 @@ operation::ProgramWithCallbacks upsample_multi_core(
         out_cb_id,
         false,
         config_cb_id,
-    };
-    auto writer_kernel_fname = std::string(
-        "ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp");
+        input_stick_nbytes,
+        input_nsticks_per_core,
+        scale_factor_h,
+        scale_factor_w};
+    std::string writer_kernel_fname =
+        "ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp";
     auto writer_kernel =
         CreateKernel(program, writer_kernel_fname, all_cores, WriterDataMovementConfig(writer_compile_time_args));
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        in_cb_id,
-        out_cb_id,
-        true,
-        config_cb_id,
-    };
-    auto reader_kernel_fname = std::string(
-        "ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp");
+    std::vector<uint32_t> reader_compile_time_args = writer_compile_time_args;
+    reader_compile_time_args[2] = true;  // reader
+
+    std::string reader_kernel_fname =
+        "ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/writer_upsample_multi_core_sharded.cpp";
     auto reader_kernel =
         CreateKernel(program, reader_kernel_fname, all_cores, ReaderDataMovementConfig(reader_compile_time_args));
 
-    // no compute kernel
-
-    // runtime args
-
-    uint32_t writer_nargs = 7;
-    std::vector<uint32_t> writer_rt_args(writer_nargs);
-    writer_rt_args[0] = input_stick_nbytes;
-    writer_rt_args[1] = input_nsticks_per_core;
-    writer_rt_args[2] = scale_factor_h;
-    writer_rt_args[3] = scale_factor_w;
-
-    uint32_t start_input_stick_id = 0;
-    if (input.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {
-        uint16_t ch_start_core = 0, ch_end_core = 0, nhw_start_core = 0, nhw_end_core = 0;
-        if (shard_spec.orientation == ShardOrientation::ROW_MAJOR) {
-            ch_start_core = all_cores.ranges().begin()->start_coord.x;
-            ch_end_core = all_cores.ranges().begin()->end_coord.x;
-            nhw_start_core = all_cores.ranges().begin()->start_coord.y;
-            nhw_end_core = all_cores.ranges().begin()->end_coord.y;
-        } else {
-            ch_start_core = all_cores.ranges().begin()->start_coord.y;
-            ch_end_core = all_cores.ranges().begin()->end_coord.y;
-            nhw_start_core = all_cores.ranges().begin()->start_coord.x;
-            nhw_end_core = all_cores.ranges().begin()->end_coord.x;
-        }
-        for (int32_t core = nhw_start_core; core <= nhw_end_core; ++core) {
-            for (int32_t core_x = ch_start_core; core_x <= ch_end_core; ++core_x) {
-                CoreCoord core_coord(core_x, core);  // logical
-                writer_rt_args[6] = start_input_stick_id;
-                SetRuntimeArgs(program, writer_kernel, core_coord, writer_rt_args);
-                SetRuntimeArgs(program, reader_kernel, core_coord, writer_rt_args);
-            }
-            start_input_stick_id += input_nsticks_per_core;
-        }
-    } else if (input.memory_config().memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
-        auto cores = corerange_to_cores(all_cores);
-        for (auto core : cores) {
-            writer_rt_args[6] = start_input_stick_id;
-            SetRuntimeArgs(program, writer_kernel, core, writer_rt_args);
-            SetRuntimeArgs(program, reader_kernel, core, writer_rt_args);
-            start_input_stick_id += input_nsticks_per_core;
-        }
-    } else {
-        TT_THROW("Unsupported memory layout");
-    }
-
-    // Capture config_storage to cache this with the program
-    auto override_runtime_args_callback = [writer_kernel, cb_src0, out_cb, config_cb, config_storage](
+    // Capture config_buffer to cache this with the program
+    auto override_runtime_args_callback = [writer_kernel, cb_src0, out_cb, config_cb, config_storage, config_buffer](
                                               const void* operation,
                                               Program& program,
                                               const std::vector<Tensor>& input_tensors,


### PR DESCRIPTION
### Problem description
The existing upsample op did not support using uneven shards, which was restricting the sets of valid core grids for any particular input shape

### What's changed
- Add "dummy" transfers to the final core config tensor when the final core contains padding due to uneven shards
- Add tests cases covering uneven shards
- Shallow UNet N300 performance improved to 2170 fps 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14622815981
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes https://github.com/tenstorrent/tt-metal/actions/runs/14622992088
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14622823540
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14622818584
- [x] Frequent model and ttnn tests https://github.com/tenstorrent/tt-metal/actions/runs/14622821407
- [x] New/Existing tests provide coverage for changes