### PR TITLE
Increase lower tolerance for Falcon7b t3k/tg targets since CI varies too much

### DIFF
--- a/models/demos/t3000/falcon7b/demo_t3000.py
+++ b/models/demos/t3000/falcon7b/demo_t3000.py
@@ -11,7 +11,7 @@ from models.utility_functions import is_wormhole_b0
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
         (True, 128, {"prefill_t/s": 11070, "decode_t/s": 3710, "decode_t/s/u": 14.5}, False, None),
-        (True, 1024, {"prefill_t/s": 12530, "decode_t/s": 3434, "decode_t/s/u": 13.4}, False, None),
+        (True, 1024, {"prefill_t/s": 12200, "decode_t/s": 3434, "decode_t/s/u": 13.4}, False, None),
         (True, 2048, {"prefill_t/s": 10770, "decode_t/s": 3203, "decode_t/s/u": 12.5}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),

--- a/models/demos/tg/falcon7b/demo_tg.py
+++ b/models/demos/tg/falcon7b/demo_tg.py
@@ -10,9 +10,9 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 21408, "decode_t/s": 7425, "decode_t/s/u": 7.25}, False, None),
-        (True, 1024, {"prefill_t/s": 19180, "decode_t/s": 6867, "decode_t/s/u": 6.7}, False, None),
-        (True, 2048, {"prefill_t/s": 14500, "decode_t/s": 7262, "decode_t/s/u": 7.19}, False, None),
+        (True, 128, {"prefill_t/s": 21200, "decode_t/s": 7066, "decode_t/s/u": 6.90}, False, None),
+        (True, 1024, {"prefill_t/s": 19180, "decode_t/s": 6867, "decode_t/s/u": 6.70}, False, None),
+        (True, 2048, {"prefill_t/s": 14500, "decode_t/s": 7168, "decode_t/s/u": 7.00}, False, None),
         (True, 128, None, False, None),
         (True, 1024, None, False, None),
         (True, 2048, None, False, None),


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- The TG Falcon7b demo targets were updated without sufficient margin for CI variation in 3623ec573949894604c9824448b66b29d7a1f870
- The T3K Falcon7b demo target needs to be slightly adjusted to account for CI variance

### What's changed
- Slightly modified t3k/tg falcon7b demo targets

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes