### PR TITLE
[skip ci] Add TG demo to choose your own TG pipeline

### DIFF
--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -25,6 +25,10 @@ on:
         required: false
         type: boolean
         default: false
+      tg-demo:
+        required: false
+        type: boolean
+        default: false
       tg-unit:
         required: false
         type: boolean
@@ -76,6 +80,15 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/tg-frequent-tests-impl.yaml
+    with:
+      extra-tag: ${{ inputs.extra-tag }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  tg-demo-tests:
+    if: ${{ inputs.tg-demo }}
+    needs: build-artifact
+    uses: ./.github/workflows/tg-demo-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -60,6 +60,7 @@ jobs:
   tg-quick:
     if: ${{ inputs.tg-quick }}
     needs: build-artifact
+    secrets: inherit
     uses: ./.github/workflows/tg-quick.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
@@ -69,6 +70,7 @@ jobs:
   tg-unit-tests:
     if: ${{ inputs.tg-unit }}
     needs: build-artifact
+    secrets: inherit
     uses: ./.github/workflows/tg-unit-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}
@@ -88,6 +90,7 @@ jobs:
   tg-demo-tests:
     if: ${{ inputs.tg-demo }}
     needs: build-artifact
+    secrets: inherit
     uses: ./.github/workflows/tg-demo-tests-impl.yaml
     with:
       extra-tag: ${{ inputs.extra-tag }}


### PR DESCRIPTION
### Ticket
Ask from https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1745274026984479

### Problem description
TG demo was missing from Choose Your Own TG pipeline

### What's changed
Added TG demo checkbox

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes