### PR TITLE
Remove async_mode from LLMs Tech Report

### DIFF
--- a/tech_reports/LLMs/llms.md
+++ b/tech_reports/LLMs/llms.md
@@ -22,21 +22,20 @@ Authors: Mark O'Connor, Djordje Ivanovic, Jack (Xun) Cai, Kartik Paigwar, Johann
     - [3.5 vLLM Integration](#35-vllm-integration)
   - [4. Best Practices and Optimizations](#4-best-practices-and-optimizations)
     - [4.1 Tracing](#41-tracing)
-    - [4.2 Async Mode](#42-async-mode)
-    - [4.3 Multiple CQs](#43-multiple-cqs)
-    - [4.4 Op Configs](#44-op-configs)
-    - [4.5 Accuracy](#45-accuracy)
-    - [4.6 Performance Analysis](#46-performance-analysis)
-    - [4.7 Misc. Performance Optimizations](#47-misc-performance-optimizations)
-    - [4.8 Module Tests](#48-module-tests)
-    - [4.9 Performance Testing](#49-performance-testing)
-    - [4.10 Common Pitfalls](#410-common-pitfalls)
-      - [4.10.1 Error Messages](#4101-error-messages)
-      - [4.10.2 Shard Spec Mismatches](#4102-shard-spec-mismatches)
-      - [4.10.3 Ethernet Dispatch Cores](#4103-ethernet-dispatch-cores)
-      - [4.10.4 Hangs](#4104-hangs)
-        - [4.10.4.1 Tracing](#41041-tracing)
-        - [4.10.4.2 Large Matmuls](#41042-large-matmuls)
+    - [4.2 Multiple CQs](#42-multiple-cqs)
+    - [4.3 Op Configs](#43-op-configs)
+    - [4.4 Accuracy](#44-accuracy)
+    - [4.5 Performance Analysis](#45-performance-analysis)
+    - [4.6 Misc. Performance Optimizations](#46-misc-performance-optimizations)
+    - [4.7 Module Tests](#47-module-tests)
+    - [4.8 Performance Testing](#48-performance-testing)
+    - [4.9 Common Pitfalls](#49-common-pitfalls)
+      - [4.9.1 Error Messages](#491-error-messages)
+      - [4.9.2 Shard Spec Mismatches](#492-shard-spec-mismatches)
+      - [4.9.3 Ethernet Dispatch Cores](#493-ethernet-dispatch-cores)
+      - [4.9.4 Hangs](#494-hangs)
+        - [4.9.4.1 Tracing](#4941-tracing)
+        - [4.9.4.2 Large Matmuls](#4942-large-matmuls)
 
 ## 1. Overview
 This document provides guidance on how to bring up high-performance multi-chip models on Tenstorrent hardware using the TT-Metal stack. It targets users with previous experience on TT-Metal and shares our current best practices, tips, caveats, and workarounds on model bringup.
@@ -1407,24 +1406,11 @@ We typically use tracing for the decode pass of LLMs but not the prefill pass. T
 
 Tracing doesn’t work with prefill; sequence length and matmul row counts will likely change. Tracing works with decode, reference sections on handling KV-cache and paging with tracing. Conveniently, in prefill we have large operations in the millisecond plus range which the host can dispatch quickly. Decode, with a comparatively small batch size, we iterate through the entire model in 10ms with microsecond-length OP times where we can't wait for a CPU or Linux process scheduling, the speed at which electrons coruscate from DRAM and the NOC through our cores.
 
-### 4.2 Async Mode
-
-Async mode allows the host to continuously send commands to the device without blocking until data is read back from device, improving performance. Enable async mode with:
-
-```python
-
-```
-
-Without async mode each python call to TT-NN will block until the device has finished and results are available. This is good for debugging, any crash or error will show you the offending line of code. With async mode enabled your python thread keeps on running while the host and device handle background calls, only blocking when data needs to be read back from device.
-
-Async mode is faster, in case of asserts or crashes your python stack will be several lines further on than the call that caused the problem.
-For performance work async mode should always be enabled. For debugging it can be useful to disable it.
-
-### 4.3 Multiple CQs
+### 4.2 Multiple CQs
 
   - How to feed back output to input and read output asyncronously.
 
-### 4.4 Op Configs
+### 4.3 Op Configs
 
 Program and memory configurations are your greatest levers for performance. As a prerequisite for this section, you should understand [Tensor and Memory Layouts](../tensor_layouts/tensor_layouts.md) and the concepts in [ViT-TTNN](../VIT-TTNN/vit.md).
 
@@ -1446,7 +1432,7 @@ output = ttnn.linear(
 When you don't pass program or memory configurations, the operation will choose default values. These defaults are often sub-optimal. `memory_config` typically defaults to a DRAM interleaved configuration, while `program_config` defaults to something reasonable but still sub-optimal.
 See [Matrix Engine](../matrix_engine/matrix_engine.md) for background on `compute_kernel_config`.
 
-#### 4.4.1 Memory Configs
+#### 4.3.1 Memory Configs
 For the LLM context, memory configs are not as important in prefill mode, where activations are large due to the long sequence lengths. Memory configs should generally be DRAM interleaved; otherwise it wouldn't fit on L1. In prefill mode, each OP should consume DRAM interleaved inputs and produce DRAM interleaved outputs.
 
 Memory configs are most important in decode mode. For an operation like `ttnn.matmul`, both the activation and the output will be sharded according to their memory configs. Decode mode activations are of shape `[batch_size, hidden_size]` and should be width-sharded in L1 (sharding the `hidden_size` dimension). By keeping activations and outputs width-sharded in L1 we reduce DRAM traffic for better performance. The TT-Transformers codebase has examples of how to create a width-sharded memory config (see [model config](/../../models/tt_transformers/tt/model_config.py)).
@@ -1475,12 +1461,12 @@ As always, you should try running your `ttnn` OP in a unit test with whichever s
 > [!TIP]
 > Be careful when your memory config creates shards that require padding (i.e, the shard shape does not divide evenly into 32x32 tiles). Padded shards and padded OPs are under active development and can be sources of bugs. When your memory config requires padding, instead find a core grid which divides evenly into the tensor shape.
 
-#### 4.4.2 Program Configs and Picking the Right Matmul
+#### 4.3.2 Program Configs and Picking the Right Matmul
 Each `ttnn` operation has a unique program config class. Program configs configure the OP with hyperparameters that affect functionality and performance. There are too many OPs and program configs to cover in detail. We will focus on `ttnn.matmul` since it has multiple variants and it requires much care.
 
 Picking a matmul variant is a key decision in optimizing a model. The choice depends on the shapes of the inputs and outputs and how the matmul fits into the rest of the model. Choose a variant by providing a specific `program_config` to `ttnn.matmul`. The following presents three matmul variants that are commonly used in LLMs:
 
-##### 4.4.2.1 Matmul 2D
+##### 4.3.2.1 Matmul 2D
 Matmul 2D is named because it parallelizes an `(M x K) @ (K x N)` matmul over the M and N dimensions. It is useful to have this 2D parallelization when M and N are largeer than or equal to 256.
 
 > [!TIP]
@@ -1534,7 +1520,7 @@ fuse_batch=False,
 
 Since we use matmul 2D for large matmuls, there might be issues where we run out of L1 space to store intermediate values in the kernel. When this happens, reduce `in0_block_w` and `out_subblock_h` and `out_subblock_w`.
 
-##### 4.4.2.2 DRAM-Sharded Matmul
+##### 4.3.2.2 DRAM-Sharded Matmul
 DRAM-sharded matmul should be used in decode mode, where activations are small and DRAM-bandwidth to read weights is the limiting factor in OP performance. DRAM-Sharded matmul is named because rather than having weights interleaved in DRAM, they are sharded across DRAM banks to optimally collocate weights with compute. For more details on implmentation see: [DRAM-Sharded Matmul](../Saturating_DRAM_bandwidth/Saturating_DRAM_bandwidth.md).
 
 DRAM-Sharded matmul is used for all matmuls in decode mode. The activation and output are width-sharded in L1, and the weights width-sharded in DRAM.
@@ -1576,7 +1562,7 @@ output = ttnn.linear(
 > [!CAUTION]
 > Take care that the core grid evenly divides both activations and output. Padding functionality is not implemented for DRAM-Sharded matmuls.
 
-#### 4.4.2.3 Matmul 1D
+#### 4.3.2.3 Matmul 1D
 
 Matmul 1D is named because it only parallelizes over the N dimension. The activation and outputs are width-sharded in L1. Weights are DRAM interleaved.
 
@@ -1599,11 +1585,11 @@ model_config["FUSED_QKV_MM_PROGCFG"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgr
 Parameters are the same as matmul 2D. The only difference is that each core is responsible for some width shard of the output, rather than some 2D shard of the output.
 Maximize the `in0_block_w` and `out_subblock` parameters and sweep `compute_with_storage_grid_size` to find the fastest core grid.
 
-### 4.5 Accuracy
+### 4.4 Accuracy
 
 While maximizing performance of LLMs on Tenstorrent hardware, we ensure that models are functionally correct and produce outputs of the expected quality. This section describes methods for evaluating the accuracy, functionality, or correctness of a given model and how to debug issues pertaining to this.
 
-#### 4.5.1 Accuracy Testing
+#### 4.4.1 Accuracy Testing
 
 The following is a list of metrics used to evaluate accuracy:
 - **Pearson Correlation Coefficient (PCC):** A measure of the linear relationship between two variables, where a PCC of 1 indicates a perfect positive correlation, and a PCC of 0 indicates no linear correlation.
@@ -1617,7 +1603,7 @@ To thoroughly test the accuracy of a model, a bottom up approach is taken such t
 - **Model-level Unit Tests:** In addition to the sub-module unit tests, there should also be unit tests for a full layer of the model with all sub-modules, and the full model comprising of all layers. For example, the [model test](../../models/tt_transformers/tests/test_model.py) runs one or many layers of the model over multiple iterations and checks the PCC against the reference model. The full model PCC should be approximately ~0.99.
 - **Dataset Evaluation:** Once a model has been brought up with sufficient accuracy on the smaller unit tests, it should be tested on a larger set of prompts such as a full dataset or a subset of it. For example, the [Falcon7b perplexity test](../../models/demos/falcon7b_common/tests/perplexity/test_perplexity_falcon.py) loads a subset of the [WikiText dataset](https://huggingface.co/datasets/Salesforce/wikitext) and computes several metrics (including perplexity and top-1/5 accuracy) for evaluating the TT model with respect to the ground truth from the dataset. The results of these metrics should be within a couple percentage points of difference to those obtained from running the evaluation with the reference model on CPU / GPU.
 
-#### 4.5.2 Debugging Accuracy
+#### 4.4.2 Debugging Accuracy
 
 During model bringup or optimization, if model outputs do not seem reasonable or any of the evaluations above are failing, the following steps can be taken to debug the accuracy:
 1. Locate the smallest module test that is failing. The fewer the number of operations that could be causing the issue, the easier it will be to debug the root cause. In most cases, the issue should be able to be found using a one layer or submodule test.
@@ -1636,7 +1622,7 @@ For suspicious operations, possible solutions are to:
 
 It's possible the issue is not with the model and that there is a bug with a TT-NN operation. If suspected, verify using a unit test with the exact input/output configurations and file an issue with the TT-Metalium team.
 
-### 4.6 Performance Analysis
+### 4.5 Performance Analysis
 
 TT-NN performance has five components:
 
@@ -1654,7 +1640,7 @@ TT-NN performance has five components:
 
 For more inforation see: [4.1 Tracing](#41-tracing).
 
-#### 4.6.1 Main Python Thread
+#### 4.5.1 Main Python Thread
 
 The main python thread is only used if you are NOT tracing. The Metal Profiler/Tracy can also show python performance but for pure python analysis, we recommend the Viztracer tool: [viztracer](https://github.com/gaogaotiantian/viztracer).
 
@@ -1687,13 +1673,13 @@ What to look for:
 > Generate shard spec and compute kernel config objects once, in a constructor, instead of recreating them every time you run the forward pass. Keep the forward pass clean.
 
 > [!TIP]
-> Make sure Metal is compiled in Release mode (default) and you are using TT-NN’s async mode (see above).
+> Make sure Metal is compiled in Release mode (default).
 
-#### 4.6.2 Host API
+#### 4.5.2 Host API
 
 Any overhead here is outside your control and in our experience is minimal. Use a C++ profiler or [Metal Profiler/Tracy](../MetalProfiler/metal-profiler.md) with host stack traces enabled to see this time.
 
-#### 4.6.3 Host-Device Communications
+#### 4.5.3 Host-Device Communications
 
 As little communication as possible between the host and the device is preferred. For LLMs this means:
 
@@ -1712,14 +1698,14 @@ torch_tok = ttnn.to_torch(tt_tok)
 ```
 
 > [!CAUTION]
-> Looking at host-device communications in a python profiler like `viztracer` is possible but take care! When async-mode is on, time spent in a communication call like `to_torch`, can be comprised of up to three measures:
+> Looking at host-device communications in a python profiler like `viztracer` is possible but take care! Time spent in a communication call like `to_torch`, can be comprised of up to three measures:
 > 1. Time spent waiting for the device.
 > 2. Time spent transferring data.
 > 3. Time spent untilizing data.
 >
-> If you want to measure calls this way, turn async mode off. The time your main python thread spends in `to_torch` will not include any time spent waiting for the device and will be a closer approximation the measures above.
+> The time your main python thread spends in `to_torch` can include any time spent waiting for the device and will depend on the measures above.
 
-#### 4.6.4 Device Dispatch and OP Performance
+#### 4.5.4 Device Dispatch and OP Performance
 
 A bit of preparation is required to get started. First, metal must be compiled with `-p` to enable device profiling:
 
@@ -1763,13 +1749,13 @@ Ideally you should run your model in as close to end-user form as possible, simp
 
 Here is an example without tracing enabled. You can instantly see that more time (756us) is spent in between OPs (OP-to-OP gap) than running OPs on device (362us)!
 
-#### 4.6.5 Reducing OP-to-OP Gap
+#### 4.5.5 Reducing OP-to-OP Gap
 
 ![op-to-op gap](images/4.6-op-to-op-gap.png)
 
 There are two main contributors to op-to-op gap: **host time** and **dispatch time**.
 
-* **Host time** is optimized in steps 1-3. If you are already tracing or are using async mode and have ensured that your python thread is dispatching faster than the device is generating outputs, then this has already been minimized.
+* **Host time** is optimized in steps 1-3. If you are already tracing and have ensured that your python thread is dispatching faster than the device is generating outputs, then this has already been minimized.
 * **Dispatch time** is out of your hands, but as an example, it is influenced by the number of runtime args a kernel uses.
     * You can examine the source code for any kernel with high OP-to-OP latency and see if you can convert some runtime args into compile-time args for your use case.
     * You can fuse multiple OPs into a single kernel. Examples where this was worthwhile in the past include `LayerNorm` and `ScaledDotProductAttentionDecode`.
@@ -1778,7 +1764,7 @@ Typically tracing reduces the OP-to-OP gap below 6us and as of November 2024 the
 
 See [the next section](#47-misc-performance-optimizations) for tips on how to optimize OP performance.
 
-### 4.7 Misc. Performance Optimizations
+### 4.6 Misc. Performance Optimizations
 
 There are many individual tips, let’s start with overall advice:
 
@@ -1788,7 +1774,7 @@ There are many individual tips, let’s start with overall advice:
 
 The perfect OP runs on the entire core grid using sharded inputs from L1. Let’s look more at data movement first, then specific tips.
 
-#### 4.7.1 Data movement
+#### 4.6.1 Data movement
 
 OPs can read data from:
 
@@ -1804,7 +1790,7 @@ L1 sharded is particularly fast when the data an OP requires is already placed i
 
 See the [op config section](#44-op-configs) for more details on writing shard specs in your code.
 
-#### 4.7.2 Specific tips
+#### 4.6.2 Specific tips
 
 If OPs are reading from the fastest memory they can, sharded if possible, what might still make things slow?
 
@@ -1851,9 +1837,9 @@ self.compute_kernel_config_hifi2 = ttnn.WormholeComputeKernelConfig(
 > [!IMPORTANT]
 > Do NOT recreate for every forward pass if you want your python thread to be fast.
 
-### 4.8 Module Tests
+### 4.7 Module Tests
 
-#### 4.8.1 Llama3 Module and Test Differences
+#### 4.7.1 Llama3 Module and Test Differences
 
 In the current TT-Transformers code, the attention module class (`Attention`) implements two primary methods for attention computation: `forward_prefill` and `forward_decode`.
 To test these, we provide two separate attention test files, `test_attention_decode` and `test_attention_prefill`, which create the appropriate input tensors:
@@ -1866,21 +1852,20 @@ The current version of the MLP module class (`MLP`) handles prefill and decode i
 
 The decoder module, which encapsulates both attention and MLP, and model module, which encapsulates the decoder and the remaining parts of the model, also handle prefill and decode in the same file, but call the respective modes within the attention and MLP modules.
 
-### 4.9 Performance Testing
-### 4.10 Common Pitfalls
-#### 4.10.1 Error Messages
+### 4.8 Performance Testing
+### 4.9 Common Pitfalls
+#### 4.9.1 Error Messages
   - Running out of L1
   - Shard spec and program config mismatches
   - For some TT-NN OPs (e.g. ttnn.all_gather) it's not supported to pass -1 in the dim argument.
     - You'll see an error related to op invocation where the arguments don't match
-#### 4.10.2 Shard Spec Mismatches
-#### 4.10.3 Ethernet Dispatch Cores
+#### 4.9.2 Shard Spec Mismatches
+#### 4.9.3 Ethernet Dispatch Cores
   - link to any other description, and mention it is needed for N300 and T3K
-#### 4.10.4 Hangs
-##### 4.10.4.1 Tracing
+#### 4.9.4 Hangs
+##### 4.9.4.1 Tracing
   - Host communications cause tracing to hang.
-  - Running without async mode enabled causes tracing to hang.
   - Careful with print in tracing.
-##### 4.10.4.2 Large Matmuls
+##### 4.9.4.2 Large Matmuls
   - Large matmuls hanging? Link to appropriate ticket with workaround.
   - Issue is being investigated with a workaround of setting the output subblock to 1,1 and grid size to 8x7.


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
Async mode is no longer a user exposed feature and should thus be removed from user facing documentation.
Additionally, some comments about async mode in the `llms.md` tech report were incorrect.

### What's changed
Update `llms.md tech` report.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes