### PR TITLE
Nest import of torch inside test function

### DIFF
--- a/ttnn/ttnn/operations/complex_binary_backward.py
+++ b/ttnn/ttnn/operations/complex_binary_backward.py
@@ -2,11 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import ttnn
-import torch
-
 
 def _golden_function_complex_add(grad_tensor, input_tensor_a, input_tensor_b, alpha, *args, **kwargs):
+    import torch
+
     input_tensor_a.retain_grad()
 
     pyt_y = torch.add(input_tensor_a, input_tensor_b, alpha=alpha)
@@ -27,6 +26,8 @@ def _golden_function_complex_add(grad_tensor, input_tensor_a, input_tensor_b, al
 
 
 def _golden_function_complex_sub(grad_tensor, input_tensor_a, input_tensor_b, alpha, *args, **kwargs):
+    import torch
+
     input_tensor_a.retain_grad()
 
     pyt_y = torch.sub(input_tensor_a, input_tensor_b, alpha=alpha)
@@ -47,6 +48,8 @@ def _golden_function_complex_sub(grad_tensor, input_tensor_a, input_tensor_b, al
 
 
 def _golden_function_complex_mul(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
     input_tensor_a.retain_grad()
 
     pyt_y = torch.mul(input_tensor_a, input_tensor_b)
@@ -67,6 +70,8 @@ def _golden_function_complex_mul(grad_tensor, input_tensor_a, input_tensor_b, *a
 
 
 def _golden_function_complex_div(grad_tensor, input_tensor_a, input_tensor_b, *args, **kwargs):
+    import torch
+
     input_tensor_a.retain_grad()
 
     pyt_y = torch.div(input_tensor_a, input_tensor_b)


### PR DESCRIPTION
### Ticket
Closes [#21148](https://github.com/tenstorrent/tt-metal/issues/21148)

### Problem description
Can't import `ttnn` without having torch installed.
`ttnn` should be usable without torch in an ideal world.

### What's changed
Nest `torch` import inside of golden functions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14646645518) CI passes
- [x] New/Existing tests provide coverage for changes
