### PR TITLE
#19918 bcast test CB assert

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h.cpp
@@ -50,17 +50,10 @@ operation::ProgramWithCallbacks bcast_sharded_h(
     uint32_t output_tile_size = tt::tt_metal::detail::TileSize(out_df);
 
     TT_FATAL(input_tile_size == output_tile_size, "Input and output tile size should be same");
-    uint32_t shard_size_in_bytes = shard_spec.numel() * a.element_size();
 
-    uint32_t num_tile_per_core = 0;
-    if (a.get_dtype() == DataType::BFLOAT8_B) {
-        uint32_t ntiles_along_width = std::ceil(shard_spec.shape[1] / (float)tt::constants::TILE_WIDTH);
-        uint32_t ntiles_along_height = std::ceil(shard_spec.shape[0] / (float)tt::constants::TILE_HEIGHT);
-        num_tile_per_core = ntiles_along_width * ntiles_along_height;
-    } else {
-        num_tile_per_core = (shard_size_in_bytes + input_tile_size - 1) / (TILE_HW * a.element_size());  // ceil value
-    }
-    TT_FATAL(input_tile_size <= shard_size_in_bytes, "Input tile size should be less than shard size");
+    uint32_t ntiles_along_width = std::ceil(shard_spec.shape[1] / (float)tt::constants::TILE_WIDTH);
+    uint32_t ntiles_along_height = std::ceil(shard_spec.shape[0] / (float)tt::constants::TILE_HEIGHT);
+    uint32_t num_tile_per_core = ntiles_along_width * ntiles_along_height;
 
     uint32_t Wt, Ht;
     if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
@@ -50,17 +50,10 @@ operation::ProgramWithCallbacks bcast_sharded_h_optimised(
     uint32_t output_tile_size = tt::tt_metal::detail::TileSize(out_df);
 
     TT_FATAL(input_tile_size == output_tile_size, "Input and output tile size should be same");
-    uint32_t shard_size_in_bytes = shard_spec.numel() * a.element_size();
 
-    uint32_t num_tile_per_core = 0;
-    if (a.get_dtype() == DataType::BFLOAT8_B) {
-        uint32_t ntiles_along_width = std::ceil(shard_spec.shape[1] / (float)tt::constants::TILE_WIDTH);
-        uint32_t ntiles_along_height = std::ceil(shard_spec.shape[0] / (float)tt::constants::TILE_HEIGHT);
-        num_tile_per_core = ntiles_along_width * ntiles_along_height;
-    } else {
-        num_tile_per_core = (shard_size_in_bytes + input_tile_size - 1) / (TILE_HW * a.element_size());  // ceil value
-    }
-    TT_FATAL(input_tile_size <= shard_size_in_bytes, "Input tile size should be less than shard size");
+    uint32_t ntiles_along_width = std::ceil(shard_spec.shape[1] / (float)tt::constants::TILE_WIDTH);
+    uint32_t ntiles_along_height = std::ceil(shard_spec.shape[0] / (float)tt::constants::TILE_HEIGHT);
+    uint32_t num_tile_per_core = ntiles_along_width * ntiles_along_height;
 
     uint32_t Wt, Ht;
     if (a.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED) {

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/multi_core_h/bcast_op_sharded_h_optimised.cpp
@@ -52,7 +52,14 @@ operation::ProgramWithCallbacks bcast_sharded_h_optimised(
     TT_FATAL(input_tile_size == output_tile_size, "Input and output tile size should be same");
     uint32_t shard_size_in_bytes = shard_spec.numel() * a.element_size();
 
-    uint32_t num_tile_per_core = (shard_size_in_bytes + input_tile_size - 1) / TILE_HW;  // ceil value
+    uint32_t num_tile_per_core = 0;
+    if (a.get_dtype() == DataType::BFLOAT8_B) {
+        uint32_t ntiles_along_width = std::ceil(shard_spec.shape[1] / (float)tt::constants::TILE_WIDTH);
+        uint32_t ntiles_along_height = std::ceil(shard_spec.shape[0] / (float)tt::constants::TILE_HEIGHT);
+        num_tile_per_core = ntiles_along_width * ntiles_along_height;
+    } else {
+        num_tile_per_core = (shard_size_in_bytes + input_tile_size - 1) / (TILE_HW * a.element_size());  // ceil value
+    }
     TT_FATAL(input_tile_size <= shard_size_in_bytes, "Input tile size should be less than shard size");
 
     uint32_t Wt, Ht;


### PR DESCRIPTION
Fixed the way to calculate no. of tiles, both block format and regular type

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19918)

### Problem description
Buffer size is over-allocated. It is a warning in release build, but will assert in debug build. Since it is over-allocated, not under-allocated, it pass its own unit tests and CI. In release build, it could still cause potential problem downstream.

### What's changed
Calculate the number of tiles correctly, so that buffer is not over-allocated.

All unit test in test_bcast.py pass now for debug build.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes