### PR TITLE
[skip ci] Run Smoke on T3K in Merge 

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -106,13 +106,14 @@ jobs:
       matrix:
         platform: [
           "N300",
+          "N300-llmbox",
         ]
     uses: ./.github/workflows/smoke.yaml
     with:
       docker-image: ${{ needs.build-tsan.outputs.dev-docker-image }}
       package-artifact-name: ${{ needs.build-tsan.outputs.packages-artifact-name }}
       runner: ${{ matrix.platform }}
-      per-test-timeout: 5.5 # TSan can be slow; relax the timeout a bit
+      per-test-timeout: 10 # TSan can be slow; relax the timeout somewhat
 
   build-asan:
     if: ${{ github.ref_name == 'main' ||

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -19,7 +19,11 @@ on:
 
 jobs:
   metalium-smoke:
-    runs-on: ${{ format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner) }}
+    runs-on: >-
+      ${{
+        ((inputs.runner == 'N150' || inputs.runner == 'N300' || inputs.runner == 'N300-llmbox') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner))
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner))
+      }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!'}}
       env:

--- a/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/dispatch/CMakeLists.txt
@@ -9,10 +9,7 @@ target_sources(
         dispatch_device/test_enqueue_read_write_l1.cpp
         dispatch_event/test_EnqueueWaitForEvent.cpp
         dispatch_event/test_events.cpp
-        dispatch_program/test_dispatch.cpp
         dispatch_program/test_dispatch_stress.cpp
-        dispatch_program/test_global_circular_buffers.cpp
-        dispatch_program/test_program_reuse.cpp
         dispatch_program/test_sub_device.cpp
         dispatch_util/test_device_command.cpp
         dispatch_util/test_dispatch_settings.cpp
@@ -32,7 +29,14 @@ target_link_libraries(unit_tests_dispatch_smoke PRIVATE test_metal_common_libs)
 add_library(unit_tests_dispatch_basic OBJECT)
 add_library(TT::Metalium::Test::Dispatch::Basic ALIAS unit_tests_dispatch_basic)
 TT_ENABLE_UNITY_BUILD(unit_tests_dispatch_basic)
-target_sources(unit_tests_dispatch_basic PRIVATE dispatch_trace/test_sub_device.cpp)
+target_sources(
+    unit_tests_dispatch_basic
+    PRIVATE
+        dispatch_program/test_dispatch.cpp
+        dispatch_program/test_global_circular_buffers.cpp
+        dispatch_program/test_program_reuse.cpp
+        dispatch_trace/test_sub_device.cpp
+)
 target_include_directories(
     unit_tests_dispatch_basic
     PRIVATE


### PR DESCRIPTION
### Ticket
N/A

### Problem description
New Cluster test needs at least T3K to be useful.  Galaxy is far too rare a commodity.  But T3K might be okay.  Let's find out.

### What's changed
Run Smokes on T3K in Merge Gate (1x per PR).