### PR TITLE
Get rid of unused `MULTI_DEVICE` storage type enum

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_op.cpp
@@ -78,10 +78,7 @@ void RMSAllGather::validate(
         TT_FATAL(stats.value().is_sharded(), "Stats must be sharded");
         TT_FATAL(stats.value().get_layout() == Layout::TILE, "Only tile layout is supported for stats");
         TT_FATAL(stats.value().get_dtype() == DataType::BFLOAT16, "Only bfloat16 is supported for stats");
-        TT_FATAL(
-            stats.value().storage_type() == StorageType::DEVICE ||
-                stats.value().storage_type() == StorageType::MULTI_DEVICE,
-            "Operands to layernorm need to be on device!");
+        TT_FATAL(stats.value().storage_type() == StorageType::DEVICE, "Operands to layernorm need to be on device!");
         TT_FATAL(stats.value().buffer() != nullptr, "Operands to layernorm need to be allocated in buffers on device!");
         TT_FATAL(
             stats.value().get_padded_shape()[-1] % input_width == 0,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_op.cpp
@@ -61,9 +61,7 @@ void RMSAllGather::validate(
         a.get_dtype() == DataType::FLOAT32 or a.get_dtype() == DataType::BFLOAT16 or
             a.get_dtype() == DataType::BFLOAT8_B,
         "Error");
-    TT_FATAL(
-        a.storage_type() == StorageType::DEVICE || a.storage_type() == StorageType::MULTI_DEVICE,
-        "Operands to frmsnorm need to be on device!");
+    TT_FATAL(a.storage_type() == StorageType::DEVICE, "Operands to frmsnorm need to be on device!");
     TT_FATAL(a.buffer() != nullptr, "Operands to frmsnorm need to be allocated in buffers on device!");
 
     if (b.has_value()) {

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -68,11 +68,13 @@ bool is_floating_point(DataType dtype);
 
 bool is_block_float(DataType dtype);
 
+// Enums are explicitly enumerated due to serialization dependency
+// TODO: #16067 - This shouldn't be needed. Serialize this enum to flatbuffer.
 enum class StorageType {
-    OWNED,
-    DEVICE,
-    BORROWED,           // for storing torch/numpy/etc tensors
-    MULTI_DEVICE_HOST,  // host storage for multi-device context
+    OWNED = 0,
+    DEVICE = 1,
+    BORROWED = 2,           // for storing torch/numpy/etc tensors
+    MULTI_DEVICE_HOST = 4,  // host storage for multi-device context
 };
 
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -72,7 +72,6 @@ enum class StorageType {
     OWNED,
     DEVICE,
     BORROWED,           // for storing torch/numpy/etc tensors
-    MULTI_DEVICE,       // on-device storage for multi-device context
     MULTI_DEVICE_HOST,  // host storage for multi-device context
 };
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -170,7 +170,6 @@ from ttnn.types import (
     TILE_LAYOUT,
     StorageType,
     DEVICE_STORAGE_TYPE,
-    MULTI_DEVICE_STORAGE_TYPE,
     CoreGrid,
     CoreRange,
     Shape,

--- a/ttnn/ttnn/core.py
+++ b/ttnn/ttnn/core.py
@@ -9,7 +9,6 @@ import ttnn
 
 from ttnn.types import (
     DEVICE_STORAGE_TYPE,
-    MULTI_DEVICE_STORAGE_TYPE,
     MemoryConfig,
     ShardStrategy,
     ShardOrientation,
@@ -34,7 +33,7 @@ def has_storage_type_of(tensor: "ttnn.Tensor", storage_type) -> bool:
 
 
 def is_tensor_storage_on_device(tensor: "ttnn.Tensor") -> bool:
-    return tensor.storage_type() in (DEVICE_STORAGE_TYPE, MULTI_DEVICE_STORAGE_TYPE)
+    return tensor.storage_type() == DEVICE_STORAGE_TYPE
 
 
 def is_sharded(tensor) -> bool:

--- a/ttnn/ttnn/database.py
+++ b/ttnn/ttnn/database.py
@@ -321,20 +321,6 @@ def insert_tensor(report_path, tensor):
                 "address": tensor.buffer_address(),
             }
         )
-    elif ttnn.has_storage_type_of(tensor, ttnn.MULTI_DEVICE_STORAGE_TYPE) and tensor.is_allocated():
-        memory_config = ttnn.get_memory_config(tensor)
-        buffer_type = memory_config.buffer_type.value
-        for device_tensor in ttnn.get_device_tensors(tensor):
-            if device_id is None:
-                device_id = device_tensor.device().id()
-            if address is None:
-                address = device_tensor.buffer_address()
-            device_tensors.append(
-                {
-                    "device_id": device_tensor.device().id(),
-                    "address": device_tensor.buffer_address(),
-                }
-            )
 
     cursor.execute(
         f"""

--- a/ttnn/ttnn/types.py
+++ b/ttnn/ttnn/types.py
@@ -34,7 +34,6 @@ TILE_LAYOUT = Layout.TILE
 
 StorageType = ttnn._ttnn.tensor.StorageType
 DEVICE_STORAGE_TYPE = StorageType.DEVICE
-MULTI_DEVICE_STORAGE_TYPE = StorageType.MULTI_DEVICE
 
 TILE_SIZE = 32
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The enum value is no longer used, with TT-mesh integrated.

### What's changed
Removed the old code

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14653167414)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14656149372)