### PR TITLE
#19201: add extra syncs to sdpa decode

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -383,8 +383,5 @@ ALWI void cb_matmul_blocks(
         }
         in0_index_offset += subblock_h * in0_block_w;
     }
-#ifndef BLACKHOLE
-    cb_pop_front(in0_cb, M * K);  // #19201 BH hang workaround
-#endif
     cb_pop_front(in1_cb, K * N);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -383,5 +383,8 @@ ALWI void cb_matmul_blocks(
         }
         in0_index_offset += subblock_h * in0_block_w;
     }
+#ifndef BLACKHOLE
+    cb_wait_front(in0_cb, M * K);
+#endif
     cb_pop_front(in1_cb, K * N);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -346,7 +346,7 @@ ALWI void cb_matmul_blocks(
         in0_cb, in1_cb, transpose /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
 
     reconfig_data_format(in1_cb, in0_cb);
-    cb_wait_front(in0_cb, M * K);
+    cb_wait_front(in0_cb, M * K);  // #19201 BH hang workaround
     cb_wait_front(in1_cb, K * N);
 
     uint32_t output_num_tiles = M * N;
@@ -384,7 +384,7 @@ ALWI void cb_matmul_blocks(
         in0_index_offset += subblock_h * in0_block_w;
     }
 #ifndef BLACKHOLE
-    cb_wait_front(in0_cb, M * K);
+    cb_wait_front(in0_cb, M * K);  // #19201 BH hang workaround
 #endif
     cb_pop_front(in1_cb, K * N);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -346,6 +346,7 @@ ALWI void cb_matmul_blocks(
         in0_cb, in1_cb, transpose /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
 
     reconfig_data_format(in1_cb, in0_cb);
+    cb_wait_front(in0_cb, M * K);
     cb_wait_front(in1_cb, K * N);
 
     uint32_t output_num_tiles = M * N;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -384,7 +384,7 @@ ALWI void cb_matmul_blocks(
         in0_index_offset += subblock_h * in0_block_w;
     }
 #ifndef BLACKHOLE
-    cb_wait_front(in0_cb, M * K);  // #19201 BH hang workaround
+    cb_pop_front(in0_cb, M * K);  // #19201 BH hang workaround
 #endif
     cb_pop_front(in1_cb, K * N);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -388,7 +388,7 @@ void MAIN {
                     copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
                     copy_block(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
 #ifndef ARCH_WORMHOLE
-                    UNPACK(asm volatile("fence"));
+                    UNPACK(asm volatile("fence"));  // #19201 BH hang workaround
 #endif
                 }
             }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -387,6 +387,9 @@ void MAIN {
                     cb_pop_front(cb_m_in, Sq_chunk_t);
                     copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
                     copy_block(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
+#ifndef ARCH_WORMHOLE
+                    UNPACK(asm volatile("fence"));
+#endif
                 }
             }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -156,7 +156,7 @@ void kernel_main() {
         generate_mask<cb_mask_in, PNHt>(k_num_chunks, Sk_chunk_t_dynamic, cur_pos);
     }
 
-    noc_async_write_barrier();
+    noc_async_write_barrier();  // #19201 BH hang workaround
     for (uint32_t cur_head = cur_head_group * num_heads_per_core;
          cur_head < cur_head_group * num_heads_per_core + num_heads_per_core;
          ++cur_head) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -156,6 +156,7 @@ void kernel_main() {
         generate_mask<cb_mask_in, PNHt>(k_num_chunks, Sk_chunk_t_dynamic, cur_pos);
     }
 
+    noc_async_write_barrier();
     for (uint32_t cur_head = cur_head_group * num_heads_per_core;
          cur_head < cur_head_group * num_heads_per_core + num_heads_per_core;
          ++cur_head) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #19201

### Problem description
The BH llama tests were still hanging in SDPA decode after several other changes and reverts

### What's changed
- added a cb_wait_front for in0 of cb_matmul_blocks (looks like it's needed as well, but you can't have the corresponding pop front)
- added a write barrier before a reduction loop in the writer kernel (helped with some hangs)
- added a fence instruction to unpack at the end of an inner loop in the compute kernel (helped with the remainder of the hangs)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14699768596
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14694812959 similar behaviour to main: https://github.com/tenstorrent/tt-metal/actions/runs/14695664842 https://github.com/tenstorrent/tt-metal/actions/runs/14693835044/job/41232906759
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14694810535
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) fails the same as main https://github.com/tenstorrent/tt-metal/actions/runs/14669695220 (main) vs https://github.com/tenstorrent/tt-metal/actions/runs/14671211480 (this branch)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A (future PR will add tests)