### PR TITLE
Use device fixture instead of MeshDevice for test_matmul_1d_ring_llama_perf

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py
@@ -848,9 +848,8 @@ def test_multi_core_matmul_1d_gs(
     [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
     indirect=True,
 )
-@pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
 def test_matmul_1d_ring_llama_perf(
-    mesh_device,
+    device,
     in0_dtype,
     in1_dtype,
     output_dtype,
@@ -868,7 +867,6 @@ def test_matmul_1d_ring_llama_perf(
     use_program_cache,
     function_level_defaults,
 ):
-    device = mesh_device.get_device(mesh_device.get_device_ids()[0])
     # Only run these tests on unharvested TG
     device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
     if device_grid != (7, 10):


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
`test_matmul_1d_ring_llama_perf` failing locally since it extracts a device from a mesh device and queries its program cache. Support for this has been deprecated with TT-Mesh.

### What's changed
Use the `device` fixture for single device execution instead.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes