### PR TITLE
Fix Host Side Performance Modelling for Ops with TT-Mesh

### DIFF
--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -107,21 +107,7 @@ run_async_ccl_T3000_test() {
     fi
 }
 
-run_single_op_test() {
-    remove_default_log_locations
-
-    $PROFILER_SCRIPTS_ROOT/profile_this.py -c "pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_matmul.py::test_run_matmul_test[BFLOAT16-input_shapes0]"
-
-    runDate=$(ls $PROFILER_OUTPUT_DIR/)
-
-    CORE_COUNT=7
-    res=$(verify_perf_column "$PROFILER_OUTPUT_DIR/$runDate/ops_perf_results_$runDate.csv" "$CORE_COUNT" "1" "1")
-    echo $res
-}
-
 run_profiling_test() {
-    run_single_op_test
-
     run_async_test
 
     run_ccl_T3000_test
@@ -132,7 +118,9 @@ run_profiling_test() {
 
     run_mid_run_tracy_push
 
-    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py
+    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py --noconftest
+
+    pytest tests/ttnn/tracy/test_perf_op_report.py --noconftest
 
     remove_default_log_locations
 }

--- a/tests/ttnn/tracy/test_perf_op_report.py
+++ b/tests/ttnn/tracy/test_perf_op_report.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from tt_metal.tools.profiler.process_model_log import post_process_ops_log, run_device_profiler
+from models.utility_functions import skip_for_blackhole
+
+
+@pytest.fixture(scope="class")
+def run_test(request):
+    assert "command" in request.param, "Bad test setup, command not found in test setup dict"
+    assert "name" in request.param, "Bad test setup, name not found in test setup dict"
+    run_device_profiler(request.param["command"], request.param["name"])
+    return request.param
+
+
+@pytest.fixture(scope="class")
+def do_postproc(request, run_test):
+    columns = post_process_ops_log(run_test["name"])
+    return columns, run_test
+
+
+@pytest.fixture(scope="class", autouse=True)
+def run_test_do_post_proc(request, do_postproc):
+    return do_postproc
+
+
+def verify_equal(received, expected, column):
+    ret = None
+    if expected != received:
+        ret = f"Bad column value on perf report, expected {column} to be {expected} but received {received}"
+    return ret
+
+
+def verify_columns(received_columns, expected_columns, verify_func):
+    failures = []
+    for column, limit in expected_columns.items():
+        assert column in received_columns, f"Bad test results: column {column} does not exist in op perf report csv"
+        verification_res = verify_func(received_columns[column], limit, column)
+        if verification_res is not None:
+            failures.append(verification_res)
+    assert len(failures) == 0, "\n" + "\n".join(failures)
+
+
+matmul_test = {
+    "name": "Matmul",
+    "command": "pytest tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_matmul.py::test_run_matmul_test[BFLOAT16-input_shapes0]",
+}
+
+
+@skip_for_blackhole()
+@pytest.mark.parametrize("run_test", [pytest.param(matmul_test, id=matmul_test["name"])], indirect=True)
+class TestSingleOp:
+    def get_first_op_columns(cls, columns):
+        firstOpIndex = 0
+        return {column: columns[column][firstOpIndex] for column in columns}
+
+    def test_core_count(self, run_test_do_post_proc):
+        res, request = run_test_do_post_proc
+        received_columns = self.get_first_op_columns(res)
+        expected_columns = {"CORE COUNT": 1}
+        verify_columns(received_columns, expected_columns, verify_equal)
+
+    def test_performance_models(self, run_test_do_post_proc):
+        res, request = run_test_do_post_proc
+        received_columns = self.get_first_op_columns(res)
+        expected_columns = {
+            "PM IDEAL [ns]": 7,
+            "PM COMPUTE [ns]": 1,
+            "PM BANDWIDTH [ns]": 7,
+            "PM REQ I BW": "[292.5714416503906; 292.5714416503906]",
+            "PM REQ O BW": "[292.5714416503906]",
+            "PM FPU UTIL (%)": 0.1,
+        }
+        verify_columns(received_columns, expected_columns, verify_equal)

--- a/tt_metal/tools/profiler/process_model_log.py
+++ b/tt_metal/tools/profiler/process_model_log.py
@@ -21,7 +21,7 @@ def get_latest_ops_log_filename(output_logs_subdir):
     return filename
 
 
-def post_process_ops_log(output_logs_subdir, columns, sum_vals=True, op_name="", has_signposts=False):
+def post_process_ops_log(output_logs_subdir, columns=None, sum_vals=True, op_name="", has_signposts=False):
     filename = get_latest_ops_log_filename(output_logs_subdir)
     df = pd.read_csv(filename)
 
@@ -35,12 +35,18 @@ def post_process_ops_log(output_logs_subdir, columns, sum_vals=True, op_name="",
         df = df[df["OP CODE"] == op_name]
 
     results = {}
-    for col in columns:
-        df_filtered = df[df[col] != "-"]
-        if sum_vals:
-            results[col] = df_filtered[col].astype(float).sum()
-        else:
-            results[col] = df_filtered[col].astype(float).to_numpy()
+    if columns:
+        assert (
+            type(columns) == list
+        ), f"Bad columns name type, requested columns should be of type list but {type(columns)} was provided"
+        for col in columns:
+            df_filtered = df[df[col] != "-"]
+            if sum_vals:
+                results[col] = df_filtered[col].astype(float).sum()
+            else:
+                results[col] = df_filtered[col].astype(float).to_numpy()
+    else:
+        results = df
     return results
 
 

--- a/ttnn/cpp/ttnn/operation.hpp
+++ b/ttnn/cpp/ttnn/operation.hpp
@@ -185,6 +185,8 @@ struct OpPerformanceModelGeneral {
                     this->ideal_bandwidth_ns = tensor_ns(t);
                 }
             }
+        } else if constexpr (std::is_same_v<OutputTensors, Tensor>) {
+            this->outputs_bytes.push_back(output_tensors.volume() * output_tensors.element_size());
         } else {
             for (const auto& ot : output_tensors) {
                 if (!ot.has_value()) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -316,7 +316,7 @@ tt::stl::hash::hash_t BinaryDeviceOperation::compute_program_hash(
         std::get<DeviceStorage>(input_tensor_a.storage()).memory_config());
 }
 
-operation::OpPerformanceModel BinaryDeviceOperation::create_op_performance_model(
+operation::OpPerformanceModelGeneral<BinaryDeviceOperation::tensor_return_value_t> BinaryDeviceOperation::create_op_performance_model(
     const operation_attributes_t& attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value) {
@@ -338,7 +338,7 @@ operation::OpPerformanceModel BinaryDeviceOperation::create_op_performance_model
     uint32_t ideal_eltwise_cycles = total_bytes / 80 / num_cores;
 
     // TODO: update OpPerformanceModel to work on variadic arguments
-    operation::OpPerformanceModel result(input_tensors, {output_tensor}, ideal_eltwise_cycles);
+    operation::OpPerformanceModelGeneral<tensor_return_value_t> result(input_tensors, output_tensor, ideal_eltwise_cycles);
 #if 0
         tt::log_info(tt::LogOp, "BinaryDeviceOperation PerfModel:");
         tt::log_info(tt::LogOp, "\t Data (Bytes): {}", total_bytes);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.hpp
@@ -237,7 +237,7 @@ struct BinaryDeviceOperation {
 
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::tt_metal::operation::OpPerformanceModel create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -125,7 +125,7 @@ tt::stl::hash::hash_t Pool2D::compute_program_hash(
         op_attr.sliding_window_config_.get_hash(), op_attr.pool_type_, op_attr.memory_config_, input_mem_config, dtype);
 }
 
-operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::create_op_performance_model(
+tt::tt_metal::operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::create_op_performance_model(
     const operation_attributes_t& op_attr, const tensor_args_t& inputs, const Tensor& output) {
     const auto& input = inputs.input_tensor_;
     const auto& input_shape = input.get_logical_shape();
@@ -157,7 +157,8 @@ operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::crea
 
     int ideal_dev_clock_cycles = std::ceil((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi));
 
-    operation::OpPerformanceModelGeneral<tensor_return_value_t> result({input}, {output}, ideal_dev_clock_cycles);
+    tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> result(
+        {input}, {output}, ideal_dev_clock_cycles);
     return result;
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -125,7 +125,7 @@ tt::stl::hash::hash_t Pool2D::compute_program_hash(
         op_attr.sliding_window_config_.get_hash(), op_attr.pool_type_, op_attr.memory_config_, input_mem_config, dtype);
 }
 
-tt::tt_metal::operation::OpPerformanceModel Pool2D::create_op_performance_model(
+operation::OpPerformanceModelGeneral<Pool2D::tensor_return_value_t> Pool2D::create_op_performance_model(
     const operation_attributes_t& op_attr, const tensor_args_t& inputs, const Tensor& output) {
     const auto& input = inputs.input_tensor_;
     const auto& input_shape = input.get_logical_shape();
@@ -157,7 +157,7 @@ tt::tt_metal::operation::OpPerformanceModel Pool2D::create_op_performance_model(
 
     int ideal_dev_clock_cycles = std::ceil((float)num_mul_adds / (float)(num_cores * tensix_mul_adds_per_cycle_lofi));
 
-    tt::tt_metal::operation::OpPerformanceModel result({input}, {output}, ideal_dev_clock_cycles);
+    operation::OpPerformanceModelGeneral<tensor_return_value_t> result({input}, {output}, ideal_dev_clock_cycles);
     return result;
 }
 

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -66,7 +66,7 @@ struct Pool2D {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static Tensor create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-    static tt::tt_metal::operation::OpPerformanceModel create_op_performance_model(
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
 - Issue reported by Forge Team, one of the users of performance modelling
 - `DeviceOperationWithMeshDeviceAdapter` does not currently have `create_op_performance_model` implemented
 - This causes perf models defined for ops to be ignored when profiling is enabled
 
### What's changed
- Implement `create_op_performance_model` for `DeviceOperationWithMeshDeviceAdapter` class and preserve model generation behaviour prior to TT-Mesh merge
- **Best for this PR to go in once @mo-tenstorrent adds a metal side test for this feature**

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes