### PR TITLE
#0: Propagate runner label for blackhole demo tests on BH post commit

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -12,6 +12,10 @@ on:
       docker-image:
         required: true
         type: string
+      runner-label:
+        required: false
+        type: string
+        default: "BH"
 
 jobs:
   single-card-demo-tests:
@@ -22,20 +26,18 @@ jobs:
           {
             name: "whisper_performance",
             arch: blackhole,
-            runs-on: ["BH", "pipeline-perf", "in-service"],
             cmd: pytest models/demos/whisper/demo/demo.py --input-path="models/demos/whisper/demo/dataset/conditional_generation" -k "conditional_generation",
             owner_id: U05RWH3QUPM #Salar Hosseini
           },
           {
             name: "Llama3-8B_performance",
             arch: blackhole,
-            runs-on: ["BH", "pipeline-perf", "in-service"],
             cmd: LLAMA_DIR=/proj_sw/user_dev/hf_data/Llama3/Llama3.1-8B-Instruct pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1,
             owner_id: U03PUAKE719 # Miguel Tairum
           }
         ]
     name: ${{ matrix.test-group.name }}
-    runs-on: ${{ matrix.test-group.runs-on }}
+    runs-on: ["in-service", "${{ inputs.runner-label }}"]
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           name: ${{ inputs.wheel-artifact-name }}
       - name: Enable Performance mode
-        if: ${{ contains(matrix.test-group.name, 'performance') }}
+        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH' }}
         run: |
           sudo cpupower frequency-set -g performance
       - name: Run demo regression tests
@@ -80,7 +80,7 @@ jobs:
           path: generated/test_reports/
           prefix: "test_reports_"
       - name: Disable Performance mode
-        if: ${{ contains(matrix.test-group.name, 'performance') }}
+        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH' }}
         run: |
           sudo cpupower frequency-set -g ondemand
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -56,6 +56,8 @@ jobs:
         with:
           name: ${{ inputs.wheel-artifact-name }}
       - name: Enable Performance mode
+        # For now we're relying on runner-label == BH to target baremetal blackhole machines in order to confirm that the demo functionality works on blackhole VMs
+        # VMs will target a different runner label so they won't touch the perf governor but still run the models.
         if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH' }}
         run: |
           sudo cpupower frequency-set -g performance

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -18,6 +18,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
+      runner-label: BH
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -145,6 +145,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
+      runner-label: ${{ inputs.runner-label || 'BH' }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Runner label not passed to demo tests workflow

### What's changed
Pass it properly, update the demo tests labels

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes