### PR TITLE
#0: [skip ci] Raise blackhole post commit fd test timeout to 40m

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
     secrets: inherit
     with:
-      timeout: 20
+      timeout: 40
       arch: blackhole
       runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}


### PR DESCRIPTION
### Ticket
None

### Problem description
In p100a VM testing, eager 6 tests are timing out, not hanging
https://github.com/tenstorrent/tt-metal/actions/runs/14624759914/job/41037927035

### What's changed
Bump timeout to 40m (eager 6 test on VM takes 25m, bump to 40m to have a good enough buffer)

### Checklist
- [ ] New/Existing tests provide coverage for changes