### PR TITLE
Resolve AllGatherAsyncMinimal segfault

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_program_minimal_variants.cpp
@@ -274,7 +274,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_async_llama_sharded(
     const GlobalSemaphore& semaphore,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
     tt::tt_metal::Program program{};
-    auto mesh_device = input_tensor.mesh_device();
+
+    IDevice* mesh_device = input_tensor.mesh_device();
+    if (!mesh_device) {
+        mesh_device = input_tensor.device();
+    }
+
     const bool enable_async_output_tensor = false;
     const bool enable_persistent_fabric_mode = true;
 


### PR DESCRIPTION
### Ticket
No Ticket, issue reported by @daminakaTT. 

### Problem description
 - Issue seen when using the legacy `all_gather_async(input_tensors...)` API with configs that get lowered to the minimal impl
- Input tensors aren't mapped to a mesh device in this case. We must instead lookup the device.
- This API is currently needed to maintain backwards compatibility for Moreh's use case.

### What's changed
- Use `tensor.device()` if `tensor.mesh_device()` is not available.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes