### PR TITLE
Fix and deduplicate reduce scatter code that computes receiver/sender IDs around cluster axis

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -187,42 +187,12 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGather::create_program_at(
     const ttnn::MeshCoordinate& mesh_coord,
     const std::vector<Tensor>& input_tensors,
     std::vector<Tensor>& output_tensors) const {
-    uint32_t device_index = 0;
-    std::optional<chip_id_t> receiver_device_id;
-    std::optional<chip_id_t> sender_device_id;
     auto target_device = input_tensors.at(0).mesh_device() ? input_tensors.at(0).mesh_device()->get_device(mesh_coord)
                                                            : input_tensors.at(0).device();
-    if (this->cluster_axis.has_value()) {
-        const auto& mesh_view = mesh_device->get_view();
-        TT_FATAL(
-            mesh_view.is_mesh_2d(),
-            "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
-        const auto view_index = (cluster_axis == 0) ? mesh_coord[1] : mesh_coord[0];
-        device_index = (cluster_axis == 0) ? mesh_coord[0] : mesh_coord[1];
-
-        auto get_chip_id = [&](std::size_t line_index) -> std::optional<chip_id_t> {
-            auto new_row = mesh_coord[0];
-            auto new_col = mesh_coord[1];
-            if (cluster_axis == 0) {
-                new_row = line_index % this->ring_size;
-            } else {
-                new_col = line_index % this->ring_size;
-            }
-            return mesh_view.find_device_id(MeshCoordinate(new_row, new_col));
-        };
-
-        bool is_last_chip_in_clockwise_direction = device_index == (this->ring_size - 1);
-        bool is_last_chip_in_counter_clockwise_direction = device_index == 0;
-        receiver_device_id = is_last_chip_in_clockwise_direction ? std::nullopt : get_chip_id(device_index + 1);
-        sender_device_id = is_last_chip_in_counter_clockwise_direction
-                               ? std::nullopt
-                               : get_chip_id(device_index + this->ring_size - 1);
-    } else {
-        std::tie(device_index, sender_device_id, receiver_device_id) =
-            ccl::get_device_index_and_sender_receiver_ids(target_device, this->devices, topology);
-    }
-
-    chip_id_t target_device_id = target_device->id();
+    ccl::SenderRecieverConfig config =
+        this->cluster_axis.has_value()
+            ? ccl::get_device_sender_receiver_config(mesh_coord, mesh_device, *cluster_axis, ring_size)
+            : ccl::get_device_sender_receiver_config(target_device, this->devices, topology);
 
     return all_gather_multi_core_with_workers(
         input_tensors[0],
@@ -230,10 +200,10 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGather::create_program_at(
         this->dim,
         this->num_links,
         this->ring_size,
-        device_index,
-        target_device_id,
-        receiver_device_id,
-        sender_device_id,
+        config.device_index,
+        target_device->id(),
+        config.receiver_device_id,
+        config.sender_device_id,
         this->topology,
         this->user_defined_num_workers,
         this->user_defined_num_buffers_per_channel);

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_op.cpp
@@ -191,7 +191,7 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGather::create_program_at(
                                                            : input_tensors.at(0).device();
     ccl::SenderRecieverConfig config =
         this->cluster_axis.has_value()
-            ? ccl::get_device_sender_receiver_config(mesh_coord, mesh_device, *cluster_axis, ring_size)
+            ? ccl::get_device_sender_receiver_config_in_ring(mesh_coord, mesh_device, *cluster_axis, ring_size)
             : ccl::get_device_sender_receiver_config(target_device, this->devices, topology);
 
     return all_gather_multi_core_with_workers(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -112,7 +112,8 @@ SenderRecieverConfig get_device_sender_receiver_config(
     SenderRecieverConfig config;
     const auto& mesh_view = mesh_device->get_view();
     TT_FATAL(
-        mesh_view.is_mesh_2d(), "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
+        mesh_view.is_mesh_2d(),
+        "CLL operation invoked with cluster_axis API on >2D mesh, which is currently unsupported");
     const auto view_index = (cluster_axis == 0) ? mesh_coord[1] : mesh_coord[0];
     config.device_index = (cluster_axis == 0) ? mesh_coord[0] : mesh_coord[1];
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -104,7 +104,7 @@ SenderRecieverConfig get_device_sender_receiver_config(
     return config;
 }
 
-SenderRecieverConfig get_device_sender_receiver_config(
+SenderRecieverConfig get_device_sender_receiver_config_in_ring(
     const MeshCoordinate& mesh_coord,
     const distributed::MeshDevice* mesh_device,
     uint32_t cluster_axis,

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -79,31 +79,61 @@ tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_pro
     return workload_with_callbacks;
 }
 
-std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> get_device_index_and_sender_receiver_ids(
-    const IDevice* target_device, const std::vector<IDevice*>& devices, const ttnn::ccl::Topology& topology) {
+SenderRecieverConfig get_device_sender_receiver_config(
+    const IDevice* target_device, const std::vector<IDevice*>& devices, ttnn::ccl::Topology topology) {
     uint32_t num_devices = devices.size();
     bool is_linear = topology == ttnn::ccl::Topology::Linear;
-    uint32_t device_index = 0;  // Initialize device index
+    SenderRecieverConfig config;
     for (uint32_t i = 0; i < num_devices; ++i) {
         if (devices.at(i) == target_device) {
-            device_index = i;
+            config.device_index = i;
             bool is_last_chip_in_clockwise_direction = is_linear && i == (num_devices - 1);
             bool is_last_chip_in_counter_clockwise_direction = is_linear && i == 0;
 
-            std::optional<chip_id_t> receiver_device_id =
-                is_last_chip_in_clockwise_direction ? std::nullopt
-                                                    : std::optional<chip_id_t>(devices.at((i + 1) % num_devices)->id());
+            config.receiver_device_id = is_last_chip_in_clockwise_direction
+                                            ? std::nullopt
+                                            : std::optional<chip_id_t>(devices.at((i + 1) % num_devices)->id());
 
-            std::optional<chip_id_t> sender_device_id =
+            config.sender_device_id =
                 is_last_chip_in_counter_clockwise_direction
                     ? std::nullopt
                     : std::optional<chip_id_t>(devices.at((i + num_devices - 1) % num_devices)->id());
-
-            return {device_index, sender_device_id, receiver_device_id};
         }
     }
 
-    return {device_index, std::nullopt, std::nullopt};  // Return null if the device is not found
+    return config;
+}
+
+SenderRecieverConfig get_device_sender_receiver_config(
+    const MeshCoordinate& mesh_coord,
+    const distributed::MeshDevice* mesh_device,
+    uint32_t cluster_axis,
+    int ring_size) {
+    SenderRecieverConfig config;
+    const auto& mesh_view = mesh_device->get_view();
+    TT_FATAL(
+        mesh_view.is_mesh_2d(), "all-gather invoked with cluster_axis API on >2D mesh, which is currently unsupported");
+    const auto view_index = (cluster_axis == 0) ? mesh_coord[1] : mesh_coord[0];
+    config.device_index = (cluster_axis == 0) ? mesh_coord[0] : mesh_coord[1];
+
+    auto get_chip_id = [&](std::size_t line_index) -> std::optional<chip_id_t> {
+        auto new_row = mesh_coord[0];
+        auto new_col = mesh_coord[1];
+        if (cluster_axis == 0) {
+            new_row = line_index % ring_size;
+        } else {
+            new_col = line_index % ring_size;
+        }
+        return mesh_view.find_device_id(MeshCoordinate(new_row, new_col));
+    };
+
+    bool is_last_chip_in_clockwise_direction = config.device_index == (ring_size - 1);
+    bool is_last_chip_in_counter_clockwise_direction = config.device_index == 0;
+    config.receiver_device_id =
+        is_last_chip_in_clockwise_direction ? std::nullopt : get_chip_id(config.device_index + 1);
+    config.sender_device_id =
+        is_last_chip_in_counter_clockwise_direction ? std::nullopt : get_chip_id(config.device_index + ring_size - 1);
+    return config;
 }
 
 std::vector<ttnn::Tensor> unpad_output_tensor(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -49,7 +49,7 @@ struct SenderRecieverConfig {
 SenderRecieverConfig get_device_sender_receiver_config(
     const IDevice* target_device, const std::vector<IDevice*>& devices, ttnn::ccl::Topology topology);
 
-SenderRecieverConfig get_device_sender_receiver_config(
+SenderRecieverConfig get_device_sender_receiver_config_in_ring(
     const MeshCoordinate& mesh_coord, const distributed::MeshDevice* mesh_device, uint32_t cluster_axis, int ring_size);
 
 std::vector<ttnn::Tensor> unpad_output_tensor(

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -8,6 +8,7 @@
 #include <numeric>
 
 #include <tt-metalium/constants.hpp>
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
 #include "ttnn/operations/ccl/common/types/ccl_types.hpp"
@@ -39,8 +40,17 @@ tt::tt_metal::operation::MeshWorkloadWithCallbacks create_mesh_workload_from_pro
     std::vector<Tensor>& output_tensors,
     const std::function<tt::tt_metal::operation::ProgramWithCallbacks(const ttnn::MeshCoordinate&)>& create_program);
 
-std::tuple<uint32_t, std::optional<chip_id_t>, std::optional<chip_id_t>> get_device_index_and_sender_receiver_ids(
-    const IDevice* target_device, const std::vector<IDevice*>& devices, const ttnn::ccl::Topology& topology);
+struct SenderRecieverConfig {
+    uint32_t device_index = 0;
+    std::optional<chip_id_t> sender_device_id;
+    std::optional<chip_id_t> receiver_device_id;
+};
+
+SenderRecieverConfig get_device_sender_receiver_config(
+    const IDevice* target_device, const std::vector<IDevice*>& devices, ttnn::ccl::Topology topology);
+
+SenderRecieverConfig get_device_sender_receiver_config(
+    const MeshCoordinate& mesh_coord, const distributed::MeshDevice* mesh_device, uint32_t cluster_axis, int ring_size);
 
 std::vector<ttnn::Tensor> unpad_output_tensor(
     const std::vector<ttnn::Tensor>& output_tensor,

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -58,7 +58,7 @@ tt::tt_metal::operation::ProgramWithCallbacks ReduceScatter::create_program_at(
                                                            : input_tensors.at(0).device();
     ccl::SenderRecieverConfig config =
         this->cluster_axis.has_value()
-            ? ccl::get_device_sender_receiver_config(mesh_coord, mesh_device, *cluster_axis, ring_size)
+            ? ccl::get_device_sender_receiver_config_in_ring(mesh_coord, mesh_device, *cluster_axis, ring_size)
             : ccl::get_device_sender_receiver_config(target_device, this->devices, topology);
 
     return ccl::reduce_scatter_detail::reduce_scatter_with_workers(

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_op.cpp
@@ -52,48 +52,14 @@ tt::tt_metal::operation::ProgramWithCallbacks ReduceScatter::create_program_at(
     const std::vector<Tensor>& input_tensors,
     std::vector<Tensor>& output_tensors) const {
     uint32_t device_index = 0;
-    std::optional<chip_id_t> sender_device_id;
     std::optional<chip_id_t> receiver_device_id;
-
+    std::optional<chip_id_t> sender_device_id;
     auto target_device = input_tensors.at(0).mesh_device() ? input_tensors.at(0).mesh_device()->get_device(mesh_coord)
                                                            : input_tensors.at(0).device();
-    if (this->cluster_axis.has_value()) {
-        auto mesh_view = mesh_device->get_view();
-        TT_FATAL(
-            mesh_view.is_mesh_2d(),
-            "reduce-scatter invoked with cluster_axis API on >2D mesh, which is currently unsupported");
-        const auto view_index = (cluster_axis == 0) ? mesh_coord[1] : mesh_coord[0];
-        device_index = (cluster_axis == 0) ? mesh_coord[0] : mesh_coord[1];
-
-        auto get_chip_id = [&](std::size_t line_index) -> std::optional<chip_id_t> {
-            auto new_row = mesh_coord[0];
-            auto new_col = mesh_coord[1];
-            if (cluster_axis == 0) {
-                new_row = line_index % this->num_links;
-            } else {
-                new_col = line_index % this->num_links;
-            }
-            return mesh_view.find_device_id(MeshCoordinate(new_row, new_col));
-        };
-
-        bool is_last_chip_in_clockwise_direction = device_index == (this->num_links - 1);
-        bool is_last_chip_in_counter_clockwise_direction = device_index == 0;
-        receiver_device_id = is_last_chip_in_clockwise_direction ? std::nullopt : get_chip_id(device_index + 1);
-        sender_device_id = is_last_chip_in_counter_clockwise_direction
-                               ? std::nullopt
-                               : get_chip_id(device_index + this->num_links - 1);
-
-    } else {
-        std::tie(device_index, sender_device_id, receiver_device_id) =
-            ccl::get_device_index_and_sender_receiver_ids(target_device, this->devices, this->topology);
-
-        TT_FATAL(
-            receiver_device_id != std::nullopt || sender_device_id != std::nullopt,
-            "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must "
-            "be identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments "
-            "may be incorrect");
-    }
-    chip_id_t target_device_id = target_device->id();
+    ccl::SenderRecieverConfig config =
+        this->cluster_axis.has_value()
+            ? ccl::get_device_sender_receiver_config(mesh_coord, mesh_device, *cluster_axis, ring_size)
+            : ccl::get_device_sender_receiver_config(target_device, this->devices, topology);
 
     return ccl::reduce_scatter_detail::reduce_scatter_with_workers(
         input_tensors.at(0),
@@ -102,10 +68,10 @@ tt::tt_metal::operation::ProgramWithCallbacks ReduceScatter::create_program_at(
         this->scatter_dim,
         this->num_links,
         this->ring_size,
-        device_index,
-        target_device_id,
-        receiver_device_id,
-        sender_device_id,
+        config.device_index,
+        target_device->id(),
+        config.receiver_device_id,
+        config.sender_device_id,
         this->topology,
         this->user_defined_num_workers,
         this->user_defined_num_buffers_per_channel);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/all_gather_matmul_op.cpp
@@ -111,7 +111,7 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherMatmul::create_program_at
     const std::vector<std::optional<const ttnn::Tensor>>& optional_input_tensors,
     std::vector<Tensor>& output_tensors) const {
     auto mesh_device = input_tensors[0].mesh_device();
-    auto [device_index, sender_device_id, receiver_device_id] = ::ttnn::ccl::get_device_index_and_sender_receiver_ids(
+    ttnn::ccl::SenderRecieverConfig config = ::ttnn::ccl::get_device_sender_receiver_config(
         mesh_device->get_device(mesh_coord), this->devices, this->all_gather_struct.topology);
     chip_id_t target_device_id = mesh_device->get_device(mesh_coord)->id();
     // Return the AllGatherMatmul program with callbacks
@@ -126,12 +126,12 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherMatmul::create_program_at
         this->all_gather_struct.dim,
         this->all_gather_struct.num_links,
         this->all_gather_struct.ring_size,
-        device_index,
+        config.device_index,
         this->all_gather_struct.user_defined_num_workers,
         this->all_gather_struct.user_defined_num_buffers_per_channel,
         target_device_id,
-        receiver_device_id,
-        sender_device_id,
+        config.receiver_device_id,
+        config.sender_device_id,
         this->all_gather_struct.topology,
         this->all_gather_core_grid_offset,
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce/device/all_reduce_op.cpp
@@ -44,9 +44,8 @@ tt::tt_metal::operation::ProgramWithCallbacks AllReduce::create_program_at(
     std::vector<Tensor>& output_tensors) const {
     auto target_device =
         input_tensors[0].mesh_device() ? input_tensors[0].mesh_device()->get_device(coord) : input_tensors[0].device();
-    auto [device_index, sender_device_id, receiver_device_id] =
-        ccl::get_device_index_and_sender_receiver_ids(target_device, this->devices, topology);
-    chip_id_t target_device_id = target_device->id();
+    ttnn::ccl::SenderRecieverConfig config =
+        ttnn::ccl::get_device_sender_receiver_config(target_device, this->devices, this->topology);
 
     return ccl::reduce_scatter_detail::reduce_scatter_with_workers(
         input_tensors.at(0),
@@ -55,10 +54,10 @@ tt::tt_metal::operation::ProgramWithCallbacks AllReduce::create_program_at(
         0,
         this->num_links,
         this->ring_size,
-        device_index,
-        target_device_id,
-        receiver_device_id,
-        sender_device_id,
+        config.device_index,
+        target_device->id(),
+        config.receiver_device_id,
+        config.sender_device_id,
         this->topology,
         this->user_defined_num_workers,
         this->user_defined_num_buffers_per_channel);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_async/device/reduce_scatter_async_op.cpp
@@ -157,11 +157,11 @@ operation::ProgramWithCallbacks ReduceScatterAsync::create_program_at(
     auto target_device =
         input_tensors[0].mesh_device() ? input_tensors[0].mesh_device()->get_device(coord) : input_tensors[0].device();
 
-    auto [device_index, sender_device_id, receiver_device_id] =
-        ccl::get_device_index_and_sender_receiver_ids(target_device, devices, topology);
+    ttnn::ccl::SenderRecieverConfig config =
+        ttnn::ccl::get_device_sender_receiver_config(target_device, devices, this->topology);
 
     TT_FATAL(
-        receiver_device_id != std::nullopt || sender_device_id != std::nullopt,
+        config.receiver_device_id != std::nullopt || config.sender_device_id != std::nullopt,
         "Error, Reduce-scatter was unable to identify either a sender or receiver device ID and atleast one must be "
         "identified for a valid Reduce-scatter configuration. The input mesh tensor or Reduce-scatter arguments may be "
         "incorrect");
@@ -193,12 +193,12 @@ operation::ProgramWithCallbacks ReduceScatterAsync::create_program_at(
         foreward_direction_remote_output_tensor,
         backward_direction_remote_output_tensor,
         target_device,
-        find_device(devices, receiver_device_id),
-        find_device(devices, sender_device_id),
+        find_device(devices, config.receiver_device_id),
+        find_device(devices, config.sender_device_id),
         this->binary_op_type,
         this->scatter_dim,
         this->ring_size,
-        device_index,
+        config.device_index,
         this->topology,
         this->num_links_preferred,
         this->from_remote_sem,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
There was duplicated code related to computing receiver/sender IDs around cluster axis, and the copy in reduce scatter OP ended up with a bug (see inline comment).

### What's changed
1. Added helper struct `SenderRecieverConfig` with named field instead of the tuple.
2. Added overload `SenderRecieverConfig get_device_sender_receiver_config` to compute IDs around cluster axis.
3. Updated the callers, and removed duplicates in all gather, barrier, reduce scatter.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14653108751/job/41123442243) - same failure [observed on main](https://github.com/tenstorrent/tt-metal/actions/runs/14648672087)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14653503694)

The following test was used to reproduce the issue and confirm the fix works:

```
def test_tilize_with_padding_for_1D():
    torch.manual_seed(2005)
    shape = (1, 1, 8192, 256)
    input_a = torch.full(shape, 0, dtype=torch.float32)
    mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 2))
    input_tensor = ttnn.from_torch(input_a, device=mesh_device, layout=ttnn.TILE_LAYOUT)
    output_tensor = ttnn.reduce_scatter(                    
                    input_tensor,
                    dim=3,
                    cluster_axis=1,
                    mesh_device=mesh_device,
                    math_op=ttnn.ReduceType.Sum,
                    num_links=1,
                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
                    topology=ttnn.Topology.Linear,
    )
```