### PR TITLE
#20506: Add int32 support for Tensor-Tensor version of minimum

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_maximum.py
@@ -52,8 +52,7 @@ def test_binary_max_int32(input_shapes, low_a, high_a, low_b, high_b, device):
     )
     tt_result = ttnn.maximum(tt_in_a, tt_in_b)
     output_tensor = ttnn.to_torch(tt_result)
-    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
-    assert pcc == 1
+    assert torch.equal(golden, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -95,8 +94,7 @@ def test_binary_max_fill_val_int32(input_shapes, input_a_val, input_b_val, devic
 
     tt_result = ttnn.maximum(tt_in_a, tt_in_b)
     output_tensor = ttnn.to_torch(tt_result)
-    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
-    assert pcc == 1
+    assert torch.equal(golden, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -145,8 +143,7 @@ def test_binary_max_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low
     )
     tt_result = ttnn.maximum(tt_in_a, tt_in_b, use_legacy=False)
     output_tensor = ttnn.to_torch(tt_result)
-    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
-    assert pcc == 1
+    assert torch.equal(golden, output_tensor)
 
 
 @pytest.mark.parametrize(
@@ -203,8 +200,7 @@ def test_binary_max_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device
 
     ttnn.maximum(tt_in_a, tt_in_b, output_tensor=tt_out, queue_id=cq_id)
     output_tensor = ttnn.to_torch(tt_out)
-    pcc = ttnn.pearson_correlation_coefficient(golden, output_tensor)
-    assert pcc == 1
+    assert torch.equal(golden, output_tensor)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_minimum.py
@@ -20,6 +20,200 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "low_a, high_a, low_b, high_b",
     [
+        (-5, 5, -10, 10),
+        (-100, 100, -300, 300),
+        (-2147483647, 2147483647, -21474, 21474),
+    ],
+)
+def test_binary_min_int32(input_shapes, low_a, high_a, low_b, high_b, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b)
+    output_tensor = ttnn.to_torch(tt_result)
+    assert torch.equal(golden, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    ((torch.Size([1, 1, 32, 32])),),
+)
+@pytest.mark.parametrize(
+    "input_a_val, input_b_val",
+    [
+        (-1, 1),
+        (1, 0),
+        (0, 0),
+        (2147483647, -2147483647),
+        (11, 53),
+    ],
+)
+def test_binary_min_fill_val_int32(input_shapes, input_a_val, input_b_val, device):
+    torch_input_a = torch.ones(input_shapes, dtype=torch.int32) * input_a_val
+    torch_input_b = torch.ones(input_shapes, dtype=torch.int32) * input_b_val
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b)
+    output_tensor = ttnn.to_torch(tt_result)
+    assert torch.equal(golden, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shape_a, input_shape_b",
+    [
+        (torch.Size([1, 2, 32]), torch.Size([1, 2, 32])),
+        (torch.Size([1]), torch.Size([1, 5, 12])),
+        (torch.Size([1, 2, 32, 64, 125]), torch.Size([1, 2, 32, 1, 1])),
+        (torch.Size([]), torch.Size([])),
+        (torch.Size([5]), torch.Size([1])),
+    ],
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-2147483647, 2147483647, -21474, 21474),
+    ],
+)
+def test_binary_min_int32_bcast(input_shape_a, input_shape_b, low_a, high_a, low_b, high_b, device):
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_a)).item()), 1)
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shape_a)
+
+    num_elements = max(int(torch.prod(torch.tensor(input_shape_b)).item()), 1)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shape_b)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_result = ttnn.minimum(tt_in_a, tt_in_b, use_legacy=False)
+    output_tensor = ttnn.to_torch(tt_result)
+    assert torch.equal(golden, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([5, 10, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
+        (-100, 100, -300, 300),
+        (-2147483647, 2147483647, -21474, 21474),
+    ],
+)
+def test_binary_min_int32_opt(input_shapes, low_a, high_a, low_b, high_b, device):
+    num_elements = torch.prod(torch.tensor(input_shapes)).item()
+    torch_input_a = torch.linspace(high_a, low_a, num_elements, dtype=torch.int32)
+    torch_input_a = torch_input_a[:num_elements].reshape(input_shapes)
+    torch_input_b = torch.linspace(high_b, low_b, num_elements, dtype=torch.int32)
+    torch_input_b = torch_input_b[:num_elements].reshape(input_shapes)
+
+    golden_function = ttnn.get_golden_function(ttnn.minimum)
+    golden = golden_function(torch_input_a, torch_input_b, device=device)
+
+    output_tensor = torch.zeros(input_shapes, dtype=torch.int32)
+
+    cq_id = 0
+
+    tt_in_a = ttnn.from_torch(
+        torch_input_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_in_b = ttnn.from_torch(
+        torch_input_b,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    tt_out = ttnn.from_torch(
+        output_tensor,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn.minimum(tt_in_a, tt_in_b, output_tensor=tt_out, queue_id=cq_id)
+    output_tensor = ttnn.to_torch(tt_out)
+    assert torch.equal(golden, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 2, 64, 120])),
+        (torch.Size([5, 8, 1024, 1024])),
+    ),
+)
+@pytest.mark.parametrize(
+    "low_a, high_a, low_b, high_b",
+    [
         (-100, 100, -300, 300),
         (-1.0 * 10**38, 1.0 * 10**38, -1.7 * 10**38, 1.7 * 10**38),
     ],

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -34,8 +34,8 @@ inline void calculate_binary_max_min(const uint dst_offset) {
     }
 }
 
-template <int ITERATIONS = 8>
-inline void calculate_binary_max_int32(const uint dst_offset) {
+template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min_int32(const uint dst_offset) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
@@ -50,12 +50,19 @@ inline void calculate_binary_max_int32(const uint dst_offset) {
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
         TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
 
+        // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         TTI_SFPNOP;
 
-        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
-        TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
-        TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_7, 0);
+        if constexpr (IS_MAX_OP) {
+            TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);
+            TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+            TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_7, 0);
+        } else {
+            TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG2, INSTR_MOD_CAST);
+            TTI_SFPSETSGN(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+            TTI_SFPSTORE(p_sfpu::LREG0, 12, ADDR_MOD_7, 0);
+        }
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -29,7 +29,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_int32, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min_int32<true>, dst_index0, dst_index1, vector_mode);
 }
 
 // Binary minimum
@@ -43,6 +43,13 @@ inline void llk_math_eltwise_binary_sfpu_binary_min(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_max_min_int32<false>, dst_index0, dst_index1, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -34,8 +34,8 @@ inline void calculate_binary_max_min(const uint dst_offset) {
     }
 }
 
-template <int ITERATIONS = 8>
-inline void calculate_binary_max_int32(const uint dst_offset) {
+template <bool IS_MAX_OP = true, int ITERATIONS = 8>
+inline void calculate_binary_max_min_int32(const uint dst_offset) {
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
@@ -43,10 +43,15 @@ inline void calculate_binary_max_int32(const uint dst_offset) {
         TTI_SFPLOAD(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);                          // a
         TT_SFPLOAD(p_sfpu::LREG1, 12, ADDR_MOD_3, dst_offset * dst_tile_size);  // b
 
+        // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
         TTI_SFPNOP;
 
-        TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_3, 0);
+        if constexpr (IS_MAX_OP) {
+            TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_3, 0);
+        } else {
+            TTI_SFPSTORE(p_sfpu::LREG0, 12, ADDR_MOD_3, 0);
+        }
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_binary_max_min.h
@@ -29,7 +29,7 @@ template <bool APPROXIMATE>
 inline void llk_math_eltwise_binary_sfpu_binary_max_int32(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
-        ckernel::sfpu::calculate_binary_max_int32, dst_index0, dst_index1, vector_mode);
+        ckernel::sfpu::calculate_binary_max_min_int32<true>, dst_index0, dst_index1, vector_mode);
 }
 
 // Binary minimum
@@ -43,6 +43,13 @@ inline void llk_math_eltwise_binary_sfpu_binary_min(
     uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
     llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
         ckernel::sfpu::calculate_binary_max_min<false>, dst_index0, dst_index1, vector_mode);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_binary_min_int32(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::calculate_binary_max_min_int32<false>, dst_index0, dst_index1, vector_mode);
 }
 
 }  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/binary_max_min.h
+++ b/tt_metal/include/compute_kernel_api/binary_max_min.h
@@ -66,6 +66,28 @@ ALWI void binary_max_tile_init() { MATH((llk_math_eltwise_binary_sfpu_binary_max
 
 // clang-format off
 /**
+ * Performs an elementwise maximum operation on inputs of int32 data type at idst0, idst1: y = min(x0, x1).
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void binary_min_int32_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_binary_min_int32<APPROX>(idst0, idst1)));
+}
+
+// clang-format off
+/**
  * Performs an elementwise minimum operation on inputs at idst0, idst1: y = min(x0, x1).
  * Output overwrites first operand in DST.
  *

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -225,7 +225,7 @@ void bind_binary_unary_max_operation(
     py::module& module,
     const binary_operation_t& operation,
     const std::string& description,
-    const std::string& supported_dtype = "BFLOAT16, FLOAT32",
+    const std::string& supported_dtype = "BFLOAT16, FLOAT32, INT32",
     const std::string& note = " ") {
     auto doc = fmt::format(
         R"doc(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -251,7 +251,11 @@ std::map<std::string, std::string> get_defines_fp32(
             break;
         case BinaryOpType::MINIMUM:
             new_defines.insert({"BINOP_INIT", fmt::format("binary_min_tile_init();")});
-            op_name = "binary_min_tile";
+            if (input_a_dtype == DataType::INT32 && input_b_dtype == DataType::INT32) {
+                op_name = "binary_min_int32_tile";
+            } else {
+                op_name = "binary_min_tile";
+            }
             break;
         case BinaryOpType::LOGADDEXP:
             // PRE_IN0_0 ===> Applies prescaling for first input

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -315,7 +315,12 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             } else {
                 return {"binary_max_tile_init();", "binary_max_tile"};
             }
-        case MINIMUM: return {"binary_min_tile_init();", "binary_min_tile"};
+        case MINIMUM:
+            if (dtype == DataType::INT32) {
+                return {"binary_min_tile_init();", "binary_min_int32_tile"};
+            } else {
+                return {"binary_min_tile_init();", "binary_min_tile"};
+            }
         case QUANT: return {"quant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "quant_tile"};
         case REQUANT:
             return {"requant_tile_init(get_arg_val<uint32_t>(QUANT_ZERO_POINT_RT_ARGS_IDX));", "requant_tile"};


### PR DESCRIPTION
### Ticket
#20506, #20978

### Problem description
Implement Tensor-Tensor version of minimum int32

### What's changed
Implemented Tensor-Tensor version of minimum int32

- Used TTI_ instructions : SFPU requires 2's complement format. Hence in BH,
  - Loaded both inputs as signed magnitude using `instr_mod0 = 12`
  - Casted to int32 2’s complement
  - Set sign from input’s bit
- Supports bcast using `use_legacy=False`
- Tested in WH, BH

<img width="848" alt="Screenshot 2025-04-27 at 2 37 52 PM" src="https://github.com/user-attachments/assets/e8bbbae3-9727-4ba4-9c32-266d9aa2d2a7" />
<img width="848" alt="Screenshot 2025-04-27 at 2 38 23 PM" src="https://github.com/user-attachments/assets/f1cf64cb-b87e-4b22-9146-aed3da744fce" />


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14669592073) 
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14669595302) 
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14687761988)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14687762910) 
- [x] [C++ tests](https://github.com/tenstorrent/tt-metal/actions/runs/14669602573)
- [x] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14669603935)
- [ ] [new models tests](https://github.com/tenstorrent/tt-metal/actions/runs/14669613631) - passed as in main
- [x] New/Existing tests provide coverage for changes