### PR TITLE
Fixed failing eth profiler tests in metal microbenchmarks workflow

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_common.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_common.py
@@ -80,15 +80,15 @@ def process_profile_results(packet_size, num_packets, channel_count, benchmark_t
                     receiver_eth = receiver & 0xFF
 
                 if metadata["zone_name"] == main_test_body_string:
-                    run_id = metadata["run_id"]
+                    run_host_id = metadata["run_host_id"]
                     if metadata["type"] == "ZONE_START":
-                        starts[run_id] = ts
+                        starts[run_host_id] = ts
                     if metadata["type"] == "ZONE_END":
-                        ends[run_id] = ts
+                        ends[run_host_id] = ts
 
                         if arch == "wormhole_b0":
                             link_stat_row = df.loc[
-                                (df["Iteration"] == run_id)
+                                (df["Iteration"] == run_host_id)
                                 & (df["Sender Device ID"] == sender_chip)
                                 & (df["Sender Eth"] == sender_eth)
                             ]
@@ -107,7 +107,7 @@ def process_profile_results(packet_size, num_packets, channel_count, benchmark_t
                                 r_total_uncorr = row["R Total Uncorr"]
                                 r_pcs_retrains = row["R Retrain by PCS"]
                                 r_crc_retrains = row["R Retrain by CRC"]
-                            link_stats[run_id] = [
+                            link_stats[run_host_id] = [
                                 s_retrain_count,
                                 s_crc_errs,
                                 s_pcs_faults,
@@ -124,7 +124,7 @@ def process_profile_results(packet_size, num_packets, channel_count, benchmark_t
                                 r_crc_retrains,
                             ]
                         else:
-                            link_stats[run_id] = []
+                            link_stats[run_host_id] = []
 
             assert sender_chip != None
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -41,6 +41,8 @@ using namespace tt;
 using namespace tt::test_utils;
 using namespace tt::test_utils::df;
 
+static uint64_t program_runtime_id = 0;
+
 struct TestParams {
     BenchmarkType benchmark_type;
     uint32_t num_packets;
@@ -325,6 +327,9 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
     for (const auto& link : device_helper.unique_links) {
         auto& sender_program = programs.at(link.sender.chip);
         auto& receiver_program = programs.at(link.receiver.chip);
+
+        sender_program.set_runtime_id(program_runtime_id++);
+        receiver_program.set_runtime_id(program_runtime_id++);
 
         auto sender_device = find_device_with_id(device_helper.devices, link.sender.chip);
         auto receiver_device = find_device_with_id(device_helper.devices, link.receiver.chip);


### PR DESCRIPTION
This PR fixes several eth profiler tests that are failing in the metal microbenchmarks workflow because they're using the wrong runtime id.

### Checklist
- [x] [Metal microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/14653992126/job/41125869627)