### PR TITLE
Filter out wheel without the + because that seems to be an older thing, I guess

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -176,7 +176,7 @@ jobs:
         with:
           name: changelog
       - name: Assert wheels exist
-        run: ls -arhl ttnn-*+*.whl
+        run: ls -arhl ttnn-*.whl
       - name: Release
         # A major release has not been tagged yet, so we need to do this to avoid
         # Node 16 deprecation warning message


### PR DESCRIPTION
…

### Ticket

Emergency fix to fix package and release pipeline. Looks like the `+` qualifier isn't there anymore in the wheel name. 

https://github.com/tenstorrent/tt-metal/actions/runs/14623859876/job/41031275891

### Problem description
Looks like the `+` qualifier isn't there anymore in the wheel name.  So detecting the wheel failed.

### What's changed

Just use one `*`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes