### PR TITLE
tt_transformets/tt/attention: Fix typo

### DIFF
--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -343,7 +343,7 @@ class Attention(LightweightModule):
             memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
             program_config=self.model_config["XQKV_DECODE_PROGCFG"],
             compute_kernel_config=self.li_qkv_decode_compute_kernel_cfg,
-            dtype=xself.ccl_dtype if self.TG else self.activation_dtype or ttnn.bfloat16,
+            dtype=self.ccl_dtype if self.TG else self.activation_dtype or ttnn.bfloat16,
         )
         # FIXME: File bug against dram-sharded matmuls with bias
         if self.wqkv_bias_decode:


### PR DESCRIPTION
### Problem description
Small typo in `tt_transformets/tt/attention.py` introduced in https://github.com/tenstorrent/tt-metal/pull/20643
It seems that this code-path is not tested in the post-commit tests

### What's changed
This PR fixes this typo