### PR TITLE
optimize circular buffer allocation in flash decode

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -351,7 +351,7 @@ operation::ProgramWithCallbacks sdpa_decode_multi_core(
     uint32_t im_tile_size = im_tile.get_tile_size(im_df);
     uint32_t stats_tile_size = stats_tile.get_tile_size(stats_df);
 
-    uint32_t intermed_output_tiles = (out0_t + 2 * PNHt) * (num_cores_per_batch - 1);
+    uint32_t intermed_output_tiles = (out0_t + 2 * PNHt) * (num_cores_per_head - 1);
 
     uint32_t pos_tensor_tile_size = 0;
     uint32_t log2_page_size = 0;


### PR DESCRIPTION
### Ticket
#21185

### Problem description
The allocation of circular buffer in the flash decode is redundant. It may lead to insufficient L1 memory in some extreme cases.

### What's changed
Modify the size of circular buffer allocation, `intermed_output_tiles `.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)