### PR TITLE
Remove all invocations of launch_op from TTNN

### DIFF
--- a/tt-train/sources/ttml/metal/operations.hpp
+++ b/tt-train/sources/ttml/metal/operations.hpp
@@ -6,8 +6,7 @@
 
 namespace ttml::metal {
 
-constexpr auto rmsnorm_fw = ttnn::register_operation_with_auto_launch_op<
-    "ttml::metal::rmsnorm_fw",
-    ttml::metal::ops::rmsnorm_fw::RMSNormForwardOperation>();
+constexpr auto rmsnorm_fw =
+    ttnn::register_operation<"ttml::metal::rmsnorm_fw", ttml::metal::ops::rmsnorm_fw::RMSNormForwardOperation>();
 
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp
@@ -20,13 +20,4 @@ std::vector<std::optional<ttnn::Tensor>> RMSNormForwardOperation::invoke(
     return {result[0], result[1]};
 }
 
-std::vector<std::optional<ttnn::Tensor>> RMSNormForwardOperation::create_async_optional_output_tensors(
-    const ttnn::Tensor& input_tensor, const ttnn::Tensor& gamma_tensor, bool return_intermediates, float epsilon) {
-    return {
-        ttnn::Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor})),
-        return_intermediates ? std::optional<ttnn::Tensor>(
-                                   ttnn::Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor})))
-                             : std::nullopt};
-}
-
 }  // namespace ttml::metal::ops::rmsnorm_fw

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.hpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/rmsnorm_fw.hpp
@@ -17,12 +17,6 @@ struct RMSNormForwardOperation {
         const ttnn::Tensor& gamma_tensor,
         bool return_intermediates = true,
         float epsilon = 1e-6F);
-
-    static std::vector<std::optional<ttnn::Tensor>> create_async_optional_output_tensors(
-        const ttnn::Tensor& input_tensor,
-        const ttnn::Tensor& gamma_tensor,
-        bool return_intermediates = true,
-        float epsilon = 1e-6F);
 };
 
 }  // namespace ttml::metal::ops::rmsnorm_fw

--- a/ttnn/cpp/ttnn/decorators.hpp
+++ b/ttnn/cpp/ttnn/decorators.hpp
@@ -240,16 +240,8 @@ constexpr auto register_operation() {
     return register_operation_impl<cpp_fully_qualified_name, operation_t>();
 }
 
-// TODO: This can just get replaced with register_operation(), but opting to defer this until after the migration
-// to minimize blast radius.
-template <reflect::fixed_string cpp_fully_qualified_name, typename operation_t>
-constexpr auto register_operation_with_auto_launch_op() {
-    return register_operation_impl<cpp_fully_qualified_name, operation_t>();
-}
-
 }  // namespace decorators
 
 using ttnn::decorators::register_operation;
-using ttnn::decorators::register_operation_with_auto_launch_op;
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/bernoulli/bernoulli.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/bernoulli.hpp
@@ -19,6 +19,5 @@ struct Bernoulli {
 }  // namespace ttnn::operations::bernoulli
 
 namespace ttnn {
-constexpr auto bernoulli =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::bernoulli", ttnn::operations::bernoulli::Bernoulli>();
+constexpr auto bernoulli = ttnn::register_operation<"ttnn::bernoulli", ttnn::operations::bernoulli::Bernoulli>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/barrier/device/barrier_op.cpp
@@ -73,18 +73,7 @@ std::vector<Tensor> barrier_function(const std::vector<Tensor>& input_tensors, c
     std::vector<Tensor> output_tensors;
     output_tensors.reserve(input_tensors.size());
     for (const auto& input_tensor : input_tensors) {
-        std::vector<Tensor> cur_output_tensors = {Tensor({input_tensor.device()})};
-        tt::tt_metal::operation::launch_op(
-            [barrier_struct](
-                const std::vector<Tensor>& input_tensors,
-                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-                const Tensor& input_tensor = input_tensors.at(0);
-                return tt::tt_metal::operation::run(barrier_struct, {input_tensor});
-            },
-            {input_tensor},
-            cur_output_tensors);
-        output_tensors.push_back(cur_output_tensors.at(0));
+        output_tensors.push_back(tt::tt_metal::operation::run(barrier_struct, {input_tensor}).at(0));
     }
     return output_tensors;
 }

--- a/ttnn/cpp/ttnn/operations/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/copy.hpp
@@ -114,7 +114,6 @@ struct Typecast {
 }  // namespace copy
 }  // namespace operations
 
-constexpr auto typecast =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::typecast", ttnn::operations::copy::Typecast>();
+constexpr auto typecast = ttnn::register_operation<"ttnn::typecast", ttnn::operations::copy::Typecast>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -69,11 +69,9 @@ using operations::core::squeeze_from_4D;
 using operations::core::to_device;
 using operations::core::unsqueeze_to_4D;
 
-constexpr auto to_dtype =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::to_dtype", ttnn::operations::core::ToDtype>();
+constexpr auto to_dtype = ttnn::register_operation<"ttnn::to_dtype", ttnn::operations::core::ToDtype>();
 constexpr auto to_memory_config =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::to_memory_config", ttnn::operations::core::ToMemoryConfig>();
-constexpr auto to_layout =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::to_layout", ttnn::operations::core::ToLayout>();
+    ttnn::register_operation<"ttnn::to_memory_config", ttnn::operations::core::ToMemoryConfig>();
+constexpr auto to_layout = ttnn::register_operation<"ttnn::to_layout", ttnn::operations::core::ToLayout>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -502,7 +502,6 @@ constexpr auto ones_like =
 constexpr auto empty_like =
     ttnn::decorators::register_operation<"ttnn::empty_like", ttnn::operations::creation::EmptyLike>();
 
-constexpr auto arange =
-    ttnn::decorators::register_operation_with_auto_launch_op<"ttnn::arange", ttnn::operations::creation::Arange>();
+constexpr auto arange = ttnn::decorators::register_operation<"ttnn::arange", ttnn::operations::creation::Arange>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/bcast.cpp
@@ -19,69 +19,54 @@ Tensor BcastOperation::invoke(
     BcastOpDim bcast_dim,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& output_tensor) {
-    auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor_a}))};
+    using namespace tt::constants;
 
-    tt::tt_metal::operation::launch_op(
-        [bcast_op, bcast_dim, output_memory_config, output_tensor, queue_id](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            using tt::constants::TILE_HEIGHT;
-            using tt::constants::TILE_WIDTH;
-            auto& input_tensor_a = input_tensors.at(0);
-            auto& input_tensor_b = input_tensors.at(1);
-            if (bcast_dim == BcastOpDim::W) {
-                TT_FATAL(input_tensor_a.get_padded_shape()[-2] == input_tensor_b.get_padded_shape()[-2], "Error");
-                if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH, "Error");
-                } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
-                    TT_FATAL(
-                        input_tensor_b.get_padded_shape()[-1] == 1 ||
-                            input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH,
-                        "Error");
-                } else {
-                    TT_THROW("Unsupported layout");
-                }
-            } else if (bcast_dim == BcastOpDim::H) {
-                TT_FATAL(input_tensor_a.get_padded_shape()[-1] == input_tensor_b.get_padded_shape()[-1], "Error");
-                if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT, "Error");
-                } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
-                    TT_FATAL(
-                        input_tensor_b.get_padded_shape()[-2] == 1 ||
-                            input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT,
-                        "Error");
-                } else {
-                    TT_THROW("Unsupported layout");
-                }
-            } else if (bcast_dim == BcastOpDim::HW) {
-                if (input_tensor_b.get_layout() == Layout::TILE) {
-                    TT_FATAL(
-                        input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT &&
-                            input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH,
-                        "Error");
-                } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
-                    TT_FATAL(
-                        (input_tensor_b.get_padded_shape()[-2] == 1 && input_tensor_b.get_padded_shape()[-1] == 1) ||
-                            (input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT &&
-                             input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH),
-                        "Error");
-                }
-            }
-            return tt::tt_metal::operation::run_with_autoformat(
-                EltwiseBinaryBroadcast{bcast_op, bcast_dim, output_memory_config},
-                {input_tensor_a, input_tensor_b},
-                {},
-                {output_tensor},
-                0, /* pad_value*/
-                queue_id);
-        },
-        {input_tensor_a, input_tensor_b},
-        output_tensors,
-        {},
-        {output_tensor});
-    return output_tensors[0];
+    auto output_memory_config = memory_config.value_or(input_tensor_a.memory_config());
+
+    if (bcast_dim == BcastOpDim::W) {
+        TT_FATAL(input_tensor_a.get_padded_shape()[-2] == input_tensor_b.get_padded_shape()[-2], "Error");
+        if (input_tensor_b.get_layout() == Layout::TILE) {
+            TT_FATAL(input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH, "Error");
+        } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
+            TT_FATAL(
+                input_tensor_b.get_padded_shape()[-1] == 1 || input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH,
+                "Error");
+        } else {
+            TT_THROW("Unsupported layout");
+        }
+    } else if (bcast_dim == BcastOpDim::H) {
+        TT_FATAL(input_tensor_a.get_padded_shape()[-1] == input_tensor_b.get_padded_shape()[-1], "Error");
+        if (input_tensor_b.get_layout() == Layout::TILE) {
+            TT_FATAL(input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT, "Error");
+        } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
+            TT_FATAL(
+                input_tensor_b.get_padded_shape()[-2] == 1 || input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT,
+                "Error");
+        } else {
+            TT_THROW("Unsupported layout");
+        }
+    } else if (bcast_dim == BcastOpDim::HW) {
+        if (input_tensor_b.get_layout() == Layout::TILE) {
+            TT_FATAL(
+                input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT &&
+                    input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH,
+                "Error");
+        } else if (input_tensor_b.get_layout() == Layout::ROW_MAJOR) {
+            TT_FATAL(
+                (input_tensor_b.get_padded_shape()[-2] == 1 && input_tensor_b.get_padded_shape()[-1] == 1) ||
+                    (input_tensor_b.get_padded_shape()[-2] == TILE_HEIGHT &&
+                     input_tensor_b.get_padded_shape()[-1] == TILE_WIDTH),
+                "Error");
+        }
+    }
+    return tt::tt_metal::operation::run_with_autoformat(
+               EltwiseBinaryBroadcast{bcast_op, bcast_dim, output_memory_config},
+               {input_tensor_a, input_tensor_b},
+               {},
+               {output_tensor},
+               0, /* pad_value*/
+               queue_id)
+        .at(0);
 }
 
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/clone.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/clone.hpp
@@ -17,6 +17,5 @@ struct Clone {
 }  // namespace ttnn::operations::data_movement::clone
 
 namespace ttnn {
-constexpr auto clone =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::clone", ttnn::operations::data_movement::clone::Clone>();
+constexpr auto clone = ttnn::register_operation<"ttnn::clone", ttnn::operations::data_movement::clone::Clone>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.hpp
@@ -27,7 +27,6 @@ struct ConcatOperation {
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto concat =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::concat", ttnn::operations::data_movement::ConcatOperation>();
+constexpr auto concat = ttnn::register_operation<"ttnn::concat", ttnn::operations::data_movement::ConcatOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/copy.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/copy.hpp
@@ -37,9 +37,7 @@ struct AssignOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto copy =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::copy", ttnn::operations::data_movement::CopyOperation>();
-constexpr auto assign =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::assign", ttnn::operations::data_movement::AssignOperation>();
+constexpr auto copy = ttnn::register_operation<"ttnn::copy", ttnn::operations::data_movement::CopyOperation>();
+constexpr auto assign = ttnn::register_operation<"ttnn::assign", ttnn::operations::data_movement::AssignOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.hpp
@@ -45,6 +45,6 @@ struct FoldOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto fold = register_operation_with_auto_launch_op<"ttnn::fold", operations::data_movement::FoldOperation>();
+constexpr auto fold = register_operation<"ttnn::fold", operations::data_movement::FoldOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -126,69 +126,57 @@ static inline Tensor move(QueueId queue_id, const Tensor& input_tensor, const st
 
 static inline Tensor move_sharded(
     QueueId queue_id, const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
-    operation::launch_op(
-        [mem_config](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& input_tensor = input_tensors.at(0);
-            TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-            auto input_mem_config = input_tensor.memory_config();
-            TT_FATAL(input_mem_config.is_sharded(), "Expected input tensor to be sharded");
-            auto input_address = input_tensor.buffer()->address();
-            auto output_mem_config = mem_config.value_or(input_mem_config);
-            TT_FATAL(output_mem_config.is_sharded(), "Expected output tensor memory config to be sharded");
-            if (not can_deallocate(input_tensor)) {
-                TT_FATAL(
-                    false,
-                    "Expect input tensor to be deallocated after move op. Cannot deallocate before there is probably "
-                    "another consumer.");
-                // TODO: Should this throw error?
-                return {input_tensor};
-            }
-            auto shard_spec = input_tensor.shard_spec().value();
-            auto shard_shape = shard_spec.shape;
-            auto shard_grid = shard_spec.grid;
-            auto input_dtype = input_tensor.get_dtype();
-            auto input_layout = input_tensor.get_layout();
-            // Special handling for Mesh vs single device. Needs to be consolidated after full
-            // migration
+    TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
+    auto input_mem_config = input_tensor.memory_config();
+    TT_FATAL(input_mem_config.is_sharded(), "Expected input tensor to be sharded");
+    auto input_address = input_tensor.buffer()->address();
+    auto output_mem_config = mem_config.value_or(input_mem_config);
+    TT_FATAL(output_mem_config.is_sharded(), "Expected output tensor memory config to be sharded");
+    if (not can_deallocate(input_tensor)) {
+        TT_FATAL(
+            false,
+            "Expect input tensor to be deallocated after move op. Cannot deallocate before there is probably "
+            "another consumer.");
+        // TODO: Should this throw error?
+        return {input_tensor};
+    }
+    auto shard_spec = input_tensor.shard_spec().value();
+    auto shard_shape = shard_spec.shape;
+    auto shard_grid = shard_spec.grid;
+    auto input_dtype = input_tensor.get_dtype();
+    auto input_layout = input_tensor.get_layout();
+    // Special handling for Mesh vs single device. Needs to be consolidated after full
+    // migration
 
-            if (input_tensor.device_storage().mesh_buffer) {
-                input_tensor.device_storage().mesh_buffer->deallocate();
-            } else {
-                DeallocateBuffer(*input_tensor.buffer());
-            }
-            // log_debug(LogOp, "OUTPUT SHARD SPEC: {}", out_shard_spec);
-            auto shard_mem_config = output_mem_config;
-            shard_mem_config.shard_spec = shard_spec;
-            auto output_tensor = create_device_tensor(
-                TensorSpec(
-                    input_tensor.get_logical_shape(),
-                    TensorLayout::fromPaddedShape(
-                        input_dtype,
-                        PageConfig(input_layout),
-                        shard_mem_config,
-                        input_tensor.get_logical_shape(),
-                        input_tensor.get_padded_shape())),
-                input_tensor.device());
-            if (input_tensor.buffer()->address() == output_tensor.buffer()->address()) {
-                tt::log_debug(
-                    tt::LogOp,
-                    "WARNING: No space to move the tensor. Move op's input address and output address are equal: {}",
-                    input_address);
-                return {output_tensor};
-            }
-            MoveOpParallelizationStrategy move_op_parallelization_strategy =
-                MoveOpParallelizationStrategy::MULTI_CORE_SHARDED;
-            return operation::run(
-                MoveDeviceOperation{output_mem_config, move_op_parallelization_strategy},
-                {input_tensor, output_tensor});
-        },
-        {input_tensor},
-        output_tensors);
-    return output_tensors.at(0);
+    if (input_tensor.device_storage().mesh_buffer) {
+        input_tensor.device_storage().mesh_buffer->deallocate();
+    } else {
+        DeallocateBuffer(*input_tensor.buffer());
+    }
+    // log_debug(LogOp, "OUTPUT SHARD SPEC: {}", out_shard_spec);
+    auto shard_mem_config = output_mem_config;
+    shard_mem_config.shard_spec = shard_spec;
+    auto output_tensor = create_device_tensor(
+        TensorSpec(
+            input_tensor.get_logical_shape(),
+            TensorLayout::fromPaddedShape(
+                input_dtype,
+                PageConfig(input_layout),
+                shard_mem_config,
+                input_tensor.get_logical_shape(),
+                input_tensor.get_padded_shape())),
+        input_tensor.device());
+    if (input_tensor.buffer()->address() == output_tensor.buffer()->address()) {
+        tt::log_debug(
+            tt::LogOp,
+            "WARNING: No space to move the tensor. Move op's input address and output address are equal: {}",
+            input_address);
+        return {output_tensor};
+    }
+    MoveOpParallelizationStrategy move_op_parallelization_strategy = MoveOpParallelizationStrategy::MULTI_CORE_SHARDED;
+    return operation::run(
+               MoveDeviceOperation{output_mem_config, move_op_parallelization_strategy}, {input_tensor, output_tensor})
+        .at(0);
 }
 
 ttnn::Tensor MoveOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.hpp
@@ -49,7 +49,6 @@ struct ExecutePad {
 
 }  // namespace operations::data_movement
 
-constexpr auto pad =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::pad", ttnn::operations::data_movement::ExecutePad>();
+constexpr auto pad = ttnn::register_operation<"ttnn::pad", ttnn::operations::data_movement::ExecutePad>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -102,19 +102,7 @@ ttnn::Tensor permute_launch(
     const ttnn::SmallVector<uint32_t>& dims,
     const MemoryConfig& output_mem_config,
     const std::optional<float>& pad_value) {
-    std::vector<ttnn::Tensor> output_tensors = {ttnn::Tensor(tt::tt_metal::operation::get_workers_for_op_output({a}))};
-    tt::tt_metal::operation::launch_op(
-        [dims, output_mem_config, pad_value](
-            const std::vector<ttnn::Tensor>& input_tensors,
-            const std::vector<std::optional<const ttnn::Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<ttnn::Tensor>>& optional_output_tensors) mutable
-            -> std::vector<ttnn::Tensor> {
-            auto& a = input_tensors.at(0);
-            return {permute_impl(a, dims, output_mem_config, pad_value)};
-        },
-        {a},
-        output_tensors);
-    return output_tensors.at(0);
+    return permute_impl(a, dims, output_mem_config, pad_value);
 }
 
 bool is_permute_nop(const ttnn::Tensor& a, const ttnn::SmallVector<uint32_t>& dims) {

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/repeat_interleave.hpp
@@ -30,8 +30,7 @@ struct ExecuteRepeatInterleave {
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto repeat_interleave = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::repeat_interleave",
-    ttnn::operations::data_movement::ExecuteRepeatInterleave>();
+constexpr auto repeat_interleave =
+    ttnn::register_operation<"ttnn::repeat_interleave", ttnn::operations::data_movement::ExecuteRepeatInterleave>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -79,7 +79,6 @@ ttnn::Tensor ReshapeOperation::invoke(
             input_tensor.device(),
             output_mem_config);
     }
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
     return tt::tt_metal::operation::run(
                ReshapeDeviceOperation{logical_output_shape, padded_output_shape, output_mem_config}, {input_tensor})
         .at(0);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/interleaved_to_sharded.hpp
@@ -30,7 +30,7 @@ struct InterleavedToShardedOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto interleaved_to_sharded = ttnn::register_operation_with_auto_launch_op<
+constexpr auto interleaved_to_sharded = ttnn::register_operation<
     "ttnn::interleaved_to_sharded",
     ttnn::operations::data_movement::InterleavedToShardedOperation>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/reshard.hpp
@@ -20,6 +20,5 @@ struct ReshardOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto reshard =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::reshard", ttnn::operations::data_movement::ReshardOperation>();
+constexpr auto reshard = ttnn::register_operation<"ttnn::reshard", ttnn::operations::data_movement::ReshardOperation>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.cpp
@@ -19,7 +19,6 @@ ttnn::Tensor ShardedToInterleavedOperation::invoke(
         return input_tensor;
     }
 
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
     auto shard_spec = input_tensor.shard_spec().value();
     return tt::tt_metal::operation::run(
                ShardedToInterleavedDeviceOperation{

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/sharded_to_interleaved.hpp
@@ -20,7 +20,7 @@ struct ShardedToInterleavedOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto sharded_to_interleaved = ttnn::register_operation_with_auto_launch_op<
+constexpr auto sharded_to_interleaved = ttnn::register_operation<
     "ttnn::sharded_to_interleaved",
     ttnn::operations::data_movement::ShardedToInterleavedOperation>();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.cpp
@@ -22,8 +22,6 @@ ttnn::Tensor InterleavedToShardedPartialOperation::invoke(
     tt::tt_metal::TensorMemoryLayout shard_scheme,
     tt::tt_metal::ShardOrientation shard_orientation,
     const std::optional<DataType>& data_type_arg) {
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-
     bool row_wise = shard_orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR;
     CoreCoord grid_size;
     CoreRangeSet grid_set;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/interleaved_to_sharded_partial/interleaved_to_sharded_partial.hpp
@@ -25,7 +25,7 @@ struct InterleavedToShardedPartialOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto interleaved_to_sharded_partial = ttnn::register_operation_with_auto_launch_op<
+constexpr auto interleaved_to_sharded_partial = ttnn::register_operation<
     "ttnn::interleaved_to_sharded_partial",
     ttnn::operations::data_movement::InterleavedToShardedPartialOperation>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.cpp
@@ -19,8 +19,6 @@ ttnn::Tensor ShardedToInterleavedPartialOperation::invoke(
     int64_t& slice_index,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DataType>& data_type_arg) {
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-
     auto memory_config = memory_config_arg.value_or(input_tensor.memory_config());
     auto shard_spec = input_tensor.shard_spec().value();
     TT_FATAL(input_tensor.shard_spec().has_value(), "Error");

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded_partial/sharded_to_interleaved_partial/sharded_to_interleaved_partial.hpp
@@ -22,7 +22,7 @@ struct ShardedToInterleavedPartialOperation {
 
 }  // namespace operations::data_movement
 
-constexpr auto sharded_to_interleaved_partial = ttnn::register_operation_with_auto_launch_op<
+constexpr auto sharded_to_interleaved_partial = ttnn::register_operation<
     "ttnn::sharded_to_interleaved_partial",
     ttnn::operations::data_movement::ShardedToInterleavedPartialOperation>();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.hpp
@@ -97,7 +97,6 @@ struct SliceOperation {
 }  // namespace data_movement
 }  // namespace operations
 
-constexpr auto slice =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::slice", ttnn::operations::data_movement::SliceOperation>();
+constexpr auto slice = ttnn::register_operation<"ttnn::slice", ttnn::operations::data_movement::SliceOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.hpp
@@ -20,7 +20,6 @@ struct ExecuteTilize {
 
 }  // namespace operations::data_movement
 
-constexpr auto tilize =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::tilize", ttnn::operations::data_movement::ExecuteTilize>();
+constexpr auto tilize = ttnn::register_operation<"ttnn::tilize", ttnn::operations::data_movement::ExecuteTilize>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp
@@ -67,11 +67,10 @@ struct ExecuteTilizeWithZeroPadding {
 
 }  // namespace operations::data_movement
 
-constexpr auto tilize_with_val_padding = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::tilize_with_val_padding",
-    ttnn::operations::data_movement::ExecuteTilizeWithValPadding>();
+constexpr auto tilize_with_val_padding = ttnn::
+    register_operation<"ttnn::tilize_with_val_padding", ttnn::operations::data_movement::ExecuteTilizeWithValPadding>();
 
-constexpr auto tilize_with_zero_padding = ttnn::register_operation_with_auto_launch_op<
+constexpr auto tilize_with_zero_padding = ttnn::register_operation<
     "ttnn::tilize_with_zero_padding",
     ttnn::operations::data_movement::ExecuteTilizeWithZeroPadding>();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -109,51 +109,40 @@ ttnn::Tensor ExecuteTranspose::invoke(
         input_unsqueezed.get_dtype() == DataType::BFLOAT8_B and !bfloat8_supported and !input_unsqueezed.is_sharded();
     Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
 
-    std::vector<Tensor> output_tensors = {Tensor(detail::get_workers_for_op_output({input_typecasted}))};
-    detail::launch_op(
-        [normalized_dim1, normalized_dim2, memory_config_arg, pad_value](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& a = input_tensors.at(0);
-            auto memory_config = memory_config_arg.value_or(a.memory_config());
+    auto memory_config = memory_config_arg.value_or(input_typecasted.memory_config());
 
-            TT_FATAL(normalized_dim1 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
-            TT_FATAL(normalized_dim2 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
+    TT_FATAL(normalized_dim1 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
+    TT_FATAL(normalized_dim2 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
 
-            if ((normalized_dim1 == normalized_dim2) ||
-                (a.get_padded_shape()[normalized_dim1] == 1 && a.get_padded_shape()[normalized_dim2] == 1)) {
-                return {ttnn::operations::experimental::auto_format::AutoFormat::move_tensor_to_mem_config(
-                    a, memory_config)};
-            }
+    if ((normalized_dim1 == normalized_dim2) || (input_typecasted.get_padded_shape()[normalized_dim1] == 1 &&
+                                                 input_typecasted.get_padded_shape()[normalized_dim2] == 1)) {
+        return {ttnn::operations::experimental::auto_format::AutoFormat::move_tensor_to_mem_config(
+            input_typecasted, memory_config)};
+    }
 
-            if (normalized_dim1 > normalized_dim2) {
-                std::swap(normalized_dim1, normalized_dim2);
-            }
+    if (normalized_dim1 > normalized_dim2) {
+        std::swap(normalized_dim1, normalized_dim2);
+    }
 
-            TransposeOpDim transpose_dim = TransposeOpDim::NW;
+    TransposeOpDim transpose_dim = TransposeOpDim::NW;
 
-            if (normalized_dim2 == 3 && normalized_dim1 == 0) {
-                transpose_dim = TransposeOpDim::NW;
-            } else if (normalized_dim2 == 3 && normalized_dim1 == 1) {
-                transpose_dim = TransposeOpDim::CW;
-            } else if (normalized_dim2 == 3 && normalized_dim1 == 2) {
-                transpose_dim = TransposeOpDim::WH;
-            } else if (normalized_dim2 == 2 && normalized_dim1 == 0) {
-                transpose_dim = TransposeOpDim::NH;
-            } else if (normalized_dim2 == 2 && normalized_dim1 == 1) {
-                transpose_dim = TransposeOpDim::HC;
-            } else if (normalized_dim2 == 1 && normalized_dim1 == 0) {
-                transpose_dim = TransposeOpDim::CN;
-            } else {
-                TT_ASSERT(false, "Unsupported transpose dims");
-            }
-            return {detail::transpose_(a, transpose_dim, memory_config, pad_value)};
-        },
-        {input_typecasted},
-        output_tensors);
+    if (normalized_dim2 == 3 && normalized_dim1 == 0) {
+        transpose_dim = TransposeOpDim::NW;
+    } else if (normalized_dim2 == 3 && normalized_dim1 == 1) {
+        transpose_dim = TransposeOpDim::CW;
+    } else if (normalized_dim2 == 3 && normalized_dim1 == 2) {
+        transpose_dim = TransposeOpDim::WH;
+    } else if (normalized_dim2 == 2 && normalized_dim1 == 0) {
+        transpose_dim = TransposeOpDim::NH;
+    } else if (normalized_dim2 == 2 && normalized_dim1 == 1) {
+        transpose_dim = TransposeOpDim::HC;
+    } else if (normalized_dim2 == 1 && normalized_dim1 == 0) {
+        transpose_dim = TransposeOpDim::CN;
+    } else {
+        TT_ASSERT(false, "Unsupported transpose dims");
+    }
 
-    auto output = output_tensors.at(0);
+    auto output = detail::transpose_(input_typecasted, transpose_dim, memory_config, pad_value);
     output = initial_rank < 4u ? ttnn::squeeze_from_4D(output, initial_rank) : output;
     return typecast ? ttnn::typecast(output, DataType::BFLOAT8_B) : output;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/untilize.hpp
@@ -23,6 +23,6 @@ struct ExecuteUntilize {
 }  // namespace operations::data_movement
 
 constexpr auto untilize =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::untilize", ttnn::operations::data_movement::ExecuteUntilize>();
+    ttnn::register_operation<"ttnn::untilize", ttnn::operations::data_movement::ExecuteUntilize>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp
@@ -21,7 +21,7 @@ struct ExecuteUntilizeWithUnpadding {
 
 }  // namespace operations::data_movement
 
-constexpr auto untilize_with_unpadding = ttnn::register_operation_with_auto_launch_op<
+constexpr auto untilize_with_unpadding = ttnn::register_operation<
     "ttnn::untilize_with_unpadding",
     ttnn::operations::data_movement::ExecuteUntilizeWithUnpadding>();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -152,112 +152,101 @@ struct BinaryOperationSfpu {
 }  // namespace binary
 }  // namespace operations
 
-constexpr auto add = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::add",
-    operations::binary::BinaryOperation<operations::binary::BinaryOpType::ADD>>();
-constexpr auto add_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto add =
+    ttnn::register_operation<"ttnn::add", operations::binary::BinaryOperation<operations::binary::BinaryOpType::ADD>>();
+constexpr auto add_ = ttnn::register_operation<
     "ttnn::add_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::ADD>>();
-constexpr auto subtract = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::subtract",
-    operations::binary::BinaryOperation<operations::binary::BinaryOpType::SUB>>();
-constexpr auto subtract_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto subtract = ttnn::
+    register_operation<"ttnn::subtract", operations::binary::BinaryOperation<operations::binary::BinaryOpType::SUB>>();
+constexpr auto subtract_ = ttnn::register_operation<
     "ttnn::subtract_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::SUB>>();
-constexpr auto multiply = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::multiply",
-    operations::binary::BinaryOperation<operations::binary::BinaryOpType::MUL>>();
-constexpr auto multiply_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto multiply = ttnn::
+    register_operation<"ttnn::multiply", operations::binary::BinaryOperation<operations::binary::BinaryOpType::MUL>>();
+constexpr auto multiply_ = ttnn::register_operation<
     "ttnn::multiply_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::MUL>>();
-constexpr auto eq = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::eq",
-    operations::binary::RelationalBinary<operations::binary::BinaryOpType::EQ>>();
-constexpr auto ne = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::ne",
-    operations::binary::RelationalBinary<operations::binary::BinaryOpType::NE>>();
-constexpr auto ge = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::ge",
-    operations::binary::RelationalBinary<operations::binary::BinaryOpType::GTE>>();
-constexpr auto gt = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::gt",
-    operations::binary::RelationalBinary<operations::binary::BinaryOpType::GT>>();
-constexpr auto le = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::le",
-    operations::binary::RelationalBinary<operations::binary::BinaryOpType::LTE>>();
-constexpr auto lt = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::lt",
-    operations::binary::RelationalBinary<operations::binary::BinaryOpType::LT>>();
-constexpr auto logical_and = ttnn::register_operation_with_auto_launch_op<
+constexpr auto eq =
+    ttnn::register_operation<"ttnn::eq", operations::binary::RelationalBinary<operations::binary::BinaryOpType::EQ>>();
+constexpr auto ne =
+    ttnn::register_operation<"ttnn::ne", operations::binary::RelationalBinary<operations::binary::BinaryOpType::NE>>();
+constexpr auto ge =
+    ttnn::register_operation<"ttnn::ge", operations::binary::RelationalBinary<operations::binary::BinaryOpType::GTE>>();
+constexpr auto gt =
+    ttnn::register_operation<"ttnn::gt", operations::binary::RelationalBinary<operations::binary::BinaryOpType::GT>>();
+constexpr auto le =
+    ttnn::register_operation<"ttnn::le", operations::binary::RelationalBinary<operations::binary::BinaryOpType::LTE>>();
+constexpr auto lt =
+    ttnn::register_operation<"ttnn::lt", operations::binary::RelationalBinary<operations::binary::BinaryOpType::LT>>();
+constexpr auto logical_and = ttnn::register_operation<
     "ttnn::logical_and",
     operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_AND>>();
-constexpr auto logical_or = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logical_or = ttnn::register_operation<
     "ttnn::logical_or",
     operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_OR>>();
-constexpr auto logical_xor = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logical_xor = ttnn::register_operation<
     "ttnn::logical_xor",
     operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGICAL_XOR>>();
-constexpr auto ldexp = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::ldexp",
-    operations::binary::BinaryOperation<operations::binary::BinaryOpType::LDEXP>>();
-constexpr auto ldexp_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto ldexp = ttnn::
+    register_operation<"ttnn::ldexp", operations::binary::BinaryOperation<operations::binary::BinaryOpType::LDEXP>>();
+constexpr auto ldexp_ = ttnn::register_operation<
     "ttnn::ldexp_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::LDEXP>>();
-constexpr auto logaddexp = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logaddexp = ttnn::register_operation<
     "ttnn::logaddexp",
     operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGADDEXP>>();
-constexpr auto logaddexp_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logaddexp_ = ttnn::register_operation<
     "ttnn::logaddexp_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::LOGADDEXP>>();
-constexpr auto logaddexp2 = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logaddexp2 = ttnn::register_operation<
     "ttnn::logaddexp2",
     operations::binary::BinaryOperation<operations::binary::BinaryOpType::LOGADDEXP2>>();
-constexpr auto logaddexp2_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logaddexp2_ = ttnn::register_operation<
     "ttnn::logaddexp2_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::LOGADDEXP2>>();
-constexpr auto squared_difference = ttnn::register_operation_with_auto_launch_op<
+constexpr auto squared_difference = ttnn::register_operation<
     "ttnn::squared_difference",
     operations::binary::BinaryOperation<operations::binary::BinaryOpType::SQUARED_DIFFERENCE>>();
-constexpr auto squared_difference_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto squared_difference_ = ttnn::register_operation<
     "ttnn::squared_difference_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::SQUARED_DIFFERENCE>>();
-constexpr auto divide = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::divide",
-    operations::binary::BinaryOperation<operations::binary::BinaryOpType::DIV>>();
-constexpr auto divide_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto divide = ttnn::
+    register_operation<"ttnn::divide", operations::binary::BinaryOperation<operations::binary::BinaryOpType::DIV>>();
+constexpr auto divide_ = ttnn::register_operation<
     "ttnn::divide_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::DIV>>();
-constexpr auto gt_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto gt_ = ttnn::register_operation<
     "ttnn::gt_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::GT>>();
-constexpr auto ge_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto ge_ = ttnn::register_operation<
     "ttnn::ge_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::GTE>>();
-constexpr auto le_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto le_ = ttnn::register_operation<
     "ttnn::le_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::LTE>>();
-constexpr auto lt_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto lt_ = ttnn::register_operation<
     "ttnn::lt_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::LT>>();
-constexpr auto logical_and_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logical_and_ = ttnn::register_operation<
     "ttnn::logical_and_",
     operations::binary::InplaceLogicalBinary<operations::binary::BinaryOpType::LOGICAL_AND>>();
-constexpr auto logical_or_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logical_or_ = ttnn::register_operation<
     "ttnn::logical_or_",
     operations::binary::InplaceLogicalBinary<operations::binary::BinaryOpType::LOGICAL_OR>>();
-constexpr auto logical_xor_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logical_xor_ = ttnn::register_operation<
     "ttnn::logical_xor_",
     operations::binary::InplaceLogicalBinary<operations::binary::BinaryOpType::LOGICAL_XOR>>();
-constexpr auto eq_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto eq_ = ttnn::register_operation<
     "ttnn::eq_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::EQ>>();
-constexpr auto ne_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto ne_ = ttnn::register_operation<
     "ttnn::ne_",
     operations::binary::InplaceRelationalBinary<operations::binary::BinaryOpType::NE>>();
-constexpr auto rsub_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rsub_ = ttnn::register_operation<
     "ttnn::rsub_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::RSUB>>();
-constexpr auto bias_gelu_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto bias_gelu_ = ttnn::register_operation<
     "ttnn::bias_gelu_",
     operations::binary::InplaceBinaryOperation<operations::binary::BinaryOpType::BIAS_GELU>>();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -496,68 +496,61 @@ struct ExecuteBitwiseRightShift {
 }  // namespace binary
 }  // namespace operations
 
-constexpr auto hypot = ttnn::register_operation_with_auto_launch_op<
+constexpr auto hypot = ttnn::register_operation<
     "ttnn::hypot",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::HYPOT>>();
-constexpr auto xlogy = ttnn::register_operation_with_auto_launch_op<
+constexpr auto xlogy = ttnn::register_operation<
     "ttnn::xlogy",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::XLOGY>>();
-constexpr auto minimum =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::minimum", operations::binary::ExecuteMinimum>();
-constexpr auto maximum =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::maximum", operations::binary::ExecuteMaximum>();
-constexpr auto atan2 = ttnn::register_operation_with_auto_launch_op<
+constexpr auto minimum = ttnn::register_operation<"ttnn::minimum", operations::binary::ExecuteMinimum>();
+constexpr auto maximum = ttnn::register_operation<"ttnn::maximum", operations::binary::ExecuteMaximum>();
+constexpr auto atan2 = ttnn::register_operation<
     "ttnn::atan2",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::ATAN2>>();
-constexpr auto nextafter = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nextafter = ttnn::register_operation<
     "ttnn::nextafter",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::NEXTAFTER>>();
-constexpr auto addalpha = ttnn::register_operation_with_auto_launch_op<
+constexpr auto addalpha = ttnn::register_operation<
     "ttnn::addalpha",
     operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::ADDALPHA>>();
-constexpr auto subalpha = ttnn::register_operation_with_auto_launch_op<
+constexpr auto subalpha = ttnn::register_operation<
     "ttnn::subalpha",
     operations::binary::ExecuteBinaryCompositeOpsFloat<operations::binary::BinaryCompositeOpType::SUBALPHA>>();
-constexpr auto isclose = ttnn::register_operation_with_auto_launch_op<
+constexpr auto isclose = ttnn::register_operation<
     "ttnn::isclose",
     operations::binary::ExecuteBinaryCompositeOpsIsClose<operations::binary::BinaryCompositeOpType::ISCLOSE>>();
-constexpr auto remainder =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::remainder", operations::binary::ExecuteBinaryRemainder>();
-constexpr auto fmod =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::fmod", operations::binary::ExecuteBinaryFmod>();
-constexpr auto div = ttnn::register_operation_with_auto_launch_op<"ttnn::div", operations::binary::ExecuteDiv>();
-constexpr auto div_no_nan = ttnn::register_operation_with_auto_launch_op<
+constexpr auto remainder = ttnn::register_operation<"ttnn::remainder", operations::binary::ExecuteBinaryRemainder>();
+constexpr auto fmod = ttnn::register_operation<"ttnn::fmod", operations::binary::ExecuteBinaryFmod>();
+constexpr auto div = ttnn::register_operation<"ttnn::div", operations::binary::ExecuteDiv>();
+constexpr auto div_no_nan = ttnn::register_operation<
     "ttnn::div_no_nan",
     operations::binary::ExecuteDivLikeOps<operations::binary::BinaryCompositeOpType::DIV_NO_NAN>>();
-constexpr auto floor_div = ttnn::register_operation_with_auto_launch_op<
+constexpr auto floor_div = ttnn::register_operation<
     "ttnn::floor_div",
     operations::binary::ExecuteDivLikeOps<operations::binary::BinaryCompositeOpType::FLOOR_DIV>>();
-constexpr auto bias_gelu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto bias_gelu = ttnn::register_operation<
     "ttnn::bias_gelu",
     operations::binary::ExecuteBiasGelu<operations::binary::BinaryOpType::BIAS_GELU>>();
-constexpr auto scatter = ttnn::register_operation_with_auto_launch_op<
+constexpr auto scatter = ttnn::register_operation<
     "ttnn::scatter",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::SCATTER>>();
-constexpr auto outer = ttnn::register_operation_with_auto_launch_op<
+constexpr auto outer = ttnn::register_operation<
     "ttnn::outer",
     operations::binary::ExecuteBinaryCompositeOps<operations::binary::BinaryCompositeOpType::OUTER>>();
-constexpr auto polyval = ttnn::register_operation_with_auto_launch_op<
+constexpr auto polyval = ttnn::register_operation<
     "ttnn::polyval",
     operations::binary::ExecuteBinaryCompositeOpsPolyval<operations::binary::BinaryCompositeOpType::POLYVAL>>();
-constexpr auto gcd = ttnn::register_operation_with_auto_launch_op<"ttnn::gcd", operations::binary::ExecuteGCD>();
-constexpr auto lcm = ttnn::register_operation_with_auto_launch_op<"ttnn::lcm", operations::binary::ExecuteLCM>();
-constexpr auto prelu = ttnn::register_operation_with_auto_launch_op<"ttnn::prelu", operations::binary::ExecutePrelu>();
-constexpr auto rsub = ttnn::register_operation_with_auto_launch_op<"ttnn::rsub", operations::binary::ExecuteRsub>();
-constexpr auto bitwise_and =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::bitwise_and", operations::binary::ExecuteBitwiseAnd>();
-constexpr auto bitwise_or =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::bitwise_or", operations::binary::ExecuteBitwiseOr>();
-constexpr auto bitwise_xor =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::bitwise_xor", operations::binary::ExecuteBitwiseXor>();
-constexpr auto bitwise_left_shift = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::bitwise_left_shift", operations::binary::ExecuteBitwiseLeftShift>();
-constexpr auto bitwise_right_shift = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::bitwise_right_shift", operations::binary::ExecuteBitwiseRightShift>();
-constexpr auto pow = ttnn::register_operation_with_auto_launch_op<"ttnn::pow", operations::binary::ExecutePower>();
+constexpr auto gcd = ttnn::register_operation<"ttnn::gcd", operations::binary::ExecuteGCD>();
+constexpr auto lcm = ttnn::register_operation<"ttnn::lcm", operations::binary::ExecuteLCM>();
+constexpr auto prelu = ttnn::register_operation<"ttnn::prelu", operations::binary::ExecutePrelu>();
+constexpr auto rsub = ttnn::register_operation<"ttnn::rsub", operations::binary::ExecuteRsub>();
+constexpr auto bitwise_and = ttnn::register_operation<"ttnn::bitwise_and", operations::binary::ExecuteBitwiseAnd>();
+constexpr auto bitwise_or = ttnn::register_operation<"ttnn::bitwise_or", operations::binary::ExecuteBitwiseOr>();
+constexpr auto bitwise_xor = ttnn::register_operation<"ttnn::bitwise_xor", operations::binary::ExecuteBitwiseXor>();
+constexpr auto bitwise_left_shift =
+    ttnn::register_operation<"ttnn::bitwise_left_shift", operations::binary::ExecuteBitwiseLeftShift>();
+constexpr auto bitwise_right_shift =
+    ttnn::register_operation<"ttnn::bitwise_right_shift", operations::binary::ExecuteBitwiseRightShift>();
+constexpr auto pow = ttnn::register_operation<"ttnn::pow", operations::binary::ExecutePower>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.hpp
@@ -52,11 +52,8 @@ struct DequantOp {
 }  // namespace ttnn::operations::quantization
 
 namespace ttnn {
-constexpr auto quantize =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::quantize", operations::quantization::QuantOp>();
-constexpr auto requantize =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::requantize", operations::quantization::RequantOp>();
-constexpr auto dequantize =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::dequantize", operations::quantization::DequantOp>();
+constexpr auto quantize = ttnn::register_operation<"ttnn::quantize", operations::quantization::QuantOp>();
+constexpr auto requantize = ttnn::register_operation<"ttnn::requantize", operations::quantization::RequantOp>();
+constexpr auto dequantize = ttnn::register_operation<"ttnn::dequantize", operations::quantization::DequantOp>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_composite.hpp
@@ -68,16 +68,16 @@ struct ExecuteTernaryCompositeMac {
 }  // namespace ternary
 }  // namespace operations
 
-constexpr auto addcmul = ttnn::register_operation_with_auto_launch_op<
+constexpr auto addcmul = ttnn::register_operation<
     "ttnn::addcmul",
     operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCMUL>>();
-constexpr auto addcdiv = ttnn::register_operation_with_auto_launch_op<
+constexpr auto addcdiv = ttnn::register_operation<
     "ttnn::addcdiv",
     operations::ternary::ExecuteTernaryCompositeOps<operations::ternary::TernaryCompositeOpType::ADDCDIV>>();
-constexpr auto lerp = ttnn::register_operation_with_auto_launch_op<
+constexpr auto lerp = ttnn::register_operation<
     "ttnn::lerp",
     operations::ternary::ExecuteTernaryCompositeLerp<operations::ternary::TernaryCompositeOpType::LERP>>();
-constexpr auto mac = ttnn::register_operation_with_auto_launch_op<
+constexpr auto mac = ttnn::register_operation<
     "ttnn::mac",
     operations::ternary::ExecuteTernaryCompositeMac<operations::ternary::TernaryCompositeOpType::MAC>>();
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/where.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/where.hpp
@@ -88,7 +88,6 @@ struct WhereOperation {
 }  // namespace ternary
 }  // namespace operations
 
-constexpr auto where =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::where", operations::ternary::WhereOperation>();
+constexpr auto where = ttnn::register_operation<"ttnn::where", operations::ternary::WhereOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/tanh_accurate/tanh_accurate.hpp
@@ -24,6 +24,6 @@ struct Tanh_accurate {
 }  // namespace operations
 
 constexpr auto tanh_accurate =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::tanh_accurate", ttnn::operations::unary::Tanh_accurate>();
+    ttnn::register_operation<"ttnn::tanh_accurate", ttnn::operations::unary::Tanh_accurate>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.hpp
@@ -222,31 +222,31 @@ struct Tanh {
 }  // namespace unary
 }  // namespace operations
 
-#define REGISTER_UNARY_OPERATION(operation_name, operation_type)                  \
-    constexpr auto operation_name = ttnn::register_operation_with_auto_launch_op< \
-        "ttnn::" #operation_name,                                                 \
+#define REGISTER_UNARY_OPERATION(operation_name, operation_type) \
+    constexpr auto operation_name = ttnn::register_operation<    \
+        "ttnn::" #operation_name,                                \
         ttnn::operations::unary::ExecuteUnary<ttnn::operations::unary::UnaryOpType::operation_type>>();
 
 #define REGISTER_UNARY_OPERATION_WITH_FAST_AND_APPROXIMATE_MODE(operation_name, operation_type) \
-    constexpr auto operation_name = ttnn::register_operation_with_auto_launch_op<               \
+    constexpr auto operation_name = ttnn::register_operation<                                   \
         "ttnn::" #operation_name,                                                               \
         ttnn::operations::unary::ExecuteUnaryWithFastAndApproximateMode<                        \
             ttnn::operations::unary::UnaryOpType::operation_type>>();
 
 #define REGISTER_UNARY_OPERATION_WITH_VECTOR_AND_FAST_AND_APPROXIMATE_MODE(operation_name, operation_type) \
-    constexpr auto operation_name = ttnn::register_operation_with_auto_launch_op<                          \
+    constexpr auto operation_name = ttnn::register_operation<                                              \
         "ttnn::" #operation_name,                                                                          \
         ttnn::operations::unary::ExecuteUnaryWithVectorAndFastAndApproximateMode<                          \
             ttnn::operations::unary::UnaryOpType::operation_type>>();
 
 #define REGISTER_UNARY_OPERATION_WITH_FLOAT_PARAMETER(operation_name, operation_type) \
-    constexpr auto operation_name = ttnn::register_operation_with_auto_launch_op<     \
+    constexpr auto operation_name = ttnn::register_operation<                         \
         "ttnn::" #operation_name,                                                     \
         ttnn::operations::unary::ExecuteUnaryWithFloatParameter<                      \
             ttnn::operations::unary::UnaryOpType::operation_type>>();
 
 #define REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(operation_name, operation_type, data_type) \
-    constexpr auto operation_name = ttnn::register_operation_with_auto_launch_op<                  \
+    constexpr auto operation_name = ttnn::register_operation<                                      \
         "ttnn::" #operation_name,                                                                  \
         ttnn::operations::unary::                                                                  \
             ExecuteUnaryWithIntegerParameter<ttnn::operations::unary::UnaryOpType::operation_type, data_type>>();
@@ -318,40 +318,34 @@ REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(power, POWER, uint32_t);
 REGISTER_UNARY_OPERATION_WITH_INTEGER_PARAMETER(round, ROUND, int32_t);
 
 // Other unaries
-constexpr auto identity =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::identity", ttnn::operations::unary::Identity>();
-constexpr auto abs = ttnn::register_operation_with_auto_launch_op<"ttnn::abs", ttnn::operations::unary::Abs>();
-constexpr auto eqz = ttnn::register_operation_with_auto_launch_op<"ttnn::eqz", ttnn::operations::unary::Eqz>();
-constexpr auto floor =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::floor", ttnn::operations::unary::Floor>();
-constexpr auto ceil = ttnn::register_operation_with_auto_launch_op<"ttnn::ceil", ttnn::operations::unary::Ceil>();
-constexpr auto mish = ttnn::register_operation_with_auto_launch_op<"ttnn::mish", ttnn::operations::unary::Mish>();
-constexpr auto softplus =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::softplus", ttnn::operations::unary::Softplus>();
-constexpr auto tanh = ttnn::register_operation_with_auto_launch_op<"ttnn::tanh", ttnn::operations::unary::Tanh>();
-constexpr auto prelu_sfpu =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
+constexpr auto identity = ttnn::register_operation<"ttnn::identity", ttnn::operations::unary::Identity>();
+constexpr auto abs = ttnn::register_operation<"ttnn::abs", ttnn::operations::unary::Abs>();
+constexpr auto eqz = ttnn::register_operation<"ttnn::eqz", ttnn::operations::unary::Eqz>();
+constexpr auto floor = ttnn::register_operation<"ttnn::floor", ttnn::operations::unary::Floor>();
+constexpr auto ceil = ttnn::register_operation<"ttnn::ceil", ttnn::operations::unary::Ceil>();
+constexpr auto mish = ttnn::register_operation<"ttnn::mish", ttnn::operations::unary::Mish>();
+constexpr auto softplus = ttnn::register_operation<"ttnn::softplus", ttnn::operations::unary::Softplus>();
+constexpr auto tanh = ttnn::register_operation<"ttnn::tanh", ttnn::operations::unary::Tanh>();
+constexpr auto prelu_sfpu = ttnn::register_operation<"ttnn::prelu_sfpu", ttnn::operations::unary::Prelu>();
 
 constexpr auto sigmoid_accurate =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::sigmoid_accurate", ttnn::operations::unary::Sigmoid_accurate>();
-constexpr auto log_sigmoid =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::log_sigmoid", ttnn::operations::unary::LogSigmoid>();
-constexpr auto unary_chain =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::unary_chain", ttnn::operations::unary::Unary_chain>();
+    ttnn::register_operation<"ttnn::sigmoid_accurate", ttnn::operations::unary::Sigmoid_accurate>();
+constexpr auto log_sigmoid = ttnn::register_operation<"ttnn::log_sigmoid", ttnn::operations::unary::LogSigmoid>();
+constexpr auto unary_chain = ttnn::register_operation<"ttnn::unary_chain", ttnn::operations::unary::Unary_chain>();
 
-constexpr auto add_sfpu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto add_sfpu = ttnn::register_operation<
     "ttnn::add_sfpu",
     ttnn::operations::unary::SymmetricBinop<ttnn::operations::unary::UnaryOpType::ADD_UNARY_SFPU>>();
-constexpr auto mul_sfpu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto mul_sfpu = ttnn::register_operation<
     "ttnn::mul_sfpu",
     ttnn::operations::unary::SymmetricBinop<ttnn::operations::unary::UnaryOpType::MUL_UNARY_SFPU>>();
 
-constexpr auto sub_sfpu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto sub_sfpu = ttnn::register_operation<
     "ttnn::sub_sfpu",
     ttnn::operations::unary::AsymmetricBinop<
         ttnn::operations::unary::UnaryOpType::SUB_UNARY_SFPU,
         ttnn::operations::unary::UnaryOpType::RSUB>>();
-constexpr auto div_sfpu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto div_sfpu = ttnn::register_operation<
     "ttnn::div_sfpu",
     ttnn::operations::unary::AsymmetricBinop<
         ttnn::operations::unary::UnaryOpType::DIV_UNARY_SFPU,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_composite.hpp
@@ -166,123 +166,121 @@ auto transform_first_matching_arg(Lambda lambda, First&& first, Rest&&... rest) 
             original_shape);                                                                           \
     })
 
-constexpr auto rdiv = ttnn::register_operation_with_auto_launch_op<"ttnn::rdiv", operations::unary::ExecuteRdiv>();
+constexpr auto rdiv = ttnn::register_operation<"ttnn::rdiv", operations::unary::ExecuteRdiv>();
 
-constexpr auto tanhshrink = ttnn::register_operation_with_auto_launch_op<
+constexpr auto tanhshrink = ttnn::register_operation<
     "ttnn::tanhshrink",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::TANHSHRINK>>();
-constexpr auto deg2rad = ttnn::register_operation_with_auto_launch_op<
+constexpr auto deg2rad = ttnn::register_operation<
     "ttnn::deg2rad",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::DEG2RAD>>();
-constexpr auto rad2deg = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rad2deg = ttnn::register_operation<
     "ttnn::rad2deg",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::RAD2DEG>>();
-constexpr auto acosh = ttnn::register_operation_with_auto_launch_op<
+constexpr auto acosh = ttnn::register_operation<
     "ttnn::acosh",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ACOSH>>();
-constexpr auto asinh = ttnn::register_operation_with_auto_launch_op<
+constexpr auto asinh = ttnn::register_operation<
     "ttnn::asinh",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ASINH>>();
-constexpr auto atanh = ttnn::register_operation_with_auto_launch_op<
+constexpr auto atanh = ttnn::register_operation<
     "ttnn::atanh",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::ATANH>>();
-constexpr auto cbrt = ttnn::register_operation_with_auto_launch_op<
+constexpr auto cbrt = ttnn::register_operation<
     "ttnn::cbrt",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::CBRT>>();
-constexpr auto cosh = ttnn::register_operation_with_auto_launch_op<
+constexpr auto cosh = ttnn::register_operation<
     "ttnn::cosh",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::COSH>>();
-constexpr auto digamma = ttnn::register_operation_with_auto_launch_op<
+constexpr auto digamma = ttnn::register_operation<
     "ttnn::digamma",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::DIGAMMA>>();
-constexpr auto lgamma = ttnn::register_operation_with_auto_launch_op<
+constexpr auto lgamma = ttnn::register_operation<
     "ttnn::lgamma",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LGAMMA>>();
-constexpr auto multigammaln = ttnn::register_operation_with_auto_launch_op<
+constexpr auto multigammaln = ttnn::register_operation<
     "ttnn::multigammaln",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::MULTIGAMMALN>>();
-constexpr auto sinh = ttnn::register_operation_with_auto_launch_op<
+constexpr auto sinh = ttnn::register_operation<
     "ttnn::sinh",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SINH>>();
-constexpr auto softsign = ttnn::register_operation_with_auto_launch_op<
+constexpr auto softsign = ttnn::register_operation<
     "ttnn::softsign",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SOFTSIGN>>();
-constexpr auto swish = ttnn::register_operation_with_auto_launch_op<
+constexpr auto swish = ttnn::register_operation<
     "ttnn::swish",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::SWISH>>();
-constexpr auto trunc = ttnn::register_operation_with_auto_launch_op<"ttnn::trunc", operations::unary::ExecuteTrunc>();
-constexpr auto var_hw = ttnn::register_operation_with_auto_launch_op<
+constexpr auto trunc = ttnn::register_operation<"ttnn::trunc", operations::unary::ExecuteTrunc>();
+constexpr auto var_hw = ttnn::register_operation<
     "ttnn::var_hw",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::VAR_HW>>();
-constexpr auto std_hw = ttnn::register_operation_with_auto_launch_op<
+constexpr auto std_hw = ttnn::register_operation<
     "ttnn::std_hw",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::STD_HW>>();
-constexpr auto normalize_hw = ttnn::register_operation_with_auto_launch_op<
+constexpr auto normalize_hw = ttnn::register_operation<
     "ttnn::normalize_hw",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_HW>>();
 
-constexpr auto hardswish = ttnn::register_operation_with_auto_launch_op<
+constexpr auto hardswish = ttnn::register_operation<
     "ttnn::hardswish",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::HARDSWISH>>();
-constexpr auto hardsigmoid = ttnn::register_operation_with_auto_launch_op<
+constexpr auto hardsigmoid = ttnn::register_operation<
     "ttnn::hardsigmoid",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::HARDSIGMOID>>();
 
-constexpr auto hardtanh = ttnn::register_operation_with_auto_launch_op<
+constexpr auto hardtanh = ttnn::register_operation<
     "ttnn::hardtanh",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::HARDTANH>>();
-constexpr auto clip =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::clip", operations::unary::ExecuteUnaryCompositeClip>();
-constexpr auto clamp =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::clamp", operations::unary::ExecuteUnaryCompositeClamp>();
-constexpr auto selu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto clip = ttnn::register_operation<"ttnn::clip", operations::unary::ExecuteUnaryCompositeClip>();
+constexpr auto clamp = ttnn::register_operation<"ttnn::clamp", operations::unary::ExecuteUnaryCompositeClamp>();
+constexpr auto selu = ttnn::register_operation<
     "ttnn::selu",
     operations::unary::ExecuteUnaryCompositeOpWithFloats<operations::unary::UnaryCompositeOpType::SELU>>();
-constexpr auto threshold = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::threshold", operations::unary::ExecuteUnaryCompositeThreshold>();
-constexpr auto glu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto threshold =
+    ttnn::register_operation<"ttnn::threshold", operations::unary::ExecuteUnaryCompositeThreshold>();
+constexpr auto glu = ttnn::register_operation<
     "ttnn::glu",
     operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::GLU>>();
-constexpr auto reglu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto reglu = ttnn::register_operation<
     "ttnn::reglu",
     operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::REGLU>>();
-constexpr auto geglu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto geglu = ttnn::register_operation<
     "ttnn::geglu",
     operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::GEGLU>>();
-constexpr auto swiglu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto swiglu = ttnn::register_operation<
     "ttnn::swiglu",
     operations::unary::ExecuteUnaryCompositeOpWithDim<operations::unary::UnaryCompositeOpType::SWIGLU>>();
-constexpr auto hardshrink = ttnn::register_operation_with_auto_launch_op<
+constexpr auto hardshrink = ttnn::register_operation<
     "ttnn::hardshrink",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::HARDSHRINK>>();
-constexpr auto logical_not_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logical_not_ = ttnn::register_operation<
     "ttnn::logical_not_",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::LOGICAL_NOT_>>();
-constexpr auto softshrink = ttnn::register_operation_with_auto_launch_op<
+constexpr auto softshrink = ttnn::register_operation<
     "ttnn::softshrink",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::SOFTSHRINK>>();
-constexpr auto logit = ttnn::register_operation_with_auto_launch_op<
+constexpr auto logit = ttnn::register_operation<
     "ttnn::logit",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::LOGIT>>();
-constexpr auto celu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto celu = ttnn::register_operation<
     "ttnn::celu",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::CELU>>();
-constexpr auto tril = ttnn::register_operation_with_auto_launch_op<
+constexpr auto tril = ttnn::register_operation<
     "ttnn::tril",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::TRIL>>();
-constexpr auto triu = ttnn::register_operation_with_auto_launch_op<
+constexpr auto triu = ttnn::register_operation<
     "ttnn::triu",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::TRIU>>();
-constexpr auto polygamma = ttnn::register_operation_with_auto_launch_op<
+constexpr auto polygamma = ttnn::register_operation<
     "ttnn::polygamma",
     operations::unary::ExecuteUnaryCompositeOpWithInt<operations::unary::UnaryCompositeOpType::POLYGAMMA>>();
-constexpr auto rpow = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rpow = ttnn::register_operation<
     "ttnn::rpow",
     operations::unary::ExecuteUnaryCompositeOpWithFloat<operations::unary::UnaryCompositeOpType::RPOW>>();
-constexpr auto normalize_global = ttnn::register_operation_with_auto_launch_op<
+constexpr auto normalize_global = ttnn::register_operation<
     "ttnn::normalize_global",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::NORMALIZE_GLOBAL>>();
-constexpr auto frac = ttnn::register_operation_with_auto_launch_op<
+constexpr auto frac = ttnn::register_operation<
     "ttnn::frac",
     operations::unary::ExecuteUnaryCompositeOp<operations::unary::UnaryCompositeOpType::FRAC>>();
 

--- a/ttnn/cpp/ttnn/operations/embedding/embedding.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/embedding.hpp
@@ -39,6 +39,6 @@ struct EmbeddingOperation {
 }  // namespace operations
 
 constexpr auto embedding =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::embedding", ttnn::operations::embedding::EmbeddingOperation>();
+    ttnn::register_operation<"ttnn::embedding", ttnn::operations::embedding::EmbeddingOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.hpp
@@ -34,8 +34,7 @@ struct EmbeddingBackwardOperation {
 }  // namespace embedding_backward
 }  // namespace operations
 
-constexpr auto embedding_bw = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::embedding_bw",
-    ttnn::operations::embedding_backward::EmbeddingBackwardOperation>();
+constexpr auto embedding_bw =
+    ttnn::register_operation<"ttnn::embedding_bw", ttnn::operations::embedding_backward::EmbeddingBackwardOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.cpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.cpp
@@ -14,11 +14,4 @@ std::vector<std::optional<Tensor>> CompositeExampleMutipleReturnOperation::invok
     return prim::example_multiple_return(input_tensor, return_output1, return_output2);
 }
 
-OptionalTensors CompositeExampleMutipleReturnOperation::create_async_optional_output_tensors(
-    const Tensor& input_tensor, bool return_output1, bool return_output2) {
-    return {
-        return_output1 ? std::optional<Tensor>(operation::get_workers_for_op_output({input_tensor})) : std::nullopt,
-        return_output2 ? std::optional<Tensor>(operation::get_workers_for_op_output({input_tensor})) : std::nullopt};
-}
-
 }  // namespace ttnn::operations::examples

--- a/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.hpp
+++ b/ttnn/cpp/ttnn/operations/examples/example_multiple_return/example_multiple_return.hpp
@@ -16,15 +16,12 @@ struct CompositeExampleMutipleReturnOperation {
     // is registered
     static std::vector<std::optional<Tensor>> invoke(
         const Tensor& input_tensor, bool return_output1, bool return_output2);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& input_tensor, bool return_output1, bool return_output2);
 };
 
 }  // namespace ttnn::operations::examples
 
 namespace ttnn {
-constexpr auto composite_example_multiple_return = ttnn::register_operation_with_auto_launch_op<
+constexpr auto composite_example_multiple_return = ttnn::register_operation<
     "ttnn::composite_example_multiple_return",
     operations::examples::CompositeExampleMutipleReturnOperation>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/bcast_to/bcast_to.hpp
@@ -18,7 +18,6 @@ struct BcastTo {
 }  // namespace ttnn::operations::experimental
 
 namespace ttnn::experimental {
-constexpr auto broadcast_to = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::broadcast_to",
-    ttnn::operations::experimental::BcastTo>();
+constexpr auto broadcast_to =
+    ttnn::register_operation<"ttnn::experimental::broadcast_to", ttnn::operations::experimental::BcastTo>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.hpp
@@ -21,7 +21,7 @@ struct ExecuteConvertToCHW {
 
 namespace ttnn::experimental {
 
-constexpr auto convert_to_chw = ttnn::register_operation_with_auto_launch_op<
+constexpr auto convert_to_chw = ttnn::register_operation<
     "ttnn::experimental::convert_to_chw",
     ttnn::operations::experimental::cnn::ExecuteConvertToCHW>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.hpp
@@ -29,8 +29,6 @@ struct ExecuteConv3d {
 }  // namespace ttnn::operations::experimental::conv3d
 
 namespace ttnn::experimental {
-constexpr auto conv3d = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::conv3d",
-    ttnn::operations::experimental::conv3d::ExecuteConv3d>();
-
+constexpr auto conv3d =
+    ttnn::register_operation<"ttnn::experimental::conv3d", ttnn::operations::experimental::conv3d::ExecuteConv3d>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/copy/typecast/typecast.hpp
@@ -28,8 +28,7 @@ struct TypecastOperation {
 }  // namespace operations::experimental::copy
 
 namespace experimental {
-constexpr auto typecast = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::typecast",
-    ttnn::operations::experimental::copy::TypecastOperation>();
+constexpr auto typecast =
+    ttnn::register_operation<"ttnn::experimental::typecast", ttnn::operations::experimental::copy::TypecastOperation>();
 }  // namespace experimental
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/dropout.hpp
@@ -16,7 +16,6 @@ struct DropoutOperation {
 };
 }  // namespace ttnn::operations::experimental
 namespace ttnn::experimental {
-constexpr auto dropout = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::dropout",
-    ttnn::operations::experimental::DropoutOperation>();
+constexpr auto dropout =
+    ttnn::register_operation<"ttnn::experimental::dropout", ttnn::operations::experimental::DropoutOperation>();
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.hpp
@@ -62,11 +62,11 @@ struct AttnMatmulFromCacheOperation {
 
 namespace experimental {
 
-constexpr auto attn_matmul = ttnn::register_operation_with_auto_launch_op<
+constexpr auto attn_matmul = ttnn::register_operation<
     "ttnn::experimental::attn_matmul",
     ttnn::operations::experimental::matmul::AttnMatmulOperation>();
 
-constexpr auto attn_matmul_from_cache = ttnn::register_operation_with_auto_launch_op<
+constexpr auto attn_matmul_from_cache = ttnn::register_operation<
     "ttnn::experimental::attn_matmul_from_cache",
     ttnn::operations::experimental::matmul::AttnMatmulFromCacheOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/group_attn_matmul.hpp
@@ -37,7 +37,7 @@ struct GroupAttnMatmulOperation {
 
 namespace experimental {
 
-constexpr auto group_attn_matmul = ttnn::register_operation_with_auto_launch_op<
+constexpr auto group_attn_matmul = ttnn::register_operation<
     "ttnn::experimental::group_attn_matmul",
     ttnn::operations::experimental::matmul::GroupAttnMatmulOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache.hpp
@@ -49,15 +49,15 @@ struct PagedFillCacheOperation {
 
 namespace experimental {
 
-constexpr auto paged_update_cache = ttnn::register_operation_with_auto_launch_op<
+constexpr auto paged_update_cache = ttnn::register_operation<
     "ttnn::experimental::paged_update_cache",
     ttnn::operations::experimental::paged_cache::PagedUpdateCacheOperation>();
 
-constexpr auto paged_fused_update_cache = ttnn::register_operation_with_auto_launch_op<
+constexpr auto paged_fused_update_cache = ttnn::register_operation<
     "ttnn::experimental::paged_fused_update_cache",
     ttnn::operations::experimental::paged_cache::PagedFusedUpdateCacheOperation>();
 
-constexpr auto paged_fill_cache = ttnn::register_operation_with_auto_launch_op<
+constexpr auto paged_fill_cache = ttnn::register_operation<
     "ttnn::experimental::paged_fill_cache",
     ttnn::operations::experimental::paged_cache::PagedFillCacheOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/plusone.hpp
@@ -19,6 +19,6 @@ struct PlusOneOperation {
 }  // namespace operations::experimental
 
 constexpr auto plus_one =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::plus_one", ttnn::operations::experimental::PlusOneOperation>();
+    ttnn::register_operation<"ttnn::plus_one", ttnn::operations::experimental::PlusOneOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.cpp
@@ -27,140 +27,128 @@ Tensor create_mask(const Tensor& input_a, const std::optional<MemoryConfig>& out
 }
 // Argmax returns the index of maximum element in the tensor
 Tensor ArgmaxOperation::invoke(
-    const Tensor& input_t, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config) {
-    auto output_memory_config = output_mem_config.value_or(input_t.memory_config());
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_t}))};
-    tt::tt_metal::operation::launch_op(
-        [_dim, all, output_memory_config](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            const auto& input = input_tensors.at(0);
-            auto input_shape = input.get_padded_shape();
-            TT_FATAL(input_shape.rank() == 4, "supported for rank-4 tensors at this time");
+    const Tensor& input, int64_t _dim, bool all, const std::optional<MemoryConfig>& output_mem_config) {
+    auto output_memory_config = output_mem_config.value_or(input.memory_config());
+    auto input_shape = input.get_padded_shape();
+    TT_FATAL(input_shape.rank() == 4, "supported for rank-4 tensors at this time");
 
-            Tensor input_a = create_mask(input, output_memory_config);
+    Tensor input_a = create_mask(input, output_memory_config);
 
-            uint32_t dim = input_shape.get_normalized_index(_dim);
-            int size = input_a.volume();
+    uint32_t dim = input_shape.get_normalized_index(_dim);
+    int size = input_a.volume();
 
-            if (!all) {
-                if ((dim == (input_shape.rank() - 1)) || (dim == (input_shape.rank() - 2))) {
-                    bool is_width = (dim == (input_shape.rank() - 1));
-                    Tensor max_val = ttnn::max(input_a, (int)dim, true, output_memory_config);
-                    Tensor max_tensor = ttnn::zeros_like(input_a);
-                    Tensor tindex = ttnn::index_width<::bfloat16>(
-                        input.get_logical_shape(),
-                        input.get_padded_shape(),
-                        DataType::BFLOAT16,
-                        Layout::TILE,
-                        input_a.device(),
-                        output_memory_config);
-                    if (is_width) {
-                        max_tensor = ttnn::add(max_tensor, max_val, std::nullopt, output_memory_config);
-                    } else {
-                        tindex = ttnn::index_height<::bfloat16>(
-                            input.get_logical_shape(),
-                            input.get_padded_shape(),
-                            DataType::BFLOAT16,
-                            Layout::TILE,
-                            input_a.device(),
-                            output_memory_config);
-                        max_tensor = ttnn::add(max_tensor, max_val, std::nullopt, output_memory_config);
-                    }
-                    tindex = tindex.to_device(input_a.device());
-                    max_val.deallocate();
-                    Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
-                    Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
-                    cmp_results.deallocate();
-                    Tensor result = ttnn::where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
-                    max_indices.deallocate();
-                    result = ttnn::min(result, (int)dim, true, output_memory_config);
-                    Tensor res_index = ttnn::zeros_like(result);
-                    result = ttnn::where(ttnn::eq(result, size), res_index, result, output_memory_config);
-                    ttnn::SmallVector<int64_t> permute_dims = {3, 0, 1, 2};
-                    if (is_width) {
-                        res_index = ttnn::add(res_index, result, std::nullopt, output_memory_config);
-                    } else {
-                        res_index = ttnn::add(res_index, result, std::nullopt, output_memory_config);
-                        permute_dims[0] = 2;
-                        permute_dims[3] = 3;
-                    }
-                    result.deallocate();
-                    Tensor transpose_res = ttnn::permute(res_index, permute_dims, output_memory_config);
-                    return {transpose_res};
-                } else if ((dim == (input_shape.rank() - 3)) || (dim == (input_shape.rank() - 4))) {
-                    bool is_channel = (dim == (input_shape.rank() - 3));
-                    Tensor max_val = ttnn::max(input_a, (int)dim, true, output_memory_config);
-                    int repeat = input.get_logical_shape()[dim];
-                    std::vector<Tensor> combined_tensors;
-                    for (int cid = 0; cid < repeat; cid++) {
-                        combined_tensors.emplace_back(max_val);
-                    }
-                    max_val.deallocate();
-                    Tensor concat_out = ttnn::concat(combined_tensors, dim, output_memory_config);
-                    // Needed till `max` stops autoformatting output
-                    concat_out = ttnn::reshape(concat_out, input_a.get_logical_shape());
-                    Tensor cmp_results = ttnn::eq(input_a, concat_out, std::nullopt, output_memory_config);
-                    concat_out.deallocate();
-                    Tensor tindex = ttnn::index_channel<::bfloat16>(
-                        input.get_logical_shape(),
-                        input.get_padded_shape(),
-                        DataType::BFLOAT16,
-                        Layout::TILE,
-                        input_a.device(),
-                        output_memory_config);
-                    if (!is_channel) {
-                        tindex = ttnn::index_batch<::bfloat16>(
-                            input.get_logical_shape(),
-                            input.get_padded_shape(),
-                            DataType::BFLOAT16,
-                            Layout::TILE,
-                            input_a.device(),
-                            output_memory_config);
-                    }
-                    tindex = tindex.to_device(input_a.device());
-                    Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
-                    cmp_results.deallocate();
-                    Tensor midx = full_like(max_indices, size);
-                    Tensor result = ttnn::where(ttnn::eqz(max_indices), midx, max_indices, output_memory_config);
-                    result = ttnn::min(result, (int)dim, true, output_memory_config);
-                    Tensor res_index = ttnn::zeros_like(result);
-                    result =
-                        ttnn::where(ttnn::eq(result, full_like(result, size)), res_index, result, output_memory_config);
-                    if (is_channel) {
-                        ttnn::SmallVector<int64_t> permute_dims = {1, 0, 2, 3};
-                        Tensor transpose_res = ttnn::permute(result, permute_dims, output_memory_config);
-                        return {transpose_res};
-                    } else {
-                        return {result};
-                    }
-                }
-            }
-            // TODO: Fix the index generation code. With the fix the code will work for argmax that return entire
-            // maximum value index
-            Tensor tindex = ttnn::index_all<::bfloat16>(
+    if (!all) {
+        if ((dim == (input_shape.rank() - 1)) || (dim == (input_shape.rank() - 2))) {
+            bool is_width = (dim == (input_shape.rank() - 1));
+            Tensor max_val = ttnn::max(input_a, (int)dim, true, output_memory_config);
+            Tensor max_tensor = ttnn::zeros_like(input_a);
+            Tensor tindex = ttnn::index_width<::bfloat16>(
                 input.get_logical_shape(),
                 input.get_padded_shape(),
                 DataType::BFLOAT16,
                 Layout::TILE,
                 input_a.device(),
                 output_memory_config);
-            Tensor max_val = ttnn::max(input_a, std::nullopt, true, output_memory_config);
-            Tensor max_tensor = ttnn::zeros_like(input_a);
-            max_tensor = ttnn::add(max_tensor, max_val, std::nullopt, output_memory_config);
+            if (is_width) {
+                max_tensor = ttnn::add(max_tensor, max_val, std::nullopt, output_memory_config);
+            } else {
+                tindex = ttnn::index_height<::bfloat16>(
+                    input.get_logical_shape(),
+                    input.get_padded_shape(),
+                    DataType::BFLOAT16,
+                    Layout::TILE,
+                    input_a.device(),
+                    output_memory_config);
+                max_tensor = ttnn::add(max_tensor, max_val, std::nullopt, output_memory_config);
+            }
+            tindex = tindex.to_device(input_a.device());
             max_val.deallocate();
             Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
             Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
             cmp_results.deallocate();
             Tensor result = ttnn::where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
             max_indices.deallocate();
-            result = ttnn::min(result, std::nullopt, true, output_memory_config);
-            return {result};
-        },
-        {input_t},
-        output_tensors);
-    return output_tensors[0];
+            result = ttnn::min(result, (int)dim, true, output_memory_config);
+            Tensor res_index = ttnn::zeros_like(result);
+            result = ttnn::where(ttnn::eq(result, size), res_index, result, output_memory_config);
+            ttnn::SmallVector<int64_t> permute_dims = {3, 0, 1, 2};
+            if (is_width) {
+                res_index = ttnn::add(res_index, result, std::nullopt, output_memory_config);
+            } else {
+                res_index = ttnn::add(res_index, result, std::nullopt, output_memory_config);
+                permute_dims[0] = 2;
+                permute_dims[3] = 3;
+            }
+            result.deallocate();
+            Tensor transpose_res = ttnn::permute(res_index, permute_dims, output_memory_config);
+            return transpose_res;
+        } else if ((dim == (input_shape.rank() - 3)) || (dim == (input_shape.rank() - 4))) {
+            bool is_channel = (dim == (input_shape.rank() - 3));
+            Tensor max_val = ttnn::max(input_a, (int)dim, true, output_memory_config);
+            int repeat = input.get_logical_shape()[dim];
+            std::vector<Tensor> combined_tensors;
+            for (int cid = 0; cid < repeat; cid++) {
+                combined_tensors.emplace_back(max_val);
+            }
+            max_val.deallocate();
+            Tensor concat_out = ttnn::concat(combined_tensors, dim, output_memory_config);
+            // Needed till `max` stops autoformatting output
+            concat_out = ttnn::reshape(concat_out, input_a.get_logical_shape());
+            Tensor cmp_results = ttnn::eq(input_a, concat_out, std::nullopt, output_memory_config);
+            concat_out.deallocate();
+            Tensor tindex = ttnn::index_channel<::bfloat16>(
+                input.get_logical_shape(),
+                input.get_padded_shape(),
+                DataType::BFLOAT16,
+                Layout::TILE,
+                input_a.device(),
+                output_memory_config);
+            if (!is_channel) {
+                tindex = ttnn::index_batch<::bfloat16>(
+                    input.get_logical_shape(),
+                    input.get_padded_shape(),
+                    DataType::BFLOAT16,
+                    Layout::TILE,
+                    input_a.device(),
+                    output_memory_config);
+            }
+            tindex = tindex.to_device(input_a.device());
+            Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
+            cmp_results.deallocate();
+            Tensor midx = full_like(max_indices, size);
+            Tensor result = ttnn::where(ttnn::eqz(max_indices), midx, max_indices, output_memory_config);
+            result = ttnn::min(result, (int)dim, true, output_memory_config);
+            Tensor res_index = ttnn::zeros_like(result);
+            result = ttnn::where(ttnn::eq(result, full_like(result, size)), res_index, result, output_memory_config);
+            if (is_channel) {
+                ttnn::SmallVector<int64_t> permute_dims = {1, 0, 2, 3};
+                Tensor transpose_res = ttnn::permute(result, permute_dims, output_memory_config);
+                return transpose_res;
+            } else {
+                return result;
+            }
+        }
+    }
+    // TODO: Fix the index generation code. With the fix the code will work for argmax that return entire
+    // maximum value index
+    Tensor tindex = ttnn::index_all<::bfloat16>(
+        input.get_logical_shape(),
+        input.get_padded_shape(),
+        DataType::BFLOAT16,
+        Layout::TILE,
+        input_a.device(),
+        output_memory_config);
+    Tensor max_val = ttnn::max(input_a, std::nullopt, true, output_memory_config);
+    Tensor max_tensor = ttnn::zeros_like(input_a);
+    max_tensor = ttnn::add(max_tensor, max_val, std::nullopt, output_memory_config);
+    max_val.deallocate();
+    Tensor cmp_results = ttnn::eq(input_a, max_tensor, std::nullopt, output_memory_config);
+    Tensor max_indices = ttnn::multiply(cmp_results, tindex, std::nullopt, output_memory_config);
+    cmp_results.deallocate();
+    Tensor result = ttnn::where(ttnn::eqz(max_indices), size, max_indices, output_memory_config);
+    max_indices.deallocate();
+    result = ttnn::min(result, std::nullopt, true, output_memory_config);
+    return result;
 }
 
 Tensor ArgminOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/argmax/argmax.hpp
@@ -32,13 +32,11 @@ struct ArgminOperation {
 
 namespace experimental {
 
-constexpr auto argmax = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::argmax",
-    ttnn::operations::experimental::reduction::ArgmaxOperation>();
+constexpr auto argmax = ttnn::
+    register_operation<"ttnn::experimental::argmax", ttnn::operations::experimental::reduction::ArgmaxOperation>();
 
-constexpr auto argmin = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::argmin",
-    ttnn::operations::experimental::reduction::ArgminOperation>();
+constexpr auto argmin = ttnn::
+    register_operation<"ttnn::experimental::argmin", ttnn::operations::experimental::reduction::ArgminOperation>();
 
 }  // namespace experimental
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/cumprod/cumprod.hpp
@@ -22,9 +22,8 @@ struct CumprodOperation {
 }  // namespace operations::experimental::reduction
 
 namespace experimental {
-constexpr auto cumprod = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::cumprod",
-    ttnn::operations::experimental::reduction::CumprodOperation>();
+constexpr auto cumprod = ttnn::
+    register_operation<"ttnn::experimental::cumprod", ttnn::operations::experimental::reduction::CumprodOperation>();
 
 }  // namespace experimental
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/device/fast_reduce_nc_device_operation.cpp
@@ -19,31 +19,18 @@ Tensor _fast_reduce_nc(
     const std::optional<const ttnn::Tensor>& output,
     const MemoryConfig& output_mem_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input}))};
-
     TT_FATAL(input.storage_type() == StorageType::DEVICE, "Error");
     auto kernel_config_val =
         init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, MathFidelity::HiFi4);
 
-    operation::launch_op(
-        [dim, output_mem_config, kernel_config_val, queue_id](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            return operation::run(
-                FastReduceNCDeviceOperation{
-                    .dim = dim, .output_mem_config = output_mem_config, .compute_kernel_config = kernel_config_val},
-                input_tensors,
-                optional_input_tensors,
-                optional_output_tensors,
-                queue_id);
-        },
-        {input},
-        output_tensors,
-        {},
-        {output});
-
-    return output_tensors.at(0);
+    return operation::run(
+               FastReduceNCDeviceOperation{
+                   .dim = dim, .output_mem_config = output_mem_config, .compute_kernel_config = kernel_config_val},
+               {input},
+               {},
+               {output},
+               queue_id)
+        .at(0);
 }
 
 void FastReduceNCDeviceOperation::validate_with_output_tensors(

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/fast_reduce_nc/fast_reduce_nc.hpp
@@ -26,7 +26,7 @@ struct FastReduceNCOperation {
 
 namespace experimental::reduction {
 
-constexpr auto fast_reduce_nc = ttnn::register_operation_with_auto_launch_op<
+constexpr auto fast_reduce_nc = ttnn::register_operation<
     "ttnn::experimental::fast_reduce_nc",
     ttnn::operations::experimental::reduction::FastReduceNCOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.cpp
@@ -188,12 +188,4 @@ std::vector<Tensor> ExecuteSort::invoke(
         input_tensor, sorted_tensors, dim, is_dim_last_idx, original_lshape, memory_config_value);
 }
 
-std::vector<Tensor> ExecuteSort::create_async_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-    const auto& input_tensor = input_tensors.at(0);
-    return {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor})),
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-}
-
 }  // namespace ttnn::operations::experimental::reduction::sort

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/sort.hpp
@@ -19,17 +19,13 @@ struct ExecuteSort {
         const bool stable,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
-
-    static std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
 };
 
 }  // namespace ttnn::operations::experimental::reduction::sort
 
 namespace ttnn::experimental {
 
-constexpr auto sort = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::sort",
-    ttnn::operations::experimental::reduction::sort::ExecuteSort>();
+constexpr auto sort = ttnn::
+    register_operation<"ttnn::experimental::sort", ttnn::operations::experimental::reduction::sort::ExecuteSort>();
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.hpp
@@ -20,8 +20,7 @@ struct ViewOperation {
 }  // namespace operations::experimental::reshape
 
 namespace experimental {
-constexpr auto view = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::view",
-    ttnn::operations::experimental::reshape::ViewOperation>();
+constexpr auto view =
+    ttnn::register_operation<"ttnn::experimental::view", ttnn::operations::experimental::reshape::ViewOperation>();
 }  // namespace experimental
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.hpp
@@ -26,6 +26,6 @@ struct SliceWriteOperation {
 }  // namespace ttnn
 
 namespace ttnn::experimental {
-constexpr auto slice_write = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::slice_write", ttnn::operations::experimental::SliceWriteOperation>();
+constexpr auto slice_write =
+    ttnn::register_operation<"ttnn::slice_write", ttnn::operations::experimental::SliceWriteOperation>();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/hc_sum_reduce/hc_sum_reduce.hpp
@@ -22,8 +22,7 @@ struct ExecuteHCSumReduce {
 
 namespace ttnn::experimental {
 
-constexpr auto hc_sum_reduce = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::hc_sum_reduce",
-    ttnn::operations::experimental::ssm::ExecuteHCSumReduce>();
+constexpr auto hc_sum_reduce = ttnn::
+    register_operation<"ttnn::experimental::hc_sum_reduce", ttnn::operations::experimental::ssm::ExecuteHCSumReduce>();
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/prefix_scan.hpp
@@ -24,8 +24,7 @@ struct ExecutePrefixScan {
 
 namespace ttnn::experimental {
 
-constexpr auto prefix_scan = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::prefix_scan",
-    ttnn::operations::experimental::ssm::ExecutePrefixScan>();
+constexpr auto prefix_scan = ttnn::
+    register_operation<"ttnn::experimental::prefix_scan", ttnn::operations::experimental::ssm::ExecutePrefixScan>();
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/repeat_and_interleave_eltwise_mul/repeat_and_interleave_eltwise_mul.hpp
@@ -24,7 +24,7 @@ struct ExecuteRepeatAndInterleaveEltwiseMul {
 
 namespace ttnn::experimental {
 
-constexpr auto repeat_and_interleave_eltwise_mul = ttnn::register_operation_with_auto_launch_op<
+constexpr auto repeat_and_interleave_eltwise_mul = ttnn::register_operation<
     "ttnn::experimental::repeat_and_interleave_eltwise_mul",
     ttnn::operations::experimental::ssm::ExecuteRepeatAndInterleaveEltwiseMul>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/concatenate_heads.hpp
@@ -42,7 +42,7 @@ struct ConcatenateHeadsOperation {
 
 namespace experimental {
 
-constexpr auto concatenate_heads = ttnn::register_operation_with_auto_launch_op<
+constexpr auto concatenate_heads = ttnn::register_operation<
     "ttnn::experimental::concatenate_heads",
     ttnn::operations::experimental::transformer::ConcatenateHeadsOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads/create_qkv_heads.hpp
@@ -33,7 +33,7 @@ struct CreateQKVHeadsOperation {
 
 namespace experimental {
 
-constexpr auto create_qkv_heads = ttnn::register_operation_with_auto_launch_op<
+constexpr auto create_qkv_heads = ttnn::register_operation<
     "ttnn::experimental::create_qkv_heads",
     ttnn::operations::experimental::transformer::CreateQKVHeadsOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/create_qkv_heads_from_separate_tensors.hpp
@@ -35,7 +35,7 @@ struct CreateQKVHeadsSeparateTensorsOperation {
 
 namespace experimental {
 
-constexpr auto create_qkv_heads_from_separate_tensors = ttnn::register_operation_with_auto_launch_op<
+constexpr auto create_qkv_heads_from_separate_tensors = ttnn::register_operation<
     "ttnn::experimental::create_qkv_heads_from_separate_tensors",
     ttnn::operations::experimental::transformer::CreateQKVHeadsSeparateTensorsOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/nlp_concat_heads.hpp
@@ -25,7 +25,7 @@ struct NLPConcatHeadsOperation {
 
 namespace experimental {
 
-constexpr auto nlp_concat_heads = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_concat_heads = ttnn::register_operation<
     "ttnn::experimental::nlp_concat_heads",
     ttnn::operations::experimental::transformer::NLPConcatHeadsOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads_decode/nlp_concat_heads_decode.hpp
@@ -27,7 +27,7 @@ struct NLPConcatHeadsDecodeOperation {
 
 namespace experimental {
 
-constexpr auto nlp_concat_heads_decode = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_concat_heads_decode = ttnn::register_operation<
     "ttnn::experimental::nlp_concat_heads_decode",
     ttnn::operations::experimental::transformer::NLPConcatHeadsDecodeOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/nlp_create_qkv_heads.hpp
@@ -35,7 +35,7 @@ struct NlpCreateHeadsOperation {
 
 namespace experimental {
 
-constexpr auto nlp_create_qkv_heads = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_create_qkv_heads = ttnn::register_operation<
     "ttnn::experimental::nlp_create_qkv_heads",
     ttnn::operations::experimental::transformer::NlpCreateHeadsOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/nlp_create_qkv_heads_decode.hpp
@@ -37,7 +37,7 @@ struct NLPCreateHeadsDecodeOperation {
 
 namespace experimental {
 
-constexpr auto nlp_create_qkv_heads_decode = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_create_qkv_heads_decode = ttnn::register_operation<
     "ttnn::experimental::nlp_create_qkv_heads_decode",
     ttnn::operations::experimental::transformer::NLPCreateHeadsDecodeOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_falcon7b/nlp_create_qkv_heads_falcon7b.hpp
@@ -27,7 +27,7 @@ struct NLPCreateHeadsFalcon7bOperation {
 
 namespace experimental {
 
-constexpr auto nlp_create_qkv_heads_falcon7b = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_create_qkv_heads_falcon7b = ttnn::register_operation<
     "ttnn::experimental::nlp_create_qkv_heads_falcon7b",
     ttnn::operations::experimental::transformer::NLPCreateHeadsFalcon7bOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_segformer/nlp_create_qkv_heads_segformer.hpp
@@ -27,7 +27,7 @@ struct NLPCreateHeadsSegformerOperation {
 
 namespace experimental {
 
-constexpr auto nlp_create_qkv_heads_segformer = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_create_qkv_heads_segformer = ttnn::register_operation<
     "ttnn::experimental::nlp_create_qkv_heads_segformer",
     ttnn::operations::experimental::transformer::NLPCreateHeadsSegformerOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_vit/nlp_create_qkv_heads_vit.hpp
@@ -27,7 +27,7 @@ struct NLPCreateHeadsVitOperation {
 
 namespace experimental {
 
-constexpr auto nlp_create_qkv_heads_vit = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_create_qkv_heads_vit = ttnn::register_operation<
     "ttnn::experimental::nlp_create_qkv_heads_vit",
     ttnn::operations::experimental::transformer::NLPCreateHeadsVitOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_kv_cache_load_slice/nlp_kv_cache_load_slice.hpp
@@ -29,7 +29,7 @@ struct NLPKVCacheLoadSliceOperation {
 
 namespace experimental {
 
-constexpr auto nlp_kv_cache_load_slice = ttnn::register_operation_with_auto_launch_op<
+constexpr auto nlp_kv_cache_load_slice = ttnn::register_operation<
     "ttnn::experimental::nlp_kv_cache_load_slice",
     ttnn::operations::experimental::transformer::NLPKVCacheLoadSliceOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/rotary_embedding.hpp
@@ -25,7 +25,7 @@ struct RotaryEmbeddingOperation {
 
 namespace experimental {
 
-constexpr auto rotary_embedding = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rotary_embedding = ttnn::register_operation<
     "ttnn::experimental::rotary_embedding",
     ttnn::operations::experimental::transformer::RotaryEmbeddingOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.cpp
@@ -16,34 +16,22 @@ Tensor RotaryEmbeddingLlamaOperation::invoke(
     const bool is_decode_mode,
     const std::optional<MemoryConfig>& memory_config,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    std::vector<Tensor> output_tensors = {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor, cos_cache, sin_cache, trans_mat}))};
-    tt::tt_metal::operation::launch_op(
-        [is_decode_mode, memory_config, compute_kernel_config](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& input_tensor = input_tensors.at(0);
+    auto arch = input_tensor.storage_type() == StorageType::DEVICE
+                    ? input_tensor.device()->arch()
+                    : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto kernel_config_val =
+        init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
 
-            auto arch = input_tensor.storage_type() == StorageType::DEVICE
-                            ? input_tensor.device()->arch()
-                            : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
-            auto kernel_config_val =
-                init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+    tt::tt_metal::MemoryConfig default_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
+    if (input_tensor.storage_type() == StorageType::DEVICE) {
+        default_memory_config = input_tensor.memory_config();
+    }
 
-            tt::tt_metal::MemoryConfig default_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
-            if (input_tensor.storage_type() == StorageType::DEVICE) {
-                default_memory_config = input_tensor.memory_config();
-            }
-
-            return tt::tt_metal::operation::run(
-                tt::tt_metal::RotaryEmbeddingLlama{
-                    is_decode_mode, memory_config.value_or(default_memory_config), kernel_config_val},
-                input_tensors);
-        },
-        {input_tensor, cos_cache, sin_cache, trans_mat},
-        output_tensors);
-    return output_tensors.at(0);
+    return tt::tt_metal::operation::run(
+               tt::tt_metal::RotaryEmbeddingLlama{
+                   is_decode_mode, memory_config.value_or(default_memory_config), kernel_config_val},
+               {input_tensor, cos_cache, sin_cache, trans_mat})
+        .at(0);
 }
 
 }  // namespace ttnn::operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp
@@ -26,7 +26,7 @@ struct RotaryEmbeddingLlamaOperation {
 
 namespace experimental {
 
-constexpr auto rotary_embedding_llama = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rotary_embedding_llama = ttnn::register_operation<
     "ttnn::experimental::rotary_embedding_llama",
     ttnn::operations::experimental::transformer::RotaryEmbeddingLlamaOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/rotary_embedding_llama_fused_qk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/rotary_embedding_llama_fused_qk.cpp
@@ -15,41 +15,25 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> RotaryEmbeddingLlamaFusedQKOperation::inv
     const Tensor& sin_cache,
     const Tensor& trans_mat,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    std::vector<Tensor> output_tensors = {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output(
-            {q_input_tensor, k_input_tensor, cos_cache, sin_cache, trans_mat})),
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output(
-            {q_input_tensor, k_input_tensor, cos_cache, sin_cache, trans_mat}))};
-    tt::tt_metal::operation::launch_op(
-        [compute_kernel_config](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& q_input_tensor = input_tensors.at(0);
-            auto& k_input_tensor = input_tensors.at(1);
+    auto arch = q_input_tensor.storage_type() == StorageType::DEVICE
+                    ? q_input_tensor.device()->arch()
+                    : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
+    auto kernel_config_val =
+        init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
 
-            auto arch = q_input_tensor.storage_type() == StorageType::DEVICE
-                            ? q_input_tensor.device()->arch()
-                            : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
-            auto kernel_config_val =
-                init_device_compute_kernel_config(arch, compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+    tt::tt_metal::MemoryConfig q_output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
+    tt::tt_metal::MemoryConfig k_output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
+    if (q_input_tensor.storage_type() == StorageType::DEVICE) {
+        q_output_memory_config = q_input_tensor.memory_config();
+    }
+    if (k_input_tensor.storage_type() == StorageType::DEVICE) {
+        k_output_memory_config = k_input_tensor.memory_config();
+    }
 
-            tt::tt_metal::MemoryConfig q_output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
-            tt::tt_metal::MemoryConfig k_output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
-            if (q_input_tensor.storage_type() == StorageType::DEVICE) {
-                q_output_memory_config = q_input_tensor.memory_config();
-            }
-            if (k_input_tensor.storage_type() == StorageType::DEVICE) {
-                k_output_memory_config = k_input_tensor.memory_config();
-            }
+    auto output_tensors = tt::tt_metal::operation::run(
+        tt::tt_metal::RotaryEmbeddingLlamaFusedQK{q_output_memory_config, k_output_memory_config, kernel_config_val},
+        {q_input_tensor, k_input_tensor, cos_cache, sin_cache, trans_mat});
 
-            return tt::tt_metal::operation::run(
-                tt::tt_metal::RotaryEmbeddingLlamaFusedQK{
-                    q_output_memory_config, k_output_memory_config, kernel_config_val},
-                input_tensors);
-        },
-        {q_input_tensor, k_input_tensor, cos_cache, sin_cache, trans_mat},
-        output_tensors);
     return {output_tensors.at(0), output_tensors.at(1)};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/rotary_embedding_llama_fused_qk.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/rotary_embedding_llama_fused_qk.hpp
@@ -25,7 +25,7 @@ struct RotaryEmbeddingLlamaFusedQKOperation {
 
 namespace experimental {
 
-constexpr auto rotary_embedding_llama_fused_qk = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rotary_embedding_llama_fused_qk = ttnn::register_operation<
     "ttnn::experimental::rotary_embedding_llama_fused_qk",
     ttnn::operations::experimental::transformer::RotaryEmbeddingLlamaFusedQKOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/rotate_half.hpp
@@ -16,7 +16,7 @@ struct RotateHalfOperation {
 }  // namespace operations::experimental::transformer
 
 namespace experimental {
-constexpr auto rotate_half = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rotate_half = ttnn::register_operation<
     "ttnn::experimental::rotate_half",
     ttnn::operations::experimental::transformer::RotateHalfOperation>();
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp
@@ -43,15 +43,6 @@ struct SplitFusedQKVAndSplitHeadsOperation {
             num_heads,
             optional_output_tensors);
     }
-
-    static inline std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-        const auto& input_tensor = input_tensors.at(0);
-        return {
-            Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor})),
-            Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor})),
-            Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-    }
 };
 
 }  // namespace operations::experimental::transformer

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/gelu_backward.hpp
@@ -22,7 +22,6 @@ struct GeluBackwardOperation {
 }  // namespace ttnn::operations::experimental
 
 namespace ttnn::experimental {
-constexpr auto gelu_bw = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::experimental::gelu_bw",
-    ttnn::operations::experimental::GeluBackwardOperation>();
+constexpr auto gelu_bw =
+    ttnn::register_operation<"ttnn::experimental::gelu_bw", ttnn::operations::experimental::GeluBackwardOperation>();
 }

--- a/ttnn/cpp/ttnn/operations/full/full.hpp
+++ b/ttnn/cpp/ttnn/operations/full/full.hpp
@@ -19,6 +19,5 @@ struct Full {
 }  // namespace ttnn::operations::full
 
 namespace ttnn {
-constexpr auto moreh_full =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_full", ttnn::operations::full::Full>();
+constexpr auto moreh_full = ttnn::register_operation<"ttnn::moreh_full", ttnn::operations::full::Full>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/full_like/full_like.hpp
+++ b/ttnn/cpp/ttnn/operations/full_like/full_like.hpp
@@ -21,5 +21,5 @@ struct FullLike {
 
 namespace ttnn {
 constexpr auto moreh_full_like =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_full_like", ttnn::operations::full_like::FullLike>();
+    ttnn::register_operation<"ttnn::moreh_full_like", ttnn::operations::full_like::FullLike>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/index_fill/index_fill.hpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/index_fill.hpp
@@ -18,6 +18,5 @@ struct IndexFill {
 }  // namespace ttnn::operations::index_fill
 
 namespace ttnn {
-constexpr auto index_fill =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::index_fill", ttnn::operations::index_fill::IndexFill>();
+constexpr auto index_fill = ttnn::register_operation<"ttnn::index_fill", ttnn::operations::index_fill::IndexFill>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_op.hpp
@@ -43,17 +43,7 @@ struct UpdateCache {
 };
 
 inline Tensor fill_cache_impl(const Tensor& cache_tensor, const Tensor& input_tensor, const uint32_t batch_idx) {
-    std::vector<Tensor> dummy_output_tensors = {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({cache_tensor, input_tensor}))};
-    tt::tt_metal::operation::launch_op(
-        [batch_idx](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            return tt::tt_metal::operation::run(UpdateCache{batch_idx, 0, 0, UpdateCacheOpType::FILL}, input_tensors);
-        },
-        {cache_tensor, input_tensor},
-        dummy_output_tensors);
+    tt::tt_metal::operation::run(UpdateCache{batch_idx, 0, 0, UpdateCacheOpType::FILL}, {cache_tensor, input_tensor});
     return cache_tensor;
 }
 
@@ -63,23 +53,11 @@ inline Tensor update_cache_impl(
     const uint32_t update_idx,
     const uint32_t batch_offset,
     std::optional<const ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt) {
-    std::vector<Tensor> dummy_output_tensors = {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({cache_tensor, input_tensor}))};
-    tt::tt_metal::operation::launch_op(
-        [update_idx, batch_offset, compute_kernel_config](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& cache_tensor = input_tensors.at(0);
-            auto& input_tensor = input_tensors.at(1);
-            auto kernel_config_val =
-                init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
-            return tt::tt_metal::operation::run(
-                UpdateCache{0, update_idx, batch_offset, UpdateCacheOpType::UPDATE, kernel_config_val},
-                {cache_tensor, input_tensor});
-        },
-        {cache_tensor, input_tensor},
-        dummy_output_tensors);
+    auto kernel_config_val = init_device_compute_kernel_config(input_tensor.device()->arch(), compute_kernel_config);
+    tt::tt_metal::operation::run(
+        UpdateCache{0, update_idx, batch_offset, UpdateCacheOpType::UPDATE, kernel_config_val},
+        {cache_tensor, input_tensor});
+
     return cache_tensor;
 }
 

--- a/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/kv_cache.hpp
@@ -41,12 +41,10 @@ struct FillCacheOperation {
 }  // namespace kv_cache
 }  // namespace operations
 
-constexpr auto fill_cache_for_user_ = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::kv_cache::fill_cache_for_user_",
-    ttnn::operations::kv_cache::ExecuteFillCache>();
-constexpr auto update_cache_for_token_ = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::kv_cache::update_cache_for_token_",
-    ttnn::operations::kv_cache::ExecuteUpdateCache>();
+constexpr auto fill_cache_for_user_ =
+    ttnn::register_operation<"ttnn::kv_cache::fill_cache_for_user_", ttnn::operations::kv_cache::ExecuteFillCache>();
+constexpr auto update_cache_for_token_ = ttnn::
+    register_operation<"ttnn::kv_cache::update_cache_for_token_", ttnn::operations::kv_cache::ExecuteUpdateCache>();
 
 constexpr auto update_cache =
     ttnn::register_operation<"ttnn::update_cache", ttnn::operations::kv_cache::UpdateCacheOperation>();

--- a/ttnn/cpp/ttnn/operations/loss/loss.hpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.hpp
@@ -55,10 +55,8 @@ struct MaeLossOperation {
 
 }  // namespace operations::loss
 
-constexpr auto mse_loss =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::mse_loss", operations::loss::MseLossOperation>();
+constexpr auto mse_loss = ttnn::register_operation<"ttnn::mse_loss", operations::loss::MseLossOperation>();
 
-constexpr auto l1_loss =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::l1_loss", operations::loss::MaeLossOperation>();
+constexpr auto l1_loss = ttnn::register_operation<"ttnn::l1_loss", operations::loss::MaeLossOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/moreh_abs_pow.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_abs_pow/moreh_abs_pow.hpp
@@ -19,7 +19,6 @@ struct MorehAbsPow {
 }  // namespace ttnn::operations::moreh::moreh_abs_pow
 
 namespace ttnn {
-constexpr auto moreh_abs_pow = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_abs_pow",
-    ttnn::operations::moreh::moreh_abs_pow::MorehAbsPow>();
+constexpr auto moreh_abs_pow =
+    ttnn::register_operation<"ttnn::moreh_abs_pow", ttnn::operations::moreh::moreh_abs_pow::MorehAbsPow>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_device_operation.hpp
@@ -102,7 +102,6 @@ struct MorehAdamOperation {
 }  // namespace ttnn::operations::moreh::moreh_adam
 
 namespace ttnn::prim {
-constexpr auto moreh_adam = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::prim::moreh_adam",
-    ttnn::operations::moreh::moreh_adam::MorehAdamOperation>();
+constexpr auto moreh_adam =
+    ttnn::register_operation<"ttnn::prim::moreh_adam", ttnn::operations::moreh::moreh_adam::MorehAdamOperation>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/moreh_adam.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/moreh_adam.cpp
@@ -50,35 +50,4 @@ std::vector<std::optional<Tensor>> MorehAdam::invoke(
         compute_kernel_config);
 }
 
-OptionalTensors MorehAdam::create_async_optional_output_tensors(
-    const Tensor& param_in,
-    const Tensor& grad,
-    const Tensor& exp_avg_in,
-    const Tensor& exp_avg_sq_in,
-    const std::optional<float> lr,
-    const std::optional<float> beta1,
-    const std::optional<float> beta2,
-    const std::optional<float> eps,
-    const std::optional<float> weight_decay,
-    const std::optional<uint32_t> step,
-    const std::optional<bool> amsgrad,
-    const std::optional<const Tensor>& max_exp_avg_sq_in,
-    const std::optional<const Tensor>& param_out,
-    const std::optional<const Tensor>& exp_avg_out,
-    const std::optional<const Tensor>& exp_avg_sq_out,
-    const std::optional<const Tensor>& max_exp_avg_sq_out,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    // First three are always true, last one depends on amsgrad
-    return {
-        std::optional<Tensor>(
-            operation::get_workers_for_op_output({param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in})),
-        std::optional<Tensor>(
-            operation::get_workers_for_op_output({param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in})),
-        std::optional<Tensor>(
-            operation::get_workers_for_op_output({param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in})),
-        amsgrad.value_or(false) ? std::optional<Tensor>(operation::get_workers_for_op_output(
-                                      {param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in}))
-                                : std::nullopt};
-}
 }  // namespace ttnn::operations::moreh::moreh_adam

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adam/moreh_adam.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adam/moreh_adam.hpp
@@ -28,30 +28,10 @@ struct MorehAdam {
         const std::optional<const Tensor>& max_exp_avg_sq_out,
         const std::optional<ttnn::MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& param_in,
-        const Tensor& grad,
-        const Tensor& exp_avg_in,
-        const Tensor& exp_avg_sq_in,
-        const std::optional<float> lr,
-        const std::optional<float> beta1,
-        const std::optional<float> beta2,
-        const std::optional<float> eps,
-        const std::optional<float> weight_decay,
-        const std::optional<uint32_t> step,
-        const std::optional<bool> amsgrad,
-        const std::optional<const Tensor>& max_exp_avg_sq_in,
-        const std::optional<const Tensor>& param_out,
-        const std::optional<const Tensor>& exp_avg_out,
-        const std::optional<const Tensor>& exp_avg_sq_out,
-        const std::optional<const Tensor>& max_exp_avg_sq_out,
-        const std::optional<ttnn::MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_adam
 
 namespace ttnn {
 constexpr auto moreh_adam =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_adam", ttnn::operations::moreh::moreh_adam::MorehAdam>();
+    ttnn::register_operation<"ttnn::moreh_adam", ttnn::operations::moreh::moreh_adam::MorehAdam>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/moreh_adamw.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/moreh_adamw.cpp
@@ -52,37 +52,4 @@ std::vector<std::optional<Tensor>> MorehAdamw::invoke(
         compute_kernel_config);
 }
 
-OptionalTensors MorehAdamw::create_async_optional_output_tensors(
-    const Tensor& param_in,
-    const Tensor& grad,
-    const Tensor& exp_avg_in,
-    const Tensor& exp_avg_sq_in,
-
-    const std::optional<float> lr,
-    const std::optional<float> beta1,
-    const std::optional<float> beta2,
-    const std::optional<float> eps,
-    const std::optional<float> weight_decay,
-    const std::optional<uint32_t> step,
-    const std::optional<bool> amsgrad,
-
-    const std::optional<Tensor>& max_exp_avg_sq_in,
-    const std::optional<Tensor>& param_out,
-    const std::optional<Tensor>& exp_avg_out,
-    const std::optional<Tensor>& exp_avg_sq_out,
-    const std::optional<Tensor>& max_exp_avg_sq_out,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config) {
-    return {
-        std::optional<Tensor>(
-            operation::get_workers_for_op_output({param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in})),
-        std::optional<Tensor>(
-            operation::get_workers_for_op_output({param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in})),
-        std::optional<Tensor>(
-            operation::get_workers_for_op_output({param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in})),
-        amsgrad.value_or(false) ? std::optional<Tensor>(operation::get_workers_for_op_output(
-                                      {param_in, grad, exp_avg_in, exp_avg_sq_in}, {max_exp_avg_sq_in}))
-                                : std::nullopt,
-    };
-}
 }  // namespace ttnn::operations::moreh::moreh_adamw

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/moreh_adamw.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_adamw/moreh_adamw.hpp
@@ -32,33 +32,11 @@ struct MorehAdamw {
         const std::optional<Tensor>& max_exp_avg_sq_out,
         const std::optional<ttnn::MemoryConfig>& memory_config,
         const std::optional<const DeviceComputeKernelConfig> compute_kernel_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& param_in,
-        const Tensor& grad,
-        const Tensor& exp_avg_in,
-        const Tensor& exp_avg_sq_in,
-
-        const std::optional<float> lr,
-        const std::optional<float> beta1,
-        const std::optional<float> beta2,
-        const std::optional<float> eps,
-        const std::optional<float> weight_decay,
-        const std::optional<uint32_t> step,
-        const std::optional<bool> amsgrad,
-
-        const std::optional<Tensor>& max_exp_avg_sq_in,
-        const std::optional<Tensor>& param_out,
-        const std::optional<Tensor>& exp_avg_out,
-        const std::optional<Tensor>& exp_avg_sq_out,
-        const std::optional<Tensor>& max_exp_avg_sq_out,
-        const std::optional<ttnn::MemoryConfig>& memory_config,
-        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::moreh::moreh_adamw
 
 namespace ttnn {
 constexpr auto moreh_adamw =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_adamw", operations::moreh::moreh_adamw::MorehAdamw>();
+    ttnn::register_operation<"ttnn::moreh_adamw", operations::moreh::moreh_adamw::MorehAdamw>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/moreh_arange.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/moreh_arange.hpp
@@ -21,6 +21,6 @@ struct MorehArange {
 }  // namespace ttnn::operations::moreh::moreh_arange
 
 namespace ttnn {
-constexpr auto moreh_arange = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::moreh_arange", ttnn::operations::moreh::moreh_arange::MorehArange>();
+constexpr auto moreh_arange =
+    ttnn::register_operation<"ttnn::moreh_arange", ttnn::operations::moreh::moreh_arange::MorehArange>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_bmm/moreh_bmm.hpp
@@ -19,6 +19,5 @@ struct MorehBMM {
 }  // namespace ttnn::operations::moreh::moreh_bmm
 
 namespace ttnn {
-constexpr auto moreh_bmm =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_bmm", ttnn::operations::moreh::moreh_bmm::MorehBMM>();
+constexpr auto moreh_bmm = ttnn::register_operation<"ttnn::moreh_bmm", ttnn::operations::moreh::moreh_bmm::MorehBMM>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.hpp
@@ -23,7 +23,7 @@ struct MorehClipGradNorm {
 }  // namespace ttnn::operations::moreh::moreh_clip_grad_norm
 
 namespace ttnn {
-constexpr auto moreh_clip_grad_norm = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_clip_grad_norm = ttnn::register_operation<
     "ttnn::moreh_clip_grad_norm",
     ttnn::operations::moreh::moreh_clip_grad_norm::MorehClipGradNorm>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/moreh_cumsum.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_cumsum/moreh_cumsum.hpp
@@ -28,10 +28,9 @@ struct MorehCumsumBackward {
 }  // namespace ttnn::operations::moreh::moreh_cumsum
 
 namespace ttnn {
-constexpr auto moreh_cumsum = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::moreh_cumsum", ttnn::operations::moreh::moreh_cumsum::MorehCumsum>();
+constexpr auto moreh_cumsum =
+    ttnn::register_operation<"ttnn::moreh_cumsum", ttnn::operations::moreh::moreh_cumsum::MorehCumsum>();
 
-constexpr auto moreh_cumsum_backward = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_cumsum_backward",
-    ttnn::operations::moreh::moreh_cumsum::MorehCumsumBackward>();
+constexpr auto moreh_cumsum_backward = ttnn::
+    register_operation<"ttnn::moreh_cumsum_backward", ttnn::operations::moreh::moreh_cumsum::MorehCumsumBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot/moreh_dot.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot/moreh_dot.hpp
@@ -20,6 +20,5 @@ struct MorehDot {
 }  // namespace ttnn::operations::moreh::moreh_dot
 
 namespace ttnn {
-constexpr auto moreh_dot =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_dot", ttnn::operations::moreh::moreh_dot::MorehDot>();
+constexpr auto moreh_dot = ttnn::register_operation<"ttnn::moreh_dot", ttnn::operations::moreh::moreh_dot::MorehDot>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/moreh_dot_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/moreh_dot_backward.cpp
@@ -19,20 +19,4 @@ std::vector<std::optional<Tensor>> MorehDotBackward::invoke(
     return ttnn::prim::moreh_dot_backward(output_grad, input, other, input_grad, other_grad, memory_config);
 }
 
-OptionalTensors MorehDotBackward::create_async_optional_output_tensors(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& other,
-    const std::optional<const Tensor>& input_grad,
-    const std::optional<const Tensor>& other_grad,
-    const std::optional<MemoryConfig>& memory_config) {
-    return {
-        input_grad.has_value()
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, other}))
-            : std::nullopt,
-        other_grad.has_value()
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, other}))
-            : std::nullopt};
-}
-
 }  // namespace ttnn::operations::moreh::moreh_dot_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/moreh_dot_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_dot_backward/moreh_dot_backward.hpp
@@ -13,19 +13,10 @@ struct MorehDotBackward {
         const std::optional<const Tensor>& input_grad,
         const std::optional<const Tensor>& other_grad,
         const std::optional<MemoryConfig>& memory_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& other,
-        const std::optional<const Tensor>& input_grad,
-        const std::optional<const Tensor>& other_grad,
-        const std::optional<MemoryConfig>& memory_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_dot_backward
 
 namespace ttnn {
-constexpr auto moreh_dot_backward = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_dot_backward",
-    ttnn::operations::moreh::moreh_dot_backward::MorehDotBackward>();
+constexpr auto moreh_dot_backward = ttnn::
+    register_operation<"ttnn::moreh_dot_backward", ttnn::operations::moreh::moreh_dot_backward::MorehDotBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_fold/fold.hpp
@@ -22,5 +22,5 @@ struct MorehFold {
 
 namespace ttnn {
 constexpr auto moreh_fold =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_fold", ttnn::operations::moreh::moreh_fold::MorehFold>();
+    ttnn::register_operation<"ttnn::moreh_fold", ttnn::operations::moreh::moreh_fold::MorehFold>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_getitem/moreh_getitem.hpp
@@ -20,7 +20,6 @@ struct MorehGetItem {
 }  // namespace ttnn::operations::moreh::moreh_getitem
 
 namespace ttnn {
-constexpr auto moreh_getitem = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_getitem",
-    ttnn::operations::moreh::moreh_getitem::MorehGetItem>();
+constexpr auto moreh_getitem =
+    ttnn::register_operation<"ttnn::moreh_getitem", ttnn::operations::moreh::moreh_getitem::MorehGetItem>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm.cpp
@@ -39,26 +39,4 @@ std::vector<std::optional<Tensor>> MorehGroupNorm::invoke(
         compute_kernel_config);
 }
 
-OptionalTensors MorehGroupNorm::create_async_optional_output_tensors(
-    const Tensor& input,
-    const uint32_t num_groups,
-    const float eps,
-    const std::optional<const Tensor>& gamma,
-    const std::optional<const Tensor>& beta,
-    const std::vector<bool>& are_required_outputs,
-    const std::optional<const Tensor>& output,
-    const std::optional<const Tensor>& mean,
-    const std::optional<const Tensor>& rstd,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<MemoryConfig>& mean_memory_config,
-    const std::optional<MemoryConfig>& rstd_memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        are_required_outputs.at(0) ? std::optional<Tensor>(operation::get_workers_for_op_output({input}, {gamma, beta}))
-                                   : std::nullopt,
-        are_required_outputs.at(1) ? std::optional<Tensor>(operation::get_workers_for_op_output({input}, {gamma, beta}))
-                                   : std::nullopt,
-        are_required_outputs.at(2) ? std::optional<Tensor>(operation::get_workers_for_op_output({input}, {gamma, beta}))
-                                   : std::nullopt};
-}
 }  // namespace ttnn::operations::moreh::moreh_group_norm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/moreh_group_norm.hpp
@@ -22,26 +22,10 @@ struct MorehGroupNorm {
         const std::optional<MemoryConfig>& mean_memory_config,
         const std::optional<MemoryConfig>& rstd_memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& input,
-        const uint32_t num_groups,
-        const float eps,
-        const std::optional<const Tensor>& gamma,
-        const std::optional<const Tensor>& beta,
-        const std::vector<bool>& are_required_outputs,
-        const std::optional<const Tensor>& output,
-        const std::optional<const Tensor>& mean,
-        const std::optional<const Tensor>& rstd,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<MemoryConfig>& mean_memory_config,
-        const std::optional<MemoryConfig>& rstd_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_group_norm
 
 namespace ttnn {
-constexpr auto moreh_group_norm = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_group_norm",
-    ttnn::operations::moreh::moreh_group_norm::MorehGroupNorm>();
+constexpr auto moreh_group_norm =
+    ttnn::register_operation<"ttnn::moreh_group_norm", ttnn::operations::moreh::moreh_group_norm::MorehGroupNorm>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.cpp
@@ -65,34 +65,4 @@ std::vector<std::optional<Tensor>> MorehGroupNormBackward::invoke(
     return std::move(outputs);
 }
 
-OptionalTensors MorehGroupNormBackward::create_async_optional_output_tensors(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& mean,
-    const Tensor& rstd,
-    const uint32_t num_groups,
-    const std::vector<bool>& are_required_outputs,
-    const std::optional<const Tensor>& gamma,
-    const std::optional<const Tensor>& input_grad,
-    const std::optional<const Tensor>& gamma_grad,
-    const std::optional<const Tensor>& beta_grad,
-    const std::optional<MemoryConfig>& input_grad_memory_config,
-    const std::optional<MemoryConfig>& gamma_grad_memory_config,
-    const std::optional<MemoryConfig>& beta_grad_memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    TT_FATAL(
-        are_required_outputs[0] or are_required_outputs[1] or are_required_outputs[2],
-        "backward is called, but all gradients are not required");
-
-    return {
-        are_required_outputs.at(0)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, mean, rstd}, {gamma}))
-            : std::nullopt,
-        are_required_outputs.at(1)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, mean, rstd}, {gamma}))
-            : std::nullopt,
-        are_required_outputs.at(2)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, mean, rstd}, {gamma}))
-            : std::nullopt};
-}
 }  // namespace ttnn::operations::moreh::moreh_group_norm_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.hpp
@@ -23,27 +23,11 @@ struct MorehGroupNormBackward {
         const std::optional<MemoryConfig>& gamma_grad_memory_config,
         const std::optional<MemoryConfig>& beta_grad_memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& mean,
-        const Tensor& rstd,
-        const uint32_t num_groups,
-        const std::vector<bool>& are_required_outputs,
-        const std::optional<const Tensor>& gamma,
-        const std::optional<const Tensor>& input_grad,
-        const std::optional<const Tensor>& gamma_grad,
-        const std::optional<const Tensor>& beta_grad,
-        const std::optional<MemoryConfig>& input_grad_memory_config,
-        const std::optional<MemoryConfig>& gamma_grad_memory_config,
-        const std::optional<MemoryConfig>& beta_grad_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_group_norm_backward
 
 namespace ttnn {
-constexpr auto moreh_group_norm_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_group_norm_backward = ttnn::register_operation<
     "ttnn::moreh_group_norm_backward",
     ttnn::operations::moreh::moreh_group_norm_backward::MorehGroupNormBackward>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/moreh_layer_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/moreh_layer_norm.cpp
@@ -24,25 +24,4 @@ std::vector<std::optional<Tensor>> MorehLayerNorm::invoke(
         input, normalized_dims, eps, gamma, beta, output, mean, rstd, memory_config, compute_kernel_config);
 }
 
-OptionalTensors MorehLayerNorm::create_async_optional_output_tensors(
-    const Tensor& input,
-    const uint32_t normalized_dims,
-    const float eps,
-    const std::optional<const Tensor>& gamma,
-    const std::optional<const Tensor>& beta,
-    const std::optional<const Tensor>& output,
-    const std::optional<const Tensor>& mean,
-    const std::optional<const Tensor>& rstd,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    const auto return_mean = mean.has_value();
-    const auto return_rstd = rstd.has_value();
-
-    return {
-        std::optional<Tensor>(operation::get_workers_for_op_output({input}, {gamma, beta})),
-        return_mean ? std::optional<Tensor>(operation::get_workers_for_op_output({input}, {gamma, beta}))
-                    : std::nullopt,
-        return_rstd ? std::optional<Tensor>(operation::get_workers_for_op_output({input}, {gamma, beta}))
-                    : std::nullopt};
-}
 }  // namespace ttnn::operations::moreh::moreh_layer_norm

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/moreh_layer_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/moreh_layer_norm.hpp
@@ -20,24 +20,10 @@ struct MorehLayerNorm {
         const std::optional<const Tensor>& rstd,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
-    // The parameters of this function must be identical to those of invoke.
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& input,
-        const uint32_t normalized_dims,
-        const float eps,
-        const std::optional<const Tensor>& gamma,
-        const std::optional<const Tensor>& beta,
-        const std::optional<const Tensor>& output,
-        const std::optional<const Tensor>& mean,
-        const std::optional<const Tensor>& rstd,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_layer_norm
 
 namespace ttnn {
-constexpr auto moreh_layer_norm = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_layer_norm",
-    ttnn::operations::moreh::moreh_layer_norm::MorehLayerNorm>();
+constexpr auto moreh_layer_norm =
+    ttnn::register_operation<"ttnn::moreh_layer_norm", ttnn::operations::moreh::moreh_layer_norm::MorehLayerNorm>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_device_operation.hpp
@@ -73,7 +73,7 @@ struct MorehLayerNormBackwardInputGradOperation {
 }  // namespace ttnn::operations::moreh::moreh_layer_norm_backward_input_grad
 
 namespace ttnn::prim {
-constexpr auto moreh_layer_norm_backward_input_grad = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_layer_norm_backward_input_grad = ttnn::register_operation<
     "ttnn::prim::moreh_layer_norm_backward_input_grad",
     operations::moreh::moreh_layer_norm_backward_input_grad::MorehLayerNormBackwardInputGradOperation>();
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/moreh_layer_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/moreh_layer_norm_backward.cpp
@@ -72,30 +72,4 @@ std::vector<std::optional<Tensor>> MorehLayerNormBackward::invoke(
     return outputs;
 }
 
-OptionalTensors MorehLayerNormBackward::create_async_optional_output_tensors(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& mean,
-    const Tensor& rstd,
-    uint32_t normalized_dims,
-    const std::optional<const Tensor>& gamma,
-    const std::optional<const Tensor>& input_grad,
-    const std::optional<const Tensor>& gamma_grad,
-    const std::optional<const Tensor>& beta_grad,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    const auto return_input_grad = input_grad.has_value();
-    const auto return_gamma_grad = gamma_grad.has_value();
-    const auto return_beta_grad = beta_grad.has_value();
-    return {
-        return_input_grad
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, mean, rstd}, {gamma}))
-            : std::nullopt,
-        return_gamma_grad
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, mean, rstd}, {gamma}))
-            : std::nullopt,
-        return_beta_grad
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, mean, rstd}, {gamma}))
-            : std::nullopt};
-}
 }  // namespace ttnn::operations::moreh::moreh_layer_norm_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/moreh_layer_norm_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/moreh_layer_norm_backward.hpp
@@ -21,25 +21,11 @@ struct MorehLayerNormBackward {
         const std::optional<const Tensor>& beta_grad,
         const std::optional<MemoryConfig>& memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
-    // The parameters of this function must be identical to those of invoke.
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& mean,
-        const Tensor& rstd,
-        uint32_t normalized_dims,
-        const std::optional<const Tensor>& gamma,
-        const std::optional<const Tensor>& input_grad,
-        const std::optional<const Tensor>& gamma_grad,
-        const std::optional<const Tensor>& beta_grad,
-        const std::optional<MemoryConfig>& memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_layer_norm_backward
 
 namespace ttnn {
-constexpr auto moreh_layer_norm_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_layer_norm_backward = ttnn::register_operation<
     "ttnn::moreh_layer_norm_backward",
     ttnn::operations::moreh::moreh_layer_norm_backward::MorehLayerNormBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear/moreh_linear.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear/moreh_linear.hpp
@@ -20,6 +20,6 @@ struct MorehLinear {
 }  // namespace ttnn::operations::moreh::moreh_linear
 
 namespace ttnn {
-constexpr auto moreh_linear = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::moreh_linear", ttnn::operations::moreh::moreh_linear::MorehLinear>();
+constexpr auto moreh_linear =
+    ttnn::register_operation<"ttnn::moreh_linear", ttnn::operations::moreh::moreh_linear::MorehLinear>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.cpp
@@ -180,29 +180,4 @@ std::vector<std::optional<Tensor>> MorehLinearBackward::invoke(
     return result;
 }
 
-OptionalTensors MorehLinearBackward::create_async_optional_output_tensors(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& weight,
-    const std::vector<bool>& are_required_outputs,
-    const std::optional<Tensor>& bias,
-    const std::optional<Tensor>& input_grad,
-    const std::optional<Tensor>& weight_grad,
-    const std::optional<Tensor>& bias_grad,
-    const std::optional<ttnn::MemoryConfig>& input_grad_memory_config,
-    const std::optional<ttnn::MemoryConfig>& weight_grad_memory_config,
-    const std::optional<ttnn::MemoryConfig>& bias_grad_memory_config,
-    const DeviceComputeKernelConfig compute_kernel_config) {
-    return {
-        are_required_outputs.at(0)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, weight}))
-            : std::nullopt,
-        are_required_outputs.at(1)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, weight}))
-            : std::nullopt,
-        are_required_outputs.at(2)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, weight}))
-            : std::nullopt};
-}
-
 }  // namespace ttnn::operations::moreh::moreh_linear_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_linear_backward/moreh_linear_backward.hpp
@@ -25,25 +25,11 @@ struct MorehLinearBackward {
         const std::optional<ttnn::MemoryConfig>& weight_grad_memory_config,
         const std::optional<ttnn::MemoryConfig>& bias_grad_memory_config,
         const DeviceComputeKernelConfig compute_kernel_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& weight,
-        const std::vector<bool>& are_required_outputs,
-        const std::optional<Tensor>& bias,
-        const std::optional<Tensor>& input_grad,
-        const std::optional<Tensor>& weight_grad,
-        const std::optional<Tensor>& bias_grad,
-        const std::optional<ttnn::MemoryConfig>& input_grad_memory_config,
-        const std::optional<ttnn::MemoryConfig>& weight_grad_memory_config,
-        const std::optional<ttnn::MemoryConfig>& bias_grad_memory_config,
-        const DeviceComputeKernelConfig compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_linear_backward
 
 namespace ttnn {
-constexpr auto moreh_linear_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_linear_backward = ttnn::register_operation<
     "ttnn::moreh_linear_backward",
     ttnn::operations::moreh::moreh_linear_backward::MorehLinearBackward>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/moreh_matmul.hpp
@@ -20,6 +20,6 @@ struct MorehMatmul {
 }  // namespace ttnn::operations::moreh::moreh_matmul
 
 namespace ttnn {
-constexpr auto moreh_matmul = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::moreh_matmul", ttnn::operations::moreh::moreh_matmul::MorehMatmul>();
+constexpr auto moreh_matmul =
+    ttnn::register_operation<"ttnn::moreh_matmul", ttnn::operations::moreh::moreh_matmul::MorehMatmul>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.cpp
@@ -77,22 +77,4 @@ std::vector<std::optional<Tensor>> MorehMatmulBackward::invoke(
     return outputs;
 }
 
-OptionalTensors MorehMatmulBackward::create_async_optional_output_tensors(
-    const Tensor& output_grad,
-    const Tensor& input,
-    const Tensor& other,
-    const std::vector<bool>& are_required_outputs,
-    const std::optional<const Tensor>& input_grad,
-    const std::optional<const Tensor>& other_grad,
-    const std::optional<ttnn::MemoryConfig>& memory_config,
-    const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config) {
-    return {
-        are_required_outputs.at(0)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, other}))
-            : std::nullopt,
-        are_required_outputs.at(1)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({output_grad, input, other}))
-            : std::nullopt};
-}
-
 }  // namespace ttnn::operations::moreh::moreh_matmul_backward

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul_backward/moreh_matmul_backward.hpp
@@ -16,21 +16,11 @@ struct MorehMatmulBackward {
         const std::optional<const Tensor>& other_grad,
         const std::optional<ttnn::MemoryConfig>& memory_config,
         const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& output_grad,
-        const Tensor& input,
-        const Tensor& other,
-        const std::vector<bool>& are_required_outputs,
-        const std::optional<const Tensor>& input_grad,
-        const std::optional<const Tensor>& other_grad,
-        const std::optional<ttnn::MemoryConfig>& memory_config,
-        const std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_matmul_backward
 
 namespace ttnn {
-constexpr auto moreh_matmul_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_matmul_backward = ttnn::register_operation<
     "ttnn::moreh_matmul_backward",
     ttnn::operations::moreh::moreh_matmul_backward::MorehMatmulBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean/moreh_mean.hpp
@@ -20,5 +20,5 @@ struct MorehMean {
 
 namespace ttnn {
 constexpr auto moreh_mean =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_mean", ttnn::operations::moreh::moreh_mean::MorehMean>();
+    ttnn::register_operation<"ttnn::moreh_mean", ttnn::operations::moreh::moreh_mean::MorehMean>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_mean_backward/moreh_mean_backward.hpp
@@ -19,7 +19,6 @@ struct MorehMeanBackward {
 }  // namespace ttnn::operations::moreh::moreh_mean_backward
 
 namespace ttnn {
-constexpr auto moreh_mean_backward = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_mean_backward",
-    ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackward>();
+constexpr auto moreh_mean_backward = ttnn::
+    register_operation<"ttnn::moreh_mean_backward", ttnn::operations::moreh::moreh_mean_backward::MorehMeanBackward>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss.hpp
@@ -26,6 +26,6 @@ struct MorehNllLoss {
 }  // namespace ttnn::operations::moreh::moreh_nll_loss
 
 namespace ttnn {
-constexpr auto moreh_nll_loss = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::moreh_nll_loss", operations::moreh::moreh_nll_loss::MorehNllLoss>();
+constexpr auto moreh_nll_loss =
+    ttnn::register_operation<"ttnn::moreh_nll_loss", operations::moreh::moreh_nll_loss::MorehNllLoss>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/moreh_nll_loss_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_backward/moreh_nll_loss_backward.hpp
@@ -26,7 +26,7 @@ struct MorehNllLossBackward {
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_backward
 
 namespace ttnn {
-constexpr auto moreh_nll_loss_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_nll_loss_backward = ttnn::register_operation<
     "ttnn::moreh_nll_loss_backward",
     operations::moreh::moreh_nll_loss_backward::MorehNllLossBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/moreh_nll_loss_unreduced_backward.hpp
@@ -24,7 +24,7 @@ struct MorehNllLossUnreducedBackward {
 }  // namespace ttnn::operations::moreh::moreh_nll_loss_unreduced_backward
 
 namespace ttnn {
-constexpr auto moreh_nll_loss_unreduced_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_nll_loss_unreduced_backward = ttnn::register_operation<
     "ttnn::moreh_nll_loss_unreduced_backward",
     operations::moreh::moreh_nll_loss_unreduced_backward::MorehNllLossUnreducedBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm/moreh_norm.hpp
@@ -22,5 +22,5 @@ struct MorehNorm {
 
 namespace ttnn {
 constexpr auto moreh_norm =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_norm", ttnn::operations::moreh::moreh_norm::MorehNorm>();
+    ttnn::register_operation<"ttnn::moreh_norm", ttnn::operations::moreh::moreh_norm::MorehNorm>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/moreh_norm_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_norm_backward/moreh_norm_backward.hpp
@@ -23,7 +23,6 @@ struct MorehNormBackward {
 }  // namespace ttnn::operations::moreh::moreh_norm_backward
 
 namespace ttnn {
-constexpr auto moreh_norm_backward = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_norm_backward",
-    ttnn::operations::moreh::moreh_norm_backward::MorehNormBackward>();
+constexpr auto moreh_norm_backward = ttnn::
+    register_operation<"ttnn::moreh_norm_backward", ttnn::operations::moreh::moreh_norm_backward::MorehNormBackward>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/moreh_sgd.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/moreh_sgd.cpp
@@ -41,26 +41,4 @@ std::vector<std::optional<Tensor>> MorehSgd::invoke(
         compute_kernel_config);
 }
 
-OptionalTensors MorehSgd::create_async_optional_output_tensors(
-    const Tensor& param_in,
-    const Tensor& grad,
-    const std::optional<Tensor>& momentum_buffer_in,
-    const std::optional<Tensor>& param_out,
-    const std::optional<Tensor>& momentum_buffer_out,
-    float lr,
-    float momentum,
-    float dampening,
-    float weight_decay,
-    bool nesterov,
-    bool momentum_initialized,
-    const std::optional<MemoryConfig>& param_out_memory_config,
-    const std::optional<MemoryConfig>& momentum_buffer_out_memory_config,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config) {
-    return {
-        std::optional<Tensor>(operation::get_workers_for_op_output({param_in, grad}, {momentum_buffer_in})),
-        (momentum != 0.0f)
-            ? std::optional<Tensor>(operation::get_workers_for_op_output({param_in, grad}, {momentum_buffer_in}))
-            : std::nullopt};
-}
-
 }  // namespace ttnn::operations::moreh::moreh_sgd

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/moreh_sgd.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sgd/moreh_sgd.hpp
@@ -24,26 +24,9 @@ struct MorehSgd {
         const std::optional<MemoryConfig>& param_out_memory_config,
         const std::optional<MemoryConfig>& momentum_buffer_out_memory_config,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
-
-    static OptionalTensors create_async_optional_output_tensors(
-        const Tensor& param_in,
-        const Tensor& grad,
-        const std::optional<Tensor>& momentum_buffer_in,
-        const std::optional<Tensor>& param_out,
-        const std::optional<Tensor>& momentum_buffer_out,
-        float lr,
-        float momentum,
-        float dampening,
-        float weight_decay,
-        bool nesterov,
-        bool momentum_initialized,
-        const std::optional<MemoryConfig>& param_out_memory_config,
-        const std::optional<MemoryConfig>& momentum_buffer_out_memory_config,
-        const std::optional<DeviceComputeKernelConfig>& compute_kernel_config);
 };
 }  // namespace ttnn::operations::moreh::moreh_sgd
 
 namespace ttnn {
-constexpr auto moreh_sgd =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_sgd", ttnn::operations::moreh::moreh_sgd::MorehSgd>();
+constexpr auto moreh_sgd = ttnn::register_operation<"ttnn::moreh_sgd", ttnn::operations::moreh::moreh_sgd::MorehSgd>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/moreh_softmax.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/moreh_softmax.hpp
@@ -29,13 +29,10 @@ DEFINE_MOREH_SOFT_OP(MorehLogSoftmax);
 }  // namespace ttnn::operations::moreh::moreh_softmax
 
 namespace ttnn {
-constexpr auto moreh_softmax = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_softmax",
-    ttnn::operations::moreh::moreh_softmax::MorehSoftmax>();
-constexpr auto moreh_softmin = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_softmin",
-    ttnn::operations::moreh::moreh_softmax::MorehSoftmin>();
-constexpr auto moreh_logsoftmax = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_logsoftmax",
-    ttnn::operations::moreh::moreh_softmax::MorehLogSoftmax>();
+constexpr auto moreh_softmax =
+    ttnn::register_operation<"ttnn::moreh_softmax", ttnn::operations::moreh::moreh_softmax::MorehSoftmax>();
+constexpr auto moreh_softmin =
+    ttnn::register_operation<"ttnn::moreh_softmin", ttnn::operations::moreh::moreh_softmax::MorehSoftmin>();
+constexpr auto moreh_logsoftmax =
+    ttnn::register_operation<"ttnn::moreh_logsoftmax", ttnn::operations::moreh::moreh_softmax::MorehLogSoftmax>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/moreh_softmax_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/moreh_softmax_backward.hpp
@@ -30,13 +30,13 @@ DEFINE_MOREH_SOFT_BACKWARD_OP(MorehLogSoftmaxBackward);
 }  // namespace ttnn::operations::moreh::moreh_softmax_backward
 
 namespace ttnn {
-constexpr auto moreh_softmax_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_softmax_backward = ttnn::register_operation<
     "ttnn::moreh_softmax_backward",
     ttnn::operations::moreh::moreh_softmax_backward::MorehSoftmaxBackward>();
-constexpr auto moreh_softmin_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_softmin_backward = ttnn::register_operation<
     "ttnn::moreh_softmin_backward",
     ttnn::operations::moreh::moreh_softmax_backward::MorehSoftminBackward>();
-constexpr auto moreh_logsoftmax_backward = ttnn::register_operation_with_auto_launch_op<
+constexpr auto moreh_logsoftmax_backward = ttnn::register_operation<
     "ttnn::moreh_logsoftmax_backward",
     ttnn::operations::moreh::moreh_softmax_backward::MorehLogSoftmaxBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum/moreh_sum.hpp
@@ -18,6 +18,5 @@ struct MorehSum {
 }  // namespace ttnn::operations::moreh::moreh_sum
 
 namespace ttnn {
-constexpr auto moreh_sum =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moreh_sum", ttnn::operations::moreh::moreh_sum::MorehSum>();
+constexpr auto moreh_sum = ttnn::register_operation<"ttnn::moreh_sum", ttnn::operations::moreh::moreh_sum::MorehSum>();
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/moreh_sum_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_sum_backward/moreh_sum_backward.hpp
@@ -19,7 +19,6 @@ struct MorehSumBackward {
 }  // namespace ttnn::operations::moreh::moreh_sum_backward
 
 namespace ttnn {
-constexpr auto moreh_sum_backward = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::moreh_sum_backward",
-    ttnn::operations::moreh::moreh_sum_backward::MorehSumBackward>();
+constexpr auto moreh_sum_backward = ttnn::
+    register_operation<"ttnn::moreh_sum_backward", ttnn::operations::moreh::moreh_sum_backward::MorehSumBackward>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.hpp
@@ -24,6 +24,5 @@ struct BatchNorm {
 };
 }  // namespace operations::normalization
 
-constexpr auto batch_norm =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::batch_norm", ttnn::operations::normalization::BatchNorm>();
+constexpr auto batch_norm = ttnn::register_operation<"ttnn::batch_norm", ttnn::operations::normalization::BatchNorm>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.hpp
@@ -30,7 +30,7 @@ struct ExecuteGroupNorm {
 }  // namespace normalization
 }  // namespace operations
 
-constexpr auto group_norm = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::group_norm", ttnn::operations::normalization::ExecuteGroupNorm>();
+constexpr auto group_norm =
+    ttnn::register_operation<"ttnn::group_norm", ttnn::operations::normalization::ExecuteGroupNorm>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/layernorm.hpp
@@ -26,7 +26,7 @@ struct ExecuteLayerNorm {
 
 }  // namespace operations::normalization
 
-constexpr auto layer_norm = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::layer_norm", ttnn::operations::normalization::ExecuteLayerNorm>();
+constexpr auto layer_norm =
+    ttnn::register_operation<"ttnn::layer_norm", ttnn::operations::normalization::ExecuteLayerNorm>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp
@@ -27,7 +27,7 @@ struct ExecuteLayerNormPostAllGather {
 
 }  // namespace operations::normalization
 
-constexpr auto layer_norm_post_all_gather = ttnn::register_operation_with_auto_launch_op<
+constexpr auto layer_norm_post_all_gather = ttnn::register_operation<
     "ttnn::layer_norm_post_all_gather",
     ttnn::operations::normalization::ExecuteLayerNormPostAllGather>();
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp
@@ -24,7 +24,7 @@ struct ExecuteLayerNormPreAllGather {
 
 }  // namespace operations::normalization
 
-constexpr auto layer_norm_pre_all_gather = ttnn::register_operation_with_auto_launch_op<
+constexpr auto layer_norm_pre_all_gather = ttnn::register_operation<
     "ttnn::layer_norm_pre_all_gather",
     ttnn::operations::normalization::ExecuteLayerNormPreAllGather>();
 

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm/rmsnorm.hpp
@@ -27,7 +27,6 @@ struct ExecuteRMSNorm {
 
 }  // namespace operations::normalization
 
-constexpr auto rms_norm =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::rms_norm", ttnn::operations::normalization::ExecuteRMSNorm>();
+constexpr auto rms_norm = ttnn::register_operation<"ttnn::rms_norm", ttnn::operations::normalization::ExecuteRMSNorm>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_post_all_gather.hpp
@@ -27,7 +27,7 @@ struct ExecuteRMSNormPostAllGather {
 
 }  // namespace operations::normalization
 
-constexpr auto rms_norm_post_all_gather = ttnn::register_operation_with_auto_launch_op<
+constexpr auto rms_norm_post_all_gather = ttnn::register_operation<
     "ttnn::rms_norm_post_all_gather",
     ttnn::operations::normalization::ExecuteRMSNormPostAllGather>();
 

--- a/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/rmsnorm_distributed/rmsnorm_pre_all_gather.hpp
@@ -24,8 +24,7 @@ struct ExecuteRMSNormPreAllGather {
 
 }  // namespace operations::normalization
 
-constexpr auto rms_norm_pre_all_gather = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::rms_norm_pre_all_gather",
-    ttnn::operations::normalization::ExecuteRMSNormPreAllGather>();
+constexpr auto rms_norm_pre_all_gather = ttnn::
+    register_operation<"ttnn::rms_norm_pre_all_gather", ttnn::operations::normalization::ExecuteRMSNormPreAllGather>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_op.cpp
@@ -209,32 +209,20 @@ Tensor scale_mask_softmax_in_place(
     const bool is_causal_mask,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
-    std::vector<Tensor> dummy_output_tensors = {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-    tt::tt_metal::operation::launch_op(
-        [scale, mask, program_config, is_causal_mask, compute_kernel_config, numeric_stable](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& input_tensor = input_tensors.at(0);
-            auto& mask = optional_input_tensors.at(0);
-            auto kernel_config_val = init_device_compute_kernel_config(
-                input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-            return tt::tt_metal::operation::run(
-                Softmax{
-                    .scale = scale,
-                    .inplace = true,
-                    .output_mem_config = input_tensor.memory_config(),
-                    .program_config = program_config,
-                    .is_causal_mask = is_causal_mask,
-                    .compute_kernel_config = kernel_config_val,
-                    .numeric_stable = numeric_stable},
-                {input_tensor},
-                {mask});
-        },
+    auto kernel_config_val = init_device_compute_kernel_config(
+        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+    tt::tt_metal::operation::run(
+        Softmax{
+            .scale = scale,
+            .inplace = true,
+            .output_mem_config = input_tensor.memory_config(),
+            .program_config = program_config,
+            .is_causal_mask = is_causal_mask,
+            .compute_kernel_config = kernel_config_val,
+            .numeric_stable = numeric_stable},
         {input_tensor},
-        dummy_output_tensors,
         {mask});
+
     return input_tensor;
 }
 
@@ -245,32 +233,19 @@ Tensor scale_causal_mask_hw_dims_softmax_in_place(
     const SoftmaxProgramConfig& program_config,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
-    std::vector<Tensor> dummy_output_tensors = {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-    tt::tt_metal::operation::launch_op(
-        [scale, mask, program_config, compute_kernel_config, numeric_stable](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& input_tensor = input_tensors.at(0);
-            auto& mask = optional_input_tensors.at(0);
-            auto kernel_config_val = init_device_compute_kernel_config(
-                input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-            return tt::tt_metal::operation::run(
-                Softmax{
-                    .scale = scale,
-                    .inplace = true,
-                    .output_mem_config = input_tensor.memory_config(),
-                    .program_config = program_config,
-                    .is_causal_mask = true,
-                    .compute_kernel_config = kernel_config_val,
-                    .is_scale_causal_mask_hw_dims_softmax = true,
-                    .numeric_stable = numeric_stable},
-                {input_tensor},
-                {mask});
-        },
+    auto kernel_config_val = init_device_compute_kernel_config(
+        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+    tt::tt_metal::operation::run(
+        Softmax{
+            .scale = scale,
+            .inplace = true,
+            .output_mem_config = input_tensor.memory_config(),
+            .program_config = program_config,
+            .is_causal_mask = true,
+            .compute_kernel_config = kernel_config_val,
+            .is_scale_causal_mask_hw_dims_softmax = true,
+            .numeric_stable = numeric_stable},
         {input_tensor},
-        dummy_output_tensors,
         {mask});
     return input_tensor;
 }
@@ -292,57 +267,44 @@ Tensor scale_mask_softmax(
     const bool is_causal_mask,
     std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const bool numeric_stable) {
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-    tt::tt_metal::operation::launch_op(
-        [scale, mask, output_mem_config, is_causal_mask, compute_kernel_config, numeric_stable](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            auto& input_tensor = input_tensors.at(0);
-            auto& mask = optional_input_tensors.at(0);
-            ttnn::Shape input_pad_shape = ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(
-                input_tensor.get_padded_shape());
-            ttnn::operations::experimental::auto_format::FormatParams input_format_params = {
-                .pad_shape = input_pad_shape,
-                .pad_value = -std::numeric_limits<float>::infinity(),
-                .target_layout = tt::tt_metal::Layout::TILE};
-            std::optional<ttnn::operations::experimental::auto_format::FormatParams> mask_format_params = std::nullopt;
-            if (mask.has_value()) {
-                TT_FATAL(input_tensor.get_padded_shape()[-1] == mask.value().get_padded_shape()[-1], "Error");
-                TT_FATAL(input_tensor.get_padded_shape()[0] == mask.value().get_padded_shape()[0], "Error");
-                TT_FATAL(
-                    mask.value().get_padded_shape()[-2] == 1 or mask.value().get_padded_shape()[-2] == TILE_HEIGHT,
-                    "Error");
-                for (uint32_t i = 1; i < input_tensor.get_padded_shape().rank() - 2; i++) {
-                    TT_FATAL(mask.value().get_padded_shape()[i] == 1, "Error");
-                }
-                ttnn::Shape mask_pad_shape = ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(
-                    mask.value().get_padded_shape());
-                mask_format_params = {
-                    .pad_shape = mask_pad_shape,
-                    .pad_value = -std::numeric_limits<float>::infinity(),
-                    .target_layout = tt::tt_metal::Layout::TILE};
-            }
-            auto kernel_config_val = init_device_compute_kernel_config(
-                input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
-            return tt::tt_metal::operation::run_with_autoformat(
-                Softmax{
-                    .scale = scale,
-                    .inplace = false,
-                    .output_mem_config = output_mem_config,
-                    .is_causal_mask = is_causal_mask,
-                    .compute_kernel_config = kernel_config_val,
-                    .numeric_stable = numeric_stable},
-                {input_tensor},
-                {input_format_params},
-                {tt::tt_metal::Layout::TILE},
-                {mask},
-                {mask_format_params});
-        },
-        {input_tensor},
-        output_tensors,
-        {mask});
-    return output_tensors.at(0);
+    ttnn::Shape input_pad_shape =
+        ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(input_tensor.get_padded_shape());
+    ttnn::operations::experimental::auto_format::FormatParams input_format_params = {
+        .pad_shape = input_pad_shape,
+        .pad_value = -std::numeric_limits<float>::infinity(),
+        .target_layout = tt::tt_metal::Layout::TILE};
+    std::optional<ttnn::operations::experimental::auto_format::FormatParams> mask_format_params = std::nullopt;
+    if (mask.has_value()) {
+        TT_FATAL(input_tensor.get_padded_shape()[-1] == mask.value().get_padded_shape()[-1], "Error");
+        TT_FATAL(input_tensor.get_padded_shape()[0] == mask.value().get_padded_shape()[0], "Error");
+        TT_FATAL(
+            mask.value().get_padded_shape()[-2] == 1 or mask.value().get_padded_shape()[-2] == TILE_HEIGHT, "Error");
+        for (uint32_t i = 1; i < input_tensor.get_padded_shape().rank() - 2; i++) {
+            TT_FATAL(mask.value().get_padded_shape()[i] == 1, "Error");
+        }
+        ttnn::Shape mask_pad_shape =
+            ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(mask.value().get_padded_shape());
+        mask_format_params = {
+            .pad_shape = mask_pad_shape,
+            .pad_value = -std::numeric_limits<float>::infinity(),
+            .target_layout = tt::tt_metal::Layout::TILE};
+    }
+    auto kernel_config_val = init_device_compute_kernel_config(
+        input_tensor.device()->arch(), compute_kernel_config, MathFidelity::HiFi4, true, false, false);
+    return tt::tt_metal::operation::run_with_autoformat(
+               Softmax{
+                   .scale = scale,
+                   .inplace = false,
+                   .output_mem_config = output_mem_config,
+                   .is_causal_mask = is_causal_mask,
+                   .compute_kernel_config = kernel_config_val,
+                   .numeric_stable = numeric_stable},
+               {input_tensor},
+               {input_format_params},
+               {tt::tt_metal::Layout::TILE},
+               {mask},
+               {mask_format_params})
+        .at(0);
 }
 
 }  // namespace ttnn::operations::normalization

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/softmax.hpp
@@ -68,18 +68,15 @@ struct ExecuteScaleCausalMaskHWSoftmaxInPlace {
 
 }  // namespace operations::normalization
 
-constexpr auto softmax =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::softmax", ttnn::operations::normalization::ExecuteSoftmax>();
-constexpr auto scale_mask_softmax = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::scale_mask_softmax",
-    ttnn::operations::normalization::ExecuteScaleMaskSoftmax>();
-constexpr auto softmax_in_place = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::softmax_in_place",
-    ttnn::operations::normalization::ExecuteSoftmaxInPlace>();
-constexpr auto scale_mask_softmax_in_place = ttnn::register_operation_with_auto_launch_op<
+constexpr auto softmax = ttnn::register_operation<"ttnn::softmax", ttnn::operations::normalization::ExecuteSoftmax>();
+constexpr auto scale_mask_softmax =
+    ttnn::register_operation<"ttnn::scale_mask_softmax", ttnn::operations::normalization::ExecuteScaleMaskSoftmax>();
+constexpr auto softmax_in_place =
+    ttnn::register_operation<"ttnn::softmax_in_place", ttnn::operations::normalization::ExecuteSoftmaxInPlace>();
+constexpr auto scale_mask_softmax_in_place = ttnn::register_operation<
     "ttnn::scale_mask_softmax_in_place",
     ttnn::operations::normalization::ExecuteScaleMaskSoftmaxInPlace>();
-constexpr auto scale_causal_mask_hw_dims_softmax_in_place = ttnn::register_operation_with_auto_launch_op<
+constexpr auto scale_causal_mask_hw_dims_softmax_in_place = ttnn::register_operation<
     "ttnn::scale_causal_mask_hw_dims_softmax_in_place",
     ttnn::operations::normalization::ExecuteScaleCausalMaskHWSoftmaxInPlace>();
 

--- a/ttnn/cpp/ttnn/operations/pool/downsample/downsample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/downsample/downsample.hpp
@@ -18,5 +18,5 @@ struct ExecuteDownsample {
 }  // namespace operations
 
 constexpr auto downsample =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::downsample", ttnn::operations::downsample::ExecuteDownsample>();
+    ttnn::register_operation<"ttnn::downsample", ttnn::operations::downsample::ExecuteDownsample>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.hpp
@@ -36,11 +36,9 @@ struct Pool2DOp {
 
 }  // namespace operations::pool
 
-constexpr auto max_pool2d = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::max_pool2d",
-    operations::pool::Pool2DOp<operations::pool::Pool2DType::MAX_POOL2D>>();
-constexpr auto avg_pool2d = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::avg_pool2d",
-    operations::pool::Pool2DOp<operations::pool::Pool2DType::AVG_POOL2D>>();
+constexpr auto max_pool2d = ttnn::
+    register_operation<"ttnn::max_pool2d", operations::pool::Pool2DOp<operations::pool::Pool2DType::MAX_POOL2D>>();
+constexpr auto avg_pool2d = ttnn::
+    register_operation<"ttnn::avg_pool2d", operations::pool::Pool2DOp<operations::pool::Pool2DType::AVG_POOL2D>>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/global_avg_pool/global_avg_pool.hpp
@@ -42,7 +42,7 @@ struct GlobalAveragePool2D {
 }  // namespace pool
 }  // namespace operations
 
-constexpr auto global_avg_pool2d = ttnn::
-    register_operation_with_auto_launch_op<"ttnn::global_avg_pool2d", ttnn::operations::pool::GlobalAveragePool2D>();
+constexpr auto global_avg_pool2d =
+    ttnn::register_operation<"ttnn::global_avg_pool2d", ttnn::operations::pool::GlobalAveragePool2D>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/pool/upsample/upsample.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/upsample.hpp
@@ -22,6 +22,5 @@ struct ExecuteUpSample {
 };
 }  // namespace upsample
 }  // namespace operations
-constexpr auto upsample =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::upsample", ttnn::operations::upsample::ExecuteUpSample>();
+constexpr auto upsample = ttnn::register_operation<"ttnn::upsample", ttnn::operations::upsample::ExecuteUpSample>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.cpp
@@ -16,19 +16,7 @@ Tensor ExecuteDramPrefetcher::invoke(
     const uint32_t num_layers,
     const std::optional<const GlobalCircularBuffer>& global_cb,
     const bool enable_performance_mode) {
-    std::vector<Tensor> output_tensors = {Tensor(tt::tt_metal::operation::get_workers_for_op_output(tensors))};
-    tt::tt_metal::operation::launch_op(
-        [num_layers, global_cb, enable_performance_mode](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-            return tt::tt_metal::operation::run(
-                DramPrefetcher{global_cb, num_layers, enable_performance_mode}, input_tensors);
-        },
-        tensors,
-        output_tensors);
-
-    return output_tensors.at(0);
+    return tt::tt_metal::operation::run(DramPrefetcher{global_cb, num_layers, enable_performance_mode}, tensors).at(0);
 }
 
 }  // namespace ttnn::operations::dram_prefetcher

--- a/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/prefetcher/prefetcher/dram_prefetcher.hpp
@@ -23,8 +23,7 @@ struct ExecuteDramPrefetcher {
 
 }  // namespace operations::dram_prefetcher
 
-constexpr auto dram_prefetcher = ttnn::register_operation_with_auto_launch_op<
-    "ttnn::dram_prefetcher",
-    ttnn::operations::dram_prefetcher::ExecuteDramPrefetcher>();
+constexpr auto dram_prefetcher =
+    ttnn::register_operation<"ttnn::dram_prefetcher", ttnn::operations::dram_prefetcher::ExecuteDramPrefetcher>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/argmax.hpp
@@ -25,7 +25,6 @@ struct ArgMaxOperation {
 
 }  // namespace operations::reduction
 
-constexpr auto argmax =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::argmax", ttnn::operations::reduction::ArgMaxOperation>();
+constexpr auto argmax = ttnn::register_operation<"ttnn::argmax", ttnn::operations::reduction::ArgMaxOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -193,80 +193,60 @@ Tensor reduce(
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true));
 
-    std::vector<Tensor> output_tensors = {Tensor(operation::get_workers_for_op_output({input_tensor}))};
     if (is_multicore_hw) {
-        operation::launch_op(
-            [reduce_math, reduce_dim, pad_value, scaler, output_dtype, output_mem_config, config](
-                const std::vector<Tensor>& input_tensors,
-                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-                const auto& input_tensor = input_tensors.at(0);
-                IDevice* device;
-
-                // Get the device
-                if (input_tensor.storage_type() != StorageType::DEVICE) {
-                    device = ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice();
-                    TT_ASSERT(device != nullptr, "Requires setting default device if no inputs to op are on device");
-                } else {
-                    device = input_tensor.device();
-                }
-                auto input_tensor_pad_shape =
-                    ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(
-                        input_tensor.get_padded_shape());
-                auto formatted_input_tensor = input_tensor;
-                if (!ttnn::operations::experimental::auto_format::AutoFormat::check_input_tensor_format(
-                        input_tensor, input_tensor_pad_shape)) {
-                    formatted_input_tensor =
-                        ttnn::operations::experimental::auto_format::AutoFormat::format_input_tensor(
-                            input_tensor, device, input_tensor_pad_shape, pad_value, Layout::TILE);
-                }
-                const Tensor output_tensor = operation::run(
-                                                 Reduce{
-                                                     reduce_math,
-                                                     ReduceOpDim::W,
-                                                     1.0,
-                                                     output_mem_config,
-                                                     output_dtype.value_or(input_tensor.get_dtype()),
-                                                     config},
-                                                 {formatted_input_tensor})
-                                                 .at(0);
-                return operation::run(
-                    Reduce{
-                        reduce_math,
-                        ReduceOpDim::H,
-                        scaler,
-                        output_mem_config,
-                        output_dtype.value_or(input_tensor.get_dtype()),
-                        config},
-                    {output_tensor});
-            },
-            {input_tensor},
-            output_tensors);
+        IDevice* device;
+        // Get the device
+        if (input_tensor.storage_type() != StorageType::DEVICE) {
+            device = ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice();
+            TT_ASSERT(device != nullptr, "Requires setting default device if no inputs to op are on device");
+        } else {
+            device = input_tensor.device();
+        }
+        auto input_tensor_pad_shape =
+            ttnn::operations::experimental::auto_format::AutoFormat::pad_to_tile_shape(input_tensor.get_padded_shape());
+        auto formatted_input_tensor = input_tensor;
+        if (!ttnn::operations::experimental::auto_format::AutoFormat::check_input_tensor_format(
+                input_tensor, input_tensor_pad_shape)) {
+            formatted_input_tensor = ttnn::operations::experimental::auto_format::AutoFormat::format_input_tensor(
+                input_tensor, device, input_tensor_pad_shape, pad_value, Layout::TILE);
+        }
+        const Tensor output_tensor = operation::run(
+                                         Reduce{
+                                             reduce_math,
+                                             ReduceOpDim::W,
+                                             1.0,
+                                             output_mem_config,
+                                             output_dtype.value_or(input_tensor.get_dtype()),
+                                             config},
+                                         {formatted_input_tensor})
+                                         .at(0);
+        return operation::run(
+                   Reduce{
+                       reduce_math,
+                       ReduceOpDim::H,
+                       scaler,
+                       output_mem_config,
+                       output_dtype.value_or(input_tensor.get_dtype()),
+                       config},
+                   {output_tensor})
+            .at(0);
     } else {
-        operation::launch_op(
-            [reduce_math, reduce_dim, pad_value, scaler, output_dtype, output_mem_config, config](
-                const std::vector<Tensor>& input_tensors,
-                const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-                const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-                const auto& input_tensor = input_tensors.at(0);
-                return operation::run_with_autoformat(
-                    Reduce{
-                        reduce_math,
-                        reduce_dim,
-                        scaler,
-                        output_mem_config,
-                        output_dtype.value_or(input_tensor.get_dtype()),
-                        config},
-                    {input_tensor},
-                    {},
-                    {},
-                    pad_value);
-            },
-            {input_tensor},
-            output_tensors);
+        return operation::run_with_autoformat(
+                   Reduce{
+                       reduce_math,
+                       reduce_dim,
+                       scaler,
+                       output_mem_config,
+                       output_dtype.value_or(input_tensor.get_dtype()),
+                       config},
+                   {input_tensor},
+                   {},
+                   {},
+                   pad_value)
+            .at(0);
     }
-    return output_tensors.at(0);
 }
+
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -45,27 +45,27 @@ Tensor pool_sum(
 }  // namespace operations::reduction
 
 // Generic reductions
-constexpr auto sum = ttnn::register_operation_with_auto_launch_op<
+constexpr auto sum = ttnn::register_operation<
     "ttnn::sum",
     ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Sum>>();
 
-constexpr auto mean = ttnn::register_operation_with_auto_launch_op<
+constexpr auto mean = ttnn::register_operation<
     "ttnn::mean",
     ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Mean>>();
 
-constexpr auto max = ttnn::register_operation_with_auto_launch_op<
+constexpr auto max = ttnn::register_operation<
     "ttnn::max",
     ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Max>>();
 
-constexpr auto min = ttnn::register_operation_with_auto_launch_op<
+constexpr auto min = ttnn::register_operation<
     "ttnn::min",
     ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Min>>();
 
-constexpr auto std = ttnn::register_operation_with_auto_launch_op<
+constexpr auto std = ttnn::register_operation<
     "ttnn::std",
     ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Std>>();
 
-constexpr auto var = ttnn::register_operation_with_auto_launch_op<
+constexpr auto var = ttnn::register_operation<
     "ttnn::var",
     ttnn::operations::reduction::Reduce<ttnn::operations::reduction::ReduceType::Var>>();
 

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe.cpp
@@ -49,13 +49,4 @@ auto MoeOperation::invoke(
         std::move(optional_output_tensor));
 }
 
-std::vector<Tensor> MoeOperation::create_async_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-    const auto& input_tensor = input_tensors.at(0);
-    const auto& expert_mask_tensor = input_tensors.at(1);
-    const auto& topk_mask_tensor = input_tensors.at(2);
-    return {Tensor(
-        tt::tt_metal::operation::get_workers_for_op_output({input_tensor, expert_mask_tensor, topk_mask_tensor}))};
-}
-
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/moe/moe.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/moe.hpp
@@ -29,13 +29,9 @@ struct MoeOperation {
         const uint16_t k,
         const std::optional<MemoryConfig>& memory_config = std::nullopt,
         std::optional<Tensor> optional_output_tensor = std::nullopt);
-
-    static std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
 };
 }  // namespace operations::reduction
 
-constexpr auto moe =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::moe", ttnn::operations::reduction::MoeOperation>();
+constexpr auto moe = ttnn::register_operation<"ttnn::moe", ttnn::operations::reduction::MoeOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
@@ -30,7 +30,6 @@ struct ProdOperation {
 
 }  // namespace operations::reduction
 
-constexpr auto prod =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::prod", ttnn::operations::reduction::ProdOperation>();
+constexpr auto prod = ttnn::register_operation<"ttnn::prod", ttnn::operations::reduction::ProdOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling.hpp
@@ -34,7 +34,6 @@ struct SamplingOperation {
 
 }  // namespace operations::reduction
 
-constexpr auto sampling =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::sampling", ttnn::operations::reduction::SamplingOperation>();
+constexpr auto sampling = ttnn::register_operation<"ttnn::sampling", ttnn::operations::reduction::SamplingOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -146,12 +146,4 @@ std::vector<Tensor> ExecuteTopK::invoke(
         input_memory_config);
 }
 
-std::vector<Tensor> ExecuteTopK::create_async_output_tensors(
-    const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-    const auto& input_tensor = input_tensors.at(0);
-    return {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor})),
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}))};
-}
-
 }  // namespace ttnn::operations::reduction

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -22,14 +22,10 @@ struct ExecuteTopK {
         const bool sorted,
         const std::optional<MemoryConfig>& memory_config,
         std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
-
-    static std::vector<Tensor> create_async_output_tensors(
-        const std::vector<Tensor>& input_tensors, const std::vector<std::optional<const Tensor>>& optional_inputs);
 };
 
 }  // namespace operations::reduction
 
-constexpr auto topk =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::topk", ttnn::operations::reduction::ExecuteTopK>();
+constexpr auto topk = ttnn::register_operation<"ttnn::topk", ttnn::operations::reduction::ExecuteTopK>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -233,59 +233,46 @@ Tensor halo_op(
     //       for BLOCK_SHARDED, ncores_nhw is just the ncores along height dim (last tensor dim is split along
     //       width)
     bool is_block_sharded = input_tensor.memory_config().memory_layout == TensorMemoryLayout::BLOCK_SHARDED;
-    auto halo_func =
-        [config, pad_val, remote_read, is_block_sharded, transpose_mcast, output_memory_config, is_out_tiled, in_place](
-            const std::vector<Tensor>& input_tensors,
-            const std::vector<std::optional<const Tensor>>& optional_input_tensors,
-            const std::vector<std::optional<Tensor>>& optional_output_tensors) mutable -> std::vector<Tensor> {
-        auto input_tensor = input_tensors.at(0);
 
-        auto device = input_tensor.device();
+    auto device = input_tensor.device();
 
-        auto sliding_window_hash = config.get_hash();
-        if (!HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.contains(sliding_window_hash)) {
-            auto op_trace_metadata = sliding_window::generate_op_trace_metadata(config);
-            auto shard_boundaries = sliding_window::generate_shard_boundaries(config, op_trace_metadata);
-            HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.emplace(
-                sliding_window_hash, sliding_window::generate_max_out_nsticks_per_core(shard_boundaries));
-        }
+    auto sliding_window_hash = config.get_hash();
+    if (!HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.contains(sliding_window_hash)) {
+        auto op_trace_metadata = sliding_window::generate_op_trace_metadata(config);
+        auto shard_boundaries = sliding_window::generate_shard_boundaries(config, op_trace_metadata);
+        HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.emplace(
+            sliding_window_hash, sliding_window::generate_max_out_nsticks_per_core(shard_boundaries));
+    }
 
-        uint32_t max_out_nsticks_per_core =
-            HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.at(sliding_window_hash);
-        uint32_t in_nsticks_per_core = input_tensor.memory_config().shard_spec->shape[0];
-        ParallelConfig p_config;
-        p_config.grid = input_tensor.shard_spec().value().grid;
-        p_config.shard_scheme = input_tensor.memory_config().memory_layout;
-        p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
+    uint32_t max_out_nsticks_per_core =
+        HaloDeviceOperation::sliding_window_max_out_nsticks_per_core.at(sliding_window_hash);
+    uint32_t in_nsticks_per_core = input_tensor.memory_config().shard_spec->shape[0];
+    ParallelConfig p_config;
+    p_config.grid = input_tensor.shard_spec().value().grid;
+    p_config.shard_scheme = input_tensor.memory_config().memory_layout;
+    p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
 
-        if (in_place && in_nsticks_per_core > max_out_nsticks_per_core) {
-            tt::log_info(
-                tt::LogAlways,
-                "halo_device_operation - in place operation is not supported for parameterizations with "
-                "input shard size larger than output shard size, falling back to normal operation");
-            in_place = false;
-        }
+    if (in_place && in_nsticks_per_core > max_out_nsticks_per_core) {
+        tt::log_info(
+            tt::LogAlways,
+            "halo_device_operation - in place operation is not supported for parameterizations with "
+            "input shard size larger than output shard size, falling back to normal operation");
+        in_place = false;
+    }
 
-        return operation::run(
-            HaloDeviceOperation{
-                .config_ = config,
-                .parallel_config_ = p_config,
-                .pad_val_ = pad_val,
-                .remote_read_ = remote_read,
-                .transpose_mcast_ = transpose_mcast,
-                .max_out_nsticks_per_core_ = max_out_nsticks_per_core,
-                .in_nsticks_per_core_ = in_nsticks_per_core,
-                .output_memory_config_ = output_memory_config,
-                .is_out_tiled_ = is_out_tiled,
-                .in_place_ = in_place},
-            {input_tensor});
-    };
-
-    std::vector<Tensor> output_tensors = {
-        Tensor(tt::tt_metal::operation::get_workers_for_op_output({input_tensor}, {}))};
-    operation::launch_op(halo_func, {input_tensor}, output_tensors);
-
-    return output_tensors.at(0);
+    return operation::run(
+        HaloDeviceOperation{
+            .config_ = config,
+            .parallel_config_ = p_config,
+            .pad_val_ = pad_val,
+            .remote_read_ = remote_read,
+            .transpose_mcast_ = transpose_mcast,
+            .max_out_nsticks_per_core_ = max_out_nsticks_per_core,
+            .in_nsticks_per_core_ = in_nsticks_per_core,
+            .output_memory_config_ = output_memory_config,
+            .is_out_tiled_ = is_out_tiled,
+            .in_place_ = in_place},
+        {input_tensor}).at(0);
 }
 
 }  // namespace ttnn::operations::sliding_window::halo

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
@@ -34,7 +34,7 @@ namespace ttnn {
 constexpr auto halo = ttnn::register_operation<"ttnn::halo", operations::sliding_window::halo::HaloOperation>();
 
 // Alternatively, the operation can be registered as asynchronous
-// constexpr auto example = ttnn::register_operation_with_auto_launch_op<"ttnn::example",
+// constexpr auto example = ttnn::register_operation<"ttnn::example",
 // operations::examples::ExampleOperation>();
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/transformer/attention_softmax/attention_softmax.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/attention_softmax/attention_softmax.hpp
@@ -27,11 +27,11 @@ struct ExecuteAttentionSoftmax {
 
 namespace transformer {
 
-constexpr auto attention_softmax = ttnn::register_operation_with_auto_launch_op<
+constexpr auto attention_softmax = ttnn::register_operation<
     "ttnn::transformer::attention_softmax",
     ttnn::operations::transformer::ExecuteAttentionSoftmax<false>>();
 
-constexpr auto attention_softmax_ = ttnn::register_operation_with_auto_launch_op<
+constexpr auto attention_softmax_ = ttnn::register_operation<
     "ttnn::transformer::attention_softmax_",
     ttnn::operations::transformer::ExecuteAttentionSoftmax<true>>();
 

--- a/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/concatenate_heads/concatenate_heads.hpp
@@ -15,7 +15,7 @@ struct ExecuteConcatenateHeads {
 }  // namespace operations::transformer
 
 namespace transformer {
-constexpr auto concatenate_heads = ttnn::register_operation_with_auto_launch_op<
+constexpr auto concatenate_heads = ttnn::register_operation<
     "ttnn::transformer::concatenate_heads",
     ttnn::operations::transformer::ExecuteConcatenateHeads>();
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -92,15 +92,15 @@ struct ExecuteJointAttention {
 
 namespace transformer {
 
-constexpr auto scaled_dot_product_attention = ttnn::register_operation_with_auto_launch_op<
+constexpr auto scaled_dot_product_attention = ttnn::register_operation<
     "ttnn::transformer::scaled_dot_product_attention",
     ttnn::operations::transformer::ExecuteScaledDotProductAttention>();
 
-constexpr auto chunked_scaled_dot_product_attention = ttnn::register_operation_with_auto_launch_op<
+constexpr auto chunked_scaled_dot_product_attention = ttnn::register_operation<
     "ttnn::transformer::chunked_scaled_dot_product_attention",
     ttnn::operations::transformer::ExecuteChunkedScaledDotProductAttention>();
 
-constexpr auto joint_scaled_dot_product_attention = ttnn::register_operation_with_auto_launch_op<
+constexpr auto joint_scaled_dot_product_attention = ttnn::register_operation<
     "ttnn::transformer::joint_scaled_dot_product_attention",
     ttnn::operations::transformer::ExecuteJointAttention>();
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/sdpa_decode.hpp
@@ -73,11 +73,11 @@ struct ExecutePagedScaledDotProductAttentionDecode {
 
 namespace transformer {
 
-constexpr auto scaled_dot_product_attention_decode = ttnn::register_operation_with_auto_launch_op<
+constexpr auto scaled_dot_product_attention_decode = ttnn::register_operation<
     "ttnn::transformer::scaled_dot_product_attention_decode",
     ttnn::operations::transformer::ExecuteScaledDotProductAttentionDecode>();
 
-constexpr auto paged_scaled_dot_product_attention_decode = ttnn::register_operation_with_auto_launch_op<
+constexpr auto paged_scaled_dot_product_attention_decode = ttnn::register_operation<
     "ttnn::transformer::paged_scaled_dot_product_attention_decode",
     ttnn::operations::transformer::ExecutePagedScaledDotProductAttentionDecode>();
 

--- a/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp
@@ -22,7 +22,7 @@ struct SplitQueryKeyValueAndSplitHeadsOperation {
 }  // namespace operations::transformer
 
 namespace transformer {
-constexpr auto split_query_key_value_and_split_heads = ttnn::register_operation_with_auto_launch_op<
+constexpr auto split_query_key_value_and_split_heads = ttnn::register_operation<
     "ttnn::transformer::split_query_key_value_and_split_heads",
     ttnn::operations::transformer::SplitQueryKeyValueAndSplitHeadsOperation>();
 

--- a/ttnn/cpp/ttnn/operations/uniform/uniform.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/uniform.hpp
@@ -19,6 +19,5 @@ struct Uniform {
 }  // namespace ttnn::operations::uniform
 
 namespace ttnn {
-constexpr auto uniform =
-    ttnn::register_operation_with_auto_launch_op<"ttnn::uniform", ttnn::operations::uniform::Uniform>();
+constexpr auto uniform = ttnn::register_operation<"ttnn::uniform", ttnn::operations::uniform::Uniform>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -62,32 +62,6 @@ Tensor* get_tensor(T& maybe_tensor) {
     return output_tensor;
 }
 
-void check_output(auto& output_tensors, const std::vector<IDevice*>& workers) {
-    for (auto& output_tensor_like : output_tensors) {
-        auto output_tensor = get_tensor(output_tensor_like);
-        if (!output_tensor) {
-            continue;
-        }
-        TT_FATAL(
-            output_tensor->workers.size(),
-            "Worker threads must be specified for outputs populated by launch_op. This API can only be used for "
-            "creating output tensors on device.");
-        TT_FATAL(
-            output_tensor->workers == workers,
-            "Worker threads must be consistent across all outputs populated by launch_op.");
-    }
-}
-
-auto& get_workers(auto& output_tensors) {
-    for (auto& output_tensor_like : output_tensors) {
-        Tensor* output_tensor = get_tensor(output_tensor_like);
-        if (output_tensor) {
-            return output_tensor->workers;
-        }
-    }
-    TT_THROW("Workers not found in output tensors.");
-}
-
 }  // namespace detail
 }  // namespace tt::tt_metal::operation
 
@@ -331,63 +305,5 @@ Tensors run_with_autoformat(
 
     return output_tensors;
 }
-
-std::vector<IDevice*> get_workers_for_op_output(
-    const std::vector<Tensor>& inputs, const std::vector<std::optional<const Tensor>>& optional_inputs) {
-    using ttnn::operations::experimental::auto_format::AutoFormat;
-    std::vector<IDevice*> workers_for_op = {};
-    // Infer output workers from inputs. For multi-device tensors the number
-    // of workers used for the op (and assigned to the ouput) is the minimum
-    // number of workers across all inputs. Additionally, in this case, at least
-    // 1 worker must be specified across all inputs, i.e. host inputs are not allowed.
-    size_t min_workers_size = std::numeric_limits<uint32_t>::max();
-    for (auto& input : inputs) {
-        auto workers = input.get_workers();
-        min_workers_size = std::min(min_workers_size, workers.size());
-        if (workers.size() == min_workers_size) {
-            workers_for_op = workers;
-        }
-    }
-
-    if (not workers_for_op.size()) {
-        for (auto& input : optional_inputs) {
-            if (input.has_value()) {
-                auto workers = input.value().get_workers();
-                min_workers_size = std::min(min_workers_size, workers.size());
-                if (workers.size() == min_workers_size) {
-                    workers_for_op = workers;
-                }
-            }
-        }
-    }
-    return workers_for_op;
-}
-
-template <class OutputType>
-void launch_op_func(
-    const std::function<OutputType(const Tensors&, const OptionalConstTensors&, const OptionalTensors&)>& op_func,
-    const Tensors input_tensors,
-    OutputType& output_tensors,
-    const OptionalConstTensors optional_input_tensors,
-    const OptionalTensors optional_output_tensors) {
-    // Send host side op compile and run to the worker queue
-    // Assert to ensure that worker threads are specified.
-    ZoneScopedN("LaunchOp");
-    output_tensors = op_func(input_tensors, optional_input_tensors, optional_output_tensors);
-    return;
-}
-
-template void launch_op_func<Tensors>(
-    const std::function<Tensors(const Tensors&, const OptionalConstTensors&, const OptionalTensors&)>& op_func,
-    const Tensors input_tensors,
-    Tensors& output_tensors,
-    const OptionalConstTensors optional_input_tensors,
-    const OptionalTensors optional_output_tensors);
-template void launch_op_func<OptionalTensors>(
-    const std::function<OptionalTensors(const Tensors&, const OptionalConstTensors&, const OptionalTensors&)>& op_func,
-    const Tensors input_tensors,
-    OptionalTensors& output_tensors,
-    const OptionalConstTensors optional_input_tensors,
-    const OptionalTensors optional_output_tensors);
 
 }  // namespace tt::tt_metal::operation

--- a/ttnn/cpp/ttnn/run_operation.hpp
+++ b/ttnn/cpp/ttnn/run_operation.hpp
@@ -119,35 +119,6 @@ inline auto run_with_autoformat(
         cq_id);
 }
 
-template <class OutputType = Tensors>
-__attribute__((noinline)) void launch_op_func(
-    const std::function<OutputType(const Tensors&, const OptionalConstTensors&, const OptionalTensors&)>& op_func,
-    const Tensors input_tensors,
-    OutputType& output_tensors,
-    const OptionalConstTensors optional_input_tensors = {},
-    const OptionalTensors optional_output_tensors = {});
-
-/*
- */
-template <class F, class OutputType>
-void launch_op(
-    F&& op_func,
-    const Tensors input_tensors,
-    OutputType& output_tensors,
-    const OptionalConstTensors optional_input_tensors = {},
-    const OptionalTensors optional_output_tensors = {}) {
-    using FuncType = std::function<OutputType(const Tensors&, const OptionalConstTensors&, const OptionalTensors&)>;
-    launch_op_func(
-        FuncType(std::forward<F>(op_func)),
-        input_tensors,
-        output_tensors,
-        optional_input_tensors,
-        optional_output_tensors);
-}
-
-std::vector<IDevice*> get_workers_for_op_output(
-    const std::vector<Tensor>& inputs, const std::vector<std::optional<const Tensor>>& optional_inputs = {});
-
 namespace detail {
 IDevice* get_device(const Tensors& input_tensors, const OptionalConstTensors& optional_input_tensors = {});
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21102)

### Problem description
`launch_op` and its derivatives are no longer needed, with async mode removed from TTNN.

### What's changed
Kill `launch_op` and wrappers around it.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes