### PR TITLE
[skip ci] Cleanup codeowner file a bit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,40 +1,18 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-.pre-commit-config.yaml @tenstorrent/metalium-developers-infra
-.clang-format @tenstorrent/metalium-developers-infra
-.clang-tidy @tenstorrent/metalium-developers-infra
+# Default owners
+* @tenstorrent/metalium-developers-infra
 
+METALIUM_GUIDE.md @davorchap
+
+# CI/CD
 .github/ @tenstorrent/metalium-developers-infra
 .github/workflows/ttnn-run-sweeps.yaml @xanderchin @jdesousa-TT @sjameelTT
 
-.gitattributes @tenstorrent/metalium-developers-infra
-
 /infra/ @tenstorrent/metalium-developers-infra
 
-CONTRIBUTING.md @tenstorrent/metalium-developers-infra
-
-.github/CODEOWNERS @tenstorrent/metalium-developers-infra
-
-INSTALLING.md @tenstorrent/metalium-developers-infra
-METALIUM_GUIDE.md @davorchap
-
-# Build stuff
-
-MANIFEST.in @tenstorrent/metalium-developers-infra
-setup.py @tenstorrent/metalium-developers-infra
-pyproject.toml @tenstorrent/metalium-developers-infra
-requirements*.txt @tenstorrent/metalium-developers-infra
-
-scripts/build_scripts/ @tenstorrent/metalium-developers-infra
-cmake/ @tenstorrent/metalium-developers-infra
-build_metal.sh @tenstorrent/metalium-developers-infra
-
-/CMakeLists.txt @tenstorrent/metalium-developers-infra
-tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
-
 # Testing scripts and infra
-
 conftest.py @tenstorrent/metalium-developers-infra
 /conftest.py @cfjchu @SeanNijjar @tenstorrent/metalium-developers-infra
 
@@ -243,8 +221,6 @@ docs/source/ttnn/ @patrickroberts @ayerofieiev-tt @razorback3 @dongjin-na
 tests/python_api_testing/unit_testing/fallback_ops @tt-aho
 scripts/profiler/ @mo-tenstorrent
 scripts/docker @tenstorrent/metalium-developers-infra
-
-dockerfile @tenstorrent/metalium-developers-infra
 
 ttnn/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,8 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# Default owners
-* @tenstorrent/metalium-developers-infra
-
+# Top-level files
+/* @tenstorrent/metalium-developers-infra
 METALIUM_GUIDE.md @davorchap
 
 # CI/CD
@@ -11,12 +10,15 @@ METALIUM_GUIDE.md @davorchap
 .github/workflows/ttnn-run-sweeps.yaml @xanderchin @jdesousa-TT @sjameelTT
 
 /infra/ @tenstorrent/metalium-developers-infra
+scripts/build_scripts/ @tenstorrent/metalium-developers-infra
+cmake/ @tenstorrent/metalium-developers-infra
 
 # Testing scripts and infra
 conftest.py @tenstorrent/metalium-developers-infra
 /conftest.py @cfjchu @SeanNijjar @tenstorrent/metalium-developers-infra
 
 # test scripts
+tests/CMakeLists.txt @tenstorrent/metalium-developers-infra
 tests/scripts/ @tenstorrent/metalium-developers-infra
 tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra
 tests/scripts/run_pre_post_commit_regressions_multi_device.sh @aliuTT @tt-aho @TT-BrianLiu @tenstorrent/metalium-developers-infra

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,16 +16,10 @@ METALIUM_GUIDE.md @davorchap
 conftest.py @tenstorrent/metalium-developers-infra
 /conftest.py @cfjchu @SeanNijjar @tenstorrent/metalium-developers-infra
 
-tests/scripts/run_pre_post_commit_regressions.sh @tenstorrent/metalium-developers-infra
-tests/scripts/run_tests.sh @tenstorrent/metalium-developers-infra
+# test scripts
+tests/scripts/ @tenstorrent/metalium-developers-infra
+tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra
 tests/scripts/run_pre_post_commit_regressions_multi_device.sh @aliuTT @tt-aho @TT-BrianLiu @tenstorrent/metalium-developers-infra
-tests/scripts/run_pre_post_commit_regressions_fast_dispatch.sh @tenstorrent/metalium-developers-infra
-tests/scripts/run_models.sh @tenstorrent/metalium-developers-infra
-tests/scripts/single_card/ @tenstorrent/metalium-developers-infra
-tests/scripts/single_card/nightly/ @tenstorrent/metalium-developers-infra
-tests/scripts/t3000/ @tenstorrent/metalium-developers-infra
-tests/scripts/tg/ @tenstorrent/metalium-developers-infra
-tests/scripts/tgg/ @tenstorrent/metalium-developers-infra
 
 # Metalium - public API
 tt_metal/api @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @cfjchu @omilyutin-tt
@@ -76,10 +70,6 @@ tt-metal/tt_metal/programming_examples/profiler @mo-tenstorrent
 
 # Metalium - flatbuffer schemas
 tt_metal/impl/flatbuffer/ @kmabeeTT @nsmithtt @omilyutin-tt
-
-# test scripts
-tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra
-tests/scripts/run_performance.sh @tenstorrent/metalium-developers-infra
 
 # TTNN
 ttnn/ @ayerofieiev-tt @dmakoviichuk-tt @cfjchu @TT-BrianLiu @omilyutin-tt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,9 +27,6 @@ tests/scripts/run_pre_post_commit_regressions_multi_device.sh @aliuTT @tt-aho @T
 tt_stl/ @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt
 tt_stl/**/CMakeLists.txt @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt @tenstorrent/metalium-developers-infra
 
-# Metalium - public API
-tt_metal/api/ @tenstorrent/metalium-api-owners
-
 # metal - base
 tt_metal/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @cfjchu @omilyutin-tt @jbaumanTT
 tt_metal/**/CMakeLists.txt @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @cfjchu @omilyutin-tt @jbaumanTT @tenstorrent/metalium-developers-infra
@@ -39,6 +36,9 @@ tt_metal/impl/**/CMakeLists.txt @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @
 tt_metal/impl/device/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu @omilyutin-tt @nhuang-tt @jbaumanTT
 tt_metal/impl/device/**/CMakeLists.txt @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu @omilyutin-tt @nhuang-tt @jbaumanTT @tenstorrent/metalium-developers-infra
 tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra
+
+# Metalium - public API
+tt_metal/api/ @tenstorrent/metalium-api-owners
 
 # fabric
 tt_metal/fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,10 @@ tests/scripts/ @tenstorrent/metalium-developers-infra
 tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-developers-infra
 tests/scripts/run_pre_post_commit_regressions_multi_device.sh @aliuTT @tt-aho @TT-BrianLiu @tenstorrent/metalium-developers-infra
 
+# TT-STL
+tt_stl/ @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt
+tt_stl/**/CMakeLists.txt @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt @tenstorrent/metalium-developers-infra
+
 # Metalium - public API
 tt_metal/api/ @tenstorrent/metalium-api-owners
 
@@ -64,7 +68,6 @@ tt_metal/include/compute_kernel_api.h @davorchap @rtawfik01 @rdjogoTT @ttmtrajko
 tt_metal/include/compute_kernel_api/ @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
 tt_metal/include/dataflow_kernel_api.h @davorchap @ntarafdar @rtawfik01 @rdjogoTT @ttmtrajkovic @nvelickovicTT
 tt_metal/third_party/tt_llk @rtawfik01 @ttmtrajkovic @rdjogoTT @nvelickovicTT
-tt_metal/tt_stl/ @patrickroberts @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt @omilyutin-tt
 tests/tt_metal/tt_metal/data_movement @rtawfik01 @vvukomanovicTT @atatuzunerTT
 
 # metal - profiler

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@ tests/scripts/run_profiler_regressions.sh @mo-tenstorrent @tenstorrent/metalium-
 tests/scripts/run_pre_post_commit_regressions_multi_device.sh @aliuTT @tt-aho @TT-BrianLiu @tenstorrent/metalium-developers-infra
 
 # Metalium - public API
-tt_metal/api @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @cfjchu @omilyutin-tt
+tt_metal/api/ @tenstorrent/metalium-api-owners
 
 # metal - base
 tt_metal/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @cfjchu @omilyutin-tt @jbaumanTT
@@ -224,6 +224,3 @@ ttnn/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt
 
 # tt-train
 tt-train/** @dmakoviichuk-tt @rfurko-tt @ayerofieiev-tt
-
-# tt-metal public apis
-tt_metal/api/ @tenstorrent/metalium-api-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,14 +26,19 @@ tt_metal/api @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheem
 
 # metal - base
 tt_metal/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @cfjchu @omilyutin-tt @jbaumanTT
+tt_metal/**/CMakeLists.txt @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @cfjchu @omilyutin-tt @jbaumanTT @tenstorrent/metalium-developers-infra
 tt_metal/host_api.hpp @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @davorchap @cfjchu @omilyutin-tt @jbaumanTT
 tt_metal/impl/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu @omilyutin-tt @nhuang-tt @jbaumanTT
+tt_metal/impl/**/CMakeLists.txt @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu @omilyutin-tt @nhuang-tt @jbaumanTT @tenstorrent/metalium-developers-infra
 tt_metal/impl/device/ @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu @omilyutin-tt @nhuang-tt @jbaumanTT
+tt_metal/impl/device/**/CMakeLists.txt @abhullar-tt @pgkeller @aliuTT @tt-aho @tt-dma @tt-asaigal @ubcheema @davorchap @cfjchu @omilyutin-tt @nhuang-tt @jbaumanTT @tenstorrent/metalium-developers-infra
 tt_metal/**/requirements*.txt @tenstorrent/metalium-developers-infra
 
 # fabric
 tt_metal/fabric/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT
+tt_metal/fabric/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT @tenstorrent/metalium-developers-infra
 tests/tt_metal/microbenchmarks/ethernet/ @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT
+tests/tt_metal/microbenchmarks/ethernet/**/CMakeLists.txt @ubcheema @aliuTT @aagarwalTT @tt-aho @SeanNijjar @yugaoTT @daminakaTT @tenstorrent/metalium-developers-infra
 
 # metal - dispatch
 tt_metal/impl/dispatch/kernels/packet_* @ubcheema @aliuTT
@@ -42,8 +47,10 @@ tests/tt_metal/tt_metal/perf_microbenchmark/routing/ @ubcheema @aagarwalTT
 
 # Metalium - Distributed
 tt_metal/distributed/ @cfjchu @aliuTT @tt-asaigal @omilyutin-tt
+tt_metal/distributed/**/CMakeLists.txt @cfjchu @aliuTT @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra
 tt_metal/distributed/**/requirements*.txt @tenstorrent/metalium-developers-infra @cfjchu @tt-asaigal @omilyutin-tt
 tests/tt_metal/distributed/ @cfjchu @tt-asaigal @omilyutin-tt
+tests/tt_metal/distributed/**/CMakeLists.txt @cfjchu @tt-asaigal @omilyutin-tt @tenstorrent/metalium-developers-infra
 tests/tt_metal/distributed/**/requirements*.txt @tenstorrent/metalium-developers-infra @cfjchu @tt-asaigal @omilyutin-tt
 
 # metal - fw, llks, risc-v
@@ -70,6 +77,7 @@ tt-metal/tt_metal/programming_examples/profiler @mo-tenstorrent
 
 # Metalium - flatbuffer schemas
 tt_metal/impl/flatbuffer/ @kmabeeTT @nsmithtt @omilyutin-tt
+tt_metal/impl/flatbuffer/**/CMakeLists.txt @kmabeeTT @nsmithtt @omilyutin-tt @tenstorrent/metalium-developers-infra
 
 # TTNN
 ttnn/ @ayerofieiev-tt @dmakoviichuk-tt @cfjchu @TT-BrianLiu @omilyutin-tt


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Figuring out ownership is hard.  First tidy up the file, then use teams to group.  Hopefully then PRs will have more clarity.

### What's changed
* Set metal-infra to own top-level files by default
* Shared ownership of CMakeLists.txt in tt_metal with the code owners in each section
* Fix TT-STL to re-gain their ownership
* Fixed tt_metal/api ownership (it was being shadowed and misleading as to who was enforced as owners)