### PR TITLE
Remove dispatch profiler test for BH until CI HW setup stabilizes

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -209,6 +209,7 @@ def test_full_buffer():
         assert stats[statName]["stats"]["Count"] in REF_COUNT_DICT[ENV_VAR_ARCH_NAME], "Wrong Marker Repeat count"
 
 
+@skip_for_blackhole()
 def test_dispatch_cores():
     OP_COUNT = 1
     RISC_COUNT = 1


### PR DESCRIPTION
### Ticket
#21083 

### Problem description
Fast dispatch profiler keeps on failing on various BH HW setups.

### What's changed
Disable it until BH CI stabilizes and criteria can be fixed for it.

### Checklist
- [x] [APC Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14644556498)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14644549623)
- [x] [BH Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14644544574)