### PR TITLE
Include enough Git info for Git Describe to do its job

### DIFF
--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -51,6 +51,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 500 # Need enough history for `git describe`
+          fetch-tags: true # Need tags for `git describe`
           path: docker-job # Here be dragons; keep it scoped to our desired volume, yet must be under github.workspace and be sure to clean up at the end
 
       - name: Build UMD device and tests


### PR DESCRIPTION
### Ticket
N/A

### Problem description
This job checked out a single commit.  That's only enough for git describe that if that commit is tagged directly.  Between tags it's insufficient.

### What's changed
Made more context available for git describe to use.