### PR TITLE
Added custom Watcher error messages for NOC flush asserts

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_asserts.cpp
@@ -19,6 +19,7 @@ void MAIN {
 
     uint32_t a = get_arg_val<uint32_t>(0);
     uint32_t b = get_arg_val<uint32_t>(1);
+    uint32_t assert_type = get_arg_val<uint32_t>(2);
 
     // Conditionally enable using defines for each trisc
 #if (defined(UCK_CHLKC_UNPACK) and defined(TRISC0)) or \
@@ -63,7 +64,7 @@ void MAIN {
 #endif
 #endif
 
-    ASSERT(a != b);
+    ASSERT(a != b, static_cast<debug_assert_type_t>(assert_type));
 #endif
 
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_ERISC)

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -231,10 +231,14 @@ struct debug_assert_msg_t {
     volatile uint8_t which;
 };
 
-enum debug_assert_tripped_enum {
+typedef enum debug_assert_tripped_enum {
     DebugAssertOK = 2,
     DebugAssertTripped = 3,
-};
+    DebugAssertNCriscNOCReadsFlushedTripped = 4,
+    DebugAssertNCriscNOCNonpostedWritesSentTripped = 5,
+    DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped = 6,
+    DebugAssertNCriscNOCPostedWritesSentTripped = 7
+} debug_assert_type_t;
 
 // XXXX TODO(PGK): why why why do we not have this standardized
 enum riscv_id_t {

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -231,14 +231,14 @@ struct debug_assert_msg_t {
     volatile uint8_t which;
 };
 
-typedef enum debug_assert_tripped_enum {
+enum debug_assert_type_t {
     DebugAssertOK = 2,
     DebugAssertTripped = 3,
     DebugAssertNCriscNOCReadsFlushedTripped = 4,
     DebugAssertNCriscNOCNonpostedWritesSentTripped = 5,
     DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped = 6,
     DebugAssertNCriscNOCPostedWritesSentTripped = 7
-} debug_assert_type_t;
+};
 
 // XXXX TODO(PGK): why why why do we not have this standardized
 enum riscv_id_t {

--- a/tt_metal/hw/firmware/src/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/active_erisck.cc
@@ -39,11 +39,10 @@ void kernel_launch(uint32_t kernel_base_addr) {
             WAYPOINT("NKFW");
             // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the
             // NOC interface is in a known idle state for the next kernel.
-            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
+            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
+            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             WAYPOINT("NKFD");
         }
 

--- a/tt_metal/hw/firmware/src/brisck.cc
+++ b/tt_metal/hw/firmware/src/brisck.cc
@@ -53,11 +53,10 @@ void kernel_launch(uint32_t kernel_base_addr) {
             // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the
             // NOC interface is in a known idle state for the next kernel. Dispatch kernels don't increment noc counters
             // so we only include this for non-dispatch kernels
-            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
+            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
+            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             WAYPOINT("NKFD");
         }
     }

--- a/tt_metal/hw/firmware/src/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/idle_erisck.cc
@@ -38,11 +38,10 @@ void kernel_launch(uint32_t kernel_base_addr) {
             WAYPOINT("NKFW");
             // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC
             // interface is in a known idle state for the next kernel.
-            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
-            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+            ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
+            ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
+            ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+            ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             WAYPOINT("NKFD");
         }
     }

--- a/tt_metal/hw/firmware/src/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/ncrisck.cc
@@ -63,11 +63,10 @@ void kernel_launch(uint32_t kernel_base_addr) {
         WAYPOINT("NKFW");
         // Assert that no noc transactions are outstanding, to ensure that all reads and writes have landed and the NOC
         // interface is in a known idle state for the next kernel.
-        ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX));
-        ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX));
-        ASSERT(ncrisc_noc_nonposted_writes_flushed(NOC_INDEX));
-        ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX));
-        ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX));
+        ASSERT(ncrisc_noc_reads_flushed(NOC_INDEX), DebugAssertNCriscNOCReadsFlushedTripped);
+        ASSERT(ncrisc_noc_nonposted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCNonpostedWritesSentTripped);
+        ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
+        ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
         WAYPOINT("NKFD");
     }
 #endif

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -8,12 +8,12 @@
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT) && !defined(FORCE_WATCHER_OFF)
 
-void assert_and_hang(uint32_t line_num) {
+void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type = DebugAssertTripped) {
     // Write the line number into the memory mailbox for host to read.
     debug_assert_msg_t tt_l1_ptr* v = GET_MAILBOX_ADDRESS_DEV(watcher.assert_status);
     if (v->tripped == DebugAssertOK) {
         v->line_num = line_num;
-        v->tripped = DebugAssertTripped;
+        v->tripped = assert_type;
         v->which = debug_get_which_riscv();
     }
 
@@ -36,10 +36,10 @@ void assert_and_hang(uint32_t line_num) {
 
 // The do... while(0) in this macro allows for it to be called more flexibly, e.g. in an if-else
 // without {}s.
-#define ASSERT(condition)              \
-    do {                               \
-        if (not(condition))            \
-            assert_and_hang(__LINE__); \
+#define ASSERT(condition, ...)                        \
+    do {                                              \
+        if (not(condition))                           \
+            assert_and_hang(__LINE__, ##__VA_ARGS__); \
     } while (0)
 
 #define WATCHER_ASSERT_ENABLED 1

--- a/tt_metal/hw/inc/debug/assert.h
+++ b/tt_metal/hw/inc/debug/assert.h
@@ -46,7 +46,7 @@ void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type = DebugA
 
 #else  // !WATCHER_ENABLED
 
-#define ASSERT(condition)
+#define ASSERT(condition, ...)
 
 #define WATCHER_ASSERT_ENABLED 0
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -636,7 +636,7 @@ void WatcherDeviceReader::DumpAssertStatus(CoreDescriptor& core, const string& c
         }
         case DebugAssertNCriscNOCReadsFlushedTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "{}: {} detected an inter-kernel data race due to kernel completing with pending "
                 "NOC transactions (missing NOC reads flushed barrier). Current kernel: {}.",
                 core_str,
                 get_riscv_name(core.coord, assert_status->which),
@@ -646,7 +646,7 @@ void WatcherDeviceReader::DumpAssertStatus(CoreDescriptor& core, const string& c
         }
         case DebugAssertNCriscNOCNonpostedWritesSentTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "{}: {} detected an inter-kernel data race due to kernel completing with pending "
                 "NOC transactions (missing NOC non-posted writes sent barrier). Current kernel: {}.",
                 core_str,
                 get_riscv_name(core.coord, assert_status->which),
@@ -656,7 +656,7 @@ void WatcherDeviceReader::DumpAssertStatus(CoreDescriptor& core, const string& c
         }
         case DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "{}: {} detected an inter-kernel data race due to kernel completing with pending "
                 "NOC transactions (missing NOC non-posted atomics flushed barrier). Current kernel: {}.",
                 core_str,
                 get_riscv_name(core.coord, assert_status->which),
@@ -666,7 +666,7 @@ void WatcherDeviceReader::DumpAssertStatus(CoreDescriptor& core, const string& c
         }
         case DebugAssertNCriscNOCPostedWritesSentTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "{}: {} detected an inter-kernel data race due to kernel completing with pending "
                 "NOC transactions (missing NOC posted writes sent barrier). Current kernel: {}.",
                 core_str,
                 get_riscv_name(core.coord, assert_status->which),

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -636,37 +636,41 @@ void WatcherDeviceReader::DumpAssertStatus(CoreDescriptor& core, const string& c
         }
         case DebugAssertNCriscNOCReadsFlushedTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race in core {} RISC {} due to kernel completing with pending "
-                "NOC transactions (missing NCRISC NOC reads flushed barrier)",
+                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "NOC transactions (missing NOC reads flushed barrier). Current kernel: {}.",
                 core_str,
-                get_riscv_name(core.coord, assert_status->which));
+                get_riscv_name(core.coord, assert_status->which),
+                GetKernelName(core, launch_msg, assert_status->which).c_str());
             this->DumpAssertTrippedDetails(core, error_msg, mbox_data);
             break;
         }
         case DebugAssertNCriscNOCNonpostedWritesSentTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race in core {} RISC {} due to kernel completing with pending "
-                "NOC transactions (missing NCRISC NOC non-posted writes sent barrier)",
+                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "NOC transactions (missing NOC non-posted writes sent barrier). Current kernel: {}.",
                 core_str,
-                get_riscv_name(core.coord, assert_status->which));
+                get_riscv_name(core.coord, assert_status->which),
+                GetKernelName(core, launch_msg, assert_status->which).c_str());
             this->DumpAssertTrippedDetails(core, error_msg, mbox_data);
             break;
         }
         case DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race in core {} RISC {} due to kernel completing with pending "
-                "NOC transactions (missing NCRISC NOC non-posted atomics flushed barrier)",
+                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "NOC transactions (missing NOC non-posted atomics flushed barrier). Current kernel: {}.",
                 core_str,
-                get_riscv_name(core.coord, assert_status->which));
+                get_riscv_name(core.coord, assert_status->which),
+                GetKernelName(core, launch_msg, assert_status->which).c_str());
             this->DumpAssertTrippedDetails(core, error_msg, mbox_data);
             break;
         }
         case DebugAssertNCriscNOCPostedWritesSentTripped: {
             const string error_msg = fmt::format(
-                "Watcher detected an inter-kernel data race in core {} RISC {} due to kernel completing with pending "
-                "NOC transactions (missing NCRISC NOC posted writes sent barrier)",
+                "Watcher detected an inter-kernel data race on core {} RISC {} due to kernel completing with pending "
+                "NOC transactions (missing NOC posted writes sent barrier). Current kernel: {}.",
                 core_str,
-                get_riscv_name(core.coord, assert_status->which));
+                get_riscv_name(core.coord, assert_status->which),
+                GetKernelName(core, launch_msg, assert_status->which).c_str());
             this->DumpAssertTrippedDetails(core, error_msg, mbox_data);
             break;
         }

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -51,6 +51,7 @@ private:
     void DumpNocSanitizeStatus(
         CoreDescriptor& core, const std::string& core_str, const mailboxes_t* mbox_data, int noc);
     void DumpAssertStatus(CoreDescriptor& core, const std::string& core_str, const mailboxes_t* mbox_data);
+    void DumpAssertTrippedDetails(CoreDescriptor& core, const std::string& error_msg, const mailboxes_t* mbox_data);
     void DumpPauseStatus(CoreDescriptor& core, const std::string& core_str, const mailboxes_t* mbox_data);
     void DumpRingBuffer(CoreDescriptor& core, const mailboxes_t* mbox_data, bool to_stdout);
     void DumpRunState(CoreDescriptor& core, const launch_msg_t* launch_msg, uint32_t state);


### PR DESCRIPTION
### Ticket
#20259 

### What's changed
This PR adds custom error messages for NOC flush asserts so that when they're triggered, it is clearer what Watcher is complaining about.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14669843649)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/14669846811)
- [x] New/Existing tests provide coverage for changes