### PR TITLE
[skip ci] Produce data: Downgrade arch-label exception to warning

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -230,7 +230,7 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
 
     if labels_have_overlap(["E150", "grayskull", "arch-grayskull"], labels):
         detected_arch = "grayskull"
-    elif labels_have_overlap(["N150", "N300", "wormhole_b0", "arch-wormhole_b0"], labels):
+    elif labels_have_overlap(["N150", "N300", "wormhole_b0", "arch-wormhole_b0", "config-t3000"], labels):
         detected_arch = "wormhole_b0"
     elif labels_have_overlap(["BH", "arch-blackhole"], labels):
         detected_arch = "blackhole"

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -243,8 +243,11 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
     # In order of preference
     if detected_config:
         if not detected_arch:
-            raise Exception(f"There must be an arch detected for config {detected_config}")
-        card_type = f"{detected_config}-{detected_arch}"
+            # This will occur for jobs where runs-on: has a config-* label but doesn't have an arch-* or card-specific label
+            logger.warning(f"No arch label found for config {detected_config} in job label, unable to infer card type")
+            card_type = None
+        else:
+            card_type = f"{detected_config}-{detected_arch}"
     elif single_cards_overlap:
         logger.info(f"Detected overlap in single cards: {single_cards_overlap}")
         card_type = list(single_cards_overlap)[0]


### PR DESCRIPTION
### Ticket
None

### Problem description
T3k smoketest is running with `config-t3000` label.
The produce data workflow assumes that any job running with `config-*` has an associated `arch-*` label, raising an exception otherwise.

https://github.com/tenstorrent/tt-metal/actions/runs/14672808714/job/41183054472
```
  File "/home/runner/work/tt-metal/tt-metal/infra/data_collection/github/utils.py", line 246, in get_job_row_from_github_job
    raise Exception(f"There must be an arch detected for config {detected_config}")
Exception: There must be an arch detected for config t3000
Error: Process completed with exit code 1.
```

### What's changed
Downgrade the exception to a warning. 
Assume config-t3000 label means wormhole cards.

### Checklist
- [x] New/Existing tests provide coverage for changes
Pipeline run on branch with fix: https://github.com/tenstorrent/tt-metal/actions/runs/14673018956