### PR TITLE
#0: Don't fail generate-system-logs action

### DIFF
--- a/.github/actions/generate-system-logs/action.yml
+++ b/.github/actions/generate-system-logs/action.yml
@@ -14,9 +14,10 @@ runs:
       run: |
         echo "HOSTNAME=$(hostname)" >> $GITHUB_ENV
         echo "TIMESTAMP=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
-    - name: Determine Docker Tag to use
+    - name: Generate System Logs
       shell: bash
       run: |
+        set +e
         rm -rf ~/run-log
         mkdir -p ~/run-log/
         sudo dmesg > ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_dmesg.log

--- a/.github/actions/generate-system-logs/action.yml
+++ b/.github/actions/generate-system-logs/action.yml
@@ -25,7 +25,9 @@ runs:
         sudo lshw > ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_lshw.log
     - name: 'Tar files'
       shell: bash
-      run: tar -cvf ~/run-log/sys_logs.tar ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_*
+      run: |
+        set +e
+        tar -cvf ~/run-log/sys_logs.tar ~/run-log/${{ env.TIMESTAMP}}_${{ env.HOSTNAME }}_*
     - name: 'Upload Artifact'
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -97,7 +97,7 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: /work/.github/actions/generate-system-logs
+        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
         if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -97,7 +97,7 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: ./.github/actions/generate-system-logs
+        uses: /work/.github/actions/generate-system-logs
         if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -105,7 +105,7 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: /work/.github/actions/generate-system-logs
+        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
         if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -105,7 +105,7 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: ./.github/actions/generate-system-logs
+        uses: /work/.github/actions/generate-system-logs
         if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -80,7 +80,7 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: /work/.github/actions/generate-system-logs
+        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
         if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -80,7 +80,7 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: ./.github/actions/generate-system-logs
+        uses: /work/.github/actions/generate-system-logs
         if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -83,5 +83,5 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: /work/.github/actions/generate-system-logs
+        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
         if: ${{ failure() }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -83,5 +83,5 @@ jobs:
         with:
           prefix: "test_reports_"
       - name: Generate system logs on failure
-        uses: ./.github/actions/generate-system-logs
+        uses: /work/.github/actions/generate-system-logs
         if: ${{ failure() }}


### PR DESCRIPTION
### Ticket
None

### Problem description

Below error causes the action to fail.
```
dmesg: read kernel buffer failed: Operation not permitted
Error: Process completed with exit code 1.
```
This makes looking at failed jobs slightly annoying because the action failure is the most recent error, and the log will open that step by default instead of the test failure
E.g. https://github.com/tenstorrent/tt-metal/actions/runs/14626776163/job/41047901224 

Also seeing in newly provisioned machines running the containerized flows:
https://github.com/tenstorrent/tt-metal/actions/runs/14627550388/job/41044407810#step:8:1
```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/ubuntu/actions-runner/_work/tt-metal/tt-metal/.github/actions/generate-system-logs'. Did you forget to run actions/checkout before running your local action?
```
This seems to imply the current method of running the action inadvertently uses a (possibly stale) checked out copy on the `action-runners` dir, and not the one checked out in the container.

### What's changed
Add `set +e` to ignore the system log commands if they fail and proceed to the next command.
Use repo path to action due to running inside container.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes