### PR TITLE
Add auto sharding in pool2d with L1 memory usage check

### DIFF
--- a/tests/sweep_framework/sweep_utils/max_pool2d_common.py
+++ b/tests/sweep_framework/sweep_utils/max_pool2d_common.py
@@ -55,7 +55,7 @@ def run_max_pool2d(
     dilation_w,
     dtype,
     device,
-    sharding=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+    sharding=None,
     ceil_mode=False,
     memory_config=None,
     in_place=False,

--- a/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
+++ b/tests/ttnn/nightly/unit_tests/operations/pool/test_avg_pool2d_sweeps.py
@@ -79,5 +79,5 @@ def test_ttnn_pytorch_sweep(device, tensor_map, input_spec):
         ceil_mode=ceil_mode,
         divisor_override=None,
         count_include_pad=count_include_pad,
-        shard_scheme=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        shard_scheme=None,
     )

--- a/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_avgpool2d.py
@@ -67,6 +67,7 @@ def tensor_map():
 @pytest.mark.parametrize(
     "shard_scheme",
     [
+        None,
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
         ttnn.TensorMemoryLayout.WIDTH_SHARDED,
         ttnn.TensorMemoryLayout.BLOCK_SHARDED,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -259,7 +259,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t num_shards_c,
     const MemoryConfig& out_mem_config,
     uint32_t nblocks,
-    std::optional<int32_t> divisor_override) {
+    std::optional<int32_t> divisor_override,
+    uint32_t memory_used) {
     // This should allocate a DRAM buffer on the device
     IDevice* device = input.device();
     tt::tt_metal::Buffer* src_dram_buffer = input.buffer();
@@ -608,6 +609,19 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
 
     auto compute_kernel = CreateKernel(program, compute_kernel_fname, all_cores, compute_config);
 
+    uint32_t temporary_size = program.get_cb_memory_size();
+    uint32_t post_allocate_size =
+        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
+    uint32_t l1_usage = calculate_L1_usage(
+        input, kernel_size_h, kernel_size_w, out_h, out_w, input.memory_config(), output.memory_config(), pool_type);
+    uint32_t output_cb_size = post_allocate_size - memory_used;
+
+    TT_FATAL(
+        temporary_size + output_cb_size == l1_usage,
+        "Calculated CB size {} does not match with the actual CB size {}  ",
+        temporary_size + output_cb_size,
+        l1_usage);
+
     {  // debug
         log_debug(tt::LogOp, "raw_in_cb :: PS = {}, NP = {}", raw_in_cb_pagesize, raw_in_cb_npages);
         log_debug(tt::LogOp, "in_cb :: PS = {}, NP = {}", in_cb_pagesize, in_cb_npages);
@@ -746,7 +760,8 @@ Pool2D::MultiCore::cached_program_t Pool2D::MultiCore::create(
         num_shards_c,
         out_mem_config,
         1,
-        divisor_override);
+        divisor_override,
+        op_attr.memory_used);
 }
 
 void Pool2D::MultiCore::override_runtime_arguments(

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -183,7 +183,8 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
     DataType output_dtype,
     MemoryConfig memory_config,
     bool count_include_pad,
-    std::optional<int32_t> divisor_override) {
+    std::optional<int32_t> divisor_override,
+    uint32_t memory_used) {
     return {
         operation_attributes_t{
             .sliding_window_config_ = sliding_window_config,
@@ -191,7 +192,8 @@ std::tuple<Pool2D::operation_attributes_t, Pool2D::tensor_args_t> Pool2D::invoke
             .output_dtype_ = output_dtype,
             .memory_config_ = std::move(memory_config),
             .count_include_pad_ = count_include_pad,
-            .divisor_override_ = divisor_override},
+            .divisor_override_ = divisor_override,
+            .memory_used = memory_used},
         tensor_args_t{input_tensor}};
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -28,6 +28,7 @@ struct Pool2D {
         MemoryConfig memory_config_;
         bool count_include_pad_;
         std::optional<int32_t> divisor_override_;
+        uint32_t memory_used;
     };
 
     struct tensor_args_t {
@@ -80,7 +81,8 @@ struct Pool2D {
         DataType output_dtype,
         MemoryConfig memory_config,
         bool count_include_pad,
-        std::optional<int32_t> divisor_override);
+        std::optional<int32_t> divisor_override,
+        uint32_t memory_used);
 };
 
 }  // namespace pool

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -6,6 +6,11 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/assert.hpp>
 
+#include "tt-metalium/constants.hpp"
+#include "tt-metalium/hal.hpp"
+
+#include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
+
 namespace ttnn::operations::pool {
 // Return a single bf16 scalar for the pool type in u32 (packed in the least 16 bits)
 // For the maxpool it is 1, for the avg pool it is 1/kernel_size or the divisor override used to initialize compile
@@ -50,4 +55,257 @@ std::map<std::string, std::string> get_defines(Pool2DType pool_type) {
 
     return defines;
 }
+
+using sliding_window::ParallelConfig;
+using sliding_window::SlidingWindowConfig;
+
+std::optional<ParallelConfig> determine_valid_parallel_config(
+    const TensorMemoryLayout shard_layout,
+    uint32_t batch_size,
+    uint32_t channels,
+    uint32_t output_height,
+    uint32_t output_width,
+    const CoreCoord& compute_grid_size,
+    ShardOrientation block_shard_orientation,
+    bool enable_channels_padding,
+    bool is_shard_height_tile_multiple,
+    bool is_shard_width_tile_multiple,
+    uint32_t act_block_h_override) {
+    if (shard_layout != TensorMemoryLayout::HEIGHT_SHARDED && shard_layout != TensorMemoryLayout::BLOCK_SHARDED &&
+        shard_layout != TensorMemoryLayout::WIDTH_SHARDED) {
+        TT_THROW("Pool2d supports Height, Block or Width Sharded Layouts but got {}", shard_layout);
+    }
+    auto pconfig = conv::determine_parallel_config(
+        shard_layout,
+        batch_size,
+        channels,
+        output_height,
+        output_width,
+        channels,
+        compute_grid_size,
+        block_shard_orientation,
+        enable_channels_padding,
+        is_shard_height_tile_multiple,
+        is_shard_width_tile_multiple,
+        act_block_h_override);
+
+    // pooling can accept any height and either a tile multiple or half a tile for width.
+    if (shard_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        uint32_t num_cores_c = 1;
+        uint32_t tile_size = channels / num_cores_c;
+        if (tile_size != 16 && tile_size % tt::constants::TILE_WIDTH != 0) {
+            return std::nullopt;
+        }
+    } else if (shard_layout == TensorMemoryLayout::BLOCK_SHARDED) {
+        auto grid_x = pconfig.grid.ranges()[0].end_coord.x - pconfig.grid.ranges()[0].start_coord.x + 1;
+        auto grid_y = pconfig.grid.ranges()[0].end_coord.y - pconfig.grid.ranges()[0].start_coord.y + 1;
+        uint32_t num_cores_c = block_shard_orientation == ShardOrientation::COL_MAJOR ? grid_y : grid_x;
+        uint32_t tile_size = channels / num_cores_c;
+        if (tile_size != 16 && tile_size % tt::constants::TILE_WIDTH != 0) {
+            return std::nullopt;
+        }
+    } else if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        uint32_t num_cores_c = pconfig.grid.num_cores();
+        uint32_t tile_size = channels / num_cores_c;
+        if (tile_size != 16 && tile_size % tt::constants::TILE_WIDTH != 0) {
+            return std::nullopt;
+        }
+    }
+
+    return pconfig;
+}
+
+uint32_t calculate_L1_usage(
+    const Tensor& input,
+    const uint32_t kernel_h,
+    const uint32_t kernel_w,
+    const uint32_t out_h,
+    const uint32_t out_w,
+    const MemoryConfig& input_memory,
+    const MemoryConfig& output_memory,
+    Pool2DType pool_type) {
+    const auto input_shape = input.get_padded_shape();
+
+    auto in_dtype = input.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input.dtype();
+    tt::DataFormat in_df = datatype_to_dataformat_converter(in_dtype);
+    uint32_t in_nbytes = datum_size(in_df);
+    uint32_t out_nbytes = in_nbytes;
+
+    auto pconfig = input.memory_config();
+    const auto grid_size = input_memory.shard_spec().value().grid.bounding_box().grid_size();
+    uint32_t num_shards_c = 0;
+    if (pconfig.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED) {
+        num_shards_c = 1;
+    } else if (pconfig.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+        num_shards_c = input_memory.shard_spec().value().grid.num_cores();
+    } else if (input_memory.shard_spec().value().orientation == ShardOrientation::COL_MAJOR) {
+        num_shards_c = grid_size.y;
+    } else {
+        num_shards_c = grid_size.x;
+    }
+
+    uint32_t kernel_size_hw = kernel_h * kernel_w;  // number of valid rows, to read
+    uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[3] / num_shards_c / tt::constants::TILE_WIDTH);
+
+    TT_ASSERT(input_shape[3] % num_shards_c == 0);
+    const bool is_partial_tile = (input_shape[3] / num_shards_c) == 16;
+
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+    const bool is_wide_reduction = in_ntiles_c > MAX_TILES_PER_REDUCTION;
+
+    const bool is_large_kernel =
+        is_partial_tile ? kernel_size_hw > tt::constants::TILE_HEIGHT / 2 : kernel_size_hw > tt::constants::TILE_HEIGHT;
+
+    // ToDo: enable 32 sticks per tile for reduction for all cases.
+    const uint32_t max_rows_for_reduction =
+        (!is_partial_tile && !is_large_kernel) ? tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT / 2;
+    const bool is_blackhole = tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE;
+
+    if (input_shape[3] < tt::constants::TILE_WIDTH) {
+        TT_FATAL(input_shape[3] == 16, "Error");
+    }
+
+    uint32_t nblocks = 1;
+
+    // CBs
+    uint32_t multi_buffering_factor = 2;
+
+    bool split_reader = true;
+
+    // scalar CB as coefficient of reduce
+    uint32_t in_scalar_cb_pagesize = tile_size(in_df);
+    uint32_t in_scalar_cb_npages = 1 * multi_buffering_factor;
+    uint32_t in_scalar_cb_size_0 = in_scalar_cb_npages * in_scalar_cb_pagesize;
+    uint32_t in_scalar_cb_size_1 = 0;
+
+    // For avgpool, instantiate and use this CB, which consists of 1s. We don't want to divide
+    // twice by kernel size for large kernel case.
+    uint32_t in_one_cb_size = 0;
+    if (pool_type == Pool2DType::AVG_POOL2D) {
+        uint32_t in_one_cb_pagesize = tile_size(in_df);
+        uint32_t in_one_cb_npages = 1;
+        in_one_cb_size = in_one_cb_pagesize * in_one_cb_npages;
+        if (split_reader) {
+            in_scalar_cb_size_1 = in_scalar_cb_npages * in_scalar_cb_pagesize;
+        }
+    }
+
+    uint32_t clear_value_cb_size = 0;
+    const bool avg_pool_on_blackhole = is_blackhole && pool_type == Pool2DType::AVG_POOL2D;
+    if (max_rows_for_reduction == tt::constants::TILE_HEIGHT || avg_pool_on_blackhole) {
+        // CB storing just "clear value" (-inf for maxpool, 0 for avgpool)
+        // is needed only if we use more then 16 sticks per tile for reduction.
+        clear_value_cb_size = tile_size(in_df);
+    }
+
+    uint32_t in_cb_sz = 0;
+    // uint32_t in_nblocks_c = 1;
+    if (is_wide_reduction) {
+        in_cb_sz = MAX_TILES_PER_REDUCTION * tt::constants::TILE_HW;
+    } else {
+        in_cb_sz = in_ntiles_c * tt::constants::TILE_HW;
+    }
+
+    uint32_t in_cb_page_padded = tt::round_up(
+        in_cb_sz,
+        tt::constants::TILE_HW);  // NOTE: ceil to tile size since triscs work with tilesize instead of pagesize
+    uint32_t in_cb_pagesize = in_nbytes * in_cb_page_padded;
+    uint32_t in_cb_npages = multi_buffering_factor * nblocks;
+    uint32_t in_cb_config_0_size = in_cb_npages * in_cb_pagesize;
+    uint32_t in_cb_config_1_size = 0;
+
+    if (split_reader) {
+        in_cb_config_1_size = in_cb_npages * in_cb_pagesize;
+    }
+
+    // after reduction
+    uint32_t out_cb_pagesize = std::min(tt::constants::TILE_WIDTH, output_memory.shard_spec().value().shape[1]) *
+                               out_nbytes;  // there is just one row of channels after each reduction (or 1 block
+                                            // of c if its greater than 8 tiles)
+    uint32_t out_cb_npages = output_memory.shard_spec().value().shape[0] * in_ntiles_c;
+    uint32_t out_cb_config_size = out_cb_npages * out_cb_pagesize;
+
+    uint32_t max_pool_partials_cb_config_size = 0;
+    if (is_large_kernel) {
+        uint32_t max_pool_partials_cb_pagesize = out_cb_pagesize;
+        uint32_t max_pool_partials_cb_npages = nblocks;
+        max_pool_partials_cb_config_size = max_pool_partials_cb_npages * max_pool_partials_cb_pagesize;
+    }
+
+    return in_scalar_cb_size_0 + in_scalar_cb_size_1 + in_one_cb_size + clear_value_cb_size + in_cb_config_0_size +
+           in_cb_config_1_size + out_cb_config_size /* global, involved */
+           + max_pool_partials_cb_config_size;
+}
+
+std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
+    const Tensor& input_tensor,
+    const SlidingWindowConfig& sliding_window_config,
+    uint32_t channels,
+    Pool2DType pool_type) {
+    auto batch_size = sliding_window_config.batch_size;
+    auto output_shape = sliding_window_config.get_output_shape();
+    auto compute_grid_size = input_tensor.device()->compute_with_storage_grid_size();
+
+    struct l1_usage_config {
+        uint32_t l1_usage;
+        std::optional<ParallelConfig> config;
+    };
+
+    auto get_memconfig = [&](const ParallelConfig& parallel_config) {
+        uint32_t nhw = batch_size * output_shape[1] * output_shape[2];
+        uint32_t out_channel_padded = tt::round_up(
+            channels, conv::get_num_cores_channels_from_parallel_config(parallel_config) * tt::constants::TILE_WIDTH);
+        return conv::create_sharded_memory_config_from_parallel_config(
+            ttnn::Shape({1, 1, nhw, out_channel_padded}), parallel_config, tt::constants::TILE_HEIGHT);
+    };
+
+    auto calc_l1_usage_inner = [&](TensorMemoryLayout layout, ShardOrientation orientation) -> l1_usage_config {
+        auto input_parallel_config = pool::determine_valid_parallel_config(
+            layout,
+            batch_size,
+            channels,
+            output_shape[1],
+            output_shape[2],
+            compute_grid_size,
+            orientation,
+            false,
+            false,
+            0);
+
+        if (!input_parallel_config.has_value()) {
+            return {std::numeric_limits<uint32_t>::max(), input_parallel_config};
+        }
+        uint32_t l1_usage = calculate_L1_usage(
+            input_tensor,
+            sliding_window_config.window_hw.first,
+            sliding_window_config.window_hw.second,
+            sliding_window_config.get_output_shape()[1],
+            sliding_window_config.get_output_shape()[2],
+            get_memconfig(input_parallel_config.value()),
+            get_memconfig(input_parallel_config.value()),
+            pool_type);
+
+        return {l1_usage, input_parallel_config};
+    };
+
+    auto l1_config_height = calc_l1_usage_inner(TensorMemoryLayout::HEIGHT_SHARDED, ShardOrientation::ROW_MAJOR);
+    auto l1_config_width = calc_l1_usage_inner(TensorMemoryLayout::WIDTH_SHARDED, ShardOrientation::ROW_MAJOR);
+    auto l1_config_block = calc_l1_usage_inner(TensorMemoryLayout::BLOCK_SHARDED, ShardOrientation::ROW_MAJOR);
+
+    uint32_t l1_usage_height = l1_config_height.l1_usage;
+    uint32_t l1_usage_width = l1_config_width.l1_usage;
+    uint32_t l1_usage_block = l1_config_block.l1_usage;
+
+    if (l1_usage_height > l1_usage_width) {
+        if (l1_usage_width > l1_usage_block) {
+            return l1_config_block.config;
+        }
+        return l1_config_width.config;
+    }
+    if (l1_usage_height > l1_usage_block) {
+        return l1_config_block.config;
+    }
+    return l1_config_height.config;
+}
+
 }  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.cpp
@@ -242,7 +242,7 @@ std::optional<ParallelConfig> determine_pool_config_for_auto_shard(
     const SlidingWindowConfig& sliding_window_config,
     uint32_t channels,
     Pool2DType pool_type) {
-    auto batch_size = sliding_window_config.batch_size;
+    uint32_t batch_size = sliding_window_config.batch_size;
     auto output_shape = sliding_window_config.get_output_shape();
     auto compute_grid_size = input_tensor.device()->compute_with_storage_grid_size();
 

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <string>
 #include <map>
-#include <cstdint>
 #include <optional>
 
 #include "ttnn/tensor/tensor.hpp"

--- a/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/pool_utils.hpp
@@ -5,7 +5,12 @@
 #include <cstdint>
 #include <string>
 #include <map>
+#include <cstdint>
 #include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include "ttnn/tensor/types.hpp"
 
 namespace ttnn::operations::pool {
 
@@ -37,5 +42,34 @@ uint32_t get_bf16_pool_scalar(
     Pool2DType pool_type, uint32_t kernel_h, uint32_t kernel_w, std::optional<int32_t> divisor_override);
 uint32_t get_bf16_pool_init_value(Pool2DType pool_type);
 std::map<std::string, std::string> get_defines(Pool2DType pool_type);
+
+std::optional<sliding_window::ParallelConfig> determine_valid_parallel_config(
+    const tt::tt_metal::TensorMemoryLayout shard_layout,
+    uint32_t batch_size,
+    uint32_t channels,
+    uint32_t output_height,
+    uint32_t output_width,
+    const CoreCoord& compute_grid_size,
+    tt::tt_metal::ShardOrientation block_shard_orientation,
+    bool enable_channels_padding,
+    bool is_shard_height_tile_multiple = false,
+    bool is_shard_width_tile_multiple = false,
+    uint32_t act_block_h_override = 0);
+
+std::optional<sliding_window::ParallelConfig> determine_pool_config_for_auto_shard(
+    const Tensor& input_tensor,
+    const sliding_window::SlidingWindowConfig& sliding_window_config,
+    uint32_t channels,
+    Pool2DType pool_type);
+
+uint32_t calculate_L1_usage(
+    const Tensor& input,
+    const uint32_t kernel_h,
+    const uint32_t kernel_w,
+    const uint32_t out_h,
+    const uint32_t out_w,
+    const tt::tt_metal::MemoryConfig& input_memory,
+    const tt::tt_metal::MemoryConfig& output_memory,
+    Pool2DType pool_type);
 
 }  // namespace ttnn::operations::pool


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14436)

### Problem description
Currently, pool2d only support height sharding. We would like to extend this functionality to width and block sharding. This PR is based on https://github.com/tenstorrent/tt-metal/pull/19078. L1 memory usage check is also added.

### What's changed
I added width/block sharding in tt-metal/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp and test it by tt-metal/tests/ttnn/unit_tests/operations/pool/test_maxpool2d.py.



### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/15595996418
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/15595999878
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/15596003572
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/15596005928
- [x] [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes:
(wormhole) https://github.com/tenstorrent/tt-metal/actions/runs/15596014268
(blackhole) https://github.com/tenstorrent/tt-metal/actions/runs/15596011641
- [x] [Frequent model](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI passes:
https://github.com/tenstorrent/tt-metal/actions/runs/15596017895
- [x] New/Existing tests provide coverage for changes