### PR TITLE
Add resnet accuracy test

### DIFF
--- a/models/demos/ttnn_resnet/tests/demo_utils.py
+++ b/models/demos/ttnn_resnet/tests/demo_utils.py
@@ -9,6 +9,7 @@ import glob
 from models.sample_data.huggingface_imagenet_classes import IMAGENET2012_CLASSES
 from datasets import load_dataset
 from torchvision import models
+from tqdm import tqdm
 
 
 class InputExample(object):
@@ -49,7 +50,7 @@ def get_batch(data_loader, image_processor):
     return images, labels
 
 
-def get_data_loader(input_loc, batch_size, iterations):
+def get_data_loader(input_loc, batch_size, iterations, download_entire_dataset=False):
     img_dir = input_loc + "/"
     data_path = os.path.join(img_dir, "*G")
     files = glob.glob(data_path)
@@ -83,10 +84,12 @@ def get_data_loader(input_loc, batch_size, iterations):
                 examples = []
 
     if len(files) == 0:
-        files_raw = iter(load_dataset("imagenet-1k", split="validation", use_auth_token=True, streaming=True))
+        files_raw = iter(
+            load_dataset("imagenet-1k", split="validation", use_auth_token=True, streaming=not download_entire_dataset)
+        )
         files = []
         sample_count = batch_size * iterations
-        for _ in range(sample_count):
+        for _ in tqdm(range(sample_count), desc="Loading samples"):
             files.append(next(files_raw))
         del files_raw
         return loader_hf()

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
@@ -16,7 +16,7 @@ from models.utility_functions import (
 )
 from tqdm import tqdm
 
-NUM_VALIDATION_IMAGES_IMAGENET = 50000
+NUM_VALIDATION_IMAGES_IMAGENET = 49920
 
 
 @run_for_wormhole_b0()
@@ -37,6 +37,7 @@ def test_run_resnet50_trace_2cqs_inference(
     weight_dtype,
     model_location_generator,
     entire_imagenet_dataset=False,
+    expected_accuracy=0.7555288461538462,
 ):
     batch_size = batch_size_per_device * mesh_device.get_num_devices()
     iterations = iterations // mesh_device.get_num_devices()
@@ -102,7 +103,9 @@ def test_run_resnet50_trace_2cqs_inference(
         logger.info(f"=============")
         logger.info(f"Accuracy for {batch_size}x{iterations} inputs: {accuracy}")
         if entire_imagenet_dataset:
-            assert accuracy >= 0.7556
+            assert (
+                accuracy == expected_accuracy
+            ), f"Accuracy {accuracy} does not match expected accuracy {expected_accuracy}"
 
         first_iter_time = profiler.get(f"compile")
         # ensuring inference time fluctuations is not noise
@@ -125,6 +128,7 @@ def test_run_resnet50_trace_2cqs_inference(
 )
 @pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
 @pytest.mark.parametrize("entire_imagenet_dataset", [True])
+@pytest.mark.parametrize("expected_accuracy", [0.7555288461538462])
 def test_run_resnet50_trace_2cqs_accuracy(
     mesh_device,
     use_program_cache,
@@ -136,6 +140,7 @@ def test_run_resnet50_trace_2cqs_accuracy(
     enable_async_mode,
     model_location_generator,
     entire_imagenet_dataset,
+    expected_accuracy,
 ):
     test_run_resnet50_trace_2cqs_inference(
         mesh_device,
@@ -148,4 +153,5 @@ def test_run_resnet50_trace_2cqs_accuracy(
         enable_async_mode,
         model_location_generator,
         entire_imagenet_dataset,
+        expected_accuracy,
     )

--- a/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
+++ b/models/demos/wormhole/resnet50/tests/test_resnet50_performant_imagenet.py
@@ -14,6 +14,9 @@ from transformers import AutoImageProcessor
 from models.utility_functions import (
     profiler,
 )
+from tqdm import tqdm
+
+NUM_VALIDATION_IMAGES_IMAGENET = 50000
 
 
 @run_for_wormhole_b0()
@@ -33,9 +36,14 @@ def test_run_resnet50_trace_2cqs_inference(
     act_dtype,
     weight_dtype,
     model_location_generator,
+    entire_imagenet_dataset=False,
 ):
     batch_size = batch_size_per_device * mesh_device.get_num_devices()
     iterations = iterations // mesh_device.get_num_devices()
+
+    if entire_imagenet_dataset:
+        iterations = NUM_VALIDATION_IMAGES_IMAGENET // batch_size
+
     profiler.clear()
     with torch.no_grad():
         resnet50_trace_2cq = ResNet50Trace2CQ()
@@ -52,11 +60,11 @@ def test_run_resnet50_trace_2cqs_inference(
         image_processor = AutoImageProcessor.from_pretrained(model_version)
         logger.info("ImageNet-1k validation Dataset")
         input_loc = str(model_location_generator("ImageNet_data"))
-        data_loader = get_data_loader(input_loc, batch_size, iterations)
+        data_loader = get_data_loader(input_loc, batch_size, iterations, entire_imagenet_dataset)
 
         input_tensors_all = []
         input_labels_all = []
-        for iter in range(iterations):
+        for iter in tqdm(range(iterations), desc="Preparing images"):
             inputs, labels = get_batch(data_loader, image_processor)
             input_tensors_all.append(inputs)
             input_labels_all.append(labels)
@@ -93,6 +101,8 @@ def test_run_resnet50_trace_2cqs_inference(
         accuracy = correct / (batch_size * iterations)
         logger.info(f"=============")
         logger.info(f"Accuracy for {batch_size}x{iterations} inputs: {accuracy}")
+        if entire_imagenet_dataset:
+            assert accuracy >= 0.7556
 
         first_iter_time = profiler.get(f"compile")
         # ensuring inference time fluctuations is not noise
@@ -103,3 +113,39 @@ def test_run_resnet50_trace_2cqs_inference(
         f"ttnn_{model_version}_batch_size{batch_size} tests inference time (avg): {inference_time_avg}, FPS: {batch_size/inference_time_avg}"
     )
     logger.info(f"ttnn_{model_version}_batch_size{batch_size} compile time: {compile_time}")
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 24576, "trace_region_size": 1605632, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size_per_device, iterations, act_dtype, weight_dtype",
+    ((16, 100, ttnn.bfloat8_b, ttnn.bfloat8_b),),
+)
+@pytest.mark.parametrize("enable_async_mode", (True,), indirect=True)
+@pytest.mark.parametrize("entire_imagenet_dataset", [True])
+def test_run_resnet50_trace_2cqs_accuracy(
+    mesh_device,
+    use_program_cache,
+    batch_size_per_device,
+    iterations,
+    imagenet_label_dict,
+    act_dtype,
+    weight_dtype,
+    enable_async_mode,
+    model_location_generator,
+    entire_imagenet_dataset,
+):
+    test_run_resnet50_trace_2cqs_inference(
+        mesh_device,
+        use_program_cache,
+        batch_size_per_device,
+        iterations,
+        imagenet_label_dict,
+        act_dtype,
+        weight_dtype,
+        enable_async_mode,
+        model_location_generator,
+        entire_imagenet_dataset,
+    )


### PR DESCRIPTION
### Problem description
Added a test that uses the entire imagenet-1k dataset to check accuracy of the resnet model

### What's changed
Modified `get_data_loader` to not stream if the entire dataset is downloaded since this way it can be cached instead of downloaded one chunk at a time.
Added a default parameter `entire_imagenet_dataset` in `test_run_resnet50_trace_2cqs_inference` method to differentiate between demo/perf runs and accuracy test. Since `@pytest.mark.parametrize` can't be used with default parameters, there was a need to create another method that specifically targets this accuracy test.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14647171067) CI passes
- [x] [Single card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/14647173689) CI passes
- [x] [Single card device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14709708888)
- [x] [Single card model perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/14647181101) CI passes