### PR TITLE
#20623: ttnn.sort multi core implementation

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -23,7 +23,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([1, 2048, 1, 64], -1, False),
     ],
 )
-def test_sort_output_shape(shape, dim, descending, device):
+def test_sort_standard(shape, dim, descending, device):
     torch.manual_seed(0)
 
     torch_dtype = torch.bfloat16
@@ -59,7 +59,7 @@ def test_sort_output_shape(shape, dim, descending, device):
         ([1, 2048, 1, 64], -1, False),
     ],
 )
-def test_sort_output_shape_prealocated_output(shape, dim, descending, device):
+def test_sort_prealocated_output(shape, dim, descending, device):
     torch.manual_seed(0)
 
     torch_dtype = torch.bfloat16

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -21,6 +21,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([], -1, True),
         ([1, 1, 32, 64], -1, False),
         ([1, 2048, 1, 64], -1, False),
+        ([1, 55, 43], -1, True),
+        ([11, 29, 14, 1], -1, True),
     ],
 )
 def test_sort_standard(shape, dim, descending, device):
@@ -57,6 +59,8 @@ def test_sort_standard(shape, dim, descending, device):
         ([], -1, True),
         ([1, 1, 32, 64], -1, False),
         ([1, 2048, 1, 64], -1, False),
+        ([1, 55, 43], -1, True),
+        ([11, 29, 14, 1], -1, True),
     ],
 )
 def test_sort_prealocated_output(shape, dim, descending, device):

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -23,6 +23,8 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
         ([1, 2048, 1, 64], -1, False),
         ([1, 55, 43], -1, True),
         ([11, 29, 14, 1], -1, True),
+        ([1, 1, 512, 64], -1, False),
+        ([1, 1, 2112, 64], -1, False),
     ],
 )
 def test_sort_standard(shape, dim, descending, device):
@@ -61,6 +63,8 @@ def test_sort_standard(shape, dim, descending, device):
         ([1, 2048, 1, 64], -1, False),
         ([1, 55, 43], -1, True),
         ([11, 29, 14, 1], -1, True),
+        ([1, 1, 512, 64], -1, False),
+        ([1, 1, 2112, 64], -1, False),
     ],
 )
 def test_sort_prealocated_output(shape, dim, descending, device):

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -85,6 +85,7 @@ void MAIN {
     constexpr bool stable =
         get_compile_time_arg_val(8);  // TODO: In the future change LLK to have the option or add additional step with
                                       // checking values and indexes after the sorting
+                                      // Issue: https://github.com/tenstorrent/tt-metal/issues/20625
 
     constexpr uint32_t one_tile = 1;
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -15,37 +15,64 @@
 
 namespace NAMESPACE {
 /*
-The sorting algorithm is based on Bitonic Merge Sort.
+This sorting algorithm is based on Bitonic Merge Sort and operates on input data arranged in tiles.
 
- The program operates on the arrangement of input data in the form of tiles. After the data passes through
- preprocessing, the dimension by which the data is to be sorted is the last dimension in the tensor, hence from the
- point of view of the arrangement of tiles, the sorting is practically based on sorting successive rows of the matrix.
+The algorithm processes the data such that the dimension to be sorted becomes the last dimension of the tensor.
+From the perspective of tile arrangement, sorting is performed row by row in a matrix-like structure.
 
- First, the program reads one full row of tiles (size Wt) from DRAM to L1 and generates a corresponding set of tiles
- containing the data indices in the initial arrangement. The basis for the described sorting implementation is
- ckernel::topk_local_sort LLK, which takes as input arguments to the DST register two tiles on which
- the sorting is to be performed and two tiles containing the indices of this data. LLK sorts the two input tiles in the
- inplace method and sets the indices of the data that have been changed in place. However, it performs sorting on
- columns, hence the additional step of performing transposition. Since LLK always takes a set of two tiles, their number
- in the Wt dimension must always be a multiple of 64 (2 * Tile_Width (32)).
+### Overview:
+1. **Tile Initialization**:
+    - A full row of tiles (size `Wt`) is read from DRAM into L1 memory.
+    - Corresponding tiles containing the initial data indices are also generated.
 
- sort_Wt_tiles_row_to_bitonic_sequence takes pairs of tiles and sorts them among themselves changing the sorting order
- (for the first pair according to the desired order, for the next one vice versa, etc.), as a result we get a set of
- sorted pairs of tiles with a variable sorting order.
+2. **Sorting Mechanism**:
+    - The core of the sorting is performed using `ckernel::topk_local_sort`, which:
+      - Sorts two input tiles in-place.
+      - Updates the indices of the data to reflect the new order.
+    - Since `ckernel::topk_local_sort` operates on columns, an additional transposition step is required.
+    - The number of tiles in the `Wt` dimension must be a multiple of 64 (2 * Tile_Width (32)) to ensure compatibility.
 
- The next step is to sort the tiles among themselves, so that the entire row of input data is sorted. As in the
- bitonic merge sort algorithm, this is done in stages – the next indexes of tiles in CB are calculated, which are to be
- sorted among themselves. Finally, all tiles have their values ​​sorted with respect to one dimension and are
- ready to be transposed to the desired dimension and written to DRAM memory.
+3. **Bitonic Sequence Formation**:
+    - The function `sort_Wt_tiles_row_to_bitonic_sequence`:
+      - Sorts pairs of tiles alternately in ascending and descending order.
+      - Produces a set of sorted tile pairs with alternating sorting directions.
 
- Example:
- The input tensor is a 32x128 matrix, which translates to 1x4 tiles: T0 T1 T2 T3, we sort the values ​​ascending.
- Pairwise sorting: Tiles T0 and T1 are sorted as a pair ascending, T2 and T3 are sorted as a pair descending.
- Sorting among themselves: Stage 1 - we sort T0 and T2 ascending and T1 and T3 ascending (we do not change the order),
-                           Stage 2 – We sort T0 and T1 ascending and T2 and T3 ascending.
- Data saving: Values ​​have been sorted by a common dimension and are ready to be saved.
+4. **Bitonic Merge Sort**:
+    - The tiles are further sorted in stages to ensure the entire row is sorted.
+    - At each stage, tile indices are calculated, and tiles are sorted pairwise.
+    - This process continues until all tiles in the row are sorted.
+
+5. **Multicore Calculation**:
+    - Multicore parallelism is enabled by assigning each row of tiles (`Wt`) to a separate core.
+    - If the number of rows (`Ht`) exceeds the number of available cores, the workload is distributed such that some
+cores process multiple rows.
+    - This ensures efficient utilization of all cores and minimizes idle time during computation.
+
+6. **Final Steps**:
+    - Once sorted, the tiles are transposed back to the desired dimension.
+    - The sorted data is then written back to DRAM.
+
+### Example:
+- Input: A 64x128 matrix, represented as 2x4 tiles: T0, T1, T2, T3
+                                                    T4, T5, T6, T7
+- Sorting (ascending order):
+0. Distributing workload across cores:
+   - Core 0 processes T0, T1, T2, T3
+   - Core 1 processes T4, T5, T6, T7
+Calculation of each row:
+  1. **Pairwise Sorting**:
+      - T0 and T1 are sorted as a pair in ascending order.
+      - T2 and T3 are sorted as a pair in descending order.
+  2. **Sorting Across Pairs**:
+      - **Stage 1**: T0 and T2 are sorted in ascending order, and T1 and T3 are sorted in ascending order.
+      - **Stage 2**: T0 and T1 are sorted in ascending order, and T2 and T3 are sorted in ascending order.
+  3. **Data Saving**:
+      - The tiles are now fully sorted along the desired dimension and ready to be saved.
  */
 void MAIN {
+    // Runtime args
+    const uint32_t core_loop_count = get_arg_val<uint32_t>(0);
+
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
@@ -53,11 +80,10 @@ void MAIN {
     constexpr uint32_t index_tensor_transposed_cb_index = get_compile_time_arg_val(3);
     constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(4);
     constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(5);
-    constexpr uint32_t Ht = get_compile_time_arg_val(6);
-    constexpr uint32_t Wt = get_compile_time_arg_val(7);
-    constexpr bool descending = get_compile_time_arg_val(8);
+    constexpr uint32_t Wt = get_compile_time_arg_val(6);
+    constexpr bool descending = get_compile_time_arg_val(7);
     constexpr bool stable =
-        get_compile_time_arg_val(9);  // TODO: In the future change LLK to have the option or add additional step with
+        get_compile_time_arg_val(8);  // TODO: In the future change LLK to have the option or add additional step with
                                       // checking values and indexes after the sorting
 
     constexpr uint32_t one_tile = 1;
@@ -70,7 +96,7 @@ void MAIN {
     ckernel::topk_tile_init();
     transpose_wh_init(input_tensor_cb_index, input_tensor_transposed_cb_index);
 
-    for (uint32_t h = 0; h < Ht; h++) {
+    for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
         const bool ascending = !descending;
 
         sort_Wt_tiles_row_to_bitonic_sequence(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp
@@ -23,14 +23,18 @@ void kernel_main() {
     // Runtime args
     const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(0);
     const uint32_t index_tensor_buffer_addr = get_arg_val<uint32_t>(1);
+    const uint32_t core_loop_count = get_arg_val<uint32_t>(2);
 
     // Compile time args
     constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
     constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(1);
     constexpr bool input_tensor_is_dram = get_compile_time_arg_val(2) == 1;
     constexpr bool index_tensor_is_dram = get_compile_time_arg_val(3) == 1;
-    constexpr uint32_t Ht = get_compile_time_arg_val(4);
-    constexpr uint32_t Wt = get_compile_time_arg_val(5);
+    constexpr uint32_t Wt = get_compile_time_arg_val(4);
+    constexpr uint32_t Ht = get_compile_time_arg_val(5);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(6);
+    constexpr uint32_t compute_with_storage_grid_size_x = get_compile_time_arg_val(7);
+    constexpr uint32_t compute_with_storage_grid_size_y = get_compile_time_arg_val(8);
 
     // Input tensor config
     constexpr uint32_t one_tile = 1;
@@ -49,7 +53,11 @@ void kernel_main() {
         .page_size = index_tensor_output_tile_size_bytes,
         .data_format = index_tensor_output_data_format};
 
-    for (uint32_t h = 0; h < Ht; h++) {
+    for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
+        // Calculate tile h coordinate
+        const uint32_t h = core_loop * total_number_of_cores +
+                           get_absolute_logical_y() * compute_with_storage_grid_size_x + get_absolute_logical_x();
+
         // Read input value data
         for (uint32_t w = 0; w < Wt; w++) {
             cb_reserve_back(input_tensor_cb_index, one_tile);
@@ -67,5 +75,5 @@ void kernel_main() {
             noc_async_write_barrier();
             cb_pop_front(index_tensor_output_cb_index, one_tile);
         }  // Wt loop
-    }  // Ht loop
+    }  // core_loop_count loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -8,8 +8,6 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::reduction::sort {
 
-constexpr uint32_t MAX_SINGLE_CORE_SORT_HEIGHT = 2;
-
 SortDeviceOperation::program_factory_t SortDeviceOperation::select_program_factory(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     return sort::program::SortProgramFactory{};

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -8,6 +8,8 @@ using namespace tt::tt_metal;
 
 namespace ttnn::operations::experimental::reduction::sort {
 
+constexpr uint32_t MAX_SINGLE_CORE_SORT_HEIGHT = 2;
+
 SortDeviceOperation::program_factory_t SortDeviceOperation::select_program_factory(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     return sort::program::SortProgramFactory{};
@@ -22,6 +24,27 @@ void SortDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     // Validate shapes of input and output tensors
     const auto input_tensor_shape = tensor_args.input_tensor.get_padded_shape();
+    const uint32_t Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
+
+    const auto input_data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.get_dtype());
+    const auto input_data_format_size_bytes = tt::datum_size(input_data_format);
+
+    const uint32_t input_tensor_tile_size = tt::constants::TILE_HW * input_data_format_size_bytes;
+    const uint32_t value_tensor_tile_size = tt::constants::TILE_HW * input_data_format_size_bytes;
+    const uint32_t index_tensor_tile_size = tt::constants::TILE_HW * sizeof(uint16_t);
+    const uint32_t row_memory_size_bytes =
+        (input_tensor_tile_size + value_tensor_tile_size + index_tensor_tile_size) * Wt;
+
+    const auto device = tensor_args.input_tensor.device();
+    const auto l1_mem_size_bytes = device->l1_size_per_core();
+
+    // NOTE: This will be updated when support for sorting a single row on multicore is implemented.
+    TT_FATAL(
+        row_memory_size_bytes < l1_mem_size_bytes,
+        "Row memory size {} bytes exceeds L1 memory size {} bytes. "
+        "Consider using a smaller input tensor or increasing the L1 memory size.",
+        row_memory_size_bytes,
+        l1_mem_size_bytes);
 
     TT_FATAL(
         tensor_args.input_tensor.buffer() != nullptr,

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_device_operation.cpp
@@ -37,6 +37,7 @@ void SortDeviceOperation::validate_on_program_cache_miss(
     const auto l1_mem_size_bytes = device->l1_size_per_core();
 
     // NOTE: This will be updated when support for sorting a single row on multicore is implemented.
+    // Issue: https://github.com/tenstorrent/tt-metal/issues/21187
     TT_FATAL(
         row_memory_size_bytes < l1_mem_size_bytes,
         "Row memory size {} bytes exceeds L1 memory size {} bytes. "

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.cpp
@@ -4,7 +4,6 @@
 
 #include "sort_program_factory.hpp"
 
-#include <cstdint>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
@@ -15,9 +14,7 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {
     // Program config
     tt::tt_metal::Program program{};
-    const CoreCoord core = {0, 0};
 
-    // Tensor config info
     const tt::DataFormat input_tensor_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.get_dtype());
     const tt::DataFormat value_tensor_cb_data_format =
@@ -48,20 +45,54 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
     constexpr uint32_t num_cb_unit = 2;                // Number of circular buffer units for double buffering
     constexpr uint32_t cb_in_units = 2 * num_cb_unit;  // Total number of circular buffer units
 
+    // Calculate the number of cores available for computation
+    auto device = tensor_args.input_tensor.device();
+    const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t total_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
+
+    // Calculate the number of cores utilized based on the input tensor shape
+    const uint32_t all_core_utilization_loop_count = Ht / total_number_of_cores;
+    const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
+
+    // Calculate core range
+    CoreRangeSet core_range;
+    if (Ht >= total_number_of_cores) {
+        core_range = CoreRangeSet(
+            CoreRange({0, 0}, {compute_with_storage_grid_size.x - 1, compute_with_storage_grid_size.y - 1}));
+    } else {
+        const uint32_t core_grid_calculated_rows_number = Ht / compute_with_storage_grid_size.x;
+        const uint32_t core_grid_calculated_columns_number = Ht % compute_with_storage_grid_size.x;
+
+        if (core_grid_calculated_rows_number == 0 && core_grid_calculated_columns_number == 0) {
+            core_range = CoreRangeSet(CoreCoord({0, 0}));
+        } else if (core_grid_calculated_rows_number == 0) {
+            core_range = CoreRangeSet(CoreRange({0, 0}, {core_grid_calculated_columns_number - 1, 0}));
+        } else {
+            CoreRangeSet core_range(
+                CoreRange({0, 0}, {compute_with_storage_grid_size.x - 1, core_grid_calculated_rows_number - 1}));
+            if (core_grid_calculated_columns_number != 0) {
+                const CoreRange additional_range(
+                    {0, core_grid_calculated_rows_number},
+                    {core_grid_calculated_columns_number, core_grid_calculated_rows_number});
+                core_range = core_range.merge(CoreRangeSet(additional_range));
+            }
+        }
+    }
+
     // Circular buffers
     constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
     const tt::tt_metal::CircularBufferConfig input_tensor_cb_config =
         tt::tt_metal::CircularBufferConfig(
             cb_in_units * input_tensor_tile_size, {{input_tensor_cb_index, input_tensor_cb_data_format}})
             .set_page_size(input_tensor_cb_index, input_tensor_tile_size);
-    auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, core, input_tensor_cb_config);
+    auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, core_range, input_tensor_cb_config);
 
     constexpr uint32_t index_tensor_cb_index = tt::CBIndex::c_1;
     const tt::tt_metal::CircularBufferConfig index_tensor_cb_config =
         tt::tt_metal::CircularBufferConfig(
             cb_in_units * index_tensor_tile_size, {{index_tensor_cb_index, index_tensor_cb_data_format}})
             .set_page_size(index_tensor_cb_index, index_tensor_tile_size);
-    auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_tensor_cb_config);
+    auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_cb_config);
 
     constexpr uint32_t input_tensor_transposed_cb_index = tt::CBIndex::c_24;
     const tt::tt_metal::CircularBufferConfig input_tensor_transposed_cb_config =
@@ -69,7 +100,7 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
             Wt * input_tensor_tile_size, {{input_tensor_transposed_cb_index, input_tensor_cb_data_format}})
             .set_page_size(input_tensor_transposed_cb_index, input_tensor_tile_size);
     auto cb_input_tensor_transposed =
-        tt::tt_metal::CreateCircularBuffer(program, core, input_tensor_transposed_cb_config);
+        tt::tt_metal::CreateCircularBuffer(program, core_range, input_tensor_transposed_cb_config);
 
     constexpr uint32_t index_tensor_transposed_cb_index = tt::CBIndex::c_25;
     const tt::tt_metal::CircularBufferConfig index_tensor_transposed_cb_config =
@@ -77,21 +108,22 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
             Wt * index_tensor_tile_size, {{index_tensor_transposed_cb_index, index_tensor_cb_data_format}})
             .set_page_size(index_tensor_transposed_cb_index, index_tensor_tile_size);
     auto cb_index_tensor_transposed =
-        tt::tt_metal::CreateCircularBuffer(program, core, index_tensor_transposed_cb_config);
+        tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_transposed_cb_config);
 
     constexpr uint32_t value_tensor_cb_index = tt::CBIndex::c_16;
     const tt::tt_metal::CircularBufferConfig value_tensor_cb_config =
         tt::tt_metal::CircularBufferConfig(
             num_cb_unit * value_tensor_tile_size, {{value_tensor_cb_index, value_tensor_cb_data_format}})
             .set_page_size(value_tensor_cb_index, index_tensor_tile_size);
-    auto cb_value_tensor = tt::tt_metal::CreateCircularBuffer(program, core, value_tensor_cb_config);
+    auto cb_value_tensor = tt::tt_metal::CreateCircularBuffer(program, core_range, value_tensor_cb_config);
 
     constexpr uint32_t index_tensor_output_cb_index = tt::CBIndex::c_17;
     const tt::tt_metal::CircularBufferConfig index_tensor_output_cb_config =
         tt::tt_metal::CircularBufferConfig(
             num_cb_unit * index_tensor_tile_size, {{index_tensor_output_cb_index, index_tensor_cb_data_format}})
             .set_page_size(index_tensor_output_cb_index, index_tensor_tile_size);
-    auto cb_index_tensor_output = tt::tt_metal::CreateCircularBuffer(program, core, index_tensor_output_cb_config);
+    auto cb_index_tensor_output =
+        tt::tt_metal::CreateCircularBuffer(program, core_range, index_tensor_output_cb_config);
 
     // Kernels
     const std::vector<uint32_t> reader_compile_time_args = {
@@ -99,23 +131,41 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
         index_tensor_output_cb_index,
         static_cast<uint32_t>(input_tensor_is_dram),
         static_cast<uint32_t>(index_tensor_is_dram),
+        Wt,
         Ht,
-        Wt};
+        total_number_of_cores,
+        compute_with_storage_grid_size.x,
+        compute_with_storage_grid_size.y};
     const std::string reader_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/reader.cpp";
     tt::tt_metal::KernelHandle reader_kernel_id = tt::tt_metal::CreateKernel(
-        program, reader_kernel_path, core, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
-
-    SetRuntimeArgs(program, reader_kernel_id, core, {input_buffer->address(), index_buffer->address()});
+        program, reader_kernel_path, core_range, tt::tt_metal::ReaderDataMovementConfig{reader_compile_time_args});
+    SetRuntimeArgs(
+        program,
+        reader_kernel_id,
+        core_range,
+        {input_buffer->address(),
+         index_buffer->address(),
+         all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
 
     const std::vector<uint32_t> writer_compile_time_args = {
-        value_tensor_cb_index, index_tensor_cb_index, static_cast<uint32_t>(value_tensor_is_dram), Ht, Wt};
+        value_tensor_cb_index,
+        index_tensor_cb_index,
+        static_cast<uint32_t>(value_tensor_is_dram),
+        Wt,
+        Ht,
+        total_number_of_cores,
+        compute_with_storage_grid_size.x,
+        compute_with_storage_grid_size.y};
     const std::string writer_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp";
     tt::tt_metal::KernelHandle writer_kernel_id = tt::tt_metal::CreateKernel(
-        program, writer_kernel_path, core, tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
-
-    SetRuntimeArgs(program, writer_kernel_id, core, {value_buffer->address()});
+        program, writer_kernel_path, core_range, tt::tt_metal::WriterDataMovementConfig{writer_compile_time_args});
+    SetRuntimeArgs(
+        program,
+        writer_kernel_id,
+        core_range,
+        {value_buffer->address(), all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
 
     const std::vector<uint32_t> compute_compile_time_args = {
         input_tensor_cb_index,
@@ -124,16 +174,52 @@ SortProgramFactory::cached_program_t SortProgramFactory::create(
         index_tensor_transposed_cb_index,
         value_tensor_cb_index,
         index_tensor_output_cb_index,
-        Ht,
         Wt,
         static_cast<uint32_t>(attributes.descending),
-        static_cast<uint32_t>(attributes.stable)};
+        static_cast<uint32_t>(attributes.stable),
+        compute_with_storage_grid_size.x,
+        compute_with_storage_grid_size.y};
     const std::string compute_kernel_path =
         "ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp";
     tt::tt_metal::KernelHandle compute_kernel_id = tt::tt_metal::CreateKernel(
-        program, compute_kernel_path, core, tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+        program,
+        compute_kernel_path,
+        core_range,
+        tt::tt_metal::ComputeConfig{.compile_args = compute_compile_time_args});
+    SetRuntimeArgs(
+        program,
+        compute_kernel_id,
+        core_range,
+        {all_core_utilization_loop_count ? all_core_utilization_loop_count : 1});
 
-    return {std::move(program), {reader_kernel_id, compute_kernel_id, writer_kernel_id}};
+    if (all_core_utilization_loop_residuum != 0 && all_core_utilization_loop_count != 0) {
+        uint32_t residuum_count = 0;
+        for (uint32_t core_y = 0; core_y < compute_with_storage_grid_size.y; core_y++) {
+            for (uint32_t core_x = 0; core_x < compute_with_storage_grid_size.x; core_x++) {
+                const uint32_t new_loop_count = all_core_utilization_loop_count + 1;
+                const CoreCoord core = {core_x, core_y};
+
+                SetRuntimeArgs(
+                    program,
+                    reader_kernel_id,
+                    core,
+                    {input_buffer->address(), index_buffer->address(), new_loop_count});
+
+                SetRuntimeArgs(program, writer_kernel_id, core, {value_buffer->address(), new_loop_count});
+
+                SetRuntimeArgs(program, compute_kernel_id, core, {new_loop_count});
+
+                residuum_count++;
+                if (residuum_count >= all_core_utilization_loop_residuum) {
+                    core_y = compute_with_storage_grid_size.y;  // Break outer loop
+                    break;
+                }
+            }  // core_x loop
+        }  // core_y loop
+    }
+
+    return {
+        std::move(program), {reader_kernel_id, compute_kernel_id, writer_kernel_id, compute_with_storage_grid_size}};
 }
 
 void SortProgramFactory::override_runtime_arguments(
@@ -145,17 +231,36 @@ void SortProgramFactory::override_runtime_arguments(
     auto value_tensor_buffer = output_tensors.at(0).buffer();
     auto index_tensor_buffer = output_tensors.at(1).buffer();
 
-    CoreCoord core = {0, 0};
+    const auto input_shape = tensor_args.input_tensor.get_padded_shape();
+    const uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tt::constants::TILE_HEIGHT;
+    const uint32_t total_number_of_cores =
+        cached_program.shared_variables.storage_grid_size.x * cached_program.shared_variables.storage_grid_size.y;
 
-    {
-        auto& reader_runtime_args =
-            GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
-        reader_runtime_args[0] = input_tensor_buffer->address();
-        reader_runtime_args[1] = index_tensor_buffer->address();
+    // Calculate the number of cores utilized based on the input tensor shape
+    const uint32_t all_core_utilization_loop_count = Ht / total_number_of_cores;
+    const uint32_t all_core_utilization_loop_residuum = Ht % total_number_of_cores;
 
-        auto& writer_runtime_args =
-            GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
-        writer_runtime_args[0] = value_tensor_buffer->address();
+    uint32_t residuum_count = 0;
+    for (uint32_t core_y = 0; core_y < cached_program.shared_variables.storage_grid_size.y; core_y++) {
+        for (uint32_t core_x = 0; core_x < cached_program.shared_variables.storage_grid_size.x; core_x++) {
+            const CoreCoord core = {core_x, core_y};
+            auto& reader_runtime_args =
+                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.reader_kernel_id, core);
+            reader_runtime_args[0] = input_tensor_buffer->address();
+
+            auto& writer_runtime_args =
+                GetRuntimeArgs(cached_program.program, cached_program.shared_variables.writer_kernel_id, core);
+            writer_runtime_args[0] = value_tensor_buffer->address();
+            writer_runtime_args[1] = index_tensor_buffer->address();
+
+            if (all_core_utilization_loop_count < 1 && all_core_utilization_loop_residuum != 0) {
+                residuum_count++;
+                if (residuum_count >= all_core_utilization_loop_residuum) {
+                    core_y = cached_program.shared_variables.storage_grid_size.y;  // Break outer loop
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/sort_program_factory.hpp
@@ -9,18 +9,17 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/device_operation.hpp"
 
 namespace ttnn::operations::experimental::reduction::sort::program {
 using namespace tt::tt_metal;
-
 struct SortProgramFactory {
     struct shared_variables_t {
         KernelHandle reader_kernel_id;
         KernelHandle compute_kernel_id;
         KernelHandle writer_kernel_id;
+        CoreCoord storage_grid_size;
     };
 
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -134,6 +134,18 @@ bool validate_optional_output_tensors_for_early_exit(
            output_tensor_1.get_logical_shape() == original_lshape;
 }
 
+void convert_tensor_dtype(Tensor& tensor, const DataType& target_dtype, IDevice* device) {
+    if (tensor.get_dtype() == target_dtype) {
+        // No need to change the dtype
+        return;
+    }
+    // Convert the tensor to the target dtype
+    // ttnn::to_dtype does not convert the tensor on Device, need to move it to CPU first
+    tensor = tensor.cpu();  // blocking
+    tensor = ttnn::to_dtype(tensor, target_dtype);
+    tensor = tensor.to_device(device);
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -173,8 +185,14 @@ std::vector<Tensor> ExecuteSort::invoke(
         output_tensors = reduction_common::tuple_to_vector_optional(*optional_output_tensors);
         output_tensors[0] = CMAKE_UNIQUE_NAMESPACE::pre_sort_transform_tensor(
             output_tensors[0].value(), dim, is_dim_last_idx, is_rank_le_4d, descending);
+
         output_tensors[1] = CMAKE_UNIQUE_NAMESPACE::pre_sort_transform_tensor(
             output_tensors[1].value(), dim, is_dim_last_idx, is_rank_le_4d, descending);
+
+        const auto target_index_dtype = DataType::UINT16;
+        CMAKE_UNIQUE_NAMESPACE::convert_tensor_dtype(
+            output_tensors[1].value(), target_index_dtype, input_tensor.device());
+
     } else {
         output_tensors = std::vector<std::optional<Tensor>>{
             std::nullopt,  // Placeholder for values tensor

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
@@ -18,7 +18,7 @@ struct ExecuteSort {
         const bool descending,
         const bool stable,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
-        std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
+        std::optional<std::tuple<Tensor&, Tensor&>> optional_output_tensors = std::nullopt);
 };
 
 }  // namespace ttnn::operations::experimental::reduction::sort

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -67,7 +67,7 @@ void bind_reduction_sort_operation(py::module& module) {
                const int8_t dim,
                const bool descending,
                const bool stable,
-               std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
+               std::optional<std::tuple<ttnn::Tensor&, ttnn::Tensor&>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                QueueId queue_id) -> std::vector<ttnn::Tensor> {
                 return self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -70,22 +70,7 @@ void bind_reduction_sort_operation(py::module& module) {
                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                QueueId queue_id) -> std::vector<ttnn::Tensor> {
-                auto output_tensors =
-                    self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
-
-                // Check if padding or dtype conversion changed buffer address
-                if (optional_output_tensors.has_value()) {
-                    if (std::get<0>(optional_output_tensors.value()).buffer() != output_tensors.at(0).buffer()) {
-                        std::get<0>(optional_output_tensors.value())
-                            .populate_buffers_and_metadata(output_tensors.at(0));
-                    }
-                    if (std::get<1>(optional_output_tensors.value()).buffer() != output_tensors.at(1).buffer()) {
-                        std::get<1>(optional_output_tensors.value())
-                            .populate_buffers_and_metadata(output_tensors.at(1));
-                    }
-                }
-
-                return output_tensors;
+                return self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("dim") = -1,

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort_pybind.cpp
@@ -70,7 +70,22 @@ void bind_reduction_sort_operation(py::module& module) {
                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
                QueueId queue_id) -> std::vector<ttnn::Tensor> {
-                return self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
+                auto output_tensors =
+                    self(queue_id, input_tensor, dim, descending, stable, memory_config, optional_output_tensors);
+
+                // Check if padding or dtype conversion changed buffer address
+                if (optional_output_tensors.has_value()) {
+                    if (std::get<0>(optional_output_tensors.value()).buffer() != output_tensors.at(0).buffer()) {
+                        std::get<0>(optional_output_tensors.value())
+                            .populate_buffers_and_metadata(output_tensors.at(0));
+                    }
+                    if (std::get<1>(optional_output_tensors.value()).buffer() != output_tensors.at(1).buffer()) {
+                        std::get<1>(optional_output_tensors.value())
+                            .populate_buffers_and_metadata(output_tensors.at(1));
+                    }
+                }
+
+                return output_tensors;
             },
             py::arg("input_tensor").noconvert(),
             py::arg("dim") = -1,


### PR DESCRIPTION
### Ticket
Add ttnn.sort multi-core implementation - https://github.com/tenstorrent/tt-metal/issues/20623

### Problem description
- Improve ttnn sort OP performance by adding multicore option,
- Fix issue with data type for preallocated tensors,
- Update docs.

### What's changed
- Added multicore implementation for the OP that allows sorting multiple rows of tiles at the same time,
- Fixed data type issue for preallocated index tensors variant,
- Fixed `optional_output_tensors` output data when manual padding is added,
- Updated docs.

### Performance check

#### General measurements
| Input Shape               | Device Kernel Duration per Core Max [ns] |
|---------------------------|-------------------------------------------|
| [32, 64]                  | 42762                                    |
| [32, 128 * 32]            | 13355382                                |
| [64, 64]                  | 42884                                    |
| [64, 128 * 32]            | 13358557                                |
| [64 * 32, 64]             | 47706                                    |
| [64 * 32, 128 * 32]       | 13669454                                |
| [128 * 32, 128 * 32]      | 27038558                                |
| [192 * 32, 128 * 32]      | 40373655                                |

#### The impact of increasing Ht number on the times achieved
| Input Shape             | Device Kernel Duration per Core Max [ns] |
|-------------------------|-------------------------------------------|
| [1 * 1  * 32, 64]       | 42838                                    |
| [1 * 32 * 64, 64]       | 47712                                    |
| [2 * 32 * 64, 64]       | 90192                                    |
| [3 * 32 * 64, 64]       | 133272                                   |
| [4 * 32 * 64, 64]       | 176002                                   |
| [5 * 32 * 64, 64]       | 217636                                   |
| [6 * 32 * 64, 64]       | 260333                                   |

![kernel_duration_plot](https://github.com/user-attachments/assets/ff8dea12-7d3f-4e1f-827d-63609821aae8)

#### The impact of increasing Wt number on the time achieved
| Input Shape               | Device Kernel Duration per Core Max [ns] |
|---------------------------|-------------------------------------------|
| [32, 32 * 2] | 42721 |
| [32, 32 * 4] | 105796 |
| [32, 32 * 8] | 279955 |
| [32, 32 * 16] | 754899 |
| [32, 32 * 32] | 2018155 |
| [32, 32 * 64] | 5245173 |
| [32, 32 * 128] | 13355985 |

64 - core number on wormhole
32 - tile height

![kernel_duration_plot_with_trend](https://github.com/user-attachments/assets/563f4b7f-e240-4618-b422-0a3d949c73c8)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes