### PR TITLE
[skip ci] Move CODEOWNERS to .github/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 
 CONTRIBUTING.md @tenstorrent/metalium-developers-infra
 
-CODEOWNERS @tenstorrent/metalium-developers-infra
+.github/CODEOWNERS @tenstorrent/metalium-developers-infra
 
 INSTALLING.md @tenstorrent/metalium-developers-infra
 METALIUM_GUIDE.md @davorchap


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The root of our repo has a lot of clutter.
GitHub actually prefers an owner file under .github/ and would ignore the one in root if the former is present.  That would be super misleading.

### What's changed
Address 2 birds with 1 rename.  /CODEOWNERS -> /.github/CODEOWNERS