### PR TITLE
Enable modernize-use-using rule in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -134,7 +134,6 @@ Checks: >
   -modernize-use-nullptr,
   -modernize-use-trailing-return-type,
   -modernize-use-transparent-functors,
-  -modernize-use-using,
   -performance-avoid-endl,
   -performance-faster-string-find,
   -performance-inefficient-string-concatenation,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -47,14 +47,14 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-typedef enum sanitization_features {
+enum watcher_features_t {
     SanitizeAddress,
     SanitizeAlignmentL1Write,
     SanitizeAlignmentL1Read,
     SanitizeZeroL1Write,
     SanitizeMailboxWrite,
     SanitizeInlineWriteDram,
-} watcher_features_t;
+};
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
     return feature == watcher_features_t::SanitizeInlineWriteDram ? tt_metal::HalMemType::DRAM

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -123,7 +123,7 @@ inline std::vector<uint32_t> get_random_numbers_from_range(uint32_t start, uint3
     return std::vector<uint32_t>(range.begin(), range.begin() + count);
 }
 
-typedef struct test_board {
+struct test_board_t {
     std::vector<chip_id_t> available_chip_ids;
     std::vector<chip_id_t> physical_chip_ids;
     std::vector<std::pair<chip_id_t, std::vector<chip_id_t>>> tx_rx_map;
@@ -133,7 +133,7 @@ typedef struct test_board {
     uint32_t num_chips_to_use;
     std::string mesh_graph_descriptor;
 
-    test_board(std::string& board_type_) {
+    test_board_t(std::string& board_type_) {
         if ("n300" == board_type_) {
             mesh_graph_descriptor = "n300_mesh_graph_descriptor.yaml";
             num_chips_to_use = 2;
@@ -509,10 +509,9 @@ typedef struct test_board {
     }
 
     inline void close_devices() { tt::tt_metal::detail::CloseDevices(device_handle_map); }
+};
 
-} test_board_t;
-
-typedef struct test_device {
+struct test_device_t {
     chip_id_t physical_chip_id;
     test_board_t* board_handle;
     tt_metal::IDevice* device_handle;
@@ -531,7 +530,7 @@ typedef struct test_device {
     std::unordered_map<chan_id_t, std::vector<std::pair<uint32_t, CoreCoord>>>
         router_worker_map;  // router chan to worker logical cores
 
-    test_device(chip_id_t chip_id_, test_board_t* board_handle_) {
+    test_device_t(chip_id_t chip_id_, test_board_t* board_handle_) {
         physical_chip_id = chip_id_;
         board_handle = board_handle_;
 
@@ -663,7 +662,7 @@ typedef struct test_device {
 
     void get_available_router_cores(
         uint32_t num_hops,
-        std::shared_ptr<test_device>& rx_device,
+        std::shared_ptr<test_device_t>& rx_device,
         std::vector<chan_id_t>& src_routers,
         std::vector<chan_id_t>& dest_routers) {
         // shortest route possible with least number of internal noc hops
@@ -817,10 +816,9 @@ typedef struct test_device {
     inline stl::Span<const chip_id_t> get_intra_chip_neighbors(RoutingDirection routing_direction) {
         return board_handle->get_intra_chip_neighbors(mesh_id, logical_chip_id, routing_direction);
     }
+};
 
-} test_device_t;
-
-typedef struct test_traffic {
+struct test_traffic_t {
     std::shared_ptr<test_device_t> tx_device;
     std::vector<std::shared_ptr<test_device_t>> rx_devices;
     uint32_t num_tx_workers;
@@ -847,7 +845,7 @@ typedef struct test_traffic {
     std::optional<uint32_t> remote_controller_noc_encoding;
     std::optional<uint32_t> remote_controller_mesh_chip_id;
 
-    test_traffic(
+    test_traffic_t(
         std::shared_ptr<test_device_t>& tx_device_,
         std::vector<std::shared_ptr<test_device_t>>& rx_devices_,
         uint32_t num_src_endpoints,
@@ -904,7 +902,7 @@ typedef struct test_traffic {
         }
     }
 
-    void set_remote_controller(test_traffic& reverse_traffic) {
+    void set_remote_controller(test_traffic_t& reverse_traffic) {
         sync_with_remote_controller_kernel = true;
         auto remote_tx_device = reverse_traffic.tx_device;
         controller_outbound_eth_chan = std::get<0>(tx_workers[0]);
@@ -1326,8 +1324,7 @@ typedef struct test_traffic {
             }
         }
     }
-
-} test_traffic_t;
+};
 
 int main(int argc, char **argv) {
 

--- a/tests/tt_metal/tt_metal/test_gold_impls.hpp
+++ b/tests/tt_metal/tt_metal/test_gold_impls.hpp
@@ -174,4 +174,4 @@ inline std::vector<uint16_t> gold_bmm(
     return result;
 }
 
-typedef BcastOp EltwiseOp;
+using EltwiseOp = BcastOp;

--- a/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_sharded_address_generators_new.cpp
@@ -149,15 +149,14 @@ TEST(CclnewHeightShardedTensorSliceIndexer_Wormhole, height_sharded_test) {
     static constexpr std::size_t pages_per_shard_width = 1;
     static constexpr std::size_t rows_per_shard_height = 8;
     static constexpr std::size_t tensor_address = 0x100000;
-    typedef ShardedInfo<
+    using ct_shard_info = ShardedInfo<
         shard_type,
         number_of_cores,
         page_size_jump,
         pages_per_tensor_row,
         contiguity,
         pages_per_shard_width,
-        rows_per_shard_height>
-        ct_shard_info;
+        rows_per_shard_height>;
     auto info_var = ct_shard_info{};
     ::experimental::ShardedAddrGen<ct_shard_info> addrgen = {
         .bank_base_address = tensor_address, .shard_array = sharding_testing_parameters::map};
@@ -174,15 +173,14 @@ TEST(CclnewBlockShardedTensorSliceIndexer_Wormhole, block_sharded_test) {
     static constexpr std::size_t pages_per_shard_width = 8;
     static constexpr std::size_t rows_per_shard_height = 8;
     static constexpr std::size_t tensor_address = 0x1000000;
-    typedef ShardedInfo<
+    using ct_shard_info = ShardedInfo<
         shard_type,
         number_of_cores,
         page_size_jump,
         pages_per_tensor_row,
         contiguity,
         pages_per_shard_width,
-        rows_per_shard_height>
-        ct_shard_info;
+        rows_per_shard_height>;
     auto info_var = ct_shard_info{};
     ::experimental::ShardedAddrGen<ct_shard_info> addrgen = {
         .bank_base_address = tensor_address, .shard_array = sharding_testing_parameters::map};

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -146,7 +146,7 @@ struct BufferConfig {
     TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED;
 };
 
-typedef BufferConfig InterleavedBufferConfig;
+using InterleavedBufferConfig = BufferConfig;
 
 // copied from above instead of using inheritance such that we can use
 // designator constructor

--- a/tt_metal/api/tt-metalium/dev_msgs.h
+++ b/tt_metal/api/tt-metalium/dev_msgs.h
@@ -237,7 +237,7 @@ enum debug_assert_tripped_enum {
 };
 
 // XXXX TODO(PGK): why why why do we not have this standardized
-typedef enum debug_sanitize_which_riscv {
+enum riscv_id_t {
     DebugBrisc = 0,
     DebugNCrisc = 1,
     DebugTrisc0 = 2,
@@ -247,14 +247,9 @@ typedef enum debug_sanitize_which_riscv {
     DebugIErisc = 6,
     DebugSlaveIErisc = 7,
     DebugNumUniqueRiscs
-} riscv_id_t;
+};
 
-typedef enum debug_transaction_type {
-    TransactionRead = 0,
-    TransactionWrite = 1,
-    TransactionAtomic = 2,
-    TransactionNumTypes
-} debug_transaction_type_t;
+enum debug_transaction_type_t { TransactionRead = 0, TransactionWrite = 1, TransactionAtomic = 2, TransactionNumTypes };
 
 struct debug_pause_msg_t {
     volatile uint8_t flags[DebugNumUniqueRiscs];

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -72,7 +72,7 @@ std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program& program, CBHand
 class Internal_;
 }  // namespace detail
 
-typedef std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX> kernel_id_array_t;
+using kernel_id_array_t = std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX>;
 
 struct KernelGroup {
     uint32_t programmable_core_type_index;

--- a/tt_metal/api/tt-metalium/tt_memory.h
+++ b/tt_metal/api/tt-metalium/tt_memory.h
@@ -14,8 +14,8 @@ namespace ll_api {
 
 class memory {
 public:
-    typedef std::uint64_t address_t;
-    typedef std::uint32_t word_t;
+    using address_t = std::uint64_t;
+    using word_t = std::uint32_t;
     enum class Loading : std::uint8_t { DISCRETE, CONTIGUOUS, CONTIGUOUS_XIP };
 
 private:

--- a/tt_metal/fabric/hw/inc/tt_fabric.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric.h
@@ -55,7 +55,7 @@ inline uint64_t get_timestamp() {
     return (((uint64_t)timestamp_high) << 32) | timestamp_low;
 }
 
-typedef struct fvc_outbound_push_state {
+struct fvc_outbound_push_state_t {
     uint32_t local_rdptr;
     uint32_t buffer_size;
     uint32_t buffer_slot_start[FABRIC_ROUTER_OUTBOUND_BUF_SLOTS];
@@ -72,7 +72,7 @@ typedef struct fvc_outbound_push_state {
     volatile uint64_t* slots_cleared_ack_addr;
 
     inline void init(uint32_t buffer_id, uint32_t data_buf_start, uint32_t data_buf_size_words) {
-        uint32_t words = sizeof(fvc_outbound_push_state) / 4;
+        uint32_t words = sizeof(fvc_outbound_push_state_t) / 4;
         uint32_t* ptr = (uint32_t*)this;
         for (uint32_t i = 0; i < words; i++) {
             ptr[i] = 0;
@@ -210,12 +210,11 @@ typedef struct fvc_outbound_push_state {
         *update_slot_credits = (-1) << REMOTE_DEST_BUF_WORDS_FREE_INC;
         return true;
     }
-
-} fvc_outbound_push_state_t;
+};
 
 static_assert(sizeof(fvc_outbound_push_state_t) % 4 == 0);
 
-typedef struct fvc_inbound_push_state {
+struct fvc_inbound_push_state_t {
     chan_payload_ptr inbound_wrptr;
     uint32_t slots_inbound;
     uint32_t slots_cleared;
@@ -252,7 +251,7 @@ typedef struct fvc_inbound_push_state {
 #endif
 
     inline void init(uint32_t data_buf_start, uint32_t data_buf_size_words) {
-        uint32_t words = sizeof(fvc_inbound_push_state) / 4;
+        uint32_t words = sizeof(fvc_inbound_push_state_t) / 4;
         uint32_t* ptr = (uint32_t*)this;
         for (uint32_t i = 0; i < words; i++) {
             ptr[i] = 0;
@@ -836,11 +835,11 @@ typedef struct fvc_inbound_push_state {
         free_receiver_buffer_space<fvc_mode>(slots_cleared);
         slots_cleared = 0;
     }
-} fvc_inbound_push_state_t;
+};
 
 static_assert(sizeof(fvc_inbound_push_state_t) % 4 == 0);
 
-typedef struct fvc_outbound_pull_state {
+struct fvc_outbound_pull_state_t {
     uint8_t chan_num;
     uint8_t pad[3];
     uint32_t packet_in_progress;
@@ -873,7 +872,7 @@ typedef struct fvc_outbound_pull_state {
     }
 
     inline void init(uint32_t data_buf_start, uint32_t data_buf_size_words) {
-        uint32_t words = sizeof(fvc_outbound_pull_state) / 4;
+        uint32_t words = sizeof(fvc_outbound_pull_state_t) / 4;
         uint32_t* ptr = (uint32_t*)this;
         for (uint32_t i = 0; i < words; i++) {
             ptr[i] = 0;
@@ -1089,7 +1088,7 @@ typedef struct fvc_outbound_pull_state {
         register_move_data(PACKET_HEADER_SIZE_WORDS);
         return PACKET_HEADER_SIZE_WORDS;
     }
-} fvc_outbound_pull_state_t;
+};
 
 static_assert(sizeof(fvc_outbound_pull_state_t) % 4 == 0);
 
@@ -1107,7 +1106,7 @@ enum ProcessingFlags : uint8_t {
 // direction, socket receiver/consumer buffer, center worker/consumer buffer.
 // Which ever entity receives the pull request is responsible draining the required amount of data from
 // FVC Producer.
-typedef struct fvc_inbound_pull_state {
+struct fvc_inbound_pull_state_t {
     chan_payload_ptr inbound_wrptr;
     chan_payload_ptr inbound_rdptr;
     uint32_t my_id;
@@ -1149,7 +1148,7 @@ typedef struct fvc_inbound_pull_state {
     }
 
     inline void init(uint32_t data_buf_start, uint32_t data_buf_size_words) {
-        uint32_t words = sizeof(fvc_inbound_pull_state) / 4;
+        uint32_t words = sizeof(fvc_inbound_pull_state_t) / 4;
         uint32_t* ptr = (uint32_t*)this;
         for (uint32_t i = 0; i < words; i++) {
             ptr[i] = 0;
@@ -1764,10 +1763,10 @@ typedef struct fvc_inbound_pull_state {
         free_receiver_buffer_space<fvc_mode>(words_cleared);
         words_cleared = 0;
     }
-} fvc_inbound_pull_state_t;
+};
 
 static_assert(sizeof(fvc_inbound_pull_state_t) % 4 == 0);
-typedef struct fvcc_outbound_state {
+struct fvcc_outbound_state_t {
     volatile chan_payload_ptr remote_rdptr;
     uint32_t remote_ptr_update_addr;
     volatile ctrl_chan_msg_buf*
@@ -1788,7 +1787,7 @@ typedef struct fvcc_outbound_state {
     }
 
     inline void init(uint32_t buf_start, uint32_t sync_buf_start, uint32_t remote_buf_start, uint32_t ptr_update_addr) {
-        uint32_t words = sizeof(fvcc_outbound_state) / 4;
+        uint32_t words = sizeof(fvcc_outbound_state_t) / 4;
         uint32_t* ptr = (uint32_t*)this;
         for (uint32_t i = 0; i < words; i++) {
             ptr[i] = 0;
@@ -1853,8 +1852,7 @@ typedef struct fvcc_outbound_state {
         forward_data_from_fvcc_buffer();
         advance_fvcc_rdptr();
     }
-
-} fvcc_outbound_state_t;
+};
 
 static_assert(sizeof(fvcc_outbound_state_t) % 4 == 0);
 
@@ -1865,7 +1863,7 @@ static_assert(sizeof(fvcc_outbound_state_t) % 4 == 0);
 // direction, if not meant for local device.
 // If control packet is addressed to local device, FVCC producer can process the packet locally if
 // it is a read/write ack, or forward the packet to Gatekeeper for further local processing.
-typedef struct fvcc_inbound_state {
+struct fvcc_inbound_state_t {
     volatile chan_payload_ptr inbound_wrptr;
     volatile chan_payload_ptr inbound_rdptr;
     uint32_t remote_ptr_update_addr;
@@ -1883,7 +1881,7 @@ typedef struct fvcc_inbound_state {
     volatile packet_header_t* current_packet_header;
 
     inline void init(uint32_t buf_start, uint32_t ptr_update_addr, uint64_t gk_fvcc_buf_start) {
-        uint32_t words = sizeof(fvcc_inbound_state) / 4;
+        uint32_t words = sizeof(fvcc_inbound_state_t) / 4;
         uint32_t* ptr = (uint32_t*)this;
         for (uint32_t i = 0; i < words; i++) {
             ptr[i] = 0;
@@ -2067,10 +2065,9 @@ typedef struct fvcc_inbound_state {
         }
         update_remote_rdptr_sent<fvc_mode>();
     }
+};
 
-} fvcc_inbound_state_t;
-
-typedef struct socket_reader_state {
+struct socket_reader_state_t {
     volatile chan_payload_ptr remote_rdptr;
     uint8_t packet_in_progress;
 
@@ -2104,7 +2101,7 @@ typedef struct socket_reader_state {
     }
 
     inline void init(uint32_t data_buf_start, uint32_t data_buf_size_words) {
-        uint32_t words = sizeof(socket_reader_state) / 4;
+        uint32_t words = sizeof(socket_reader_state_t) / 4;
         uint32_t* ptr = (uint32_t*)this;
         for (uint32_t i = 0; i < words; i++) {
             ptr[i] = 0;
@@ -2276,17 +2273,17 @@ typedef struct socket_reader_state {
         words_since_last_sync -= total_words_to_forward;
         return total_words_to_forward;
     }
-} socket_reader_state_t;
+};
 
 static_assert(sizeof(socket_reader_state_t) % 4 == 0);
 
-typedef struct router_state {
+struct router_state_t {
     uint32_t sync_in;
     uint32_t padding_in[3];
     uint32_t sync_out;
     uint32_t padding_out[3];
     uint32_t scratch[4];
-} router_state_t;
+};
 
 inline uint64_t get_timestamp_32b() { return reg_read(RISCV_DEBUG_REG_WALL_CLOCK_L); }
 

--- a/tt_metal/fabric/hw/inc/tt_fabric_interface.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_interface.h
@@ -14,10 +14,10 @@ static_assert(false, "tt_fabric_interface.h should only be included in kernel or
 
 namespace tt::tt_fabric {
 
-typedef struct _endpoint_sync {
+struct endpoint_sync_t {
     uint32_t sync_addr : 24;
     uint32_t endpoint_type : 8;
-} endpoint_sync_t;
+};
 
 static_assert(sizeof(endpoint_sync_t) == 4);
 
@@ -36,7 +36,7 @@ constexpr uint32_t FVC_SYNC_THRESHOLD = 256;
 #define TERMINATE 0x40
 #define NOP 0xFF
 
-typedef struct _tt_routing {
+struct tt_routing {
     uint32_t packet_size_bytes;
     uint16_t dst_mesh_id;  // Remote mesh
     uint16_t dst_dev_id;   // Remote device
@@ -45,11 +45,11 @@ typedef struct _tt_routing {
     uint16_t ttl;
     uint8_t version;
     uint8_t flags;
-} tt_routing;
+};
 
 static_assert(sizeof(tt_routing) == 16);
 
-typedef struct _tt_low_latency_routing_vector {
+struct tt_low_latency_routing_vector {
     static constexpr uint32_t FIELD_WIDTH = 8;
     static constexpr uint32_t FIELD_MASK = 0b1111;
     static constexpr uint32_t NOOP = 0b0000;
@@ -65,9 +65,9 @@ typedef struct _tt_low_latency_routing_vector {
     static constexpr uint32_t WR_ONLY_FIELD = 0x55555555;
     uint32_t hop_index;
     uint32_t value[4];
-} tt_low_latency_routing_vector;
+};
 
-typedef struct _tt_low_latency_routing {
+struct tt_low_latency_routing {
     uint32_t packet_size_bytes;
     uint32_t target_offset_l;
     uint32_t target_offset_h;
@@ -77,11 +77,11 @@ typedef struct _tt_low_latency_routing {
     uint32_t atomic_offset_h;
     uint16_t atomic_increment;
     uint16_t atomic_wrap;
-} tt_low_latency_routing;
+};
 
 static_assert(sizeof(tt_low_latency_routing) == PACKET_HEADER_SIZE_BYTES);
 
-typedef struct _tt_session {
+struct tt_session {
     uint32_t command;
     uint32_t target_offset_l;  // RDMA address
     uint32_t target_offset_h;
@@ -89,19 +89,19 @@ typedef struct _tt_session {
                             // This is complete end-to-end acknowledgement of sessoin command completion at the remote
                             // device.
     uint32_t ack_offset_h;
-} tt_session;
+};
 
 static_assert(sizeof(tt_session) == 20);
 
-typedef struct _mcast_params {
+struct mcast_params {
     uint32_t socket_id;  // Socket Id for DSocket Multicast. Ignored for ASYNC multicast.
     uint16_t east;
     uint16_t west;
     uint16_t north;
     uint16_t south;
-} mcast_params;
+};
 
-typedef struct _socket_params {
+struct socket_params {
     uint32_t padding1;
     uint16_t socket_id;
     uint16_t epoch_id;
@@ -109,34 +109,34 @@ typedef struct _socket_params {
     uint8_t socket_direction;
     uint8_t routing_plane;
     uint8_t padding;
-} socket_params;
+};
 
-typedef struct _atomic_params {
+struct atomic_params {
     uint32_t padding;
     uint32_t
         return_offset;  // L1 offset where atomic read should be returned. Noc X/Y is taken from tt_session.ack_offset
     uint32_t increment : 24;  // NOC atomic increment wrapping value.
     uint32_t wrap_boundary : 8;
-} atomic_params;
+};
 
-typedef struct _async_wr_atomic_params {
+struct async_wr_atomic_params {
     uint32_t padding;
     uint32_t l1_offset;
     uint32_t noc_xy : 24;
     uint32_t increment : 8;
-} async_wr_atomic_params;
+};
 
-typedef struct _read_params {
+struct read_params {
     uint32_t return_offset_l;  // address where read data should be copied
     uint32_t return_offset_h;
     uint32_t size;  // number of bytes to read
-} read_params;
+};
 
-typedef struct _misc_params {
+struct misc_params {
     uint32_t words[3];
-} misc_params;
+};
 
-typedef union _packet_params {
+union packet_params {
     mcast_params mcast_parameters;
     socket_params socket_parameters;
     atomic_params atomic_parameters;
@@ -144,24 +144,24 @@ typedef union _packet_params {
     read_params read_parameters;
     misc_params misc_parameters;
     uint8_t bytes[12];
-} packet_params;
+};
 
 #ifdef FVC_MODE_PULL
-typedef struct _packet_header {
+struct packet_header_t {
     packet_params packet_parameters;
     tt_session session;
     tt_routing routing;
-} packet_header_t;
+};
 #else
-typedef struct _packet_header {
+struct packet_header_t {
     tt_routing routing;
     tt_session session;
     packet_params packet_parameters;
-} packet_header_t;
+};
 #endif
-typedef struct _low_latency_packet_header {
+struct low_latency_packet_header_t {
     tt_low_latency_routing routing;
-} low_latency_packet_header_t;
+};
 
 static_assert(sizeof(low_latency_packet_header_t) == PACKET_HEADER_SIZE_BYTES);
 
@@ -209,7 +209,7 @@ bool tt_fabric_is_header_valid(packet_header_t* p_header) {
 //   request queue.
 //     This is typical of fabric routers forwarding data over noc/ethernet hops.
 //
-typedef struct _pull_request {
+struct pull_request_t {
     uint32_t wr_ptr;        // Current value of write pointer.
     uint32_t rd_ptr;        // Current value of read pointer. Points to first byte of pull data.
     uint32_t size;          // Total number of bytes that need to be forwarded.
@@ -222,25 +222,25 @@ typedef struct _pull_request {
     uint32_t words_read;
     uint8_t padding[7];
     uint8_t flags;  // Router command.
-} pull_request_t;
+};
 
 constexpr uint32_t PULL_REQ_SIZE_BYTES = 48;
 
 static_assert(sizeof(pull_request_t) == PULL_REQ_SIZE_BYTES);
 static_assert(sizeof(pull_request_t) == sizeof(packet_header_t));
 
-typedef union _chan_request_entry {
+union chan_request_entry_t {
     pull_request_t pull_request;
     packet_header_t packet_header;
     uint8_t bytes[48];
     uint32_t words[12];
-} chan_request_entry_t;
+};
 
 constexpr uint32_t CHAN_PTR_SIZE_BYTES = 16;
-typedef struct _chan_ptr {
+struct chan_ptr {
     uint32_t ptr;
     uint32_t pad[3];
-} chan_ptr;
+};
 static_assert(sizeof(chan_ptr) == CHAN_PTR_SIZE_BYTES);
 
 constexpr uint32_t CHAN_REQ_BUF_LOG_SIZE = 4;  // must be 2^N
@@ -249,25 +249,25 @@ constexpr uint32_t CHAN_REQ_BUF_SIZE_MASK = (CHAN_REQ_BUF_SIZE - 1);
 constexpr uint32_t CHAN_REQ_BUF_PTR_MASK = ((CHAN_REQ_BUF_SIZE << 1) - 1);
 constexpr uint32_t CHAN_REQ_BUF_SIZE_BYTES = 2 * CHAN_PTR_SIZE_BYTES + CHAN_REQ_BUF_SIZE * PULL_REQ_SIZE_BYTES;
 
-typedef struct _chan_req_buf {
+struct chan_req_buf {
     chan_ptr wrptr;
     chan_ptr rdptr;
     chan_request_entry_t chan_req[CHAN_REQ_BUF_SIZE];
-} chan_req_buf;
+};
 
 static_assert(sizeof(chan_req_buf) == CHAN_REQ_BUF_SIZE_BYTES);
 
-typedef struct _local_pull_request {
+struct local_pull_request_t {
     chan_ptr wrptr;
     chan_ptr rdptr;
     pull_request_t pull_request;
-} local_pull_request_t;
+};
 
-typedef struct _chan_payload_ptr {
+struct chan_payload_ptr {
     uint32_t ptr;
     uint32_t pad[2];
     uint32_t ptr_cleared;
-} chan_payload_ptr;
+};
 
 static_assert(sizeof(chan_payload_ptr) == CHAN_PTR_SIZE_BYTES);
 
@@ -293,30 +293,30 @@ inline bool fvcc_buf_ptrs_full(uint32_t wrptr, uint32_t rdptr) {
 // write pointer update. this is sent over ethernet.
 // For incoming requests over ethernet, we only need storate for the request
 // entry. The pointer update goes to fvcc state.
-typedef struct _ctrl_chan_msg_buf {
+struct ctrl_chan_msg_buf {
     chan_ptr wrptr;
     chan_ptr rdptr;
     chan_request_entry_t msg_buf[FVCC_BUF_SIZE];
-} ctrl_chan_msg_buf;
+};
 
-typedef struct _ctrl_chan_sync_buf {
+struct ctrl_chan_sync_buf {
     chan_payload_ptr ptr[FVCC_BUF_SIZE];
-} ctrl_chan_sync_buf;
+};
 
 static_assert(sizeof(ctrl_chan_msg_buf) == FVCC_BUF_SIZE_BYTES);
 
-typedef struct _sync_word {
+struct sync_word_t {
     uint32_t val;
     uint32_t padding[3];
-} sync_word_t;
+};
 
-typedef struct _gatekeeper_info {
+struct gatekeeper_info_t {
     sync_word_t router_sync;
     sync_word_t ep_sync;
     uint32_t routing_planes;
     uint32_t padding[3];
     ctrl_chan_msg_buf gk_msg_buf;
-} gatekeeper_info_t;
+};
 
 static_assert(sizeof(gatekeeper_info_t) == GATEKEEPER_INFO_SIZE);
 
@@ -332,7 +332,7 @@ enum SocketState : uint8_t {
     CLOSING = 3,
 };
 
-typedef struct _socket_handle {
+struct socket_handle_t {
     uint16_t socket_id;
     uint16_t epoch_id;
     uint8_t socket_state;
@@ -348,12 +348,12 @@ typedef struct _socket_handle {
     uint64_t pull_notification_adddr;
     uint64_t status_notification_addr;
     uint32_t padding[2];
-} socket_handle_t;
+};
 
 static_assert(sizeof(socket_handle_t) % 16 == 0);
 
 constexpr uint32_t MAX_SOCKETS = 64;
-typedef struct _socket_info {
+struct socket_info_t {
     uint32_t socket_count;
     uint32_t socket_setup_pending;
     uint32_t padding[2];
@@ -361,10 +361,10 @@ typedef struct _socket_info {
     chan_ptr wrptr;
     chan_ptr rdptr;
     chan_request_entry_t gk_message;
-} socket_info_t;
+};
 static_assert(sizeof(socket_info_t) % 16 == 0);
 
-typedef struct _fabric_client_interface {
+struct fabric_client_interface_t {
     uint64_t gk_interface_addr;
     uint64_t gk_msg_buf_addr;
     uint64_t pull_req_buf_addr;
@@ -377,16 +377,16 @@ typedef struct _fabric_client_interface {
     chan_request_entry_t gk_message;
     local_pull_request_t local_pull_request;
     socket_handle_t socket_handles[MAX_SOCKETS];
-} fabric_client_interface_t;
+};
 
-typedef struct _fabric_pull_client_interface {
+struct fabric_pull_client_interface_t {
     uint64_t pull_req_buf_addr;
     uint32_t num_routing_planes;
     uint32_t routing_tables_l1_offset;
     uint32_t return_status[4];
     local_pull_request_t local_pull_request;
     packet_header_t header_buffer[CLIENT_HEADER_BUFFER_ENTRIES];
-} fabric_pull_client_interface_t;
+};
 
 static_assert(sizeof(fabric_client_interface_t) % 16 == 0);
 static_assert(sizeof(fabric_client_interface_t) == CLIENT_INTERFACE_SIZE);
@@ -395,24 +395,24 @@ static_assert(sizeof(fabric_pull_client_interface_t) % 16 == 0);
 static_assert(sizeof(fabric_pull_client_interface_t) == PULL_CLIENT_INTERFACE_SIZE);
 
 constexpr uint32_t FABRIC_ROUTER_CLIENT_QUEUE_SIZE = 48;
-typedef struct _fabric_push_client_queue {
+struct fabric_push_client_queue_t {
     chan_ptr client_idx_counter;
     chan_ptr curr_client_idx;
     chan_ptr router_wr_ptr;
-} fabric_push_client_queue_t;
+};
 static_assert(sizeof(fabric_push_client_queue_t) % 16 == 0);
 static_assert(sizeof(fabric_push_client_queue_t) == FABRIC_ROUTER_CLIENT_QUEUE_SIZE);
 
 constexpr uint32_t FABRIC_ROUTER_CLIENT_QUEUE_LOCAL_SIZE = 48;
-typedef struct _fabric_push_client_queue_local {
+struct fabric_push_client_queue_local_t {
     chan_ptr my_client_idx;
     chan_ptr remote_curr_client_idx;
     chan_ptr remote_router_wr_ptr;
-} fabric_push_client_queue_local_t;
+};
 static_assert(sizeof(fabric_push_client_queue_local_t) % 16 == 0);
 static_assert(sizeof(fabric_push_client_queue_local_t) == FABRIC_ROUTER_CLIENT_QUEUE_LOCAL_SIZE);
 
-typedef struct _fabric_push_client_interface {
+struct fabric_push_client_interface_t {
     uint32_t num_routing_planes;
     uint32_t routing_tables_l1_offset;
     uint32_t router_addr_h;
@@ -425,7 +425,7 @@ typedef struct _fabric_push_client_interface {
     uint32_t reserved[3];
     fabric_push_client_queue_local_t local_client_req_entry;
     packet_header_t header_buffer[CLIENT_HEADER_BUFFER_ENTRIES];
-} fabric_push_client_interface_t;
+};
 
 static_assert(sizeof(fabric_push_client_interface_t) % 16 == 0);
 static_assert(sizeof(fabric_push_client_interface_t) == PUSH_CLIENT_INTERFACE_SIZE);

--- a/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
@@ -15,10 +15,10 @@
 // different name here so that this header can be included in both.
 #if !defined(KERNEL_BUILD) && !defined(FW_BUILD)  // SW
 #include <tt-metalium/tt_backend_api_types.hpp>
-typedef tt::DataFormat CommonDataFormat;
+using CommonDataFormat = tt::DataFormat;
 #else  // HW already includes tensix_types.h
 #include "core_config.h"
-typedef DataFormat CommonDataFormat;
+using CommonDataFormat = DataFormat;
 #endif
 
 #include <cstddef>

--- a/tt_metal/hw/inc/blackhole/noc/noc_overlay_parameters.hpp
+++ b/tt_metal/hw/inc/blackhole/noc/noc_overlay_parameters.hpp
@@ -114,21 +114,21 @@ extern "C" {
 
 namespace Noc {
 
-typedef struct OverlayField_ {
+struct OverlayField {
     std::string name;
     std::uint32_t offset;
     std::uint32_t width;
     std::string description;
-} OverlayField;
+};
 
-typedef struct OverlayReg_ {
+struct OverlayReg {
     std::string name;
     std::uint32_t index;
     std::unordered_map<std::string, std::uint32_t> fields_by_name;
     std::unordered_map<std::uint32_t, std::uint32_t> fields_by_offset;
     std::vector<OverlayField> fields;
     std::string description;
-} OverlayReg;
+};
 
 // OverLayParams
 class OLP {

--- a/tt_metal/hw/inc/blackhole/tensix.h
+++ b/tt_metal/hw/inc/blackhole/tensix.h
@@ -15,8 +15,8 @@
 #include "cfg_defines.h"
 
 // Convenience and type defines
-typedef std::uint32_t uint;
-typedef std::uint8_t byte;
+using uint = std::uint32_t;
+using byte = std::uint8_t;
 
 #define PREPROCESSOR_EVAL(x, y, z) x##y##z
 #define PREPROCESSOR_EXPAND(x, y, z) PREPROCESSOR_EVAL(x, y, z)
@@ -226,32 +226,32 @@ end
 #define RISCV_DEBUG_REG_WDT_CNTL (RISCV_DEBUG_REGS_START_ADDR | 0x1E4)
 #define RISCV_DEBUG_REG_WDT_STATUS (RISCV_DEBUG_REGS_START_ADDR | 0x1E8)
 
-typedef struct {
+struct riscv_debug_reg_dbg_dbus_cntl_t {
     uint dbg_sig_sel : 16;
     uint dbg_daisy_sel : 8;
     uint dbg_rd_sel : 4;
     uint dbg_reg_ovrd_en : 1;
     uint dbg_daisy_en : 1;
     uint dbg_reserved : 2;
-} riscv_debug_reg_dbg_dbus_cntl_t;
+};
 
-typedef union {
+union riscv_debug_reg_dbg_dbus_cntl_u {
     uint val;
     riscv_debug_reg_dbg_dbus_cntl_t f;
-} riscv_debug_reg_dbg_dbus_cntl_u;
+};
 
-typedef struct {
+struct riscv_debug_reg_dbg_l1_mem_reg2_t {
     uint mem_dump_mode : 4;
     uint skip_cycles : 8;
     uint mem_write : 1;
     uint mem_read : 1;
     uint reserved : 18;
-} riscv_debug_reg_dbg_l1_mem_reg2_t;
+};
 
-typedef union {
+union riscv_debug_reg_dbg_l1_mem_reg2_u {
     uint val;
     riscv_debug_reg_dbg_l1_mem_reg2_t f;
-} riscv_debug_reg_dbg_l1_mem_reg2_u;
+};
 
 #define SOFT_RESET_UNPACKER(arg) ((arg & 0x3) << 0)
 #define SOFT_RESET_PACKER(arg) ((arg & 0xf) << 2)
@@ -663,7 +663,7 @@ static constexpr unsigned int R63 = 63;
 #define R63_LO 126
 #define R63_HI 127
 
-typedef enum { UNP0 = 1, UNP1 = 2, PCK0 = 4 } cnt_id_t;
+enum cnt_id_t { UNP0 = 1, UNP1 = 2, PCK0 = 4 };
 
 #ifdef CPU_JAWBRIDGE
 #define TENSIX_MAX_KERNEL_LOOP_COUNT 128u
@@ -686,7 +686,7 @@ inline T bitmask(unsigned int bits) {
 
 template <class T>
 inline typename std::make_unsigned<T>::type pack_field(T x, unsigned int to_shift) {
-    typedef typename std::make_unsigned<T>::type u_T;
+    using u_T = typename std::make_unsigned<T>::type;
     u_T u_x(x);
 
     // verify that no bits are shifted away

--- a/tt_metal/hw/inc/blackhole/tensix_types.h
+++ b/tt_metal/hw/inc/blackhole/tensix_types.h
@@ -21,30 +21,25 @@
 /////////////
 // Global enums and defines
 ////////////
-typedef enum {
+enum xmov_direction_t {
     XMOV_L0_TO_L1 = 0,
     XMOV_L1_TO_L0 = 1,
     XMOV_L0_TO_L0 = 2,
     XMOV_L1_TO_L1 = 3,
-} xmov_direction_t;
+};
 
-typedef enum { TDMA_MOVER0 = 0, TDMA_MOVER1 = 1 } tdma_mover_id_t;
+enum tdma_mover_id_t { TDMA_MOVER0 = 0, TDMA_MOVER1 = 1 };
 
-typedef enum { MATH_HF = 1, MATH_AUTO = 2, MATH_LF = 4 } math_fidelity_t;
+enum math_fidelity_t { MATH_HF = 1, MATH_AUTO = 2, MATH_LF = 4 };
 
-typedef enum { RELU_NONE = 0, RELU_PLAIN = 1, RELU_THRESH = 2, RELU_MAX = 3 } relu_mode_t;
+enum relu_mode_t { RELU_NONE = 0, RELU_PLAIN = 1, RELU_THRESH = 2, RELU_MAX = 3 };
 
-typedef enum {
-    STOCH_RND_NONE = 0,
-    STOCH_RND_FPU = 1,
-    STOCH_RND_GASKET = 2,
-    STOCH_RND_PACKER = 4
-} stochastic_round_settings_t;
+enum stochastic_round_settings_t { STOCH_RND_NONE = 0, STOCH_RND_FPU = 1, STOCH_RND_GASKET = 2, STOCH_RND_PACKER = 4 };
 
 /////////////
 // TDMA Registers
 ////////////
-typedef struct {
+struct packer_config_t {
     uint32_t row_section_size : 16;
     uint32_t exp_section_size : 16;
     uint32_t tile_dst_addr : 32;
@@ -55,7 +50,7 @@ typedef struct {
     uint32_t in_data_format : 2;
     uint32_t reserved_2 : 22;
     uint32_t reserved_3 : 32;
-} packer_config_t;  // 16B
+};  // 16B
 
 struct fifo_ctl_t {
     uint32_t rd_ptr;
@@ -69,30 +64,30 @@ struct fifo_ctl_t {
 #endif
 };
 
-typedef struct {
+struct packer_config_u {
     uint32_t val[4];
     packer_config_t f;
-} packer_config_u;
+};
 
-typedef struct {
+struct mover_config_t {
     uint32_t src_addr : 32;
     uint32_t dst_addr : 32;
     uint32_t xfer_size : 32;
     uint32_t xfer_dir : 2;
     uint32_t reserved_0 : 30;
-} mover_config_t;  // 16B
+};  // 16B
 
-typedef struct {
+struct mover_config_u {
     uint32_t val[4];
     mover_config_t f;
-} mover_config_u;
+};
 
 /////////////
 // Data section structures
 /////////////
 
 // Tile descriptor
-typedef struct {
+struct tile_descriptor_t {
     uint32_t data_format : 4;
     uint32_t uncompressed : 1;
     uint32_t reserved_0 : 3;
@@ -105,12 +100,12 @@ typedef struct {
     uint32_t blobs_y_start : 32;
     uint32_t digest_type : 8;  // Not used
     uint32_t digest_size : 8;  // Not used
-} tile_descriptor_t;           // Unpack configuration
+};  // Unpack configuration
 
-typedef union {
+union tile_descriptor_u {
     uint32_t val[4];
     tile_descriptor_t f;
-} tile_descriptor_u;
+};
 
 struct TileHeader {
     // occupied part of the 16B line
@@ -136,7 +131,7 @@ struct TileHeader {
 
     std::size_t size() const { return 16; }
     const void* data() const { return this; }
-    typedef std::uint8_t value_type;
+    using value_type = std::uint8_t;
 
     bool operator!=(const TileHeader& rhs) const {
         bool result =

--- a/tt_metal/hw/inc/debug/dprint_tile.h
+++ b/tt_metal/hw/inc/debug/dprint_tile.h
@@ -35,14 +35,14 @@
 // MAXCOUNT is the size of reserved space in the print buffer
 // if the total element data_count produced by the slice spec exceeds MAXCOUNT, it will be truncated
 //
-typedef bool dprint_tslice_ptr_t;
+using dprint_tslice_ptr_t = bool;
 #define TSLICE_RD_PTR true
 #define TSLICE_WR_PTR false
-typedef bool dprint_tslice_cb_t;
+using dprint_tslice_cb_t = bool;
 #define TSLICE_INPUT_CB true
 #define TSLICE_OUTPUT_CB false
 
-typedef struct {
+struct tile_info_t {
     uint32_t tile_dim_r;
     uint32_t tile_dim_c;
     uint32_t tile_size;
@@ -51,7 +51,7 @@ typedef struct {
     uint32_t num_faces;
     uint32_t cb_ptr;
     uint8_t data_format;
-} tile_info_t;
+};
 
 #if defined(DEBUG_PRINT_ENABLED)
 // Helper function to get a single datum, whose indexing depends on DataFormat

--- a/tt_metal/hw/inc/debug/sanitize_noc.h
+++ b/tt_metal/hw/inc/debug/sanitize_noc.h
@@ -37,13 +37,13 @@
 // A couple defines for specifying read/write and multi/unicast
 #define DEBUG_SANITIZE_NOC_READ true
 #define DEBUG_SANITIZE_NOC_WRITE false
-typedef bool debug_sanitize_noc_dir_t;
+using debug_sanitize_noc_dir_t = bool;
 #define DEBUG_SANITIZE_NOC_MULTICAST true
 #define DEBUG_SANITIZE_NOC_UNICAST false
-typedef bool debug_sanitize_noc_cast_t;
+using debug_sanitize_noc_cast_t = bool;
 #define DEBUG_SANITIZE_NOC_TARGET true
 #define DEBUG_SANITIZE_NOC_LOCAL false
-typedef bool debug_sanitize_noc_which_core_t;
+using debug_sanitize_noc_which_core_t = bool;
 
 // Helper function to get the core type from noc coords.
 AddressableCoreType get_core_type(uint8_t noc_id, uint8_t x, uint8_t y, bool& is_virtual_coord) {

--- a/tt_metal/hw/inc/grayskull/tensix.h
+++ b/tt_metal/hw/inc/grayskull/tensix.h
@@ -12,8 +12,8 @@
 #include "cfg_defines.h"
 
 // Convenience and type defines
-typedef std::uint32_t uint;
-typedef std::uint8_t byte;
+using uint = std::uint32_t;
+using byte = std::uint8_t;
 
 #define PREPROCESSOR_EVAL(x, y, z) x##y##z
 #define PREPROCESSOR_EXPAND(x, y, z) PREPROCESSOR_EVAL(x, y, z)
@@ -132,32 +132,32 @@ typedef std::uint8_t byte;
 #define RISCV_DEBUG_REG_WALL_CLOCK_L (RISCV_DEBUG_REGS_START_ADDR | 0x1F0)
 #define RISCV_DEBUG_REG_WALL_CLOCK_H (RISCV_DEBUG_REGS_START_ADDR | 0x1F8)
 
-typedef struct {
+struct riscv_debug_reg_dbg_dbus_cntl_t {
     uint dbg_sig_sel : 16;
     uint dbg_daisy_sel : 8;
     uint dbg_rd_sel : 4;
     uint dbg_reg_ovrd_en : 1;
     uint dbg_daisy_en : 1;
     uint dbg_reserved : 2;
-} riscv_debug_reg_dbg_dbus_cntl_t;
+};
 
-typedef union {
+union riscv_debug_reg_dbg_dbus_cntl_u {
     uint val;
     riscv_debug_reg_dbg_dbus_cntl_t f;
-} riscv_debug_reg_dbg_dbus_cntl_u;
+};
 
-typedef struct {
+struct riscv_debug_reg_dbg_l1_mem_reg2_t {
     uint mem_dump_mode : 4;
     uint skip_cycles : 8;
     uint mem_write : 1;
     uint mem_read : 1;
     uint reserved : 18;
-} riscv_debug_reg_dbg_l1_mem_reg2_t;
+};
 
-typedef union {
+union riscv_debug_reg_dbg_l1_mem_reg2_u {
     uint val;
     riscv_debug_reg_dbg_l1_mem_reg2_t f;
-} riscv_debug_reg_dbg_l1_mem_reg2_u;
+};
 
 #define SOFT_RESET_UNPACKER(arg) ((arg & 0x3) << 0)
 #define SOFT_RESET_PACKER(arg) ((arg & 0xf) << 2)
@@ -553,7 +553,7 @@ static constexpr unsigned int R63 = 63;
 #define R63_LO 126
 #define R63_HI 127
 
-typedef enum { UNP0 = 1, UNP1 = 2, PCK0 = 4 } cnt_id_t;
+enum cnt_id_t { UNP0 = 1, UNP1 = 2, PCK0 = 4 };
 
 #ifdef CPU_JAWBRIDGE
 #define TENSIX_MAX_KERNEL_LOOP_COUNT 128u
@@ -576,7 +576,7 @@ inline T bitmask(unsigned int bits) {
 
 template <class T>
 inline typename std::make_unsigned<T>::type pack_field(T x, unsigned int to_shift) {
-    typedef typename std::make_unsigned<T>::type u_T;
+    using u_T = typename std::make_unsigned<T>::type;
     u_T u_x(x);
 
     // verify that no bits are shifted away

--- a/tt_metal/hw/inc/grayskull/tensix_types.h
+++ b/tt_metal/hw/inc/grayskull/tensix_types.h
@@ -21,23 +21,23 @@
 /////////////
 // Global enums and defines
 ////////////
-typedef enum {
+enum xmov_direction_t {
     XMOV_L0_TO_L1 = 0,
     XMOV_L1_TO_L0 = 1,
     XMOV_L0_TO_L0 = 2,
     XMOV_L1_TO_L1 = 3,
-} xmov_direction_t;
+};
 
-typedef enum { TDMA_MOVER0 = 0, TDMA_MOVER1 = 1 } tdma_mover_id_t;
+enum tdma_mover_id_t { TDMA_MOVER0 = 0, TDMA_MOVER1 = 1 };
 
-typedef enum { MATH_HF = 1, MATH_AUTO = 2, MATH_LF = 4 } math_fidelity_t;
+enum math_fidelity_t { MATH_HF = 1, MATH_AUTO = 2, MATH_LF = 4 };
 
-typedef enum { RELU_NONE = 0, RELU_PLAIN = 1, RELU_THRESH = 2, RELU_MAX = 3 } relu_mode_t;
+enum relu_mode_t { RELU_NONE = 0, RELU_PLAIN = 1, RELU_THRESH = 2, RELU_MAX = 3 };
 
 /////////////
 // TDMA Registers
 ////////////
-typedef struct {
+struct packer_config_t {
     uint32_t row_section_size : 16;
     uint32_t exp_section_size : 16;
     uint32_t tile_dst_addr : 32;
@@ -48,7 +48,7 @@ typedef struct {
     uint32_t in_data_format : 2;
     uint32_t reserved_2 : 22;
     uint32_t reserved_3 : 32;
-} packer_config_t;  // 16B
+};  // 16B
 
 struct fifo_ctl_t {
     uint32_t rd_ptr;
@@ -62,30 +62,30 @@ struct fifo_ctl_t {
 #endif
 };
 
-typedef struct {
+struct packer_config_u {
     uint32_t val[4];
     packer_config_t f;
-} packer_config_u;
+};
 
-typedef struct {
+struct mover_config_t {
     uint32_t src_addr : 32;
     uint32_t dst_addr : 32;
     uint32_t xfer_size : 32;
     uint32_t xfer_dir : 2;
     uint32_t reserved_0 : 30;
-} mover_config_t;  // 16B
+};  // 16B
 
-typedef struct {
+struct mover_config_u {
     uint32_t val[4];
     mover_config_t f;
-} mover_config_u;
+};
 
 /////////////
 // Data section structures
 /////////////
 
 // Tile descriptor
-typedef struct {
+struct tile_descriptor_t {
     uint32_t data_format : 4;
     uint32_t uncompressed : 1;
     uint32_t reserved_0 : 3;
@@ -98,12 +98,12 @@ typedef struct {
     uint32_t blobs_y_start : 32;
     uint32_t digest_type : 8;  // Not used
     uint32_t digest_size : 8;  // Not used
-} tile_descriptor_t;           // Unpack configuration
+};  // Unpack configuration
 
-typedef union {
+union tile_descriptor_u {
     uint32_t val[4];
     tile_descriptor_t f;
-} tile_descriptor_u;
+};
 
 struct TileHeader {
     // occupied part of the 16B line
@@ -129,7 +129,7 @@ struct TileHeader {
 
     std::size_t size() const { return 16; }
     const void* data() const { return this; }
-    typedef std::uint8_t value_type;
+    using value_type = std::uint8_t;
 
     bool operator!=(const TileHeader& rhs) const {
         bool result =

--- a/tt_metal/hw/inc/wormhole/noc/noc_overlay_parameters.hpp
+++ b/tt_metal/hw/inc/wormhole/noc/noc_overlay_parameters.hpp
@@ -89,21 +89,21 @@
 
 namespace Noc {
 
-typedef struct OverlayField_ {
+struct OverlayField {
     std::string name;
     std::uint32_t offset;
     std::uint32_t width;
     std::string description;
-} OverlayField;
+};
 
-typedef struct OverlayReg_ {
+struct OverlayReg {
     std::string name;
     std::uint32_t index;
     std::unordered_map<std::string, std::uint32_t> fields_by_name;
     std::unordered_map<std::uint32_t, std::uint32_t> fields_by_offset;
     std::vector<OverlayField> fields;
     std::string description;
-} OverlayReg;
+};
 
 // OverLayParams
 class OLP {

--- a/tt_metal/hw/inc/wormhole/tensix.h
+++ b/tt_metal/hw/inc/wormhole/tensix.h
@@ -13,8 +13,8 @@
 #include "dev_mem_map.h"
 
 // Convenience and type defines
-typedef std::uint32_t uint;
-typedef std::uint8_t byte;
+using uint = std::uint32_t;
+using byte = std::uint8_t;
 
 #define PREPROCESSOR_EVAL(x, y, z) x##y##z
 #define PREPROCESSOR_EXPAND(x, y, z) PREPROCESSOR_EVAL(x, y, z)
@@ -144,32 +144,32 @@ typedef std::uint8_t byte;
 #define RISCV_DEBUG_REG_WALL_CLOCK_H (RISCV_DEBUG_REGS_START_ADDR | 0x1F8)
 #define RISCV_DEBUG_REG_TIMESTAMP (RISCV_DEBUG_REGS_START_ADDR | 0x1FC)
 #define RISCV_DEBUG_REG_TIMESTAMP_STATUS (RISCV_DEBUG_REGS_START_ADDR | 0x204)
-typedef struct {
+struct riscv_debug_reg_dbg_dbus_cntl_t {
     uint dbg_sig_sel : 16;
     uint dbg_daisy_sel : 8;
     uint dbg_rd_sel : 4;
     uint dbg_reg_ovrd_en : 1;
     uint dbg_daisy_en : 1;
     uint dbg_reserved : 2;
-} riscv_debug_reg_dbg_dbus_cntl_t;
+};
 
-typedef union {
+union riscv_debug_reg_dbg_dbus_cntl_u {
     uint val;
     riscv_debug_reg_dbg_dbus_cntl_t f;
-} riscv_debug_reg_dbg_dbus_cntl_u;
+};
 
-typedef struct {
+struct riscv_debug_reg_dbg_l1_mem_reg2_t {
     uint mem_dump_mode : 4;
     uint skip_cycles : 8;
     uint mem_write : 1;
     uint mem_read : 1;
     uint reserved : 18;
-} riscv_debug_reg_dbg_l1_mem_reg2_t;
+};
 
-typedef union {
+union riscv_debug_reg_dbg_l1_mem_reg2_u {
     uint val;
     riscv_debug_reg_dbg_l1_mem_reg2_t f;
-} riscv_debug_reg_dbg_l1_mem_reg2_u;
+};
 
 #define SOFT_RESET_UNPACKER(arg) ((arg & 0x3) << 0)
 #define SOFT_RESET_PACKER(arg) ((arg & 0xf) << 2)
@@ -567,7 +567,7 @@ static constexpr unsigned int R63 = 63;
 #define R63_LO 126
 #define R63_HI 127
 
-typedef enum { UNP0 = 1, UNP1 = 2, PCK0 = 4 } cnt_id_t;
+enum cnt_id_t { UNP0 = 1, UNP1 = 2, PCK0 = 4 };
 
 #ifdef CPU_JAWBRIDGE
 #define TENSIX_MAX_KERNEL_LOOP_COUNT 128u
@@ -590,7 +590,7 @@ inline T bitmask(unsigned int bits) {
 
 template <class T>
 inline typename std::make_unsigned<T>::type pack_field(T x, unsigned int to_shift) {
-    typedef typename std::make_unsigned<T>::type u_T;
+    using u_T = typename std::make_unsigned<T>::type;
     u_T u_x(x);
 
     // verify that no bits are shifted away

--- a/tt_metal/hw/inc/wormhole/wormhole_b0_defines/tensix_types.h
+++ b/tt_metal/hw/inc/wormhole/wormhole_b0_defines/tensix_types.h
@@ -21,30 +21,25 @@
 /////////////
 // Global enums and defines
 ////////////
-typedef enum {
+enum xmov_direction_t {
     XMOV_L0_TO_L1 = 0,
     XMOV_L1_TO_L0 = 1,
     XMOV_L0_TO_L0 = 2,
     XMOV_L1_TO_L1 = 3,
-} xmov_direction_t;
+};
 
-typedef enum { TDMA_MOVER0 = 0, TDMA_MOVER1 = 1 } tdma_mover_id_t;
+enum tdma_mover_id_t { TDMA_MOVER0 = 0, TDMA_MOVER1 = 1 };
 
-typedef enum { MATH_HF = 1, MATH_AUTO = 2, MATH_LF = 4 } math_fidelity_t;
+enum math_fidelity_t { MATH_HF = 1, MATH_AUTO = 2, MATH_LF = 4 };
 
-typedef enum { RELU_NONE = 0, RELU_PLAIN = 1, RELU_THRESH = 2, RELU_MAX = 3 } relu_mode_t;
+enum relu_mode_t { RELU_NONE = 0, RELU_PLAIN = 1, RELU_THRESH = 2, RELU_MAX = 3 };
 
-typedef enum {
-    STOCH_RND_NONE = 0,
-    STOCH_RND_FPU = 1,
-    STOCH_RND_GASKET = 2,
-    STOCH_RND_PACKER = 4
-} stochastic_round_settings_t;
+enum stochastic_round_settings_t { STOCH_RND_NONE = 0, STOCH_RND_FPU = 1, STOCH_RND_GASKET = 2, STOCH_RND_PACKER = 4 };
 
 /////////////
 // TDMA Registers
 ////////////
-typedef struct {
+struct packer_config_t {
     uint32_t row_section_size : 16;
     uint32_t exp_section_size : 16;
     uint32_t tile_dst_addr : 32;
@@ -55,7 +50,7 @@ typedef struct {
     uint32_t in_data_format : 2;
     uint32_t reserved_2 : 22;
     uint32_t reserved_3 : 32;
-} packer_config_t;  // 16B
+};  // 16B
 
 struct fifo_ctl_t {
     uint32_t rd_ptr;
@@ -69,30 +64,30 @@ struct fifo_ctl_t {
 #endif
 };
 
-typedef struct {
+struct packer_config_u {
     uint32_t val[4];
     packer_config_t f;
-} packer_config_u;
+};
 
-typedef struct {
+struct mover_config_t {
     uint32_t src_addr : 32;
     uint32_t dst_addr : 32;
     uint32_t xfer_size : 32;
     uint32_t xfer_dir : 2;
     uint32_t reserved_0 : 30;
-} mover_config_t;  // 16B
+};  // 16B
 
-typedef struct {
+struct mover_config_u {
     uint32_t val[4];
     mover_config_t f;
-} mover_config_u;
+};
 
 /////////////
 // Data section structures
 /////////////
 
 // Tile descriptor
-typedef struct {
+struct tile_descriptor_t {
     uint32_t data_format : 4;
     uint32_t uncompressed : 1;
     uint32_t reserved_0 : 3;
@@ -105,12 +100,12 @@ typedef struct {
     uint32_t blobs_y_start : 32;
     uint32_t digest_type : 8;  // Not used
     uint32_t digest_size : 8;  // Not used
-} tile_descriptor_t;           // Unpack configuration
+};  // Unpack configuration
 
-typedef union {
+union tile_descriptor_u {
     uint32_t val[4];
     tile_descriptor_t f;
-} tile_descriptor_u;
+};
 
 struct TileHeader {
     // occupied part of the 16B line
@@ -137,7 +132,7 @@ struct TileHeader {
 
     std::size_t size() const { return 16; }
     const void* data() const { return this; }
-    typedef std::uint8_t value_type;
+    using value_type = std::uint8_t;
 
     bool operator!=(const TileHeader& rhs) const {
         bool result =

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -28,11 +28,11 @@ constexpr uint16_t DEBUG_SANITIZE_NOC_SENTINEL_OK_16 = 0xbada;
 constexpr uint8_t DEBUG_SANITIZE_NOC_SENTINEL_OK_8 = 0xda;
 
 // Struct containing relevant info for stack usage
-typedef struct {
+struct stack_usage_info_t {
     CoreDescriptor core;
     uint16_t stack_usage;
     uint16_t kernel_id;
-} stack_usage_info_t;
+};
 
 class WatcherDeviceReader {
 public:

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -18,13 +18,13 @@ class Program;
 struct KernelGroup;
 }  // namespace tt_metal
 
-typedef enum e_data_collector_t {
+enum data_collector_t {
     DISPATCH_DATA_CB_CONFIG,
     DISPATCH_DATA_SEMAPHORE,
     DISPATCH_DATA_RTARGS,
     DISPATCH_DATA_BINARY,
     DISPATCH_DATA_COUNT
-} data_collector_t;
+};
 
 /* Record a single dispatch write, to be dumped with stats on program exit. Should only be called once per transaction
  * per program (if a program is enqueued multiple times, don't call this multiple times).

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -545,7 +545,7 @@ void dump_issue_queue_entries(
 }
 
 // Define a queue type, for when they're interchangeable.
-typedef enum e_cq_queue_t { CQ_COMPLETION_QUEUE = 0, CQ_ISSUE_QUEUE = 1 } cq_queue_t;
+enum cq_queue_t { CQ_COMPLETION_QUEUE = 0, CQ_ISSUE_QUEUE = 1 };
 
 void dump_command_queue_raw_data(
     std::ofstream& out_file,

--- a/tt_metal/impl/dispatch/kernel_config/demux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.hpp
@@ -10,7 +10,7 @@
 #include "fd_kernel.hpp"
 #include "system_memory_manager.hpp"
 
-typedef struct demux_static_config {
+struct demux_static_config_t {
     std::optional<uint32_t> endpoint_id_start_index;
     std::optional<uint32_t> rx_queue_start_addr_words;
     std::optional<uint32_t> rx_queue_size_words;
@@ -29,9 +29,9 @@ typedef struct demux_static_config {
         output_depacketize_local_sem_id;  // [26:29]
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT>
         output_depacketize_remove_header;  // [26:29]
-} demux_static_config_t;
+};
 
-typedef struct demux_dependent_config {
+struct demux_dependent_config_t {
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT> remote_tx_x;  // [4:7], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT> remote_tx_y;  // [4:7], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT>
@@ -47,7 +47,7 @@ typedef struct demux_dependent_config {
     std::optional<uint32_t> output_depacketize;                                                    // Dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT>
         output_depacketize_downstream_sem_id;  // [26:29], dependent
-} demux_dependent_config_t;
+};
 
 class DemuxKernel : public FDKernel {
 public:

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -16,7 +16,7 @@
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include <umd/device/tt_xy_pair.h>
 
-typedef struct dispatch_static_config {
+struct dispatch_static_config_t {
     std::optional<uint32_t> dispatch_cb_base;  // 0
     std::optional<uint32_t> dispatch_cb_log_page_size;
     std::optional<uint32_t> dispatch_cb_pages;
@@ -50,9 +50,9 @@ typedef struct dispatch_static_config {
 
     // Populated if fabric is being used to talk to downstream
     std::optional<uint32_t> client_interface_addr;
-} dispatch_static_config_t;
+};
 
-typedef struct dispatch_dependent_config {
+struct dispatch_dependent_config_t {
     std::optional<tt_cxy_pair> upstream_logical_core;      // Dependant
     std::optional<tt_cxy_pair> downstream_logical_core;    // Dependant
     std::optional<tt_cxy_pair> downstream_s_logical_core;  // Dependant
@@ -76,7 +76,7 @@ typedef struct dispatch_dependent_config {
     std::optional<uint32_t> downstream_mesh_id;
     std::optional<uint32_t> downstream_dev_id;
     std::optional<uint32_t> outbound_eth_chan;
-} dispatch_dependent_config_t;
+};
 
 class DispatchKernel : public FDKernel {
 public:

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -10,7 +10,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/tt_xy_pair.h>
 
-typedef struct dispatch_s_static_config {
+struct dispatch_s_static_config_t {
     std::optional<uint32_t> cb_base;
     std::optional<uint32_t> cb_log_page_size;
     std::optional<uint32_t> cb_size;
@@ -23,13 +23,13 @@ typedef struct dispatch_s_static_config {
     std::optional<uint32_t> first_stream_used;
     std::optional<uint32_t> max_num_worker_sems;
     std::optional<uint32_t> max_num_go_signal_noc_data_entries;
-} dispatch_s_static_config_t;
+};
 
-typedef struct dispatch_s_dependent_config {
+struct dispatch_s_dependent_config_t {
     std::optional<tt_cxy_pair> upstream_logical_core;     // Dependant
     std::optional<tt_cxy_pair> downstream_logical_core;   // Dependant
     std::optional<uint32_t> upstream_dispatch_cb_sem_id;  // Dependent
-} dispatch_s_dependent_config_t;
+};
 
 class DispatchSKernel : public FDKernel {
 public:

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.hpp
@@ -10,7 +10,7 @@
 #include "fd_kernel.hpp"
 #include "system_memory_manager.hpp"
 
-typedef struct eth_router_static_config {
+struct eth_router_static_config_t {
     std::optional<uint32_t> vc_count;                   // Set from arch level
     std::optional<uint32_t> fwd_vc_count;               // # of VCs continuing on to the next chip
     std::optional<uint32_t> rx_queue_start_addr_words;  // 1
@@ -28,9 +28,9 @@ typedef struct eth_router_static_config {
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> input_packetize;                // [30:33]
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> input_packetize_log_page_size;  // [30:33]
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> input_packetize_local_sem;      // [30:33]
-} eth_router_static_config_t;
+};
 
-typedef struct eth_router_dependent_config {
+struct eth_router_dependent_config_t {
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT> remote_tx_x;         // [4:7], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT> remote_tx_y;         // [4:7], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_OUT> remote_tx_queue_id;  // [4:7], dependent
@@ -53,7 +53,7 @@ typedef struct eth_router_dependent_config {
         input_packetize_upstream_sem;  // [30:33], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> input_packetize_src_endpoint;  // Dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> input_packetize_dst_endpoint;  // Dependent
-} eth_router_dependent_config_t;
+};
 
 class EthRouterKernel : public FDKernel {
 public:

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.hpp
@@ -11,7 +11,7 @@
 #include "system_memory_manager.hpp"
 #include <umd/device/tt_core_coordinates.h>
 
-typedef struct eth_tunneler_static_config {
+struct eth_tunneler_static_config_t {
     std::optional<uint32_t> endpoint_id_start_index;
     std::optional<uint32_t> vc_count;  // Set from arch level
     std::optional<uint32_t> in_queue_start_addr_words;
@@ -20,9 +20,9 @@ typedef struct eth_tunneler_static_config {
     std::optional<uint32_t> kernel_status_buf_addr_arg;
     std::optional<uint32_t> kernel_status_buf_size_bytes;
     std::optional<uint32_t> timeout_cycles;
-} eth_tunneler_static_config_t;
+};
 
-typedef struct eth_tunneler_dependent_config {
+struct eth_tunneler_dependent_config_t {
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_TUNNEL_LANES> remote_receiver_x;  // [4:13], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_TUNNEL_LANES> remote_receiver_y;  // [4:13], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_TUNNEL_LANES>
@@ -41,7 +41,7 @@ typedef struct eth_tunneler_dependent_config {
         remote_sender_network_type;  // [34:43], dependent
 
     std::optional<uint32_t> inner_stop_mux_d_bypass;  // Dependent
-} eth_tunneler_dependent_config_t;
+};
 
 class EthTunnelerKernel : public FDKernel {
 public:

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -32,11 +32,11 @@ enum NOC : uint8_t;
 #define UNUSED_LOGICAL_CORE tt_cxy_pair(device_->id(), 0, 0)
 #define UNUSED_SEM_ID 0
 
-typedef struct {
+struct noc_selection_t {
     tt::tt_metal::NOC non_dispatch_noc;  // For communicating with workers/DRAM/host
     tt::tt_metal::NOC upstream_noc;      // For communicating with upstream dispatch modules
     tt::tt_metal::NOC downstream_noc;    // For communicating with downstream dispatch modules
-} noc_selection_t;
+};
 
 static std::vector<string> dispatch_kernel_file_names = {
     "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",        // PREFETCH

--- a/tt_metal/impl/dispatch/kernel_config/mux.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.hpp
@@ -10,7 +10,7 @@
 #include "fd_kernel.hpp"
 #include "system_memory_manager.hpp"
 
-typedef struct mux_static_config {
+struct mux_static_config_t {
     std::optional<uint32_t> reserved;
     std::optional<uint32_t> rx_queue_start_addr_words;
     std::optional<uint32_t> rx_queue_size_words;
@@ -27,9 +27,9 @@ typedef struct mux_static_config {
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> input_packetize_local_sem;
     std::optional<uint32_t> input_packetize_src_endpoint;   // Packed w/ max 4 assumption
     std::optional<uint32_t> input_packetize_dest_endpoint;  // Same as src
-} mux_static_config_t;
+};
 
-typedef struct mux_dependent_config {
+struct mux_dependent_config_t {
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> remote_rx_x;         // [4:7], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> remote_rx_y;         // [4:7], dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> remote_rx_queue_id;  // [4:7], dependent
@@ -42,7 +42,7 @@ typedef struct mux_dependent_config {
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN>
         input_packetize_log_page_size;                                                                      // Dependent
     std::array<std::optional<uint32_t>, tt::packet_queue::MAX_SWITCH_FAN_IN> input_packetize_upstream_sem;  // Dependent
-} mux_dependent_config_t;
+};
 
 class MuxKernel : public FDKernel {
 public:

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -15,7 +15,7 @@
 #include <umd/device/tt_xy_pair.h>
 #include <umd/device/types/cluster_descriptor_types.h>
 
-typedef struct prefetch_static_config {
+struct prefetch_static_config_t {
     std::optional<uint32_t> my_downstream_cb_sem_id;
 
     std::optional<uint32_t> pcie_base;
@@ -50,9 +50,9 @@ typedef struct prefetch_static_config {
 
     // Populated if fabric is being used to talk to downstream
     std::optional<uint32_t> client_interface_addr;
-} prefetch_static_config_t;
+};
 
-typedef struct prefetch_dependent_config {
+struct prefetch_dependent_config_t {
     std::optional<tt_cxy_pair> upstream_logical_core;
     std::optional<tt_cxy_pair> downstream_logical_core;
     std::optional<tt_cxy_pair> downstream_s_logical_core;
@@ -73,7 +73,7 @@ typedef struct prefetch_dependent_config {
     std::optional<uint32_t> downstream_mesh_id;
     std::optional<uint32_t> downstream_dev_id;
     std::optional<uint32_t> outbound_eth_chan;
-} prefetch_dependent_config_t;
+};
 
 class PrefetchKernel : public FDKernel {
 public:

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -125,10 +125,10 @@ constexpr uint32_t l1_cache_elements_rounded =
 
 // Used to send go signals asynchronously. Currently unused but this is a prototype for a GoSignalState
 // ring buffer that can be used to store and then asynchronously send Go Signals.
-typedef struct GoSignalState {
+struct GoSignalState {
     uint32_t go_signal;
     uint32_t wait_count;
-} GoSignalState;
+};
 
 static GoSignalState go_signal_state_ring_buf[4];
 static uint8_t go_signal_state_wr_ptr = 0;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -21,10 +21,10 @@ constexpr uint32_t CQ_PREFETCH_CMD_BARE_MIN_SIZE = PCIE_ALIGNMENT;  // for NOC P
 struct CQPrefetchHToPrefetchDHeader_s {
     uint32_t length;
 };
-typedef union {
-    struct CQPrefetchHToPrefetchDHeader_s header;
+union CQPrefetchHToPrefetchDHeader {
+    CQPrefetchHToPrefetchDHeader_s header;
     unsigned char padding[CQ_PREFETCH_CMD_BARE_MIN_SIZE];
-} CQPrefetchHToPrefetchDHeader;
+};
 static_assert((sizeof(CQPrefetchHToPrefetchDHeader) & (CQ_PREFETCH_CMD_BARE_MIN_SIZE - 1)) == 0);
 
 using prefetch_q_entry_type = uint16_t;
@@ -159,13 +159,13 @@ struct DispatchSRelayInlineState {
     static constexpr uint32_t downstream_cb_end_addr = dispatch_s_buffer_end;
 };
 
-typedef struct PrefetchExecBufState {
+struct PrefetchExecBufState {
     uint32_t page_id;
     uint32_t base_addr;
     uint32_t log_page_size;
     uint32_t pages;
     uint32_t length;
-} PrefetchExecBufState;
+};
 
 // Global Variables
 static uint32_t pcie_read_ptr = pcie_base;

--- a/tt_metal/impl/dispatch/kernels/packet_queue.hpp
+++ b/tt_metal/impl/dispatch/kernels/packet_queue.hpp
@@ -100,8 +100,6 @@ void set_64b_result(uint32_t* buf, uint64_t val, uint32_t index = 0) {
     }
 }
 
-typedef struct dispatch_packet_header_t dispatch_packet_header_t;
-
 static_assert(sizeof(dispatch_packet_header_t) == PACKET_WORD_SIZE_BYTES);
 
 // A sequence of DispatchRemoteNetworkType's used for stamping out multiple input/output queue templates

--- a/tt_metal/jit_build/build.hpp
+++ b/tt_metal/jit_build/build.hpp
@@ -149,7 +149,7 @@ public:
 
 // Set of build states
 // Used for parallel builds, builds all members in one call
-typedef std::vector<std::shared_ptr<JitBuildState>> JitBuildStateSet;
+using JitBuildStateSet = std::vector<std::shared_ptr<JitBuildState>>;
 
 // Exracts a slice of builds from a JitBuildState
 // Used for parallel building a subset of the builds in a JitBuildStateSet

--- a/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/kernels/ccl_send_reader_two_input.cpp
@@ -116,7 +116,7 @@ static_assert(test_object2.number_of_cores > 0, "Misconfigured sharded addrgen f
 static_assert(test_object2.page_size_jump > 0, "Misconfigured sharded addrgen fields for tensor1. Field \"page_size_jump\" was resolved to 0 but it must not be 0.");
 static_assert(test_object2.pages_per_tensor_row > 0, "Misconfigured sharded addrgen fields for tensor1. Field \"pages_per_tensor_row\" was resolved to 0 but it must not be 0.");
 #else
-typedef ShardedInfo<0,0,0,0,0,0,0> Tensor1ShardInfo;
+using Tensor1ShardInfo = ShardedInfo<0,0,0,0,0,0,0>;
 #endif
 #endif
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -140,14 +140,14 @@ std::pair<const mapping_table_t* const, uint32_t> get_shard_map(uint32_t L1_addr
 /*
 * ShardedAddrGen requires the type definition of a ShardedInfo class object whose templates hold the CT information
     ex.
-    typedef ShardedInfo <
+    using tensor_1_shard_info = ShardedInfo <
     SHARD_TYPE,
     NUMBER_OF_CORES,
     PAGE_SIZE_JUMP,
     PAGES_PER_TENSOR_ROW,
     CONTIGUITY,
     PAGES_PER_SHARD_WIDTH,
-    ROWS_PER_SHARD_HEIGHT> tensor_1_shard_info;
+    ROWS_PER_SHARD_HEIGHT>;
 
     The above parameters are usually obtained using get_compile_time_arg_val.
     In the program factory you can create an vector containing the above parameters in order using the function

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/dataflow/fill_pad_writer.cpp
@@ -31,15 +31,14 @@ void kernel_main() {
     uint32_t num_2d_tensors = get_arg_val<uint32_t>(rt_arg_ind++);
 
 #ifdef SHARDED
-    typedef ShardedInfo<
-        get_compile_time_arg_val(12),  // Memory layout
-        get_compile_time_arg_val(13),  // The number of sharding cores
-        get_compile_time_arg_val(14),  // The page size we offset each write to
-        get_compile_time_arg_val(15),  // The number of pages in each sharding row not including padding pages
-        get_compile_time_arg_val(16),  // This defines times when contiguous pages can't be calculated
-        get_compile_time_arg_val(17),  // pages_per_shard_x
-        get_compile_time_arg_val(18)>  // pages_per_shard_y
-        tensor_shard_info;
+    using tensor_shard_info = ShardedInfo<
+        get_compile_time_arg_val(12),   // Memory layout
+        get_compile_time_arg_val(13),   // The number of sharding cores
+        get_compile_time_arg_val(14),   // The page size we offset each write to
+        get_compile_time_arg_val(15),   // The number of pages in each sharding row not including padding pages
+        get_compile_time_arg_val(16),   // This defines times when contiguous pages can't be calculated
+        get_compile_time_arg_val(17),   // pages_per_shard_x
+        get_compile_time_arg_val(18)>;  // pages_per_shard_y
 
     const auto [mapping_table, rt_increment] =
         experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(rt_arg_ind));

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp
@@ -7,7 +7,7 @@
 namespace ttnn::operations::data_movement::reshape::detail {
 
 struct SegmentMapData {
-    typedef uint32_t value_type;
+    using value_type = uint32_t;
 
     value_type input_page_index;
     value_type input_page_offset;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding_common.hpp
@@ -5,5 +5,5 @@
 #pragma once
 
 namespace ttnn {
-typedef std::variant<uint32_t, float> PadValue;
+using PadValue = std::variant<uint32_t, float>;
 }

--- a/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/kernels/dataflow/embeddings_common.hpp
@@ -10,9 +10,9 @@
 constexpr uint32_t tile_height = 32;
 
 #if defined BFP16
-typedef uint16_t input_token_t;
+using input_token_t = uint16_t;
 #else
-typedef uint32_t input_token_t;
+using input_token_t = uint32_t;
 #endif
 
 // TODO: Can probably make this not global

--- a/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
+++ b/ttnn/cpp/ttnn/operations/full/device/kernels/writer_full.cpp
@@ -6,10 +6,10 @@
 
 #include "dataflow_api.h"
 
-typedef union {
+union value {
     float f;
     uint32_t u;
-} u;
+};
 constexpr uint32_t onetile = 1;
 
 void kernel_main() {
@@ -22,7 +22,7 @@ void kernel_main() {
     const uint32_t cb_page_size = get_tile_size(cb_value);
     const auto cb_data_format = get_dataformat(cb_value);
 
-    u val;
+    value val;
     val.u = fill_value;
 
     cb_reserve_back(cb_value, onetile);

--- a/ttnn/cpp/ttnn/operations/index_fill/device/kernels/reader_index_fill.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/kernels/reader_index_fill.cpp
@@ -6,10 +6,10 @@
 
 #include "dataflow_api.h"
 #include "cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/moreh_common.hpp"
-typedef union {
+union value {
     float f;
     uint32_t u;
-} value;
+};
 
 bool is_in_indices(uint32_t* index_ptr, uint32_t size, uint32_t row_id) {
     for (uint32_t i = 0; i < size; i++) {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange.cpp
@@ -22,11 +22,11 @@ void kernel_main() {
 
     const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = num_bytes_per_tile};
 
-    typedef union {
+    union value {
         float f;
         uint32_t u;
-    } u;
-    u start_u, step_u;
+    };
+    value start_u, step_u;
 
     start_u.u = start;
     step_u.u = step;
@@ -42,13 +42,13 @@ void kernel_main() {
         auto ptr = reinterpret_cast<uint16_t*>(w_addr);
         for (uint32_t w = 0; w < 16; w++) {
             int32_t idx = w + tile_idx * TILE_WIDTH;
-            u val;
+            value val;
             val.f = start_u.f + step_u.f * idx;
             ptr[w] = uint16_t(val.u >> 16);
         }
         for (uint32_t w = 0; w < 16; w++) {
             int32_t idx = (w + 16) + tile_idx * TILE_WIDTH;
-            u val;
+            value val;
             val.f = start_u.f + step_u.f * idx;
             ptr[w + 256] = uint16_t(val.u >> 16);
         }
@@ -72,13 +72,13 @@ void kernel_main() {
         auto ptr = reinterpret_cast<uint32_t*>(w_addr);
         for (uint32_t w = 0; w < 16; w++) {
             int32_t idx = w + tile_idx * TILE_WIDTH;
-            u val;
+            value val;
             val.f = start_u.f + step_u.f * idx;
             ptr[w] = val.u;
         }
         for (uint32_t w = 0; w < 16; w++) {
             int32_t idx = (w + 16) + tile_idx * TILE_WIDTH;
-            u val;
+            value val;
             val.f = start_u.f + step_u.f * idx;
             ptr[w + 256] = val.u;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_arange/device/kernels/writer_moreh_arange_rm.cpp
@@ -23,11 +23,11 @@ void kernel_main() {
 
     const InterleavedAddrGen<dst_is_dram> s0 = {.bank_base_address = dst_addr, .page_size = num_bytes_per_tile};
 
-    typedef union {
+    union value {
         float f;
         uint32_t u;
-    } u;
-    u start_u, step_u;
+    };
+    value start_u, step_u;
 
     start_u.u = start;
     step_u.u = step;
@@ -44,7 +44,7 @@ void kernel_main() {
 
         for (uint32_t w = 0; w < TILE_WIDTH; w++) {
             int32_t idx = w + tile_idx * TILE_WIDTH;
-            u val;
+            value val;
             val.f = start_u.f + step_u.f * idx;
             ptr[w] = uint16_t(val.u >> 16);
         }
@@ -64,7 +64,7 @@ void kernel_main() {
 
         for (uint32_t w = 0; w < TILE_WIDTH; w++) {
             int32_t idx = w + tile_idx * TILE_WIDTH;
-            u val;
+            value val;
             val.f = start_u.f + step_u.f * idx;
             ptr[w] = val.u;
         }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_helper.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss/moreh_nll_loss_helper.hpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-typedef const std::string loss_reduction;
+using loss_reduction = const std::string;
 
 namespace ttnn::operations::moreh {
 

--- a/ttnn/cpp/ttnn/tensor/types.hpp
+++ b/ttnn/cpp/ttnn/tensor/types.hpp
@@ -81,14 +81,14 @@ tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
 
 static constexpr std::size_t MAX_NUM_DIMENSIONS = 8;
 
-typedef std::array<uint32_t, 1> Array1D;
-typedef std::array<uint32_t, 2> Array2D;
-typedef std::array<uint32_t, 3> Array3D;
-typedef std::array<uint32_t, 4> Array4D;
-typedef std::array<uint32_t, 5> Array5D;
-typedef std::array<uint32_t, 6> Array6D;
-typedef std::array<uint32_t, 7> Array7D;
-typedef std::array<uint32_t, 8> Array8D;
+using Array1D = std::array<uint32_t, 1>;
+using Array2D = std::array<uint32_t, 2>;
+using Array3D = std::array<uint32_t, 3>;
+using Array4D = std::array<uint32_t, 4>;
+using Array5D = std::array<uint32_t, 5>;
+using Array6D = std::array<uint32_t, 6>;
+using Array7D = std::array<uint32_t, 7>;
+using Array8D = std::array<uint32_t, 8>;
 
 struct MemoryConfig {
     TensorMemoryLayout memory_layout = TensorMemoryLayout::INTERLEAVED;  // Interleave the data across multiple banks


### PR DESCRIPTION
### Ticket
#21242

### Problem description
Let's stop writing C and start writing C++. Prefer `using` over `typedef`, and eliminate alias declarations altogether where the misconception that in C++, `typedef struct { ... } type;` is needed in order to name `type` instead of `struct type`.

### What's changed
- Enable clang-tidy rule to error on `typedef` usage.
- Remove all usage of `typedef`.
- Replace with `using` where a type alias is truly needed.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14673293263) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes