### PR TITLE
Add missing noc selecting opt to 1d fabric device init

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/fabric_edm_bandwidth_golden_6u.csv
+++ b/tests/tt_metal/microbenchmarks/ethernet/fabric_edm_bandwidth_golden_6u.csv
@@ -187,7 +187,7 @@ mcast_RingAsLinear,noc_fused_unicast_write_no_flush_atomic_inc,4096,4,1,False,Tr
 unicast_RingAsLinear,noc_fused_unicast_write_no_flush_atomic_inc,4096,4,1,False,True,True,5.36951625207451,1310917.0537291283
 mcast_RingAsLinear,noc_fused_unicast_write_no_flush_atomic_inc,4096,4,1,True,True,True,10.45763915732262,2553134.5598932174
 unicast_RingAsLinear,noc_fused_unicast_write_no_flush_atomic_inc,4096,4,1,True,True,True,11.34550140205302,2769897.8032356007
-mcast_Linear_0x4_mesh,noc_unicast_write,2048,8,4,False,False,True,5.099294442399,2489889.8644526363
-mcast_Linear_0x4_mesh,noc_unicast_write,4096,8,4,False,False,True,6.496705504341471,1586109.742270867
-mcast_Linear_8x0_mesh,noc_unicast_write,2048,4,4,False,False,True,5.195646073959388,2536936.5595504823
-mcast_Linear_8x0_mesh,noc_unicast_write,4096,4,4,False,False,True,6.350775215726054,1550482.2304018687
+mcast_Linear_0x4_mesh,noc_unicast_write,2048,8,4,False,False,True,4.840191851804669,2363374.9276389987
+mcast_Linear_0x4_mesh,noc_unicast_write,4096,8,4,False,False,True,9.142152681834224,2231970.8695884338
+mcast_Linear_8x0_mesh,noc_unicast_write,2048,4,4,False,False,True,4.899498205738207,2392333.108270609
+mcast_Linear_8x0_mesh,noc_unicast_write,4096,4,4,False,False,True,9.735902415975712,2376929.3007753203

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -9,6 +9,7 @@
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <tt-metalium/metal_soc_descriptor.h>
 #include "impl/context/metal_context.hpp"
+#include <tt-metalium/erisc_datamover_builder.hpp>
 #include <set>
 #include <vector>
 #include <algorithm>
@@ -62,6 +63,62 @@ std::vector<chan_id_t> get_ordered_fabric_eth_chans(chip_id_t chip_id, const std
         ordered_eth_chans.push_back(chan);
     }
     return ordered_eth_chans;
+}
+
+void get_optimal_noc_for_edm(
+    tt::tt_fabric::FabricEriscDatamoverBuilder& edm_builder1,
+    tt::tt_fabric::FabricEriscDatamoverBuilder& edm_builder2,
+    const uint32_t num_links,
+    const tt_fabric::Topology topology) {
+    constexpr uint32_t ring_noc_selection_link_threshold = 3;
+    constexpr uint32_t line_noc_selection_link_threshold = 2;
+    bool enable_noc_selection_opt = false;
+    if (topology == tt_fabric::Topology::Ring) {
+        enable_noc_selection_opt =
+            (num_links > ring_noc_selection_link_threshold) && (edm_builder1.my_noc_y != edm_builder2.my_noc_y);
+    } else {
+        enable_noc_selection_opt =
+            (num_links > line_noc_selection_link_threshold) && (edm_builder1.my_noc_y != edm_builder2.my_noc_y);
+    }
+    log_debug(
+        tt::LogTest,
+        "device {} edm_builder1 {} {} is connecting to edm_builder2 {} {} num links {}",
+        edm_builder1.my_chip_id,
+        edm_builder1.my_noc_x,
+        edm_builder1.my_noc_y,
+        edm_builder2.my_noc_x,
+        edm_builder2.my_noc_y,
+        num_links);
+
+    if (enable_noc_selection_opt) {
+        if (edm_builder1.my_noc_x < edm_builder2.my_noc_x) {
+            for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
+                edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 0;
+                edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 1;
+            }
+            for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
+                edm_builder1.config.receiver_channel_local_write_noc_ids[i] = 1;
+                edm_builder2.config.receiver_channel_local_write_noc_ids[i] = 1;
+            }
+            for (uint32_t i = 0; i < edm_builder1.config.num_sender_channels; i++) {
+                edm_builder1.config.sender_channel_ack_noc_ids[i] = 1;
+                edm_builder2.config.sender_channel_ack_noc_ids[i] = 0;
+            }
+        } else if (edm_builder1.my_noc_x > edm_builder2.my_noc_x) {
+            for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
+                edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 1;
+                edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 0;
+            }
+            for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
+                edm_builder1.config.receiver_channel_local_write_noc_ids[i] = 1;
+                edm_builder2.config.receiver_channel_local_write_noc_ids[i] = 1;
+            }
+            for (uint32_t i = 0; i < edm_builder1.config.num_sender_channels; i++) {
+                edm_builder1.config.sender_channel_ack_noc_ids[i] = 0;
+                edm_builder2.config.sender_channel_ack_noc_ids[i] = 1;
+            }
+        }
+    }
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <tt-metalium/fabric_types.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
+#include <tt-metalium/erisc_datamover_builder.hpp>
 #include <set>
 #include <vector>
 
@@ -21,5 +22,11 @@ Topology get_1d_topology(tt::tt_metal::FabricConfig fabric_config);
 FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type);
 
 std::vector<chan_id_t> get_ordered_fabric_eth_chans(chip_id_t chip_id, const std::set<chan_id_t>& eth_chans);
+
+void get_optimal_noc_for_edm(
+    FabricEriscDatamoverBuilder& edm_builder1,
+    FabricEriscDatamoverBuilder& edm_builder2,
+    const uint32_t num_links,
+    const Topology topology);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1167,55 +1167,8 @@ std::unique_ptr<Program> create_and_compile_1d_fabric_program(IDevice* device, F
                 edm_builder1.connect_to_downstream_edm(edm_builder2);
                 edm_builder2.connect_to_downstream_edm(edm_builder1);
 
-                bool enable_core_placement_opt = false;
                 if (is_galaxy) {
-                    if (topology == Topology::Ring) {
-                        enable_core_placement_opt = (num_links > 3) && (edm_builder1.my_noc_y != edm_builder2.my_noc_y);
-                    } else {
-                        enable_core_placement_opt = (num_links > 2) && (edm_builder1.my_noc_y != edm_builder2.my_noc_y);
-                    }
-                }
-                log_debug(
-                    tt::LogTest,
-                    "device {} edm_builder1 {} {} is connecting to edm_builder2 {} {} on channel1 {} and channel2 {}, "
-                    "num links {}",
-                    edm_builder1.my_chip_id,
-                    edm_builder1.my_noc_x,
-                    edm_builder1.my_noc_y,
-                    edm_builder2.my_noc_x,
-                    edm_builder2.my_noc_y,
-                    eth_chan_dir1,
-                    eth_chan_dir2,
-                    num_links);
-
-                if (enable_core_placement_opt) {
-                    if (edm_builder1.my_noc_x < edm_builder2.my_noc_x) {
-                        for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
-                            edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 0;
-                            edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 1;
-                        }
-                        for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
-                            edm_builder1.config.receiver_channel_local_write_noc_ids[i] = 1;
-                            edm_builder2.config.receiver_channel_local_write_noc_ids[i] = 1;
-                        }
-                        for (uint32_t i = 0; i < edm_builder1.config.num_sender_channels; i++) {
-                            edm_builder1.config.sender_channel_ack_noc_ids[i] = 1;
-                            edm_builder2.config.sender_channel_ack_noc_ids[i] = 0;
-                        }
-                    } else if (edm_builder1.my_noc_x > edm_builder2.my_noc_x) {
-                        for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
-                            edm_builder1.config.receiver_channel_forwarding_noc_ids[i] = 1;
-                            edm_builder2.config.receiver_channel_forwarding_noc_ids[i] = 0;
-                        }
-                        for (uint32_t i = 0; i < edm_builder1.config.num_receiver_channels; i++) {
-                            edm_builder1.config.receiver_channel_local_write_noc_ids[i] = 1;
-                            edm_builder2.config.receiver_channel_local_write_noc_ids[i] = 1;
-                        }
-                        for (uint32_t i = 0; i < edm_builder1.config.num_sender_channels; i++) {
-                            edm_builder1.config.sender_channel_ack_noc_ids[i] = 0;
-                            edm_builder2.config.sender_channel_ack_noc_ids[i] = 1;
-                        }
-                    }
+                    get_optimal_noc_for_edm(edm_builder1, edm_builder2, num_links, topology);
                 }
 
                 eth_chans_dir1_it++;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21012

better congestion avoidance in  the device init fabric test for 4K, slightly worse for 2K (expected)
```

mast_Linear_0x4_mesh,noc_unicast_write,2048,8,4,False,False,True,4.840191851804669,2363374.9276389987
mcast_Linear_0x4_mesh,noc_unicast_write,4096,8,4,False,False,True,9.142152681834224,2231970.8695884338
mcast_Linear_8x0_mesh,noc_unicast_write,2048,4,4,False,False,True,4.899498205738207,2392333.108270609
mcast_Linear_8x0_mesh,noc_unicast_write,4096,4,4,False,False,True,9.735902415975712,2376929.3007753203
```

CCLs are mainly not affected by this change, some of them slightly improved. test_all_reduce_tg_llama improved from ~59 to 57.732
```

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_gather_tg_llama -k sdpa
Measured performance: 11.199 us vs. target: 12.9 us

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_gather_tg_llama -k binary_mult
Measured performance: 10.980 us vs. target: 12.54 us

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_gather_tg_llama -k layernorm
Measured performance: 4.981 us vs. target: 5.4 us

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_reduce_tg_llama -k ff2
 Measured performance: 17.483 us vs. target: 18.6 us

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_reduce_tg_llama -k qkv
Measured performance: 10.626 us vs. target: 11.9 us

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_reduce_tg_llama -k ff1
Measured performance: 17.356 us vs. target: 19.2 us

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py::test_all_reduce_tg_llama -k lm_head
Measured performance: 57.732 us vs. target: 61.8 us

Test: pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py::test_concat_fuse
Measured performance: 13.855 us vs. target: 17 us
```

### Checklist
- [x] [All post commit] https://github.com/tenstorrent/tt-metal/actions/runs/14670381714
- [ ] ubenchmark https://github.com/tenstorrent/tt-metal/actions/runs/14670395445 should still be broken as in main
