### PR TITLE
TM Stress test  + 2 tiny fixes

### DIFF
--- a/tests/ttnn/stress_tests/test_data_movement.py
+++ b/tests/ttnn/stress_tests/test_data_movement.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+from ttnn.device import get_device_core_grid, is_blackhole, is_wormhole_b0
+
+NUM_REPEATS = 5
+
+##### WORMMHOLE #######
+L1_INPUT_SHAPE_WH = (30_000, 8, 8)
+L1_OUTPUT_SHAPE_WH = (3_000, 16, 40)
+
+DRAM_INPUT_SHAPE_WH = (3_125_000, 8, 8)
+DRAM_OUTPUT_SHAPE_WH = (312_500, 16, 40)
+
+SHARDING_INPUT_SHAPE_WH = (1, 6_000, 2_000)
+
+##### BLACKHOLE #######
+L1_INPUT_SHAPE_BH = (60_000, 8, 8)
+L1_OUTPUT_SHAPE_BH = (6_000, 16, 40)
+
+DRAM_INPUT_SHAPE_BH = (7_500_000, 8, 8)
+DRAM_OUTPUT_SHAPE_BH = (750_000, 16, 40)
+
+SHARDING_INPUT_SHAPE_BH = (1, 6_000, 6_000)
+
+
+if is_blackhole():
+    l1_input_shape, l1_output_shape = (L1_INPUT_SHAPE_BH, L1_OUTPUT_SHAPE_BH)
+    dram_input_shape, dram_output_shape = (DRAM_INPUT_SHAPE_BH, DRAM_OUTPUT_SHAPE_BH)
+    sharding_input_shape = SHARDING_INPUT_SHAPE_BH
+elif is_wormhole_b0():
+    l1_input_shape, l1_output_shape = (L1_INPUT_SHAPE_WH, L1_OUTPUT_SHAPE_WH)
+    dram_input_shape, dram_output_shape = (DRAM_INPUT_SHAPE_WH, DRAM_OUTPUT_SHAPE_WH)
+    sharding_input_shape = SHARDING_INPUT_SHAPE_WH
+else:
+    raise RuntimeError("Unidentifiable device")
+
+
+@pytest.mark.parametrize(
+    "shapes_memory_config",
+    [
+        (l1_input_shape, l1_output_shape, ttnn.L1_MEMORY_CONFIG),
+        (dram_input_shape, dram_output_shape, ttnn.DRAM_MEMORY_CONFIG),
+    ],
+)
+def test_stress_reshape(device, use_program_cache, shapes_memory_config):
+    input_shape, output_shape, memory_config = shapes_memory_config
+    for _ in range(NUM_REPEATS):
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
+        input_tensor = ttnn.from_torch(torch_input_tensor, memory_config=memory_config, device=device)
+        input_tensor = ttnn.to_layout(input_tensor, ttnn.TILE_LAYOUT)
+        output_tensor = ttnn.reshape(input_tensor, output_shape)
+
+        del input_tensor
+        del output_tensor
+
+    assert True
+
+
+def test_stress_reshard(device, use_program_cache):
+    input_tensor_shape = sharding_input_shape
+    core_grid = get_device_core_grid(device)
+
+    l1_shard_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(core_grid.x - 1, core_grid.y - 1))}
+    )
+
+    shard_shape = input_tensor_shape[1] // core_grid.x, input_tensor_shape[2] // core_grid.y
+    shard_shape = tuple(s + 32 - s % 32 for s in shard_shape)
+
+    shard_spec = ttnn.ShardSpec(l1_shard_grid, shard_shape, ttnn.ShardOrientation.COL_MAJOR)
+
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    for _ in range(NUM_REPEATS):
+        input_tensor_torch = torch.randn(input_tensor_shape)
+        input_tensor = ttnn.from_torch(input_tensor_torch, layout=ttnn.TILE_LAYOUT, device=device)
+
+        output_tensor = ttnn.interleaved_to_sharded(input_tensor, sharded_mem_config)
+
+        del input_tensor
+        del output_tensor
+
+    assert True

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -1350,7 +1350,7 @@ Tensor pad(
             output_strides.push_back(compute_stride(output_padded_shape, index));
         }
 
-        auto flat_output_index = 0;
+        size_t flat_output_index = 0;
         auto output_buffer = owned_buffer::create<T>(output_padded_shape.volume());
         std::function<void(std::size_t)> pad_to_tile = [&](std::size_t dim) -> void {
             for (auto i = 0; i < pad_size[dim][0] * output_strides[dim]; i++) {
@@ -1360,7 +1360,7 @@ Tensor pad(
             for (auto i = 0; i < input_padded_shape[dim]; i++) {
                 input_indices[dim] = i;
                 if (dim == input_padded_shape.rank() - 1) {
-                    auto flat_input_index = compute_flat_input_index(input_indices, input_strides);
+                    size_t flat_input_index = compute_flat_input_index(input_indices, input_strides);
                     output_buffer[flat_output_index++] = input_buffer[flat_input_index];
                 } else {
                     pad_to_tile(dim + 1);


### PR DESCRIPTION
### Ticket
TM stress test for https://github.com/tenstorrent/tt-metal/issues/21069

### Problem description
Op stress tests were desired to check machine reliability 

### What's changed
- Added `tests/ttnn/stress_tests/` subdirectory
- Added TM stress test. Basically increased the input sizes until things started crashing.
- Fixed a tiny overflow bug in the course of the above.
- Noticed that `test_reshape.py::test_tile` wasn't actually testing L1 tensors so fixed that.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes