### PR TITLE
Restore torch to pyproject.toml

### DIFF
--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -105,6 +105,10 @@ jobs:
         with:
           submodules: recursive
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
+      - name: Test ttnn import
+        timeout-minutes: 1
+        run: |
+            python -c "import ttnn"
       - name: Run frequent regression tests
         timeout-minutes: ${{ inputs.timeout }}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "loguru>=0.6.0",
   "networkx>=3.1",
   "graphviz>=0.20.3",
+  "torch==2.2.1+cpu",
 ]
 requires-python = ">=3.10"
 description = "General compute framework for Tenstorrent devices"


### PR DESCRIPTION
### Problem description
Can't import ttnn, without having torch, because torch is imported on import of ttnn.

### What's changed
Add torch (again) as a ttnn dependency, because we can't live without it.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14648623344) CI passes
- [x] [Publish Release Image](https://github.com/tenstorrent/tt-metal/actions/runs/14648824594)
- [x] New/Existing tests provide coverage for changes