### PR TITLE
Fix Segfault Caused by Pattern of query_op_runtime and query_op_constraints Calls

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -19,6 +19,7 @@
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/operations/eltwise/binary/binary.hpp"
+#include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/tensor/enum_types.hpp"
 #include "ttnn/tensor/layout/page_config.hpp"
 #include "ttnn/tensor/layout/tensor_layout.hpp"
@@ -105,4 +106,137 @@ INSTANTIATE_TEST_SUITE_P(
         BinaryOpTraceRuntime::m_interleaved_1_3_1024_1024_tiled,
         BinaryOpTraceRuntime::m_interleaved_1_3_1024_1024_tiled)));
 
+class ReshapeOp : public TTNNFixtureWithTraceEnabledDevice {};
+
+TEST_F(ReshapeOp, Reshape1) {
+    auto dram_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::DRAM_MEMORY_CONFIG));
+
+    auto l1_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+
+    auto constraints_query = ttnn::graph::query_op_constraints(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), dram_spec.memory_config());
+    EXPECT_EQ(constraints_query.status, ttnn::graph::ExecutionStatus::Success);
+
+    constraints_query = ttnn::graph::query_op_constraints(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), l1_spec.memory_config());
+    EXPECT_EQ(constraints_query.status, ttnn::graph::ExecutionStatus::Success);
+
+    // okay!
+}
+
+TEST_F(ReshapeOp, Reshape2) {
+    auto dram_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::DRAM_MEMORY_CONFIG));
+
+    auto l1_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+
+    auto query = ttnn::graph::query_op_runtime(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), dram_spec.memory_config());
+    EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+    tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
+
+    query = ttnn::graph::query_op_runtime(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), l1_spec.memory_config());
+    EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+    tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
+
+    // okay!
+}
+
+TEST_F(ReshapeOp, Reshape3) {
+    auto dram_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::DRAM_MEMORY_CONFIG));
+
+    auto constraints_query = ttnn::graph::query_op_constraints(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), dram_spec.memory_config());
+    EXPECT_EQ(constraints_query.status, ttnn::graph::ExecutionStatus::Success);
+
+    auto query = ttnn::graph::query_op_runtime(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), dram_spec.memory_config());
+    EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+    tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
+
+    // okay!
+}
+
+TEST_F(ReshapeOp, Reshape4) {
+    auto dram_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::DRAM_MEMORY_CONFIG));
+
+    auto l1_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+
+    auto constraints_query = ttnn::graph::query_op_constraints(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), l1_spec.memory_config());
+    EXPECT_EQ(constraints_query.status, ttnn::graph::ExecutionStatus::Success);
+
+    auto query = ttnn::graph::query_op_runtime(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), l1_spec.memory_config());
+    EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+    tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
+
+    // okay!
+}
+
+TEST_F(ReshapeOp, Reshape5) {
+    auto dram_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::DRAM_MEMORY_CONFIG));
+
+    auto l1_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+
+    auto constraints_query = ttnn::graph::query_op_constraints(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), dram_spec.memory_config());
+    EXPECT_EQ(constraints_query.status, ttnn::graph::ExecutionStatus::Success);
+
+    auto query = ttnn::graph::query_op_runtime(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), dram_spec.memory_config());
+    EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
+    tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
+
+    constraints_query = ttnn::graph::query_op_constraints(
+        ttnn::reshape, device_, dram_spec, ttnn::Shape({64 * 4, 1024 / 4}), l1_spec.memory_config());
+    EXPECT_EQ(constraints_query.status, ttnn::graph::ExecutionStatus::Success);
+
+    // segfaults!!!
+}
 }  // namespace ttnn::operations::binary::test

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -114,14 +114,12 @@ public:
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::DRAM_MEMORY_CONFIG));
-    ;
     const ttnn::TensorSpec l1_spec = ttnn::TensorSpec(
         ttnn::Shape({64, 1024}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16,
             tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
             ttnn::L1_MEMORY_CONFIG));
-    ;
 };
 // Test various combinations of getOpRuntime and getOpConstraints to make sure there are no segfaults due to incorrect
 // memory handling

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -108,25 +108,23 @@ INSTANTIATE_TEST_SUITE_P(
 
 class MemorySmokeTest : public TTNNFixtureWithTraceEnabledDevice {
 public:
-    static const ttnn::TensorSpec dram_spec;
-    static const ttnn::TensorSpec l1_spec;
+    const ttnn::TensorSpec dram_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::DRAM_MEMORY_CONFIG));
+    ;
+    const ttnn::TensorSpec l1_spec = ttnn::TensorSpec(
+        ttnn::Shape({64, 1024}),
+        tt::tt_metal::TensorLayout(
+            tt::tt_metal::DataType::BFLOAT16,
+            tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+            ttnn::L1_MEMORY_CONFIG));
+    ;
 };
 // Test various combinations of getOpRuntime and getOpConstraints to make sure there are no segfaults due to incorrect
 // memory handling
-
-const ttnn::TensorSpec MemorySmokeTest::dram_spec = ttnn::TensorSpec(
-    ttnn::Shape({64, 1024}),
-    tt::tt_metal::TensorLayout(
-        tt::tt_metal::DataType::BFLOAT16,
-        tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
-        ttnn::DRAM_MEMORY_CONFIG));
-
-const ttnn::TensorSpec MemorySmokeTest::l1_spec = ttnn::TensorSpec(
-    ttnn::Shape({64, 1024}),
-    tt::tt_metal::TensorLayout(
-        tt::tt_metal::DataType::BFLOAT16,
-        tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
-        ttnn::L1_MEMORY_CONFIG));
 
 TEST_F(MemorySmokeTest, Reshape1) {
     auto constraints_query = ttnn::graph::query_op_constraints(

--- a/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
+++ b/ttnn/cpp/ttnn/graph/graph_query_op_runtime.hpp
@@ -60,9 +60,12 @@ auto capture_op_trace(Op op, IDevice* device, Args&&... args) {
         // Ensure trace capture is stopped and released before returning to avoid a memory leak
         ttnn::operations::trace::end_trace_capture(device, trace_id, ttnn::DefaultQueueId);
         ttnn::operations::trace::release_trace(device, trace_id);
+        device->disable_and_clear_program_cache();
         throw e;
     }
     ttnn::operations::trace::end_trace_capture(device, trace_id, ttnn::DefaultQueueId);
+
+    device->disable_and_clear_program_cache();
 
     return trace_id;
 }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/3054

### Problem description
https://github.com/tenstorrent/tt-metal/commit/ed0a405798854df682adba309d33e5ea75a0f45d led to a segfault in TTMLIR OpModel unit tests that had a particular sequence of calls to `query_op_constraints` and `query_op_runtime`.

#### Context about `query_op_constraints` and `query_op_runtime`
`query_op_constraints` and `query_op_runtime` are used by the TTNNOptimizer in TT-MLIR to generate better TTNN Ops for a given input IR. These functions are never encountered during the execution of a user program. They are only called during compilation by the mlir compiler. As a result, **this change has no impact on the program cache setting during the execution of any user program and does not affect user perf.**

#### Cause of the segfault from @amorrisonTT 
There's a double free of a [BankManager](https://github.com/tenstorrent/tt-metal/blob/e190030bc90e3fcb23e0f39dfa4519013dc004e8/tt_metal/impl/allocator/bank_manager.hpp#L29) during device teardown in certain situations. The exact root cause is unclear. If we want to keep digging I'd recommend splitting that off into a new ticket that can be assigned and prioritized appropriately so that the tt-forge team can be unblocked.

### What's changed
- A fix for the segfaults, curtesy of @amorrisonTT 
  - In `query_op_runtime`, disable and clear the program cache after enabling it to capture a trace
- Unit tests ported over from TT-MLIR to avoid identical future regressions

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [X] New/Existing tests provide coverage for changes