### PR TITLE
Disallow 2D sharding over submeshes

### DIFF
--- a/ttnn/ttnn/distributed/distributed.py
+++ b/ttnn/ttnn/distributed/distributed.py
@@ -279,7 +279,7 @@ class ShardTensor2dMesh(TensorToMesh):
         self.dims: Tuple[Optional[int], Optional[int]] = dims
 
         mesh_device_rows, mesh_device_cols = self.mesh_device.shape
-        if mesh_shape[0] > mesh_device_rows or mesh_shape[1] > mesh_device_cols:
+        if mesh_shape[0] != mesh_device_rows or mesh_shape[1] != mesh_device_cols:
             raise ValueError("ShardTensor2dMesh: Device mesh shape does not match the provided mesh shape.")
 
     def map(self, tensor: "torch.Tensor") -> List["torch.Tensor"]:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
If this functionality isn't needed, it is best to remove, for simplicity. This PR attempts this.

### What's changed
Add a check that the passed mesh shape matches device shape.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14626336231)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14626343294)
- [ ] TG tests