### PR TITLE
#21082: Disable TensixInlineWriteDynamicNoc on BH

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -437,6 +437,11 @@ TEST_F(DeviceFixture, TensixInlineWriteDedicatedNocMisaligned) {
 
 // Both data movement riscs issue inline writes using the same noc
 TEST_F(DeviceFixture, TensixInlineWriteDynamicNoc) {
+    // #21082
+    auto arch = tt::get_arch_from_string(get_umd_arch_name());
+    if (arch == tt::ARCH::BLACKHOLE) {
+        GTEST_SKIP();
+    }
     CoreCoord writer_core{0, 0};
     CoreCoord receiver_core(0, 1);
     uint32_t value_to_write = 39;


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21082)

### Problem description
Blocking CI

### What's changed
Disable for BH as a temporary work around

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes