### PR TITLE
Add torch as a runtime dependency

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -312,8 +312,11 @@ ENV VIRTUAL_ENV="$PYTHON_ENV_DIR"
 # Ensure the virtual environment is activated on shell startup
 RUN echo "source $PYTHON_ENV_DIR/bin/activate" >> /etc/bash.bashrc
 
+# Install torch. ttnn team would like to remove this dependency, but this is a temporary solution to unblock
+# tt-installer and downstream container users. See GitHub issue https://github.com/tenstorrent/tt-metal/issues/17057
 RUN mkdir -p /etc && \
     echo "[global]\nextra-index-url = https://download.pytorch.org/whl/cpu" > /etc/pip.conf
+RUN pip3 install torch
 
 ARG WHEEL_FILENAME
 ADD $WHEEL_FILENAME $WHEEL_FILENAME


### PR DESCRIPTION
Currently, running `import ttnn` in the release container fails because we are missing the torch dependency. To resolve this, we should install it until such time as we can rework ttnn to not depend on torch.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/17057

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes