### PR TITLE
Add support for 2D torus at device init for 6u

### DIFF
--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -111,6 +111,7 @@ jobs:
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
           TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+          ./build/test/ttnn/unit_tests_ttnn_ccl --gtest_filter="EdmFabric.RingDeadlockStabilityTest"
           pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick";
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "quick";
           pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py;

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -111,7 +111,6 @@ jobs:
           ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
           TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
           TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
-          ./build/test/ttnn/unit_tests_ttnn_ccl --gtest_filter="EdmFabric.RingDeadlockStabilityTest"
           pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick";
           pytest models/demos/llama3_subdevices/demo/demo_decode.py -k "quick";
           pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1391,14 +1391,32 @@ TEST(EdmFabric, BasicMcastThroughputTest_4_WithLineSync) {
 }
 
 TEST(EdmFabric, RingDeadlockStabilityTest) {
-    const size_t num_mcasts = 200000;
-    const size_t num_links = 1;
-    const size_t num_op_invocations = 5;
-    const bool line_sync = true;
-    log_trace(tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only");
-    RunRingDeadlockStabilityTestWithPersistentFabric(num_mcasts, num_links, num_op_invocations, true, false);
-    log_trace(tt::LogTest, "Running RingDeadlockStabilityTest with backward mcast only");
-    RunRingDeadlockStabilityTestWithPersistentFabric(num_mcasts, num_links, num_op_invocations, false, true);
-    log_trace(tt::LogTest, "Running RingDeadlockStabilityTest with forward and backward mcast");
-    RunRingDeadlockStabilityTestWithPersistentFabric(num_mcasts, num_links, num_op_invocations, true, true);
+    constexpr size_t num_mcasts = 200000;
+    constexpr size_t num_op_invocations = 5;
+    constexpr bool line_sync = true;
+    size_t num_links = 1;
+    std::vector<size_t> num_devices;
+    auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
+    if (cluster_type == tt::ClusterType::GALAXY) {
+        num_devices = {4, 8};
+        num_links = 4;
+    } else {
+        num_devices = {8};
+    }
+    for (const auto& num_devices : num_devices) {
+        log_trace(
+            tt::LogTest, "Running RingDeadlockStabilityTest with forward mcast only with {} devices", num_devices);
+        RunRingDeadlockStabilityTestWithPersistentFabric(
+            num_mcasts, num_links, num_devices, num_op_invocations, true, false);
+        log_trace(
+            tt::LogTest, "Running RingDeadlockStabilityTest with backward mcast only with {} devices", num_devices);
+        RunRingDeadlockStabilityTestWithPersistentFabric(
+            num_mcasts, num_links, num_devices, num_op_invocations, false, true);
+        log_trace(
+            tt::LogTest,
+            "Running RingDeadlockStabilityTest with forward and backward mcast with {} devices",
+            num_devices);
+        RunRingDeadlockStabilityTestWithPersistentFabric(
+            num_mcasts, num_links, num_devices, num_op_invocations, true, true);
+    }
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1399,7 +1399,6 @@ TEST(EdmFabric, RingDeadlockStabilityTest) {
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     if (cluster_type == tt::ClusterType::GALAXY) {
         num_devices = {4, 8};
-        num_links = 4;
     } else {
         num_devices = {8};
     }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -361,6 +361,7 @@ void ControlPlane::initialize_from_mesh_graph_desc_file(const std::string& mesh_
             this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id));
     } else if (
         mesh_graph_desc_filename == "quanta_galaxy_mesh_graph_descriptor.yaml" ||
+        mesh_graph_desc_filename == "quanta_galaxy_torus_2d_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p100_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p150_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p150_x2_mesh_graph_descriptor.yaml" ||

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -78,7 +78,10 @@ void append_fabric_connection_rt_args(
     }
 
     TT_FATAL(
-        candidate_ethernet_cores.has_value(), "Could not find any fabric ethernet cores between src and dst chips");
+        candidate_ethernet_cores.has_value(),
+        "Could not find any fabric ethernet cores between src {} and dst {} chips",
+        src_chip_id,
+        dst_chip_id);
 
     TT_FATAL(link_idx < candidate_ethernet_cores.value().size(), "link idx out of bounds");
 

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -15,17 +15,17 @@
 
 namespace tt::tt_fabric {
 
-bool is_1d_fabric_config(const tt::tt_metal::FabricConfig& fabric_config) {
+bool is_1d_fabric_config(tt::tt_metal::FabricConfig fabric_config) {
     return fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D ||
            fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D_RING;
 }
 
-bool is_2d_fabric_config(const tt::tt_metal::FabricConfig& fabric_config) {
+bool is_2d_fabric_config(tt::tt_metal::FabricConfig fabric_config) {
     return fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D ||
            fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_PUSH;
 }
 
-Topology get_1d_topology(const tt::tt_metal::FabricConfig& fabric_config) {
+Topology get_1d_topology(tt::tt_metal::FabricConfig fabric_config) {
     switch (fabric_config) {
         case tt::tt_metal::FabricConfig::FABRIC_1D: return tt::tt_fabric::Topology::Linear;
         case tt::tt_metal::FabricConfig::FABRIC_1D_RING: return tt::tt_fabric::Topology::Ring;
@@ -36,6 +36,13 @@ Topology get_1d_topology(const tt::tt_metal::FabricConfig& fabric_config) {
             TT_THROW("Unsupported fabric config for 1D: {}", magic_enum::enum_name(fabric_config));
     }
     return tt::tt_fabric::Topology::Linear;
+}
+
+FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type) {
+    if (cluster_type == tt::ClusterType::GALAXY && fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D_RING) {
+        return FabricType::TORUS_2D;
+    }
+    return FabricType::MESH;
 }
 
 std::vector<chan_id_t> get_ordered_fabric_eth_chans(chip_id_t chip_id, const std::set<chan_id_t>& eth_chans) {

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -13,10 +13,12 @@
 
 namespace tt::tt_fabric {
 
-bool is_1d_fabric_config(const tt::tt_metal::FabricConfig& fabric_config);
-bool is_2d_fabric_config(const tt::tt_metal::FabricConfig& fabric_config);
+bool is_1d_fabric_config(tt::tt_metal::FabricConfig fabric_config);
+bool is_2d_fabric_config(tt::tt_metal::FabricConfig fabric_config);
 
-Topology get_1d_topology(const tt::tt_metal::FabricConfig& fabric_config);
+Topology get_1d_topology(tt::tt_metal::FabricConfig fabric_config);
+
+FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type);
 
 std::vector<chan_id_t> get_ordered_fabric_eth_chans(chip_id_t chip_id, const std::set<chan_id_t>& eth_chans);
 

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -88,11 +88,11 @@ void MeshGraph::add_to_connectivity(
 std::unordered_map<chip_id_t, RouterEdge> MeshGraph::get_valid_connections(
     chip_id_t src_chip_id, std::uint32_t row_size, std::uint32_t num_chips_in_board, FabricType fabric_type) const {
     std::unordered_map<chip_id_t, RouterEdge> valid_connections;
-    chip_id_t N = src_chip_id - row_size;
-    chip_id_t E = src_chip_id + 1;
-    chip_id_t S = src_chip_id + row_size;
-    chip_id_t W = src_chip_id - 1;
     if (fabric_type == FabricType::MESH) {
+        chip_id_t N = src_chip_id - row_size;
+        chip_id_t E = src_chip_id + 1;
+        chip_id_t S = src_chip_id + row_size;
+        chip_id_t W = src_chip_id - 1;
         if (N >= 0) {
             valid_connections.insert(
                 {N,
@@ -127,6 +127,37 @@ std::unordered_map<chip_id_t, RouterEdge> MeshGraph::get_valid_connections(
         }
     } else if (fabric_type == FabricType::TORUS_1D) {
         // TODO: add support
+    } else if (fabric_type == FabricType::TORUS_2D) {
+        auto row = src_chip_id / row_size;
+        auto col = src_chip_id % row_size;
+        chip_id_t N = (src_chip_id - row_size + num_chips_in_board) % num_chips_in_board;
+        chip_id_t E = row * row_size + (col + 1) % row_size;
+        chip_id_t S = (src_chip_id + row_size) % num_chips_in_board;
+        chip_id_t W = row * row_size + (col - 1 + row_size) % row_size;
+        valid_connections.insert(
+            {N,
+             RouterEdge{
+                 .port_direction = RoutingDirection::N,
+                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, N),
+                 .weight = 0}});
+        valid_connections.insert(
+            {E,
+             RouterEdge{
+                 .port_direction = RoutingDirection::E,
+                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, E),
+                 .weight = 0}});
+        valid_connections.insert(
+            {S,
+             RouterEdge{
+                 .port_direction = RoutingDirection::S,
+                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, S),
+                 .weight = 0}});
+        valid_connections.insert(
+            {W,
+             RouterEdge{
+                 .port_direction = RoutingDirection::W,
+                 .connected_chip_ids = std::vector<chip_id_t>(this->chip_spec_.num_eth_ports_per_direction, W),
+                 .weight = 0}});
     }
     return valid_connections;
 }

--- a/tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_torus_2d_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_torus_2d_graph_descriptor.yaml
@@ -1,0 +1,27 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
+  }
+}
+
+
+Board: [
+  { name: Galaxy,
+    type: TORUS_2D,
+    topology: [8, 4]}
+ ]
+
+Mesh: [
+{
+  id: 0,
+  board: Galaxy,
+  topology: [1, 1],
+  host_mapping: [[]]}
+]
+
+Graph: [
+]

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1046,7 +1046,7 @@ bool check_dateline(
             // Row dateline
             // chip0 is the first row, chip1 is the last row on the same column
             (chip0 < physical_mesh_shape[1] && chip1 >= (physical_mesh_shape[1] * (physical_mesh_shape[0] - 1)) &&
-             chip1 % physical_mesh_shape[1] == 0);
+             chip1 % physical_mesh_shape[1] == chip0);
     }
     return false;
 }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -35,6 +35,7 @@
 #include "llrt/hal.hpp"
 #include "sanitize_noc_host.hpp"
 #include "tracy/Tracy.hpp"
+#include "tt_metal/fabric/fabric_host_utils.hpp"
 #include "tt_metal/llrt/tlb_config.hpp"
 #include <umd/device/cluster.h>
 #include <umd/device/hugepage.h>
@@ -1294,7 +1295,14 @@ void Cluster::initialize_control_plane() {
         case tt::ClusterType::N150: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::N300: mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::T3K: mesh_graph_descriptor = "t3k_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::GALAXY: mesh_graph_descriptor = "quanta_galaxy_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::GALAXY:
+            if (tt::tt_fabric::get_fabric_type(this->fabric_config_, this->cluster_type_) ==
+                tt::tt_fabric::FabricType::TORUS_2D) {
+                mesh_graph_descriptor = "quanta_galaxy_torus_2d_graph_descriptor.yaml";
+            } else {
+                mesh_graph_descriptor = "quanta_galaxy_mesh_graph_descriptor.yaml";
+            }
+            break;
         case tt::ClusterType::TG: mesh_graph_descriptor = "tg_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::P100: mesh_graph_descriptor = "p100_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::P150: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
On 6u, we only supported Mesh, and didn't handle the wraparound connections for 6U through control plane.

### What's changed
Add support for TORUS_2D fabric type in control plane, which adds the wraparound links to the MeshGraph.
Use TORUS_2D when specifying 1D ring on 6U (Untested for using 2D fabric).
Add test that uses the wraparound links with fabric initialized at device init.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14665941196
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

TG Quick: https://github.com/tenstorrent/tt-metal/actions/runs/14666553223