### PR TITLE
Remove legacy Async Mode APIs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -405,19 +405,6 @@ def use_program_cache(request):
 
 
 @pytest.fixture(scope="function")
-def enable_async_mode(request):
-    devices = get_devices(request)
-    if not devices:
-        logger.warning("No device fixture found to apply async mode to: ASYNC MODE DISABLED")
-
-    for dev in devices:
-        dev.enable_async(request.param)
-    yield request.param
-    for dev in devices:
-        dev.enable_async(False)
-
-
-@pytest.fixture(scope="function")
 def tracy_profile():
     from tracy import Profiler
 

--- a/models/demos/blackhole/resnet50/demo/demo.py
+++ b/models/demos/blackhole/resnet50/demo/demo.py
@@ -62,7 +62,6 @@ def test_demo_trace_with_imagenet(
     act_dtype,
     weight_dtype,
     model_location_generator,
-    enable_async_mode=True,
 ):
     test_run_resnet50_trace_2cqs_inference(
         mesh_device,
@@ -72,6 +71,5 @@ def test_demo_trace_with_imagenet(
         imagenet_label_dict,
         act_dtype,
         weight_dtype,
-        enable_async_mode,
         model_location_generator,
     )

--- a/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/blackhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -46,14 +46,11 @@ def test_perf(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 5554176}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
+    "batch_size, expected_inference_time, expected_compile_time",
     (
-        (16, True, 0.002, 30),
-        (16, False, 0.002, 30),
-        (32, True, 0.0034, 30),
-        (32, False, 0.0034, 30),
+        (16, 0.002, 30),
+        (32, 0.0034, 30),
     ),
-    indirect=["enable_async_mode"],
 )
 def test_perf_trace(
     device,
@@ -62,17 +59,15 @@ def test_perf_trace(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         device,
-        f"resnet50_trace_{mode}",
+        f"resnet50_trace",
         model_location_generator,
     )
 

--- a/models/demos/blackhole/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/blackhole/resnet50/tests/test_resnet50_performant.py
@@ -34,7 +34,6 @@ def test_run_resnet50_inference(
     "act_dtype, weight_dtype, math_fidelity",
     ((ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_inference(
     device,
     use_program_cache,
@@ -42,7 +41,6 @@ def test_run_resnet50_trace_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_inference(
@@ -77,7 +75,6 @@ def test_run_resnet50_2cqs_inference(
     "act_dtype, weight_dtype, math_fidelity",
     ((ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
     device,
     use_program_cache,
@@ -85,7 +82,6 @@ def test_run_resnet50_trace_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_2cqs_inference(

--- a/models/demos/blackhole/resnet50/tests/test_resnet50_performant_imagenet.py
+++ b/models/demos/blackhole/resnet50/tests/test_resnet50_performant_imagenet.py
@@ -27,7 +27,6 @@ from models.utility_functions import (
         (32, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),
     ),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
     device,
     use_program_cache,
@@ -36,7 +35,6 @@ def test_run_resnet50_trace_2cqs_inference(
     imagenet_label_dict,
     act_dtype,
     weight_dtype,
-    enable_async_mode,
     model_location_generator,
 ):
     batch_size = batch_size_per_device * device.get_num_devices()

--- a/models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py
+++ b/models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py
@@ -26,7 +26,6 @@ from models.utility_functions import is_wormhole_b0
         "decode_2048_l1_sharded",
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)  # Option to run Falcon in Async mode
 @pytest.mark.parametrize("mesh_device", (1,), indirect=True)
 def test_perplexity(
     llm_mode,
@@ -37,7 +36,6 @@ def test_perplexity(
     expected_ppl,
     expected_top1,
     expected_top5,
-    enable_async_mode,
     model_location_generator,
     get_tt_cache_path,
     mesh_device,

--- a/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
+++ b/models/demos/falcon7b_common/tests/run_falcon_end_to_end.py
@@ -120,7 +120,6 @@ def run_test_FalconCausalLM_end_to_end(
     e2e_perf=False,
     expected_inference_time=None,
     device_perf=False,
-    async_mode=False,
 ):
     assert not (e2e_perf and device_perf), "Cannot run both e2e and device perf test at the same time"
     if e2e_perf:
@@ -398,7 +397,7 @@ def run_test_FalconCausalLM_end_to_end(
     if e2e_perf:
         profiler.print()
 
-        comment = f"num_devices={num_devices}_kv_cache_len={kv_cache_len}_seq_len={seq_len}_num_layers={num_layers}_config={model_config_str}_async={async_mode}"
+        comment = f"num_devices={num_devices}_kv_cache_len={kv_cache_len}_seq_len={seq_len}_num_layers={num_layers}_config={model_config_str}"
         cpu_time = profiler.get("hugging_face_reference_model")
         first_iter_time = profiler.get("first_model_run_with_compile")
         second_iter_time = profiler.get("model_run_for_inference")

--- a/models/demos/falcon7b_common/tests/test_falcon_attention.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_attention.py
@@ -158,7 +158,6 @@ def run_test_FalconAttention_inference(
 
 
 @pytest.mark.parametrize("mesh_device", (1, 2, 4, (8, 4)), indirect=True, ids=["1chip", "2chip", "4chip", "32chipTG"])
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -185,7 +184,6 @@ def test_FalconAttention_inference(
     model_location_generator,
     get_tt_cache_path,
     mesh_device,
-    enable_async_mode,
 ):
     if model_config_str == "BFLOAT16-L1_SHARDED" and llm_mode == "prefill":
         pytest.skip(f"prefill does not support L1_SHARDED")

--- a/models/demos/falcon7b_common/tests/test_falcon_causallm.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_causallm.py
@@ -187,7 +187,6 @@ def run_test_FalconCausalLM_inference(
 
 
 @pytest.mark.parametrize("mesh_device", (1, 2, 4, (8, 4)), indirect=True, ids=["1chip", "2chip", "4chip", "32chipTG"])
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -222,7 +221,6 @@ def test_FalconCausalLM_inference(
     model_location_generator,
     get_tt_cache_path,
     mesh_device,
-    enable_async_mode,
 ):
     if model_config_str == "BFLOAT16-L1_SHARDED" and llm_mode == "prefill":
         pytest.skip(f"prefill does not support L1_SHARDED")

--- a/models/demos/falcon7b_common/tests/test_falcon_decoder.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_decoder.py
@@ -147,7 +147,6 @@ def run_test_FalconDecoder_inference(
 
 
 @pytest.mark.parametrize("mesh_device", (1, 2, 4, (8, 4)), indirect=True, ids=["1chip", "2chip", "4chip", "32chipTG"])
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -175,7 +174,6 @@ def test_FalconDecoder_inference(
     model_location_generator,
     get_tt_cache_path,
     mesh_device,
-    enable_async_mode,
 ):
     if model_config_str == "BFLOAT16-L1_SHARDED" and llm_mode == "prefill":
         pytest.skip(f"prefill does not support L1_SHARDED")

--- a/models/demos/falcon7b_common/tests/test_falcon_mlp.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_mlp.py
@@ -99,7 +99,6 @@ def run_test_FalconMLP_inference(
 
 
 @pytest.mark.parametrize("mesh_device", (1, 2, 4, (8, 4)), indirect=True, ids=["1chip", "2chip", "4chip", "32chipTG"])
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "model_version, llm_mode, batch, seq_len, pcc",
     (
@@ -145,7 +144,6 @@ def test_FalconMLP_inference(
     model_location_generator,
     get_tt_cache_path,
     mesh_device,
-    enable_async_mode,
 ):
     model_config = get_model_config(model_config_str, seq_len, batch)
     tt_cache_path = get_tt_cache_path(

--- a/models/demos/falcon7b_common/tests/test_falcon_model.py
+++ b/models/demos/falcon7b_common/tests/test_falcon_model.py
@@ -181,7 +181,6 @@ def run_test_FalconModel_inference(
 
 
 @pytest.mark.parametrize("mesh_device", (1, 2, 4, (8, 4)), indirect=True, ids=["1chip", "2chip", "4chip", "32chipTG"])
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "llm_mode, batch, seq_len, kv_cache_len",
     (
@@ -213,7 +212,6 @@ def test_FalconModel_inference(
     model_location_generator,
     get_tt_cache_path,
     mesh_device,
-    enable_async_mode,
 ):
     if model_config_str == "BFLOAT16-L1_SHARDED" and llm_mode == "prefill":
         pytest.skip(f"prefill does not support L1_SHARDED")

--- a/models/demos/falcon7b_common/tests/test_perf_falcon.py
+++ b/models/demos/falcon7b_common/tests/test_perf_falcon.py
@@ -126,7 +126,6 @@ class TestParametrized:
         model_location_generator,
         get_tt_cache_path,
         mesh_device,
-        async_mode,
     ):
         if model_config_str == "BFLOAT16-L1_SHARDED" and llm_mode == "prefill":
             pytest.skip(f"prefill does not support L1_SHARDED")
@@ -153,7 +152,6 @@ class TestParametrized:
             model_location_generator,
             e2e_perf=True,
             expected_inference_time=expected_inference_time,
-            async_mode=async_mode,
         )
 
     @pytest.mark.models_performance_bare_metal
@@ -188,7 +186,6 @@ class TestParametrized:
             "decode_batch32_2047_bf16_l1_sharded",
         ],
     )
-    @pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True, ids=["noasync", "async"])
     @pytest.mark.parametrize("mesh_device", (1,), indirect=True)
     @skip_for_grayskull()
     def test_perf_wh_bare_metal(
@@ -205,14 +202,7 @@ class TestParametrized:
         get_tt_cache_path,
         mesh_device,
         use_program_cache,
-        enable_async_mode,
     ):
-        if enable_async_mode:
-            if llm_mode == "decode" and not (kv_cache_len == 2047):
-                pytest.skip(
-                    f"Skipping {llm_mode} with {kv_cache_len} in async mode. Config is supported but provides redundant testing."
-                )
-
         if llm_mode == "prefill":
             expected_output_pcc, expected_k_cache_pcc, expected_v_cache_pcc = PREFILL_CONFIG_TO_PCC[
                 DeviceSetup.WORMHOLE_B0
@@ -235,27 +225,19 @@ class TestParametrized:
             model_location_generator,
             get_tt_cache_path,
             mesh_device,
-            enable_async_mode,
         )
 
     @pytest.mark.model_perf_t3000
     @pytest.mark.parametrize(
-        "llm_mode, mesh_device, num_layers, batch, seq_len, kv_cache_len, model_config_str, expected_inference_time, enable_async_mode",
+        "llm_mode, mesh_device, num_layers, batch, seq_len, kv_cache_len, model_config_str, expected_inference_time",
         (
-            ("prefill", 4, 32, 1, 128, 0, "BFLOAT16-DRAM", 0.071, False),
-            ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.142, False),
-            ("prefill", 4, 32, 1, 1024, 0, "BFLOAT16-DRAM", 0.42, False),
-            ("prefill", 4, 32, 1, 2048, 0, "BFLOAT16-DRAM", 1.02, False),
-            ("decode", 4, 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.067, False),
-            ("decode", 4, 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.069, False),
-            ("decode", 4, 32, 32, 1, 2047, "BFLOAT16-L1_SHARDED", 0.073, False),
-            ("prefill", 4, 32, 1, 128, 0, "BFLOAT16-DRAM", 0.070, True),  # Issue 9422
-            ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.142, True),
-            ("prefill", 4, 32, 1, 1024, 0, "BFLOAT16-DRAM", 0.41, True),
-            ("prefill", 4, 32, 1, 2048, 0, "BFLOAT16-DRAM", 0.98, True),
-            ("decode", 4, 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.059, True),
-            ("decode", 4, 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.065, True),
-            ("decode", 4, 32, 32, 1, 2047, "BFLOAT16-L1_SHARDED", 0.071, True),
+            ("prefill", 4, 32, 1, 128, 0, "BFLOAT16-DRAM", 0.070),
+            ("prefill", 4, 32, 1, 256, 0, "BFLOAT16-DRAM", 0.142),
+            ("prefill", 4, 32, 1, 1024, 0, "BFLOAT16-DRAM", 0.41),
+            ("prefill", 4, 32, 1, 2048, 0, "BFLOAT16-DRAM", 0.98),
+            ("decode", 4, 32, 32, 1, 128, "BFLOAT16-L1_SHARDED", 0.059),
+            ("decode", 4, 32, 32, 1, 1024, "BFLOAT16-L1_SHARDED", 0.065),
+            ("decode", 4, 32, 32, 1, 2047, "BFLOAT16-L1_SHARDED", 0.071),
         ),
         ids=[
             "prefill_seq128",
@@ -265,15 +247,8 @@ class TestParametrized:
             "decode_batch32_128",
             "decode_batch32_1024",
             "decode_batch32_2047",
-            "prefill_seq128_async",
-            "prefill_seq256_async",
-            "prefill_seq1024_async",
-            "prefill_seq2048_async",
-            "decode_batch32_128_async",
-            "decode_batch32_1024_async",
-            "decode_batch32_2047_async",
         ],
-        indirect=["mesh_device", "enable_async_mode"],
+        indirect=["mesh_device"],
     )
     @skip_for_grayskull()
     def test_perf_t3000_bare_metal(
@@ -285,7 +260,6 @@ class TestParametrized:
         seq_len,
         kv_cache_len,
         expected_inference_time,
-        enable_async_mode,
         num_layers,
         model_config_str,
         model_location_generator,
@@ -314,5 +288,4 @@ class TestParametrized:
             model_location_generator,
             get_tt_cache_path,
             mesh_device,
-            enable_async_mode,
         )

--- a/models/demos/falcon7b_common/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
+++ b/models/demos/falcon7b_common/tests/unit_tests/test_falcon_matmuls_and_bmms_with_mixed_precision.py
@@ -484,19 +484,16 @@ def test_falcon7b_attnention_sliced(
 @pytest.mark.parametrize("seq_len", [128, 1024, 2048], ids=["seq_len_128", "seq_len_1024", "seq_len_2048"])
 @pytest.mark.parametrize("num_cores", [64])
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="non-determinstic hang, see issue #5882")
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_falcon7b_attention_softmax_sequence(
     device,
     seq_len,
     num_cores,
-    async_mode,
     use_program_cache,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-    device.enable_async(async_mode)
     grid_size = (8, 8)
     num_heads = 64
 

--- a/models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/grayskull/resnet50/tests/test_perf_e2e_resnet50.py
@@ -40,12 +40,8 @@ def test_perf(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1332224}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    (
-        (20, True, 0.0068, 20),
-        (20, False, 0.0068, 20),
-    ),
-    indirect=["enable_async_mode"],
+    "batch_size, expected_inference_time, expected_compile_time",
+    ((20, 0.0068, 20)),
 )
 def test_perf_trace(
     device,
@@ -54,17 +50,15 @@ def test_perf_trace(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         device,
-        f"resnet50_trace_{mode}",
+        f"resnet50_trace",
         model_location_generator,
     )
 

--- a/models/demos/grayskull/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/grayskull/resnet50/tests/test_resnet50_performant.py
@@ -30,7 +30,6 @@ def test_run_resnet50_inference(device, batch_size, act_dtype, weight_dtype, mat
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     ((20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_inference(
     device,
     use_program_cache,
@@ -38,7 +37,6 @@ def test_run_resnet50_trace_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_inference(
@@ -71,7 +69,6 @@ def test_run_resnet50_2cqs_inference(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     ((20, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
     device,
     use_program_cache,
@@ -79,7 +76,6 @@ def test_run_resnet50_trace_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_2cqs_inference(

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -685,8 +685,6 @@ def test_llama_demo(
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
-    mesh_device.enable_async(True)
-
     if paged_attention:
         paged_attention_config = PagedAttentionConfig(
             block_size=page_params["page_block_size"],

--- a/models/demos/llama3_subdevices/demo/demo_performance.py
+++ b/models/demos/llama3_subdevices/demo/demo_performance.py
@@ -468,8 +468,6 @@ def test_llama_decode_performance(
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
-    mesh_device.enable_async(True)
-
     if paged_attention:
         paged_attention_config = PagedAttentionConfig(
             block_size=page_params["page_block_size"],

--- a/models/demos/llama3_subdevices/demo/text_demo.py
+++ b/models/demos/llama3_subdevices/demo/text_demo.py
@@ -309,7 +309,6 @@ def test_demo_text(
     if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [32]:
         pytest.skip("Llama TG only supports batch-32")
 
-    mesh_device.enable_async(True)
     enable_trace = True  # Use tracing for better perf
     prefill_enable_trace = repeat_batches > 1
     print_to_file = False  # Enable this flag to print the output of all users to a file

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -312,8 +312,6 @@ def test_llama_demo(
     if os.environ.get("FAKE_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
-    mesh_device.enable_async(True)
-
     if paged_attention:
         paged_attention_config = PagedAttentionConfig(
             block_size=page_params["page_block_size"],

--- a/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_accuracy.py
@@ -129,8 +129,6 @@ def test_tt_model_acc(
 
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     # Load model args and tokenizer
     model_args = TtModelArgs(
         mesh_device, optimizations=optimizations, max_batch_size=batch_size, max_seq_len=max_seq_len, instruct=True

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder.py
@@ -79,7 +79,6 @@ def test_llama_decoder_inference(
     ensure_gc,
 ):
     dtype = ttnn.bfloat8_b
-    mesh_device.enable_async(True)
 
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len, dummy_weights=False)
     model_args.n_layers = 1

--- a/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_decoder_nd.py
@@ -54,7 +54,6 @@ def test_llama_decoder_same(
 ):
     dtype = ttnn.bfloat8_b
     seqlen = 1
-    mesh_device.enable_async(True)
 
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len, dummy_weights=True)
     model_args.n_layers = 1

--- a/models/demos/llama3_subdevices/tests/test_llama_embedding.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_embedding.py
@@ -39,7 +39,6 @@ from models.demos.llama3_subdevices.tt.llama_common import HostEmbedding
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_llama_embedding(max_seq_len, batch_size, mesh_device, use_program_cache, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat16
-    mesh_device.enable_async(True)
 
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1

--- a/models/demos/llama3_subdevices/tests/test_llama_model.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model.py
@@ -98,7 +98,7 @@ def test_llama_model_inference(
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
     cache_pcc = layers == 1  # Flag to measure KV cache PCC. Avoid running for all layers to speed up test time.
     dtype = ttnn.bfloat8_b
-    mesh_device.enable_async(True)
+
     mode_accuracy = optimizations == LlamaOptimizations.accuracy
     instruct = True if weights == "instruct" else False
     dummy_weights = True if weights == "random" else False

--- a/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
+++ b/models/demos/llama3_subdevices/tests/test_llama_model_nd.py
@@ -84,7 +84,6 @@ def test_llama_model_inference(
     ensure_gc,
 ):
     dtype = ttnn.bfloat8_b
-    mesh_device.enable_async(True)
     mode_accuracy = optimizations == LlamaOptimizations.accuracy
     instruct = True
     dummy_weights = True

--- a/models/demos/llama3_subdevices/tests/test_lm_head.py
+++ b/models/demos/llama3_subdevices/tests/test_lm_head.py
@@ -46,8 +46,6 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 def test_llama_lm_head_inference(seq_len, batch_size, mesh_device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=seq_len, dummy_weights=True)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention.py
@@ -74,8 +74,6 @@ def test_llama_attention_inference(
     dtype = ttnn.bfloat8_b
     pcc = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device, dummy_weights=True, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1  # For the unit test, just run a sigle layer
 

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_attention_prefill.py
@@ -76,8 +76,6 @@ def test_llama_attention_inference(
     pcc = 0.99
     batch_size = 1  # For prefill we only support batch_size = 1
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1
     model_args.use_prefetcher = False

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_decoder_prefill.py
@@ -73,8 +73,6 @@ def test_llama_decoder_inference(
     dtype = ttnn.bfloat8_b
     batch_size = 1  # For prefill we only support batch_size = 1
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.use_prefetcher = False
 

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp.py
@@ -47,8 +47,6 @@ def test_llama_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache
     dtype = ttnn.bfloat8_b
     mode = "decode" if seq_len <= 32 else "prefill"
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, dummy_weights=False, max_seq_len=128)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
@@ -47,8 +47,6 @@ def test_llama_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache
     dtype = ttnn.bfloat8_b
     mode = "decode" if seq_len <= 32 else "prefill"
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, dummy_weights=False, max_seq_len=128)
     model_args.n_layers = 1
     model_args.use_prefetcher = False

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
@@ -91,8 +91,6 @@ def test_llama_model_inference(
         assert optimizations == LlamaOptimizations.performance
         pcc = 0.869  # TODO Look on improving PCC
 
-    mesh_device.enable_async(True)
-
     # Use instruct weights instead of general weights
     instruct = True
 

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_rms_norm.py
@@ -59,8 +59,6 @@ def test_llama_rms_norm_inference(
 ):
     dtype = ttnn.bfloat16
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len, dummy_weights=True)
 
     model_args.n_layers = 1

--- a/models/demos/qwen/demo/demo.py
+++ b/models/demos/qwen/demo/demo.py
@@ -697,8 +697,6 @@ def test_qwen_demo(
     if is_ci_env and (instruct_weights == False or "long" in input_prompts or single_layer == True):
         pytest.skip("CI demo test only runs instruct weights to reduce CI pipeline load (both are supported)")
 
-    mesh_device.enable_async(True)
-
     return run_qwen_demo(
         user_input=input_prompts,
         batch_size=1,

--- a/models/demos/qwen/tests/test_lm_head.py
+++ b/models/demos/qwen/tests/test_lm_head.py
@@ -36,8 +36,6 @@ def test_qwen_lm_head_inference(mesh_device, seq_len, use_program_cache, reset_s
         pytest.skip("Only N150 is supported")
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/qwen/tests/test_qwen_attention.py
+++ b/models/demos/qwen/tests/test_qwen_attention.py
@@ -37,8 +37,6 @@ def test_qwen_attention_inference(mesh_device, use_program_cache, reset_seeds, e
     dtype = ttnn.bfloat8_b
     pcc = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/qwen/tests/test_qwen_decoder.py
+++ b/models/demos/qwen/tests/test_qwen_decoder.py
@@ -36,8 +36,6 @@ def test_qwen_decoder_inference(mesh_device, use_program_cache, reset_seeds, ens
         pytest.skip("Only N150 is supported")
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/qwen/tests/test_qwen_embedding.py
+++ b/models/demos/qwen/tests/test_qwen_embedding.py
@@ -33,8 +33,6 @@ def test_qwen_embedding(mesh_device, use_program_cache, reset_seeds, ensure_gc):
         pytest.skip("Only N150 is supported")
     dtype = ttnn.bfloat16
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/qwen/tests/test_qwen_mlp.py
+++ b/models/demos/qwen/tests/test_qwen_mlp.py
@@ -43,8 +43,6 @@ def test_qwen_mlp_inference(mesh_device, seq_len, use_program_cache, reset_seeds
     dtype = ttnn.bfloat8_b
     mode = "decode" if seq_len <= 32 else "prefill"
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/qwen/tests/test_qwen_model.py
+++ b/models/demos/qwen/tests/test_qwen_model.py
@@ -54,8 +54,6 @@ def test_qwen_model_inference(mesh_device, weights, layers, use_program_cache, r
 
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     # This sets the minimum PCC for each iteration
     pcc = 0.79
 

--- a/models/demos/qwen/tests/test_qwen_perf.py
+++ b/models/demos/qwen/tests/test_qwen_perf.py
@@ -43,8 +43,6 @@ if not os.getenv("CI") == "true":  # Enable tracy signpost support in local runs
 def test_qwen_model_perf(mesh_device, kv_cache_len, expected_compile_time, use_program_cache, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device)
     tokenizer = Tokenizer(model_args.tokenizer_path)
 

--- a/models/demos/qwen/tests/test_qwen_rms_norm.py
+++ b/models/demos/qwen/tests/test_qwen_rms_norm.py
@@ -34,8 +34,6 @@ def test_qwen_rms_norm_inference(mesh_device, use_program_cache, reset_seeds, en
         pytest.skip("Only N150 is supported")
     dtype = ttnn.bfloat16
 
-    mesh_device.enable_async(True)
-
     model_args = TtModelArgs(mesh_device)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_1_layer_t3000.py
@@ -62,10 +62,6 @@ from models.utility_functions import (
         ),
     ),
 )
-@pytest.mark.parametrize(
-    "async_mode",
-    (True,),
-)
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,
@@ -81,7 +77,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     get_tt_cache_path,
     t3k_mesh_device,
     use_program_cache,
-    async_mode,
 ):
     model_config_str = f"{data_type}-{memcfg}"
     if llm_mode == "prefill" and memcfg != "DRAM" or num_devices != 8:
@@ -96,7 +91,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    t3k_mesh_device.enable_async(async_mode)
     compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
+++ b/models/demos/t3000/falcon40b/tests/ci/test_falcon_end_to_end_60_layer_t3000_prefill_10_loops.py
@@ -58,10 +58,6 @@ from models.utility_functions import (
         ),
     ),
 )
-@pytest.mark.parametrize(
-    "async_mode",
-    (True,),
-)
 def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     model_version,
     seq_len,
@@ -73,7 +69,6 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     get_tt_cache_path,
     t3k_mesh_device,
     use_program_cache,
-    async_mode,
 ):
     num_devices = 8
     llm_mode = "prefill"
@@ -87,7 +82,6 @@ def test_FalconCausalLM_prefill_end_to_end_t3000_ci_loops_10(
     input_shape = [batch, seq_len]
     model_config_str = f"{data_type}-{memcfg}"
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    t3k_mesh_device.enable_async(async_mode)
     compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon40b/tests/test_demo.py
+++ b/models/demos/t3000/falcon40b/tests/test_demo.py
@@ -17,7 +17,6 @@ def test_demo_generate_reference_output(
         pytest.skip("Skip generating reference output in CI")
 
     input_file = "models/demos/t3000/falcon40b/demo/input_data.json"
-    t3k_mesh_device.enable_async(True)
 
     generated_text, measurements = run_falcon_demo_kv(
         user_input=input_file,
@@ -49,7 +48,6 @@ def test_demo(
     use_program_cache,
 ):
     input_file = "models/demos/t3000/falcon40b/demo/input_data.json"
-    t3k_mesh_device.enable_async(True)
 
     generated_text, measurements = run_falcon_demo_kv(
         user_input=input_file,

--- a/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
+++ b/models/demos/t3000/falcon40b/tests/test_falcon_end_to_end.py
@@ -439,10 +439,6 @@ def run_test_FalconCausalLM_end_to_end(
         ),
     ),
 )
-@pytest.mark.parametrize(
-    "async_mode",
-    (True,),
-)
 def test_FalconCausalLM_end_to_end_with_program_cache(
     num_devices,
     model_version,
@@ -458,7 +454,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     get_tt_cache_path,
     t3k_mesh_device,
     use_program_cache,
-    async_mode,
 ):
     model_config_str = f"{data_type}-{memcfg}"
     if llm_mode == "prefill" and memcfg != "DRAM" or num_devices != 8:
@@ -519,8 +514,6 @@ def test_FalconCausalLM_end_to_end_with_program_cache(
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
     devices = t3k_mesh_device.get_devices()
-    # Set async mode
-    t3k_mesh_device.enable_async(async_mode)
     compute_grid_size = devices[0].compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
+++ b/models/demos/t3000/falcon40b/tests/test_perf_falcon.py
@@ -345,10 +345,6 @@ def run_test_FalconCausalLM_end_to_end(
     ("tiiuae/falcon-40b-instruct",),
     ids=["falcon_40b"],
 )
-@pytest.mark.parametrize(
-    "async_mode",
-    (True,),
-)
 def test_perf_bare_metal(
     num_devices,
     model_version,
@@ -366,7 +362,6 @@ def test_perf_bare_metal(
     t3k_mesh_device,
     use_program_cache,
     is_ci_env,
-    async_mode,
 ):
     if llm_mode == "prefill" and (model_config_str not in ["BFLOAT8_B-DRAM", "BFLOAT16-DRAM"] or num_devices != 8):
         pytest.skip("Prefill is only supported for DRAM memory config and 8 chips!")
@@ -375,7 +370,6 @@ def test_perf_bare_metal(
 
     input_shape = [batch, seq_len]
     model_config = get_model_config(model_config_str, llm_mode, input_shape, num_devices)
-    t3k_mesh_device.enable_async(async_mode)
     compute_grid_size = t3k_mesh_device.compute_with_storage_grid_size()
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")

--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -32,7 +32,6 @@ from models.utility_functions import is_wormhole_b0
         "default_mode_1024_stochastic",
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)  # Option to run Falcon in Async mode
 @pytest.mark.parametrize("mesh_device", (1, 2, 3, 4, 5, 6, 7, 8), indirect=True)
 def test_demo_multichip(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
@@ -45,7 +44,6 @@ def test_demo_multichip(
     get_tt_cache_path,
     mesh_device,
     use_program_cache,
-    enable_async_mode,
     is_ci_env,
 ):
     num_devices = mesh_device.get_num_devices()

--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -455,8 +455,6 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    t3k_mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching.py
@@ -371,8 +371,6 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    t3k_mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
+++ b/models/demos/t3000/llama2_70b/demo/demo_continuous_batching_paged_attention.py
@@ -410,8 +410,6 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    t3k_mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/t3000/llama2_70b/demo/eval.py
+++ b/models/demos/t3000/llama2_70b/demo/eval.py
@@ -378,8 +378,6 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    t3k_mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/t3000/llama2_70b/demo/eval_t3000.py
+++ b/models/demos/t3000/llama2_70b/demo/eval_t3000.py
@@ -184,8 +184,6 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    t3k_mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/t3000/llama2_70b/tests/test_chunked_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_chunked_generation.py
@@ -158,7 +158,6 @@ def test_chunked_prefill_single_user(
 
     # Check device compatibility
     check_mesh_device(t3k_mesh_device, model_config)
-    t3k_mesh_device.enable_async(True)
 
     # Create args
     model_args = ModelArgs(
@@ -325,7 +324,6 @@ def test_batch_prefill(t3k_mesh_device, llama_version, num_layers, max_batch_siz
 
     # Check device compatibility
     check_mesh_device(t3k_mesh_device, model_config)
-    t3k_mesh_device.enable_async(True)
 
     # Create args
     model_args = ModelArgs(

--- a/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_generation.py
@@ -133,7 +133,6 @@ def test_LlamaModel_inference(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    t3k_mesh_device.enable_async(True)
     t3k_mesh_device.enable_program_cache()
 
     args = construct_arg(

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf.py
@@ -306,7 +306,6 @@ def test_Llama_perf_host(
     if compute_grid_size.x < model_config["MAX_GRID_SIZE"][0] or compute_grid_size.y < model_config["MAX_GRID_SIZE"][1]:
         pytest.skip(f"Requires grid size of at least {model_config['MAX_GRID_SIZE']} to run")
 
-    t3k_mesh_device.enable_async(True)
     t3k_mesh_device.enable_program_cache()
 
     run_test_LlamaModel_end_to_end(

--- a/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
+++ b/models/demos/t3000/llama2_70b/tests/test_llama_perf_decode.py
@@ -224,8 +224,6 @@ def test_Llama_perf_host(
 
     check_mesh_device(mesh_device, model_config)
 
-    mesh_device.enable_async(True)
-
     run_test_LlamaModel_end_to_end(
         mesh_device,
         llama_version,
@@ -432,7 +430,6 @@ def test_Llama_perf_hybrid_data_tensor_parallel(
     )
 
     check_mesh_device(mesh_device, model_config)
-    mesh_device.enable_async(True)
 
     run_test_LlamaModel_end_to_end_hybrid_data_tensor_parallel(
         mesh_device,

--- a/models/demos/t3000/llama3_70b/demo/demo.py
+++ b/models/demos/t3000/llama3_70b/demo/demo.py
@@ -99,8 +99,6 @@ def test_LlamaModel_demo(
 
     check_mesh_device(t3k_mesh_device, model_config)
 
-    t3k_mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         ckpt_dir=ckpt_dir,

--- a/models/demos/t3000/mixtral8x7b/demo/demo.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo.py
@@ -271,8 +271,6 @@ def test_mixtral8x7b_demo(t3k_mesh_device, use_program_cache, input_prompts, ins
     if is_ci_env and instruct_weights == True:
         pytest.skip("CI demo test only runs general weights to reduce CI pipeline load (both are supported)")
 
-    t3k_mesh_device.enable_async(True)
-
     return run_mixtral_demo(
         user_input=input_prompts,
         batch_size=32,

--- a/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/demo/demo_with_prefill.py
@@ -507,8 +507,6 @@ def test_mixtral8x7b_demo(t3k_mesh_device, use_program_cache, input_prompts, ins
     else:
         batch_size = 32
 
-    t3k_mesh_device.enable_async(True)
-
     return run_mixtral_demo(
         user_input=input_prompts,
         batch_size=batch_size,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention.py
@@ -17,8 +17,6 @@ from models.utility_functions import (
 
 
 def test_mixtral_attention_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
-
     pcc = 0.99
     dtype = ttnn.bfloat8_b
     batch = 32

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_attention_prefill.py
@@ -33,8 +33,6 @@ from models.utility_functions import (
 )
 @torch.no_grad()
 def test_mixtral_attention_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
-    t3k_mesh_device.enable_async(True)
-
     pcc = 0.99
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_mesh_device.get_device(0))

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder.py
@@ -27,7 +27,6 @@ def test_mixtral_decoder_inference(t3k_mesh_device, use_program_cache, reset_see
     s: sequence length
     h: hidden size
     """
-    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_decoder_prefill.py
@@ -34,7 +34,6 @@ def test_mixtral_decoder_inference(t3k_mesh_device, use_program_cache, reset_see
     s: sequence length
     h: hidden size
     """
-    t3k_mesh_device.enable_async(True)
 
     pcc = 0.99
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_embedding.py
@@ -24,8 +24,6 @@ class Emb(torch.nn.Module):
 
 
 def test_mixtral_embedding(device, use_program_cache, reset_seeds):
-    device.enable_async(True)
-
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(device)

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp.py
@@ -17,8 +17,6 @@ from models.utility_functions import (
 
 
 def test_mixtral_mlp_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
-
     # Specify different dtypes for each feedForward weights
     dtypes = {
         "w1": ttnn.bfloat4_b,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_mlp_prefill.py
@@ -27,8 +27,6 @@ from models.utility_functions import (
     ),
 )
 def test_mixtral_mlp_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
-    t3k_mesh_device.enable_async(True)
-
     # Specify different dtypes for each feedForward weights
     dtypes = {
         "w1": ttnn.bfloat8_b,

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model.py
@@ -35,8 +35,6 @@ class Emb(torch.nn.Module):
     ),
 )
 def test_mixtral_model_inference(t3k_mesh_device, use_program_cache, reset_seeds, batch):
-    t3k_mesh_device.enable_async(True)
-
     valid_pcc = 0.964
     dtype = ttnn.bfloat8_b
     iterations = 10

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_model_prefill.py
@@ -45,8 +45,6 @@ def test_mixtral_model_inference_CI(t3k_mesh_device, use_program_cache, reset_se
     if is_ci_env:
         os.environ["MIXTRAL_REF_OUTPUT_PATH"] = "/mnt/MLPerf/tt_dnn-models/Mistral/Mixtral-8x7B-v0.1/prefill/"
 
-    t3k_mesh_device.enable_async(True)
-
     n_layers = 32
 
     pcc = 0.91

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe.py
@@ -19,8 +19,6 @@ from models.utility_functions import (
 
 
 def test_mixtral_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
-
     pcc = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_moe_prefill.py
@@ -29,8 +29,6 @@ from models.utility_functions import (
     ),
 )
 def test_mixtral_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds, seq_len):
-    t3k_mesh_device.enable_async(True)
-
     pcc = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perf.py
@@ -50,8 +50,6 @@ def test_mixtral_model_perf(
     reset_seeds,
     is_ci_env,
 ):
-    t3k_mesh_device.enable_async(True)
-
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost
 
@@ -166,8 +164,6 @@ def test_mixtral_model_with_prefill_perf(
     reset_seeds,
     is_ci_env,
 ):
-    t3k_mesh_device.enable_async(True)
-
     if not is_ci_env:  # Enable tracy signpost support in local runs only
         from tracy import signpost
 

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_perplexity.py
@@ -278,8 +278,6 @@ def test_mixtral_perplexity(
         llm_mode == "decode"
     ), "Only decode mode is supported for now"  # TODO Add prefill support when it reaches main
 
-    t3k_mesh_device.enable_async(True)
-
     # Adjust the batch size based on the max prefill length
     if max_seq_len >= 16 * 1024:
         batch_size = 8

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_rms_norm.py
@@ -17,8 +17,6 @@ from models.utility_functions import (
 
 
 def test_mixtral_rms_norm_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
-
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(t3k_mesh_device.get_device(0))

--- a/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
+++ b/models/demos/t3000/mixtral8x7b/tests/test_mixtral_topk.py
@@ -41,8 +41,6 @@ class Emb(torch.nn.Module):
 def test_mixtral_model_inference(
     t3k_mesh_device, use_program_cache, reset_seeds, iterations, expected_top1, expected_top5
 ):
-    t3k_mesh_device.enable_async(True)
-
     # TODO Currently topk test is supporting decode-only mode. Add prefill support.
 
     dtype = ttnn.bfloat8_b

--- a/models/demos/t3000/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/t3000/resnet50/tests/test_perf_e2e_resnet50.py
@@ -12,9 +12,8 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.model_perf_t3000
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0100, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0100, 60),),
 )
 def test_perf(
     mesh_device,
@@ -23,17 +22,15 @@ def test_perf(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_{mode}",
+        f"resnet50",
         model_location_generator,
     )
 
@@ -42,9 +39,8 @@ def test_perf(
 @pytest.mark.model_perf_t3000
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0057, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0057, 60),),
 )
 def test_perf_trace(
     mesh_device,
@@ -53,17 +49,15 @@ def test_perf_trace(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_trace_{mode}",
+        f"resnet50_trace",
         model_location_generator,
     )
 
@@ -72,9 +66,8 @@ def test_perf_trace(
 @pytest.mark.model_perf_t3000
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0105, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0105, 60),),
 )
 def test_perf_2cqs(
     mesh_device,
@@ -83,17 +76,15 @@ def test_perf_2cqs(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_2cqs_{mode}",
+        f"resnet50_2cqs",
         model_location_generator,
     )
 
@@ -104,9 +95,8 @@ def test_perf_2cqs(
     "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1332224}], indirect=True
 )
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0043, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0043, 60),),
 )
 def test_perf_trace_2cqs(
     mesh_device,
@@ -115,16 +105,14 @@ def test_perf_trace_2cqs(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_trace_2cqs_{mode}",
+        f"resnet50_trace_2cqs",
         model_location_generator,
     )

--- a/models/demos/t3000/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/t3000/resnet50/tests/test_resnet50_performant.py
@@ -21,7 +21,6 @@ from models.demos.ttnn_resnet.tests.resnet50_performant import (
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 def test_run_resnet50_inference(
     mesh_device,
     use_program_cache,
@@ -29,7 +28,6 @@ def test_run_resnet50_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     if len(mesh_device.get_devices()) != 8:
@@ -51,7 +49,6 @@ def test_run_resnet50_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 def test_run_resnet50_trace_inference(
     mesh_device,
     use_program_cache,
@@ -59,7 +56,6 @@ def test_run_resnet50_trace_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     if len(mesh_device.get_devices()) != 8:
@@ -81,7 +77,6 @@ def test_run_resnet50_trace_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 def test_run_resnet50_2cqs_inference(
     mesh_device,
     use_program_cache,
@@ -89,7 +84,6 @@ def test_run_resnet50_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     if len(mesh_device.get_devices()) != 8:
@@ -113,7 +107,6 @@ def test_run_resnet50_2cqs_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
     mesh_device,
     use_program_cache,
@@ -121,7 +114,6 @@ def test_run_resnet50_trace_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     if len(mesh_device.get_devices()) != 8:

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -32,7 +32,6 @@ from models.utility_functions import is_wormhole_b0
         "default_mode_1024_stochastic",
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)  # Option to run Falcon in Async mode
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 4),),
@@ -50,7 +49,6 @@ def test_demo_multichip(
     get_tt_cache_path,
     mesh_device,
     use_program_cache,
-    enable_async_mode,
     is_ci_env,
     ensure_devices_tg,
 ):

--- a/models/demos/tg/llama3_70b/demo/demo.py
+++ b/models/demos/tg/llama3_70b/demo/demo.py
@@ -507,8 +507,6 @@ def test_LlamaModel_demo(
 
     check_mesh_device(mesh_device, model_config)
 
-    mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_demo_nightly.py
@@ -86,9 +86,6 @@ def test_llama3_tg_nightly_demo(
 
     check_mesh_device(mesh_device, model_config)
 
-    # TODO: Renable when issue #11089 is resolved
-    mesh_device.enable_async(True)
-
     args = construct_arg(
         implementation=implementation,
         llama_version=llama_version,

--- a/models/demos/tg/llama3_70b/tests/test_llama_perf.py
+++ b/models/demos/tg/llama3_70b/tests/test_llama_perf.py
@@ -194,7 +194,7 @@ def test_Llama_perf_host(
     )
 
     check_mesh_device(mesh_device, model_config)
-    mesh_device.enable_async(True)
+
     mesh_device.enable_program_cache()
 
     run_test_LlamaModel_end_to_end(

--- a/models/demos/tg/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/tg/resnet50/tests/test_perf_e2e_resnet50.py
@@ -12,9 +12,8 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.model_perf_tg
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0500, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0500, 60),),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -28,17 +27,15 @@ def test_perf(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_{mode}",
+        f"resnet50",
         model_location_generator,
     )
 
@@ -47,9 +44,8 @@ def test_perf(
 @pytest.mark.model_perf_tg
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0081, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0081, 60),),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -63,17 +59,15 @@ def test_perf_trace(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_trace_{mode}",
+        f"resnet50_trace",
         model_location_generator,
     )
 
@@ -82,9 +76,8 @@ def test_perf_trace(
 @pytest.mark.model_perf_tg
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0530, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0530, 60),),
 )
 def test_perf_2cqs(
     mesh_device,
@@ -93,17 +86,15 @@ def test_perf_2cqs(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_2cqs_{mode}",
+        f"resnet50_2cqs",
         model_location_generator,
     )
 
@@ -114,9 +105,8 @@ def test_perf_2cqs(
     "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1332224}], indirect=True
 )
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0069, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0069, 60),),
 )
 def test_perf_trace_2cqs(
     mesh_device,
@@ -125,16 +115,14 @@ def test_perf_trace_2cqs(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_trace_2cqs_{mode}",
+        f"resnet50_trace_2cqs",
         model_location_generator,
     )

--- a/models/demos/tg/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/tg/resnet50/tests/test_resnet50_performant.py
@@ -21,7 +21,6 @@ from models.demos.ttnn_resnet.tests.resnet50_performant import (
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 4),),
@@ -34,7 +33,6 @@ def test_run_resnet50_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_inference(
@@ -53,7 +51,6 @@ def test_run_resnet50_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 4),),
@@ -66,7 +63,6 @@ def test_run_resnet50_trace_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_inference(
@@ -85,7 +81,6 @@ def test_run_resnet50_trace_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 4),),
@@ -98,7 +93,6 @@ def test_run_resnet50_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_2cqs_inference(
@@ -119,7 +113,6 @@ def test_run_resnet50_2cqs_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 4),),
@@ -132,7 +125,6 @@ def test_run_resnet50_trace_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_2cqs_inference(

--- a/models/demos/tgg/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/tgg/resnet50/tests/test_perf_e2e_resnet50.py
@@ -12,9 +12,8 @@ from models.utility_functions import run_for_wormhole_b0
 @pytest.mark.model_perf_tgg
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0910, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0910, 60),),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -28,17 +27,15 @@ def test_perf(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_{mode}",
+        f"resnet50",
         model_location_generator,
     )
 
@@ -47,9 +44,8 @@ def test_perf(
 @pytest.mark.model_perf_tgg
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0084, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0084, 60),),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -63,17 +59,15 @@ def test_perf_trace(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_trace_{mode}",
+        f"resnet50_trace",
         model_location_generator,
     )
 
@@ -82,9 +76,8 @@ def test_perf_trace(
 @pytest.mark.model_perf_tgg
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "num_command_queues": 2}], indirect=True)
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    ((16, True, 0.0950, 60),),
-    indirect=["enable_async_mode"],
+    "device_batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.0950, 60),),
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -98,17 +91,15 @@ def test_perf_2cqs(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_2cqs_{mode}",
+        f"resnet50_2cqs",
         model_location_generator,
     )
 
@@ -119,9 +110,8 @@ def test_perf_2cqs(
     "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 1332224}], indirect=True
 )
 @pytest.mark.parametrize(
-    "device_batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
+    "device_batch_size, expected_inference_time, expected_compile_time",
     ((16, True, 0.0073, 60),),
-    indirect=["enable_async_mode"],
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -135,16 +125,14 @@ def test_perf_trace_2cqs(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         device_batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         mesh_device,
-        f"resnet50_trace_2cqs_{mode}",
+        f"resnet50_trace_2cqs",
         model_location_generator,
     )

--- a/models/demos/tgg/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/tgg/resnet50/tests/test_resnet50_performant.py
@@ -21,7 +21,6 @@ from models.demos.ttnn_resnet.tests.resnet50_performant import (
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 8),),
@@ -34,7 +33,6 @@ def test_run_resnet50_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_2cqs_inference(
@@ -55,7 +53,6 @@ def test_run_resnet50_2cqs_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 8),),
@@ -68,7 +65,6 @@ def test_run_resnet50_trace_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_2cqs_inference(
@@ -87,7 +83,6 @@ def test_run_resnet50_trace_2cqs_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 8),),
@@ -100,7 +95,6 @@ def test_run_resnet50_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_inference(
@@ -119,7 +113,6 @@ def test_run_resnet50_inference(
     "device_batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", [True], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     ((8, 8),),
@@ -132,7 +125,6 @@ def test_run_resnet50_trace_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_inference(

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_attention.py
@@ -65,10 +65,6 @@ def torch_model():
     ],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "enable_async",
-    [True, False],
-)
 def test_falcon_attention(
     mesh_device,
     model_name,
@@ -79,10 +75,7 @@ def test_falcon_attention(
     expected_pcc,
     model_config_str,
     torch_model,
-    enable_async,
 ):
-    mesh_device.enable_async(enable_async)
-
     torch.manual_seed(0)
     batch = device_batch_size * mesh_device.get_num_devices()
     if llm_mode == "decode":
@@ -188,5 +181,3 @@ def test_falcon_attention(
     assert_with_pcc(
         pytorch_layer_present[1].squeeze(1), tt_layer_present[1].to(pytorch_layer_present[1].dtype), expected_pcc
     )
-
-    mesh_device.enable_async(False)

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -62,10 +62,7 @@ PRETRAINED_MODEL_NAME = f"tiiuae/falcon-7b-instruct"
     ],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 20), (False, 1)),
-)
+@pytest.mark.parametrize("num_loops", [20])
 def test_falcon_causal_lm(
     mesh_device,
     use_program_cache,
@@ -77,11 +74,8 @@ def test_falcon_causal_lm(
     num_layers,
     expected_pcc,
     model_config_str,
-    enable_async,
     num_loops,
 ):
-    mesh_device.enable_async(enable_async)
-
     torch.manual_seed(0)
     batch = device_batch_size * mesh_device.get_num_devices()
     if llm_mode == "decode":
@@ -246,8 +240,6 @@ def test_falcon_causal_lm(
 
     logger.info("Falcon CausalLM Passed!")
 
-    mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize(
     "llm_mode, device_batch_size, seq_len, kv_cache_len",
@@ -276,10 +268,7 @@ def test_falcon_causal_lm(
     ids=["falcon_7b"],
 )
 @pytest.mark.parametrize("model_config_str", ("BFLOAT16-DRAM", "BFLOAT16-L1"))
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 50), (False, 50)),
-)
+@pytest.mark.parametrize("num_loops", [50])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 4829184}], indirect=True)
 def test_t3k_falcon_causal_lm_with_trace(
     t3k_mesh_device,
@@ -292,10 +281,8 @@ def test_t3k_falcon_causal_lm_with_trace(
     num_layers,
     expected_pcc,
     model_config_str,
-    enable_async,
     num_loops,
 ):
-    t3k_mesh_device.enable_async(enable_async)
     t3k_mesh_device.enable_program_cache()
 
     torch.manual_seed(0)
@@ -505,5 +492,3 @@ def test_t3k_falcon_causal_lm_with_trace(
         logger.success(f"Passed: pcc: {pcc}, expected: {expected_pcc}")
 
     logger.info("Falcon CausalLM Passed!")
-
-    t3k_mesh_device.enable_async(False)

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_decoder.py
@@ -65,10 +65,6 @@ def torch_model():
     ],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "enable_async",
-    [True, False],
-)
 def test_falcon_decoder(
     mesh_device,
     model_name,
@@ -79,10 +75,7 @@ def test_falcon_decoder(
     expected_pcc,
     model_config_str,
     torch_model,
-    enable_async,
 ):
-    mesh_device.enable_async(enable_async)
-
     torch.manual_seed(0)
     batch = device_batch_size * mesh_device.get_num_devices()
     if llm_mode == "decode":
@@ -183,5 +176,3 @@ def test_falcon_decoder(
     assert_with_pcc(
         pytorch_layer_present[1].squeeze(1), tt_layer_present[1].to(pytorch_layer_present[1].dtype), expected_pcc
     )
-
-    mesh_device.enable_async(False)

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_mlp.py
@@ -57,10 +57,6 @@ def torch_model():
     ],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "enable_async",
-    [True, False],
-)
 def test_falcon_mlp(
     mesh_device,
     model_name,
@@ -69,10 +65,7 @@ def test_falcon_mlp(
     expected_pcc,
     model_config_str,
     torch_model,
-    enable_async,
 ):
-    mesh_device.enable_async(enable_async)
-
     torch.manual_seed(0)
 
     configuration = transformers.FalconConfig.from_pretrained(PRETRAINED_MODEL_NAME)
@@ -110,5 +103,3 @@ def test_falcon_mlp(
         expected_pcc,
     )
     logger.success(f"Passed: pcc: {pcc}, expected: {expected_pcc}")
-
-    mesh_device.enable_async(False)

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -443,11 +443,8 @@ def run_demo_whisper_for_conditional_generation_dataset(ttnn_model, device):
     "num_inputs",
     ((1),),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_audio_classification(
-    input_path, ttnn_model, device, num_inputs, use_program_cache, enable_async_mode
-):
+def test_demo_for_audio_classification(input_path, ttnn_model, device, num_inputs, use_program_cache):
     return run_demo_whisper_for_audio_classification_inference(input_path, ttnn_model, device, num_inputs)
 
 
@@ -455,9 +452,8 @@ def test_demo_for_audio_classification(
     "ttnn_model",
     (ttnn_optimized_functional_whisper,),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_audio_classification_dataset(ttnn_model, device, use_program_cache, enable_async_mode, is_ci_env):
+def test_demo_for_audio_classification_dataset(ttnn_model, device, use_program_cache, is_ci_env):
     if is_ci_env:
         pytest.skip("Skipping test in CI since it provides redundant testing")
     return run_demo_whisper_for_audio_classification_dataset(ttnn_model, device)
@@ -471,11 +467,8 @@ def test_demo_for_audio_classification_dataset(ttnn_model, device, use_program_c
     "num_inputs",
     (2,),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_conditional_generation(
-    input_path, ttnn_model, device, num_inputs, use_program_cache, enable_async_mode, is_ci_env
-):
+def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inputs, use_program_cache, is_ci_env):
     ttft, decode_throughput = run_demo_whisper_for_conditional_generation_inference(
         input_path, ttnn_model, device, num_inputs
     )
@@ -493,9 +486,8 @@ def test_demo_for_conditional_generation(
     "ttnn_model",
     (ttnn_optimized_functional_whisper,),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_demo_for_conditional_generation_dataset(ttnn_model, device, use_program_cache, enable_async_mode, is_ci_env):
+def test_demo_for_conditional_generation_dataset(ttnn_model, device, use_program_cache, is_ci_env):
     if is_ci_env:
         pytest.skip("Skipping test in CI since it provides redundant testing")
     return run_demo_whisper_for_conditional_generation_dataset(ttnn_model, device)

--- a/models/demos/whisper/tests/test_performance.py
+++ b/models/demos/whisper/tests/test_performance.py
@@ -36,7 +36,6 @@ def get_expected_times(model_name):
 @pytest.mark.parametrize("decoder_sequence_size", [1])
 @pytest.mark.parametrize("use_kv_cache", [True])
 @pytest.mark.parametrize("functional_whisper", [ttnn_optimized_functional_whisper])
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
 def test_performance(
     device,
@@ -46,7 +45,6 @@ def test_performance(
     decoder_sequence_size,
     use_kv_cache,
     functional_whisper,
-    enable_async_mode,
 ):
     config = WhisperConfig.from_pretrained(model_name)
 

--- a/models/demos/whisper/tests/test_whisper_modules.py
+++ b/models/demos/whisper/tests/test_whisper_modules.py
@@ -40,7 +40,6 @@ MODEL_NAME = "distil-whisper/distil-large-v3"
         "decoder_cross_attn",
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
 def test_whisper_attention(
     device,
@@ -52,7 +51,6 @@ def test_whisper_attention(
     use_attn_mask,
     use_kv_cache,
     use_program_cache,
-    enable_async_mode,
 ):
     torch.manual_seed(0)
     config = transformers.WhisperConfig.from_pretrained(model_name)
@@ -167,9 +165,8 @@ def test_whisper_attention(
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_size", [1500])
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_encoder_layer(device, ttnn_model, model_name, batch_size, sequence_size, use_program_cache, enable_async_mode):
+def test_encoder_layer(device, ttnn_model, model_name, batch_size, sequence_size, use_program_cache):
     torch.manual_seed(0)
     config = transformers.WhisperConfig.from_pretrained(model_name)
     model = transformers.models.whisper.modeling_whisper.WhisperEncoderLayer(config).eval()
@@ -200,9 +197,8 @@ def test_encoder_layer(device, ttnn_model, model_name, batch_size, sequence_size
 @pytest.mark.parametrize("model_name", [MODEL_NAME])
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("sequence_length", [3000])
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_encoder(device, ttnn_model, model_name, batch_size, sequence_length, use_program_cache, enable_async_mode):
+def test_encoder(device, ttnn_model, model_name, batch_size, sequence_length, use_program_cache):
     torch.manual_seed(0)
     config = transformers.WhisperConfig.from_pretrained(model_name)
     model = transformers.models.whisper.modeling_whisper.WhisperEncoder(config).eval()
@@ -244,7 +240,6 @@ def test_encoder(device, ttnn_model, model_name, batch_size, sequence_length, us
         [1, True],
     ),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
 def test_decoder_layer(
     device,
@@ -255,7 +250,6 @@ def test_decoder_layer(
     decoder_sequence_size,
     use_kv_cache,
     use_program_cache,
-    enable_async_mode,
 ):
     torch.manual_seed(0)
     config = transformers.WhisperConfig.from_pretrained(model_name)
@@ -320,7 +314,6 @@ def test_decoder_layer(
         [1, True],
     ),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
 def test_decoder(
     device,
@@ -331,7 +324,6 @@ def test_decoder(
     decoder_sequence_size,
     use_kv_cache,
     use_program_cache,
-    enable_async_mode,
 ):
     torch.manual_seed(0)
     config = transformers.WhisperConfig.from_pretrained(model_name)
@@ -398,11 +390,8 @@ def test_decoder(
         [1, True],
     ),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": WHISPER_L1_SMALL_SIZE}], indirect=True)
-def test_ttnn_whisper(
-    tmp_path, device, ttnn_model, model_name, decoder_sequence_size, use_kv_cache, use_program_cache, enable_async_mode
-):
+def test_ttnn_whisper(tmp_path, device, ttnn_model, model_name, decoder_sequence_size, use_kv_cache, use_program_cache):
     torch.manual_seed(0)
     config = WhisperConfig.from_pretrained(model_name)
     feature_extractor = AutoFeatureExtractor.from_pretrained(model_name)

--- a/models/demos/wormhole/resnet50/demo/demo.py
+++ b/models/demos/wormhole/resnet50/demo/demo.py
@@ -53,7 +53,6 @@ def test_demo_trace_with_imagenet(
     act_dtype,
     weight_dtype,
     model_location_generator,
-    enable_async_mode=True,
 ):
     test_run_resnet50_trace_2cqs_inference(
         mesh_device,
@@ -63,6 +62,5 @@ def test_demo_trace_with_imagenet(
         imagenet_label_dict,
         act_dtype,
         weight_dtype,
-        enable_async_mode,
         model_location_generator,
     )

--- a/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
+++ b/models/demos/wormhole/resnet50/tests/test_perf_e2e_resnet50.py
@@ -39,12 +39,8 @@ def test_perf(
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1500000}], indirect=True)
 @pytest.mark.parametrize(
-    "batch_size, enable_async_mode, expected_inference_time, expected_compile_time",
-    (
-        (16, True, 0.005, 30),
-        (16, False, 0.0046, 30),
-    ),
-    indirect=["enable_async_mode"],
+    "batch_size, expected_inference_time, expected_compile_time",
+    ((16, 0.005, 30),),
 )
 def test_perf_trace(
     device,
@@ -53,17 +49,15 @@ def test_perf_trace(
     expected_inference_time,
     expected_compile_time,
     hf_cat_image_sample_input,
-    enable_async_mode,
     model_location_generator,
 ):
-    mode = "async" if enable_async_mode else "sync"
     run_perf_resnet(
         batch_size,
         expected_inference_time,
         expected_compile_time,
         hf_cat_image_sample_input,
         device,
-        f"resnet50_trace_{mode}",
+        f"resnet50_trace",
         model_location_generator,
     )
 

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_performant.py
@@ -32,7 +32,6 @@ def test_run_resnet50_inference(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_inference(
     device,
     use_program_cache,
@@ -40,7 +39,6 @@ def test_run_resnet50_trace_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_inference(
@@ -73,7 +71,6 @@ def test_run_resnet50_2cqs_inference(
     "batch_size, act_dtype, weight_dtype, math_fidelity",
     ((16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
     device,
     use_program_cache,
@@ -81,7 +78,6 @@ def test_run_resnet50_trace_2cqs_inference(
     act_dtype,
     weight_dtype,
     math_fidelity,
-    enable_async_mode,
     model_location_generator,
 ):
     run_resnet50_trace_2cqs_inference(

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
@@ -24,7 +24,6 @@ from models.utility_functions import (
     "batch_size_per_device, iterations, act_dtype, weight_dtype",
     ((16, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_resnet50_trace_2cqs_inference(
     mesh_device,
     use_program_cache,
@@ -33,7 +32,6 @@ def test_run_resnet50_trace_2cqs_inference(
     imagenet_label_dict,
     act_dtype,
     weight_dtype,
-    enable_async_mode,
     model_location_generator,
 ):
     batch_size = batch_size_per_device * mesh_device.get_num_devices()

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_stability.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_stability.py
@@ -34,7 +34,6 @@ def test_resnet_stability(
     weight_dtype,
     model_location_generator,
     test_duration_seconds,
-    enable_async_mode=True,
 ):
     logger.info(f"Running ResNet50 stability test for {test_duration_seconds} seconds")
 
@@ -53,7 +52,6 @@ def test_resnet_stability(
             act_dtype,
             weight_dtype,
             model_location_generator,
-            enable_async_mode=True,
         )
 
         if time.time() - start > test_duration_seconds:

--- a/models/demos/yolov4/tests/perf/test_e2e_performant.py
+++ b/models/demos/yolov4/tests/perf/test_e2e_performant.py
@@ -21,7 +21,6 @@ from models.utility_functions import run_for_wormhole_b0
     "batch_size, act_dtype, weight_dtype",
     ((1, ttnn.bfloat16, ttnn.bfloat16),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "resolution",
     [
@@ -35,7 +34,6 @@ def test_e2e_performant(
     batch_size,
     act_dtype,
     weight_dtype,
-    enable_async_mode,
     model_location_generator,
     resolution,
 ):

--- a/models/demos/yolov4/tests/test_stability.py
+++ b/models/demos/yolov4/tests/test_stability.py
@@ -22,7 +22,6 @@ from models.utility_functions import run_for_wormhole_b0
     "batch_size, act_dtype, weight_dtype",
     ((1, ttnn.bfloat16, ttnn.bfloat16),),
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize(
     "resolution",
     [
@@ -38,7 +37,6 @@ def test_yolov4_stability(
     batch_size,
     act_dtype,
     weight_dtype,
-    enable_async_mode,
     model_location_generator,
     resolution,
     test_duration,

--- a/models/experimental/functional_unet/tests/test_unet_bottleneck.py
+++ b/models/experimental/functional_unet/tests/test_unet_bottleneck.py
@@ -43,11 +43,8 @@ def test_unet_bottleneck(batch: int, groups: int, device: ttnn.Device, reset_see
 
 @pytest.mark.parametrize("batch", [1])
 @pytest.mark.parametrize("groups", [4])
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
-def test_unet_bottleneck_multi_device(
-    batch: int, groups: int, mesh_device: ttnn.MeshDevice, reset_seeds, enable_async_mode
-):
+def test_unet_bottleneck_multi_device(batch: int, groups: int, mesh_device: ttnn.MeshDevice, reset_seeds):
     if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")
 

--- a/models/experimental/functional_unet/tests/test_unet_downblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_downblock.py
@@ -73,10 +73,9 @@ def test_unet_downblock(
         ("downblock4", 32, 132, 20),
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_downblock_multi_device(
-    batch, groups, block_name, input_channels, input_height, input_width, mesh_device, reset_seeds, enable_async_mode
+    batch, groups, block_name, input_channels, input_height, input_width, mesh_device, reset_seeds
 ):
     if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")

--- a/models/experimental/functional_unet/tests/test_unet_perf.py
+++ b/models/experimental/functional_unet/tests/test_unet_perf.py
@@ -96,11 +96,7 @@ def test_unet_trace_perf(
     indirect=True,
 )
 @pytest.mark.parametrize(
-    "batch, groups, iterations, expected_compile_time, expected_throughput, use_async_mode",
-    (
-        (1, 4, 256, 30.0, 1500.0, True),  # Model using trace+2CQ is slower with async mode enabled (#16985)
-        (1, 4, 256, 30.0, 2160.0, False),
-    ),
+    "batch, groups, iterations, expected_compile_time, expected_throughput", ((1, 4, 256, 30.0, 2160.0),)
 )
 def test_unet_trace_perf_multi_device(
     batch: int,
@@ -108,7 +104,6 @@ def test_unet_trace_perf_multi_device(
     iterations: int,
     expected_compile_time: float,
     expected_throughput: float,
-    use_async_mode: bool,
     mesh_device,
     use_program_cache,
     reset_seeds,
@@ -117,13 +112,11 @@ def test_unet_trace_perf_multi_device(
         test_unet_trace_2cq_same_io_multi_device,
     )
 
-    mesh_device.enable_async(use_async_mode)
     model_name = "unet_shallow-trace_2cq_same_io-multi_device"
-    model_name += "-async" if use_async_mode else "-no_async"
 
     logger.info(f"Invoking underlying model test for {iterations} iterations...")
     result = test_unet_trace_2cq_same_io_multi_device(
-        batch, groups, iterations, mesh_device, use_async_mode, use_program_cache, reset_seeds
+        batch, groups, iterations, mesh_device, use_program_cache, reset_seeds
     )
 
     total_num_samples = result.batch * result.groups * result.num_devices

--- a/models/experimental/functional_unet/tests/test_unet_trace.py
+++ b/models/experimental/functional_unet/tests/test_unet_trace.py
@@ -214,7 +214,6 @@ def test_unet_trace_2cq(
 
 
 @skip_for_grayskull("UNet not currently supported on GS")
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
@@ -225,7 +224,7 @@ def test_unet_trace_2cq(
     ((1, 4, 128),),
 )
 def test_unet_trace_2cq_multi_device(
-    batch: int, groups: int, iterations: int, mesh_device, use_program_cache, reset_seeds, enable_async_mode
+    batch: int, groups: int, iterations: int, mesh_device, use_program_cache, reset_seeds
 ):
     if not is_n300_with_eth_dispatch_cores(mesh_device) and not is_t3k_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300 or T3000")
@@ -470,7 +469,6 @@ def test_unet_trace_2cq_same_io(
 
 
 @skip_for_grayskull("UNet not currently supported on GS")
-@pytest.mark.parametrize("enable_async_mode", (True, False), indirect=True)
 @pytest.mark.parametrize(
     "device_params",
     [{"l1_small_size": 68864, "trace_region_size": UNET_TRACE_REGION_SIZE, "num_command_queues": 2}],
@@ -485,7 +483,6 @@ def test_unet_trace_2cq_same_io_multi_device(
     groups: int,
     iterations: int,
     mesh_device,
-    enable_async_mode,
     use_program_cache,
     reset_seeds,
 ):

--- a/models/experimental/functional_unet/tests/test_unet_upblock.py
+++ b/models/experimental/functional_unet/tests/test_unet_upblock.py
@@ -82,7 +82,6 @@ def test_unet_upblock(
         ("upblock4", 16, 528, 80, 16),
     ],
 )
-@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_unet_upblock_multi_device(
     batch,
@@ -94,7 +93,6 @@ def test_unet_upblock_multi_device(
     residual_channels,
     mesh_device,
     reset_seeds,
-    enable_async_mode,
 ):
     if not is_n300_with_eth_dispatch_cores(mesh_device):
         pytest.skip("Test is only valid for N300")

--- a/models/experimental/functional_vgg_unet/tests/test_e2e_performant.py
+++ b/models/experimental/functional_vgg_unet/tests/test_e2e_performant.py
@@ -20,12 +20,10 @@ from models.experimental.functional_vgg_unet.tests.vgg_unet_e2e_performant impor
     "batch_size",
     ((1),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_vgg_unet_trace_2cqs_inference(
     device,
     use_program_cache,
     batch_size,
-    enable_async_mode,
     model_location_generator,
 ):
     vgg_unet_trace_2cq = VggUnetTrace2CQ()

--- a/models/experimental/functional_vgg_unet/tests/test_vgg_unet_performant.py
+++ b/models/experimental/functional_vgg_unet/tests/test_vgg_unet_performant.py
@@ -20,11 +20,9 @@ def test_run_vgg_unet_inference(device, use_program_cache, model_location_genera
 
 @run_for_wormhole_b0()
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1843200}], indirect=True)
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_vgg_unet_trace_inference(
     device,
     use_program_cache,
-    enable_async_mode,
     model_location_generator,
 ):
     run_vgg_unet_trace_inference(
@@ -37,11 +35,9 @@ def test_run_vgg_unet_trace_inference(
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768, "trace_region_size": 3686400, "num_command_queues": 2}], indirect=True
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_vgg_unet_trace_2cqs_inference(
     device,
     use_program_cache,
-    enable_async_mode,
     model_location_generator,
 ):
     vgg_unet_trace_2cq = VggUnetTrace2CQ()

--- a/models/experimental/functional_yolov9c/tests/perf/test_e2e_performant.py
+++ b/models/experimental/functional_yolov9c/tests/perf/test_e2e_performant.py
@@ -20,7 +20,6 @@ from models.experimental.functional_yolov9c.runner.performant_runner import YOLO
     "batch_size, act_dtype, weight_dtype",
     ((1, ttnn.bfloat8_b, ttnn.bfloat8_b),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize(
     "resolution",
     [
@@ -35,7 +34,6 @@ def test_e2e_performant(
     batch_size,
     act_dtype,
     weight_dtype,
-    enable_async_mode,
     model_location_generator,
     resolution,
 ):

--- a/models/experimental/grok/tests/test_grok_attention.py
+++ b/models/experimental/grok/tests/test_grok_attention.py
@@ -24,7 +24,6 @@ from models.utility_functions import (
 
 
 def test_grok_attention_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
     pcc = 0.99
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/grok/tests/test_grok_decoder.py
+++ b/models/experimental/grok/tests/test_grok_decoder.py
@@ -28,7 +28,7 @@ def test_grok_decoder_inference(t3k_mesh_device, use_program_cache, reset_seeds)
     s: sequence length
     h: hidden size
     """
-    t3k_mesh_device.enable_async(True)
+
     pcc = 0.98
     dtype = ttnn.bfloat8_b
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/grok/tests/test_grok_embedding.py
+++ b/models/experimental/grok/tests/test_grok_embedding.py
@@ -31,7 +31,6 @@ class Emb(torch.nn.Module):
 
 
 def test_grok_embedding(device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
     dtype = ttnn.bfloat16
 
     model_args = TtModelArgs(device, dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/grok/tests/test_grok_mlp.py
+++ b/models/experimental/grok/tests/test_grok_mlp.py
@@ -26,7 +26,6 @@ from models.utility_functions import (
 
 @pytest.mark.timeout(500)
 def test_grok_mlp_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
     # Specify different dtypes for each feedForward weights
     dtypes = {
         "linear": ttnn.bfloat4_b,

--- a/models/experimental/grok/tests/test_grok_model.py
+++ b/models/experimental/grok/tests/test_grok_model.py
@@ -41,7 +41,6 @@ from models.experimental.grok.reference.configuration_grok1 import Grok1Config
     (1, 2, 10),
 )
 def test_grok_model_inference(t3k_mesh_device, use_program_cache, reset_seeds, iterations, n_layers, validation_type):
-    t3k_mesh_device.enable_async(True)
     pcc = 0.97
     dtype = ttnn.bfloat8_b
 

--- a/models/experimental/grok/tests/test_grok_moe.py
+++ b/models/experimental/grok/tests/test_grok_moe.py
@@ -27,7 +27,6 @@ from models.utility_functions import (
 
 @pytest.mark.timeout(600)
 def test_grok_moe_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
     pcc = 0.87  # real weights = 0.99
     iterations = 1
     dtype = ttnn.bfloat8_b

--- a/models/experimental/grok/tests/test_grok_perf.py
+++ b/models/experimental/grok/tests/test_grok_perf.py
@@ -47,7 +47,6 @@ def test_grok_model_perf(
     reset_seeds,
 ):
     dtype = ttnn.bfloat8_b
-    t3k_mesh_device.enable_async(True)
 
     # Can use dummy_weights=True correctness is not tested, but it is much slower
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=False)

--- a/models/experimental/grok/tests/test_grok_rms_norm.py
+++ b/models/experimental/grok/tests/test_grok_rms_norm.py
@@ -25,7 +25,6 @@ from models.utility_functions import (
 
 def test_grok_rms_norm_inference(t3k_mesh_device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
-    t3k_mesh_device.enable_async(True)
 
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")
     model_args.n_layers = 1
@@ -73,7 +72,6 @@ def test_grok_rms_norm_inference(t3k_mesh_device, use_program_cache, reset_seeds
 
 
 def test_grok_rms_norm_sharded_inference(t3k_mesh_device, use_program_cache, reset_seeds):
-    t3k_mesh_device.enable_async(True)
     dtype = ttnn.bfloat8_b
 
     model_args = TtModelArgs(t3k_mesh_device.get_device(0), dummy_weights=os.getenv("CI") == "true")

--- a/models/experimental/mobilenetv2/tests/test_e2e_performant.py
+++ b/models/experimental/mobilenetv2/tests/test_e2e_performant.py
@@ -20,12 +20,10 @@ from models.experimental.mobilenetv2.tests.mobilenetv2_e2e_performant import Mob
     "batch_size",
     ((1),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_mobilenetv2_trace_2cqs_inference(
     device,
     use_program_cache,
     batch_size,
-    enable_async_mode,
     model_location_generator,
 ):
     mobilenetv2_trace_2cq = MobileNetV2Trace2CQ()

--- a/models/experimental/ufld_v2/tests/test_UFLD_v2_e2e_performant.py
+++ b/models/experimental/ufld_v2/tests/test_UFLD_v2_e2e_performant.py
@@ -20,12 +20,10 @@ from models.experimental.ufld_v2.tests.UFLD_v2_e2e_performant import UFLDv2Trace
     "batch_size",
     ((1),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_ufldv2_trace_2cqs_inference(
     device,
     use_program_cache,
     batch_size,
-    enable_async_mode,
     model_location_generator,
 ):
     ufldv2_trace_2cq = UFLDv2Trace2CQ()

--- a/models/experimental/yolov8x/tests/test_e2e_performant.py
+++ b/models/experimental/yolov8x/tests/test_e2e_performant.py
@@ -22,12 +22,10 @@ from models.experimental.yolov8x.tests.yolov8x_e2e_performant import Yolov8xTrac
     "batch_size",
     ((1),),
 )
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 def test_run_yolov8x_trace_2cqs_inference(
     device,
     use_program_cache,
     batch_size,
-    enable_async_mode,
     model_location_generator,
 ):
     yolov8x_trace_2cq = Yolov8xTrace2CQ()

--- a/models/tt_transformers/demo/multimodal_demo_chat.py
+++ b/models/tt_transformers/demo/multimodal_demo_chat.py
@@ -62,7 +62,7 @@ def test_multimodal_demo_chat(
     else:
         logger.info(f"Creating TT model on {len(mesh_device.get_devices())} devices")
         mesh_device.enable_program_cache()
-        mesh_device.enable_async(True)
+
         model_args, model, _ = create_multimodal_model(
             mesh_device, max_batch_size=max_batch_size, max_seq_len=max_seq_len
         )

--- a/models/tt_transformers/demo/multimodal_demo_text.py
+++ b/models/tt_transformers/demo/multimodal_demo_text.py
@@ -69,7 +69,7 @@ def test_multimodal_demo_text(
     else:
         logger.info(f"Creating TT model on {len(mesh_device.get_devices())} devices")
         mesh_device.enable_program_cache()
-        mesh_device.enable_async(True)
+
         model_args, model, _ = create_multimodal_model(
             mesh_device, max_batch_size=max_batch_size, max_seq_len=max_seq_len
         )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -456,7 +456,6 @@ def test_demo_text(
     if os.environ.get("MESH_DEVICE") == "TG" and batch_size not in [1, 32]:
         pytest.skip("TG only supports batch 1 and 32")
 
-    mesh_device.enable_async(True)
     enable_trace = True  # Use tracing for better perf
     print_to_file = False  # Enable this flag to print the output of all users to a file
 

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -152,7 +152,6 @@ def test_multimodal_demo_text(
     tokenizer_path = str(Path(ckpt_dir) / "tokenizer.model")
 
     mesh_device.enable_program_cache()
-    mesh_device.enable_async(True)
 
     num_devices = mesh_device.get_num_devices() if isinstance(mesh_device, ttnn.MeshDevice) else 1
     max_batch_size *= data_parallel  # input batch_size is interpreted as size per DP group

--- a/models/tt_transformers/tests/multimodal/test_llama_class_embedding.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_class_embedding.py
@@ -84,8 +84,6 @@ def test_class_embedding_inference(
     dtype = ttnn.bfloat16
     pcc_required = 0.9999
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
     first_layer_prefix = "vision_model.vision_encoder."

--- a/models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_conv2d_patch.py
@@ -45,8 +45,6 @@ def test_conv2d_inference(
     pcc_required = 0.9999
     dtype = ttnn.bfloat16
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
 

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention.py
@@ -44,8 +44,6 @@ def test_cross_attention_inference(text_seq_len, batch, mesh_device, reset_seeds
     dtype = ttnn.bfloat16
     pcc_required = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     model_args.max_seq_len = text_seq_len
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_attention_transformer_text.py
@@ -57,8 +57,6 @@ def test_cross_attention_transformer_text_inference(
     prefill_pcc_required = 0.98
     decode_pcc_required = 0.965
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch)
     # Limit the max seqlen to 4k to avoid OOM on host
     model_args.max_seq_len = 4096

--- a/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_cross_block.py
@@ -42,8 +42,6 @@ def test_cross_attention_transformer_block_inference(
     dtype = ttnn.bfloat16
     pcc_required = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch)
     # Limit the max seqlen to 4k to avoid OOM on host
     model_args.max_seq_len = 4096

--- a/models/tt_transformers/tests/multimodal/test_llama_image_attention.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_image_attention.py
@@ -37,8 +37,6 @@ def test_attention_inference(batch, num_chunks, mesh_device, use_program_cache, 
     dtype = ttnn.bfloat16
     pcc_required = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
 

--- a/models/tt_transformers/tests/multimodal/test_llama_image_block.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_image_block.py
@@ -42,8 +42,6 @@ def test_block_inference(batch, num_chunks, mesh_device, gated, use_program_cach
     dtype = ttnn.bfloat16
     pcc_required = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
 

--- a/models/tt_transformers/tests/multimodal/test_llama_image_mlp.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_image_mlp.py
@@ -36,8 +36,6 @@ from models.utility_functions import skip_for_grayskull
 def test_mlp_inference(batch, num_chunks, mesh_device, use_program_cache, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat16
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
 

--- a/models/tt_transformers/tests/multimodal/test_llama_image_transformer.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_image_transformer.py
@@ -43,8 +43,6 @@ def test_image_transformer_inference(
     dtype = ttnn.bfloat16
     pcc_required = 0.86
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
 

--- a/models/tt_transformers/tests/multimodal/test_llama_layernorm.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_layernorm.py
@@ -32,8 +32,6 @@ from models.utility_functions import skip_for_grayskull
 def test_layernorm_inference(mesh_device, use_program_cache, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat16
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     width = model_args.vision_dim
     num_chunks = 4

--- a/models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_positional_embedding.py
@@ -94,8 +94,6 @@ def test_positional_embedding_inference(
     layout = ttnn.TILE_LAYOUT
     pcc_required = 0.9999
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
     first_layer_prefix = "vision_model.vision_encoder."

--- a/models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py
+++ b/models/tt_transformers/tests/multimodal/test_llama_tile_position_embedding.py
@@ -64,8 +64,6 @@ def test_conv2d_inference(
     gated = True
     pcc_required = 0.9999
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
 

--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -133,8 +133,6 @@ def test_tt_model_acc(
 
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     json_config_file = request.config.getoption("--decoder_config_file")
     if json_config_file:
         optimizations = parse_decoder_json(json_config_file)

--- a/models/tt_transformers/tests/test_attention.py
+++ b/models/tt_transformers/tests/test_attention.py
@@ -67,8 +67,6 @@ def test_attention_inference(
     dtype = ttnn.bfloat8_b
     pcc = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1  # For the unit test, just run a single layer
 

--- a/models/tt_transformers/tests/test_attention_prefill.py
+++ b/models/tt_transformers/tests/test_attention_prefill.py
@@ -69,8 +69,6 @@ def test_attention_inference(
     pcc = 0.99
     batch_size = 1  # For prefill we only support batch_size = 1
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/tt_transformers/tests/test_chunked_generation.py
+++ b/models/tt_transformers/tests/test_chunked_generation.py
@@ -68,8 +68,6 @@ def test_chunked_prefill_single_user(
     is_ci_env,
     request,
 ):
-    mesh_device.enable_async(True)
-
     dtype = ttnn.bfloat8_b
     batch_size = 1  # For prefill we only support batch_size = 1
 

--- a/models/tt_transformers/tests/test_decoder.py
+++ b/models/tt_transformers/tests/test_decoder.py
@@ -65,7 +65,6 @@ def test_decoder_inference(
     ensure_gc,
 ):
     dtype = ttnn.bfloat8_b
-    mesh_device.enable_async(True)
 
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1

--- a/models/tt_transformers/tests/test_decoder_prefill.py
+++ b/models/tt_transformers/tests/test_decoder_prefill.py
@@ -66,8 +66,6 @@ def test_decoder_inference(
     dtype = ttnn.bfloat8_b
     batch_size = 1  # For prefill we only support batch_size = 1
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1
 

--- a/models/tt_transformers/tests/test_embedding.py
+++ b/models/tt_transformers/tests/test_embedding.py
@@ -36,7 +36,6 @@ from models.utility_functions import skip_for_grayskull
 )
 def test_embedding(max_seq_len, batch_size, mesh_device, use_program_cache, reset_seeds, ensure_gc):
     dtype = ttnn.bfloat16
-    mesh_device.enable_async(True)
 
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1

--- a/models/tt_transformers/tests/test_interleaved_to_sharded.py
+++ b/models/tt_transformers/tests/test_interleaved_to_sharded.py
@@ -22,8 +22,6 @@ from models.utility_functions import skip_for_grayskull
     indirect=True,
 )
 def test_decoder_inference(mesh_device, use_program_cache, reset_seeds):
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device)
     state_dict = torch.load(model_args.consolidated_weights_path, map_location=torch.device("cpu"))
 

--- a/models/tt_transformers/tests/test_lm_head.py
+++ b/models/tt_transformers/tests/test_lm_head.py
@@ -38,8 +38,6 @@ from models.utility_functions import skip_for_grayskull
 def test_lm_head_inference(seq_len, batch_size, mesh_device, use_program_cache, reset_seeds):
     dtype = ttnn.bfloat8_b
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=seq_len)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/tt_transformers/tests/test_mlp.py
+++ b/models/tt_transformers/tests/test_mlp.py
@@ -43,8 +43,6 @@ def test_mlp_inference(seq_len, batch_size, mesh_device, use_program_cache, rese
     dtype = ttnn.bfloat8_b
     mode = "decode" if seq_len <= 32 else "prefill"
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=128)
     model_args.n_layers = 1
     state_dict = model_args.load_state_dict()

--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -88,7 +88,7 @@ def test_model_inference(
     run_ref_pt = True  # Flag to run reference PyTorch model and compare PCC
     cache_pcc = layers == 1  # Flag to measure KV cache PCC. Avoid running for all layers to speed up test time.
     dtype = ttnn.bfloat8_b
-    mesh_device.enable_async(True)
+
     test_id = request.node.callspec.id
     mode_accuracy = "accuracy" in test_id
     instruct = False  # True if weights == "instruct" else False

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -90,8 +90,6 @@ def test_model_inference(
         assert "performance" in test_id
         pcc = 0.869  # TODO Look on improving PCC
 
-    mesh_device.enable_async(True)
-
     # Use instruct weights instead of general weights
     instruct = True
 

--- a/models/tt_transformers/tests/test_ref.py
+++ b/models/tt_transformers/tests/test_ref.py
@@ -56,8 +56,6 @@ def test_attention_inference(
     dtype = ttnn.bfloat8_b
     pcc = 0.99
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
     model_args.n_layers = 1  # For the unit test, just run a single layer
 

--- a/models/tt_transformers/tests/test_rms_norm.py
+++ b/models/tt_transformers/tests/test_rms_norm.py
@@ -47,8 +47,6 @@ def test_rms_norm_inference(
 ):
     dtype = ttnn.bfloat16
 
-    mesh_device.enable_async(True)
-
     model_args = ModelArgs(mesh_device, max_batch_size=batch_size, max_seq_len=max_seq_len)
 
     model_args.n_layers = 1

--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -1412,7 +1412,7 @@ Tracing doesn’t work with prefill; sequence length and matmul row counts will 
 Async mode allows the host to continuously send commands to the device without blocking until data is read back from device, improving performance. Enable async mode with:
 
 ```python
-mesh_device.enable_async(True)
+
 ```
 
 Without async mode each python call to TT-NN will block until the device has finished and results are available. This is good for debugging, any crash or error will show you the offending line of code. With async mode enabled your python thread keeps on running while the host and device handle background calls, only blocking when data needs to be read back from device.

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -11,7 +11,7 @@ run_async_test() {
     if [ "$ARCH_NAME" == "wormhole_b0" ]; then
         remove_default_log_locations
         mkdir -p $PROFILER_ARTIFACTS_DIR
-        ./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-True-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
+        ./tt_metal/tools/profiler/profile_this.py -c "pytest -svv models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py::test_falcon_causal_lm[wormhole_b0-20-2-BFLOAT16-L1-falcon_7b-layers_2-decode_batch32]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
 
         if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
         then
@@ -32,7 +32,7 @@ run_async_tracing_T3000_test() {
         remove_default_log_locations
         mkdir -p $PROFILER_ARTIFACTS_DIR
 
-        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./tt_metal/tools/profiler/profile_this.py -c "pytest models/demos/t3000/resnet50/tests/test_resnet50_performant.py::test_run_resnet50_trace_2cqs_inference[wormhole_b0-True-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml ./tt_metal/tools/profiler/profile_this.py -c "pytest models/demos/t3000/resnet50/tests/test_resnet50_performant.py::test_run_resnet50_trace_2cqs_inference[wormhole_b0-16-act_dtype0-weight_dtype0-math_fidelity0-device_params0]" | tee $PROFILER_ARTIFACTS_DIR/test_out.log
 
         if cat $PROFILER_ARTIFACTS_DIR/test_out.log | grep "SKIPPED"
         then

--- a/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
+++ b/tests/sweep_framework/sweeps/ccl/all_gather_n300.py
@@ -43,7 +43,6 @@ parameters = {
             ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
             ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
         ],
-        "enable_async": [True],
         "num_iters": [1],
         "tile": [(32, 32)],
     },
@@ -90,7 +89,6 @@ def run(
     input_dtype,
     layout,
     mem_config,
-    enable_async,
     num_iters,
     tile,
     *,
@@ -98,11 +96,6 @@ def run(
 ) -> list:
     all_devices = device
 
-    for device in all_devices:
-        device.enable_async(enable_async)
-
-    if enable_async:
-        logger.info(f"Using Async Mode for All Gather Op Dispatch")
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
 

--- a/tests/sweep_framework/sweeps/ccl/all_gather_n300_focused.py
+++ b/tests/sweep_framework/sweeps/ccl/all_gather_n300_focused.py
@@ -119,7 +119,6 @@ parameters = {
         "mem_config": [
             ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
         ],
-        "enable_async": [True],
         "num_iters": [1],
         "tile": [(32, 32)],
     },
@@ -133,7 +132,6 @@ parameters = {
         "mem_config": [
             ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
         ],
-        "enable_async": [True],
         "num_iters": [1],
         "tile": [(32, 32)],
     },
@@ -179,7 +177,6 @@ def run(
     input_dtype,
     layout,
     mem_config,
-    enable_async,
     num_iters,
     tile,
     *,
@@ -187,11 +184,6 @@ def run(
 ) -> list:
     all_devices = device
 
-    for device in all_devices:
-        device.enable_async(enable_async)
-
-    if enable_async:
-        logger.info(f"Using Async Mode for All Gather Op Dispatch")
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
 

--- a/tests/sweep_framework/sweeps/ccl/line_all_gather.py
+++ b/tests/sweep_framework/sweeps/ccl/line_all_gather.py
@@ -37,7 +37,6 @@ parameters = {
         "layout": [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT],
         "input_dtype": [ttnn.bfloat16],
         "mem_config": [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)],
-        "enable_async": [True, False],
         "num_iters": [1],
         "tile": [(32, 32)],
     },
@@ -89,14 +88,12 @@ def run(
     input_dtype,
     layout,
     mem_config,
-    enable_async,
     num_iters,
     tile,
     *,
     device,
 ) -> list:
     t3k_mesh_device = device
-    t3k_mesh_device.enable_async(enable_async)
 
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")

--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_interleaved.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_interleaved.py
@@ -108,7 +108,6 @@ def run(
     *,
     device,
 ) -> list:
-    device.enable_async(False)
     torch_input_tensors = []
 
     torch_input_tensors.append(torch_random(concat_specs["shape1"], -0.1, 0.1, dtype=torch.bfloat16))

--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_interleaved_n_tensors.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_interleaved_n_tensors.py
@@ -140,7 +140,6 @@ def run(
     device,
 ) -> list:
     torch_input_tensors = []
-    device.enable_async(False)
     for i in range(0, concat_specs[0]):
         torch_input_tensors.append(torch_random(concat_specs[3][i], -0.1, 0.1, dtype=torch.bfloat16))
 

--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_pytorch2.py
@@ -4181,7 +4181,6 @@ def run(
     *,
     device,
 ) -> list:
-    device.enable_async(False)
     torch_input_tensors = [torch_random(shape, -0.1, 0.1, dtype=torch.bfloat16) for shape in concat_specs["shapes"]]
     torch_output_tensor = torch.concat(torch_input_tensors, dim=concat_specs["dim"])
 
@@ -4203,7 +4202,6 @@ def run(
 def test_concat_pytorch2(concat_spec, dtype, layout, device):
     shapes = concat_spec["shapes"]
     dim = concat_spec["dim"]
-    device.enable_async(False)
     if dtype == ttnn.bfloat16 and any([shape[-1] % 2 != 0 for shape in shapes]) and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Skipping test for RM bfloat16 with odd last dimension")
 

--- a/tests/sweep_framework/sweeps/data_movement/concat/concat_sharded.py
+++ b/tests/sweep_framework/sweeps/data_movement/concat/concat_sharded.py
@@ -267,7 +267,6 @@ def run(
     device,
 ) -> list:
     torch_input_tensors = []
-    device.enable_async(False)
     if input_mem_config == ttnn.L1_BLOCK_SHARDED_MEMORY_CONFIG:
         input_mem_config_a = ttnn.create_sharded_memory_config(
             shape=concat_specs["shape1"],

--- a/tests/sweep_framework/sweeps/data_movement/embedding/embedding_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/embedding/embedding_pytorch2.py
@@ -111,8 +111,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     # Extract the weight and indices shape from embedding_specs
     weight_shape = embedding_specs["weight_shape"]
     indices_shape = embedding_specs["indices_shape"]

--- a/tests/sweep_framework/sweeps/data_movement/interleaved_to_sharded/interleaved_to_sharded_e2e.py
+++ b/tests/sweep_framework/sweeps/data_movement/interleaved_to_sharded/interleaved_to_sharded_e2e.py
@@ -92,8 +92,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     shape = shard_specs["shape"]
     shard_shape = shard_specs["shard_shape"]
 

--- a/tests/sweep_framework/sweeps/data_movement/repeat/repeat_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/repeat/repeat_pytorch2.py
@@ -58,8 +58,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     # Extract the shape and repeat dimensions from repeat_specs
     shape = repeat_specs["shape"]
     repeat_dims = repeat_specs["repeats"]  # Number of repetitions for each dimension

--- a/tests/sweep_framework/sweeps/data_movement/slice/slice_forge.py
+++ b/tests/sweep_framework/sweeps/data_movement/slice/slice_forge.py
@@ -52,8 +52,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     dims = slice_specs["dims"]
     begins = slice_specs["begins"]
     ends = slice_specs["ends"]

--- a/tests/sweep_framework/sweeps/data_movement/slice/slice_pytorch2_rm.py
+++ b/tests/sweep_framework/sweeps/data_movement/slice/slice_pytorch2_rm.py
@@ -199,8 +199,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     dims = slice_specs["dims"]
     dim = slice_specs["dim"]
     start = slice_specs["start"]

--- a/tests/sweep_framework/sweeps/data_movement/slice/slice_pytorch2_tiled.py
+++ b/tests/sweep_framework/sweeps/data_movement/slice/slice_pytorch2_tiled.py
@@ -199,8 +199,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     dims = slice_specs["dims"]
     dim = slice_specs["dim"]
     start = slice_specs["start"]

--- a/tests/sweep_framework/sweeps/data_movement/split/split_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/split/split_pytorch2.py
@@ -65,8 +65,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     # Extract the shape and split_size from split_specs
     shape = split_specs["shape"]
     dim = split_specs.get("dim", 0)  # Get the dimension to split, default to 0 if unspecified

--- a/tests/sweep_framework/sweeps/data_movement/squeeze/squeeze_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/squeeze/squeeze_pytorch2.py
@@ -89,8 +89,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     # Extract the shape from squeeze_specs
     shape = squeeze_specs["shape"]
     dim = squeeze_specs.get("dim")  # Get the dimension to squeeze, if specified

--- a/tests/sweep_framework/sweeps/data_movement/unsqueeze/unsqueeze_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/unsqueeze/unsqueeze_pytorch2.py
@@ -288,8 +288,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     # Extract the shape from unsqueeze_specs
     shape = unsqueeze_specs["shape"]
     dim = unsqueeze_specs.get("dim")  # Get the dimension to unsqueeze, if specified

--- a/tests/sweep_framework/sweeps/data_movement/view/view_pytorch2.py
+++ b/tests/sweep_framework/sweeps/data_movement/view/view_pytorch2.py
@@ -93,8 +93,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     # Extract the shape and new size (target shape) from view_specs
     shape = view_specs["shape"]
     size = view_specs["size"]  # New shape for the view/reshape operation

--- a/tests/sweep_framework/sweeps/data_movement/view/view_tt_torch.py
+++ b/tests/sweep_framework/sweeps/data_movement/view/view_tt_torch.py
@@ -79,8 +79,6 @@ def run(
     *,
     device,
 ):
-    device.enable_async(False)
-
     # Extract the shape and new size (target shape) from view_specs
     shape = view_specs["shape"]
     size = view_specs["size"]  # New shape for the view/reshape operation

--- a/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_argmax.py
+++ b/tests/tt_eager/python_api_testing/non_working_unit_tests/grayskull/test_argmax.py
@@ -25,13 +25,12 @@ from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs
 )
 @pytest.mark.parametrize("all", (True, False))
 @pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 5), (False, 1)),
+    "num_loops",
+    [5],
 )
 class TestArgmax:
-    def test_argmax(self, input_shapes, dim, all, device, enable_async, num_loops):
+    def test_argmax(self, input_shapes, dim, all, device, num_loops):
         torch.manual_seed(0)
-        device.enable_async(enable_async)
         for _ in range(num_loops):
             input_data = torch.randn(input_shapes).bfloat16()
             input_tensor = ttnn.Tensor(input_data, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
@@ -58,4 +57,3 @@ class TestArgmax:
             logger.info(comp_out)
             status = comp_pass | comp_all
             assert status
-        device.enable_async(False)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
@@ -33,13 +33,9 @@ def generate_input_shapes():
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 20), (False, 1)),
-)
-def test_attn_matmul(num_loops, enable_async, in0_dtype, in1_dtype, out_dtype, device):
+@pytest.mark.parametrize("num_loops", [20])
+def test_attn_matmul(num_loops, in0_dtype, in1_dtype, out_dtype, device):
     torch.manual_seed(0)
-    device.enable_async(enable_async)
 
     for input_shape_a, input_shape_b in generate_input_shapes():
         for _ in range(num_loops):
@@ -67,18 +63,12 @@ def test_attn_matmul(num_loops, enable_async, in0_dtype, in1_dtype, out_dtype, d
             allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
             assert allclose, f"FAILED: {output}"
 
-    device.enable_async(False)
-
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b])
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 20), (False, 1)),
-)
-def test_attn_matmul_fp32(num_loops, enable_async, in_dtype, device):
+@pytest.mark.parametrize("num_loops", [20])
+def test_attn_matmul_fp32(num_loops, in_dtype, device):
     torch.manual_seed(0)
-    device.enable_async(enable_async)
 
     for input_shape_a, input_shape_b in generate_input_shapes():
         for _ in range(num_loops):
@@ -112,21 +102,13 @@ def test_attn_matmul_fp32(num_loops, enable_async, in_dtype, device):
             allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
             assert allclose, f"FAILED: {output}"
 
-    device.enable_async(False)
-
 
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 20), (False, 1)),
-)
-def test_attn_matmul_with_program_cache(
-    num_loops, enable_async, in0_dtype, in1_dtype, out_dtype, device, use_program_cache
-):
+@pytest.mark.parametrize("num_loops", [20])
+def test_attn_matmul_with_program_cache(num_loops, in0_dtype, in1_dtype, out_dtype, device, use_program_cache):
     torch.manual_seed(0)
-    device.enable_async(enable_async)
     for input_shape_a, input_shape_b in generate_input_shapes():
         for _ in range(num_loops):
             input_tensor_a = torch.randn(input_shape_a).bfloat16()
@@ -150,7 +132,6 @@ def test_attn_matmul_with_program_cache(
 
             allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
             assert allclose, f"FAILED: {output}"
-    device.enable_async(False)
 
 
 @pytest.mark.parametrize(
@@ -177,13 +158,9 @@ def test_attn_matmul_with_program_cache(
         (32, 64, 128, 16, 1),
     ),
 )
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 5), (False, 1)),
-)
+@pytest.mark.parametrize("num_loops", [5])
 def test_group_attn_matmul(
     num_loops,
-    enable_async,
     batch,
     K,
     seq_len,
@@ -196,8 +173,6 @@ def test_group_attn_matmul(
     device,
 ):
     torch.manual_seed(0)
-
-    device.enable_async(enable_async)
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
@@ -271,23 +246,16 @@ def test_group_attn_matmul(
         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
         assert allclose, f"FAILED: {output}"
 
-    device.enable_async(False)
-
 
 @pytest.mark.parametrize("sharded", [False, True])
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 5), (False, 1)),
-)
+@pytest.mark.parametrize("num_loops", [5])
 def test_group_attn_matmul_with_program_cache(
-    num_loops, enable_async, in0_dtype, in1_dtype, output_dtype, sharded, device, use_program_cache
+    num_loops, in0_dtype, in1_dtype, output_dtype, sharded, device, use_program_cache
 ):
     torch.manual_seed(0)
-
-    device.enable_async(enable_async)
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
@@ -365,8 +333,6 @@ def test_group_attn_matmul_with_program_cache(
 
     assert num_cache_entries == 1
 
-    device.enable_async(False)
-
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16])
@@ -394,13 +360,9 @@ def test_group_attn_matmul_with_program_cache(
         (32, 32, 32, 2, 1),
     ),
 )
-@pytest.mark.parametrize(
-    "enable_async, num_loops",
-    ((True, 5), (False, 1)),
-)
+@pytest.mark.parametrize("num_loops", [5])
 def test_group_attn_matmul_fp32(
     num_loops,
-    enable_async,
     batch,
     K,
     seq_len,
@@ -414,8 +376,6 @@ def test_group_attn_matmul_fp32(
     device,
 ):
     torch.manual_seed(0)
-
-    device.enable_async(enable_async)
 
     compute_grid_size = device.compute_with_storage_grid_size()
 
@@ -492,4 +452,3 @@ def test_group_attn_matmul_fp32(
 
         allclose, output = comp_pcc(tt_output_tensor, golden_output_tensor)
         assert allclose, f"FAILED: {output}"
-    device.enable_async(False)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul.py
@@ -21,7 +21,7 @@ from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import (
 @pytest.mark.parametrize("N", [1024])
 @pytest.mark.parametrize("activations_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("weights_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
-@pytest.mark.parametrize("enable_async, num_loops", ((True, 2), (False, 1)))
+@pytest.mark.parametrize("num_loops", [2])
 def test_matmul_1d_in0_batched(
     device,
     batch,
@@ -33,7 +33,6 @@ def test_matmul_1d_in0_batched(
     weights_dtype,
     function_level_defaults,
     num_loops,
-    enable_async,
 ):
     grid_size = (12, 8)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -55,7 +54,6 @@ def test_matmul_1d_in0_batched(
         memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         buffer_type=ttnn.BufferType.L1,
     )
-    device.enable_async(enable_async)
     for _ in range(num_loops):
         in0 = torch.randn(in0_shape).bfloat16().float()
         in1 = torch.randn(in1_shape).bfloat16().float()
@@ -110,7 +108,6 @@ def test_matmul_1d_in0_batched(
         passing, output = comp_pcc(pt_out, tt_out)
         logger.info(output)
         assert passing
-    device.enable_async(False)
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
@@ -123,7 +120,7 @@ def test_matmul_1d_in0_batched(
 @pytest.mark.parametrize("N", [1024])
 @pytest.mark.parametrize("activations_dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("weights_dtype", [ttnn.bfloat8_b])
-@pytest.mark.parametrize("enable_async, num_loops", ((True, 2), (False, 1)))
+@pytest.mark.parametrize("num_loops", [2])
 def test_linear_fp32_acc_l1(
     device,
     packer_l1_acc,
@@ -137,7 +134,6 @@ def test_linear_fp32_acc_l1(
     weights_dtype,
     function_level_defaults,
     num_loops,
-    enable_async,
 ):
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -159,7 +155,6 @@ def test_linear_fp32_acc_l1(
         memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         buffer_type=ttnn.BufferType.L1,
     )
-    device.enable_async(enable_async)
     for _ in range(num_loops):
         in0 = torch.randn(in0_shape).bfloat16().float()
         in1 = torch.randn(in1_shape).bfloat16().float()
@@ -219,7 +214,6 @@ def test_linear_fp32_acc_l1(
         passing, output = comp_pcc(pt_out, tt_out)
         logger.info(output)
         assert passing
-    device.enable_async(False)
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
@@ -230,7 +224,7 @@ def test_linear_fp32_acc_l1(
 @pytest.mark.parametrize("out_sharded", [True, False], ids=["out_sharded", "out_unsharded"])
 @pytest.mark.parametrize("B, H, M, K, N, out_subblock_h, out_subblock_w", [[2, 16, 384, 64, 128, 1, 4]])
 @pytest.mark.parametrize("activations_dtype", [ttnn.bfloat8_b])
-@pytest.mark.parametrize("enable_async, num_loops", ((True, 2), (False, 1)))
+@pytest.mark.parametrize("num_loops", [2])
 def test_matmul_no_mcast_fp32_acc_l1(
     device,
     packer_l1_acc,
@@ -248,7 +242,6 @@ def test_matmul_no_mcast_fp32_acc_l1(
     activations_dtype,
     function_level_defaults,
     num_loops,
-    enable_async,
 ):
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -266,7 +259,6 @@ def test_matmul_no_mcast_fp32_acc_l1(
         memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         buffer_type=ttnn.BufferType.L1,
     )
-    device.enable_async(enable_async)
     for _ in range(num_loops):
         in0 = torch.randn(in0_shape).bfloat16().float()
         in1 = torch.randn(in1_shape).bfloat16().float()
@@ -327,7 +319,6 @@ def test_matmul_no_mcast_fp32_acc_l1(
         passing, output = comp_pcc(pt_out, tt_out)
         logger.info(output)
         assert passing
-    device.enable_async(False)
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
@@ -346,7 +337,7 @@ def test_matmul_no_mcast_fp32_acc_l1(
 @pytest.mark.parametrize("N", [1024])
 @pytest.mark.parametrize("activations_dtype", [ttnn.float32])
 @pytest.mark.parametrize("weights_dtype", [ttnn.float32])
-@pytest.mark.parametrize("enable_async, num_loops", ((True, 2), (False, 1)))
+@pytest.mark.parametrize("num_loops", [2])
 def test_matmul_1d_fp32_input_output(
     device,
     packer_l1_acc,
@@ -360,7 +351,6 @@ def test_matmul_1d_fp32_input_output(
     weights_dtype,
     function_level_defaults,
     num_loops,
-    enable_async,
 ):
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -382,7 +372,6 @@ def test_matmul_1d_fp32_input_output(
         memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         buffer_type=ttnn.BufferType.L1,
     )
-    device.enable_async(enable_async)
     for _ in range(num_loops):
         in0 = torch.rand(in0_shape).float()
         in1 = torch.rand(in1_shape).float()
@@ -442,7 +431,6 @@ def test_matmul_1d_fp32_input_output(
         passing, output = comp_pcc(pt_out, tt_out)
         logger.info(output)
         assert passing
-    device.enable_async(False)
 
 
 @pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
@@ -459,7 +447,7 @@ def test_matmul_1d_fp32_input_output(
 @pytest.mark.parametrize("out_sharded", [True, False], ids=["out_sharded", "out_unsharded"])
 @pytest.mark.parametrize("B, H, M, K, N, out_subblock_h, out_subblock_w", [[2, 16, 384, 64, 128, 1, 4]])
 @pytest.mark.parametrize("activations_dtype", [ttnn.float32])
-@pytest.mark.parametrize("enable_async, num_loops", ((True, 2), (False, 1)))
+@pytest.mark.parametrize("num_loops", [2])
 def test_matmul_no_mcast_fp32_input_output(
     device,
     packer_l1_acc,
@@ -477,7 +465,6 @@ def test_matmul_no_mcast_fp32_input_output(
     activations_dtype,
     function_level_defaults,
     num_loops,
-    enable_async,
 ):
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -495,7 +482,6 @@ def test_matmul_no_mcast_fp32_input_output(
         memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         buffer_type=ttnn.BufferType.L1,
     )
-    device.enable_async(enable_async)
     for _ in range(num_loops):
         in0 = torch.rand(in0_shape).float() * 1000.0
         in1 = torch.rand(in1_shape).float() * 1000.0
@@ -556,7 +542,6 @@ def test_matmul_no_mcast_fp32_input_output(
         passing, output = comp_pcc(pt_out, tt_out)
         logger.info(output)
         assert passing
-    device.enable_async(False)
 
 
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
@@ -574,7 +559,7 @@ def test_matmul_no_mcast_fp32_input_output(
 @pytest.mark.parametrize("B, H, M, K, N, out_subblock_h, out_subblock_w", [[2, 16, 384, 128, 64, 2, 2]])
 @pytest.mark.parametrize("activations_dtype", [ttnn.bfloat8_b])
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.float32])
-@pytest.mark.parametrize("enable_async, num_loops", ((True, 2), (False, 1)))
+@pytest.mark.parametrize("num_loops", [2])
 def test_matmul_no_untilize_output_param(
     device,
     packer_l1_acc,
@@ -593,7 +578,6 @@ def test_matmul_no_untilize_output_param(
     output_dtype,
     function_level_defaults,
     num_loops,
-    enable_async,
 ):
     grid_size = (8, 4)
     compute_grid_size = device.compute_with_storage_grid_size()
@@ -613,7 +597,6 @@ def test_matmul_no_untilize_output_param(
         memory_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         buffer_type=ttnn.BufferType.L1,
     )
-    device.enable_async(enable_async)
     for _ in range(num_loops):
         in0 = torch.rand(in0_shape).float() * 1000.0
         in1 = torch.rand(in1_shape).float() * 1000.0
@@ -680,4 +663,3 @@ def test_matmul_no_untilize_output_param(
         passing, output = comp_pcc(pt_out, tt_out)
         logger.info(output)
         assert passing
-    device.enable_async(False)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -510,7 +510,6 @@ def test_sharded_matmul_1d_in1(
     [ttnn.bfloat16, ttnn.bfloat8_b],
     ids=["out_BFLOAT16", "out_BFLOAT8_B"],
 )
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_sharded_partial_op(
     device,
     H,
@@ -518,13 +517,11 @@ def test_sharded_partial_op(
     num_slices,
     activations_dtype,
     output_dtype,
-    async_mode,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, 64]
     W = in0_shape[-1]
@@ -587,14 +584,12 @@ def test_sharded_partial_op(
     [ttnn.bfloat16, ttnn.bfloat8_b],
     ids=["out_BFLOAT16", "out_BFLOAT8_B"],
 )
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_block_sharded_partial_op(
-    device, H, W, num_cores, activations_dtype, output_dtype, async_mode, function_level_defaults, use_program_cache
+    device, H, W, num_cores, activations_dtype, output_dtype, function_level_defaults, use_program_cache
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, W]
     W = in0_shape[-1]
@@ -734,7 +729,6 @@ def test_bcast_hw(device, num_cores, in0_height_sharded, out_height_sharded, in_
     [ttnn.bfloat16, ttnn.bfloat8_b],
     ids=["out_BFLOAT16", "out_BFLOAT8_B"],
 )
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_width_sharded_partial_op(
     device,
     H,
@@ -743,13 +737,11 @@ def test_width_sharded_partial_op(
     num_slices,
     activations_dtype,
     output_dtype,
-    async_mode,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, W]
 
@@ -811,7 +803,6 @@ def test_width_sharded_partial_op(
     [ttnn.bfloat16, ttnn.bfloat8_b],
     ids=["out_BFLOAT16", "out_BFLOAT8_B"],
 )
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
 def test_partial_sharded_op_binary(
     device,
     in0_sharded,
@@ -822,13 +813,11 @@ def test_partial_sharded_op_binary(
     num_slices,
     activations_dtype,
     output_dtype,
-    async_mode,
     function_level_defaults,
 ):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")
-    device.enable_async(async_mode)
     grid_size = (8, 8)
     in0_shape = [1, 1, H, 96]
     in1_shape = in0_shape

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_untilize_test.py
@@ -28,7 +28,6 @@ from models.utility_functions import is_grayskull, skip_for_blackhole
 def test_run_untilize_subcoregrid_test(dtype, nb, nc, nh, nw, device):
     if is_grayskull():
         pytest.skip("Skipping tests on Grayskull")
-    device.enable_async(True)
     shape = [nb, nc, nh, nw]
 
     torch.set_printoptions(precision=3, sci_mode=False, linewidth=3000, threshold=10000, edgeitems=128)

--- a/tests/tt_eager/tensors/test_async_tensor_apis.cpp
+++ b/tests/tt_eager/tensors/test_async_tensor_apis.cpp
@@ -127,7 +127,6 @@ TEST_F(DispatchFixture, TestTensorOwnershipSanity) {
 
 TEST_F(DispatchFixture, TestAsyncEltwiseBinary) {
     IDevice* device = this->devices_[0];
-    device->enable_async(true);
     // Populate these in first loop and verify that deallocation worked - addresses should be identical across loops
     std::size_t input_a_addr = 0;
     std::size_t input_b_addr = 0;
@@ -177,14 +176,12 @@ TEST_F(DispatchFixture, TestAsyncEltwiseBinary) {
             EXPECT_EQ(bfloat16(buf[j]), bfloat16(static_cast<float>(i - 2 * i * i)));
         }
     }
-    device->enable_async(false);
 }
 
 Tensor tensor_identity_copy_function(const Tensor& tensor) { return tensor; }
 
 TEST_F(DispatchFixture, TestAsyncRefCountManager) {
     IDevice* device = this->devices_[0];
-    device->enable_async(true);
 
     log_info(LogTest, "Testing Device tensor copy assignment");
     for (int i = 0; i < 5; i++) {
@@ -261,7 +258,6 @@ TEST_F(DispatchFixture, TestAsyncRefCountManager) {
 #endif
     EXPECT_EQ(get_device_buffer_address(tensor_to_self_assign), tensor_to_self_assign_address);
     auto barrier_tensor = tensor_to_self_assign.cpu();
-    device->enable_async(false);
 }
 
 TEST_F(DispatchFixture, TestTensorAsyncDataMovement) {

--- a/tests/ttnn/distributed/test_hybrid_data_tensor_parallel_example_T3000.py
+++ b/tests/ttnn/distributed/test_hybrid_data_tensor_parallel_example_T3000.py
@@ -47,7 +47,6 @@ def test_tensor_parallel_falcon_mlp():
     mesh_device = ttnn.open_mesh_device(
         ttnn.MeshShape(2, 4),
     )
-    mesh_device.enable_async(True)
 
     # Set PyTorch seed for reproducibility
     torch.manual_seed(0)

--- a/tests/ttnn/distributed/test_multidevice_TG.py
+++ b/tests/ttnn/distributed/test_multidevice_TG.py
@@ -1431,8 +1431,7 @@ def test_line_all_gather_column_major(mesh_device):
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("cluster_axis", (1,))
 @pytest.mark.parametrize("dim", (0,))
-@pytest.mark.parametrize("async_mode", (False, True))
-def test_device_line_all_gather_8x4_data(mesh_device, cluster_axis: int, dim: int, async_mode: bool):
+def test_device_line_all_gather_8x4_data(mesh_device, cluster_axis: int, dim: int):
     """
     Test the line-all-gather operation on a 8x4 mesh.
     Data Pattern for initial sharding [TILE_SIZE*mesh_device_ROWS, TILE_SIZE*mesh_device_COLS]:
@@ -1448,8 +1447,6 @@ def test_device_line_all_gather_8x4_data(mesh_device, cluster_axis: int, dim: in
     - Every device along the column contains the whole column tensor stacked on `dim` dimension
     - Every device will have the shape: [4, 1, 32, 32]
     """
-    if async_mode:
-        mesh_device.enable_async(True)
 
     (rows, cols), tile_size = mesh_device.shape, 32
     full_tensor = torch.zeros((1, 1, tile_size * rows, tile_size * cols), dtype=torch.bfloat16)

--- a/tests/ttnn/tracy/test_trace_runs.py
+++ b/tests/ttnn/tracy/test_trace_runs.py
@@ -11,7 +11,6 @@ import ttnn
 
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 1996800}], indirect=True)
 def test_with_ops(device):
-    device.enable_async(True)
     ttnn.enable_program_cache(device)
 
     torch.manual_seed(0)

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -69,7 +69,6 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(true);
     mesh_device->enable_program_cache();
 
     auto view = mesh_device->get_view();
@@ -216,7 +215,6 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
     constexpr size_t test_expected_num_devices = 4;
 
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(true);
     mesh_device->enable_program_cache();
 
     auto view = mesh_device->get_view();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor_multi_device.cpp
@@ -31,11 +31,10 @@ using ::tt::tt_metal::MemoryConfig;
 using ::tt::tt_metal::StorageType;
 using ::tt::tt_metal::TensorMemoryLayout;
 
-class MultiDeviceTensorCreationTest : public GenericMeshDeviceFixture, public ::testing::WithParamInterface<bool> {};
+using MultiDeviceTensorCreationTest = GenericMeshDeviceFixture;
 
-TEST_P(MultiDeviceTensorCreationTest, Empty) {
+TEST_F(MultiDeviceTensorCreationTest, Empty) {
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(GetParam());
 
     const Tensor mesh_replicated_tensor = ttnn::empty(
         ttnn::Shape({32, 32}),
@@ -47,9 +46,8 @@ TEST_P(MultiDeviceTensorCreationTest, Empty) {
     EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
-TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
+TEST_F(MultiDeviceTensorCreationTest, EmptyLike) {
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(GetParam());
 
     ASSERT_FALSE(mesh_device->get_devices().empty());
 
@@ -72,9 +70,8 @@ TEST_P(MultiDeviceTensorCreationTest, EmptyLike) {
     EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
-TEST_P(MultiDeviceTensorCreationTest, Full) {
+TEST_F(MultiDeviceTensorCreationTest, Full) {
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(GetParam());
 
     const Tensor mesh_replicated_tensor = ttnn::full(
         ttnn::Shape({32, 32}),
@@ -97,9 +94,8 @@ TEST_P(MultiDeviceTensorCreationTest, Full) {
     }
 }
 
-TEST_P(MultiDeviceTensorCreationTest, FullLike) {
+TEST_F(MultiDeviceTensorCreationTest, FullLike) {
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(GetParam());
 
     ASSERT_FALSE(mesh_device->get_devices().empty());
 
@@ -131,9 +127,8 @@ TEST_P(MultiDeviceTensorCreationTest, FullLike) {
     }
 }
 
-TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
+TEST_F(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(GetParam());
 
     ASSERT_FALSE(mesh_device->get_devices().empty());
 
@@ -169,9 +164,8 @@ TEST_P(MultiDeviceTensorCreationTest, FullLikeWithOptTensor) {
     EXPECT_THAT(get_device_tensors(mesh_replicated_tensor), SizeIs(mesh_device->num_devices()));
 }
 
-TEST_P(MultiDeviceTensorCreationTest, Arange) {
+TEST_F(MultiDeviceTensorCreationTest, Arange) {
     MeshDevice* mesh_device = this->mesh_device_.get();
-    mesh_device->enable_async(GetParam());
 
     Tensor tensor = ttnn::arange(
         /*start=*/0,
@@ -191,8 +185,6 @@ TEST_P(MultiDeviceTensorCreationTest, Arange) {
         EXPECT_THAT(values, Pointwise(FloatEq(), expected));
     }
 }
-
-INSTANTIATE_TEST_SUITE_P(AllTests, MultiDeviceTensorCreationTest, ::testing::Bool());
 
 }  // namespace
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -72,8 +72,6 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
     const bfloat16* golden_output = std::get<owned_buffer::Buffer<bfloat16>>(
                                         std::get<MultiDeviceHostStorage>(np_out_host.get_storage()).buffers.at(0))
                                         .begin();
-    // Enable Asynchronous Execution and test ttnn runtime APIs
-    device_->enable_async(true);
     // Events for host - device synchronization
     // Running sum-reduce with preallocated output
     // Preallocate Input and Output Tensors on Device
@@ -107,7 +105,6 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncPreallocatedOutputs) {
 }
 
 TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
-    device_->enable_async(true);
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -164,7 +161,6 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeBufferDestructor) {
     // Test functionality for the buffer destructor, which will call deallocate asynchronously
     // We must ensure that the deallocate step, which can run after the buffer has been destroyed
     // does not rely on stale buffer state, after the buffer has been destroyed on host
-    device_->enable_async(true);
     MemoryConfig mem_cfg = MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
         .buffer_type = BufferType::DRAM,
@@ -180,7 +176,6 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeBufferDestructor) {
     TensorSpec tensor_spec(shape, tensor_layout);
     for (int loop = 0; loop < 100000; loop++) {
         auto input_buffer_dummy = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(device_, tensor_spec);
-        device_->synchronize();
     }
 }
 }  // namespace

--- a/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
@@ -309,8 +309,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
             input_tensor_1,
             /*bias=*/std::nullopt,
             /*parameters=*/matmul_params);
-        device->push_work([device]() mutable { Synchronize(device, std::nullopt, std::vector<SubDeviceId>()); });
-        device->synchronize();
+        Synchronize(device, std::nullopt, std::vector<SubDeviceId>());
         output_tensor.deallocate();
     }
 
@@ -335,8 +334,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
         {
             ZoneScopedN("Matmul trace iterations");
             ttnn::operations::trace::execute_trace(device, tid, ttnn::DefaultQueueId, false);
-            device->push_work([device]() mutable { Synchronize(device, std::nullopt, std::vector<SubDeviceId>()); });
-            device->synchronize();
+            Synchronize(device, std::nullopt, std::vector<SubDeviceId>());
         }
 
         auto end_time = std::chrono::high_resolution_clock::now();
@@ -353,9 +351,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
                     input_tensor_1,
                     /*bias=*/std::nullopt,
                     /*parameters=*/matmul_params);
-                device->push_work(
-                    [device]() mutable { Synchronize(device, std::nullopt, std::vector<SubDeviceId>()); });
-                device->synchronize();
+                Synchronize(device, std::nullopt, std::vector<SubDeviceId>());
                 auto end_time = std::chrono::high_resolution_clock::now();
                 total_time += end_time - start_time;
                 output_tensor.deallocate();

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -44,8 +44,6 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     // This leads to shared access of the work_executor and host side worker queue.
     // Test thread safety.
     IDevice* device = this->device_;
-    // Enable async engine and set queue setting to lock_based
-    device->enable_async(true);
 
     const ttnn::Shape tensor_shape{1, 1, 1024, 1024};
     const MemoryConfig mem_cfg = MemoryConfig{
@@ -96,8 +94,6 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
     // Writer cannot update location until reader has picked up data.
     // Use write_event to stall reader and read_event to stall writer.
     auto device = this->device_;
-    // Enable async engine and set queue setting to lock_based
-    device->enable_async(true);
 
     const ttnn::Shape tensor_shape{1, 1, 1024, 1024};
     const MemoryConfig mem_cfg = MemoryConfig{

--- a/tests/ttnn/unit_tests/light_metal/test_single_device_light_metal_trace.py
+++ b/tests/ttnn/unit_tests/light_metal/test_single_device_light_metal_trace.py
@@ -36,13 +36,11 @@ def reset_device_and_replay_binary(reset_device, device, binary_data):
 
 # Simple bringup single op test to see if everything uses host APIs and if it can be light-metal traced.
 @pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 32, 32)])
-@pytest.mark.parametrize("enable_async", [False])
 @pytest.mark.parametrize("blocking", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}])
-def test_single_op_test_light_metal_capture(device, reset_device, shape, enable_async, blocking, tmp_path):
+def test_single_op_test_light_metal_capture(device, reset_device, shape, blocking, tmp_path):
     ttnn.light_metal_begin_capture()
 
-    device.enable_async(enable_async)
     device.enable_program_cache()
 
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
@@ -61,13 +59,11 @@ def test_single_op_test_light_metal_capture(device, reset_device, shape, enable_
 
 # Simple bringup, multiple ops in chain
 @pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 32, 32)])
-@pytest.mark.parametrize("enable_async", [False])
 @pytest.mark.parametrize("blocking", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}])
-def test_chain_op_test_light_metal_capture(device, reset_device, shape, enable_async, blocking, tmp_path):
+def test_chain_op_test_light_metal_capture(device, reset_device, shape, blocking, tmp_path):
     ttnn.light_metal_begin_capture()
 
-    device.enable_async(enable_async)
     device.enable_program_cache()
     input_0_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)
     input_1_dev = ttnn.allocate_tensor_on_device(ttnn.Shape(shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device)

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/concat_fuse_test.py
@@ -123,7 +123,6 @@ def run_concat_fuse_impl(
     input_shard_grid,
     all_gather_topology,
     num_iters=1,
-    enable_async=False,
     trace_mode=False,
     output_shard_shape=None,
     output_shard_grid=None,
@@ -134,10 +133,6 @@ def run_concat_fuse_impl(
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
     # Use Async mode based on test input config
-    mesh_device.enable_async(enable_async)
-
-    if enable_async:
-        logger.info(f"Using Async Mode for All Gather Op Dispatch")
 
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -28,7 +28,6 @@ def run_rms_trace(
     output_shard_grid,
     all_gather_topology,
     num_iters=1,
-    enable_async=True,
     input_dtype=ttnn.bfloat8_b,
     layout=ttnn.TILE_LAYOUT,
     topology=ttnn.Topology.Linear,
@@ -38,7 +37,6 @@ def run_rms_trace(
     profiler=BenchmarkProfiler(),
 ):
     ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 1))})
-    mesh_device.enable_async(enable_async)
     worker_sub_device = ttnn.SubDevice(
         [
             ccl_sub_device_crs,
@@ -316,14 +314,12 @@ def run_rms_fuse_impl(
     output_shard_grid,
     all_gather_topology,
     num_iters=1,
-    enable_async=False,
     input_dtype=ttnn.bfloat8_b,
     layout=ttnn.TILE_LAYOUT,
     topology=ttnn.Topology.Linear,
     epsilon=1e-05,
 ):
     ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 1))})
-    mesh_device.enable_async(enable_async)
     worker_sub_device = ttnn.SubDevice(
         [
             ccl_sub_device_crs,

--- a/tests/ttnn/unit_tests/operations/ccl/perf/test_ccl_async_perf.py
+++ b/tests/ttnn/unit_tests/operations/ccl/perf/test_ccl_async_perf.py
@@ -40,7 +40,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_gather_TG_post_commit import 
     ],
 )
 @pytest.mark.parametrize("num_iters", [20])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 1824800}], indirect=True)
 def test_all_gather_async_t3000(
     t3k_mesh_device,
@@ -54,7 +53,6 @@ def test_all_gather_async_t3000(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     output_shape[dim] *= num_devices
     run_all_gather_impl(
@@ -69,7 +67,6 @@ def test_all_gather_async_t3000(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        enable_async=enable_async,
         rand_tensor=True,
         mem_config=mem_config,
         trace_mode=True,
@@ -102,7 +99,6 @@ def test_all_gather_async_t3000(
     ],
 )
 @pytest.mark.parametrize("replication_factor", [4])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 1824800}], indirect=True)
 def test_all_gather_async_tg(
@@ -116,7 +112,6 @@ def test_all_gather_async_tg(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -134,7 +129,6 @@ def test_all_gather_async_tg(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=0,
@@ -169,7 +163,6 @@ def test_all_gather_async_tg(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [False])
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 1824800}], indirect=True)
 def test_reduce_scatter_async_t3000(
@@ -184,7 +177,6 @@ def test_reduce_scatter_async_t3000(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     trace_mode,
     num_iters=20,
 ):
@@ -201,7 +193,6 @@ def test_reduce_scatter_async_t3000(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         topology=ttnn.Topology.Linear,
         trace_mode=trace_mode,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/perf/test_ccl_perf.py
+++ b/tests/ttnn/unit_tests/operations/ccl/perf/test_ccl_perf.py
@@ -46,7 +46,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_reduce_scatter_TG_nightly import 
     ],
 )
 @pytest.mark.parametrize("num_iters", [20])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 1824800}], indirect=True)
 def test_all_gather_on_n300(
     n300_mesh_device,
@@ -60,7 +59,6 @@ def test_all_gather_on_n300(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_on_n300_impl(
         n300_mesh_device,
@@ -75,7 +73,6 @@ def test_all_gather_on_n300(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        enable_async=enable_async,
         trace_mode=True,
     )
 
@@ -103,7 +100,6 @@ def test_all_gather_on_n300(
     ],
 )
 @pytest.mark.parametrize("num_iters", [20])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("topology", [ttnn.Topology.Ring, ttnn.Topology.Linear])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)
 def test_all_gather_on_t3000(
@@ -119,7 +115,6 @@ def test_all_gather_on_t3000(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
         t3k_mesh_device,
@@ -134,7 +129,6 @@ def test_all_gather_on_t3000(
         function_level_defaults,
         all_gather_topology=topology,
         num_iters=num_iters,
-        enable_async=enable_async,
         trace_mode=True,
     )
 
@@ -170,7 +164,6 @@ def test_all_gather_on_t3000(
 )
 @pytest.mark.parametrize("num_iters", [20])
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("topology", [ttnn.Topology.Linear, ttnn.Topology.Ring])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)
 def test_reduce_scatter_on_t3000(
@@ -185,7 +178,6 @@ def test_reduce_scatter_on_t3000(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters,
     topology,
 ):
@@ -202,7 +194,6 @@ def test_reduce_scatter_on_t3000(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         topology=topology,
         trace_mode=True,
     )
@@ -239,7 +230,6 @@ def test_reduce_scatter_on_t3000(
 )
 @pytest.mark.parametrize("num_iters", [20])
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)
 def test_reduce_scatter_on_n300(
     n300_mesh_device,
@@ -253,7 +243,6 @@ def test_reduce_scatter_on_n300(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters,
 ):
     run_reduce_scatter_test(
@@ -269,7 +258,6 @@ def test_reduce_scatter_on_n300(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         trace_mode=True,
     )
 
@@ -299,7 +287,6 @@ def test_reduce_scatter_on_n300(
 )
 @pytest.mark.parametrize("replication_factor", [8])
 @pytest.mark.parametrize("num_iters", [20])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 532480}], indirect=True)
 def test_all_gather_on_tg(
@@ -313,7 +300,6 @@ def test_all_gather_on_tg(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters,
 ):
@@ -331,7 +317,6 @@ def test_all_gather_on_tg(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=1,
@@ -362,7 +347,6 @@ def test_all_gather_on_tg(
     ],
 )
 @pytest.mark.parametrize("replication_factor", [8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("num_iters", [20])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
@@ -379,7 +363,6 @@ def test_reduce_scatter_on_tg(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters,
 ):
@@ -396,7 +379,6 @@ def test_reduce_scatter_on_tg(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=1,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather.py
@@ -128,17 +128,12 @@ def run_all_gather_impl(
     function_level_defaults,
     all_gather_topology,
     num_iters=1,
-    enable_async=False,
     trace_mode=False,
     tile=(32, 32),
 ):
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
-    # Use Async mode based on test input config
-    mesh_device.enable_async(enable_async)
 
-    if enable_async:
-        logger.info(f"Using Async Mode for All Gather Op Dispatch")
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
 
@@ -196,7 +191,6 @@ def run_all_gather_on_n300_impl(
     function_level_defaults,
     all_gather_topology,
     num_iters=1,
-    enable_async=False,
     trace_mode=False,
     tile=(32, 32),
 ):
@@ -221,7 +215,6 @@ def run_all_gather_on_n300_impl(
         function_level_defaults,
         all_gather_topology=all_gather_topology,
         num_iters=num_iters,
-        enable_async=enable_async,
         trace_mode=trace_mode,
         tile=tile,
     )
@@ -240,7 +233,6 @@ def run_all_gather_on_t3000_impl(
     function_level_defaults,
     all_gather_topology,
     num_iters=1,
-    enable_async=False,
     trace_mode=False,
     tile=(32, 32),
 ):
@@ -265,7 +257,6 @@ def run_all_gather_on_t3000_impl(
         function_level_defaults,
         all_gather_topology=all_gather_topology,
         num_iters=num_iters,
-        enable_async=enable_async,
         trace_mode=trace_mode,
         tile=tile,
     )
@@ -284,7 +275,6 @@ def run_all_gather_on_t3000_impl_tight_loop(
     function_level_defaults,
     all_gather_topology,
     num_iters,
-    enable_async=False,
     trace_mode=False,
     tile=(32, 32),
 ):
@@ -301,7 +291,6 @@ def run_all_gather_on_t3000_impl_tight_loop(
         function_level_defaults,
         all_gather_topology=all_gather_topology,
         num_iters=num_iters,
-        enable_async=enable_async,
         trace_mode=trace_mode,
         tile=tile,
     )
@@ -341,7 +330,6 @@ def run_all_gather_on_t3000_impl_tight_loop(
     ],
 )
 @pytest.mark.parametrize("num_iters", [1000])  # restore to 500: https://github.com/tenstorrent/tt-metal/issues/9686
-@pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_on_t3000_post_commit_looping(
     t3k_mesh_device,
     num_devices,
@@ -354,7 +342,6 @@ def test_all_gather_on_t3000_post_commit_looping(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
         t3k_mesh_device,
@@ -369,7 +356,6 @@ def test_all_gather_on_t3000_post_commit_looping(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -399,7 +385,6 @@ def test_all_gather_on_t3000_post_commit_looping(
     ],
 )
 @pytest.mark.parametrize("num_iters", [1000])  # TODO: restore to 500
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_all_gather_on_t3000_nightly_commit_looping(
     t3k_mesh_device,
     num_devices,
@@ -412,7 +397,6 @@ def test_all_gather_on_t3000_nightly_commit_looping(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
         t3k_mesh_device,
@@ -427,7 +411,6 @@ def test_all_gather_on_t3000_nightly_commit_looping(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -457,7 +440,6 @@ def test_all_gather_on_t3000_nightly_commit_looping(
     ],
 )
 @pytest.mark.parametrize("num_iters", [1000])  # TODO: restore to 500
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_all_gather_on_t3000_nightly_commit_looping_4chip_ring(
     pcie_mesh_device,
     num_devices,
@@ -470,7 +452,6 @@ def test_all_gather_on_t3000_nightly_commit_looping_4chip_ring(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_on_t3000_impl_tight_loop(
         pcie_mesh_device,
@@ -485,7 +466,6 @@ def test_all_gather_on_t3000_nightly_commit_looping_4chip_ring(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -708,7 +688,6 @@ def test_all_gather_on_t3000_post_commit_4chip_ring(
         # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -720,7 +699,6 @@ def test_line_all_gather_on_t3000_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     if t3k_mesh_device.get_num_devices() < num_devices:
@@ -738,7 +716,6 @@ def test_line_all_gather_on_t3000_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
-        enable_async=enable_async,
         num_iters=num_iters,
     )
 
@@ -771,7 +748,6 @@ def test_line_all_gather_on_t3000_post_commit(
         # ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_post_commit_4chip_ring(
     pcie_mesh_device,
     num_devices,
@@ -783,7 +759,6 @@ def test_line_all_gather_on_t3000_post_commit_4chip_ring(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     if pcie_mesh_device.get_num_devices() < num_devices:
@@ -801,7 +776,6 @@ def test_line_all_gather_on_t3000_post_commit_4chip_ring(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
-        enable_async=enable_async,
         num_iters=num_iters,
     )
 
@@ -838,7 +812,6 @@ def test_line_all_gather_on_t3000_post_commit_4chip_ring(
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_nightly(
     t3k_mesh_device,
     num_devices,
@@ -850,7 +823,6 @@ def test_line_all_gather_on_t3000_nightly(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     if t3k_mesh_device.get_num_devices() < num_devices:
@@ -868,7 +840,6 @@ def test_line_all_gather_on_t3000_nightly(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
-        enable_async=enable_async,
         num_iters=num_iters,
     )
 
@@ -1132,7 +1103,6 @@ def run_all_gather_sharded(
     use_program_cache,
     function_level_defaults,
     all_gather_topology,
-    enable_async,
     n_worker=None,
     n_buffer=None,
     num_iter=1,
@@ -1283,7 +1253,6 @@ def run_all_gather_sharded_t3k(
     use_program_cache,
     function_level_defaults,
     all_gather_topology,
-    enable_async,
     n_worker=None,
     n_buffer=None,
     num_iter=1,
@@ -1292,8 +1261,6 @@ def run_all_gather_sharded_t3k(
 ):
     if t3k_mesh_device.get_num_devices() < num_devices:
         pytest.skip("Not T3000!")
-
-    t3k_mesh_device.enable_async(enable_async)
 
     return run_all_gather_sharded(
         t3k_mesh_device,
@@ -1311,7 +1278,6 @@ def run_all_gather_sharded_t3k(
         use_program_cache,
         function_level_defaults,
         all_gather_topology,
-        enable_async,
         n_worker,
         n_buffer,
         num_iter,
@@ -1336,7 +1302,6 @@ def run_all_gather_sharded_n300(
     use_program_cache,
     function_level_defaults,
     all_gather_topology,
-    enable_async,
     n_worker=None,
     n_buffer=None,
     num_iter=1,
@@ -1344,8 +1309,6 @@ def run_all_gather_sharded_n300(
 ):
     if mesh_device.get_num_devices() != 2:
         pytest.skip("Not N300!")
-
-    mesh_device.enable_async(enable_async)
 
     return run_all_gather_sharded(
         mesh_device,
@@ -1363,7 +1326,6 @@ def run_all_gather_sharded_n300(
         use_program_cache,
         function_level_defaults,
         all_gather_topology,
-        enable_async,
         n_worker,
         n_buffer,
         num_iter,
@@ -1420,7 +1382,6 @@ def run_all_gather_sharded_n300(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_sharded_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -1436,7 +1397,6 @@ def test_all_gather_sharded_post_commit(
     # num_cores,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_sharded_t3k(
         t3k_mesh_device,
@@ -1454,7 +1414,6 @@ def test_all_gather_sharded_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
-        enable_async=enable_async,
     )
 
 
@@ -1510,7 +1469,6 @@ def test_all_gather_sharded_post_commit(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_height_sharded_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -1526,7 +1484,6 @@ def test_all_gather_height_sharded_post_commit(
     # num_cores,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_sharded_t3k(
         t3k_mesh_device,
@@ -1544,7 +1501,6 @@ def test_all_gather_height_sharded_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
-        enable_async=enable_async,
     )
 
 
@@ -1594,7 +1550,6 @@ def test_all_gather_height_sharded_post_commit(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_block_sharded_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -1610,7 +1565,6 @@ def test_all_gather_block_sharded_post_commit(
     # num_cores,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_sharded_t3k(
         t3k_mesh_device,
@@ -1628,7 +1582,6 @@ def test_all_gather_block_sharded_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
-        enable_async=enable_async,
     )
 
 
@@ -1686,7 +1639,6 @@ def test_all_gather_block_sharded_post_commit(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 def test_line_all_gather_sharded_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -1702,7 +1654,6 @@ def test_line_all_gather_sharded_post_commit(
     # num_cores,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_sharded_t3k(
         t3k_mesh_device,
@@ -1720,7 +1671,6 @@ def test_line_all_gather_sharded_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
-        enable_async=enable_async,
     )
 
 
@@ -1848,7 +1798,6 @@ def test_line_all_gather_sharded_post_commit(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("all_gather_topology", [ttnn.Topology.Ring, ttnn.Topology.Linear])
 def test_sharded_all_gather_nightly(
     t3k_mesh_device,
@@ -1866,7 +1815,6 @@ def test_sharded_all_gather_nightly(
     use_program_cache,
     function_level_defaults,
     all_gather_topology,
-    enable_async,
 ):
     run_all_gather_sharded_t3k(
         t3k_mesh_device,
@@ -1884,7 +1832,6 @@ def test_sharded_all_gather_nightly(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=all_gather_topology,
-        enable_async=enable_async,
     )
 
 
@@ -1969,7 +1916,6 @@ def test_all_gather_fp32(  # https://github.com/tenstorrent/tt-metal/issues/9686
     ),
 )
 @pytest.mark.parametrize("tile_h", [2])
-@pytest.mark.parametrize("enable_async", [True])
 def test_tiny_all_gather_sharded_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -1985,7 +1931,6 @@ def test_tiny_all_gather_sharded_post_commit(
     # num_cores,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     tile_h,
 ):
     run_all_gather_sharded_t3k(
@@ -2004,7 +1949,6 @@ def test_tiny_all_gather_sharded_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
-        enable_async=enable_async,
         tile=(tile_h, 32),
     )
 
@@ -2028,7 +1972,6 @@ def test_tiny_all_gather_sharded_post_commit(
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("tile_h", [1, 4, 8, 16])
 def test_tiny_line_all_gather_post_commit(
     t3k_mesh_device,
@@ -2041,7 +1984,6 @@ def test_tiny_line_all_gather_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     tile_h,
     num_iters=1,
 ):
@@ -2060,7 +2002,6 @@ def test_tiny_line_all_gather_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
-        enable_async=enable_async,
         num_iters=num_iters,
         tile=(tile_h, 32),
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_N300_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_N300_post_commit.py
@@ -52,7 +52,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_gather import (
     ],
 )
 @pytest.mark.parametrize("num_iters", [1])
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_all_gather_on_n300_post_commit(
     n300_mesh_device,
     num_devices,
@@ -65,7 +64,6 @@ def test_all_gather_on_n300_post_commit(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_on_n300_impl(
         n300_mesh_device,
@@ -80,7 +78,6 @@ def test_all_gather_on_n300_post_commit(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -117,7 +114,6 @@ def test_all_gather_on_n300_post_commit(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 def test_all_gather_sharded_n300_post_commit(
     n300_mesh_device,
     num_devices,
@@ -133,7 +129,6 @@ def test_all_gather_sharded_n300_post_commit(
     # num_cores,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_sharded_n300(
         n300_mesh_device,
@@ -151,5 +146,4 @@ def test_all_gather_sharded_n300_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
-        enable_async=enable_async,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_nightly.py
@@ -52,7 +52,6 @@ from ttnn import ShardTensor2dMesh, ConcatMesh2dToTensor
     ),
 )
 @pytest.mark.parametrize("replication_factor", [8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_line_all_gather_sharded_on_TG_rows_post_commit(
@@ -69,7 +68,6 @@ def test_line_all_gather_sharded_on_TG_rows_post_commit(
     layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -92,7 +90,6 @@ def test_line_all_gather_sharded_on_TG_rows_post_commit(
         ttnn.BufferType.L1,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         input_shard_spec=input_shard_spec,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
@@ -185,7 +182,6 @@ def test_line_all_gather_sharded_on_TG_rows_post_commit(
     ),
 )
 @pytest.mark.parametrize("replication_factor", [4])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_line_all_gather_sharded_on_TG_cols_post_commit(
@@ -202,7 +198,6 @@ def test_line_all_gather_sharded_on_TG_cols_post_commit(
     layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -230,7 +225,6 @@ def test_line_all_gather_sharded_on_TG_cols_post_commit(
         ttnn.BufferType.L1,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         input_shard_spec=input_shard_spec,
         num_all_gather_instances=replication_factor,
@@ -264,7 +258,6 @@ def test_line_all_gather_sharded_on_TG_cols_post_commit(
         ttnn.BufferType.L1,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [4])  # 1, 4])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
@@ -279,7 +272,6 @@ def test_line_all_gather_on_TG_cols_nightly(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -297,7 +289,6 @@ def test_line_all_gather_on_TG_cols_nightly(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=0,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_TG_post_commit.py
@@ -173,7 +173,6 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
     buffer_type: ttnn.BufferType,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_spec: ttnn.ShardSpec = None,
     output_shard_spec: ttnn.ShardSpec = None,
     num_all_gather_instances: int = 1,
@@ -190,8 +189,6 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
 ):
     if use_persistent_output and not use_all_gather_async:
         pytest.skip("Persistent output tensor requires all-gather-async")
-
-    mesh_device.enable_async(enable_async)
 
     input_shape_per_chip = list(per_chip_output_shape)
     input_shape_per_chip[dim] //= num_devices_per_line
@@ -403,7 +400,6 @@ def run_line_all_gather_on_TG_with_mesh_tensor_along_rows(
     ],
 )
 @pytest.mark.parametrize("replication_factor", [8])  # 1, 8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_line_all_gather_on_TG_rows_post_commit(
@@ -417,7 +413,6 @@ def test_line_all_gather_on_TG_rows_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -435,7 +430,6 @@ def test_line_all_gather_on_TG_rows_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=1,
@@ -466,7 +460,6 @@ def test_line_all_gather_on_TG_rows_post_commit(
         ttnn.BufferType.DRAM,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [4])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
@@ -481,7 +474,6 @@ def test_line_all_gather_on_TG_cols_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -499,7 +491,6 @@ def test_line_all_gather_on_TG_cols_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=0,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_async_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_async_TG_nightly.py
@@ -57,7 +57,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_new_all_gather import (
 )
 @pytest.mark.parametrize("use_persistent_output", [True, False])
 @pytest.mark.parametrize("replication_factor", [8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_line_all_gather_sharded_on_TG_rows_post_commit(
@@ -75,7 +74,6 @@ def test_line_all_gather_sharded_on_TG_rows_post_commit(
     use_persistent_output,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -100,7 +98,6 @@ def test_line_all_gather_sharded_on_TG_rows_post_commit(
         ttnn.BufferType.L1,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         input_shard_spec=input_shard_spec,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
@@ -198,7 +195,6 @@ def test_line_all_gather_sharded_on_TG_rows_post_commit(
 )
 @pytest.mark.parametrize("use_persistent_output", [True, False])
 @pytest.mark.parametrize("replication_factor", [4])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_line_all_gather_sharded_on_TG_cols_post_commit(
@@ -216,7 +212,6 @@ def test_line_all_gather_sharded_on_TG_cols_post_commit(
     use_persistent_output,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -242,7 +237,6 @@ def test_line_all_gather_sharded_on_TG_cols_post_commit(
         ttnn.BufferType.L1,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         input_shard_spec=input_shard_spec,
         num_all_gather_instances=replication_factor,
@@ -286,7 +280,6 @@ def test_line_all_gather_sharded_on_TG_cols_post_commit(
 )
 @pytest.mark.parametrize("use_persistent_output", [True, False])
 @pytest.mark.parametrize("replication_factor", [4])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_line_all_gather_on_TG_cols_nightly(
@@ -301,7 +294,6 @@ def test_line_all_gather_on_TG_cols_nightly(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -319,7 +311,6 @@ def test_line_all_gather_on_TG_cols_nightly(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=0,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_llama_perf_sweep.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_llama_perf_sweep.py
@@ -70,7 +70,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_all_gather import run_all_gather_
     ),
 )
 @pytest.mark.parametrize("num_iter", [1000])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 17068032}], indirect=True)
 def test_all_gather_sharded_post_commit(
     t3k_mesh_device,
@@ -89,7 +88,6 @@ def test_all_gather_sharded_post_commit(
     # num_cores,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iter,
 ):
     logger.info(f"Running for n_worker={n_worker}, n_buffer={n_buffer}:")
@@ -109,7 +107,6 @@ def test_all_gather_sharded_post_commit(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
-        enable_async=enable_async,
         n_worker=n_worker,
         n_buffer=n_buffer,
         num_iter=num_iter,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_matmul.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_matmul.py
@@ -296,13 +296,6 @@ def run_all_gather_matmul_on_t3000_impl(
         )
     ],
 )
-@pytest.mark.parametrize(
-    "enable_async",
-    [
-        True,
-        False,
-    ],
-)
 def test_all_gather_matmul_on_t3000_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -320,7 +313,6 @@ def test_all_gather_matmul_on_t3000_post_commit(
     mem_config_mm,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_matmul_on_t3000_impl(
         t3k_mesh_device,
@@ -398,13 +390,6 @@ def test_all_gather_matmul_on_t3000_post_commit(
         )
     ],
 )
-@pytest.mark.parametrize(
-    "enable_async",
-    [
-        True,
-        False,
-    ],
-)
 def test_all_gather_matmul_1d_on_t3000_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -422,7 +407,6 @@ def test_all_gather_matmul_1d_on_t3000_post_commit(
     mem_config_mm,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_matmul_on_t3000_impl(
         t3k_mesh_device,
@@ -529,13 +513,6 @@ def test_all_gather_matmul_1d_on_t3000_post_commit(
     ids=("llama_selfout",),
 )
 @pytest.mark.parametrize(
-    "enable_async",
-    [
-        True,
-        False,
-    ],
-)
-@pytest.mark.parametrize(
     "device_params", [{"trace_region_size": 90112}], indirect=True
 )  # TODO: Update once trace fails
 def test_all_gather_matmul_1d_llama_selfout_on_t3000_post_commit(
@@ -556,7 +533,6 @@ def test_all_gather_matmul_1d_llama_selfout_on_t3000_post_commit(
     mem_config_weights,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_matmul_on_t3000_impl(
         t3k_mesh_device,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_gather_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_gather_nightly.py
@@ -47,7 +47,6 @@ from ttnn import ShardTensorToMesh
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
 @pytest.mark.parametrize("tile_h", [32])
 def test_line_all_gather_on_t3000_nightly(
     t3k_mesh_device,
@@ -60,7 +59,6 @@ def test_line_all_gather_on_t3000_nightly(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     tile_h,
     num_iters=1,
 ):
@@ -76,7 +74,6 @@ def test_line_all_gather_on_t3000_nightly(
         use_program_cache,
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
-        enable_async=enable_async,
         num_iters=num_iters,
         tile=(tile_h, 32),
     )
@@ -109,7 +106,6 @@ def test_line_all_gather_on_t3000_nightly(
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_nightly_two_link(
     pcie_mesh_device,
     num_devices,
@@ -121,7 +117,6 @@ def test_line_all_gather_on_t3000_nightly_two_link(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_all_gather_on_t3000_impl(
@@ -137,7 +132,6 @@ def test_line_all_gather_on_t3000_nightly_two_link(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -153,14 +147,11 @@ def run_line_all_gather_instances(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
     tile=(32, 32),
 ):
     if t3k_mesh_device.get_num_devices() != 8:
         pytest.skip("Not T3000!")
-
-    t3k_mesh_device.enable_async(enable_async)
 
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
@@ -240,7 +231,6 @@ def run_line_all_gather_instances(
         ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True, False])
 def test_line_all_gather_on_t3000_nightly_instances(
     t3k_mesh_device,
     num_devices,
@@ -253,7 +243,6 @@ def test_line_all_gather_on_t3000_nightly_instances(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_line_all_gather_instances(
@@ -268,6 +257,5 @@ def test_line_all_gather_on_t3000_nightly_instances(
         mem_config,
         use_program_cache,
         function_level_defaults,
-        enable_async,
         num_iters,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_async.py
@@ -22,7 +22,6 @@ def run_all_reduce_test(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async=True,
     num_iters=1,
     topology=ttnn.Topology.Linear,
 ):
@@ -50,10 +49,6 @@ def run_all_reduce_test(
     gather_semaphore_handles = ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0)
 
     debug = False
-
-    mesh_device.enable_async(enable_async)
-    if enable_async:
-        logger.info(f"Using Async Mode for All Reduce Op Dispatch")
 
     logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}")
     # Generate input tensors
@@ -168,7 +163,6 @@ def run_all_reduce_test(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_ring_all_reduce_post_commit(
     t3k_mesh_device,
@@ -181,7 +175,6 @@ def test_ring_all_reduce_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=2,
 ):
     run_all_reduce_test(
@@ -196,7 +189,6 @@ def test_ring_all_reduce_post_commit(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -234,7 +226,6 @@ def test_ring_all_reduce_post_commit(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_ring_all_reduce_post_commit_2chip(
     t3k_mesh_device,
@@ -247,7 +238,6 @@ def test_ring_all_reduce_post_commit_2chip(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=2,
 ):
     run_all_reduce_test(
@@ -262,7 +252,6 @@ def test_ring_all_reduce_post_commit_2chip(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         topology=ttnn.Topology.Linear,
     )
 
@@ -278,7 +267,6 @@ def run_all_reduce_with_mesh_tensor_along_row(
     buffer_type: ttnn.BufferType,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_all_reduce_instances: int = 1,
     num_iters: int = 1,
     cluster_axis: int = 0,
@@ -305,10 +293,6 @@ def run_all_reduce_with_mesh_tensor_along_row(
 
     try:
         debug = False
-
-        mesh_device.enable_async(enable_async)
-        if enable_async:
-            logger.info(f"Using Async Mode for All Reduce Op Dispatch")
 
         logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices_per_line}")
         # Generate input tensors
@@ -420,7 +404,6 @@ def run_all_reduce_with_mesh_tensor_along_row(
     ],
 )
 @pytest.mark.parametrize("replication_factor", [8])  # 1, 8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
@@ -435,7 +418,6 @@ def test_line_all_reduce_on_TG_rows_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=16,
 ):
@@ -453,7 +435,6 @@ def test_line_all_reduce_on_TG_rows_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_reduce_instances=replication_factor,
         cluster_axis=1,
@@ -479,7 +460,6 @@ def test_line_all_reduce_on_TG_rows_post_commit(
         ttnn.BufferType.DRAM,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [4])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
@@ -495,7 +475,6 @@ def test_line_all_reduce_on_TG_cols_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=16,
 ):
@@ -513,7 +492,6 @@ def test_line_all_reduce_on_TG_cols_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_reduce_instances=replication_factor,
         cluster_axis=0,

--- a/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_all_reduce_t3000_frequent.py
@@ -81,7 +81,6 @@ def run_all_reduce_test(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async=True,
     num_iters=1,
     topology=ttnn.Topology.Ring,
 ):
@@ -97,10 +96,6 @@ def run_all_reduce_test(
     )
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
-
-    mesh_device.enable_async(enable_async)
-    if enable_async:
-        logger.info(f"Using Async Mode for All Reduce Op Dispatch")
 
     logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}")
     # Generate input tensors
@@ -209,7 +204,6 @@ def run_all_reduce_test(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_ring_all_reduce_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -221,7 +215,6 @@ def test_ring_all_reduce_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=2,
 ):
     run_all_reduce_test(
@@ -236,7 +229,6 @@ def test_ring_all_reduce_post_commit(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -274,7 +266,6 @@ def test_ring_all_reduce_post_commit(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_ring_all_reduce_post_commit_2chip(
     pcie_mesh_device,
     num_devices,
@@ -286,7 +277,6 @@ def test_ring_all_reduce_post_commit_2chip(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=2,
 ):
     run_all_reduce_test(
@@ -301,6 +291,5 @@ def test_ring_all_reduce_post_commit_2chip(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         topology=ttnn.Topology.Linear,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_barrier_t3000_frequent.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_barrier_t3000_frequent.py
@@ -27,7 +27,6 @@ def sharded_impl(
     tensor_layout,
     tensor_mem_layout,
     all_gather_topology,
-    enable_async,
     trace_mode,
     num_iter,
     tile=(32, 32),
@@ -36,7 +35,6 @@ def sharded_impl(
         pytest.skip("Not T3000!")
     n_worker = None
     n_buffer = None
-    device.enable_async(enable_async)
     unchunked_input_shape = list(input_shape)
     unchunked_input_shape[dim] *= num_devices
 
@@ -120,15 +118,12 @@ def run_normal(
     layout,
     num_iters,
     all_gather_topology,
-    enable_async,
     tile=(32, 32),
 ):
     print("Running barrier test")
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
 
-    if enable_async:
-        logger.info(f"Using Async Mode for Barrier Op Dispatch")
     logger.info(f"Input shape: {input_shape}")
     logger.info(f"dim: {dim}")
 
@@ -136,7 +131,6 @@ def run_normal(
     logger.info(f"dim: {dim}")
     input_tensor = torch.rand(input_shape).bfloat16()
     # Use Async mode based on test input config
-    device.enable_async(enable_async)
     input_tensor_mesh = ttnn.from_torch(
         input_tensor,
         device=device,
@@ -231,7 +225,6 @@ def run_with_trace(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("all_gather_topology", [ttnn.Topology.Ring])
 @pytest.mark.parametrize("num_iters", [1000])
 @pytest.mark.parametrize("mem_config", [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)])
@@ -247,7 +240,6 @@ def test_run_barrier_impl(
     layout,
     num_iters,
     all_gather_topology,
-    enable_async,
 ):
     if t3k_mesh_device.get_num_devices() < num_devices:
         pytest.skip("Not T3000!")
@@ -261,7 +253,6 @@ def test_run_barrier_impl(
         layout,
         num_iters,
         all_gather_topology,
-        enable_async,
     )
 
 
@@ -291,7 +282,6 @@ def test_run_barrier_impl(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("all_gather_topology", [ttnn.Topology.Ring])
 @pytest.mark.parametrize("num_iters", [1000])
 @pytest.mark.parametrize("mem_config", [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)])
@@ -307,7 +297,6 @@ def test_run_barrier_impl_pcie(
     layout,
     num_iters,
     all_gather_topology,
-    enable_async,
 ):
     if pcie_mesh_device.get_num_devices() < num_devices:
         pytest.skip("Not T3000!")
@@ -321,7 +310,6 @@ def test_run_barrier_impl_pcie(
         layout,
         num_iters,
         all_gather_topology,
-        enable_async,
     )
 
 
@@ -353,7 +341,6 @@ def test_run_barrier_impl_pcie(
     ),
 )
 @pytest.mark.parametrize("trace_mode", [True, False])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("num_iter", [1000])
 @pytest.mark.parametrize("all_gather_topology", [ttnn.Topology.Ring])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 7840768}], indirect=True)
@@ -372,7 +359,6 @@ def test_barrier_sharded(
     tensor_layout,
     tensor_mem_layout,
     all_gather_topology,
-    enable_async,
     trace_mode,
     num_iter,
 ):
@@ -391,7 +377,6 @@ def test_barrier_sharded(
         tensor_layout,
         tensor_mem_layout,
         all_gather_topology,
-        enable_async,
         trace_mode,
         num_iter,
     )
@@ -423,7 +408,6 @@ def test_barrier_sharded(
         ),
     ),
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("all_gather_topology", [ttnn.Topology.Ring])
 @pytest.mark.parametrize("num_iters", [1000])
 @pytest.mark.parametrize("mem_config", [ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM)])
@@ -440,7 +424,6 @@ def test_run_barrier_tiny_tile(
     layout,
     num_iters,
     all_gather_topology,
-    enable_async,
     tile_h,
 ):
     if t3k_mesh_device.get_num_devices() < num_devices:
@@ -455,6 +438,5 @@ def test_run_barrier_tiny_tile(
         layout,
         num_iters,
         all_gather_topology,
-        enable_async,
         tile=(tile_h, 32),
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
@@ -125,7 +125,6 @@ CORE_RANGE_SET_1x1 = ttnn.CoreRangeSet(
     ],
 )
 @pytest.mark.parametrize("replication_factor", [8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "device_params", [{"trace_region_size": 17068032, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
@@ -146,7 +145,6 @@ def test_all_gather_tg_llama(
     layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters,
     warmup_iters,
@@ -182,7 +180,6 @@ def test_all_gather_tg_llama(
         ttnn.BufferType.L1,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         warmup_iters=warmup_iters,
         input_shard_spec=input_shard_spec,
@@ -218,7 +215,6 @@ def test_all_gather_tg_llama(
         (NUM_ITERATIONS, 10),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize(
     "device_params",
@@ -251,7 +247,6 @@ def test_all_reduce_tg_llama(
     output_core_range_set,
     num_iters,
     warmup_iters,
-    enable_async,
     trace_mode,
     use_program_cache,
     function_level_defaults,
@@ -272,7 +267,6 @@ def test_all_reduce_tg_llama(
         output_dtype=output_dtype,
         num_iters=num_iters,
         warmup_iters=warmup_iters,
-        enable_async=enable_async,
         trace_mode=trace_mode,
         validate_all=False,
         profiler=profiler,

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -70,7 +70,6 @@ def run_reduce_scatter_test(
     output_grid=None,
     dtype=ttnn.bfloat8_b,
 ):
-    mesh_device.enable_async(True)
     mesh_device.enable_program_cache()
     num_pages_per_packet = 4
 

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -87,7 +87,6 @@ def run_all_gather_impl(
     input_shard_grid,
     all_gather_topology,
     num_iters=1,
-    enable_async=False,
     trace_mode=False,
     output_shard_shape=None,
     output_shard_grid=None,
@@ -95,11 +94,6 @@ def run_all_gather_impl(
 ):
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
-    # Use Async mode based on test input config
-    mesh_device.enable_async(enable_async)
-
-    if enable_async:
-        logger.info(f"Using Async Mode for All Gather Op Dispatch")
 
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
@@ -299,7 +293,6 @@ def run_all_gather_impl(
     ],
 )
 @pytest.mark.parametrize("num_iters", [8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_all_gather_only(
     t3k_mesh_device,
@@ -312,7 +305,6 @@ def test_all_gather_only(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_shape,
     input_shard_grid,
     output_shard_shape,
@@ -333,7 +325,6 @@ def test_all_gather_only(
         input_shard_grid,
         all_gather_topology=ttnn.Topology.Linear,
         num_iters=num_iters,
-        enable_async=enable_async,
         output_shard_shape=output_shard_shape,
         output_shard_grid=output_shard_grid,
         tensor_mem_layout=tensor_mem_layout,
@@ -365,7 +356,6 @@ def test_all_gather_only(
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize("use_new_version", [True])
 @pytest.mark.parametrize("num_iters, warmup_iters", [[100, 10]])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize(
     "device_params",
@@ -387,7 +377,6 @@ def test_tg_trace_rms_fuse(
     warmup_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_grid,
     output_shard_grid,
     trace_mode,
@@ -405,7 +394,6 @@ def test_tg_trace_rms_fuse(
         output_shard_grid,
         ttnn.Topology.Linear,
         num_iters=num_iters,
-        enable_async=enable_async,
         warmup_iters=warmup_iters,
         profiler=profiler,
         use_new_version=use_new_version,
@@ -442,7 +430,6 @@ def test_tg_trace_rms_fuse(
 )
 @pytest.mark.parametrize("num_links", [1])
 @pytest.mark.parametrize("num_iters", [20])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
@@ -457,7 +444,6 @@ def test_rms_fuse(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_grid,
     output_shard_grid,
 ):
@@ -472,7 +458,6 @@ def test_rms_fuse(
         output_shard_grid,
         ttnn.Topology.Linear,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -535,7 +520,6 @@ def test_rms_fuse(
     ],
 )
 @pytest.mark.parametrize("num_iters, warmup_iters", [[75, 5]])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize(
     "device_params",
@@ -561,7 +545,6 @@ def test_concat_fuse(
     warmup_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_shape,
     input_shard_grid,
     output_shard_shape,
@@ -585,7 +568,6 @@ def test_concat_fuse(
         all_gather_topology=ttnn.Topology.Linear,
         warmup_iters=warmup_iters,
         num_iters=num_iters,
-        enable_async=enable_async,
         output_shard_shape=output_shard_shape,
         output_shard_grid=output_shard_grid,
         tensor_mem_layout=tensor_mem_layout,

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_gather.py
@@ -117,7 +117,6 @@ def run_all_gather_impl(
     function_level_defaults,
     all_gather_topology,
     num_iters=1,
-    enable_async=False,
     trace_mode=False,
     rand_tensor=True,
     mem_config=None,
@@ -131,11 +130,6 @@ def run_all_gather_impl(
 ):
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
-    # Use Async mode based on test input config
-    mesh_device.enable_async(enable_async)
-
-    if enable_async:
-        logger.info(f"Using Async Mode for All Gather Op Dispatch")
 
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
@@ -328,7 +322,6 @@ def run_all_gather_impl(
     ],
 )
 @pytest.mark.parametrize("num_iters", [10])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_all_gather(
     t3k_mesh_device,
@@ -343,7 +336,6 @@ def test_all_gather(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
 ):
     run_all_gather_impl(
         t3k_mesh_device,
@@ -357,7 +349,6 @@ def test_all_gather(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
         num_iters=num_iters,
-        enable_async=enable_async,
         rand_tensor=True,
         mem_config=mem_config,
     )
@@ -445,7 +436,6 @@ def test_all_gather(
     ],
 )
 @pytest.mark.parametrize("num_iters", [8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_all_gather_sharded(
     t3k_mesh_device,
@@ -458,7 +448,6 @@ def test_all_gather_sharded(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_shape,
     input_shard_grid,
     output_shard_shape,
@@ -480,7 +469,6 @@ def test_all_gather_sharded(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Linear,
         num_iters=num_iters,
-        enable_async=enable_async,
         rand_tensor=True,
         input_shard_shape=input_shard_shape,
         input_shard_grid=input_shard_grid,
@@ -517,7 +505,6 @@ def test_all_gather_sharded(
     ],
 )
 @pytest.mark.parametrize("num_iters", [8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING}], indirect=True)
 def test_all_gather_sharded_ring(
     t3k_mesh_device,
@@ -530,7 +517,6 @@ def test_all_gather_sharded_ring(
     num_iters,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_shape,
     input_shard_grid,
     output_shard_shape,
@@ -552,7 +538,6 @@ def test_all_gather_sharded_ring(
         function_level_defaults,
         all_gather_topology=ttnn.Topology.Ring,
         num_iters=num_iters,
-        enable_async=enable_async,
         rand_tensor=True,
         input_shard_shape=input_shard_shape,
         input_shard_grid=input_shard_grid,
@@ -585,7 +570,6 @@ def test_all_gather_sharded_ring(
         ttnn.BufferType.DRAM,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [4])
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
@@ -600,7 +584,6 @@ def test_line_all_gather_async_on_T3K_cols_persistent_fabric_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -618,7 +601,6 @@ def test_line_all_gather_async_on_T3K_cols_persistent_fabric_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=0,
@@ -653,7 +635,6 @@ def test_line_all_gather_async_on_T3K_cols_persistent_fabric_post_commit(
     ],
 )
 @pytest.mark.parametrize("replication_factor", [2])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
@@ -667,7 +648,6 @@ def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
     use_program_cache,
     function_level_defaults,
     mesh_device,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -685,7 +665,6 @@ def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor,
         cluster_axis=1,
@@ -717,7 +696,6 @@ def test_line_all_gather_async_on_T3K_rows_persistent_fabric_post_commit(
     ],
 )
 @pytest.mark.parametrize("replication_factor1", [4])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize(
     "num_devices2, num_links2, per_chip_output_shape2, dim2, layout2",
     [
@@ -747,7 +725,6 @@ def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabr
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor1,
     replication_factor2,
     num_iters=1,
@@ -766,7 +743,6 @@ def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabr
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor1,
         cluster_axis=0,
@@ -785,7 +761,6 @@ def test_line_all_gather_async_on_T3K_back_to_back_cols_and_rows_persistent_fabr
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_all_gather_instances=replication_factor2,
         cluster_axis=1,

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
@@ -74,7 +74,6 @@ def run_all_reduce_impl(
     loopback_size=1,
     num_iters=1,
     warmup_iters=0,
-    enable_async=False,
     trace_mode=False,
     validate_all=True,
     profiler=BenchmarkProfiler(),
@@ -86,11 +85,6 @@ def run_all_reduce_impl(
 
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
-    # Use Async mode based on test input config
-    mesh_device.enable_async(enable_async)
-
-    if enable_async:
-        logger.info(f"Using Async Mode for All Reduce Op Dispatch")
 
     ##################################
     ##### Set up fabric stuff
@@ -349,7 +343,6 @@ def run_all_reduce_impl(
         (1000, 100),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize(
     "device_params",
@@ -381,7 +374,6 @@ def test_all_reduce(
     output_core_range_set,
     num_iters,
     warmup_iters,
-    enable_async,
     trace_mode,
     use_program_cache,
     function_level_defaults,
@@ -405,7 +397,6 @@ def test_all_reduce(
         output_core_range_set,
         num_iters=num_iters,
         warmup_iters=warmup_iters,
-        enable_async=enable_async,
         trace_mode=trace_mode,
         validate_all=False,
         profiler=profiler,
@@ -442,7 +433,6 @@ def test_all_reduce(
         (100, 10),
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("trace_mode", [True])
 @pytest.mark.parametrize(
     "device_params",
@@ -474,7 +464,6 @@ def test_all_reduce_loopback(
     output_core_range_set,
     num_iters,
     warmup_iters,
-    enable_async,
     trace_mode,
     use_program_cache,
     function_level_defaults,
@@ -495,7 +484,6 @@ def test_all_reduce_loopback(
         loopback_size=4,
         num_iters=num_iters,
         warmup_iters=warmup_iters,
-        enable_async=enable_async,
         trace_mode=trace_mode,
         validate_all=False,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_qkv_all_reduce_minimal.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_qkv_all_reduce_minimal.py
@@ -62,7 +62,6 @@ def run_all_reduce_qkv_heads_fuse_perf_impl(
     input_num_cores,
     output_num_cores,
     use_program_cache=False,
-    enable_async=False,
     num_iters=1,
     warmup_iters=0,
     trace_mode=True,
@@ -73,9 +72,6 @@ def run_all_reduce_qkv_heads_fuse_perf_impl(
 
     if num_iters < 1:
         pytest.fail("num_iters must be >= 1")
-
-    # Use Async mode based on test input config
-    mesh_device.enable_async(enable_async)
 
     ##################################
     ##### Set up fabric stuff
@@ -354,7 +350,6 @@ def run_all_reduce_qkv_heads_fuse_perf_impl(
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_iters, warmup_iters", [[1, 0]])
 @pytest.mark.parametrize("trace_mode", [False])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("validate_all", [True])
 @pytest.mark.parametrize(
     "output_shape, cluster_axis, num_links, input_num_cores, output_num_cores",
@@ -401,7 +396,6 @@ def test_all_reduce_qkv_heads_fuse(
     num_links,
     input_num_cores,
     output_num_cores,
-    enable_async,
     use_program_cache,
     num_iters,
     warmup_iters,
@@ -421,7 +415,6 @@ def test_all_reduce_qkv_heads_fuse(
         input_num_cores,
         output_num_cores,
         use_program_cache,
-        enable_async=enable_async,
         num_iters=num_iters,
         warmup_iters=warmup_iters,
         trace_mode=trace_mode,
@@ -434,7 +427,6 @@ def test_all_reduce_qkv_heads_fuse(
 @skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize("num_iters, warmup_iters", [[30, 10]])
 @pytest.mark.parametrize("trace_mode", [True])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("validate_all", [True])
 @pytest.mark.parametrize(
     "output_shape, cluster_axis, num_links, input_num_cores, output_num_cores",
@@ -481,7 +473,6 @@ def test_all_reduce_qkv_heads_fuse_perf(
     num_links,
     input_num_cores,
     output_num_cores,
-    enable_async,
     use_program_cache,
     num_iters,
     warmup_iters,
@@ -501,7 +492,6 @@ def test_all_reduce_qkv_heads_fuse_perf(
         input_num_cores,
         output_num_cores,
         use_program_cache,
-        enable_async=enable_async,
         num_iters=num_iters,
         warmup_iters=warmup_iters,
         trace_mode=trace_mode,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_N300_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_N300_post_commit.py
@@ -45,7 +45,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_reduce_scatter_post_commit import
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_ring_reduce_scatter_n300_post_commit(
     n300_mesh_device,
     num_devices,
@@ -58,7 +57,6 @@ def test_ring_reduce_scatter_n300_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=5,
 ):
     run_reduce_scatter_test(
@@ -74,7 +72,6 @@ def test_ring_reduce_scatter_n300_post_commit(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -119,7 +116,6 @@ def test_ring_reduce_scatter_n300_post_commit(
     ),
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_width_sharded_reduce_scatter_N300_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -135,7 +131,6 @@ def test_width_sharded_reduce_scatter_N300_post_commit(
     tensor_mem_layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=5,
 ):
     run_reduce_scatter_sharded_test(
@@ -153,6 +148,5 @@ def test_width_sharded_reduce_scatter_N300_post_commit(
         tensor_mem_layout,
         use_program_cache=use_program_cache,
         function_level_defaults=function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_TG_nightly.py
@@ -110,7 +110,6 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
     buffer_type: ttnn.BufferType,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     input_shard_spec: ttnn.ShardSpec = None,
     num_reduce_scatter_instances: int = 1,
     num_iters: int = 1,
@@ -121,7 +120,6 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
     use_persistent_output=False,
 ):
     ttnn.enable_program_cache(mesh_device)
-    mesh_device.enable_async(enable_async)
 
     per_reduce_scatter_output_shape = list(per_chip_input_shape)
     per_reduce_scatter_output_shape[dim] *= num_devices_per_line
@@ -367,7 +365,6 @@ def run_line_reduce_scatter_on_TG_with_mesh_tensor_along_rows(
     ],
 )
 @pytest.mark.parametrize("replication_factor", [8])  # 1, 8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize(
@@ -385,7 +382,6 @@ def test_line_reduce_scatter_on_TG_rows_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=16,
 ):
@@ -404,7 +400,6 @@ def test_line_reduce_scatter_on_TG_rows_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=1,
@@ -432,7 +427,6 @@ def test_line_reduce_scatter_on_TG_rows_post_commit(
         ttnn.BufferType.DRAM,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [4])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
@@ -449,7 +443,6 @@ def test_line_reduce_scatter_on_TG_cols_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=16,
 ):
@@ -469,7 +462,6 @@ def test_line_reduce_scatter_on_TG_cols_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=0,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async.py
@@ -101,7 +101,6 @@ def run_reduce_scatter_test(
     input_shard_shape=None,
     shard_grid=None,
     tensor_mem_layout=None,
-    enable_async=True,
     topology=ttnn.Topology.Ring,
     trace_mode=False,
 ):
@@ -143,10 +142,6 @@ def run_reduce_scatter_test(
     )
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
-
-    mesh_device.enable_async(enable_async)
-    if enable_async:
-        logger.info(f"Using Async Mode for Reduce Scatter Op Dispatch")
 
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
     ccl_sub_device_crs = ttnn.CoreRangeSet(
@@ -330,7 +325,6 @@ def run_reduce_scatter_test(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [False])
 @pytest.mark.parametrize("trace_mode", [False])
 @pytest.mark.parametrize(
     "device_params", [{"trace_region_size": 27648, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
@@ -348,7 +342,6 @@ def test_line_reduce_scatter_async_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     trace_mode,
     num_iters=16,
 ):
@@ -365,7 +358,6 @@ def test_line_reduce_scatter_async_post_commit(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         topology=ttnn.Topology.Linear,
         trace_mode=trace_mode,
     )
@@ -397,7 +389,6 @@ def test_line_reduce_scatter_async_post_commit(
         ttnn.BufferType.L1,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [4])
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
@@ -414,7 +405,6 @@ def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -434,7 +424,6 @@ def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=0,
@@ -464,7 +453,6 @@ def test_line_reduce_scatter_async_on_T3K_cols_post_commit(
         ttnn.BufferType.L1,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [2])
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
@@ -481,7 +469,6 @@ def test_line_reduce_scatter_async_on_T3K_rows_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
 ):
@@ -501,7 +488,6 @@ def test_line_reduce_scatter_async_on_T3K_rows_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=1,
@@ -586,7 +572,6 @@ def test_line_reduce_scatter_async_on_T3K_rows_post_commit(
     ),
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [False])
 @pytest.mark.parametrize("replication_factor", [1])
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 4), id="2x4_grid")], indirect=True)
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
@@ -606,7 +591,6 @@ def test_line_reduce_scatter_cluster_axis_on_T3K_width_sharded_reduce_scatter_po
     tensor_mem_layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     num_iters=1,
     trace_mode=False,
@@ -633,7 +617,6 @@ def test_line_reduce_scatter_cluster_axis_on_T3K_width_sharded_reduce_scatter_po
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         input_shard_spec=input_shard_spec,
         num_reduce_scatter_instances=replication_factor,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async_TG_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_async_TG_nightly.py
@@ -43,7 +43,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_reduce_scatter_TG_nightly import 
     ],
 )
 @pytest.mark.parametrize("replication_factor", [8])  # 1, 8])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
 @pytest.mark.parametrize(
@@ -61,7 +60,6 @@ def test_line_reduce_scatter_on_TG_rows_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     use_persistent_output,
     num_iters=16,
@@ -81,7 +79,6 @@ def test_line_reduce_scatter_on_TG_rows_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=1,
@@ -117,7 +114,6 @@ def test_line_reduce_scatter_on_TG_rows_post_commit(
         False,
     ],
 )
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("replication_factor", [4])
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
@@ -134,7 +130,6 @@ def test_line_reduce_scatter_on_TG_cols_post_commit(
     buffer_type,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     replication_factor,
     use_persistent_output,
     num_iters=16,
@@ -155,7 +150,6 @@ def test_line_reduce_scatter_on_TG_cols_post_commit(
         buffer_type,
         use_program_cache,
         function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         num_reduce_scatter_instances=replication_factor,
         cluster_axis=0,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_llama_perf_sweep.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_llama_perf_sweep.py
@@ -74,7 +74,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_reduce_scatter_post_commit import
 )
 @pytest.mark.parametrize("num_iters", [1000])
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 17068032}], indirect=True)
 def test_width_sharded_reduce_scatter_post_commit(
     t3k_mesh_device,
@@ -91,7 +90,6 @@ def test_width_sharded_reduce_scatter_post_commit(
     tensor_mem_layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters,
     n_worker,
     n_buffer,
@@ -112,7 +110,6 @@ def test_width_sharded_reduce_scatter_post_commit(
         tensor_mem_layout,
         use_program_cache=use_program_cache,
         function_level_defaults=function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
         n_worker=n_worker,
         n_buffer=n_buffer,

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_nightly.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_nightly.py
@@ -53,7 +53,6 @@ from models.utility_functions import skip_for_grayskull
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_reduce_scatter_t3k_8chip_nightly(
     t3k_mesh_device,
     num_devices,
@@ -66,7 +65,6 @@ def test_reduce_scatter_t3k_8chip_nightly(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_test(
@@ -82,7 +80,6 @@ def test_reduce_scatter_t3k_8chip_nightly(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -131,7 +128,6 @@ def test_reduce_scatter_t3k_8chip_nightly(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_reduce_scatter_t3k_4chip_nightly(
     pcie_mesh_device,
     num_devices,
@@ -144,7 +140,6 @@ def test_reduce_scatter_t3k_4chip_nightly(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_test(
@@ -160,5 +155,4 @@ def test_reduce_scatter_t3k_4chip_nightly(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_post_commit.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_reduce_scatter_post_commit.py
@@ -89,7 +89,6 @@ def run_reduce_scatter_test(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async=True,
     num_iters=1,
     topology=ttnn.Topology.Ring,
     trace_mode=False,
@@ -106,10 +105,6 @@ def run_reduce_scatter_test(
     )
     if is_known_failure:
         pytest.skip(f"Skipping unsupported case {message}.")
-
-    mesh_device.enable_async(enable_async)
-    if enable_async:
-        logger.info(f"Using Async Mode for Reduce Scatter Op Dispatch")
 
     logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}, dim: {dim}")
 
@@ -227,7 +222,6 @@ def run_reduce_scatter_test(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_ring_reduce_scatter_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -240,7 +234,6 @@ def test_ring_reduce_scatter_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_test(
@@ -256,7 +249,6 @@ def test_ring_reduce_scatter_post_commit(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
     )
 
 
@@ -292,7 +284,6 @@ def test_ring_reduce_scatter_post_commit(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_line_reduce_scatter_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -305,7 +296,6 @@ def test_line_reduce_scatter_post_commit(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_test(
@@ -321,7 +311,6 @@ def test_line_reduce_scatter_post_commit(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         topology=ttnn.Topology.Linear,
     )
 
@@ -355,7 +344,6 @@ def test_line_reduce_scatter_post_commit(
     ],
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_line_reduce_scatter_post_commit_4chip(
     pcie_mesh_device,
     num_devices,
@@ -368,7 +356,6 @@ def test_line_reduce_scatter_post_commit_4chip(
     mem_config,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_test(
@@ -384,7 +371,6 @@ def test_line_reduce_scatter_post_commit_4chip(
         use_program_cache,
         function_level_defaults,
         num_iters=num_iters,
-        enable_async=enable_async,
         topology=ttnn.Topology.Linear,
     )
 
@@ -407,7 +393,6 @@ def run_reduce_scatter_sharded_test(
     in_shard_override=None,
     in_shard_grid_override=None,
     topology=ttnn.Topology.Ring,
-    enable_async=True,
     num_iters=1,
     n_worker=None,
     n_buffer=None,
@@ -421,8 +406,6 @@ def run_reduce_scatter_sharded_test(
     logger.info(f"Per chip output shape: {per_chip_output_shape}, devices: {num_devices}, dim: {dim}")
 
     debug = False
-
-    t3k_mesh_device.enable_async(enable_async)
 
     # Generate input tensors
     if in_shard_grid_override is None:
@@ -577,7 +560,6 @@ def run_reduce_scatter_sharded_test(
     ),
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_width_sharded_reduce_scatter_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -593,7 +575,6 @@ def test_width_sharded_reduce_scatter_post_commit(
     tensor_mem_layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_sharded_test(
@@ -611,7 +592,6 @@ def test_width_sharded_reduce_scatter_post_commit(
         tensor_mem_layout,
         use_program_cache=use_program_cache,
         function_level_defaults=function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
     )
 
@@ -662,7 +642,6 @@ def test_width_sharded_reduce_scatter_post_commit(
 )
 @pytest.mark.parametrize("topology", [ttnn.Topology.Ring, ttnn.Topology.Linear])
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_width_sharded_reduce_scatter_post_commit_4chip(
     pcie_mesh_device,
     num_devices,
@@ -681,7 +660,6 @@ def test_width_sharded_reduce_scatter_post_commit_4chip(
     function_level_defaults,
     in_shard_override,
     in_shard_grid_override,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_sharded_test(
@@ -702,7 +680,6 @@ def test_width_sharded_reduce_scatter_post_commit_4chip(
         in_shard_override=in_shard_override,
         in_shard_grid_override=in_shard_grid_override,
         topology=topology,
-        enable_async=enable_async,
         num_iters=num_iters,
     )
 
@@ -743,7 +720,6 @@ def test_width_sharded_reduce_scatter_post_commit_4chip(
     ),
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_height_sharded_reduce_scatter_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -759,7 +735,6 @@ def test_height_sharded_reduce_scatter_post_commit(
     tensor_mem_layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_sharded_test(
@@ -777,7 +752,6 @@ def test_height_sharded_reduce_scatter_post_commit(
         tensor_mem_layout,
         use_program_cache=use_program_cache,
         function_level_defaults=function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
     )
 
@@ -817,7 +791,6 @@ def test_height_sharded_reduce_scatter_post_commit(
     ),
 )
 @pytest.mark.parametrize("math_op", [ttnn.ReduceType.Sum])
-@pytest.mark.parametrize("enable_async", [True])
 def test_block_sharded_reduce_scatter_post_commit(
     t3k_mesh_device,
     num_devices,
@@ -833,7 +806,6 @@ def test_block_sharded_reduce_scatter_post_commit(
     tensor_mem_layout,
     use_program_cache,
     function_level_defaults,
-    enable_async,
     num_iters=1,
 ):
     run_reduce_scatter_sharded_test(
@@ -851,6 +823,5 @@ def test_block_sharded_reduce_scatter_post_commit(
         tensor_mem_layout,
         use_program_cache=use_program_cache,
         function_level_defaults=function_level_defaults,
-        enable_async=enable_async,
         num_iters=num_iters,
     )

--- a/tests/ttnn/unit_tests/operations/test_concat.py
+++ b/tests/ttnn/unit_tests/operations/test_concat.py
@@ -15,10 +15,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "concat_spec",
     (([[1, 1, 12, 50], [1, 1, 12, 50]], -1),),
 )
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
-def test_tiled_concat(device, concat_spec, async_mode):
+def test_tiled_concat(device, concat_spec):
     shapes, dim = concat_spec
-    device.enable_async(async_mode)
     torch_input_tensors = [torch.rand(shape, dtype=torch.bfloat16) for shape in shapes]
     torch_output_tensor = torch.concat(torch_input_tensors, dim=dim)
 
@@ -36,9 +34,7 @@ def test_tiled_concat(device, concat_spec, async_mode):
 @pytest.mark.parametrize("height", [20, 32])
 @pytest.mark.parametrize("width", [4, 32])
 @pytest.mark.parametrize("dim", [0, 1])
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
-def test_concat(device, height, width, dim, async_mode):
-    device.enable_async(async_mode)
+def test_concat(device, height, width, dim):
     torch_input_tensor_a = torch.rand((height, width), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((height, width), dtype=torch.bfloat16)
     torch_output_tensor = torch.concat([torch_input_tensor_a, torch_input_tensor_b], dim=dim)
@@ -157,9 +153,7 @@ def test_concat(device, height, width, dim, async_mode):
         ),
     ),
 )
-@pytest.mark.parametrize("async_mode", [True, False], ids=["async_on", "async_off"])
-def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy, layout, cache_mode, async_mode):
-    device.enable_async(async_mode)
+def test_sharded_concat(device, inputs, output_shard_shape, shard_grid, strategy, layout, cache_mode):
     if cache_mode:
         device.enable_program_cache()
 

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -212,9 +212,7 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
 
 @pytest.mark.parametrize("H, num_cores", [[64, 64]])
 @pytest.mark.parametrize("num_slices", [2])
-@pytest.mark.parametrize("enable_async", [True, False])
-def test_sharded_partial_op(device, H, num_cores, num_slices, enable_async):
-    device.enable_async(enable_async)
+def test_sharded_partial_op(device, H, num_cores, num_slices):
     compute_grid_size = device.compute_with_storage_grid_size()
     if num_cores > (compute_grid_size.x * compute_grid_size.y):
         pytest.skip(f"Need {num_cores} cores to run this test but core grid is {compute_grid_size}")

--- a/tests/ttnn/unit_tests/operations/test_plus_one.py
+++ b/tests/ttnn/unit_tests/operations/test_plus_one.py
@@ -13,7 +13,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("w", [1, 4, 8, 32])
 def test_plus_one(device, w):
-    device.enable_async(True)
     torch_input_tensor = torch.randint(32000, (w,))
     torch_output_tensor = torch_input_tensor + 1
 
@@ -21,12 +20,10 @@ def test_plus_one(device, w):
     ttnn.plus_one(input_tensor)
     output_tensor = ttnn.to_torch(input_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
-    device.enable_async(False)
 
 
 @pytest.mark.parametrize("w", [1, 4, 8, 32])
 def test_plus_one_subdevice(device, w):
-    device.enable_async(True)
     torch_input_tensor = torch.randint(32000, (w,))
     torch_output_tensor = torch_input_tensor + 1
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.int32, device=device)
@@ -35,7 +32,6 @@ def test_plus_one_subdevice(device, w):
     )
     output_tensor = ttnn.to_torch(input_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
-    device.enable_async(False)
 
 
 @pytest.mark.parametrize("input_shape", [(16, 32), (32, 32), (4, 16, 32), (4, 8, 16, 32)])

--- a/tests/ttnn/unit_tests/operations/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/test_sampling.py
@@ -133,7 +133,6 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None):
 @pytest.mark.parametrize("p", [[0.0, 0.3, 0.5, 0.7, 0.9] * 6 + [0.1, 0.8]])  # Example of per-user p
 @pytest.mark.parametrize("seed", [2024, 11, 0])
 def test_sampling_callback(shape, k, p, seed, device, use_program_cache):
-    device.enable_async(True)
     torch.manual_seed(seed)
     num_program_cache_entries_list = []
     for _ in range(2):
@@ -161,7 +160,6 @@ def test_sampling_callback(shape, k, p, seed, device, use_program_cache):
     "sub_core_grids", [ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8 - 1, 4 - 1))})]
 )
 def test_sampling_subcores_callback(shape, k, p, seed, device, sub_core_grids, use_program_cache):
-    device.enable_async(True)
     torch.manual_seed(seed)
     num_program_cache_entries_list = []
     for _ in range(2):

--- a/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_prealloc_and_write.py
@@ -16,14 +16,10 @@ from models.utility_functions import is_grayskull
 @pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED])
 @pytest.mark.parametrize("memory_location", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
 @pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-@pytest.mark.parametrize("enable_async", (False, True))
-def test_tensor_preallocation_and_write_apis(
-    enable_async, shape, in_dtype, mem_layout, memory_location, tensor_layout, device
-):
+def test_tensor_preallocation_and_write_apis(shape, in_dtype, mem_layout, memory_location, tensor_layout, device):
     if in_dtype == ttnn.bfloat8_b and tensor_layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Row Major Layout not supported for Bfp8")
     torch.manual_seed(0)
-    device.enable_async(enable_async)
 
     # Preallocate tensor on device
     preallocated_tensor = ttnn.allocate_tensor_on_device(
@@ -48,15 +44,11 @@ def test_tensor_preallocation_and_write_apis(
 @pytest.mark.parametrize("mem_layout", [ttnn.TensorMemoryLayout.INTERLEAVED])
 @pytest.mark.parametrize("memory_location", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
 @pytest.mark.parametrize("tensor_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
-@pytest.mark.parametrize("enable_async", (False, True))
 @pytest.mark.parametrize("mesh_device", ((1, 1), 4), indirect=True)
-def test_tensor_preallocation_and_write_apis(
-    enable_async, shape, in_dtype, mem_layout, memory_location, tensor_layout, mesh_device
-):
+def test_tensor_preallocation_and_write_apis(shape, in_dtype, mem_layout, memory_location, tensor_layout, mesh_device):
     if in_dtype == ttnn.bfloat8_b and tensor_layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Row Major Layout not supported for Bfp8")
     torch.manual_seed(0)
-    mesh_device.enable_async(enable_async)
     shapes = [(1, 10, 64, 96), (32, 1, 64, 64), (32, 3, 256, 256), (16, 1, 1024, 1024)]
 
     # Preallocate tensor on device

--- a/tests/ttnn/unit_tests/test_async.py
+++ b/tests/ttnn/unit_tests/test_async.py
@@ -14,8 +14,6 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize("scalar", [3])
 @pytest.mark.parametrize("size", [64])
 def test_add_1D_tensor_and_scalar(device, scalar, size):
-    device.enable_async(True)
-
     torch.manual_seed(0)
 
     torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
@@ -32,8 +30,6 @@ def test_add_1D_tensor_and_scalar(device, scalar, size):
 @pytest.mark.parametrize("h", [32])
 @pytest.mark.parametrize("w", [64])
 def test_add_2D_tensors(device, h, w):
-    device.enable_async(True)
-
     torch_input_tensor_a = torch.rand((h, w), dtype=torch.bfloat16)
     torch_input_tensor_b = torch.rand((h, w), dtype=torch.bfloat16)
     torch_output_tensor = torch.add(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/ttnn/unit_tests/test_global_circular_buffer.py
+++ b/tests/ttnn/unit_tests/test_global_circular_buffer.py
@@ -32,11 +32,9 @@ def run_global_circular_buffer(device):
     global_circular_buffer = ttnn.create_global_circular_buffer(device, sender_receiver_mapping, 3200)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-def test_global_circular_buffer(device, enable_async_mode):
+def test_global_circular_buffer(device):
     run_global_circular_buffer(device)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-def test_global_circular_buffer_mesh(mesh_device, enable_async_mode):
+def test_global_circular_buffer_mesh(mesh_device):
     run_global_circular_buffer(mesh_device)

--- a/tests/ttnn/unit_tests/test_global_semaphore.py
+++ b/tests/ttnn/unit_tests/test_global_semaphore.py
@@ -33,11 +33,9 @@ def run_global_semaphore(device):
     ttnn.reset_global_semaphore_value(global_sem0, 3)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-def test_global_semaphore(device, enable_async_mode):
+def test_global_semaphore(device):
     run_global_semaphore(device)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
-def test_global_semaphore_mesh(mesh_device, enable_async_mode):
+def test_global_semaphore_mesh(mesh_device):
     run_global_semaphore(mesh_device)

--- a/tests/ttnn/unit_tests/test_multi_device_async.py
+++ b/tests/ttnn/unit_tests/test_multi_device_async.py
@@ -26,8 +26,6 @@ def test_ttnn_to_and_from_multi_device_shard(pcie_mesh_device, layout, memory_co
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
 
-    pcie_mesh_device.enable_async(True)
-
     for i in range(100):
         torch_tensor = torch.rand((1, 1, 256, 512), dtype=torch.bfloat16)
         ttnn_tensor = ttnn.from_torch(
@@ -40,8 +38,6 @@ def test_ttnn_to_and_from_multi_device_shard(pcie_mesh_device, layout, memory_co
         )
         assert_with_pcc(torch_tensor, torch_loop_back_tensor, pcc=0.9999)
 
-    pcie_mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
@@ -52,8 +48,6 @@ def test_multi_device_check_per_device_shard(pcie_mesh_device, layout, memory_co
 
     if dtype == ttnn.bfloat8_b and layout == ttnn.ROW_MAJOR_LAYOUT:
         pytest.skip("Unsupported test permutation: bfloat8_b with ROW_MAJOR_LAYOUT")
-
-    pcie_mesh_device.enable_async(True)
 
     num_loops = 50
     if dtype == ttnn.bfloat8_b:
@@ -76,8 +70,6 @@ def test_multi_device_check_per_device_shard(pcie_mesh_device, layout, memory_co
             )
             shard_offset += shard_size
 
-    pcie_mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 1040, 1040)])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -85,8 +77,6 @@ def test_multi_device_check_per_device_shard(pcie_mesh_device, layout, memory_co
 def test_multi_device_replicate(pcie_mesh_device, shape, layout, memory_config):
     """Test ReplicateTensorToMesh to broadcast a tensor across multiple devices"""
     from ttnn import ReplicateTensorToMesh
-
-    pcie_mesh_device.enable_async(True)
 
     for i in range(100):
         full_tensor = torch.rand(shape, dtype=torch.bfloat16)
@@ -106,8 +96,6 @@ def test_multi_device_replicate(pcie_mesh_device, shape, layout, memory_config):
         for loopback_replicated_tensor in loopback_replicated_tensors:
             assert torch.all(full_tensor == loopback_replicated_tensor)
 
-    pcie_mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
@@ -117,7 +105,6 @@ def test_ttnn_to_multi_device_tilized_parallel(pcie_mesh_device, layout, memory_
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
     shard_dim = 3
-    pcie_mesh_device.enable_async(True)
     for loop in range(20):
         torch_tensor = torch.rand((8, 1, 1024, 1024), dtype=torch.bfloat16)
         ttnn_tensor = ttnn.from_torch(
@@ -137,7 +124,6 @@ def test_ttnn_to_multi_device_tilized_parallel(pcie_mesh_device, layout, memory_
             readback_tensors = [ttnn.to_torch(shard) for shard in ttnn.get_device_tensors(ttnn_tensor.cpu())]
             readback_tensor = torch.cat(readback_tensors, dim=shard_dim)
         assert torch.all(readback_tensor == torch_tensor)
-    pcie_mesh_device.enable_async(False)
 
 
 @pytest.mark.parametrize("program_cache", [False, True])
@@ -146,7 +132,6 @@ def test_multi_device_unary_binary_op_chain(pcie_mesh_device, program_cache, sha
     """Multidevice API test: Running tensor-parallel multi-device chain of eltwise ops"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor
 
-    pcie_mesh_device.enable_async(True)
     if program_cache:
         pcie_mesh_device.enable_program_cache()
 
@@ -177,8 +162,6 @@ def test_multi_device_unary_binary_op_chain(pcie_mesh_device, program_cache, sha
         )
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.98)
 
-    pcie_mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize("program_cache", [False, True])
 @pytest.mark.parametrize("input_a_shape", [(4, 1, 512, 512), (16, 1, 512, 512)])
@@ -186,7 +169,6 @@ def test_multi_device_data_parallel_op_chain(pcie_mesh_device, program_cache, in
     """Multidevice API: Running data-parallel chain of ops with matmul"""
     from ttnn import ShardTensorToMesh, ConcatMeshToTensor, ReplicateTensorToMesh
 
-    pcie_mesh_device.enable_async(True)
     if program_cache:
         pcie_mesh_device.enable_program_cache()
 
@@ -226,8 +208,6 @@ def test_multi_device_data_parallel_op_chain(pcie_mesh_device, program_cache, in
         )
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.97)
 
-    pcie_mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize(
     "layout",
@@ -237,8 +217,6 @@ def test_multi_device_data_parallel_op_chain(pcie_mesh_device, program_cache, in
 )
 @pytest.mark.parametrize("mem_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
 def test_multi_device_argmax(pcie_mesh_device, layout, mem_config):
-    pcie_mesh_device.enable_async(True)
-
     torch.manual_seed(0)
     torch_input = torch.randn(1, 1, 32, 4096)
     reference_output = torch_input.squeeze(1).view(32, 1, -1).float().squeeze().argmax(axis=-1)
@@ -257,8 +235,6 @@ def test_multi_device_argmax(pcie_mesh_device, layout, mem_config):
     tt_out_1B = ttnn.to_torch(tt_out_1B, mesh_composer=ttnn.ConcatMeshToTensor(pcie_mesh_device, dim=0))[0]
 
     assert_with_pcc(tt_out_1B, reference_output, pcc=0.97)
-
-    pcie_mesh_device.enable_async(False)
 
 
 @pytest.mark.parametrize("pcie_mesh_device", [2], indirect=True)
@@ -305,8 +281,6 @@ def test_multi_device_explicit_dealloc(pcie_mesh_device):
 @pytest.mark.parametrize("pcie_mesh_device", [2], indirect=True)
 def test_add_1D_tensor_and_scalar(pcie_mesh_device, scalar, size):
     torch.manual_seed(0)
-
-    pcie_mesh_device.enable_async(True)
 
     torch_input_tensor = torch.rand((size,), dtype=torch.bfloat16)
     torch_output_tensor = torch_input_tensor + scalar

--- a/tests/ttnn/unit_tests/test_multi_device_events.py
+++ b/tests/ttnn/unit_tests/test_multi_device_events.py
@@ -19,8 +19,7 @@ def test_multi_device_events(t3k_mesh_device, shape):
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
-    # Enable Program Cache and Async Mode
-    t3k_mesh_device.enable_async(True)
+    # Enable Program Cache
     t3k_mesh_device.enable_program_cache()
 
     # Preallocate activation tensors.
@@ -80,5 +79,3 @@ def test_multi_device_events(t3k_mesh_device, shape):
             cq_id=data_movement_cq,
         )
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.96)
-
-    t3k_mesh_device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_multi_device_trace.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace.py
@@ -19,15 +19,13 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
     "shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32), (1, 1, 256, 256), (1, 3, 512, 512), (1, 3, 128, 128)]
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("enable_multi_cq", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 60000, "num_command_queues": 2}], indirect=True)
-def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enable_async, enable_multi_cq):
+def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enable_multi_cq):
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
 
     # Trace requires program cache to be enabled
-    t3k_mesh_device.enable_async(enable_async)
     t3k_mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -121,23 +119,19 @@ def test_multi_device_single_trace(t3k_mesh_device, shape, use_all_gather, enabl
     # Release trace buffer once workload is complete
     ttnn.release_trace(t3k_mesh_device, tid)
 
-    t3k_mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize(
     "shape",
     [(1, 1, 256, 256), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 512, 512), (1, 3, 32, 32)],
 )
 @pytest.mark.parametrize("use_all_gather", [True, False])
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("enable_multi_cq", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000, "num_command_queues": 2}], indirect=True)
-def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable_async, enable_multi_cq):
+def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable_multi_cq):
     torch.manual_seed(0)
     if t3k_mesh_device.get_num_devices() <= 1:
         pytest.skip("This test requires multiple devices")
     # Trace requires program cache to be enabled
-    t3k_mesh_device.enable_async(enable_async)
     t3k_mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -314,5 +308,3 @@ def test_multi_device_multi_trace(t3k_mesh_device, shape, use_all_gather, enable
     ttnn.release_trace(t3k_mesh_device, tid)
     ttnn.release_trace(t3k_mesh_device, tid_1)
     ttnn.release_trace(t3k_mesh_device, tid_2)
-
-    t3k_mesh_device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_TG.py
@@ -19,14 +19,12 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
     "shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32), (1, 1, 256, 256), (1, 3, 512, 512), (1, 3, 128, 128)]
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("enable_multi_cq", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 60000, "num_command_queues": 2}], indirect=True)
-def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_multi_cq):
+def test_multi_device_single_trace(mesh_device, shape, enable_multi_cq):
     if mesh_device.get_num_devices() < 32:
         pytest.skip("Test is only valid on Galaxy")
     # Trace requires program cache to be enabled
-    mesh_device.enable_async(True)
     mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -108,24 +106,20 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
     # Release trace buffer once workload is complete
     ttnn.release_trace(mesh_device, tid)
 
-    mesh_device.enable_async(False)
-
 
 @pytest.mark.parametrize(
     "shape",
     [(1, 1, 256, 256), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32)],
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("enable_multi_cq", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000, "num_command_queues": 2}], indirect=True)
-def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi_cq):
+def test_multi_device_multi_trace(mesh_device, shape, enable_multi_cq):
     torch.manual_seed(0)
     if mesh_device.get_num_devices() < 32:
         pytest.skip("Test is only valid on Galaxy")
 
     # Trace requires program cache to be enabled
-    mesh_device.enable_async(True)
     mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -274,5 +268,3 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
     ttnn.release_trace(mesh_device, tid)
     ttnn.release_trace(mesh_device, tid_1)
     ttnn.release_trace(mesh_device, tid_2)
-
-    mesh_device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
+++ b/tests/ttnn/unit_tests/test_multi_device_trace_tgg.py
@@ -19,14 +19,12 @@ NUM_TRACE_LOOPS = int(os.getenv("NUM_TRACE_LOOPS", 15))
     "shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32), (1, 1, 256, 256), (1, 3, 512, 512), (1, 3, 128, 128)]
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 8), id="8x8_grid")], indirect=True)
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("enable_multi_cq", [True, False])  # To be toggled when Galaxy supports Multi-CQ
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 60000, "num_command_queues": 2}], indirect=True)
-def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_multi_cq):
+def test_multi_device_single_trace(mesh_device, shape, enable_multi_cq):
     if mesh_device.get_num_devices() < 64:
         pytest.skip("Test is only valid on TGG")
     # Trace requires program cache to be enabled
-    mesh_device.enable_async(True)
     mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -107,7 +105,6 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
 
     # Release trace buffer once workload is complete
     ttnn.release_trace(mesh_device, tid)
-    mesh_device.enable_async(False)
 
 
 @pytest.mark.parametrize(
@@ -115,16 +112,14 @@ def test_multi_device_single_trace(mesh_device, shape, enable_async, enable_mult
     [(1, 1, 256, 256), (1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32)],
 )
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 8), id="8x8_grid")], indirect=True)
-@pytest.mark.parametrize("enable_async", [True])
 @pytest.mark.parametrize("enable_multi_cq", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000, "num_command_queues": 2}], indirect=True)
-def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi_cq):
+def test_multi_device_multi_trace(mesh_device, shape, enable_multi_cq):
     torch.manual_seed(0)
     if mesh_device.get_num_devices() < 64:
         pytest.skip("Test is only valid on TGG")
 
     # Trace requires program cache to be enabled
-    mesh_device.enable_async(True)
     mesh_device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -273,5 +268,3 @@ def test_multi_device_multi_trace(mesh_device, shape, enable_async, enable_multi
     ttnn.release_trace(mesh_device, tid)
     ttnn.release_trace(mesh_device, tid_1)
     ttnn.release_trace(mesh_device, tid_2)
-
-    mesh_device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_single_device_trace.py
+++ b/tests/ttnn/unit_tests/test_single_device_trace.py
@@ -12,11 +12,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("shape", [[1, 3, 1024, 1024], (1, 1, 512, 512), (1, 3, 32, 32)])
-@pytest.mark.parametrize("enable_async", [True, False])
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 200000}], indirect=True)
-def test_single_device_single_trace(device, shape, enable_async, blocking):
-    device.enable_async(enable_async)
+def test_single_device_single_trace(device, shape, blocking):
     device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -68,15 +66,12 @@ def test_single_device_single_trace(device, shape, enable_async, blocking):
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.99)
 
     ttnn.release_trace(device, tid)
-    device.enable_async(False)
 
 
 @pytest.mark.parametrize("shape", [(1, 1, 512, 512), (1, 1, 32, 32), (1, 3, 32, 32)])
-@pytest.mark.parametrize("enable_async", [True, False])
 @pytest.mark.parametrize("blocking", [True, False])
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 266240}], indirect=True)
-def test_single_device_multi_trace(device, shape, enable_async, blocking):
-    device.enable_async(enable_async)
+def test_single_device_multi_trace(device, shape, blocking):
     device.enable_program_cache()
 
     # Preallocate activation tensors. These will be used when capturing and executing the trace
@@ -160,5 +155,3 @@ def test_single_device_multi_trace(device, shape, enable_async, blocking):
     # Release trace buffer once workload is complete
     ttnn.release_trace(device, tid)
     ttnn.release_trace(device, tid_1)
-
-    device.enable_async(False)

--- a/tests/ttnn/unit_tests/test_sub_device.py
+++ b/tests/ttnn/unit_tests/test_sub_device.py
@@ -137,25 +137,21 @@ def run_sub_devices_program(device, create_fabric_sub_device=False):
     device.remove_sub_device_manager(sub_device_manager)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_devices(device, create_fabric_sub_device, enable_async_mode):
+def test_sub_devices(device, create_fabric_sub_device):
     run_sub_devices(device, create_fabric_sub_device)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_devices_mesh(mesh_device, create_fabric_sub_device, enable_async_mode):
+def test_sub_devices_mesh(mesh_device, create_fabric_sub_device):
     run_sub_devices(mesh_device, create_fabric_sub_device)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_device_program(device, create_fabric_sub_device, enable_async_mode):
+def test_sub_device_program(device, create_fabric_sub_device):
     run_sub_devices_program(device, create_fabric_sub_device)
 
 
-@pytest.mark.parametrize("enable_async_mode", (False, True), indirect=True)
 @pytest.mark.parametrize("create_fabric_sub_device", (False, True))
-def test_sub_device_program_mesh(mesh_device, create_fabric_sub_device, enable_async_mode):
+def test_sub_device_program_mesh(mesh_device, create_fabric_sub_device):
     run_sub_devices_program(mesh_device, create_fabric_sub_device)

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -580,9 +580,6 @@ int main(int argc, char **argv) {
     auto *device = &ttml::autograd::ctx().get_device();
     device->enable_program_cache();
 
-    // disable for now, unexpected freezes and crashes
-    // device->enable_async(true);
-
     struct CachedHostData {
         std::vector<uint32_t> data;
         std::vector<int32_t> targets;

--- a/tt-train/tests/ttnn_fixed/concat_op_test.cpp
+++ b/tt-train/tests/ttnn_fixed/concat_op_test.cpp
@@ -24,7 +24,6 @@ protected:
 
 TEST_F(ConcatOpTest, TestConcatLastDim) {
     auto* device = &ttml::autograd::ctx().get_device();
-    device->enable_async(true);
     auto N = 1;
     auto C = 1;
     auto H = 12;

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -182,11 +182,6 @@ public:
     // Puts device into reset
     virtual bool close() = 0;
 
-    virtual void enable_async(bool enable) = 0;
-    virtual void synchronize() = 0;
-    virtual WorkExecutorMode get_worker_mode() = 0;
-    virtual bool is_worker_queue_empty() const = 0;
-
     virtual void push_work(std::function<void()> work, bool blocking = false) = 0;
 
     // Program cache interface. Syncrhonize with worker worker threads before querying or

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -156,14 +156,6 @@ public:
     // Puts device into reset
     bool close() override;
 
-    // Calls to enable_async are ignored in effort to forcefully disable async for single device use-cases
-    // MeshDevice calls force_enable_async directly avoiding enable_async call for multi-device use-case
-    void enable_async(bool enable) override;
-    void force_enable_async(bool enable);
-    void synchronize() override;
-    WorkExecutorMode get_worker_mode() override;
-    bool is_worker_queue_empty() const override;
-
     void push_work(std::function<void()> work, bool blocking) override;
 
     // Program cache interface. Synchronize with worker worker threads before querying or
@@ -228,8 +220,6 @@ private:
     void get_associated_dispatch_virtual_cores(
         std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>>& my_dispatch_cores,
         std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>>& other_dispatch_cores);
-
-    void set_worker_mode(const WorkExecutorMode& mode);
 
     void generate_device_bank_to_noc_tables();
 

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -232,10 +232,6 @@ public:
     void init_command_queue_device() override;
     void init_fabric() override;
     bool close() override;
-    void enable_async(bool enable) override;
-    void synchronize() override;
-    WorkExecutorMode get_worker_mode() override;
-    bool is_worker_queue_empty() const override;
     void push_work(std::function<void()> work, bool blocking = false) override;
     void enable_program_cache() override;
     void disable_and_clear_program_cache() override;

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -385,6 +385,5 @@ bool ReadFromDeviceL1(
 
 bool ReadRegFromDevice(IDevice* device, const CoreCoord& logical_core, uint32_t address, uint32_t& regval);
 
-void SynchronizeWorkerThreads(const std::vector<IDevice*>& workers);
 }  // namespace detail
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -765,7 +765,6 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
             if (tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster() and dev->is_mmio_capable()) {
                 continue;
             }
-            dev->synchronize();  // Synchronize worker queue
             Synchronize(dev);    // Synchronize device
         }
     }

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -194,7 +194,6 @@ void device_module(py::module& m_device) {
                 "num_program_cache_entries",
                 &IDevice::num_program_cache_entries,
                 "Number of entries in the program cache for this device")
-            .def("enable_async", &IDevice::enable_async)
             .def(
                 "create_sub_device_manager",
                 [](IDevice* device,
@@ -657,13 +656,7 @@ void device_module(py::module& m_device) {
     m_device.def(
         "synchronize_device",
         [](IDevice* device, std::optional<QueueId> cq_id, const std::vector<SubDeviceId>& sub_device_ids) {
-            // Send finish command to issue queue through worker thread
-            // Worker thread will stall until the device is flushed.
-            device->push_work([device, cq_id, &sub_device_ids]() mutable {
-                Synchronize(device, cq_id.has_value() ? std::make_optional(**cq_id) : std::nullopt, sub_device_ids);
-            });
-            // Main thread stalls until worker is complete (full device and worker queue flush).
-            device->synchronize();
+            Synchronize(device, cq_id.has_value() ? std::make_optional(**cq_id) : std::nullopt, sub_device_ids);
         },
         synchronize_device_doc.data(),
         py::arg("device"),

--- a/ttnn/cpp/ttnn/async_runtime.cpp
+++ b/ttnn/cpp/ttnn/async_runtime.cpp
@@ -57,18 +57,10 @@ void read_buffer(
                 tt::tt_metal::memcpy(worker->command_queue(*cq_id), dst_for_device.get(), shard, region, blocking);
             });
         }
-        if (blocking) {
-            for (auto worker : src.get_workers()) {
-                worker->synchronize();
-            }
-        }
     }
 }
 
 void queue_synchronize(CommandQueue& cq) {
-    // Ensure that all work pushed to async engine has been passed
-    // off to device CQ
-    cq.device()->synchronize();
     // Wait for device CQ to finish
     Finish(cq);
 }

--- a/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_pybind.cpp
@@ -231,17 +231,6 @@ void py_module(py::module& module) {
                Arch: The arch of the first device in the device mesh.
        )doc")
         .def(
-            "enable_async",
-            &MeshDevice::enable_async,
-            py::arg("enable"),
-            R"doc(
-               Enable or disable async mode across all devices in the mesh.
-
-
-               Args:
-                   enable (bool): True to enable async mode, False to disable it.
-           )doc")
-        .def(
             "enable_program_cache",
             &MeshDevice::enable_program_cache,
             R"doc(

--- a/ttnn/cpp/ttnn/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn/global_semaphore.cpp
@@ -95,9 +95,6 @@ MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
                 }
             });
         }
-        for (auto device : devices) {
-            device->synchronize();
-        }
     }
 
     return multi_device_global_semaphore;

--- a/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
@@ -80,7 +80,6 @@ auto capture_op_trace(Op op, IDevice* device, Args&&... args) {
 template <typename TraceID>
 uint64_t execute_time_and_release_trace(TraceID trace_id, IDevice* device) {
     try {
-        device->synchronize();
         uint64_t duration = 0;
         for (int i = 0; i < NUM_TRACE_EXECUTIONS; ++i) {
             auto start = std::chrono::high_resolution_clock::now();

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -386,8 +386,6 @@ void write_tensor(const Tensor& host_tensor, Tensor device_tensor, ttnn::QueueId
 
 Tensor set_tensor_id(const Tensor& tensor);
 
-bool validate_worker_modes(const std::vector<IDevice*>& workers);
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -75,8 +75,6 @@ void insert_buffer_and_shape_for_device(
     Tensor& tensor_to_modify,
     std::optional<int> buffer_index = std::nullopt);
 
-Tensor copy_borrowed_tensor_in_async_mode(IDevice* worker, const Tensor& tensor);
-
 inline bool is_tensor_on_device(const ttnn::Tensor& tensor) { return tensor.storage_type() == StorageType::DEVICE; }
 
 [[deprecated("Use is_tensor_on_device instead")]] inline bool is_tensor_on_device_or_multidevice(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20966

### Problem description
 - Async Mode is no longer a user exposed feature, since TT-Mesh handles multithreaded dispatch under the hood
 - Multiple APIs need to be removed

### What's changed
  - The following APIs are removed from `device.hpp`: 
  ``` 
void enable_async(bool enable);
void synchronize();
WorkExecutorMode get_worker_mode();
bool is_worker_queue_empty();
```

  - The following TTNN C++ Functions are removed:

``` 
void copy_borrowed_tensor_in_async_mode(IDevice* worker, const Tensor& tensor);
void validate_worker_modes(const std::vector<IDevice*>& workers) enable_async(bool enable);
```
  - Remove async mode fixture from all tests, since this provides redundant testing with the TT-Mesh backend
  - **This PR is mostly removing unused functions from tests**

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes