### PR TITLE
Convert tt-metalium logger.hpp to use spdlog

### DIFF
--- a/scripts/validate_metalium_api.py
+++ b/scripts/validate_metalium_api.py
@@ -25,6 +25,7 @@ ALLOWED_PREFIXES = {
     "magic_enum",
     "nlohmann",
     "pybind11",
+    "spdlog",
 }
 
 STD_HEADERS = {

--- a/tests/tt_eager/integration_tests/test_bert.cpp
+++ b/tests/tt_eager/integration_tests/test_bert.cpp
@@ -236,7 +236,7 @@ void test_bert() {
     CoreCoord compute_grid_size = device->compute_with_storage_grid_size();
 
     if (compute_grid_size.x * compute_grid_size.y == 88) {
-        tt::log_info(tt::LogTest, "Skipping test_bert for E75");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Skipping test_bert for E75");
         return;
     }
 
@@ -343,7 +343,7 @@ void test_bert() {
         auto output = qa_head(std::move(hidden_states), parameters).cpu();
         auto end = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
-        tt::log_info(tt::LogTest, "run_bert finished in {} microseconds", duration);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "run_bert finished in {} microseconds", duration);
         return duration;
     };
 
@@ -354,9 +354,9 @@ void test_bert() {
         }
         auto average_duration = total_duration / num_iterations;
         auto num_samples_per_second = 1e6 / average_duration * batch_size;
-        tt::log_info(tt::LogTest, "total duration: {} microseconds", total_duration);
-        tt::log_info(tt::LogTest, "average duration: {} average_duration", total_duration);
-        tt::log_info(tt::LogTest, "samples per second: {}", num_samples_per_second);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "total duration: {} microseconds", total_duration);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "average duration: {} average_duration", total_duration);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "samples per second: {}", num_samples_per_second);
     };
     device->enable_program_cache();
     run_bert();

--- a/tests/tt_eager/ops/test_bcast_op.cpp
+++ b/tests/tt_eager/ops/test_bcast_op.cpp
@@ -129,7 +129,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_eager/ops/test_bmm_op.cpp
+++ b/tests/tt_eager/ops/test_bmm_op.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -118,7 +118,7 @@ bool run_test(MeshDevice* device, const ttnn::Shape& shape, float low, float hig
 
 void test_operation_infrastructure() {
     using namespace tt::constants;
-    tt::log_info(tt::LogTest, "Running {}", __func__);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running {}", __func__);
 
     using ttnn::operations::unary::UnaryOpType;
     using ttnn::operations::unary::UnaryWithParam;
@@ -144,7 +144,7 @@ void test_operation_infrastructure() {
 
 void test_shape_padding() {
     using namespace tt::constants;
-    tt::log_info(tt::LogTest, "Running {}", __func__);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running {}", __func__);
 
     using ttnn::operations::unary::UnaryOpType;
     using ttnn::operations::unary::UnaryWithParam;
@@ -181,7 +181,7 @@ struct exp_with_param {
 }  // namespace tt
 
 void test_numerically() {
-    tt::log_info(tt::LogTest, "Running {}", __func__);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running {}", __func__);
 
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;
@@ -237,7 +237,7 @@ void test_numerically() {
 }
 
 void test_program_cache() {
-    tt::log_info(tt::LogTest, "Running {}", __func__);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running {}", __func__);
 
     using tt::constants::TILE_HEIGHT;
     using tt::constants::TILE_WIDTH;

--- a/tests/tt_eager/ops/test_layernorm_op.cpp
+++ b/tests/tt_eager/ops/test_layernorm_op.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -237,14 +237,14 @@ bool run_sfpu_test(const std::string& sfpu_name, int tile_factor = 1, bool use_D
 }
 
 bool run_unit_test(std::string op_name, int tile_factor, bool use_DRAM) {
-    log_info(LogTest, "Running {}", op_name);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Running {}", op_name);
 
     bool pass_ = run_sfpu_test(op_name, tile_factor, use_DRAM);
 
     if (pass_) {
-        log_info(LogTest, "{} test passed", op_name);
+        TT_LOG_INFO_WITH_CAT(LogTest, "{} test passed", op_name);
     } else {
-        log_info(LogTest, "{} test failed", op_name);
+        TT_LOG_INFO_WITH_CAT(LogTest, "{} test failed", op_name);
     }
     return pass_;
 }
@@ -263,9 +263,9 @@ int main(int argc, char** argv) {
         for (const auto& [op_name, _] : sfpu_op_to_hlk_op_name) {
             pass &= run_unit_test(op_name, arg_tile_factor, arg_use_DRAM);
             if (pass) {
-                log_info(LogTest, "PASS-SFPU test {}", op_name);
+                TT_LOG_INFO_WITH_CAT(LogTest, "PASS-SFPU test {}", op_name);
             } else {
-                log_info(LogTest, "FAIL-SFPU test {}", op_name);
+                TT_LOG_INFO_WITH_CAT(LogTest, "FAIL-SFPU test {}", op_name);
             }
         }
     } else {
@@ -294,7 +294,7 @@ int main(int argc, char** argv) {
             for (const auto& [op_name, _] : sfpu_op_to_hlk_op_name) {
                 ss << op_name << ", ";
             }
-            log_info(LogTest, "Help: {}", ss.str().c_str());
+            TT_LOG_INFO_WITH_CAT(LogTest, "Help: {}", ss.str().c_str());
             exit(0);
         }
         for (uint32_t idx = 0; idx < operators.size(); idx++) {
@@ -303,7 +303,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Sfpu tests passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Sfpu tests passed");
     } else {
         TT_THROW("Sfpu tests failed");
     }

--- a/tests/tt_eager/ops/test_softmax_op.cpp
+++ b/tests/tt_eager/ops/test_softmax_op.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     run_softmax(device.get(), Shape({1, 1, TILE_HEIGHT * 2, TILE_WIDTH * 2}));
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -255,7 +255,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_eager/tensors/test_host_device_loopback.cpp
+++ b/tests/tt_eager/tensors/test_host_device_loopback.cpp
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_eager/tensors/test_ranks.cpp
+++ b/tests/tt_eager/tensors/test_ranks.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -103,7 +103,7 @@ protected:
 TEST_F(MeshTraceTestSuite, Sanity) {
     auto random_seed = 10;
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
     uint32_t num_workloads_per_trace = 5;
@@ -508,7 +508,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
 TEST_F(MeshTraceTestSuite, MeshTraceAsserts) {
     auto random_seed = 10;
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
     MeshCoordinateRange all_devices(mesh_device_->shape());
     auto workload = std::make_shared<MeshWorkload>();
@@ -527,7 +527,7 @@ void run_heterogenous_trace_sweep(
     const std::vector<std::vector<MeshCoordinateRange>>& workload_grids) {
     auto random_seed = 10;
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
     uint32_t num_workloads = 10;

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -186,7 +186,7 @@ TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
     uint32_t num_iters = 500;
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
     std::vector<std::shared_ptr<MeshWorkload>> workloads = {};
-    log_info("Create {} workloads", num_workloads);
+    TT_LOG_INFO("Create {} workloads", num_workloads);
     for (int i = 0; i < num_workloads; i++) {
         std::shared_ptr<MeshWorkload> workload = std::make_shared<MeshWorkload>();
         for (const auto& device_coord : MeshCoordinateRange(mesh_device_->shape())) {
@@ -201,7 +201,7 @@ TEST_F(MeshWorkloadTestSuite, TestMeshWorkloadOnActiveEth) {
     }
     for (int i = 0; i < num_iters; i++) {
         if (i % 100 == 0) {
-            log_info(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
         }
         for (auto& workload : workloads) {
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
@@ -234,16 +234,16 @@ TEST_F(MeshWorkloadTestT3000, SimultaneousMeshWorkloads) {
     uint32_t num_iterations = 1000;
     auto random_seed = 0;
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
-    log_info("Create MeshWorkloads with multiple programs each");
+    TT_LOG_INFO("Create MeshWorkloads with multiple programs each");
 
     auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
         num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
 
-    log_info(tt::LogTest, "Compile and load {} MeshWorkloads", num_programs);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Compile and load {} MeshWorkloads", num_programs);
     for (int i = 0; i < num_programs; i += 2) {
         std::shared_ptr<MeshWorkload> random_workload = std::make_shared<MeshWorkload>();
         if (i % 2) {
@@ -302,7 +302,7 @@ TEST_F(MeshWorkloadTestT3000, SimultaneousMeshWorkloads) {
 
     for (int i = 0; i < num_iterations; i++) {
         if (i % 100 == 0) {
-            log_info(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
         }
         for (auto& workload : mesh_workloads) {
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
@@ -318,14 +318,14 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
     uint32_t num_iterations = 1000;
     auto random_seed = 0;
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
-    log_info("Create MeshWorkloads with multiple programs each");
+    TT_LOG_INFO("Create MeshWorkloads with multiple programs each");
 
     std::vector<std::shared_ptr<MeshWorkload>> mesh_workloads = {};
 
-    log_info(tt::LogTest, "Compile and load {} MeshWorkloads", 2 * (num_programs_0 + num_programs_1));
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Compile and load {} MeshWorkloads", 2 * (num_programs_0 + num_programs_1));
 
     auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
         num_programs_0, mesh_device_->compute_with_storage_grid_size(), seed);
@@ -397,7 +397,7 @@ TEST_F(MeshWorkloadTestTG, SimultaneousMeshWorkloads) {
     }
     for (int i = 0; i < num_iterations; i++) {
         if (i % 100 == 0) {
-            log_info(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
         }
         for (auto& workload : mesh_workloads) {
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
@@ -411,9 +411,9 @@ TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
     uint32_t num_iterations = 1500;
     auto random_seed = 10;
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
-    log_info("Create {} MeshWorkloads", num_programs);
+    TT_LOG_INFO("Create {} MeshWorkloads", num_programs);
     auto programs = tt::tt_metal::distributed::test::utils::create_random_programs(
         num_programs, mesh_device_->compute_with_storage_grid_size(), seed);
     std::mt19937 rng(seed);
@@ -423,7 +423,7 @@ TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
 
     // Create multiple mesh workloads on grids of random sizes.
     // Compile the workload (lower + send binaries to mesh device here as well)
-    log_info(tt::LogTest, "Compile and load {} MeshWorkloads", num_programs);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Compile and load {} MeshWorkloads", num_programs);
     for (int i = 0; i < num_programs; i += 1) {
         // Choose a grid of random dimensions and run a MeshWorkload on it
         MeshCoordinateRange device_range(MeshCoordinate{0, 0}, MeshCoordinate{gen_row(rng) - 1, gen_col(rng) - 1});
@@ -434,13 +434,13 @@ TEST_F(MeshWorkloadTestSuite, RandomizedMeshWorkload) {
     }
     for (int i = 0; i < num_iterations; i++) {
         if (i % 100 == 0) {
-            log_info(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Run MeshWorkloads for iteration {}", i);
         }
         for (auto& workload : mesh_workloads) {
             EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), *workload, false);
         }
     }
-    log_info(tt::LogTest, "Calling Finish");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Calling Finish");
     Finish(mesh_device_->mesh_command_queue());
 }
 
@@ -591,7 +591,7 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
     }
 
     for (int iter = 0; iter < 100; iter++) {
-        log_info(LogTest, "Run iter {}", iter);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Run iter {}", iter);
         if (iter) {
             auto& program = mesh_workload.get_programs().at(devices_0);
             auto& rtas = GetRuntimeArgs(program, reader_writer_kernel);

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -19,7 +19,7 @@ class ControlPlaneFixture : public ::testing::Test {
        void SetUp() override {
            auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
            if (not slow_dispatch) {
-               tt::log_info(
+               TT_LOG_INFO_WITH_CAT(
                    tt::LogTest,
                    "Control plane test suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
                GTEST_SKIP();
@@ -39,9 +39,9 @@ public:
     void SetUpDevices(tt_metal::FabricConfig fabric_config) {
         slow_dispatch_ = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch_) {
-            tt::log_info(tt::LogTest, "Running fabric api tests with slow dispatch");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running fabric api tests with slow dispatch");
         } else {
-            tt::log_info(tt::LogTest, "Running fabric api tests with fast dispatch");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running fabric api tests with fast dispatch");
         }
         // Set up all available devices
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -156,7 +156,8 @@ void RunAsyncWriteTest(
     }
 
     std::string test_type = is_raw_write ? "Raw Async Write" : "Async Write";
-    tt::log_info(tt::LogTest, "{} from {} to {}", test_type, start_mesh_chip_id.second, end_mesh_chip_id.second);
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "{} from {} to {}", test_type, start_mesh_chip_id.second, end_mesh_chip_id.second);
 
     // Get the optimal routers (no internal hops) on the start chip that will forward in the direction of the end chip
     auto routers = control_plane->get_routers_to_chip(
@@ -507,7 +508,7 @@ void RunAsyncWriteMulticastTest(
     // Log test configuration
     std::string test_type = is_raw_write ? "Raw" : "";
     std::string direction_type = multidirectional ? "Multidirectional" : "";
-    tt::log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Async {} Write Mcast {} from {} to {}",
         test_type,

--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -57,7 +57,7 @@ TEST(Cluster, ReportSystemHealth) {
         }
         ss << std::endl;
     }
-    log_info(tt::LogTest, "{}", ss.str());
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "{}", ss.str());
 
     // Print a summary of unexpected system states
     for (const auto& err_str : unexpected_system_states) {

--- a/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
@@ -14,22 +14,22 @@
 namespace tt::test::buffer::detail {
 inline void writeL1Backdoor(
     tt::tt_metal::IDevice* device, CoreCoord coord, uint32_t address, std::vector<uint32_t>& data) {
-    tt::log_info("{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
+    TT_LOG_INFO("{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
     tt_metal::detail::WriteToDeviceL1(device, coord, address, data);
 }
 inline void readL1Backdoor(
     tt::tt_metal::IDevice* device, CoreCoord coord, uint32_t address, uint32_t byte_size, std::vector<uint32_t>& data) {
-    tt::log_info("{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, byte_size);
+    TT_LOG_INFO("{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, byte_size);
     tt_metal::detail::ReadFromDeviceL1(device, coord, address, byte_size, data);
 }
 inline void writeDramBackdoor(
     tt::tt_metal::IDevice* device, uint32_t channel, uint32_t address, std::vector<uint32_t>& data) {
-    tt::log_info("{} -- channel={} address={}", __FUNCTION__, channel, address);
+    TT_LOG_INFO("{} -- channel={} address={}", __FUNCTION__, channel, address);
     tt_metal::detail::WriteToDeviceDRAMChannel(device, channel, address, data);
 }
 inline void readDramBackdoor(
     tt::tt_metal::IDevice* device, uint32_t channel, uint32_t address, uint32_t byte_size, std::vector<uint32_t>& data) {
-    tt::log_info("{} -- channel={} address={} byte_size={}", __FUNCTION__, channel, address, byte_size);
+    TT_LOG_INFO("{} -- channel={} address={} byte_size={}", __FUNCTION__, channel, address, byte_size);
     tt_metal::detail::ReadFromDeviceDRAMChannel(device, channel, address, byte_size, data);
 }
 }  // namespace tt::test::buffer::detail

--- a/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
+++ b/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
@@ -71,11 +71,11 @@ private:
     bool are_env_vars_set() {
         bool are_set = true;
         if (!tt_metal::MetalContext::instance().rtoptions().is_root_dir_specified()) {
-            log_info(LogTest, "Skipping test: TT_METAL_HOME must be set");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skipping test: TT_METAL_HOME must be set");
             are_set = false;
         }
         if (!tt_metal::MetalContext::instance().rtoptions().is_kernel_dir_specified()) {
-            log_info(LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be set");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be set");
             are_set = false;
         }
         return are_set;
@@ -86,7 +86,7 @@ private:
         const std::string& kernel_dir = tt_metal::MetalContext::instance().rtoptions().get_kernel_dir();
         if (!this->does_path_exist(kernel_dir) || !this->is_path_a_directory(kernel_dir) ||
             !this->is_dir_empty(kernel_dir)) {
-            log_info(LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be an existing, empty directory");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skipping test: TT_METAL_KERNEL_PATH must be an existing, empty directory");
             is_valid = false;
         }
         return is_valid;

--- a/tests/tt_metal/tt_metal/api/test_dram.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram.cpp
@@ -144,10 +144,10 @@ bool dram_single_core(
     auto output_dram_buffer = tt_metal::CreateBuffer(dram_config);
     uint32_t output_dram_buffer_addr = output_dram_buffer->address();
 
-    tt::log_info("Creating kernel at {}", cfg.core_range.str());
-    tt::log_info("Input DRAM Address  = {:#x}", input_dram_buffer_addr);
-    tt::log_info("Output DRAM Address = {:#x}", output_dram_buffer_addr);
-    tt::log_info("L1 Buffer Address   = {:#x}", cfg.l1_buffer_addr);
+    TT_LOG_INFO("Creating kernel at {}", cfg.core_range.str());
+    TT_LOG_INFO("Input DRAM Address  = {:#x}", input_dram_buffer_addr);
+    TT_LOG_INFO("Output DRAM Address = {:#x}", output_dram_buffer_addr);
+    TT_LOG_INFO("L1 Buffer Address   = {:#x}", cfg.l1_buffer_addr);
     // Create the kernel
     tt::tt_metal::KernelHandle kernel = CreateKernelFromVariant(program, cfg);
 
@@ -260,7 +260,7 @@ TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCorePreAllocated) {
 
 TEST_F(DispatchFixture, TensixDRAMLoopbackSingleCoreDB) {
     if (!this->IsSlowDispatch()) {
-        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     }
     for (unsigned int id = 0; id < devices_.size(); id++) {
@@ -272,7 +272,7 @@ TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
     constexpr uint32_t buffer_size = 2 * 1024 * 25;
 
     if (!this->IsSlowDispatch()) {
-        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     }
 
@@ -289,7 +289,7 @@ TEST_F(DispatchFixture, ActiveEthDRAMLoopbackSingleCore) {
 
     for (unsigned int id = 0; id < devices_.size(); id++) {
         for (auto active_eth_core : devices_.at(id)->get_active_ethernet_cores(true)) {
-            tt::log_info("Active Eth Loopback. Logical core {}", active_eth_core.str());
+            TT_LOG_INFO("Active Eth Loopback. Logical core {}", active_eth_core.str());
             dram_test_config.core_range = {active_eth_core, active_eth_core};
             ASSERT_TRUE(unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config));
         }
@@ -300,7 +300,7 @@ TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
     constexpr uint32_t buffer_size = 2 * 1024 * 25;
 
     if (!this->IsSlowDispatch()) {
-        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     }
 
@@ -317,7 +317,7 @@ TEST_F(DispatchFixture, IdleEthDRAMLoopbackSingleCore) {
 
     for (unsigned int id = 0; id < devices_.size(); id++) {
         for (auto idle_eth_core : devices_.at(id)->get_inactive_ethernet_cores()) {
-            tt::log_info("Single Idle Eth Loopback. Logical core {}", idle_eth_core.str());
+            TT_LOG_INFO("Single Idle Eth Loopback. Logical core {}", idle_eth_core.str());
             dram_test_config.core_range = {idle_eth_core, idle_eth_core};
             unit_tests_common::dram::test_dram::dram_single_core(this, devices_.at(id), dram_test_config);
         }

--- a/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_to_l1_multicast.cpp
@@ -136,7 +136,7 @@ bool dram_to_l1_multicast(
             auto dest_core_data_unpacked = unpack_uint32_vec_into_bfloat16_vec(dest_core_data);
             pass &= (dest_core_data_unpacked == tensor.get_values());
             if (not(dest_core_data_unpacked == tensor.get_values())) {
-                log_info(LogTest, "Mismatch on core {}, {}", dest_core.x, dest_core.y);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Mismatch on core {}, {}", dest_core.x, dest_core.y);
                 print_vec_of_bfloat16(dest_core_data_unpacked, 1, "Result");
             }
         }
@@ -178,7 +178,7 @@ TEST_F(DispatchFixture, TensixDRAMtoL1MulticastExcludeRegionUpLeft) {
         .exclude_direction = {0, 0}};
     for (unsigned int id = 0; id < devices_.size(); id++) {
         if (!(this->devices_.at(id)->arch() == tt::ARCH::BLACKHOLE)) {
-            tt::log_info(tt::LogTest, "This test is only supported on Blackhole");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported on Blackhole");
             GTEST_SKIP();
         }
         ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(
@@ -195,7 +195,7 @@ TEST_F(DispatchFixture, TensixDRAMtoL1MulticastExcludeRegionUpRight) {
         .exclude_direction = {1, 0}};
     for (unsigned int id = 0; id < devices_.size(); id++) {
         if (!(this->devices_.at(id)->arch() == tt::ARCH::BLACKHOLE)) {
-            tt::log_info(tt::LogTest, "This test is only supported on Blackhole");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported on Blackhole");
             GTEST_SKIP();
         }
         ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(
@@ -212,7 +212,7 @@ TEST_F(DispatchFixture, TensixDRAMtoL1MulticastExcludeRegionDownLeft) {
         .exclude_direction = {0, 1}};
     for (unsigned int id = 0; id < devices_.size(); id++) {
         if (!(this->devices_.at(id)->arch() == tt::ARCH::BLACKHOLE)) {
-            tt::log_info(tt::LogTest, "This test is only supported on Blackhole");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported on Blackhole");
             GTEST_SKIP();
         }
         ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(
@@ -229,7 +229,7 @@ TEST_F(DispatchFixture, TensixDRAMtoL1MulticastExcludeRegionDownRight) {
         .exclude_direction = {1, 1}};
     for (unsigned int id = 0; id < devices_.size(); id++) {
         if (!(this->devices_.at(id)->arch() == tt::ARCH::BLACKHOLE)) {
-            tt::log_info(tt::LogTest, "This test is only supported on Blackhole");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported on Blackhole");
             GTEST_SKIP();
         }
         ASSERT_TRUE(unit_tests_common::dram::test_dram_to_l1_multicast::dram_to_l1_multicast(

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -105,14 +105,14 @@ TEST(NOC, TensixSingleDeviceHarvestingPrints) {
     }
     auto logical_grid_size = device->logical_grid_size();
     if (logical_grid_size == unharvested_logical_grid_size) {
-        tt::log_info("Harvesting Disabled in SW");
+        TT_LOG_INFO("Harvesting Disabled in SW");
     } else {
-        tt::log_info("Harvesting Enabled in SW");
-        tt::log_info("Number of Harvested Rows={}", unharvested_logical_grid_size.y - logical_grid_size.y);
+        TT_LOG_INFO("Harvesting Enabled in SW");
+        TT_LOG_INFO("Number of Harvested Rows={}", unharvested_logical_grid_size.y - logical_grid_size.y);
     }
 
-    tt::log_info("Logical -- Virtual Mapping");
-    tt::log_info("[Logical <-> Virtual] Coordinates");
+    TT_LOG_INFO("Logical -- Virtual Mapping");
+    TT_LOG_INFO("[Logical <-> Virtual] Coordinates");
     for (int r = 0; r < logical_grid_size.y; r++) {
         string output_row = "";
         for (int c = 0; c < logical_grid_size.x; c++) {
@@ -124,7 +124,7 @@ TEST(NOC, TensixSingleDeviceHarvestingPrints) {
             output_row += "-y" + std::to_string(noc_coord.y);
             output_row += "]}, ";
         }
-        tt::log_info("{}", output_row);
+        TT_LOG_INFO("{}", output_row);
     }
     ASSERT_TRUE(tt::tt_metal::CloseDevice(device));
 }

--- a/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
@@ -31,7 +31,7 @@ bool SimpleDramReadOnly(IDevice* device, size_t local_address, size_t byte_size)
     readDramBackdoor(device, dram_channel, local_address, byte_size, outputs);
     bool pass = (inputs == outputs);
     if (not pass) {
-        tt::log_info("Mismatch at Channel={}, Packet Size(in Bytes)={}", dram_channel, byte_size);
+        TT_LOG_INFO("Mismatch at Channel={}, Packet Size(in Bytes)={}", dram_channel, byte_size);
     }
     return pass;
 }
@@ -44,7 +44,7 @@ bool SimpleDramWriteOnly(IDevice* device, size_t local_address, size_t byte_size
     readDramBackdoor(device, dram_channel, local_address, byte_size, outputs);
     bool pass = (inputs == outputs);
     if (not pass) {
-        tt::log_info("Mismatch at Channel={}, Packet Size(in Bytes)={}", dram_channel, byte_size);
+        TT_LOG_INFO("Mismatch at Channel={}, Packet Size(in Bytes)={}", dram_channel, byte_size);
     }
     return pass;
 }

--- a/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
@@ -45,7 +45,7 @@ bool SimpleL1ReadOnly(IDevice* device, size_t local_address, size_t byte_size) {
     readL1Backdoor(device, bank0_logical_core, local_address, byte_size, outputs);
     bool pass = (inputs == outputs);
     if (not pass) {
-        tt::log_info("Mismatch at Core={}, Packet Size(in Bytes)={}", bank0_logical_core.str(), byte_size);
+        TT_LOG_INFO("Mismatch at Core={}, Packet Size(in Bytes)={}", bank0_logical_core.str(), byte_size);
     }
     return pass;
 }
@@ -58,7 +58,7 @@ bool SimpleL1WriteOnly(IDevice* device, size_t local_address, size_t byte_size) 
     readL1Backdoor(device, bank0_logical_core, local_address, byte_size, outputs);
     bool pass = (inputs == outputs);
     if (not pass) {
-        tt::log_info("Mismatch at Core={}, Packet Size(in Bytes)={}", bank0_logical_core.str(), byte_size);
+        TT_LOG_INFO("Mismatch at Core={}, Packet Size(in Bytes)={}", bank0_logical_core.str(), byte_size);
     }
     return pass;
 }
@@ -132,7 +132,7 @@ bool SimpleTiledL1WriteCBRead(
     tt::log_debug("inputs[0]={} == outputs[0]={}", inputs[0], outputs[0]);
     bool pass = (inputs == outputs);
     if (not pass) {
-        tt::log_info(
+        TT_LOG_INFO(
             "Mismatch at Core={}, phys_core={}, Packet Size(in Bytes)={}", core.str(), phys_core.str(), byte_size);
     }
     return pass;

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -44,7 +44,7 @@ std::unordered_set<int> get_harvested_rows(chip_id_t device_id) {
         tmp = tmp >> 1;
         row_coordinate++;
     }
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Device {} has {} harvested rows. Physical harvested row coordinates are: {}",
         device_id,
@@ -68,7 +68,7 @@ TEST(SOC, TensixValidateLogicalToPhysicalCoreCoordHostMapping) {
             tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
         const metal_SocDescriptor& soc_desc =
             tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
-        log_info(LogTest, "Device {} harvesting mask {}", device_id, harvested_rows_mask);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Device {} harvesting mask {}", device_id, harvested_rows_mask);
         std::unordered_set<int> harvested_rows = unit_tests::basic::soc_desc::get_harvested_rows(device_id);
 
         CoreCoord logical_grid_size = device->logical_grid_size();

--- a/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_worker_config_buffer.cpp
@@ -131,7 +131,7 @@ TEST(WorkerConfigBuffer, LoopAround) {
 
 TEST(WorkerConfigBuffer, Randomized) {
     const uint32_t seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(time(nullptr)));
-    log_info(tt::LogTest, "Using seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using seed: {}", seed);
     srand(seed);
     const std::vector<uint32_t> kSizes = {1024, 1024, 10, 1};
     WorkerConfigBufferMgr mgr;

--- a/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/command_queue_fixture.hpp
@@ -38,7 +38,7 @@ protected:
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = true;
             GTEST_SKIP();
@@ -84,7 +84,7 @@ protected:
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = false;
             GTEST_SKIP();
@@ -140,7 +140,7 @@ protected:
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = true;
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -40,7 +40,7 @@ protected:
         this->slow_dispatch_ = true;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
             GTEST_SKIP();
@@ -93,7 +93,7 @@ protected:
         this->slow_dispatch_ = true;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
             GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/dispatch_fixture.hpp
@@ -111,7 +111,7 @@ protected:
         // targetting device 0 by default (and to not cause issues with BMs that have E300s).
         // TODO: when we can detect only supported devices, this check can be removed.
         if (this->arch_ == tt::ARCH::GRAYSKULL && device_id > 0) {
-            log_info(tt::LogTest, "Skipping test on device {} due to unsupported E300", device_id);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Skipping test on device {} due to unsupported E300", device_id);
             return true;
         }
 
@@ -122,18 +122,18 @@ protected:
         if (SkipTest(device->id())) {
             return;
         }
-        log_info(tt::LogTest, "Running test on device {}.", device->id());
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running test on device {}.", device->id());
         run_function();
-        log_info(tt::LogTest, "Finished running test on device {}.", device->id());
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished running test on device {}.", device->id());
     }
 
     void DetectDispatchMode() {
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(tt::LogTest, "Running test using Slow Dispatch");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running test using Slow Dispatch");
             this->slow_dispatch_ = true;
         } else {
-            tt::log_info(tt::LogTest, "Running test using Fast Dispatch");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running test using Fast Dispatch");
             this->slow_dispatch_ = false;
         }
     }

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -31,7 +31,7 @@ protected:
         this->slow_dispatch_ = true;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
-            tt::log_info(tt::LogTest, "This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
             GTEST_SKIP();
         }
@@ -62,7 +62,7 @@ protected:
         this->slow_dispatch_ = true;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (!slow_dispatch) {
-            tt::log_info(tt::LogTest, "This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This suite can only be run with TT_METAL_SLOW_DISPATCH_MODE set");
             this->slow_dispatch_ = false;
             GTEST_SKIP();
         }

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -120,7 +120,7 @@ bool run_dm(IDevice* device, const DramConfig& test_config) {
             .compile_args = writer_compile_args});
 
     // Assign unique id
-    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    TT_LOG_INFO("Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Launch program and record outputs
@@ -130,9 +130,9 @@ bool run_dm(IDevice* device, const DramConfig& test_config) {
     detail::ReadFromBuffer(output_dram_buffer, packed_output);
 
     // Print output and golden vectors
-    log_info("Golden vector");
+    TT_LOG_INFO("Golden vector");
     print_vector<uint32_t>(packed_golden);
-    log_info("Output vector");
+    TT_LOG_INFO("Output vector");
     print_vector<uint32_t>(packed_output);
 
     // Return comparison
@@ -187,7 +187,7 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedCoreLocations) {
     for (unsigned int id = 0; id < num_devices_; id++) {
         // Cores
         auto grid_size = devices_.at(id)->compute_with_storage_grid_size();
-        log_info("Grid size x: {}, y: {}", grid_size.x, grid_size.y);
+        TT_LOG_INFO("Grid size x: {}, y: {}", grid_size.x, grid_size.y);
 
         for (unsigned int x = 0; x < grid_size.x; x++) {
             for (unsigned int y = 0; y < grid_size.y; y++) {
@@ -252,8 +252,8 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMSharded) {
                 .tensor_shape_in_pages = tensor_shape_in_pages,
                 .num_dram_banks = num_dram_banks};
 
-            log_info("Tensor shape in pages: {}", tensor_shape_in_pages);
-            log_info("Number of dram banks: {}", num_dram_banks);
+            TT_LOG_INFO("Tensor shape in pages: {}", tensor_shape_in_pages);
+            TT_LOG_INFO("Number of dram banks: {}", num_dram_banks);
 
             // Run
             for (unsigned int id = 0; id < num_devices_; id++) {

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/test_one_to_one.cpp
@@ -125,7 +125,7 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
     SetRuntimeArgs(program, receiver_kernel, slave_core_set, {sem_id});
 
     // Assign unique id
-    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    TT_LOG_INFO("Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
     program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Input
@@ -143,9 +143,9 @@ bool run_dm(IDevice* device, const OneToOneConfig& test_config) {
     detail::ReadFromBuffer(slave_l1_buffer, packed_output);
 
     // Print output and golden vectors
-    log_info("Golden vector");
+    TT_LOG_INFO("Golden vector");
     print_vector<uint32_t>(packed_golden);
-    log_info("Output vector");
+    TT_LOG_INFO("Output vector");
     print_vector<uint32_t>(packed_output);
 
     // Return comparison

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -13,7 +13,7 @@ inline bool OpenFile(string &file_name, std::fstream &file_stream, std::ios_base
     if (file_stream.is_open()) {
         return true;
     } else {
-        tt::log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Test Error: Couldn't open file {}.",
             file_name
@@ -26,14 +26,14 @@ inline bool OpenFile(string &file_name, std::fstream &file_stream, std::ios_base
 inline void DumpFile(string file_name) {
     std::fstream log_file;
     if (!OpenFile(file_name, log_file, std::fstream::in)) {
-        tt::log_info(tt::LogTest, "File \'{}\' does not exist!", file_name);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "File \'{}\' does not exist!", file_name);
         return;
     }
 
-    tt::log_info(tt::LogTest, "File \'{}\' contains:", file_name);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "File \'{}\' contains:", file_name);
     string line;
     while (getline(log_file, line))
-        tt::log_info(tt::LogTest, "{}", line);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "{}", line);
 }
 
 // Compare two strings with a (single-character) wildcard
@@ -100,7 +100,7 @@ inline bool FileContainsAllStrings(string file_name, const std::vector<string> &
     string missing_strings = "";
     for (const string &s : must_contain_set)
         missing_strings += s + ",";
-    tt::log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Test Error: Expected file {} to contain the following strings: {}",
         file_name,
@@ -141,7 +141,7 @@ inline bool FileContainsAllStringsInOrder(string file_name, const std::vector<st
     string missing_strings = "";
     for (const string &s : must_contain_queue)
         missing_strings += s + ",";
-    tt::log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Test Error: Expected file {} to contain the following strings: {}",
         file_name,
@@ -155,7 +155,7 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
     // Open the input file.
     std::fstream file;
     if (!OpenFile(file_name, file, std::fstream::in)) {
-        tt::log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Test Error: file {} could not be opened.",
             file_name
@@ -172,7 +172,7 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
     while (getline(file, line_a) && getline(expect_stream, line_b)) {
         line_num++;
         if (!StringCompareWithWildcard(line_a, line_b, '*')) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest,
                 "Test Error: Line {} of {} did not match expected:\n\t{}\n\t{}",
                 line_num,
@@ -186,7 +186,7 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
 
     // Make sure that there's no lines left over in either stream
     if (getline(file, line_a)) {
-        tt::log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Test Error: file {} has more lines than expected (>{}).",
             file_name,
@@ -195,7 +195,7 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
         return false;
     }
     if (getline(expect_stream, line_b)) {
-        tt::log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Test Error: file {} has less lines than expected ({}).",
             file_name,

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_eth_cores.cpp
@@ -75,14 +75,8 @@ void RunTest(
             config);
 
         // Run the program
-        log_info(
-            tt::LogTest,
-            "Running print test on eth core {}:({},{}), {}",
-            device->id(),
-            core.x,
-            core.y,
-            processor
-        );
+        TT_LOG_INFO_WITH_CAT(
+            tt::LogTest, "Running print test on eth core {}:({},{}), {}", device->id(), core.x, core.y, processor);
         fixture->RunProgram(device, program);
 
         // Check the print log against golden output.
@@ -102,13 +96,13 @@ void RunTest(
 
 TEST_F(DPrintFixture, ActiveEthTestPrint) {
     if (this->arch_ == ARCH::BLACKHOLE) {  // TODO: Re-enable when this is supported on BH
-        log_info(tt::LogTest, "DPrint on BH active eth not yet supported");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "DPrint on BH active eth not yet supported");
         GTEST_SKIP();
     }
     for (IDevice* device : this->devices_) {
         // Skip if no ethernet cores on this device
         if (device->get_active_ethernet_cores(true).size() == 0) {
-            log_info(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
             continue;
         }
         this->RunTestOnDevice(
@@ -121,13 +115,13 @@ TEST_F(DPrintFixture, ActiveEthTestPrint) {
 }
 TEST_F(DPrintFixture, IdleEthTestPrint) {
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     for (IDevice* device : this->devices_) {
         // Skip if no ethernet cores on this device
         if (device->get_inactive_ethernet_cores().size() == 0) {
-            log_info(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Skipping device {} due to no ethernet cores...", device->id());
             continue;
         }
         this->RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_buffering.cpp
@@ -87,7 +87,7 @@ void RunTest(DPrintFixture* fixture, IDevice* device) {
 
         SetRuntimeArgs(program, kernel_id, core, {core.x, core.y});
 
-        log_info(tt::LogTest, "Running test on core {}:({},{})", device->id(), core.x, core.y);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running test on core {}:({},{})", device->id(), core.x, core.y);
     }
 
     fixture->RunProgram(device, program);

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
@@ -59,7 +59,7 @@ try {
 } catch (std::runtime_error& e) {
     const string expected = "Command Queue could not finish: device hang due to unanswered DPRINT WAIT.";
     const string error = string(e.what());
-    log_info(tt::LogTest, "Caught exception (one is expected in this test)");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Caught exception (one is expected in this test)");
     EXPECT_TRUE(error.find(expected) != string::npos);
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -112,14 +112,14 @@ TEST_F(DPrintFixture, TensixTestPrintPrependDeviceCoreRisc) {
 
 TEST_F(DPrintFixture, TensixActiveEthTestPrintPrependDeviceCoreRisc) {
     if (this->arch_ == ARCH::BLACKHOLE) {  // TODO: Re-enable when this is supported on BH
-        log_info(tt::LogTest, "DPrint on BH active eth not yet supported");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "DPrint on BH active eth not yet supported");
         GTEST_SKIP();
     }
     tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, true);
     for (IDevice* device : this->devices_) {
         if (device->get_active_ethernet_cores(true).empty()) {
-            log_info(tt::LogTest, "Skipping device {} due to no active ethernet cores...", device->id());
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Skipping device {} due to no active ethernet cores...", device->id());
             continue;
         }
         this->RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_tiles.cpp
@@ -275,7 +275,7 @@ static void RunTest(DPrintFixture* fixture, IDevice* device, tt::DataFormat data
         string tmp = fmt::format("data[{:#03}:{:#03}]:", idx - 1, idx - 16);
         for (int i = 0; i < 16; i++)
             tmp += fmt::format(" 0x{:08x}", u32_vec[idx + 15 - i]);
-        log_info("{}", tmp);
+        TT_LOG_INFO("{}", tmp);
     }*/
 
     // Send input tile to dram
@@ -291,7 +291,7 @@ static void RunTest(DPrintFixture* fixture, IDevice* device, tt::DataFormat data
 
     // Check against expected prints
     string expected = GenerateGoldenOutput(data_format, u32_vec);
-    // log_info("Expected output:\n{}", expected);
+    // TT_LOG_INFO("Expected output:\n{}", expected);
     EXPECT_TRUE(
         FilesMatchesString(
             DPrintFixture::dprint_file_name,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -42,14 +42,14 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
     CoreCoord logical_core, virtual_core;
     if (riscv_type == DebugErisc) {
         if (device->get_active_ethernet_cores(true).empty()) {
-            log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skipping this test since device has no active ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_active_ethernet_cores(true).begin());
         virtual_core = device->ethernet_core_from_logical_core(logical_core);
     } else if (riscv_type == DebugIErisc) {
         if (device->get_inactive_ethernet_cores().empty()) {
-            log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skipping this test since device has no inactive ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_inactive_ethernet_cores().begin());
@@ -58,7 +58,7 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
         logical_core = CoreCoord{0, 0};
         virtual_core = device->worker_core_from_logical_core(logical_core);
     }
-    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
+    TT_LOG_INFO_WITH_CAT(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
 
     // Set up the kernel on the correct risc
     KernelHandle assert_kernel;
@@ -144,9 +144,7 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
             );
             risc = "erisc";
             break;
-        default:
-            log_info("Unsupported risc type: {}, skipping test...", riscv_type);
-            GTEST_SKIP();
+        default: TT_LOG_INFO("Unsupported risc type: {}, skipping test...", riscv_type); GTEST_SKIP();
     }
 
     // Write runtime args that should not trip an assert.
@@ -154,9 +152,9 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
     SetRuntimeArgs(program, assert_kernel, logical_core, safe_args);
 
     // Run the kernel, don't expect an issue here.
-    log_info(LogTest, "Running args that shouldn't assert...");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Running args that shouldn't assert...");
     fixture->RunProgram(device, program);
-    log_info(LogTest, "Args did not assert!");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Args did not assert!");
 
     // Write runtime args that should trip an assert.
     const std::vector<uint32_t> unsafe_args = { 3, 3 };
@@ -164,13 +162,13 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
 
     // Run the kerel, expect an exit due to the assert.
     try {
-        log_info(LogTest, "Running args that should assert...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running args that should assert...");
         fixture->RunProgram(device, program);
     } catch (std::runtime_error &e) {
         string expected = "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.\n";
         expected += tt::watcher_get_log_file_name();
         const string error = string(e.what());
-        log_info(LogTest, "Caught exception (one is expected in this test)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Caught exception (one is expected in this test)");
         EXPECT_TRUE(error.find(expected) != string::npos);
     }
 
@@ -192,12 +190,12 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
         kernel);
     expected += " Note that file name reporting is not yet implemented, and the reported line number for the assert may be from a different file.";
 
-    log_info(LogTest, "Expected error: {}", expected);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Expected error: {}", expected);
     std::string exception = "";
     do {
         exception = get_watcher_exception_message();
     } while (exception == "");
-    log_info(LogTest, "Reported error: {}", exception);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Reported error: {}", exception);
     EXPECT_TRUE(expected == get_watcher_exception_message());
 }
 }
@@ -267,7 +265,7 @@ TEST_F(WatcherFixture, TestWatcherAssertErisc) {
 TEST_F(WatcherFixture, TestWatcherAssertIErisc) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     if (this->slow_dispatch_)

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_link_training.cpp
@@ -37,7 +37,7 @@ static void RunTest(WatcherFixture* fixture, IDevice* device) {
 TEST_F(WatcherFixture, ActiveEthTestWatcherEthLinkCheck) {
     // Eth link retraining only supported on WH for now, this test is also dispatch-agnostic so just pick one.
     if (this->slow_dispatch_ || this->arch_ != tt::ARCH::WORMHOLE_B0 || this->devices_.size() == 1) {
-        log_info(LogTest, "Test only runs on fast dispatch + multi-chip WH, skipping...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test only runs on fast dispatch + multi-chip WH, skipping...");
         GTEST_SKIP();
     }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize.cpp
@@ -103,7 +103,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
     } else {
         virtual_core = device->worker_core_from_logical_core(core);
     }
-    log_info(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
+    TT_LOG_INFO_WITH_CAT(LogTest, "Running test on device {} core {}...", device->id(), virtual_core.str());
 
     // Set up dram buffers
     uint32_t single_tile_size = 2 * 1024;
@@ -131,10 +131,10 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
 
     auto input_buf_noc_xy = get_core_coord_for_test(input_buffer);
     auto output_buf_noc_xy = get_core_coord_for_test(output_buffer);
-    log_info("Input/Output Buffer mem type: {}", magic_enum::enum_name(buffer_mem_type));
-    log_info("Input Buffer NOC XY: {}", input_buf_noc_xy);
-    log_info("Output Buffer NOC XY: {}", output_buf_noc_xy);
-    log_info("Local scratch buffer addr: {:#x}", buffer_addr);
+    TT_LOG_INFO("Input/Output Buffer mem type: {}", magic_enum::enum_name(buffer_mem_type));
+    TT_LOG_INFO("Input Buffer NOC XY: {}", input_buf_noc_xy);
+    TT_LOG_INFO("Output Buffer NOC XY: {}", output_buf_noc_xy);
+    TT_LOG_INFO("Local scratch buffer addr: {:#x}", buffer_addr);
 
     // A copy kernel, we'll feed it incorrect inputs to test sanitization.
     KernelHandle dram_copy_kernel;
@@ -217,7 +217,7 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
         string expected = "Command Queue could not finish: device hang due to illegal NoC transaction. See {} for details.\n";
         expected += tt::watcher_get_log_file_name();
         const string error = string(e.what());
-        log_info(tt::LogTest, "Caught exception (one is expected in this test)");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Caught exception (one is expected in this test)");
         EXPECT_TRUE(error.find(expected) != string::npos);
     }
 
@@ -342,12 +342,12 @@ void RunTestOnCore(WatcherFixture* fixture, IDevice* device, CoreCoord &core, bo
             break;
     }
 
-    log_info(LogTest, "Expected error: {}", expected);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Expected error: {}", expected);
     std::string exception = "";
     do {
         exception = get_watcher_exception_message();
     } while (exception == "");
-    log_info(LogTest, "Reported error: {}", exception);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Reported error: {}", exception);
     EXPECT_EQ(get_watcher_exception_message(), expected);
 }
 
@@ -357,7 +357,7 @@ void RunTestEth(WatcherFixture* fixture, IDevice* device, watcher_features_t fea
     }
     // Run on the first ethernet core (if there are any).
     if (device->get_active_ethernet_cores(true).empty()) {
-        log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Skipping this test since device has no active ethernet cores.");
         GTEST_SKIP();
     }
     CoreCoord core = *(device->get_active_ethernet_cores(true).begin());
@@ -370,7 +370,7 @@ void RunTestIEth(WatcherFixture* fixture, IDevice* device, watcher_features_t fe
     }
     // Run on the first ethernet core (if there are any).
     if (device->get_inactive_ethernet_cores().empty()) {
-        log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Skipping this test since device has no active ethernet cores.");
         GTEST_SKIP();
     }
     CoreCoord core = *(device->get_inactive_ethernet_cores().begin());
@@ -388,7 +388,7 @@ void CheckHostSanitization(IDevice* device) {
     } catch (std::runtime_error& e) {
         const string expected = fmt::format("Host watcher: bad {} NOC coord {}\n", "read", core.str());
         const string error = string(e.what());
-        log_info(tt::LogTest, "Caught exception (one is expected in this test)");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Caught exception (one is expected in this test)");
         EXPECT_TRUE(error.find(expected) != string::npos);
     }
 }
@@ -479,7 +479,7 @@ TEST_F(WatcherFixture, ActiveEthTestWatcherSanitizeInlineWriteDram) {
 
 TEST_F(WatcherFixture, IdleEthTestWatcherSanitizeIEth) {
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     this->RunTestOnDevice(
@@ -489,7 +489,7 @@ TEST_F(WatcherFixture, IdleEthTestWatcherSanitizeIEth) {
 
 TEST_F(WatcherFixture, IdleEthTestWatcherSanitizeInlineWriteDram) {
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     this->RunTestOnDevice(

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -169,7 +169,7 @@ void RunDelayTestOnCore(WatcherDelayFixture* fixture, IDevice* device, CoreCoord
                 offsetof(watcher_msg_t, debug_insert_delays),
             sizeof(debug_insert_delays_msg_t));
 
-        log_info(tt::LogTest, "Read back debug_insert_delays: 0x{:x}", read_vec[0]);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Read back debug_insert_delays: 0x{:x}", read_vec[0]);
         EXPECT_TRUE((read_vec[0] >> 24) == 0x3);
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_pause.cpp
@@ -87,7 +87,7 @@ void RunTest(WatcherFixture* fixture, IDevice* device) {
         KernelHandle erisc_kid;
         std::set<CoreRange> eth_core_ranges;
         for (const auto& core : device->get_active_ethernet_cores(true)) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "Running on eth core {}({})", core.str(), device->ethernet_core_from_logical_core(core).str());
             eth_core_ranges.insert(CoreRange(core, core));
         }
@@ -105,7 +105,7 @@ void RunTest(WatcherFixture* fixture, IDevice* device) {
         KernelHandle ierisc_kid;
         std::set<CoreRange> eth_core_ranges;
         for (const auto& core : device->get_inactive_ethernet_cores()) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Running on inactive eth core {}({})",
                 core.str(),

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -48,14 +48,14 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
     CoreCoord logical_core, virtual_core;
     if (riscv_type == DebugErisc) {
         if (device->get_active_ethernet_cores(true).empty()) {
-            log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skipping this test since device has no active ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_active_ethernet_cores(true).begin());
         virtual_core = device->ethernet_core_from_logical_core(logical_core);
     } else if (riscv_type == DebugIErisc) {
         if (device->get_inactive_ethernet_cores().empty()) {
-            log_info(LogTest, "Skipping this test since device has no inactive ethernet cores.");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skipping this test since device has no inactive ethernet cores.");
             GTEST_SKIP();
         }
         logical_core = *(device->get_inactive_ethernet_cores().begin());
@@ -64,7 +64,7 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
         logical_core = CoreCoord{0, 0};
         virtual_core = device->worker_core_from_logical_core(logical_core);
     }
-    log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
 
     // Set up the kernel on the correct risc
     KernelHandle assert_kernel;
@@ -142,15 +142,13 @@ static void RunTest(WatcherFixture *fixture, IDevice* device, riscv_id_t riscv_t
                 }
             );
             break;
-        default:
-            log_info("Unsupported risc type: {}, skipping test...", riscv_type);
-            GTEST_SKIP();
+        default: TT_LOG_INFO("Unsupported risc type: {}, skipping test...", riscv_type); GTEST_SKIP();
     }
 
     // Run the program
     fixture->RunProgram(device, program, true);
 
-    log_info("Checking file: {}", fixture->log_file_name);
+    TT_LOG_INFO("Checking file: {}", fixture->log_file_name);
 
     // Check log
     EXPECT_TRUE(
@@ -225,7 +223,7 @@ TEST_F(WatcherFixture, TestWatcherRingBufferErisc) {
 TEST_F(WatcherFixture, TestWatcherRingBufferIErisc) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "FD-on-idle-eth not supported.");
         GTEST_SKIP();
     }
     for (IDevice* device : this->devices_) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -447,7 +447,7 @@ bool stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(
         try {
             bufs.push_back(CreateBuffer(dram_config));
         } catch (const std::exception& e) {
-            tt::log_info("Deallocating on iteration {}", i);
+            TT_LOG_INFO("Deallocating on iteration {}", i);
             bufs.clear();
             start = i;
             bufs = {CreateBuffer(dram_config)};
@@ -455,7 +455,7 @@ bool stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(
         EnqueueWriteBuffer(cq, bufs[bufs.size() - 1], unique_vectors[i % unique_vectors.size()], false);
     }
 
-    tt::log_info("Comparing {} buffers", bufs.size());
+    TT_LOG_INFO("Comparing {} buffers", bufs.size());
     bool pass = true;
     vector<uint32_t> dst;
     uint32_t idx = start;
@@ -509,7 +509,7 @@ namespace dram_tests {
 TEST_F(CommandQueueSingleCardBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(device, device->command_queue(), config);
     }
 }
@@ -539,7 +539,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, WriteOneTileAcrossAllDramBanksTwiceR
 TEST_F(CommandQueueSingleCardBufferFixture, Sending131072Pages) {
     for (IDevice* device : devices_) {
         TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(device, device->command_queue(), config);
     }
 }
@@ -577,7 +577,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefet
 
 TEST_F(CommandQueueSingleCardBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
 
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -618,7 +618,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThan
 
 TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
 
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
@@ -657,7 +657,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestNon32BAlignedPageSizeForDram2) {
 // Requires enqueue write buffer
 TEST_F(CommandQueueSingleCardBufferFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
     for (IDevice* device : this->devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_issue_region_size = device->sysmem_manager().get_issue_queue_size(0);
         uint32_t cq_start = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
@@ -675,7 +675,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapHostHugepageOnEnqueueReadBuf
 
 TEST_F(CommandQueueSingleCardBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (IDevice* device : this->devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
         uint32_t num_pages = command_queue_size / page_size;
@@ -693,7 +693,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpa
     uint32_t small_page_size = 2048;  // page size for second read
 
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         uint32_t command_completion_region_size = device->sysmem_manager().get_completion_queue_size(0);
 
         uint32_t first_buffer_size = tt::round_up(command_completion_region_size * 0.95, large_page_size);
@@ -731,7 +731,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBuffer) {
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(5, 0);
         CoreRange cores(start, end);
@@ -761,7 +761,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBuffer) {
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(region.size);
         EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
@@ -776,7 +776,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffset) {
     const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
     const BufferRegion region(((2 * 0xFFFF) + 25000) * page_size, 32);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(region.size);
         EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
@@ -793,7 +793,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadBufferWriteSubBuffer) {
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(buffer_region_size);
         EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
@@ -816,7 +816,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadSubBufferWriteBuffer) {
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(buffer_size);
         EnqueueWriteBuffer(device->command_queue(), *buffer, src, false);
@@ -839,7 +839,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadSubBufferInvalidRegion) {
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         vector<uint32_t> result;
         EXPECT_ANY_THROW(EnqueueReadSubBuffer(device->command_queue(), *buffer, result, region, true));
@@ -853,7 +853,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWriteSubBufferInvalidRegion) {
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::DRAM);
         auto src = local_test_functions::generate_arange_vector(buffer_region_size);
         EXPECT_ANY_THROW(EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, true));
@@ -865,7 +865,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWriteSubBufferInvalidRegion) {
 TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpace2) {
     // Using default 75-25 issue and completion queue split
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         uint32_t command_completion_region_size = device->sysmem_manager().get_completion_queue_size(0);
 
         uint32_t num_pages_buff_1 = 9;
@@ -898,7 +898,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestWrapCompletionQOnInsufficientSpa
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         CommandQueue& a = device->command_queue(0);
         CommandQueue& b = device->command_queue(1);
         vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
@@ -909,7 +909,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = uint32_t(device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -926,7 +926,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     constexpr uint32_t num_round_robins = 2;
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = num_round_robins * (device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -945,7 +945,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, Sending131072Pages) {
     // pages instead of cb num pages.
     TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         CommandQueue& a = device->command_queue(0);
         CommandQueue& b = device->command_queue(1);
         vector<std::reference_wrapper<CommandQueue>> cqs = {a, b};
@@ -956,7 +956,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, Sending131072Pages) {
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
         CommandQueue& a = device->command_queue(0);
@@ -969,7 +969,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDr
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram2) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         // From stable diffusion read buffer
         TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
@@ -983,7 +983,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDr
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
         uint32_t num_pages = command_queue_size / page_size;
@@ -1086,7 +1086,7 @@ TEST_F(MultiCommandQueueSingleDeviceBufferFixture, TestIssueMultipleReadWriteCom
 
 TEST_F(CommandQueueMultiDeviceBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         TestBufferConfig config = {
@@ -1155,7 +1155,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingWritesShar
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = 4 * page_size;
     for (IDevice* device : devices_) {
-        tt::log_info("Running on Device {}", device->id());
+        TT_LOG_INFO("Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {5, 5};
         CoreRange cores(start_coord, end_coord);
@@ -1236,7 +1236,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestMultipleNonOverlappingReadsShard
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = buffer_size / 4;
     for (IDevice* device : devices_) {
-        tt::log_info("Running on Device {}", device->id());
+        TT_LOG_INFO("Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {5, 5};
         CoreRange cores(start_coord, end_coord);
@@ -1289,7 +1289,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteShardedSubBufferMultipl
     const uint32_t buffer_region_size = page_size * 7;
     vector<uint32_t> src = local_test_functions::generate_arange_vector(buffer_region_size);
     for (IDevice* device : devices_) {
-        tt::log_info("Running on Device {}", device->id());
+        TT_LOG_INFO("Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {3, 3};
         CoreRange cores(start_coord, end_coord);
@@ -1315,7 +1315,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferForL1) {
     const uint32_t buffer_size = 128 * page_size;
     const BufferRegion region(2 * page_size, 2048);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::L1);
         auto src = local_test_functions::generate_arange_vector(region.size);
         EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
@@ -1330,7 +1330,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, TestReadWriteSubBufferLargeOffsetFor
     const uint32_t buffer_size = 512 * page_size;
     const BufferRegion region(400 * page_size, 2048);
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto buffer = Buffer::create(device, buffer_size, page_size, BufferType::L1);
         auto src = local_test_functions::generate_arange_vector(region.size);
         EnqueueWriteSubBuffer(device->command_queue(), *buffer, src, region, false);
@@ -1465,7 +1465,7 @@ TEST_F(MultiCommandQueueSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForL
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
         CommandQueue& a = device->command_queue(0);
         CommandQueue& b = device->command_queue(1);
@@ -1477,7 +1477,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto compute_with_storage_grid = device->compute_with_storage_grid_size();
         TestBufferConfig config = {
             .num_pages = uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
@@ -1494,7 +1494,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         auto compute_with_storage_grid = device->compute_with_storage_grid_size();
         TestBufferConfig config = {
             .num_pages = 2 * uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
@@ -1511,7 +1511,7 @@ TEST_F(MultiCommandQueueMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceR
 
 TEST_F(MultiCommandQueueMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForL1) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
         CommandQueue& a = device->command_queue(0);
@@ -1559,7 +1559,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, WritesToRandomBufferTypeAndThenReads
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
     for (IDevice* device : devices_) {
-        tt::log_info("Running on Device {}", device->id());
+        TT_LOG_INFO("Running on Device {}", device->id());
         EXPECT_TRUE(local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<true>(
             device, device->command_queue(), config));
     }
@@ -1623,7 +1623,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, ShardedBufferL1ReadWrites) {
                             config.num_iterations = num_iterations;
                             config.mem_config = shard_strategy;
                             config.page_shape = page_shape;
-                            tt::log_info(
+                            TT_LOG_INFO_WITH_CAT(
                                 tt::LogTest,
                                 "Device: {} cores: [{},{}] num_pages: [{},{}] page_shape: [{},{}], shard_strategy: {}, "
                                 "num_iterations: {}",
@@ -1683,7 +1683,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, ShardedBufferDRAMReadWrites) {
                             config.num_iterations = num_iterations;
                             config.mem_config = shard_strategy;
                             config.page_shape = page_shape;
-                            tt::log_info(
+                            TT_LOG_INFO_WITH_CAT(
                                 tt::LogTest,
                                 "Device: {} cores: [{},{}] num_pages: [{},{}] page_shape: [{},{}], shard_strategy: "
                                 "{}, num_iterations: {}",
@@ -1735,7 +1735,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, ShardedBufferLargeL1ReadWrites) {
                             config.num_iterations = num_iterations;
                             config.mem_config = shard_strategy;
                             config.page_shape = page_shape;
-                            tt::log_info(
+                            TT_LOG_INFO_WITH_CAT(
                                 tt::LogTest,
                                 "Device: {} cores: [{},{}] num_pages: [{},{}] page_shape: [{},{}], shard_strategy: {}, "
                                 "num_iterations: {}",
@@ -1787,7 +1787,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, ShardedBufferLargeDRAMReadWrites) {
                             config.num_iterations = num_iterations;
                             config.mem_config = shard_strategy;
                             config.page_shape = page_shape;
-                            tt::log_info(
+                            TT_LOG_INFO_WITH_CAT(
                                 tt::LogTest,
                                 "Device: {} cores: [{},{}] num_pages: [{},{}] page_shape: [{},{}], shard_strategy: "
                                 "{}, num_iterations: {}",
@@ -1812,7 +1812,7 @@ TEST_F(CommandQueueSingleCardBufferFixture, ShardedBufferLargeDRAMReadWrites) {
 
 TEST_F(CommandQueueSingleCardBufferFixture, StressWrapTest) {
     if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-        tt::log_info("cannot run this test on WH B0");
+        TT_LOG_INFO("cannot run this test on WH B0");
         GTEST_SKIP();
         return;  // skip for WH B0
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -48,7 +48,7 @@ namespace basic_tests {
 // wrap issue queue)
 TEST_F(MultiCommandQueueMultiDeviceEventFixture, TestEventsEventSynchronizeSanity) {
     for (IDevice* device : devices_) {
-        tt::log_info("Running On Device {}", device->id());
+        TT_LOG_INFO("Running On Device {}", device->id());
         vector<std::reference_wrapper<CommandQueue>> cqs = {device->command_queue(0), device->command_queue(1)};
         vector<uint32_t> cmds_issued_per_cq = {0, 0};
 
@@ -82,7 +82,7 @@ TEST_F(MultiCommandQueueMultiDeviceEventFixture, TestEventsEventSynchronizeSanit
 
         local_test_functions::FinishAllCqs(cqs);
         std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-        tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
     }
 }
 
@@ -122,7 +122,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsEventSynchronizeSani
 
     local_test_functions::FinishAllCqs(cqs);
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Simplest test to record and wait-for-events on same CQ.
@@ -150,7 +150,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsEnqueueWaitForEventS
     }
     local_test_functions::FinishAllCqs(cqs);
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Record event on one CQ, wait-for-that-event on another CQ. Then do the flip. Occasionally insert
@@ -228,7 +228,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsEnqueueWaitForEventC
     }
 
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Simple 2CQ test to mix reads, writes, record-event, wait-for-event in a basic way. It's simple because
@@ -281,7 +281,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitFor
 
     local_test_functions::FinishAllCqs(cqs);
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
     EXPECT_TRUE(pass);
 }
 
@@ -353,7 +353,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitFor
 
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = (end - start);
-    tt::log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
     EXPECT_TRUE(pass);
 }
 
@@ -480,7 +480,7 @@ TEST_F(MultiCommandQueueSingleDeviceEventFixture, TestEventsReadWriteWithWaitFor
 
     auto end = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds = (end - start);
-    tt::log_info(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {}us", elapsed_seconds.count() * 1000 * 1000);
 
     EXPECT_TRUE(pass);
 }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -66,7 +66,7 @@ TEST_F(CommandQueueEventFixture, TestEventsDataMovementWrittenToCompletionQueueI
         Finish(this->device_->command_queue());
 
         std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-        tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 
         // Read completion queue and ensure we see events 0-99 inclusive in order
         uint32_t event;
@@ -108,7 +108,7 @@ TEST_F(CommandQueueEventFixture, TestEventsEnqueueRecordEventIssueQueueWrap) {
     Finish(this->device_->command_queue());
 
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Test where Host synchronously waits for event to be completed.
@@ -139,7 +139,7 @@ TEST_F(CommandQueueEventFixture, TestEventsEnqueueRecordEventAndSynchronize) {
     Finish(this->device_->command_queue());
 
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Negative test. Host syncing on a future event that isn't actually issued.
@@ -165,7 +165,7 @@ TEST_F(CommandQueueEventFixture, TestEventsEnqueueRecordEventAndSynchronizeHang)
     tt::watcher_server_set_error_flag(false);
     Finish(this->device_->command_queue());
 
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Note: Test expects to see a hang if events feature is working. seen_expected_hang: {}",
         seen_expected_hang);
@@ -197,7 +197,7 @@ TEST_F(CommandQueueEventFixture, TestEventsQueueWaitForEventHang) {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     tt::watcher_server_set_error_flag(false);
 
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Note: Test expects to see a hang if events feature is working. seen_expected_hang: {}",
         seen_expected_hang);
@@ -231,7 +231,7 @@ TEST_F(CommandQueueEventFixture, TestEventsQueueWaitForEventBasic) {
     Finish(this->device_->command_queue());
 
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Device sync. Single CQ here, less interesting than 2CQ but still useful. Ensure no hangs.
@@ -275,7 +275,7 @@ TEST_F(CommandQueueEventFixture, TestEventsEventsQueryBasic) {
 
     Finish(this->device_->command_queue());
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 // Mix of WritesBuffers, RecordEvent, WaitForEvent, EventSynchronize with some checking.
@@ -323,7 +323,7 @@ TEST_F(CommandQueueEventFixture, TestEventsMixedWriteBufferRecordWaitSynchronize
     }
 
     std::chrono::duration<double> elapsed_seconds = (std::chrono::system_clock::now() - start);
-    tt::log_info(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Finished in {:.2f} us", elapsed_seconds.count() * 1000 * 1000);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -1198,7 +1198,8 @@ TEST_F(CommandQueueSingleCardProgramFixture, ActiveEthIncrementRuntimeArgsSanity
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-            log_info(tt::LogTest, "Issuing test for eth_core: {} using cr_set: {}", eth_core.str(), cr_set.str());
+            TT_LOG_INFO_WITH_CAT(
+                tt::LogTest, "Issuing test for eth_core: {} using cr_set: {}", eth_core.str(), cr_set.str());
             EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
                 device, dummy_program_config, 16, 16, tt::RISCV::ERISC));
         }
@@ -1215,7 +1216,8 @@ TEST_F(
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-            log_info(tt::LogTest, "Issuing test for idle eth_core: {} using cr_set: {}", eth_core.str(), cr_set.str());
+            TT_LOG_INFO_WITH_CAT(
+                tt::LogTest, "Issuing test for idle eth_core: {} using cr_set: {}", eth_core.str(), cr_set.str());
             EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
                 device, dummy_program_config, 16, 16, tt::RISCV::ERISC, true));
         }
@@ -1233,7 +1235,7 @@ TEST_F(
             CoreRange cr0(eth_core);
             CoreRangeSet cr_set({cr0});
             DummyProgramConfig dummy_program_config = {.cr_set = cr_set};
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "Issuing test for inactive eth_core: {} using cr_set: {}", eth_core.str(), cr_set.str());
             EXPECT_TRUE(local_test_functions::test_increment_runtime_args_sanity(
                 device, dummy_program_config, 16, 16, tt::RISCV::ERISC, true));
@@ -1642,14 +1644,14 @@ TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram)
     // Make random
     auto random_seed = 0;  // (unsigned int)time(NULL);
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
     CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     CoreRangeSet cr_set({cr});
 
-    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
 
     vector<Program> programs;
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
@@ -1854,7 +1856,8 @@ TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram)
     }
 
     for (uint8_t cq_id = 0; cq_id < this->device_->num_hw_cqs(); ++cq_id) {
-        log_info(tt::LogTest, "Running {} programs on cq {} for cache warmup.", programs.size(), (uint32_t)cq_id);
+        TT_LOG_INFO_WITH_CAT(
+            tt::LogTest, "Running {} programs on cq {} for cache warmup.", programs.size(), (uint32_t)cq_id);
         // This loop caches program and runs
         for (Program& program : programs) {
             EnqueueProgram(this->device_->command_queue(cq_id), program, false);
@@ -1864,7 +1867,7 @@ TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram)
         uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
                                         // iterations, need to come back to that
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Running {} programs on cq {} for {} iterations now.",
             programs.size(),
@@ -1887,7 +1890,7 @@ TEST_F(MultiCommandQueueSingleDeviceProgramFixture, TensixTestRandomizedProgram)
             }
         }
 
-        log_info(tt::LogTest, "Calling Finish.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Calling Finish.");
         Finish(this->device_->command_queue(cq_id));
     }
 }
@@ -1915,14 +1918,14 @@ TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
     // Make random
     auto random_seed = 0;  // (unsigned int)time(NULL);
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
     CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     CoreRangeSet cr_set(cr);
 
-    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
 
     vector<Program> programs;
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
@@ -1937,7 +1940,7 @@ TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
         bool USE_MAX_RT_ARGS;
 
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Compiling program {} of {}", i + 1, NUM_PROGRAMS);
         }
 
         if (i == 0) {
@@ -2130,7 +2133,7 @@ TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
         tt::tt_metal::detail::CompileProgram(this->device_, program);
     }
 
-    log_info(tt::LogTest, "Running {} programs for cache warmup.", programs.size());
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running {} programs for cache warmup.", programs.size());
     // This loop caches program and runs
     for (Program& program : programs) {
         EnqueueProgram(this->device_->command_queue(), program, false);
@@ -2140,12 +2143,12 @@ TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
     uint32_t NUM_ITERATIONS = 500;  // TODO(agrebenisan): Bump this to 5000, saw hangs for very large number of
                                     // iterations, need to come back to that
 
-    log_info(tt::LogTest, "Running {} programs for {} iterations now.", programs.size(), NUM_ITERATIONS);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running {} programs for {} iterations now.", programs.size(), NUM_ITERATIONS);
     for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
         auto rng = std::default_random_engine{};
         std::shuffle(std::begin(programs), std::end(programs), rng);
         if (i % 50 == 0) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "Enqueueing {} programs for iter: {}/{} now.", programs.size(), i + 1, NUM_ITERATIONS);
         }
         for (Program& program : programs) {
@@ -2153,14 +2156,14 @@ TEST_F(CommandQueueProgramFixture, TensixTestRandomizedProgram) {
         }
     }
 
-    log_info(tt::LogTest, "Calling Finish.");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Calling Finish.");
     Finish(this->device_->command_queue());
 }
 
 TEST_F(RandomProgramFixture, TensixTestSimplePrograms) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
         this->create_kernel(program, CoreType::WORKER, true);
@@ -2177,7 +2180,7 @@ TEST_F(RandomProgramFixture, ActiveEthTestSimplePrograms) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
         this->create_kernel(program, CoreType::ETH, true);
@@ -2194,7 +2197,7 @@ TEST_F(RandomProgramFixture, TensixActiveEthTestSimplePrograms) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
 
@@ -2216,7 +2219,7 @@ TEST_F(RandomProgramFixture, TensixActiveEthTestSimplePrograms) {
 TEST_F(RandomProgramFixture, TensixTestPrograms) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
         this->create_kernel(program, CoreType::WORKER);
@@ -2233,7 +2236,7 @@ TEST_F(RandomProgramFixture, ActiveEthTestPrograms) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
         // Large eth kernels currently don't fit in the ring buffer, so we're reducing the max number of RTAs
@@ -2255,7 +2258,7 @@ TEST_F(RandomProgramFixture, TensixActiveEthTestPrograms) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
 
@@ -2285,7 +2288,7 @@ TEST_F(RandomProgramFixture, TensixActiveEthTestPrograms) {
 TEST_F(RandomProgramFixture, TensixTestAlternatingLargeAndSmallPrograms) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
 
@@ -2306,7 +2309,7 @@ TEST_F(RandomProgramFixture, TensixTestAlternatingLargeAndSmallPrograms) {
 TEST_F(RandomProgramFixture, TensixTestLargeProgramFollowedBySmallPrograms) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
 
@@ -2327,7 +2330,7 @@ TEST_F(RandomProgramFixture, TensixTestLargeProgramFollowedBySmallPrograms) {
 TEST_F(RandomProgramFixture, TensixTestLargeProgramInBetweenFiveSmallPrograms) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         Program program = CreateProgram();
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -230,7 +230,7 @@ TEST_F(DispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
         }
 
         if (not found_overlapping_core) {
-            log_info(tt::LogTest, "No core overlaps worker and eth core ranges, skipping");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "No core overlaps worker and eth core ranges, skipping");
             return;
         }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_program_with_kernel_created_from_string.cpp
@@ -91,7 +91,8 @@ TEST_F(ProgramWithKernelCreatedFromStringFixture, ActiveEthEthernetKernel) {
         const std::unordered_set<CoreCoord>& active_ethernet_cores = device->get_active_ethernet_cores(true);
         if (active_ethernet_cores.empty()) {
             const chip_id_t device_id = device->id();
-            log_info(LogTest, "Skipping this test on device {} because it has no active ethernet cores.", device_id);
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "Skipping this test on device {} because it has no active ethernet cores.", device_id);
             continue;
         }
         Program program = CreateProgram();

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
@@ -128,7 +128,7 @@ TEST(DispatchStress, TensixRunManyTimes) {
     }
     // Run 500 times to make sure that things work
     for (int idx = 0; idx < 400; idx++) {
-        log_info(LogTest, "Running iteration #{}", idx);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running iteration #{}", idx);
         // Need to open/close the device each time in order to reproduce original issue.
         auto num_devices = tt::tt_metal::GetNumAvailableDevices();
         std::vector<chip_id_t> chip_ids;
@@ -143,7 +143,7 @@ TEST(DispatchStress, TensixRunManyTimes) {
 
         // Run the test on each device
         for (IDevice* device : devices_) {
-            log_info(LogTest, "Running on device {}", device->id());
+            TT_LOG_INFO_WITH_CAT(LogTest, "Running on device {}", device->id());
             RunTest(device);
         }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_program_reuse.cpp
@@ -229,7 +229,7 @@ TEST_F(CommandQueueMultiDeviceFixture, TestProgramReuseSanity) {
     uint32_t cb_config_buffer_size =
         NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
     for (auto device : devices_) {
-        log_info(LogTest, "Running test on {}", device->id());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running test on {}", device->id());
         EnqueueProgram(device->command_queue(), *program, false);
         Finish(device->command_queue());
         tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
@@ -414,7 +414,7 @@ TEST_F(CommandQueueMultiDeviceFixture, TestDataCopyComputeProgramReuse) {
     }
     // Run program multiple times with different RTAs and validate for each iteration
     for (int iter = 0; iter < 100; iter++) {
-        log_info(LogTest, "Run iter {}", iter);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Run iter {}", iter);
         if (iter) {
             auto& rtas = GetRuntimeArgs(program, reader_writer_kernel);
             for (auto core : full_grid) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -519,7 +519,7 @@ TEST_F(CommandQueueTraceFixture, TensixEnqueueMultiProgramTraceBenchmark) {
 
     for (bool blocking : blocking_flags) {
         std::string mode = blocking ? "Eager-B" : "Eager-NB";
-        log_info(LogTest, "Starting {} profiling with {} programs", mode, num_programs);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting {} profiling with {} programs", mode, num_programs);
         for (uint32_t iter = 0; iter < num_loops; iter++) {
             ScopedTimer timer(mode + " loop " + std::to_string(iter));
             EnqueueWriteBuffer(command_queue, input, input_data.data(), blocking);
@@ -557,7 +557,7 @@ TEST_F(CommandQueueTraceFixture, TensixEnqueueMultiProgramTraceBenchmark) {
 TEST_F(RandomProgramTraceFixture, TensixTestSimpleProgramsTrace) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -579,7 +579,7 @@ TEST_F(RandomProgramTraceFixture, ActiveEthTestSimpleProgramsTrace) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -601,7 +601,7 @@ TEST_F(RandomProgramTraceFixture, TensixActiveEthTestSimpleProgramsTrace) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -627,7 +627,7 @@ TEST_F(RandomProgramTraceFixture, TensixActiveEthTestSimpleProgramsTrace) {
 TEST_F(RandomProgramTraceFixture, TensixTestProgramsTrace) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -649,7 +649,7 @@ TEST_F(RandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -676,7 +676,7 @@ TEST_F(RandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
 
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -711,7 +711,7 @@ TEST_F(RandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
 TEST_F(RandomProgramTraceFixture, TensixTestAlternatingLargeAndSmallProgramsTrace) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -736,7 +736,7 @@ TEST_F(RandomProgramTraceFixture, TensixTestAlternatingLargeAndSmallProgramsTrac
 TEST_F(RandomProgramTraceFixture, TensixTestLargeProgramFollowedBySmallProgramsTrace) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -761,7 +761,7 @@ TEST_F(RandomProgramTraceFixture, TensixTestLargeProgramFollowedBySmallProgramsT
 TEST_F(RandomProgramTraceFixture, TensixTestLargeProgramInBetweenFiveSmallProgramsTrace) {
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -788,7 +788,7 @@ TEST_F(RandomProgramTraceFixture, TensixTestProgramsTraceAndNoTrace) {
     std::unordered_map<uint64_t, uint32_t> program_ids_to_trace_ids;
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -832,7 +832,7 @@ TEST_F(RandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) {
     std::unordered_map<uint64_t, uint32_t> program_ids_to_trace_ids;
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];
@@ -881,7 +881,7 @@ TEST_F(RandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoTrace) {
     std::unordered_map<uint64_t, uint32_t> program_ids_to_trace_ids;
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
         if (i % 10 == 0) {
-            log_info(tt::LogTest, "Creating Program {}", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Creating Program {}", i);
         }
         this->programs[i] = CreateProgram();
         Program& program = this->programs[i];

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -27,7 +27,7 @@ void ForEachCoreTypeXHWCQs(const std::function<void(const CoreType& core_type, c
         if (core_type == CoreType::ETH && MetalContext::instance().hal().get_programmable_core_type_index(
                                               tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
             // This device does not have the eth core
-            tt::log_info(tt::LogTest, "IDLE_ETH core type is not on this device");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "IDLE_ETH core type is not on this device");
             continue;
         }
         for (const auto& num_hw_cqs : num_hw_cqs_to_test) {
@@ -119,7 +119,7 @@ TEST(DispatchSettingsTest, TestDispatchSettingsMutations) {
     if (MetalContext::instance().hal().get_programmable_core_type_index(
             tt::tt_metal::HalProgrammableCoreType::IDLE_ETH) == -1) {
         // This device does not have the eth core
-        tt::log_info(tt::LogTest, "Test not supported on this device");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test not supported on this device");
         return;
     }
     const auto core_type = CoreType::WORKER;

--- a/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/multi_command_queue_fixture.hpp
@@ -25,7 +25,7 @@ protected:
 
         this->num_cqs_ = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
         if (this->num_cqs_ != 2) {
-            tt::log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
         }
 
@@ -46,7 +46,7 @@ protected:
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = true;
             GTEST_SKIP();
@@ -91,7 +91,7 @@ protected:
 
         this->num_cqs_ = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
         if (this->num_cqs_ != 2) {
-            tt::log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
         }
 
@@ -113,7 +113,7 @@ protected:
         this->slow_dispatch_ = false;
         auto slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
         if (slow_dispatch) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             this->slow_dispatch_ = true;
             GTEST_SKIP();
@@ -121,7 +121,7 @@ protected:
 
         auto num_cqs = tt::tt_metal::MetalContext::instance().rtoptions().get_num_hw_cqs();
         if (num_cqs != 2) {
-            tt::log_info(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "This suite must be run with TT_METAL_GTEST_NUM_HW_CQS=2");
             GTEST_SKIP();
         }
 

--- a/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/random_program_fixture.hpp
@@ -77,7 +77,7 @@ protected:
 
     void initialize_seed() {
         const uint32_t seed = tt::parse_env("TT_METAL_SEED", static_cast<uint32_t>(time(nullptr)));
-        log_info(tt::LogTest, "Using seed: {}", seed);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using seed: {}", seed);
         srand(seed);
     }
 

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -280,7 +280,7 @@ bool noc_reader_and_writer_kernels(
     auto eth_readback_vec = llrt::read_hex_vec_from_core(device->id(), eth_noc_xy, eth_dst_l1_address, byte_size);
     pass &= (eth_readback_vec == reader_inputs);
     if (not pass) {
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Mismatch at eth core: {}, eth kernel read incorrect values from DRAM",
             logical_eth_core.str());
@@ -289,7 +289,7 @@ bool noc_reader_and_writer_kernels(
     tt_metal::detail::ReadFromBuffer(writer_dram_buffer, dram_readback_vec);
     pass &= (dram_readback_vec == writer_inputs);
     if (not pass) {
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest, "Mismatch at eth core: {}, eth kernel wrote incorrect values to DRAM", logical_eth_core.str());
     }
 

--- a/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_buffer_movement_kernels.cpp
@@ -90,7 +90,7 @@ bool chip_to_chip_dram_buffer_transfer(
     auto output_dram_buffer = CreateBuffer(receiver_dram_config);
     uint32_t output_dram_byte_address = output_dram_buffer->address();
 
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Sending {} bytes from device {} dram bank 0 addr {} to device {} dram bank 0 addr {}, using eth core {} and "
         "{}",
@@ -424,7 +424,7 @@ TEST_F(N300DeviceFixture, ActiveEthKernelsSendInterleavedBufferChip0ToChip1) {
     for (const auto& sender_eth_core : sender_device->get_active_ethernet_cores(true)) {
         CoreCoord receiver_eth_core = std::get<1>(sender_device->get_connected_ethernet_core(sender_eth_core));
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Sending interleaved buffer from device {} to device {}, using eth core {} and {}",
             sender_device->id(),
@@ -500,7 +500,7 @@ TEST_F(DeviceFixture, ActiveEthKernelsSendInterleavedBufferAllConnectedChips) {
                     continue;
                 }
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     tt::LogTest,
                     "Sending interleaved buffer from device {} to device {}, using eth core {} and {}",
                     sender_device->id(),
@@ -575,7 +575,7 @@ TEST_F(CommandQueueMultiDeviceProgramFixture, ActiveEthKernelsSendDramBufferAllC
                 if (receiver_device->id() != device_id) {
                     continue;
                 }
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     tt::LogTest,
                     "Sending dram buffer from device {} to device {}, using eth core {} and {}",
                     sender_device->id(),
@@ -633,7 +633,7 @@ TEST_F(CommandQueueMultiDeviceProgramFixture, ActiveEthKernelsSendInterleavedBuf
                     continue;
                 }
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     tt::LogTest,
                     "Sending interleaved buffer from device {} to device {}, using eth core {} and {}",
                     sender_device->id(),

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -809,7 +809,7 @@ TEST_F(TwoDeviceFixture, ActiveEthKernelsRandomEthPacketSizeDirectSendTests) {
     std::vector<uint32_t> num_bytes_per_send_test_vals = {
         16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536};
     for (const auto& num_bytes_per_send : num_bytes_per_send_test_vals) {
-        log_info(tt::LogTest, "Random eth send tests with {} bytes per packet", num_bytes_per_send);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Random eth send tests with {} bytes per packet", num_bytes_per_send);
         for (int i = 0; i < 10; i++) {
             auto it = connectivity.begin();
             std::advance(it, rand() % (connectivity.size()));

--- a/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_ring_gather_kernels.cpp
@@ -147,7 +147,7 @@ std::vector<std::tuple<tt_metal::IDevice*, tt_metal::IDevice*, CoreCoord, CoreCo
                     sender_eth_core = second_eth_core, receiver_eth_core = first_eth_core;
                 }
                 sender_receivers.push_back({sender_device, receiver_device, sender_eth_core, receiver_eth_core});
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     tt::LogTest,
                     "Sender: {} Receiver: {} Sender Eth: {} Receiver Eth: {}",
                     sender_device->id(),
@@ -168,7 +168,7 @@ std::vector<std::tuple<tt_metal::IDevice*, tt_metal::IDevice*, CoreCoord, CoreCo
                 auto [device_id, receiver_eth_core] = sender_device->get_connected_ethernet_core(sender_eth_core);
                 if (receiver_device->id() == device_id) {
                     sender_receivers.push_back({sender_device, receiver_device, sender_eth_core, receiver_eth_core});
-                    log_info(
+                    TT_LOG_INFO_WITH_CAT(
                         tt::LogTest,
                         "Sender: {} Receiver: {} Sender Eth: {} Receiver Eth: {}",
                         sender_device->id(),

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -357,7 +357,7 @@ void matmul_tile(
     }
     DeallocateBuffer(*dst_dram_buffer);
 
-    tt::log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Math Fidelity = {}, FP32_DestAcc = {}, DstSyncFull = {}",
         cfg.math_fidelity,
@@ -440,10 +440,10 @@ TEST_F(DispatchFixture, TensixMatmulMultiTile) {
 
                 for (unsigned int id = 0; id < devices_.size(); id++) {
                     matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
-                    log_info(LogTest, "Multi tile with no bias passed");
+                    TT_LOG_INFO_WITH_CAT(LogTest, "Multi tile with no bias passed");
                     matmul_config.with_bias = true;
                     matmul_tile(this, devices_.at(id), matmul_config, stimuli.a, stimuli.w, stimuli.t);
-                    log_info(LogTest, "Multi tile with bias passed");
+                    TT_LOG_INFO_WITH_CAT(LogTest, "Multi tile with bias passed");
                 }
             }
         }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -439,20 +439,20 @@ TEST_F(DispatchFixture, TensixMatmulLargeBlock) {
         if (i == 1) {
             continue;
         };
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < devices_.size(); id++) {
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
                 this, devices_.at(id), false, false, MathFidelity(i)));
-            log_info(LogTest, "Tilized input, Tilized output Passed");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Tilized input, Tilized output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
                 this, devices_.at(id), true, false, MathFidelity(i)));
-            log_info(LogTest, "Row major input, Tilized output Passed");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Row major input, Tilized output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
                 this, devices_.at(id), false, true, MathFidelity(i)));
-            log_info(LogTest, "Tilized input, Row major output Passed");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Tilized input, Row major output Passed");
             ASSERT_TRUE(unit_tests_common::matmul::test_matmul_large_block::matmul_large_block(
                 this, devices_.at(id), true, true, MathFidelity(i)));
-            log_info(LogTest, "Row major input, Row major output Passed");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Row major input, Row major output Passed");
         }
     }
 }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -181,7 +181,7 @@ bool matmul_multi_core_single_dram(tt_metal::IDevice* device) {
     CoreCoord compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     int num_cores_r = compute_with_storage_grid_size.y;
     int num_cores_c = compute_with_storage_grid_size.x;
-    log_info(LogTest, "Num cores r = {}, Num cores c = {}", num_cores_r, num_cores_c);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Num cores r = {}, Num cores c = {}", num_cores_r, num_cores_c);
     uint32_t M = 16 * num_cores_r;
     uint32_t K = 16 * 12;
     uint32_t N = 16 * num_cores_c;
@@ -192,17 +192,17 @@ bool matmul_multi_core_single_dram(tt_metal::IDevice* device) {
     int per_core_N = N / num_cores_c;
     uint32_t single_tile_size = 2 * 1024;
     uint32_t dram_unreserved_base = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::DRAM);
-    log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-    log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-    log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
         out_subblock_h,
         in0_block_w,
         K / in0_block_w,
         M / out_subblock_h);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
         out_subblock_w,
@@ -459,18 +459,18 @@ bool matmul_multi_core_multi_dram(tt_metal::DispatchFixture* fixture, tt_metal::
     int per_core_M = M / num_cores_r;
     int per_core_N = N / num_cores_c;
     uint32_t single_tile_size = 2 * 1024;
-    log_info(LogTest, "num_cores_r={}, num_cores_c={}", num_cores_r, num_cores_c);
-    log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-    log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-    log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(LogTest, "num_cores_r={}, num_cores_c={}", num_cores_r, num_cores_c);
+    TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
         per_core_M,
         in0_block_w,
         K / in0_block_w,
         per_core_M / out_subblock_h);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
         in0_block_w,
@@ -582,10 +582,10 @@ bool matmul_multi_core_multi_dram(tt_metal::DispatchFixture* fixture, tt_metal::
 
 TEST_F(DispatchFixture, TensixMatmulMultiCoreSingleDRAM) {
     if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-        log_info(LogTest, "This test is only supported in slow dispatch mode");
+        TT_LOG_INFO_WITH_CAT(LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     } else if (this->arch_ == tt::ARCH::WORMHOLE_B0) {
-        tt::log_info("This test is disabled in WH B0");
+        TT_LOG_INFO("This test is disabled in WH B0");
         GTEST_SKIP();
     }
     for (unsigned int id = 0; id < devices_.size(); id++) {
@@ -597,7 +597,8 @@ TEST_F(DispatchFixture, TensixMatmulMultiCoreSingleDRAM) {
 TEST_F(DispatchFixture, TensixMatmulMultiCoreMultiDRAM) {
     // need to update move_tiles_to_dram to support both slow and fast
     if (getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-        log_info(LogTest, "This test is not supported in slow dispatch mode, need to update move_tiles_to_dram..");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "This test is not supported in slow dispatch mode, need to update move_tiles_to_dram..");
         GTEST_SKIP();
     }
     for (unsigned int id = 0; id < devices_.size(); id++) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -298,7 +298,7 @@ bool write_runtime_args_to_device(
     for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
             CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            // log_info(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
 
             CoreCoord left_core = {(std::size_t)start_core_x, (std::size_t)core.y};
             CoreCoord left_core_plus_one = {(std::size_t)start_core_x + 1, (std::size_t)core.y};
@@ -413,18 +413,18 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::IDevice* device)
     uint32_t in1_dram_addr = 400 * 1024 * 1024;
     uint32_t out_dram_addr = 800 * 1024 * 1024;
 
-    log_info(LogTest, "Grid size = {}x{}", num_cores_r, num_cores_c);
-    log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-    log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-    log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(LogTest, "Grid size = {}x{}", num_cores_r, num_cores_c);
+    TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
         per_core_M,
         in0_block_w,
         K / in0_block_w,
         per_core_M / out_subblock_h);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
         in0_block_w,
@@ -528,8 +528,8 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::IDevice* device)
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
             auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
 
-            // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-            // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+            // TT_LOG_INFO_WITH_CAT(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank,
+            // dram_address); print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
             pass &= (golden_tile == result_flat_layout);
         }
     }
@@ -541,7 +541,7 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::IDevice* device)
 
 TEST_F(DispatchFixture, TensixMatmulMultiCoreMultiDRAMIn0MCastIn1MCast) {
     if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     }
     for (unsigned int id = 0; id < devices_.size(); id++) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -251,7 +251,7 @@ bool write_runtime_args_to_device(
             CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
             int core_x = in1_or_in0 ? core.x : start_core_x;
             int core_y = in1_or_in0 ? start_core_y : core.y;
-            // log_info(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
             CoreCoord mcast_sender = {(std::size_t)core_x, (std::size_t)core_y};
             CoreCoord core_start = {(std::size_t)(core_x + (1 - in1_or_in0)), (std::size_t)(core_y + in1_or_in0)};
             CoreCoord core_end = {
@@ -339,17 +339,17 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::IDevice* device, int in1_o
     uint32_t in1_dram_addr = 400 * 1024 * 1024;
     uint32_t out_dram_addr = 800 * 1024 * 1024;
 
-    log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-    log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-    log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
         per_core_M,
         in0_block_w,
         K / in0_block_w,
         per_core_M / out_subblock_h);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
         in0_block_w,
@@ -445,8 +445,8 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::IDevice* device, int in1_o
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
             auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
 
-            // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-            // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+            // TT_LOG_INFO_WITH_CAT(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank,
+            // dram_address); print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
             pass &= (golden_tile == result_flat_layout);
         }
     }
@@ -457,7 +457,7 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::IDevice* device, int in1_o
 
 TEST_F(DispatchFixture, TensixMatmulMultiCoreMultiDRAMIn0MCast) {
     if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     }
     for (unsigned int id = 0; id < devices_.size(); id++) {
@@ -468,7 +468,7 @@ TEST_F(DispatchFixture, TensixMatmulMultiCoreMultiDRAMIn0MCast) {
 
 TEST_F(DispatchFixture, TensixMatmulMultiCoreMultiDRAMIn1MCast) {
     if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-        tt::log_info(tt::LogTest, "This test is only supported in slow dispatch mode");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test is only supported in slow dispatch mode");
         GTEST_SKIP();
     }
     for (unsigned int id = 0; id < devices_.size(); id++) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
@@ -66,17 +66,17 @@ bool matmul_single_core(
 
     CoreCoord core = {0, 0};
     int in0_block_w = 2;
-    log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-    log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-    log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
         out_subblock_h,
         in0_block_w,
         K / in0_block_w,
         M / out_subblock_h);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
         out_subblock_w,
@@ -277,7 +277,7 @@ TEST_F(DispatchFixture, TensixMatmulSingleCoreSmall) {
 
 TEST_F(DispatchFixture, TensixMatmulSingleCore) {
     if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
-        log_info(LogTest, "Fast dispatch buffer memory issue, skipping for now");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Fast dispatch buffer memory issue, skipping for now");
         GTEST_SKIP();
     }
     uint32_t M = 16;

--- a/tests/tt_metal/tt_metal/integration/test_autonomous_relay_streams.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_autonomous_relay_streams.cpp
@@ -651,7 +651,7 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreams) {
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info(tt::LogTest, "Test must be run on WH");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test must be run on WH");
         return;
     }
     std::srand(0);
@@ -694,7 +694,7 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreamsSmal
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info(tt::LogTest, "Test must be run on WH");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test must be run on WH");
         return;
     }
     std::srand(0);
@@ -737,7 +737,7 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreamsLoop
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info(tt::LogTest, "Test must be run on WH");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test must be run on WH");
         return;
     }
     std::srand(0);
@@ -783,11 +783,11 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreamsLoop
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     // if (num_devices != 8) {
-    //     log_info(tt::LogTest, "Need at least 2 devices to run this test");
+    //     TT_LOG_INFO_WITH_CAT(tt::LogTest, "Need at least 2 devices to run this test");
     //     return;
     // }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info(tt::LogTest, "Test must be run on WH");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test must be run on WH");
         return;
     }
     std::srand(0);
@@ -814,7 +814,7 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreamsLoop
             EXPECT_TRUE(sub_sizes.at(i) < (page_size / noc_word_size));
         }
         std::vector<Program> programs;
-        log_info(tt::LogTest, "Iteration: {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Iteration: {}", i);
         tt::tt_metal::build_and_run_autonomous_stream_test(
             programs,
             {device_},
@@ -838,7 +838,7 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreamsLoop
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info(tt::LogTest, "Test must be run on WH");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test must be run on WH");
         return;
     }
     std::srand(0);
@@ -884,7 +884,7 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreamsSwee
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info(tt::LogTest, "Test must be run on WH");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test must be run on WH");
         return;
     }
 
@@ -922,7 +922,7 @@ TEST_F(CommandQueueProgramFixture, DISABLED_TensixTestAutonomousRelayStreamsSwee
                         }
                         uint32_t enable_variable_sized_messages = 1;
 
-                        log_info(
+                        TT_LOG_INFO_WITH_CAT(
                             tt::LogTest,
                             "num_messages: {}, fw_stream_buffer_size: {}, relay_stream_buffer_size: {}, "
                             "tile_header_buffer_num_messages: {}, page_size: {}, enable_variable_sized_messages: {}",

--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -87,22 +87,22 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
         cores.push_back({i, 0});
     }
 
-    log_info(LogTest, "num_cores: {}", num_cores);
-    log_info(LogTest, "num_tiles: {}", num_tiles);
-    log_info(LogTest, "block_size_tiles: {}", block_size_tiles);
-    log_info(LogTest, "num_blocks_in_CB: {}", num_blocks_in_CB);
-    log_info(LogTest, "num_repetitions: {}", num_repetitions);
+    TT_LOG_INFO_WITH_CAT(LogTest, "num_cores: {}", num_cores);
+    TT_LOG_INFO_WITH_CAT(LogTest, "num_tiles: {}", num_tiles);
+    TT_LOG_INFO_WITH_CAT(LogTest, "block_size_tiles: {}", block_size_tiles);
+    TT_LOG_INFO_WITH_CAT(LogTest, "num_blocks_in_CB: {}", num_blocks_in_CB);
+    TT_LOG_INFO_WITH_CAT(LogTest, "num_repetitions: {}", num_repetitions);
 
     uint32_t single_tile_size = 2 * 1024;
     uint32_t block_size_bytes = block_size_tiles * single_tile_size;
-    log_info(LogTest, "block_size_bytes: {}", block_size_bytes);
-    log_info(LogTest, "CB size: {}", block_size_bytes * num_blocks_in_CB);
+    TT_LOG_INFO_WITH_CAT(LogTest, "block_size_bytes: {}", block_size_bytes);
+    TT_LOG_INFO_WITH_CAT(LogTest, "CB size: {}", block_size_bytes * num_blocks_in_CB);
 
     // source and destination buffers
     uint32_t buffer_size =
         single_tile_size * num_tiles;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
     uint32_t total_bytes_moved = buffer_size * num_repetitions;
-    log_info(LogTest, "total_bytes_moved: {}", total_bytes_moved);
+    TT_LOG_INFO_WITH_CAT(LogTest, "total_bytes_moved: {}", total_bytes_moved);
 
     // circular buffers in L1
     uint32_t cb_index = 8;
@@ -243,16 +243,16 @@ void create_and_run_row_pipeline(tt_metal::IDevice* device, const PipelineRowCon
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    log_info(LogTest, "Writing to device buffer->..");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Writing to device buffer->..");
     tt_metal::detail::WriteToBuffer(src_buffer, src_vec);
-    log_info(LogTest, "Writing to device buffer Done.");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Writing to device buffer Done.");
 
     EnqueueProgram(cq, program, false);
     Finish(cq);
 
-    log_info(LogTest, "Kernels done.");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Kernels done.");
 
-    log_info(LogTest, "Reading results from device...");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Reading results from device...");
     std::vector<uint32_t> result_vec;
     tt_metal::detail::ReadFromBuffer(dst_buffer, result_vec);
 

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -318,7 +318,7 @@ TEST_F(DispatchFixture, TensixFlatten) {
     uint32_t num_tiles_r = 2;
     uint32_t num_tiles_c = 2;
     if (!this->IsSlowDispatch()) {
-        log_info(LogTest, "Flatten running with num_tiles_r=1, num_tiles_c=1");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Flatten running with num_tiles_r=1, num_tiles_c=1");
         num_tiles_r = 1;
         num_tiles_c = 1;
     }

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -268,7 +268,7 @@ TEST_P(SingleCoreSingleCardSfpuParameterizedFixture, TensixSfpuCompute) {
             .cores = core_range_set,
             .sfpu_op = sfpu_op,
             .approx_mode = false};
-        log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
+        TT_LOG_INFO("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
         EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     }
 }
@@ -316,7 +316,7 @@ TEST_P(SingleCoreSingleCardSfpuParameterizedApproxFixture, TensixSfpuCompute) {
             .cores = core_range_set,
             .sfpu_op = sfpu_op,
             .approx_mode = true};
-        log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
+        TT_LOG_INFO("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
         EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     }
 }
@@ -366,7 +366,7 @@ TEST_P(MultiCoreSingleCardSfpuParameterizedApproxFixture, TensixAllCoreMultiTile
             .cores = core_range_set,
             .sfpu_op = sfpu_op,
             .approx_mode = true};
-        log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
+        TT_LOG_INFO("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
         EXPECT_TRUE(run_sfpu_all_same_buffer(device_->command_queue(), test_config));
     }
 }

--- a/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
+++ b/tests/tt_metal/tt_metal/lightmetal/lightmetal_fixture.hpp
@@ -65,7 +65,8 @@ protected:
             FAIL() << "Light Metal Binary is empty for test, unexpected.";
         }
         if (write_bin_to_disk_ && !this->trace_bin_path_.empty() && !binary.is_empty()) {
-            log_info(tt::LogTest, "Writing light metal binary {} bytes to {}", binary.size(), this->trace_bin_path_);
+            TT_LOG_INFO_WITH_CAT(
+                tt::LogTest, "Writing light metal binary {} bytes to {}", binary.size(), this->trace_bin_path_);
             binary.save_to_file(this->trace_bin_path_);
         }
 
@@ -92,7 +93,7 @@ protected:
         if (!success) {
             FAIL() << "Light Metal Binary failed to execute or encountered errors.";
         } else {
-            log_info(tt::LogMetalTrace, "Light Metal Binary executed successfully!");
+            TT_LOG_INFO_WITH_CAT(tt::LogMetalTrace, "Light Metal Binary executed successfully!");
         }
     }
 };

--- a/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
+++ b/tests/tt_metal/tt_metal/lightmetal/test_lightmetal.cpp
@@ -137,7 +137,7 @@ bool l1_buffer_read_write_test(IDevice* device, const L1Config& test_config) {
 
     // If any Buffers were kept alive for testing, Deallocate them now to exercise that path for capture/replay.
     if (buffers_vec.size() > 0) {
-        log_info(tt::LogTest, "Explicitly deallocating {} buffers now.", buffers_vec.size());
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Explicitly deallocating {} buffers now.", buffers_vec.size());
         for (auto& buffer : buffers_vec) {
             DeallocateBuffer(*buffer);
         }

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -214,7 +214,7 @@ void run_single_core_broadcast(tt_metal::IDevice* device, const BroadcastConfig&
     uint32_t tile_width = tile_dims.get_tile_shape()[1];
     uint32_t tile_height = tile_dims.get_tile_shape()[0];
     if (test_config.tile_shape != TileShape::FULL_TILE) {
-        log_info("Tile shape is {{{}, {}}}", tile_height, tile_width);
+        TT_LOG_INFO("Tile shape is {{{}, {}}}", tile_height, tile_width);
     }
 
     uint32_t single_tile_size = tile_width * tile_height * bfloat16::SIZEOF;
@@ -254,7 +254,7 @@ void run_single_core_broadcast(tt_metal::IDevice* device, const BroadcastConfig&
         {"BCAST_DIM", broadcast_dim_to_type.at(test_config.broadcast_dim)},
         {"BCAST_OP", eltwise_op_to_api_prefix.at(test_config.eltwise_op) + "_tiles_bcast"}};
 
-    log_info("Testing BCAST_LLKOP={} BCAST_DIM={}", defines["BCAST_LLKOP"], defines["BCAST_DIM"]);
+    TT_LOG_INFO("Testing BCAST_LLKOP={} BCAST_DIM={}", defines["BCAST_LLKOP"], defines["BCAST_DIM"]);
 
     if (test_config.api_convention == ApiConvention::SHORT_INIT ||
         test_config.api_convention == ApiConvention::SHORT_BOTH) {
@@ -269,9 +269,9 @@ void run_single_core_broadcast(tt_metal::IDevice* device, const BroadcastConfig&
                                        broadcast_dim_to_api_suffix.at(test_config.broadcast_dim) + "_init_short";
         }
 
-        log_info("Init function is {}", defines["BCAST_OP_INIT"]);
+        TT_LOG_INFO("Init function is {}", defines["BCAST_OP_INIT"]);
     } else {
-        log_info("Init function is init_bcast");
+        TT_LOG_INFO("Init function is init_bcast");
     }
 
     if (test_config.api_convention == ApiConvention::SHORT_CALL ||
@@ -280,7 +280,7 @@ void run_single_core_broadcast(tt_metal::IDevice* device, const BroadcastConfig&
         defines["BCAST_OP"] = defines["BCAST_OP"] + "_" + broadcast_dim_to_api_suffix.at(test_config.broadcast_dim);
     }
 
-    log_info("Compute function is {}", defines["BCAST_OP"]);
+    TT_LOG_INFO("Compute function is {}", defines["BCAST_OP"]);
 
     auto reader_kernel = tt_metal::CreateKernel(
         program,
@@ -378,7 +378,7 @@ TEST_P(BroadcastParameterizedDeviceFixture, TensixComputeSingleTileBroadcast) {
         if (i == 1) {
             continue;
         }
-        log_info("Math Fidelity = {}", i);
+        TT_LOG_INFO("Math Fidelity = {}", i);
         test_config.math_fidelity = MathFidelity(i);
         unit_tests::compute::broadcast::run_single_core_broadcast(this->devices_.at(0), test_config);
     }

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -212,7 +212,7 @@ TEST_F(DeviceFixture, DISABLED_TensixComputeCopyBlockSingle) {
             continue;
         }
         for (bool dst_full_sync_en : {true, false}) {
-            log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
+            TT_LOG_INFO_WITH_CAT(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
             unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
                 .num_tiles = 8, .fp32_dest_acc_en = fp32_dest_acc_en, .dst_full_sync_en = dst_full_sync_en};
             unit_tests::compute::matmul_partials::run_single_core_copy_block_matmul_partials(
@@ -227,7 +227,7 @@ TEST_F(DeviceFixture, TensixComputeCopyBlockMultiple) {
             continue;
         }
         for (bool dst_full_sync_en : {true, false}) {
-            log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
+            TT_LOG_INFO_WITH_CAT(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
             unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
                 .num_tiles = 8,
                 .reader_ublock = 8,
@@ -248,7 +248,7 @@ TEST_F(DeviceFixture, TensixComputeCopyBlockComputeBottleneck) {
             continue;
         }
         for (bool dst_full_sync_en : {true, false}) {
-            log_info(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
+            TT_LOG_INFO_WITH_CAT(LogTest, "FP32DestAcc = {}, DstSyncFull = {}", fp32_dest_acc_en, dst_full_sync_en);
             unit_tests::compute::matmul_partials::CopyBlockMatmulPartialsConfig test_config = {
                 .num_tiles = 8,
                 .reader_ublock = 8,

--- a/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_cumsum.cpp
@@ -198,7 +198,8 @@ void run_single_core_cumsum(tt_metal::IDevice* device, const CumsumConfig& test_
     auto output_packed = ::unit_tests::compute::gold_standard_untilize(
         output_packed_tilized, {test_config.N * test_config.Ht, test_config.Wt});
 
-    log_info(tt::LogTest, "Running test for N = {}, Wt = {}, Ht = {}", test_config.N, test_config.Wt, test_config.Ht);
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "Running test for N = {}, Wt = {}, Ht = {}", test_config.N, test_config.Wt, test_config.Ht);
 
     bool result = is_close_packed_vectors<bfloat16, uint32_t>(
         output_packed, golden_packed, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.01f); });

--- a/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_dropout_sfpu_compute.cpp
@@ -88,7 +88,7 @@ bool check_dropout(
             probability,
             dropout_rate);
     } else {
-        tt::log_info(tt::LogTest, "dropout probability={}, dropout_rate={} ", probability, dropout_rate);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "dropout probability={}, dropout_rate={} ", probability, dropout_rate);
     }
 
     pass &= rate_ok;
@@ -247,7 +247,7 @@ void test_dropout(tt_metal::IDevice* device, const DropoutConfig& test_config) {
         tt::log_error(
             tt::LogTest, "Same parameters gave different results probability={}, seed={}", probability, seed_0);
     } else {
-        tt::log_info(tt::LogTest, "Two attempts with same parameters matched");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Two attempts with same parameters matched");
     }
     pass &= repeatable;
 
@@ -262,7 +262,7 @@ void test_dropout(tt_metal::IDevice* device, const DropoutConfig& test_config) {
                 seed_0,
                 seed_1);
         } else {
-            tt::log_info(tt::LogTest, "Different seed gave different results");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Different seed gave different results");
         }
         pass &= unique;
     }

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -366,7 +366,7 @@ TEST_F(DeviceFixture, TensixTileCopyReconfigExplicitSplitDstAcc) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool block_copy : {true, false}) {
                     for (bool dst_full_sync_en : {true, false}) {
-                        log_info(
+                        TT_LOG_INFO_WITH_CAT(
                             LogTest,
                             "Block Copy = {}, "
                             "Explicit = {}, "
@@ -404,7 +404,8 @@ TEST_F(DeviceFixture, TensixTileCopyReconfigL1Acc) {
     }
     for (bool l1_acc : {true, false}) {
         for (bool dst_full_sync_en : {true, false}) {
-            log_info(LogTest, "L1 accumulation is {}, DstSyncFull = {}", l1_acc ? "on." : "off.", dst_full_sync_en);
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "L1 accumulation is {}, DstSyncFull = {}", l1_acc ? "on." : "off.", dst_full_sync_en);
             unit_tests::compute::reconfig::ReconfigConfig test_config = {
                 .num_tiles = 1, .ublock_size_tiles = 1, .dst_full_sync_en = dst_full_sync_en};
             for (unsigned int id = 0; id < num_devices_; id++) {

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -445,7 +445,7 @@ void run_single_core_reduce_program(tt_metal::IDevice* device, const ReduceConfi
     }
 
     EXPECT_TRUE(pass);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "TileDimH = {}, TileDimW = {}, MathFid = {}, ReduceType = {}, FP32DestAcc = {}, DstSyncFull = {}, at_start = "
         "{}",

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -264,7 +264,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedFixture, TensixSfpuCompute) {
         .cores = core_range_set,
         .sfpu_op = sfpu_op,
         .approx_mode = false};
-    log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
+    TT_LOG_INFO("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
     for (unsigned int id = 0; id < num_devices_; id++) {
         EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
     }
@@ -315,7 +315,7 @@ TEST_P(SingleCoreSingleDeviceSfpuParameterizedApproxFixture, TensixSfpuCompute) 
             .cores = core_range_set,
             .sfpu_op = sfpu_op,
             .approx_mode = true};
-        log_info("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
+        TT_LOG_INFO("Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
         for (unsigned int id = 0; id < num_devices_; id++) {
             EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
         }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -316,7 +316,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreSingleTileAdd) {
             .binary_op = "add",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -336,7 +336,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreSingleTileSub) {
             .binary_op = "sub",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -356,7 +356,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreSingleTileMul) {
             .binary_op = "mul",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -377,7 +377,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
             .full_init = true,
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -398,7 +398,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
             .full_init = true,
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -419,7 +419,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
             .full_init = true,
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -439,7 +439,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse) {
             .binary_op = "add_with_dest_reuse",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -459,7 +459,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse) {
             .binary_op = "sub_with_dest_reuse",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -479,7 +479,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse) {
             .binary_op = "mul_with_dest_reuse",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -499,7 +499,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileAdd) {
             .binary_op = "add",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -519,7 +519,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileSub) {
             .binary_op = "sub",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -539,7 +539,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileMul) {
             .binary_op = "mul",
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -565,7 +565,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
             .acc_to_dest = true,
             .math_fidelity = MathFidelity(i),
         };
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -591,7 +591,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
             .acc_to_dest = true,
             .math_fidelity = MathFidelity(i),
         };
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }
@@ -617,7 +617,7 @@ TEST_F(DeviceFixture, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
             .acc_to_dest = true,
             .math_fidelity = MathFidelity(i),
         };
-        tt::log_info(tt::LogTest, "Math Fidelity = {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
         }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -452,7 +452,7 @@ bool single_block_matmul(tt_metal::IDevice* device, uint32_t M, uint32_t K, uint
         [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.015f); },
         &failed_index);
     if (not pass) {
-        log_info("Failed Index={}", failed_index);
+        TT_LOG_INFO("Failed Index={}", failed_index);
         print_vector_fixed_numel_per_row(unpack_vector<bfloat16, uint32_t>(dest_buffer_data), 32);
     }
     return pass;
@@ -621,7 +621,7 @@ bool blocked_matmul(tt_metal::IDevice* device, uint32_t M, uint32_t K, uint32_t 
         [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b, 0.015f); },
         &failed_index);
     if (not pass) {
-        log_info("Failed Index={}", failed_index);
+        TT_LOG_INFO("Failed Index={}", failed_index);
         print_vector_fixed_numel_per_row(unpack_vector<bfloat16, uint32_t>(dest_buffer_data), 32);
     }
     return pass;

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -353,7 +353,7 @@ TEST_F(DeviceFixture, TensixComputeSingleTileUnaryBroadcast) {
                     .out0_t = out0_t_,
                     .out1_t = (out0_t_ == tt::DataFormat::Bfp8_b) ? tt::DataFormat::Float16_b : tt::DataFormat::Bfp8_b};
 
-                log_info(
+                TT_LOG_INFO(
                     "Testing UNARY BROADCAST BCAST_DIM_0={} in0_t={} out0_t={} | BCAST_DIM_1={} in1_t={} out1_t={}",
                     broadcast_dim_to_type.at(test_config.broadcast_dim_0),
                     test_config.in0_t,

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -325,7 +325,7 @@ void run_single_core_tilize_program(tt_metal::IDevice* device, const TestConfig&
         print_vector(unpack_vector<bfloat16, uint32_t>(result_vec));
     }
     ASSERT_TRUE(pass);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Done running test with: num_tiles_r = {}, num_tiles_c = {}, FP32_DestAcc = {}, DstSyncFull = {}, pass = {}",
         test_config.num_tiles_r,

--- a/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
+++ b/tests/tt_metal/tt_metal/noc/test_dynamic_noc.cpp
@@ -43,7 +43,7 @@ void build_and_run_program(
     // Make random
     auto random_seed = 0; // (unsigned int)time(NULL);
     uint32_t seed = tt::parse_env("TT_METAL_SEED", random_seed);
-    log_info(tt::LogTest, "Using Test Seed: {}", seed);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Using Test Seed: {}", seed);
     srand(seed);
 
     // CoreCoord worker_grid_size = this->device_->compute_with_storage_grid_size();
@@ -51,7 +51,7 @@ void build_and_run_program(
     CoreRange cr({0, 0}, {worker_grid_size.x - 1, worker_grid_size.y - 1});
     CoreRangeSet cr_set(cr);
 
-    log_info(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Starting compile of {} programs now.", NUM_PROGRAMS);
 
     Program program1;
     Program program2;
@@ -138,7 +138,7 @@ void build_and_run_program(
 
     // This loop caches program1 and runs
     for (uint32_t i = 0; i < NUM_PROGRAMS; i++) {
-        log_info(tt::LogTest, "Running program1 {} of {}", i + 1, NUM_PROGRAMS);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running program1 {} of {}", i + 1, NUM_PROGRAMS);
         if (i % 2 == 0) {
             if (slow_dispatch) {
                 tt::tt_metal::detail::LaunchProgram(device, program1);
@@ -155,9 +155,9 @@ void build_and_run_program(
     }
     if (!slow_dispatch) {
         Finish(device->command_queue());
-        log_info(tt::LogTest, "Finish FD runs");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finish FD runs");
     } else {
-        log_info(tt::LogTest, "Finish SD runs");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finish SD runs");
     }
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -124,7 +124,7 @@ create_programs(
     uint32_t cb_padding,
     const std::shared_ptr<tt::tt_metal::Buffer>& input_buffer,
     bool use_sub_devices) {
-    log_info("created program");
+    TT_LOG_INFO("created program");
     std::vector<tt_metal::Program> programs;
     programs.push_back(tt_metal::Program());
 
@@ -160,8 +160,8 @@ create_programs(
     uint32_t writer_page_size, writer_num_pages;
     get_max_page_size_and_num_pages(block_w / num_receivers, single_tile_size, writer_page_size, writer_num_pages);
 
-    log_info("writer_page_size: {}", writer_page_size);
-    log_info("writer_num_pages: {}", writer_num_pages);
+    TT_LOG_INFO("writer_page_size: {}", writer_page_size);
+    TT_LOG_INFO("writer_num_pages: {}", writer_num_pages);
 
     tt_metal::CircularBufferConfig reader_cb_config =
         tt_metal::CircularBufferConfig(reader_cb_size, {{reader_cb_index, tile_format}})
@@ -207,8 +207,8 @@ create_programs(
     auto receiver_cb = tt_metal::experimental::CreateCircularBuffer(
         receiver_program, l1_receiver_cores, receiver_cb_config, global_cb);
 
-    log_info("reader_cb_size: {}", reader_cb_size);
-    log_info("receiver_cb_size: {}", receiver_cb_size);
+    TT_LOG_INFO("reader_cb_size: {}", reader_cb_size);
+    TT_LOG_INFO("receiver_cb_size: {}", receiver_cb_size);
 
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)input_buffer->address(),
@@ -256,7 +256,7 @@ create_programs(
 
     // reader rt
     auto dram_reader_core_coord = dram_reader_core.ranges().begin()->start_coord;
-    log_info("dram_reader_core_coord: {}", dram_reader_core_coord);
+    TT_LOG_INFO("dram_reader_core_coord: {}", dram_reader_core_coord);
     auto dram_reader_core_coord_physical = device->worker_core_from_logical_core(dram_reader_core_coord);
     uint32_t bank_id = 0;
     uint32_t vc = bank_id & 0x1;
@@ -328,7 +328,7 @@ create_programs(
             receiver_rt_args.push_back(i % 2 == 0 ? receiver_block_num_tile : next_layer_receiver_block_num_tile);
         }
 
-        log_info("l1_receiver_core_coords: {}", l1_receiver_core_coords[i]);
+        TT_LOG_INFO("l1_receiver_core_coords: {}", l1_receiver_core_coords[i]);
 
         tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, l1_receiver_core_coords[i], receiver_rt_args);
     }
@@ -602,9 +602,9 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
         {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
         {ht, wt});
 
-    log_info("cores: {}", cores);
-    log_info("size_bytes: {}", size_bytes);
-    log_info("page_size_bytes: {}", page_size_bytes);
+    TT_LOG_INFO("cores: {}", cores);
+    TT_LOG_INFO("size_bytes: {}", size_bytes);
+    TT_LOG_INFO("page_size_bytes: {}", page_size_bytes);
 
     auto config = tt::tt_metal::ShardedBufferConfig{
         .device = device,
@@ -623,7 +623,7 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
     tt::tt_metal::detail::WriteToBuffer(input_buffer, input_vec);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
 
-    log_info("created sharded tensor");
+    TT_LOG_INFO("created sharded tensor");
 
     return input_buffer;
 }
@@ -680,8 +680,8 @@ int main(int argc, char** argv) {
             TT_ASSERT(false);
         }
 
-        log_info("num_mixed_df_layers: {} ", num_mixed_df_layers);
-        log_info("num_receivers: {} ", num_receivers);
+        TT_LOG_INFO("num_mixed_df_layers: {} ", num_mixed_df_layers);
+        TT_LOG_INFO("num_receivers: {} ", num_receivers);
 
         TT_FATAL(
             num_mixed_df_layers % 2 == 1,
@@ -841,7 +841,7 @@ int main(int argc, char** argv) {
         }
 
         for (uint32_t i = 0; i < num_mixed_df_layers; ++i) {
-            log_info("input_buffers addr: {}", input_buffers[i]->address());
+            TT_LOG_INFO("input_buffers addr: {}", input_buffers[i]->address());
         }
 
         ////////////////////////////////////////////////////////////////////////////
@@ -899,7 +899,7 @@ int main(int argc, char** argv) {
             tt_metal::detail::CompileProgram(device, program);
         }
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             if (use_sub_devices) {
                 // Enqueue the sender program
@@ -951,7 +951,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -144,7 +144,7 @@ create_programs(
     const std::shared_ptr<tt::tt_metal::Buffer>& in1_buffer,
     const std::shared_ptr<tt::tt_metal::Buffer>& output_buffer,
     bool use_sub_devices) {
-    log_info("created program");
+    TT_LOG_INFO("created program");
 
     std::vector<tt_metal::Program> programs;
     programs.push_back(tt_metal::Program());
@@ -180,8 +180,8 @@ create_programs(
     get_max_page_size_and_num_pages(
         in1_block_w / num_receivers, single_tile_size, in1_writer_page_size, in1_writer_num_pages);
 
-    log_info("in1_writer_page_size: {}", in1_writer_page_size);
-    log_info("in1_writer_num_pages: {}", in1_writer_num_pages);
+    TT_LOG_INFO("in1_writer_page_size: {}", in1_writer_page_size);
+    TT_LOG_INFO("in1_writer_num_pages: {}", in1_writer_num_pages);
 
     tt_metal::CircularBufferConfig in1_reader_cb_config =
         tt_metal::CircularBufferConfig(in1_reader_cb_size, {{in1_reader_cb_index, tile_format}})
@@ -239,8 +239,8 @@ create_programs(
             .set_page_size(sync_cb_index, sync_cb_size);
     auto sync_cb = tt_metal::CreateCircularBuffer(receiver_program, l1_receiver_cores, sync_cb_config);
 
-    log_info("in1_reader_cb_size: {}", in1_reader_cb_size);
-    log_info("in1_receiver_cb_size: {}", in1_receiver_cb_size);
+    TT_LOG_INFO("in1_reader_cb_size: {}", in1_reader_cb_size);
+    TT_LOG_INFO("in1_receiver_cb_size: {}", in1_receiver_cb_size);
 
     // in1 reader
     std::vector<uint32_t> in1_reader_compile_time_args = {
@@ -329,7 +329,7 @@ create_programs(
 
     // reader rt
     auto dram_reader_core_coord = dram_reader_core.ranges().begin()->start_coord;
-    log_info("dram_reader_core_coord: {}", dram_reader_core_coord);
+    TT_LOG_INFO("dram_reader_core_coord: {}", dram_reader_core_coord);
     auto dram_reader_core_coord_physical = device->worker_core_from_logical_core(dram_reader_core_coord);
     uint32_t bank_id = 0;
     uint32_t vc = bank_id & 0x1;
@@ -401,7 +401,7 @@ create_programs(
             receiver_rt_args.push_back(in1_receiver_block_num_tile);
         }
 
-        log_info("l1_receiver_core_coords: {}", l1_receiver_core_coords[i]);
+        TT_LOG_INFO("l1_receiver_core_coords: {}", l1_receiver_core_coords[i]);
 
         tt_metal::SetRuntimeArgs(receiver_program, in1_receiver_kernel, l1_receiver_core_coords[i], receiver_rt_args);
     }
@@ -584,10 +584,10 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
         {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
         {ht, wt});
 
-    log_info("cores: {}", cores);
-    log_info("size_bytes: {}", size_bytes);
-    log_info("page_size_bytes: {}", page_size_bytes);
-    log_info("num_receivers: {}", num_receivers);
+    TT_LOG_INFO("cores: {}", cores);
+    TT_LOG_INFO("size_bytes: {}", size_bytes);
+    TT_LOG_INFO("page_size_bytes: {}", page_size_bytes);
+    TT_LOG_INFO("num_receivers: {}", num_receivers);
 
     auto config = tt::tt_metal::ShardedBufferConfig{
         .device = device,
@@ -606,7 +606,7 @@ std::shared_ptr<tt::tt_metal::Buffer> create_and_transfer_data_sharded_cb(
     tt::tt_metal::detail::WriteToBuffer(input_buffer, input_vec);
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
 
-    log_info("created sharded tensor");
+    TT_LOG_INFO("created sharded tensor");
 
     return input_buffer;
 }
@@ -663,8 +663,8 @@ int main(int argc, char** argv) {
             TT_ASSERT(false);
         }
 
-        log_info("num_layers: {} ", num_layers);
-        log_info("num_receivers: {} ", num_receivers);
+        TT_LOG_INFO("num_layers: {} ", num_layers);
+        TT_LOG_INFO("num_receivers: {} ", num_receivers);
 
         TT_FATAL(cb_num_blocks >= num_blocks, "Global CB must contain more (or equal) blocks than a single layer");
 
@@ -859,7 +859,7 @@ int main(int argc, char** argv) {
         }
 
         for (uint32_t i = 0; i < num_layers; ++i) {
-            log_info("in1_buffers addr: {}", in1_buffers[i]->address());
+            TT_LOG_INFO("in1_buffers addr: {}", in1_buffers[i]->address());
         }
 
         ////////////////////////////////////////////////////////////////////////////
@@ -892,7 +892,7 @@ int main(int argc, char** argv) {
             tt_metal::detail::CompileProgram(device, program);
         }
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             if (use_sub_devices) {
                 // Enqueue the sender program
@@ -950,7 +950,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -341,7 +341,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         uint32_t l1_size = get_l1_size(arch);
         auto [Mt, Nt, Kt] = get_aligned_input_tile_num(M, N, K);
-        log_info(LogTest, "Input M, N, K = {}, {}, {} / {}, {}, {} tile(s)", M, N, K, Mt, Nt, Kt);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Input M, N, K = {}, {}, {} / {}, {}, {} tile(s)", M, N, K, Mt, Nt, Kt);
 
         tt::DataFormat data_format = tt::DataFormat::Bfp8_b;
         if (single_core) {
@@ -591,7 +591,7 @@ int main(int argc, char** argv) {
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);
         log_debug(LogTest, "number of matmul ops: {}", num_of_matmul_ops);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             if (!fast_dispatch_mode) {
                 log_debug(LogTest, "calling detail::LaunchProgram");
@@ -605,7 +605,7 @@ int main(int argc, char** argv) {
 
                 log_debug(LogTest, "cycle time {:.8f}s", cycle_time);
                 log_debug(LogTest, "t0_to_any_riscfw_end {}", t0_to_any_riscfw_end);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "time duration: {:.5}us ({}cycles) rmax_tflops {:.2f}",
                     execution_time,
@@ -628,7 +628,7 @@ int main(int argc, char** argv) {
 
                     log_debug(LogTest, "cycle time {:.8f}s", cycle_time);
                     log_debug(LogTest, "t0_to_any_riscfw_end {}", t0_to_any_riscfw_end);
-                    log_info(
+                    TT_LOG_INFO_WITH_CAT(
                         LogTest,
                         "time duration: {:.5}us ({}cycles) rmax_tflops {:.2f}",
                         execution_time,
@@ -644,14 +644,15 @@ int main(int argc, char** argv) {
                     auto t_end = std::chrono::high_resolution_clock::now();
                     duration = t_end - t_begin;
                     rmax_tflops.push_back(static_cast<double>(num_of_matmul_ops) / duration.count() / 1000);
-                    log_info(LogTest, "time duration: {:.5} ns, rmax_tflops {:.2f}", duration.count(), rmax_tflops[i]);
+                    TT_LOG_INFO_WITH_CAT(
+                        LogTest, "time duration: {:.5} ns, rmax_tflops {:.2f}", duration.count(), rmax_tflops[i]);
                 }
             }
         }
 
         auto avg_rmax_tflops = calculate_average(rmax_tflops);
         double rmax_per_rpeak = avg_rmax_tflops / rpeak_tflops;
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Avg Rmax(TFLOPS) {:.3f}, Rpeak {:.3f}, Rmax / Rpeak {:.2f}%",
             avg_rmax_tflops,
@@ -703,10 +704,10 @@ int main(int argc, char** argv) {
         pass &= tt_metal::CloseDevice(device);
 
         // for csv
-        log_info("CSV_MICROBENCHMARK:title:test_compute_mm");
-        log_info("CSV_INPUT:M:{}:N:{}:K:{}:fast-dispatch:{}", M, N, K, fast_dispatch_mode);
-        log_info("CSV_OUTPUT:RMax(TFLOPS):{:.2f}", avg_rmax_tflops);
-        log_info("CSV_RESULT:pass:{}", pass);
+        TT_LOG_INFO("CSV_MICROBENCHMARK:title:test_compute_mm");
+        TT_LOG_INFO("CSV_INPUT:M:{}:N:{}:K:{}:fast-dispatch:{}", M, N, K, fast_dispatch_mode);
+        TT_LOG_INFO("CSV_OUTPUT:RMax(TFLOPS):{:.2f}", avg_rmax_tflops);
+        TT_LOG_INFO("CSV_RESULT:pass:{}", pass);
 
     } catch (const std::exception& e) {
         pass = false;
@@ -717,7 +718,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }
@@ -779,7 +780,8 @@ std::tuple<uint32_t, uint32_t, uint32_t> get_aligned_input_tile_num(uint32_t M, 
     uint32_t K_aligned = align_to_tile(K);
 
     if (M % constants::TILE_WIDTH || N % constants::TILE_WIDTH || K % constants::TILE_WIDTH) {
-        log_info(LogTest, "M, N, K = {}, {}, {} are aligned to {}, {}, {}", M, N, K, M_aligned, N_aligned, K_aligned);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "M, N, K = {}, {}, {} are aligned to {}, {}, {}", M, N, K, M_aligned, N_aligned, K_aligned);
     }
 
     uint32_t Mt = M_aligned / constants::TILE_WIDTH;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_adjacent/test_noc_adjacent.cpp
@@ -239,7 +239,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::detail::CompileProgram(device, program);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
@@ -248,19 +248,20 @@ int main(int argc, char** argv) {
             unsigned long elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             unsigned long elapsed_cc = clock_freq_mhz * elapsed_us;
 
-            log_info(LogTest, "Time elapsed for NOC transfers: {}us ({}cycles)", elapsed_us, elapsed_cc);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Time elapsed for NOC transfers: {}us ({}cycles)", elapsed_us, elapsed_cc);
 
             if (use_device_profiler) {
                 elapsed_cc = get_t0_to_any_riscfw_end_cycle(device, program);
                 elapsed_us = (double)elapsed_cc / clock_freq_mhz;
-                log_info(LogTest, "Time elapsed using device profiler: {}us ({}cycles)", elapsed_us, elapsed_cc);
+                TT_LOG_INFO_WITH_CAT(
+                    LogTest, "Time elapsed using device profiler: {}us ({}cycles)", elapsed_us, elapsed_cc);
             }
 
             // total transfer amount per core = tile size * number of tiles
             // NOC bandwidth = total transfer amount per core / elapsed clock cycle
             measured_bandwidth.push_back((double)single_tile_size * num_tiles / elapsed_cc);
 
-            log_info(LogTest, "Measured NOC bandwidth: {:.3f}B/cc", measured_bandwidth[i]);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Measured NOC bandwidth: {:.3f}B/cc", measured_bandwidth[i]);
         }
 
         pass &= tt_metal::CloseDevice(device);
@@ -288,8 +289,8 @@ int main(int argc, char** argv) {
     }
 
     // for csv
-    log_info("CSV_MICROBENCHMARK:title:test_noc_adjacent");
-    log_info(
+    TT_LOG_INFO("CSV_MICROBENCHMARK:title:test_noc_adjacent");
+    TT_LOG_INFO(
         "CSV_INPUT:num-cores-r:{}:num-cores-c:{}:num-tiles:{}:tiles-per-transfer:{}:noc-index:{}:noc-direction:{}:"
         "access-type:{}:use-device-profiler:{}",
         num_cores_r,
@@ -300,11 +301,11 @@ int main(int argc, char** argv) {
         NOC_DIRECTIONToString(static_cast<NOC_DIRECTION>(noc_direction)),
         ACCESS_TYPEToString(static_cast<ACCESS_TYPE>(access_type)),
         use_device_profiler);
-    log_info("CSV_OUTPUT:Bandwidth(B/cc):{:.3f}", avg_measured_bandwidth);
-    log_info("CSV_RESULT:pass:{}", pass);
+    TT_LOG_INFO("CSV_OUTPUT:Bandwidth(B/cc):{:.3f}", avg_measured_bandwidth);
+    TT_LOG_INFO("CSV_RESULT:pass:{}", pass);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/2_noc_rtor/test_noc_rtor.cpp
@@ -201,7 +201,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::detail::CompileProgram(device, program);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
@@ -209,12 +209,13 @@ int main(int argc, char** argv) {
             auto t_end = std::chrono::steady_clock::now();
             elapsed_us.push_back(duration_cast<microseconds>(t_end - t_begin).count());
 
-            log_info(LogTest, "Time elapsed for NOC transfers: {}us", elapsed_us[i]);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Time elapsed for NOC transfers: {}us", elapsed_us[i]);
 
             if (use_device_profiler) {
                 elapsed_cc = get_t0_to_any_riscfw_end_cycle(device, program);
                 elapsed_us.push_back((double)elapsed_cc / clock_freq_mhz);
-                log_info(LogTest, "Time elapsed uisng device profiler: {}us ({}cycles)", elapsed_us[i], elapsed_cc);
+                TT_LOG_INFO_WITH_CAT(
+                    LogTest, "Time elapsed uisng device profiler: {}us ({}cycles)", elapsed_us[i], elapsed_cc);
             }
         }
 
@@ -233,8 +234,8 @@ int main(int argc, char** argv) {
     }
 
     // for csv
-    log_info("CSV_MICROBENCHMARK:title:test_noc_rtor");
-    log_info(
+    TT_LOG_INFO("CSV_MICROBENCHMARK:title:test_noc_rtor");
+    TT_LOG_INFO(
         "CSV_INPUT:num-cores-r:{}:num-cores-c:{}:num-tiles:{}:noc-index:{}:"
         "access-type:{}:use-device-profiler:{}",
         num_cores_r,
@@ -243,11 +244,11 @@ int main(int argc, char** argv) {
         NOC_INDEXToString(static_cast<NOC_INDEX>(noc_index)),
         ACCESS_TYPEToString(static_cast<ACCESS_TYPE>(access_type)),
         use_device_profiler);
-    log_info("CSV_OUTPUT:ElapsedTime(us):{}", avg_elapsed_us);
-    log_info("CSV_RESULT:pass:{}", pass);
+    TT_LOG_INFO("CSV_OUTPUT:ElapsedTime(us):{}", avg_elapsed_us);
+    TT_LOG_INFO("CSV_RESULT:pass:{}", pass);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -158,28 +158,29 @@ int main(int argc, char** argv) {
         std::vector<std::string> input_args(argv, argv + argc);
 
         if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-            log_info(LogTest, "Usage:");
-            log_info(LogTest, "  --num-tests: number of iterations");
-            log_info(
+            TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --num-tests: number of iterations");
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "  --total-transfer-size: total size to copy to hugepage in bytes (default {} B)",
                 512 * 1024 * 1024);
-            log_info(LogTest, "  --transfer-size: size of one write to hugepage (default {} B)", 64 * 1024);
-            log_info(LogTest, "  --enable-kernel-read: whether to run a kernel that reads from PCIe (default false)");
-            log_info(
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --transfer-size: size of one write to hugepage (default {} B)", 64 * 1024);
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "  --enable-kernel-read: whether to run a kernel that reads from PCIe (default false)");
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "  --simulate-wr-ptr-update: whether host writes to reg address at 32KB intervals (default false)");
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "  --wr-ptr-rdbk-interval: after this many num writes to reg address, do readback (default 0 means no "
                 "readbacks)");
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "  --copy-mode: method used to write to pcie. 0: memcpy, 1: 4 byte writes, 2: nt_memcpy (16B streaming "
                 "loads + stores), 3: nt_memcpy (16B aligned loads + streaming stores), 4: nt_memcpy (16B unaligned "
                 "loads + streaming stores), 5: nt_memcpy (32B streaming loads + stores), 6: nt_memcpy (32B aligned "
                 "loads + streaming stores), 7: nt_memcpy (32B unaligned loads + streaming stores) 8: memcpy_to_device");
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "  --addr-align: Alignment of start of data. Must be a power of 2 (default {} B)",
                 memcpy_alignment);
@@ -294,7 +295,7 @@ int main(int argc, char** argv) {
 
         const std::string copy_mode_str = copy_mode == 0 ? "memcpy" : copy_mode == 1 ? "4 byte writes" : "nt_memcpy";
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Measuring host-to-device bandwidth for "
             "total_transfer_size={} B "
@@ -310,7 +311,7 @@ int main(int argc, char** argv) {
             write_ptr_readback_interval,
             copy_mode_str);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             // Execute application
             std::thread t1([&]() {
@@ -404,7 +405,7 @@ int main(int argc, char** argv) {
 
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             h2d_bandwidth.push_back((total_transfer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));
-            log_info(LogTest, "H2D BW: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, h2d_bandwidth[i]);
+            TT_LOG_INFO_WITH_CAT(LogTest, "H2D BW: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, h2d_bandwidth[i]);
         }
 
         pass &= tt_metal::CloseDevice(device);
@@ -433,12 +434,12 @@ int main(int argc, char** argv) {
         }
     }
 
-    log_info("test_pull_from_pcie");
-    log_info("Bandwidth(GB/s): {:.3f}", avg_h2d_bandwidth);
-    log_info("pass:{}", pass);
+    TT_LOG_INFO("test_pull_from_pcie");
+    TT_LOG_INFO("Bandwidth(GB/s): {:.3f}", avg_h2d_bandwidth);
+    TT_LOG_INFO("pass:{}", pass);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
 
         // Device setup
         if (device_id >= tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices()) {
-            log_info(LogTest, "Skip! Device id {} is not applicable on this system", device_id);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skip! Device id {} is not applicable on this system", device_id);
             return 1;
         }
 
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
         device_is_mmio = device->is_mmio_capable();
 
         if (!device->using_fast_dispatch()) {
-            log_info(LogTest, "Skip! This test needs to be run with fast dispatch enabled");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Skip! This test needs to be run with fast dispatch enabled");
             return 1;
         }
 
@@ -124,7 +124,7 @@ int main(int argc, char** argv) {
             transfer_size, 1000, std::chrono::system_clock::now().time_since_epoch().count());
         std::vector<uint32_t> result_vec;
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Measuring host-to-device and device-to-host bandwidth for "
             "buffer_type={}, transfer_size={} bytes, page_size={} bytes",
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
             transfer_size,
             page_size);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         float best_write_bw = 0.0f;
         float best_read_bw = 0.0f;
         for (uint32_t i = 0; i < num_tests; ++i) {
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
                 float write_bw = transfer_size / (elapsed_us * 1000.0);
                 h2d_bandwidth.push_back(write_bw);
                 best_write_bw = std::fmax(best_write_bw, write_bw);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "EnqueueWriteBuffer to {} (H2D): {:.3f}ms, {:.3f}GB/s",
                     buffer_type == 0 ? "DRAM" : "L1",
@@ -162,7 +162,7 @@ int main(int argc, char** argv) {
                 float read_bw = transfer_size / (elapsed_us * 1000.0);
                 d2h_bandwidth.push_back(read_bw);
                 best_read_bw = std::fmax(best_read_bw, read_bw);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "EnqueueReadBuffer from {} (D2H): {:.3f}ms, {:.3f}GB/s",
                     buffer_type == 0 ? "DRAM" : "L1",
@@ -172,10 +172,10 @@ int main(int argc, char** argv) {
         }
 
         if (!skip_write) {
-            log_info(LogTest, "Best write: {} GB/s", best_write_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Best write: {} GB/s", best_write_bw);
         }
         if (!skip_read) {
-            log_info(LogTest, "Best read: {} GB/s", best_read_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Best read: {} GB/s", best_read_bw);
         }
 
         // Validation & teardown
@@ -232,16 +232,17 @@ int main(int argc, char** argv) {
     }
 
     // for csv
-    log_info("CSV_MICROBENCHMARK:title:test_rw_buffer");
-    log_info(
+    TT_LOG_INFO("CSV_MICROBENCHMARK:title:test_rw_buffer");
+    TT_LOG_INFO(
         "CSV_INPUT:buffer-type:{}:transfer-size:{}",
         BUFFER_TYPEToString(static_cast<BUFFER_TYPE>(buffer_type)),
         transfer_size);
-    log_info("CSV_OUTPUT:H2D_Bandwidth(GB/s):{:.3f}:D2H_Bandwidth(GB/s):{:.3f}", avg_h2d_bandwidth, avg_d2h_bandwidth);
-    log_info("CSV_RESULT:pass:{}", pass);
+    TT_LOG_INFO(
+        "CSV_OUTPUT:H2D_Bandwidth(GB/s):{:.3f}:D2H_Bandwidth(GB/s):{:.3f}", avg_h2d_bandwidth, avg_d2h_bandwidth);
+    TT_LOG_INFO("CSV_RESULT:pass:{}", pass);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -185,7 +185,7 @@ int main(int argc, char** argv) {
             };
 
             auto input_size_aligned = align_to_single_tile(input_size);
-            log_info(LogTest, "input size {} is aligned to {} bytes", input_size, input_size_aligned);
+            TT_LOG_INFO_WITH_CAT(LogTest, "input size {} is aligned to {} bytes", input_size, input_size_aligned);
             input_size = input_size_aligned;
         }
         ////////////////////////////////////////////////////////////////////////////
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
             [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
                 split_work_to_cores(compute_with_storage_grid_size, num_tiles);
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Measuring DRAM bandwidth for input_size = {} bytes ({:.3f} MB, "
             "{} tiles), using {} cores",
@@ -272,7 +272,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::detail::CompileProgram(device, program);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
@@ -280,7 +280,7 @@ int main(int argc, char** argv) {
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Time elapsed for DRAM accesses: {:.3f}ms ({:.3f}GB/s)",
                 elapsed_us / 1000.0,
@@ -290,7 +290,7 @@ int main(int argc, char** argv) {
                 unsigned long elapsed_cc = get_t0_to_any_riscfw_end_cycle(device, program);
                 elapsed_us = (double)elapsed_cc / clock_freq_mhz;
                 dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "Time elapsed using device profiler: {:.3f}ms ({:.3f}GB/s)",
                     elapsed_us / 1000.0,
@@ -343,17 +343,17 @@ int main(int argc, char** argv) {
     }
 
     // for csv
-    log_info("CSV_MICROBENCHMARK:title:test_dram_offchip");
-    log_info(
+    TT_LOG_INFO("CSV_MICROBENCHMARK:title:test_dram_offchip");
+    TT_LOG_INFO(
         "CSV_INPUT:input-size:{}:access-type:{}:use-device-profiler:{}",
         input_size,
         ACCESS_TYPEToString(static_cast<ACCESS_TYPE>(access_type)),
         use_device_profiler);
-    log_info("CSV_OUTPUT:Bandwidth(GB/s):{:.3f}", avg_dram_bandwidth);
-    log_info("CSV_RESULT:pass:{}", pass);
+    TT_LOG_INFO("CSV_OUTPUT:Bandwidth(GB/s):{:.3f}", avg_dram_bandwidth);
+    TT_LOG_INFO("CSV_RESULT:pass:{}", pass);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }
@@ -503,9 +503,9 @@ bool validation(
         }
     } else {
         std::vector<uint32_t> result_vec;
-        log_info(LogTest, "detail::ReadFromBuffer API may take a long time if the input size is large");
+        TT_LOG_INFO_WITH_CAT(LogTest, "detail::ReadFromBuffer API may take a long time if the input size is large");
         tt_metal::detail::ReadFromBuffer(input_buffer, result_vec);
-        log_info(LogTest, "detail::ReadFromBuffer API done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "detail::ReadFromBuffer API done");
 
         for (uint32_t i = 0, input_offset = 0; i < num_cores; ++i) {
             CoreCoord core = {i / num_cores_y, i % num_cores_y};

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/7_kernel_launch/test_kernel_launch.cpp
@@ -124,7 +124,7 @@ int main(int argc, char** argv) {
                                                         : (num_cores_r / num_core_groups) * (core_group_idx + 1) - 1};
             CoreRange group_of_cores(start_core, end_core);
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Setting kernels for core group {}, cores ({},{}) ~ ({},{})",
                 core_group_idx,
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::detail::CompileProgram(device, program);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
             auto t_end = std::chrono::steady_clock::now();
             elapsed_us.push_back(duration_cast<microseconds>(t_end - t_begin).count());
 
-            log_info(LogTest, "Time elapsed for executing empty kernels: {}us", elapsed_us[i]);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Time elapsed for executing empty kernels: {}us", elapsed_us[i]);
         }
 
         pass &= tt_metal::CloseDevice(device);
@@ -238,13 +238,13 @@ int main(int argc, char** argv) {
     }
 
     // for csv
-    log_info("CSV_MICROBENCHMARK:title:test_kernel_launch");
-    log_info("CSV_INPUT:num-cores-r:{}:num-cores-c:{}:core-groups:{}", num_cores_r, num_cores_c, num_core_groups);
-    log_info("CSV_OUTPUT:ElapsedTime(us):{}", avg_elapsed_us);
-    log_info("CSV_RESULT:pass:{}", pass);
+    TT_LOG_INFO("CSV_MICROBENCHMARK:title:test_kernel_launch");
+    TT_LOG_INFO("CSV_INPUT:num-cores-r:{}:num-cores-c:{}:core-groups:{}", num_cores_r, num_cores_c, num_core_groups);
+    TT_LOG_INFO("CSV_OUTPUT:ElapsedTime(us):{}", avg_elapsed_us);
+    TT_LOG_INFO("CSV_RESULT:pass:{}", pass);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -164,7 +164,7 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
 
         const std::array rt_args = {(std::uint32_t)bank_id, (std::uint32_t)vc};
 
-        log_info("core: {}, vc: {}", core, vc);
+        TT_LOG_INFO("core: {}, vc: {}", core, vc);
 
         tt_metal::SetRuntimeArgs(program, reader_kernel, core, rt_args);
     }
@@ -280,7 +280,7 @@ int main(int argc, char** argv) {
     uint32_t num_banks = 1;
     uint32_t bank_start_id = 1;
 
-    log_info("start DRAM benchmark");
+    TT_LOG_INFO("start DRAM benchmark");
 
     try {
         ////////////////////////////////////////////////////////////////////////////
@@ -364,7 +364,7 @@ int main(int argc, char** argv) {
             };
 
             auto input_size_aligned = align_to_single_tile(input_size);
-            log_info(LogTest, "input size {} is aligned to {} bytes", input_size, input_size_aligned);
+            TT_LOG_INFO_WITH_CAT(LogTest, "input size {} is aligned to {} bytes", input_size, input_size_aligned);
             input_size = input_size_aligned;
         }
         ////////////////////////////////////////////////////////////////////////////
@@ -392,10 +392,10 @@ int main(int argc, char** argv) {
 
         for (auto core : all_cores_list) {
             auto virtual_core = device->worker_core_from_logical_core(core);
-            log_info("logical core: {}, virtual core: {}", core, virtual_core);
+            TT_LOG_INFO("logical core: {}, virtual core: {}", core, virtual_core);
         }
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Measuring DRAM bandwidth for input_size = {} bytes ({:.3f} MB, "
             "{} tiles), using {} cores",
@@ -449,7 +449,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::detail::CompileProgram(device, program);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
@@ -458,7 +458,7 @@ int main(int argc, char** argv) {
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Time elapsed for DRAM accesses: {:.3f}ms ({:.3f}GB/s)",
                 elapsed_us / 1000.0,
@@ -512,7 +512,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -138,8 +138,8 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
     uint32_t page_size, num_pages, num_pages_w_per_receiver;
     get_max_page_size_and_num_pages(block_w, block_h, single_tile_size, page_size, num_pages, num_pages_w_per_receiver);
 
-    log_info("Input block size: {}x{}, num_blocks: {}", block_h, block_w, num_blocks);
-    log_info(
+    TT_LOG_INFO("Input block size: {}x{}, num_blocks: {}", block_h, block_w, num_blocks);
+    TT_LOG_INFO(
         "Pages set up as page_size: {}, num_pages: {}, num_pages_w_per_receiver: {}",
         page_size,
         num_pages,
@@ -207,7 +207,7 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
 
         const std::array reader_rt_args = {(std::uint32_t)bank_id, (std::uint32_t)vc};
 
-        log_info("core: {}, vc: {}", core, vc);
+        TT_LOG_INFO("core: {}, vc: {}", core, vc);
 
         tt_metal::SetRuntimeArgs(program, reader_kernel, core, reader_rt_args);
 
@@ -216,8 +216,8 @@ std::tuple<tt_metal::Program, tt_metal::KernelHandle, uint32_t> create_program(
         auto writer_core2 = all_l1_writer_cores_ordered[(i * 2) + 1];
         auto writer_core_phy2 = device->worker_core_from_logical_core(writer_core2);
 
-        log_info("writer_core_phy1: {}", writer_core_phy1);
-        log_info("writer_core_phy2: {}", writer_core_phy2);
+        TT_LOG_INFO("writer_core_phy1: {}", writer_core_phy1);
+        TT_LOG_INFO("writer_core_phy2: {}", writer_core_phy2);
 
         const std::array writer_rt_args = {
             (std::uint32_t)(vc + 2) & 0x3,
@@ -343,7 +343,7 @@ bool validation(
         }
         core_id++;
     }
-    log_info("Validation passed.");
+    TT_LOG_INFO("Validation passed.");
     return true;
 }
 
@@ -432,7 +432,7 @@ int main(int argc, char** argv) {
     uint32_t num_banks = 1;
     uint32_t bank_start_id = 1;
 
-    log_info("start DRAM benchmark");
+    TT_LOG_INFO("start DRAM benchmark");
 
     // try {
     ////////////////////////////////////////////////////////////////////////////
@@ -517,7 +517,7 @@ int main(int argc, char** argv) {
             };
 
             auto input_size_aligned = align_to_single_tile(input_size);
-            log_info(LogTest, "input size {} is aligned to {} bytes", input_size, input_size_aligned);
+            TT_LOG_INFO_WITH_CAT(LogTest, "input size {} is aligned to {} bytes", input_size, input_size_aligned);
             input_size = input_size_aligned;
         }
         ////////////////////////////////////////////////////////////////////////////
@@ -566,18 +566,18 @@ int main(int argc, char** argv) {
         uint32_t num_tiles_per_core = num_tiles / num_cores;
         uint32_t num_tiles_cb = num_tiles_per_core / num_blocks;
 
-        log_info("all_dram_reader_cores");
+        TT_LOG_INFO("all_dram_reader_cores");
         for (auto core : all_dram_reader_cores_ordered) {
             auto phys_core = device->worker_core_from_logical_core(core);
-            log_info("logical core: {}, virtual core: {}", core, phys_core);
+            TT_LOG_INFO("logical core: {}, virtual core: {}", core, phys_core);
         }
-        log_info("all_l1_writer_cores");
+        TT_LOG_INFO("all_l1_writer_cores");
         for (auto core : all_l1_writer_cores_ordered) {
             auto phys_core = device->worker_core_from_logical_core(core);
-            log_info("logical core: {}, virtual core: {}", core, phys_core);
+            TT_LOG_INFO("logical core: {}, virtual core: {}", core, phys_core);
         }
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Measuring DRAM bandwidth for input_size = {} bytes ({:.3f} MB, "
             "{} tiles), using {} DRAM reading cores",
@@ -633,7 +633,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::detail::CompileProgram(device, program);
 
-        log_info(LogTest, "Num tests {}", num_tests);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num tests {}", num_tests);
         for (uint32_t i = 0; i < num_tests; ++i) {
             auto t_begin = std::chrono::steady_clock::now();
             EnqueueProgram(device->command_queue(), program, false);
@@ -642,7 +642,7 @@ int main(int argc, char** argv) {
             auto t_end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
             dram_bandwidth.push_back((input_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Time elapsed for DRAM accesses: {:.3f}ms ({:.3f}GB/s)",
                 elapsed_us / 1000.0,
@@ -672,7 +672,7 @@ int main(int argc, char** argv) {
             num_datum_per_slice);
 
         if (!pass) {
-            log_info(LogTest, "Validation failed");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Validation failed");
         }
 
         pass &= tt_metal::CloseDevice(device);
@@ -701,7 +701,7 @@ int main(int argc, char** argv) {
         }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         log_error(LogTest, "Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -397,7 +397,7 @@ inline bool DeviceData::validate_one_core(
         results = tt::llrt::read_hex_vec_from_core(device->id(), phys_core, result_addr, size_bytes);
     }
 
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Validating {} bytes from {} bank {} log_core {}: phys_core: {} at addr: 0x{:x}",
         size_bytes,
@@ -446,7 +446,7 @@ inline bool DeviceData::validate_one_core(
 
 bool DeviceData::validate_host(std::unordered_set<CoreCoord>& validated_cores, const one_core_data_t& host_data) {
     uint32_t size_bytes = host_data.data.size() * sizeof(uint32_t);
-    log_info(tt::LogTest, "Validating {} bytes from hugepage", size_bytes);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Validating {} bytes from hugepage", size_bytes);
 
     bool failed = false;
 
@@ -505,7 +505,7 @@ bool DeviceData::validate(IDevice* device) {
         }
     }
 
-    log_info(tt::LogTest, "Validated {} non-empty cores total.", validated_cores.size());
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Validated {} non-empty cores total.", validated_cores.size());
 
     return !failed;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -87,41 +87,45 @@ void init(int argc, char** argv) {
     std::vector<std::string> input_args(argv, argv + argc);
 
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
-        log_info(LogTest, "  -i: iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -i: iterations (default {})", DEFAULT_ITERATIONS);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  -bs: batch size in K of data to xfer in one iteration (default {}K)", DEFAULT_BATCH_SIZE_K);
-        log_info(LogTest, "  -p: page size (default {})", DEFAULT_PAGE_SIZE);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -p: page size (default {})", DEFAULT_PAGE_SIZE);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  -m: source mem, 0:PCIe, 1:DRAM, 2:L1, 3:ALL_DRAMs, 4:HOST_READ, 5:HOST_WRITE, 6:MULTICAST_WRITE "
             "(default 0:PCIe)");
-        log_info(LogTest, "  -l: measure latency (default is bandwidth)");
-        log_info(LogTest, "  -rx: X of core to issue read or write (default {})", 1);
-        log_info(LogTest, "  -ry: Y of core to issue read or write (default {})", 0);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -l: measure latency (default is bandwidth)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -rx: X of core to issue read or write (default {})", 1);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -ry: Y of core to issue read or write (default {})", 0);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  -sx: when reading from L1, X of core to read from. when issuing a multicast write, X of start core to "
             "write to. (default {})",
             0);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  -sy: when reading from L1, Y of core to read from. when issuing a multicast write, Y of start core to "
             "write to. (default {})",
             0);
-        log_info(LogTest, "  -tx: when issuing a multicast write, X of end core to write to (default {})", 0);
-        log_info(LogTest, "  -ty: when issuing a multicast write, Y of end core to write to (default {})", 0);
-        log_info(LogTest, "  -wr: issue unicast write instead of read (default false)");
-        log_info(LogTest, "  -c: when reading from dram, DRAM channel (default 0)");
-        log_info(LogTest, "  -f: time just the finish call (default disabled)");
-        log_info(LogTest, "  -o: use read_one_packet API.  restricts page size to 8K max (default {})", 0);
-        log_info(LogTest, "-link: link mcast transactions");
-        log_info(LogTest, " -hr: hammer write_reg while executing (for PCIe test)");
-        log_info(LogTest, " -hp: hammer hugepage PCIe memory while executing (for PCIe test)");
-        log_info(LogTest, " -hpt:hammer hugepage PCIe hammer type: 0:32bit writes 1:128bit non-temporal writes");
-        log_info(LogTest, "  -psrta: pass page size as a runtime argument (default compile time define)");
-        log_info(LogTest, " -nop: time loop of <n> nops");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -tx: when issuing a multicast write, X of end core to write to (default {})", 0);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -ty: when issuing a multicast write, Y of end core to write to (default {})", 0);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -wr: issue unicast write instead of read (default false)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -c: when reading from dram, DRAM channel (default 0)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -f: time just the finish call (default disabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -o: use read_one_packet API.  restricts page size to 8K max (default {})", 0);
+        TT_LOG_INFO_WITH_CAT(LogTest, "-link: link mcast transactions");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -hr: hammer write_reg while executing (for PCIe test)");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -hp: hammer hugepage PCIe memory while executing (for PCIe test)");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, " -hpt:hammer hugepage PCIe hammer type: 0:32bit writes 1:128bit non-temporal writes");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -psrta: pass page size as a runtime argument (default compile time define)");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -nop: time loop of <n> nops");
         exit(0);
     }
 
@@ -147,14 +151,14 @@ void init(int argc, char** argv) {
     nop_count_g = test_args::get_command_option_uint32(input_args, "-nop", 0);
 
     if (read_one_packet_g && page_size_g > 8192) {
-        log_info(LogTest, "Page size must be <= 8K for read_one_packet\n");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Page size must be <= 8K for read_one_packet\n");
         exit(-1);
     }
     page_count_g = size_bytes / page_size_g;
 
     test_write = test_args::has_command_option(input_args, "-wr");
     if (test_write && (source_mem_g != 2 && source_mem_g != 6)) {
-        log_info(LogTest, "Writing only tested w/ L1 destination\n");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing only tested w/ L1 destination\n");
         exit(-1);
     }
 
@@ -165,14 +169,15 @@ void init(int argc, char** argv) {
 
     if (source_mem_g == 6) {
         if (mcast_end_core_x < src_core_x || mcast_end_core_y < src_core_y) {
-            log_info(LogTest, "X of end core must be >= X of start core, Y of end core must be >= Y of start core");
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "X of end core must be >= X of start core, Y of end core must be >= Y of start core");
             exit(-1);
         }
 
         mcast_src_workers_g = CoreRange({src_core_x, src_core_y}, {mcast_end_core_x, mcast_end_core_y});
 
         if (mcast_src_workers_g.intersects(worker_g)) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Multicast destination rectangle and core that issues the multicast cannot overlap - Multicast "
                 "destination rectangle: {} Master core: {}",
@@ -270,7 +275,7 @@ int main(int argc, char** argv) {
             } break;
             case 4: {
                 src_mem = "FROM_L1_TO_HOST";
-                log_info(LogTest, "Host bw test overriding page_count to 1");
+                TT_LOG_INFO_WITH_CAT(LogTest, "Host bw test overriding page_count to 1");
                 CoreCoord w = device->worker_core_from_logical_core(src_worker_g);
                 page_count_g = 1;
                 noc_addr_x = w.x;
@@ -278,7 +283,7 @@ int main(int argc, char** argv) {
             } break;
             case 5: {
                 src_mem = "FROM_HOST_TO_L1";
-                log_info(LogTest, "Host bw test overriding page_count to 1");
+                TT_LOG_INFO_WITH_CAT(LogTest, "Host bw test overriding page_count to 1");
                 CoreCoord w = device->worker_core_from_logical_core(src_worker_g);
                 page_count_g = 1;
                 noc_addr_x = w.x;
@@ -338,16 +343,16 @@ int main(int argc, char** argv) {
         std::shared_ptr<Event> sync_event = std::make_shared<Event>();
 
         CoreCoord w = device->worker_core_from_logical_core(worker_g.start_coord);
-        log_info(LogTest, "Master core: {}", w.str());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Master core: {}", w.str());
         string direction = test_write ? "Writing" : "Reading";
         if (source_mem_g == 3) {
-            log_info(LogTest, "{}: {}", direction, src_mem);
+            TT_LOG_INFO_WITH_CAT(LogTest, "{}: {}", direction, src_mem);
         } else if (source_mem_g == 4) {
-            log_info(LogTest, "{}: {} - core ({}, {})", direction, src_mem, w.x, w.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "{}: {} - core ({}, {})", direction, src_mem, w.x, w.y);
         } else if (source_mem_g == 5) {
-            log_info(LogTest, "{}: {} - core ({}, {})", test_write, src_mem, w.x, w.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "{}: {} - core ({}, {})", test_write, src_mem, w.x, w.y);
         } else if (source_mem_g == 6) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "direction: {} - core grid [({}, {}) - ({}, {})]",
                 direction,
@@ -357,7 +362,7 @@ int main(int argc, char** argv) {
                 mcast_noc_addr_end_x,
                 mcast_noc_addr_end_y);
         } else {
-            log_info(LogTest, "{}: {} - core ({}, {})", direction, src_mem, noc_addr_x, noc_addr_y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "{}: {} - core ({}, {})", direction, src_mem, noc_addr_x, noc_addr_y);
         }
         if (source_mem_g < 4 || source_mem_g == 6) {
             std::string api;
@@ -369,15 +374,15 @@ int main(int argc, char** argv) {
             } else {
                 api = "noc_async_" + read_write;
             }
-            log_info(LogTest, "Using API: {}", api);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(LogTest, "Using API: {}", api);
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Page size ({}): {}",
                 page_size_as_runtime_arg_g ? "runtime arg" : "compile time define",
                 page_size_g);
-            log_info(LogTest, "Size per iteration: {}", page_count_g * page_size_g);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Size per iteration: {}", page_count_g * page_size_g);
         }
-        log_info(LogTest, "Iterations: {}", iterations_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Iterations: {}", iterations_g);
         if (hammer_pcie_g) {
             log_warning(LogTest, "WARNING: Hardcoded PCIe addresses may not be safe w/ FD, check above if hung");
         }
@@ -474,10 +479,10 @@ int main(int argc, char** argv) {
             elapsed_seconds = (end - start);
         }
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "Ran in {}us", std::chrono::duration_cast<std::chrono::microseconds>(elapsed_seconds).count());
         if (latency_g) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Latency: {} us",
                 (float)std::chrono::duration_cast<std::chrono::microseconds>(elapsed_seconds).count() /
@@ -487,7 +492,7 @@ int main(int argc, char** argv) {
                        (elapsed_seconds.count() * 1000.0 * 1000.0 * 1000.0);
             std::stringstream ss;
             ss << std::fixed << std::setprecision(3) << bw;
-            log_info(LogTest, "BW: {} GB/s", ss.str());
+            TT_LOG_INFO_WITH_CAT(LogTest, "BW: {} GB/s", ss.str());
         }
 
         pass &= tt_metal::CloseDevice(device);
@@ -497,7 +502,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -110,45 +110,50 @@ void init(int argc, char** argv) {
     std::vector<std::string> input_args(argv, argv + argc);
 
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "    -t: test type, 0:uni_write 1:mcast_write 2:dram paged_write 3:l1 paged_write 4:packed_write "
             "5:packed_write_large (default {})",
             0);
-        log_info(LogTest, "    -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
-        log_info(LogTest, "    -i: host iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, "   -wx: right-most worker in grid (default {})", all_workers_g.end_coord.x);
-        log_info(LogTest, "   -wy: bottom-most worker in grid (default {})", all_workers_g.end_coord.y);
-        log_info(LogTest, "    -a: send to all workers (vs random) for 1-to-N cmds (default random)");
-        log_info(LogTest, "   -pi: prefetcher iterations (looping on device) (default {})", 1);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "    -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
+        TT_LOG_INFO_WITH_CAT(LogTest, "    -i: host iterations (default {})", DEFAULT_ITERATIONS);
+        TT_LOG_INFO_WITH_CAT(LogTest, "   -wx: right-most worker in grid (default {})", all_workers_g.end_coord.x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "   -wy: bottom-most worker in grid (default {})", all_workers_g.end_coord.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "    -a: send to all workers (vs random) for 1-to-N cmds (default random)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "   -pi: prefetcher iterations (looping on device) (default {})", 1);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  -lps: log of page size of prefetch/dispatch buffer (default {})",
             DEFAULT_DISPATCH_BUFFER_LOG_PAGE_SIZE);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "   -bs: dispatcher block size in pages (default {})", DEFAULT_DISPATCH_BUFFER_BLOCK_SIZE_PAGES);
-        log_info(LogTest, "    -b: dispatcher buffer size in blocks (default {})", DEFAULT_DISPATCH_BUFFER_SIZE_BLOCKS);
-        log_info(LogTest, "  -pbs: prefetcher buffer size pages (default {})", DEFAULT_PREFETCHER_BUFFER_SIZE_PAGES);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "    -b: dispatcher buffer size in blocks (default {})", DEFAULT_DISPATCH_BUFFER_SIZE_BLOCKS);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -pbs: prefetcher buffer size pages (default {})", DEFAULT_PREFETCHER_BUFFER_SIZE_PAGES);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             " -ppbs: prefetcher page batch size (process pages in batches of N to reduce overhead) (default {})",
             DEFAULT_PREFETCHER_PAGE_BATCH_SIZE);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "    -f: prefetcher fire once, use to measure dispatcher perf w/ prefetcher out of the way (default "
             "disabled)");
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "    -d: wrap all commands in debug commands and clear DRAM to known state (default disabled)");
-        log_info(LogTest, "    -c: use coherent data as payload (default false)");
-        log_info(LogTest, "   -np: paged-write number of pages (default {})", num_pages_g);
-        log_info(LogTest, "    -s: seed for randomized testing");
+        TT_LOG_INFO_WITH_CAT(LogTest, "    -c: use coherent data as payload (default false)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "   -np: paged-write number of pages (default {})", num_pages_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "    -s: seed for randomized testing");
 
-        log_info(LogTest, "Random Test args:");
-        log_info(LogTest, "  -max: max transfer size bytes (default {})", max_xfer_size_bytes_g);
-        log_info(LogTest, "  -min: min transfer size bytes (default {})", min_xfer_size_bytes_g);
-        log_info(LogTest, "  -max-addr: max paged-write dst base addr (default {})", max_paged_write_base_addr_g);
-        log_info(LogTest, "  -min-addr: min paged-write dst base addr (default {})", min_paged_write_base_addr_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Random Test args:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -max: max transfer size bytes (default {})", max_xfer_size_bytes_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -min: min transfer size bytes (default {})", min_xfer_size_bytes_g);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -max-addr: max paged-write dst base addr (default {})", max_paged_write_base_addr_g);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -min-addr: min paged-write dst base addr (default {})", min_paged_write_base_addr_g);
 
         exit(0);
     }
@@ -204,7 +209,7 @@ void init(int argc, char** argv) {
     fire_once_g = test_args::has_command_option(input_args, "-f");
     if (fire_once_g) {
         if (prefetcher_buffer_size_g != dispatch_buffer_size_g + terminate_cmd_pages) {
-            log_info(LogTest, "Fire once overriding prefetcher buffer size");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Fire once overriding prefetcher buffer size");
             prefetcher_buffer_size_g = dispatch_buffer_size_g + terminate_cmd_pages * dispatch_buffer_page_size_g;
         }
     }
@@ -242,7 +247,7 @@ void gen_linear_or_packed_write_test(
     uint32_t total_size_bytes = 0;
     uint32_t buffer_size = prefetcher_buffer_size_g - page_size;  // for terminate
     bool is_linear_write = (test_type_g == 0 || test_type_g == 1);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Generating linear: {} multicast: {} Write Test with dispatch buffer page_size: {}",
         is_linear_write,
@@ -334,7 +339,7 @@ void gen_paged_write_test(
         page_size_bytes = min_xfer_size_bytes_g;
     }
 
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Generating Paged Write test to {} for dispatch buffer page_size: {} write_cmd_page_size: {} start_page: {}",
         is_dram ? "DRAM" : "L1",
@@ -410,7 +415,7 @@ void gen_cmds(
             break;
     }
 
-    log_info(LogTest, "Generated {} commands", cmd_count);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Generated {} commands", cmd_count);
 }
 
 // Clear DRAM (helpful for paged write to DRAM debug to have a fresh slate)
@@ -421,24 +426,20 @@ void initialize_dram_banks(IDevice* device) {
     auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0xBADDF00D);
 
     for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-        log_info(
-            tt::LogTest,
-            "Initializing DRAM {} bytes for bank_id: {}",
-            bank_size,
-            bank_id);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Initializing DRAM {} bytes for bank_id: {}", bank_size, bank_id);
         tt::tt_metal::detail::WriteToDeviceDRAMChannel(device, bank_id, 0, fill);
     }
 }
 
 int main(int argc, char** argv) {
-    log_info(tt::LogTest, "test_dispatcher.cpp - Test Start");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "test_dispatcher.cpp - Test Start");
 
     init(argc, argv);
     if (seed_g == 0) {
         seed_g = std::time(nullptr);
     }
     std::srand(seed_g);  // Seed the RNG
-    log_info(LogTest, "Random seed: {}", seed_g);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Random seed: {}", seed_g);
 
     auto slow_dispatch_mode = getenv("TT_METAL_SLOW_DISPATCH_MODE");
     TT_FATAL(slow_dispatch_mode, "This test only supports TT_METAL_SLOW_DISPATCH_MODE");
@@ -663,28 +664,29 @@ int main(int argc, char** argv) {
             my_noc_index);
 
         switch (test_type_g) {
-            case 0: log_info(LogTest, "Running linear unicast test"); break;
-            case 1: log_info(LogTest, "Running linear mcast test"); break;
+            case 0: TT_LOG_INFO_WITH_CAT(LogTest, "Running linear unicast test"); break;
+            case 1: TT_LOG_INFO_WITH_CAT(LogTest, "Running linear mcast test"); break;
             case 2:
-            case 3: log_info(LogTest, "Running paged {} test", is_paged_dram_test() ? "DRAM" : "L1"); break;
-            case 4: log_info(LogTest, "Running packed write unicast"); break;
-            case 5: log_info(LogTest, "Running packed write large unicast"); break;
+            case 3: TT_LOG_INFO_WITH_CAT(LogTest, "Running paged {} test", is_paged_dram_test() ? "DRAM" : "L1"); break;
+            case 4: TT_LOG_INFO_WITH_CAT(LogTest, "Running packed write unicast"); break;
+            case 5: TT_LOG_INFO_WITH_CAT(LogTest, "Running packed write large unicast"); break;
         }
 
-        log_info(LogTest, "Worker grid {}", all_workers_g.str());
-        log_info(LogTest, "Dispatch buffer size blocks {}", std::to_string(dispatch_buffer_size_blocks_g));
-        log_info(LogTest, "Dispatch buffer block size pages {}", std::to_string(dispatch_buffer_block_size_pages_g));
-        log_info(LogTest, "Dispatch buffer page size {}", std::to_string(dispatch_buffer_page_size_g));
-        log_info(LogTest, "Dispatch buffer pages {}", std::to_string(dispatch_buffer_pages));
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Worker grid {}", all_workers_g.str());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Dispatch buffer size blocks {}", std::to_string(dispatch_buffer_size_blocks_g));
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "Dispatch buffer block size pages {}", std::to_string(dispatch_buffer_block_size_pages_g));
+        TT_LOG_INFO_WITH_CAT(LogTest, "Dispatch buffer page size {}", std::to_string(dispatch_buffer_page_size_g));
+        TT_LOG_INFO_WITH_CAT(LogTest, "Dispatch buffer pages {}", std::to_string(dispatch_buffer_pages));
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "Dispatch buffer size {}", std::to_string(dispatch_buffer_page_size_g * dispatch_buffer_pages));
-        log_info(LogTest, "Dispatch buffer base {}", std::to_string(l1_buf_base));
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Dispatch buffer base {}", std::to_string(l1_buf_base));
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Dispatch buffer end {}",
             std::to_string(l1_buf_base + dispatch_buffer_page_size_g * dispatch_buffer_pages));
-        log_info(LogTest, "Prefetcher CMD Buffer size {}", std::to_string(prefetcher_buffer_size_g));
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Prefetcher CMD Buffer size {}", std::to_string(prefetcher_buffer_size_g));
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Worker result data total bytes written {}",
             std::to_string(device_data.size() * sizeof(uint32_t)));
@@ -703,16 +705,17 @@ int main(int argc, char** argv) {
 
         std::chrono::duration<double> elapsed_seconds = (end - start);
         uint32_t total_iterations = iterations_g * prefetcher_iterations_g;
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "Ran in {}us (for total iterations: {})", elapsed_seconds.count() * 1000 * 1000, total_iterations);
-        log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / total_iterations);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / total_iterations);
         if (iterations_g > 0) {
             float total_words = device_data.size();
             total_words *= total_iterations;
             float bw = total_words * sizeof(uint32_t) / (elapsed_seconds.count() * 1024.0 * 1024.0 * 1024.0);
             std::stringstream ss;
             ss << std::fixed << std::setprecision(3) << bw;
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "BW: {} GB/s (from total_words: {} size: {} MB via host_iter: {} prefetcher_iter: {} for num_cores: "
                 "{})",
@@ -723,7 +726,7 @@ int main(int argc, char** argv) {
                 prefetcher_iterations_g,
                 all_workers_g.size());
         } else {
-            log_info(LogTest, "BW: -- GB/s (use -i 1 to report bandwidth)");
+            TT_LOG_INFO_WITH_CAT(LogTest, "BW: -- GB/s (use -i 1 to report bandwidth)");
         }
         pass &= tt_metal::CloseDevice(device);
     } catch (const std::exception& e) {
@@ -734,7 +737,7 @@ int main(int argc, char** argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "test_dispatcher.cpp - Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "test_dispatcher.cpp - Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "test_dispatcher.cpp - Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -107,35 +107,36 @@ void init(const std::vector<std::string>& input_args, TestInfo& info) {
     auto core_count = get_core_count();
 
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
-        log_info(LogTest, "  -i: iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -w: warm-up iterations before starting timer (default {}), ", DEFAULT_WARMUP_ITERATIONS);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -i: iterations (default {})", DEFAULT_ITERATIONS);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  -s: size of kernels in powers of 2 bytes (default {}, min {})",
             DEFAULT_KERNEL_SIZE_K * 1024,
             MIN_KERNEL_SIZE_BYTES);
-        log_info(LogTest, "  -x: X end of inclusive core range (default {})", 0);
-        log_info(LogTest, "  -y: Y end of inclusive core range (default {})", 0);
-        log_info(LogTest, "  -c: number of CBs (default {}, max {})", 0, MAX_CBS);
-        log_info(LogTest, "  -a: number of runtime args (default {}, max {})", 0, MAX_ARGS);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -x: X end of inclusive core range (default {})", 0);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -y: Y end of inclusive core range (default {})", 0);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -c: number of CBs (default {}, max {})", 0, MAX_CBS);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -a: number of runtime args (default {}, max {})", 0, MAX_ARGS);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, " -ca: number of common runtime args multicast to all cores (default {}, max {})", 0, MAX_ARGS);
-        log_info(LogTest, "  -S: number of semaphores (default {}, max {})", 0, NUM_SEMAPHORES);
-        log_info(LogTest, " -kg: number of kernel groups (default 1)");
-        log_info(LogTest, "  -g: use a 4 byte global variable (additional spans");
-        log_info(LogTest, " -rs: run \"slow\" kernels for exactly <n> cycles (default 0)");
-        log_info(LogTest, " -rf: run \"fast\" kernels for exactly <n> cycles (default 0)");
-        log_info(LogTest, " -nf: run <n> fast kernels between slow kernels (default 0)");
-        log_info(LogTest, "  -b: disable brisc kernel (default enabled)");
-        log_info(LogTest, "  -n: disable ncrisc kernel (default enabled)");
-        log_info(LogTest, "  -t: disable trisc kernels (default enabled)");
-        log_info(LogTest, "  +e: enable erisc kernels (default disabled)");
-        log_info(LogTest, " -ec: erisc count (default 1 if enabled)");
-        log_info(LogTest, "  -f: time just the finish call (default disabled)");
-        log_info(LogTest, " -tr: enable trace (default disabled)");
-        log_info(LogTest, " -de: dispatch from eth cores (default tensix)");
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -S: number of semaphores (default {}, max {})", 0, NUM_SEMAPHORES);
+        TT_LOG_INFO_WITH_CAT(LogTest, " -kg: number of kernel groups (default 1)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -g: use a 4 byte global variable (additional spans");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -rs: run \"slow\" kernels for exactly <n> cycles (default 0)");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -rf: run \"fast\" kernels for exactly <n> cycles (default 0)");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -nf: run <n> fast kernels between slow kernels (default 0)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -b: disable brisc kernel (default enabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -n: disable ncrisc kernel (default enabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -t: disable trisc kernels (default enabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  +e: enable erisc kernels (default disabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -ec: erisc count (default 1 if enabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -f: time just the finish call (default disabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -tr: enable trace (default disabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, " -de: dispatch from eth cores (default tensix)");
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             " -ac: use all viable worker cores (default {}x{})",
             std::get<0>(core_count),
@@ -333,7 +334,7 @@ struct FakeBenchmarkState {
 template <typename T>
 static int pgm_dispatch(T& state, TestInfo info) {
     if constexpr (std::is_same_v<T, benchmark::State>) {
-        log_info(LogTest, "Running {}", state.name());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running {}", state.name());
     }
     if (info.use_all_cores) {
         auto core_count = get_core_count();
@@ -341,29 +342,29 @@ static int pgm_dispatch(T& state, TestInfo info) {
     }
 
     if (info.use_trace) {
-        log_info(LogTest, "Running with trace enabled");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running with trace enabled");
     }
-    log_info(LogTest, "Warmup iterations: {}", info.warmup_iterations);
-    log_info(LogTest, "Iterations: {}", info.iterations);
-    log_info(
+    TT_LOG_INFO_WITH_CAT(LogTest, "Warmup iterations: {}", info.warmup_iterations);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Iterations: {}", info.iterations);
+    TT_LOG_INFO_WITH_CAT(
         LogTest,
         "Grid: ({}-{}) ({} cores)",
         info.workers.start_coord.str(),
         info.workers.end_coord.str(),
         info.workers.size());
-    log_info(LogTest, "Kernel size: {}", info.kernel_size);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Kernel size: {}", info.kernel_size);
     if (info.nfast_kernels != 0) {
-        log_info(LogTest, "Fast kernel cycles: {}", info.fast_kernel_cycles);
-        log_info(LogTest, "Slow kernel cycles: {}", info.slow_kernel_cycles);
-        log_info(LogTest, "{} fast kernels between slow kernels", info.nfast_kernels);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Fast kernel cycles: {}", info.fast_kernel_cycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Slow kernel cycles: {}", info.slow_kernel_cycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "{} fast kernels between slow kernels", info.nfast_kernels);
     } else {
-        log_info(LogTest, "Kernel cycles: {}", info.slow_kernel_cycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Kernel cycles: {}", info.slow_kernel_cycles);
     }
-    log_info(LogTest, "KGs: {}", info.n_kgs);
-    log_info(LogTest, "CBs: {}", info.n_cbs);
-    log_info(LogTest, "UniqueRTArgs: {}", info.n_args);
-    log_info(LogTest, "CommonRTArgs: {}", info.n_common_args);
-    log_info(LogTest, "Sems: {}", info.n_sems);
+    TT_LOG_INFO_WITH_CAT(LogTest, "KGs: {}", info.n_kgs);
+    TT_LOG_INFO_WITH_CAT(LogTest, "CBs: {}", info.n_cbs);
+    TT_LOG_INFO_WITH_CAT(LogTest, "UniqueRTArgs: {}", info.n_args);
+    TT_LOG_INFO_WITH_CAT(LogTest, "CommonRTArgs: {}", info.n_common_args);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Sems: {}", info.n_sems);
     if constexpr (std::is_same_v<T, benchmark::State>) {
         if (dump_test_info) {
             state.counters["cores"] = benchmark::Counter(info.workers.size(), benchmark::Counter::kDefaults);
@@ -453,8 +454,9 @@ static int pgm_dispatch(T& state, TestInfo info) {
                 state.SetIterationTime(elapsed_seconds.count());
             } else {
                 std::chrono::duration<double> elapsed_seconds = (end - start);
-                log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
-                log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / info.iterations);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
+                TT_LOG_INFO_WITH_CAT(
+                    LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / info.iterations);
             }
         }
 
@@ -473,13 +475,13 @@ static int pgm_dispatch(T& state, TestInfo info) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         if constexpr (std::is_same_v<T, benchmark::State>) {
             state.SkipWithError("Test failed");
         } else {
-            log_info(LogTest, "Test failed");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Test failed");
         }
         return 1;
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -162,46 +162,54 @@ void init(int argc, char** argv) {
     std::vector<std::string> input_args(argv, argv + argc);
 
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  -t: test type: 0:Terminate 1:Smoke 2:Random 3:PCIe 4:DRAM-read 5:DRAM-write-read 6:Host 7:Packed-read "
             "8:Ringbuffer-read"
             "(default {})",
             DEFAULT_TEST_TYPE);
-        log_info(LogTest, "  -w: warm-up before starting timer (default disabled)");
-        log_info(LogTest, "  -i: host iterations (default {})", DEFAULT_ITERATIONS);
-        log_info(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end_coord.x);
-        log_info(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end_coord.y);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -w: warm-up before starting timer (default disabled)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -i: host iterations (default {})", DEFAULT_ITERATIONS);
+        TT_LOG_INFO_WITH_CAT(LogTest, " -wx: right-most worker in grid (default {})", all_workers_g.end_coord.x);
+        TT_LOG_INFO_WITH_CAT(LogTest, " -wy: bottom-most worker in grid (default {})", all_workers_g.end_coord.y);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  -b: run a \"big\" test (fills memory w/ fewer transactions) (default false)",
             DEFAULT_TEST_TYPE);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             " -rb: gen data, readback and test every iteration - disable for perf measurements (default true)");
-        log_info(LogTest, "  -c: use coherent data as payload (default false)");
-        log_info(LogTest, "  -d: wrap all commands in debug commands and clear DRAM to known state (default disabled)");
-        log_info(LogTest, "  -hp: host huge page issue buffer size (default {})", DEFAULT_HUGEPAGE_ISSUE_BUFFER_SIZE);
-        log_info(LogTest, "  -pq: prefetch queue entries (default {})", DEFAULT_PREFETCH_Q_ENTRIES);
-        log_info(LogTest, "  -cs: cmddat q size (default {})", DEFAULT_CMDDAT_Q_SIZE);
-        log_info(LogTest, "-pdcs: prefetch_d cmddat cb size (default {})", default_settings.prefetch_d_buffer_size_);
-        log_info(LogTest, "  -ss: scratch cb size (default {})", DEFAULT_SCRATCH_DB_SIZE);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -c: use coherent data as payload (default false)");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -d: wrap all commands in debug commands and clear DRAM to known state (default disabled)");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -hp: host huge page issue buffer size (default {})", DEFAULT_HUGEPAGE_ISSUE_BUFFER_SIZE);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -pq: prefetch queue entries (default {})", DEFAULT_PREFETCH_Q_ENTRIES);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -cs: cmddat q size (default {})", DEFAULT_CMDDAT_Q_SIZE);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "-pdcs: prefetch_d cmddat cb size (default {})", default_settings.prefetch_d_buffer_size_);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -ss: scratch cb size (default {})", DEFAULT_SCRATCH_DB_SIZE);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             " -pcies: size of data to transfer in pcie bw test type (default: {})",
             PCIE_TRANSFER_SIZE_DEFAULT);
-        log_info(LogTest, " -dpgs: dram page size in dram bw test type (default: {})", DRAM_PAGE_SIZE_DEFAULT);
-        log_info(LogTest, " -dpgr: dram pages to read in dram bw test type (default: {})", DRAM_PAGES_TO_READ_DEFAULT);
-        log_info(LogTest, " -spre: split prefetcher into H and D variants (default not split)");
-        log_info(LogTest, " -sdis: split dispatcher into H and the other thing variants (default not split)");
-        log_info(LogTest, "  -packetized_timeout_en: packetized path timeout enabled (default false)");
-        log_info(LogTest, "  -packetized_en: packetized path enabled (default false)");
-        log_info(LogTest, "  -device_id: Device on which the test will be run, default = 0");
-        log_info(LogTest, "  -x: execute commands from dram exec_buf (default 0)");
-        log_info(LogTest, "  -mpps: give prefetcher the maximum number of packed data submcds to relay to dispatcher");
-        log_info(LogTest, "-xpls: execute buffer log dram page size (default {})", DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
-        log_info(LogTest, "  -s: seed for randomized tests (default 1)");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, " -dpgs: dram page size in dram bw test type (default: {})", DRAM_PAGE_SIZE_DEFAULT);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, " -dpgr: dram pages to read in dram bw test type (default: {})", DRAM_PAGES_TO_READ_DEFAULT);
+        TT_LOG_INFO_WITH_CAT(LogTest, " -spre: split prefetcher into H and D variants (default not split)");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, " -sdis: split dispatcher into H and the other thing variants (default not split)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -packetized_timeout_en: packetized path timeout enabled (default false)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -packetized_en: packetized path enabled (default false)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -device_id: Device on which the test will be run, default = 0");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -x: execute commands from dram exec_buf (default 0)");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  -mpps: give prefetcher the maximum number of packed data submcds to relay to dispatcher");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "-xpls: execute buffer log dram page size (default {})", DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  -s: seed for randomized tests (default 1)");
         exit(0);
     }
 
@@ -708,7 +716,7 @@ void gen_paged_read_dram_test(
     uint32_t pages_read = 0;
     bool finished = false;
 
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Running Paged Read DRAM test with num_pages: {} page_size: {} to worker_core: {}",
         dram_pages_to_read_g,
@@ -754,7 +762,7 @@ void gen_paged_write_read_dram_test(
     uint32_t pages_written = 0;
     bool finished = false;
 
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "Running Paged Write+Read DRAM test with num_pages: {} page_size: {} to worker_core: {}",
         dram_pages_to_read_g,
@@ -1814,7 +1822,7 @@ void initialize_dram_banks(IDevice* device) {
     auto fill = std::vector<uint32_t>(bank_size / sizeof(uint32_t), 0xBADDF00D);
 
     for (int bank_id = 0; bank_id < num_banks; bank_id++) {
-        log_info(tt::LogTest, "Initializing DRAM {} bytes for bank_id: {}", bank_size, bank_id);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Initializing DRAM {} bytes for bank_id: {}", bank_size, bank_id);
         tt::tt_metal::detail::WriteToDeviceDRAMChannel(device, bank_id, 0, fill);
     }
 }
@@ -2073,7 +2081,7 @@ void configure_for_single_chip(
     constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
 
     if (split_prefetcher_g) {
-        log_info(LogTest, "split prefetcher test, packetized_path_en={}", packetized_path_en_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "split prefetcher test, packetized_path_en={}", packetized_path_en_g);
 
         // prefetch_d
         uint32_t scratch_db_base =
@@ -2197,7 +2205,7 @@ void configure_for_single_chip(
                 packet_switch_4B_pack(dest_endpoint_start_id, 0, 0, 0),  // 24: packetized input dest id
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "run prefetch relay mux at x={},y={}", prefetch_relay_mux_core.x, prefetch_relay_mux_core.y);
 
             std::map<string, string> defines = {
@@ -2271,7 +2279,7 @@ void configure_for_single_chip(
                 packet_switch_4B_pack(0, 0, 0, 0),  // 29: output 3 packetize info
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "run prefetch relay demux at x={},y={}",
                 prefetch_relay_demux_core.x,
@@ -2367,7 +2375,7 @@ void configure_for_single_chip(
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;
     if (split_dispatcher_g) {
-        log_info(LogTest, "split dispatcher test, packetized_path_en={}", packetized_path_en_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "split dispatcher test, packetized_path_en={}", packetized_path_en_g);
 
         // dispatch_hd and dispatch_d
         uint32_t dispatch_d_preamble_size = packetized_path_en_g ? sizeof(dispatch_packet_header_t) : 0;
@@ -2488,7 +2496,7 @@ void configure_for_single_chip(
                 packet_switch_4B_pack(dest_endpoint_start_id, 0, 0, 0),  // 24: packetized input dest id
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "run dispatch relay mux at x={},y={}", dispatch_relay_mux_core.x, dispatch_relay_mux_core.y);
 
             std::map<string, string> defines = {
@@ -2562,7 +2570,7 @@ void configure_for_single_chip(
                 packet_switch_4B_pack(0, 0, 0, 0),  // 29: output 3 packetize info
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "run dispatch relay demux at x={},y={}",
                 dispatch_relay_demux_core.x,
@@ -2646,8 +2654,8 @@ void configure_for_multi_chip(
     CoreCoord tunneler_phys_core = device->ethernet_core_from_logical_core(tunneler_logical_core);
     CoreCoord r_tunneler_logical_core = device_r->get_ethernet_sockets(device_id_l)[0];
     CoreCoord r_tunneler_phys_core = device_r->ethernet_core_from_logical_core(r_tunneler_logical_core);
-    log_info(LogTest, "Left Tunneler = {}", tunneler_logical_core.str());
-    log_info(LogTest, "Right Tunneler = {}", r_tunneler_logical_core.str());
+    TT_LOG_INFO_WITH_CAT(LogTest, "Left Tunneler = {}", tunneler_logical_core.str());
+    TT_LOG_INFO_WITH_CAT(LogTest, "Right Tunneler = {}", r_tunneler_logical_core.str());
 
     // Packetized components will write their status + a few debug values here:
     uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
@@ -2807,7 +2815,7 @@ void configure_for_multi_chip(
     constexpr NOC dispatch_upstream_noc_index = NOC::NOC_1;
 
     if (split_prefetcher_g) {
-        log_info(LogTest, "split prefetcher test, packetized_path_en={}", packetized_path_en_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "split prefetcher test, packetized_path_en={}", packetized_path_en_g);
 
         // prefetch_d
         uint32_t scratch_db_base =
@@ -2933,7 +2941,7 @@ void configure_for_multi_chip(
                 packet_switch_4B_pack(dest_endpoint_start_id, 0, 0, 0),  // 24: packetized input dest id
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "run prefetch relay mux at x={},y={}", prefetch_relay_mux_core.x, prefetch_relay_mux_core.y);
 
             std::map<string, string> defines = {
@@ -3158,7 +3166,7 @@ void configure_for_multi_chip(
                 packet_switch_4B_pack(0, 0, 0, 0),  // 29: output 3 packetize info
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "run prefetch relay demux at x={},y={}",
                 prefetch_relay_demux_core.x,
@@ -3240,7 +3248,7 @@ void configure_for_multi_chip(
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;
     if (split_dispatcher_g) {
-        log_info(LogTest, "split dispatcher test, packetized_path_en={}", packetized_path_en_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "split dispatcher test, packetized_path_en={}", packetized_path_en_g);
 
         // dispatch_hd and dispatch_d
         uint32_t dispatch_d_preamble_size = packetized_path_en_g ? sizeof(dispatch_packet_header_t) : 0;
@@ -3365,7 +3373,7 @@ void configure_for_multi_chip(
                 packet_switch_4B_pack(dest_endpoint_start_id, 0, 0, 0),  // 24: packetized input dest id
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "run dispatch relay mux at x={},y={}", dispatch_relay_mux_core.x, dispatch_relay_mux_core.y);
 
             std::map<string, string> defines = {
@@ -3442,7 +3450,7 @@ void configure_for_multi_chip(
                 packet_switch_4B_pack(0, 0, 0, 0),  // 29: output 3 packetize info
             };
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "run dispatch relay demux at x={},y={}",
                 dispatch_relay_demux_core.x,
@@ -3476,7 +3484,7 @@ void configure_for_multi_chip(
 }
 
 int main(int argc, char** argv) {
-    log_info(tt::LogTest, "test_prefetcher.cpp - Test Start");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "test_prefetcher.cpp - Test Start");
     auto slow_dispatch_mode = getenv("TT_METAL_SLOW_DISPATCH_MODE");
     TT_FATAL(slow_dispatch_mode, "This test only supports TT_METAL_SLOW_DISPATCH_MODE");
 
@@ -3486,7 +3494,7 @@ int main(int argc, char** argv) {
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id_g >= num_devices) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id_g, num_devices - 1);
             throw std::runtime_error("Invalid Device Id.");
         }
@@ -3505,7 +3513,7 @@ int main(int argc, char** argv) {
             // holds mmio chips as well as remote chips accessed through that mmmio chip.
             remote_chips.erase(device_id_l);
             if (device_active_eth_cores.size() == 0) {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
                     device_id_l);
@@ -3522,7 +3530,7 @@ int main(int argc, char** argv) {
                 }
             }
             if (device_id_r == device_id_l) {
-                log_info(LogTest, "Device {} does not have a remote device connected to it.", device_id_l);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Device {} does not have a remote device connected to it.", device_id_l);
                 tt_metal::CloseDevice(device);
                 throw std::runtime_error("Test cannot run on specified device.");
             }
@@ -3592,30 +3600,31 @@ int main(int argc, char** argv) {
             exit(0);
         }
 
-        log_info(LogTest, "Hugepage buffer size {}", std::to_string(hugepage_issue_buffer_size_g));
-        log_info(LogTest, "Prefetch prefetch_q entries {}", std::to_string(prefetch_q_entries_g));
-        log_info(LogTest, "CmdDat buffer size {}", std::to_string(cmddat_q_size_g));
-        log_info(LogTest, "Prefetch scratch buffer size {}", std::to_string(scratch_db_size_g));
-        log_info(LogTest, "Max command size {}", std::to_string(max_prefetch_command_size_g));
+        TT_LOG_INFO_WITH_CAT(LogTest, "Hugepage buffer size {}", std::to_string(hugepage_issue_buffer_size_g));
+        TT_LOG_INFO_WITH_CAT(LogTest, "Prefetch prefetch_q entries {}", std::to_string(prefetch_q_entries_g));
+        TT_LOG_INFO_WITH_CAT(LogTest, "CmdDat buffer size {}", std::to_string(cmddat_q_size_g));
+        TT_LOG_INFO_WITH_CAT(LogTest, "Prefetch scratch buffer size {}", std::to_string(scratch_db_size_g));
+        TT_LOG_INFO_WITH_CAT(LogTest, "Max command size {}", std::to_string(max_prefetch_command_size_g));
         if (test_type_g >= 2) {
             perf_test_g = true;
         }
         if (test_type_g == 3) {
             perf_test_g = true;
-            log_info(LogTest, "PCIE transfer size {}", std::to_string(pcie_transfer_size_g));
+            TT_LOG_INFO_WITH_CAT(LogTest, "PCIE transfer size {}", std::to_string(pcie_transfer_size_g));
         }
         if (test_type_g == 4) {
             perf_test_g = true;
-            log_info(LogTest, "DRAM page size {}", std::to_string(dram_page_size_g));
-            log_info(LogTest, "DRAM pages to read {}", std::to_string(dram_pages_to_read_g));
+            TT_LOG_INFO_WITH_CAT(LogTest, "DRAM page size {}", std::to_string(dram_page_size_g));
+            TT_LOG_INFO_WITH_CAT(LogTest, "DRAM pages to read {}", std::to_string(dram_pages_to_read_g));
         }
         if (use_dram_exec_buf_g) {
-            log_info(LogTest, "Exec commands in DRAM exec_buf w/ page_size={}", 1 << exec_buf_log_page_size_g);
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "Exec commands in DRAM exec_buf w/ page_size={}", 1 << exec_buf_log_page_size_g);
         }
         if (debug_g) {
-            log_info(LogTest, "Debug mode enabled");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Debug mode enabled");
         }
-        log_info(LogTest, "Iterations: {}", iterations_g);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Iterations: {}", iterations_g);
 
         tt::Writer prefetch_q_writer = tt::tt_metal::MetalContext::instance().get_cluster().get_static_tlb_writer(
             tt_cxy_pair(device->id(), phys_prefetch_core_g));
@@ -3647,7 +3656,7 @@ int main(int argc, char** argv) {
         gen_terminate_cmds(terminate_cmds, terminate_sizes);
         gen_prefetcher_cmds(device_r, cmds, cmd_sizes, device_data, l1_buf_base_g);
         if (warmup_g) {
-            log_info(tt::LogTest, "Warming up cache now...");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Warming up cache now...");
             run_test(
                 1,
                 device,
@@ -3667,14 +3676,14 @@ int main(int argc, char** argv) {
             initialize_device_g = true;
         }
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "Generating cmds and running {} iterations (readback_every_iter: {}) now...",
             iterations_g,
             readback_every_iteration_g);
         if (readback_every_iteration_g) {
             for (int i = 0; i < iterations_g; i++) {
-                log_info(LogTest, "Iteration: {}", std::to_string(i));
+                TT_LOG_INFO_WITH_CAT(LogTest, "Iteration: {}", std::to_string(i));
                 initialize_device_g = true;
                 cmds.resize(0);
                 cmd_sizes.resize(0);
@@ -3719,16 +3728,17 @@ int main(int argc, char** argv) {
                 phys_prefetch_core_g,
                 prefetch_q_writer);
 
-            log_info(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
-            log_info(LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / iterations_g);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {}us", elapsed_seconds.count() * 1000 * 1000);
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "Ran in {}us per iteration", elapsed_seconds.count() * 1000 * 1000 / iterations_g);
             log_warning(LogTest, "Performance mode, not validating results");
             if (test_type_g == 2 || test_type_g == 3) {
                 float bw =
                     (long int)bytes_of_data_g * iterations_g / (elapsed_seconds.count() * 1000.0 * 1000.0 * 1000.0);
                 std::stringstream ss;
                 ss << std::fixed << std::setprecision(3) << bw;
-                log_info(LogTest, "Sent {} bytes", bytes_of_data_g * iterations_g);
-                log_info(LogTest, "BW: {} GB/s", ss.str());
+                TT_LOG_INFO_WITH_CAT(LogTest, "Sent {} bytes", bytes_of_data_g * iterations_g);
+                TT_LOG_INFO_WITH_CAT(LogTest, "BW: {} GB/s", ss.str());
             }
         }
 
@@ -3742,7 +3752,7 @@ int main(int argc, char** argv) {
                 phys_prefetch_relay_mux_core,
                 packetized_path_test_results_addr,
                 packetized_path_test_results_size);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "prefetch relay mux status = {}",
                 packet_queue_test_status_to_string(prefetch_relay_mux_results[PQ_TEST_STATUS_INDEX]));
@@ -3753,7 +3763,7 @@ int main(int argc, char** argv) {
                 phys_prefetch_relay_demux_core,
                 packetized_path_test_results_addr,
                 packetized_path_test_results_size);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "prefetch relay demux status = {}",
                 packet_queue_test_status_to_string(prefetch_relay_demux_results[PQ_TEST_STATUS_INDEX]));
@@ -3764,7 +3774,7 @@ int main(int argc, char** argv) {
                 phys_dispatch_relay_mux_core,
                 packetized_path_test_results_addr,
                 packetized_path_test_results_size);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "dispatch relay mux status = {}",
                 packet_queue_test_status_to_string(dispatch_relay_mux_results[PQ_TEST_STATUS_INDEX]));
@@ -3775,7 +3785,7 @@ int main(int argc, char** argv) {
                 phys_dispatch_relay_demux_core,
                 packetized_path_test_results_addr,
                 packetized_path_test_results_size);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "dispatch relay demux status = {}",
                 packet_queue_test_status_to_string(dispatch_relay_demux_results[PQ_TEST_STATUS_INDEX]));
@@ -3794,7 +3804,7 @@ int main(int argc, char** argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "test_prefetcher.cpp - Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "test_prefetcher.cpp - Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "test_prefetcher.cpp - Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -579,7 +579,7 @@ void run(
             for (auto device : device_helper.devices) {
                 tt_metal::EnqueueProgram(device->command_queue(), programs.at(device->id()), false);
             }
-            log_info(tt::LogTest, "Iteration {} Calling Finish", iteration);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Iteration {} Calling Finish", iteration);
             for (auto device : device_helper.devices) {
                 tt_metal::Finish(device->command_queue());
             }
@@ -646,20 +646,20 @@ int main(int argc, char** argv) {
         .disable_trid = disable_trid,
         .num_iterations = num_iterations};
 
-    log_info(tt::LogTest, "Setting up test fixture");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Setting up test fixture");
     ConnectedDevicesHelper device_helper(params);
-    log_info(tt::LogTest, "Done setting up test fixture");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Done setting up test fixture");
     if (device_helper.num_devices < 2) {
-        log_info(tt::LogTest, "Need at least 2 devices to run this test");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Need at least 2 devices to run this test");
         return 0;
     }
 
     // Add more configurations here until proper argc parsing added
     bool success = false;
     success = true;
-    log_info(tt::LogTest, "STARTING");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "STARTING");
     try {
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "benchmark type: {}, measurement type: {}, num_packets: {}, packet_size: {} B, num_buffer_slots: {}",
             magic_enum::enum_name(benchmark_type_enum.value()),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -214,11 +214,11 @@ int main(int argc, char** argv) {
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 2) {
-        log_info(tt::LogTest, "Need at least 2 devices to run this test");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Need at least 2 devices to run this test");
         return 0;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info(tt::LogTest, "Test must be run on WH");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test must be run on WH");
         return 0;
     }
 
@@ -259,7 +259,7 @@ int main(int argc, char** argv) {
         for (auto num_samples : sample_counts) {
             for (auto sample_page_size : sample_sizes) {
                 for (auto max_channels_per_direction : channel_counts) {
-                    log_info(
+                    TT_LOG_INFO_WITH_CAT(
                         tt::LogTest,
                         "num_samples: {}, sample_page_size: {}, num_channels_per_direction: {}",
                         num_samples,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -1001,21 +1001,22 @@ int main(int argc, char** argv) {
         //                      Inputs Setup
         ////////////////////////////////////////////////////////////////////////////
         if (debug) {
-            log_info(LogTest, "row {} x col {} = {} cores", num_cores_y, num_cores_x, num_cores_y * num_cores_x);
-            log_info(LogTest, "in0_block_w {}", in0_block_w);
-            log_info(LogTest, "out_subblock_h {}", out_subblock_h);
-            log_info(LogTest, "out_subblock_w {}", out_subblock_w);
-            log_info(LogTest, "per_core_mt {}", per_core_Mt);
-            log_info(LogTest, "per_core_nt {}", per_core_Nt);
-            log_info(LogTest, "l1_in0 {}", l1_in0);
-            log_info(LogTest, "l1_in1 {}", l1_in1);
-            log_info(LogTest, "l1_out {}", l1_out);
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "row {} x col {} = {} cores", num_cores_y, num_cores_x, num_cores_y * num_cores_x);
+            TT_LOG_INFO_WITH_CAT(LogTest, "in0_block_w {}", in0_block_w);
+            TT_LOG_INFO_WITH_CAT(LogTest, "out_subblock_h {}", out_subblock_h);
+            TT_LOG_INFO_WITH_CAT(LogTest, "out_subblock_w {}", out_subblock_w);
+            TT_LOG_INFO_WITH_CAT(LogTest, "per_core_mt {}", per_core_Mt);
+            TT_LOG_INFO_WITH_CAT(LogTest, "per_core_nt {}", per_core_Nt);
+            TT_LOG_INFO_WITH_CAT(LogTest, "l1_in0 {}", l1_in0);
+            TT_LOG_INFO_WITH_CAT(LogTest, "l1_in1 {}", l1_in1);
+            TT_LOG_INFO_WITH_CAT(LogTest, "l1_out {}", l1_out);
         }
 
-        log_info(LogTest, "Mt = {}, Nt = {}, Kt = {}", Mt, Nt, Kt);
-        log_info(LogTest, "activations = {}x{}", Mt * 32, Kt * 32);
-        log_info(LogTest, "weights = {}x{}", Kt * 32, Nt * 32);
-        log_info(LogTest, "output = {}x{}", Mt * 32, Nt * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Mt = {}, Nt = {}, Kt = {}", Mt, Nt, Kt);
+        TT_LOG_INFO_WITH_CAT(LogTest, "activations = {}x{}", Mt * 32, Kt * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "weights = {}x{}", Kt * 32, Nt * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "output = {}x{}", Mt * 32, Nt * 32);
 
         tt::DataFormat data_format = tt::DataFormat::Float16_b;
         uint32_t single_tile_size = 2 * 1024;
@@ -1114,11 +1115,11 @@ int main(int argc, char** argv) {
         uint64_t num_of_matmul_ops =
             (2 * static_cast<uint64_t>(Kt) * 32 - 1) * (static_cast<uint64_t>(Mt) * static_cast<uint64_t>(Nt) * 1024);
         if (debug) {
-            log_info(LogTest, "number of matmul ops: {}", num_of_matmul_ops);
+            TT_LOG_INFO_WITH_CAT(LogTest, "number of matmul ops: {}", num_of_matmul_ops);
         }
 
         double tflops = static_cast<double>(num_of_matmul_ops) / duration.count() / 1000;
-        log_info(LogTest, "time duration: {} ns, TFLOPS {}", duration.count(), tflops);
+        TT_LOG_INFO_WITH_CAT(LogTest, "time duration: {} ns, TFLOPS {}", duration.count(), tflops);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
@@ -1142,7 +1143,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
             TT_THROW("Command line arguments found exception", e.what());
         }
 
-        log_info(LogTest, "one_buffer_share {}, same_buffer_read {}", one_buffer_share, single_read);
+        TT_LOG_INFO_WITH_CAT(LogTest, "one_buffer_share {}, same_buffer_read {}", one_buffer_share, single_read);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Device Setup
@@ -133,7 +133,7 @@ int main(int argc, char** argv) {
         if (one_buffer_share) {
             shape_Nt = (num_cores_r * num_cores_c) * Nt;
         }
-        log_info(LogTest, "Activations = {}x{}", shape_Nt * 32, 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activations = {}x{}", shape_Nt * 32, 32);
 
         SHAPE shape = {1, 1, shape_Nt * 32, 32};
         std::vector<tt::deprecated::Tensor<bfloat16>> tensors;
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
         CoreCoord end_core = {(std::size_t)num_cores_c - 1, (std::size_t)num_cores_r - 1};
         const CoreRange all_cores(start_core, end_core);
 
-        log_info(LogTest, "core range {},{} - {},{}", start_core.x, start_core.y, end_core.x, end_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "core range {},{} - {},{}", start_core.x, start_core.y, end_core.x, end_core.y);
 
         uint32_t dst_cb_index = 0;
         uint32_t dst_cb_addr = 120 * 1024;
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
         if (one_buffer_share) {
             total_tiles_size_bytes = shape_Nt * single_tile_size;
         }
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "dst_cb_addr {} / {} index {} tiles, activations_addr {} / {} "
             "index {} tiles",
@@ -308,22 +308,22 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Running {} core test", num_cores_r * num_cores_c);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running {} core test", num_cores_r * num_cores_c);
         auto begin = std::chrono::steady_clock::now();
         EnqueueProgram(device->command_queue(), program, false);
         Finish(device->command_queue());
         auto end = std::chrono::steady_clock::now();
         auto elapsed_us = duration_cast<microseconds>(end - begin).count();
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-        log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
-        log_info(LogTest, "Read global to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Read global to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
         tt_metal::DumpDeviceProfileResults(device, program);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         if (validation) {
-            log_info(LogTest, "Validation");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Validation");
             for (int r = 0; r < num_cores_r; ++r) {
                 for (int c = 0; c < num_cores_c; ++c) {
                     std::vector<uint32_t> result_vec;
@@ -361,7 +361,7 @@ int main(int argc, char** argv) {
                         pass = false;
                     } else {
                         if (debug) {
-                            log_info(LogTest, "{}/{} - comparision passed", r, c);
+                            TT_LOG_INFO_WITH_CAT(LogTest, "{}/{} - comparision passed", r, c);
                         }
                     }
                 }
@@ -379,7 +379,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_local_l1.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
 
         tt::DataFormat data_format = tt::DataFormat::Float16_b;
         uint32_t single_tile_size = 2 * 1024;
-        log_info(LogTest, "Activations = {}x{}", Nt * 32, 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activations = {}x{}", Nt * 32, 32);
 
         SHAPE shape = {1, 1, Nt * 32, 32};
 
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
         CoreCoord end_core = {(std::size_t)num_cores_c - 1, (std::size_t)num_cores_r - 1};
         const CoreRange all_cores(start_core, end_core);
 
-        log_info(LogTest, "core range {},{} - {},{}", start_core.x, start_core.y, end_core.x, end_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "core range {},{} - {},{}", start_core.x, start_core.y, end_core.x, end_core.y);
 
         uint32_t dst_cb_index = 0;
         uint32_t dst_cb_addr = 120 * 1024;
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
 
         uint32_t activations_addr = dst_cb_addr + (cb_tiles * single_tile_size);
         uint32_t total_tiles_size_bytes = Nt * single_tile_size;
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "dst_cb_addr {} / {} index {} tiles, activations_addr {} / {} "
             "index {} tiles",
@@ -225,7 +225,8 @@ int main(int argc, char** argv) {
 
                 auto phy_core = device->worker_core_from_logical_core(core);
                 if (debug) {
-                    log_info(LogTest, "{} {} - logical {} {} - phy_core {} {}", r, c, c, r, phy_core.x, phy_core.y);
+                    TT_LOG_INFO_WITH_CAT(
+                        LogTest, "{} {} - logical {} {} - phy_core {} {}", r, c, c, r, phy_core.x, phy_core.y);
                 }
                 tt_metal::SetRuntimeArgs(
                     program,
@@ -235,22 +236,22 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Running {} core test", num_cores_r * num_cores_c);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running {} core test", num_cores_r * num_cores_c);
         auto begin = std::chrono::steady_clock::now();
         EnqueueProgram(device->command_queue(), program, false);
         Finish(device->command_queue());
         auto end = std::chrono::steady_clock::now();
         auto elapsed_us = duration_cast<microseconds>(end - begin).count();
         auto bw = (total_tiles_size_bytes / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-        log_info(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
-        log_info(LogTest, "Read local to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Total bytes transfered: {} Bytes", total_tiles_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Read local to L1: {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
         tt_metal::DumpDeviceProfileResults(device, program);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         if (validation) {
-            log_info(LogTest, "Validation");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Validation");
             for (int r = 0; r < num_cores_r; ++r) {
                 for (int c = 0; c < num_cores_c; ++c) {
                     std::vector<uint32_t> result_vec;
@@ -280,7 +281,7 @@ int main(int argc, char** argv) {
                         pass = false;
                     } else {
                         if (debug) {
-                            log_info(LogTest, "{}/{} - comparision passed", r, c);
+                            TT_LOG_INFO_WITH_CAT(LogTest, "{}/{} - comparision passed", r, c);
                         }
                     }
                 }
@@ -298,7 +299,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
@@ -74,11 +74,11 @@ int main(int argc, char** argv) {
         }
 
         // Device Setup
-        log_info(LogTest, "Running test using device ID {}", device_id);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running test using device ID {}", device_id);
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
         CommandQueue& cq = device->command_queue();
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Measuring performance for buffer_type={}, size={} bytes, page_size={} bytes",
             buffer_type == 0 ? "DRAM" : "L1",
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
 
             auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "EnqueueWriteBuffer to {}: {:.3f}ms, {:.3f}GB/s",
                 buffer_type == 0 ? "DRAM" : "L1",
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
 
             auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "EnqueueReadBuffer from {}: {:.3f}ms, {:.3f}GB/s",
                 buffer_type == 0 ? "DRAM" : "L1",
@@ -148,7 +148,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
         }
         uint64_t buffer_size = stoul(size_string);
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Measuring performance for buffer_type={}, size={}bytes",
             buffer_type == 0 ? "DRAM" : "L1",
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
 
             auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "detail::WriteToBuffer {}: {:.3f}ms, {:.3f}GB/s",
                 buffer_type == 0 ? "DRAM" : "L1",
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
             }
             auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "detail::ReadFromBuffer {}: {:.3f}ms, {:.3f}GB/s",
                 buffer_type == 0 ? "DRAM" : "L1",
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_dram.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
         }
         uint64_t buffer_size = stoul(size_string);
 
-        log_info(LogTest, "Measuring performance for size={}bytes", buffer_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Measuring performance for size={}bytes", buffer_size);
 
         // Device Setup
         int device_id = 0;
@@ -64,10 +64,10 @@ int main(int argc, char** argv) {
         srand(time(0));
         uint32_t dram_addr = 64;
         uint32_t dram_channel = rand() % 8;
-        log_info(LogTest, "Target DRAM channel = {}", dram_channel);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Target DRAM channel = {}", dram_channel);
 
         // Execute Application
-        log_info(LogTest, "iter {}", iter);
+        TT_LOG_INFO_WITH_CAT(LogTest, "iter {}", iter);
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
 
             auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(LogTest, "WriteToDeviceDRAMChannel {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "WriteToDeviceDRAMChannel {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
         }
 
         std::vector<uint32_t> result_vec;
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 
             auto elapsed_us = duration_cast<microseconds>(elapsed_sum / iter).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(LogTest, "ReadFromDeviceDRAMChannel {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "ReadFromDeviceDRAMChannel {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
         }
 
         // Validation & Teardown
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_device_l1.cpp
@@ -50,7 +50,7 @@ int main(int argc, char** argv) {
         }
         uint64_t buffer_size = stoul(size_string);
 
-        log_info(LogTest, "Measuring performance for size={}bytes", buffer_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Measuring performance for size={}bytes", buffer_size);
 
         // Device Setup
         int device_id = 0;
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
         srand(time(0));
         size_t core_x = rand() % 8;
         size_t core_y = rand() % 8;
-        log_info(LogTest, "Target core (x,y) = ({},{})", core_x, core_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Target core (x,y) = ({},{})", core_x, core_y);
         CoreCoord core = {core_x, core_y};
 
         // Can accomodate input size up to 920*1024
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
             auto end = std::chrono::steady_clock::now();
             auto elapsed_us = duration_cast<microseconds>(end - begin).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(LogTest, "WriteToDeviceL1 {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "WriteToDeviceL1 {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
         }
 
         std::vector<uint32_t> result_vec;
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
 
             auto elapsed_us = duration_cast<microseconds>(end - begin).count();
             auto bw = (buffer_size / 1024.0 / 1024.0 / 1024.0) / (elapsed_us / 1000.0 / 1000.0);
-            log_info(LogTest, "ReadFromDeviceL1 {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "ReadFromDeviceL1 {:.3f}ms, {:.3f}GB/s", elapsed_us / 1000.0, bw);
         }
 
         // Validation & Teardown
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux.cpp
@@ -89,39 +89,39 @@ int main(int argc, char **argv) {
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") ||
         test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
-        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
-        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
-        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
-        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
-        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
-        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
-        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
-        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
-        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
-        log_info(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
-        log_info(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
-        log_info(LogTest, "  --num_endpoints: Number of endpoints, default = {}", default_num_endpoints);
-        log_info(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
-        log_info(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
-        log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --num_endpoints: Number of endpoints, default = {}", default_num_endpoints);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
         return 0;
     }
 
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
                     tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
                 };
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -256,7 +256,7 @@ int main(int argc, char **argv) {
                     rx_disable_header_check // 18: disable_header_check
                 };
 
-            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -309,7 +309,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0, 0, 0, 0 // 17-24: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/packet_mux.cpp",
@@ -367,7 +367,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0 // 25-29: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
         auto demux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/packet_demux.cpp",
@@ -380,14 +380,14 @@ int main(int argc, char **argv) {
             }
         );
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
         tt_metal::detail::LaunchProgram(device, program);
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
         vector<vector<uint32_t>> rx_results;
@@ -396,7 +396,7 @@ int main(int argc, char **argv) {
             tx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), tx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
@@ -404,20 +404,20 @@ int main(int argc, char **argv) {
             rx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), rx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
         vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
 
         pass &= tt_metal::CloseDevice(device);
@@ -468,10 +468,10 @@ int main(int argc, char **argv) {
                 uint64_t num_packets = get_64b_result(tx_results[i], TX_TEST_IDX_NPKT);
                 double bytes_per_pkt = static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, tx_words_sent, tx_elapsed_cycles, tx_bw);
-                log_info(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
+                TT_LOG_INFO_WITH_CAT(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
                 stat[fmt::format("tx_words_sent_{}", i)] = tx_words_sent;
                 stat[fmt::format("tx_elapsed_cycles_{}", i)] = tx_elapsed_cycles;
                 stat[fmt::format("tx_bw_{}", i)] = tx_bw;
@@ -481,7 +481,7 @@ int main(int argc, char **argv) {
                 stat[fmt::format("tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["total_tx_bw (B/cycle)"] = total_tx_bw;
 
             double total_rx_bw = 0.0;
@@ -492,20 +492,20 @@ int main(int argc, char **argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, rx_words_checked, rx_elapsed_cycles, rx_bw);
                 stat[fmt::format("rx_words_checked_{}", i)] = rx_words_checked;
                 stat[fmt::format("rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
             }
 
             uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -514,10 +514,10 @@ int main(int argc, char **argv) {
             double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      mux_words_sent, mux_elapsed_cycles, mux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                         "MUX iters = {} -> cycles/iter = {:.1f}",
                         mux_iter, mux_cycles_per_iter);
             stat["mux_words_sent"] = mux_words_sent;
@@ -527,7 +527,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
             }
 
             uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -536,10 +536,10 @@ int main(int argc, char **argv) {
             uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
             double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      demux_words_sent, demux_elapsed_cycles, demux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX iters = {} -> cycles/iter = {:.1f}",
                      demux_iter, demux_cycles_per_iter);
             stat["demux_words_sent"] = demux_words_sent;
@@ -549,7 +549,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
             }
 
             if (pass) {
@@ -578,10 +578,10 @@ int main(int argc, char **argv) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 1024) {
                         target_bandwidth = 13;
-                        log_info(LogTest, "Perf check for pkt size >= 1024 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 256) {
                         target_bandwidth = 4;
-                        log_info(LogTest, "Perf check for pkt size >= 256 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (mux_bw < target_bandwidth) {
                         pass = false;
@@ -605,7 +605,7 @@ int main(int argc, char **argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_mux_demux_2level.cpp
@@ -59,22 +59,22 @@ int main(int argc, char **argv) {
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") ||
         test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
-        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
-        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
-        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
-        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
-        log_info(LogTest, "  --test_results_addr: test results buffer address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buffer size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_addr: test results buffer address, default = 0x{:x}", default_test_results_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_size: test results buffer size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
         return 0;
     }
 
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
                     0, // 20: data_sent_per_iter_low
                     0 // 21: data_sent_per_iter_high
                 };
-            log_info(LogTest, "run TX {} at x={},y={} (phys x={},y={})",
+            TT_LOG_INFO_WITH_CAT(LogTest, "run TX {} at x={},y={} (phys x={},y={})",
                             i, tx_core[i].x, tx_core[i].y, tx_phys_core[i].x, tx_phys_core[i].y);
             auto kernel = tt_metal::CreateKernel(
                 program,
@@ -233,7 +233,7 @@ int main(int argc, char **argv) {
                     timeout_mcycles * 1000 * 1000, // 17: timeout_cycles
                     0 // 18: disable_header_check
                 };
-            log_info(LogTest, "run RX {} at x={},y={} (phys x={},y={})",
+            TT_LOG_INFO_WITH_CAT(LogTest, "run RX {} at x={},y={} (phys x={},y={})",
                     i, rx_core[i].x, rx_core[i].y, rx_phys_core[i].x, rx_phys_core[i].y);
             auto kernel = tt_metal::CreateKernel(
                 program,
@@ -284,7 +284,7 @@ int main(int argc, char **argv) {
                     timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
                     0, 0, 0, 0, 0, 0, 0, 0 // 17-24: packetize/depacketize settings
                 };
-            log_info(LogTest, "run L1 MUX {} at x={},y={} (phys x={},y={})",
+            TT_LOG_INFO_WITH_CAT(LogTest, "run L1 MUX {} at x={},y={} (phys x={},y={})",
                             i, mux_l1_core[i].x, mux_l1_core[i].y, mux_l1_phys_core[i].x, mux_l1_phys_core[i].y);
             auto mux_kernel = tt_metal::CreateKernel(
                 program,
@@ -332,7 +332,7 @@ int main(int argc, char **argv) {
                 timeout_mcycles * 1000 * 1000, // 16: timeout_cycles
                 0, 0, 0, 0, 0, 0, 0, 0 // 17-24: packetize/depacketize settings
             };
-        log_info(LogTest, "run L2 MUX at x={},y={} (phys x={},y={})",
+        TT_LOG_INFO_WITH_CAT(LogTest, "run L2 MUX at x={},y={} (phys x={},y={})",
                  mux_l2_core.x, mux_l2_core.y, mux_l2_phys_core.x, mux_l2_phys_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
@@ -393,7 +393,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0 // 25-29: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run L1 DEMUX at x={},y={} (phys x={},y={})",
+        TT_LOG_INFO_WITH_CAT(LogTest, "run L1 DEMUX at x={},y={} (phys x={},y={})",
                         demux_l1_core.x, demux_l1_core.y, demux_l1_phys_core.x, demux_l1_phys_core.y);
         auto demux_kernel = tt_metal::CreateKernel(
             program,
@@ -458,7 +458,7 @@ int main(int argc, char **argv) {
                     0, 0, 0, 0, 0 // 25-29: packetize/depacketize settings
                 };
 
-            log_info(LogTest, "run L2 DEMUX at x={},y={} (phys x={},y={})",
+            TT_LOG_INFO_WITH_CAT(LogTest, "run L2 DEMUX at x={},y={} (phys x={},y={})",
                             demux_l2_core[i].x, demux_l2_core[i].y, demux_l2_phys_core[i].x, demux_l2_phys_core[i].y);
             auto demux_kernel = tt_metal::CreateKernel(
                 program,
@@ -474,14 +474,14 @@ int main(int argc, char **argv) {
 
         }
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
         tt_metal::detail::LaunchProgram(device, program);
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
         vector<vector<uint32_t>> rx_results;
@@ -494,7 +494,7 @@ int main(int argc, char **argv) {
             tx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), tx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
@@ -502,7 +502,7 @@ int main(int argc, char **argv) {
             rx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), rx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
@@ -511,14 +511,14 @@ int main(int argc, char **argv) {
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), mux_l1_phys_core[i], test_results_addr, test_results_size)
             );
-            log_info(LogTest, "L1 MUX {} status = {}", i, packet_queue_test_status_to_string(mux_l1_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "L1 MUX {} status = {}", i, packet_queue_test_status_to_string(mux_l1_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (mux_l1_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
         mux_l2_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_l2_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "L2 MUX status = {}", packet_queue_test_status_to_string(mux_l2_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "L2 MUX status = {}", packet_queue_test_status_to_string(mux_l2_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_l2_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         for (uint32_t i = 0; i < num_demux_l2; i++) {
@@ -526,14 +526,14 @@ int main(int argc, char **argv) {
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), demux_l2_phys_core[i], test_results_addr, test_results_size)
             );
-            log_info(LogTest, "L2 DEMUX {} status = {}", i, packet_queue_test_status_to_string(demux_l2_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "L2 DEMUX {} status = {}", i, packet_queue_test_status_to_string(demux_l2_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (demux_l2_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
         demux_l1_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_l1_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "L1 DEMUX status = {}", packet_queue_test_status_to_string(demux_l1_results[0]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "L1 DEMUX status = {}", packet_queue_test_status_to_string(demux_l1_results[0]));
         pass &= (demux_l1_results[0] == PACKET_QUEUE_TEST_PASS);
 
         pass &= tt_metal::CloseDevice(device);
@@ -547,29 +547,29 @@ int main(int argc, char **argv) {
                 total_tx_words_sent += tx_words_sent;
                 uint64_t tx_elapsed_cycles = get_64b_result(tx_results[i], PQ_TEST_CYCLES_INDEX);
                 double tx_bw = ((double)tx_words_sent) * PACKET_WORD_SIZE_BYTES / tx_elapsed_cycles;
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, tx_words_sent, tx_elapsed_cycles, tx_bw);
                 total_tx_bw += tx_bw;
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
             double total_rx_bw = 0.0;
             for (uint32_t i = 0; i < num_dest_endpoints; i++) {
                 uint64_t rx_words_checked = get_64b_result(rx_results[i], PQ_TEST_WORD_CNT_INDEX);
                 total_rx_words_checked += rx_words_checked;
                 uint64_t rx_elapsed_cycles = get_64b_result(rx_results[i], PQ_TEST_CYCLES_INDEX);
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, rx_words_checked, rx_elapsed_cycles, rx_bw);
                 total_rx_bw += rx_bw;
             }
-            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
             }
 
             uint64_t mux_l2_words_sent = get_64b_result(mux_l2_results, PQ_TEST_WORD_CNT_INDEX);
@@ -577,17 +577,17 @@ int main(int argc, char **argv) {
             uint64_t mux_l2_iter = get_64b_result(mux_l2_results, PQ_TEST_ITER_INDEX);
             double mux_l2_bw = ((double)mux_l2_words_sent) * PACKET_WORD_SIZE_BYTES / mux_l2_elapsed_cycles;
             double mux_l2_cycles_per_iter = ((double)mux_l2_elapsed_cycles) / mux_l2_iter;
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "L2 MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      mux_l2_words_sent, mux_l2_elapsed_cycles, mux_l2_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                     "L2 MUX iter = {}, elapsed cycles = {} -> cycles/iter = {:.2f}",
                     mux_l2_iter, mux_l2_elapsed_cycles, mux_l2_cycles_per_iter);
             if (mux_l2_words_sent != total_rx_words_checked) {
                 log_error(LogTest, "L2 MUX words sent = {} != Total RX words checked = {}", mux_l2_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "L2 MUX words sent = {} == Total RX words checked = {} -> OK", mux_l2_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "L2 MUX words sent = {} == Total RX words checked = {} -> OK", mux_l2_words_sent, total_rx_words_checked);
             }
 
             uint64_t demux_l1_words_sent = get_64b_result(demux_l1_results, PQ_TEST_WORD_CNT_INDEX);
@@ -595,17 +595,17 @@ int main(int argc, char **argv) {
             uint64_t demux_l1_iter = get_64b_result(demux_l1_results, PQ_TEST_ITER_INDEX);
             double demux_l1_bw = ((double)demux_l1_words_sent) * PACKET_WORD_SIZE_BYTES / demux_l1_elapsed_cycles;
             double demux_l1_cycles_per_iter = ((double)demux_l1_elapsed_cycles) / demux_l1_iter;
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "L1 DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      demux_l1_words_sent, demux_l1_elapsed_cycles, demux_l1_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                     "L1 DEMUX iter = {}, elapsed cycles = {} -> cycles/iter = {:.2f}",
                     demux_l1_iter, demux_l1_elapsed_cycles, demux_l1_cycles_per_iter);
             if (demux_l1_words_sent != total_rx_words_checked) {
                 log_error(LogTest, "L1 DEMUX words sent = {} != Total RX words checked = {}", demux_l1_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "L1 DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_l1_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "L1 DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_l1_words_sent, total_rx_words_checked);
             }
         }
 
@@ -617,7 +617,7 @@ int main(int argc, char **argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -118,70 +118,73 @@ int main(int argc, char** argv) {
 
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --max_packet_size_words: Max packet size in words, default = 0x{:x}",
             default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --routing_table_start_addr: Routing Table start address, default = 0x{:x}",
             default_routing_table_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be "
             "used), default = {}",
             default_check_txrx_timeout);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_data_check: Disable data check on RX, default = {}",
             default_rx_disable_data_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_header_check: Disable header check on RX, default = {}",
             default_rx_disable_header_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}",
             default_tx_skip_pkt_content_gen);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = "
             "{}",
             default_tx_pkt_dest_size_choice);  // pkt_dest_size_choices_t
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_low);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id_l);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --device_id_r: Device on which the test will be run, default = {}", default_test_device_id_r);
         return 0;
     }
@@ -271,7 +274,7 @@ int main(int argc, char** argv) {
 
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id_l >= num_devices) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id_l, num_devices - 1);
             throw std::runtime_error("Invalid Device Id.");
         }
@@ -284,7 +287,7 @@ int main(int argc, char** argv) {
         }
         device_map = tt::tt_metal::detail::CreateDevices(chip_ids);
 
-        log_info(LogTest, "Created {} Devices ...", device_map.size());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Created {} Devices ...", device_map.size());
 
         std::map<chip_id_t, tt_metal::Program> program_map;
 
@@ -292,14 +295,14 @@ int main(int argc, char** argv) {
             program_map[i] = tt_metal::CreateProgram();
         }
 
-        log_info(LogTest, "Created Programs ...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Created Programs ...");
 
         std::map<chip_id_t, std::vector<CoreCoord>> device_router_map;
 
         const auto& device_active_eth_cores = device_map[test_device_id_l]->get_active_ethernet_cores();
 
         if (device_active_eth_cores.size() == 0) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
                 test_device_id_l);
@@ -313,13 +316,13 @@ int main(int argc, char** argv) {
         auto [dev_l_mesh_id, dev_l_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_l);
         auto [dev_r_mesh_id, dev_r_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_r);
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Running on Left  Device {} : Fabric Mesh Id {} : Fabric Device Id {}",
             test_device_id_l,
             dev_l_mesh_id,
             dev_l_chip_id);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Running on Right Device {} : Fabric Mesh Id {} : Fabric Device Id {}",
             test_device_id_r,
@@ -336,9 +339,9 @@ int main(int argc, char** argv) {
         uint32_t client_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
         uint32_t client_pull_req_buf_addr = client_interface_addr + sizeof(fabric_pull_client_interface_t);
         uint32_t socket_info_addr = gk_interface_addr + sizeof(gatekeeper_info_t);
-        log_info(LogTest, "GK Routing Table Addr = 0x{:08X}", routing_table_addr);
-        log_info(LogTest, "GK Info Addr = 0x{:08X}", gk_interface_addr);
-        log_info(LogTest, "GK Socket Info Addr = 0x{:08X}", socket_info_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "GK Routing Table Addr = 0x{:08X}", routing_table_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "GK Info Addr = 0x{:08X}", gk_interface_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "GK Socket Info Addr = 0x{:08X}", socket_info_addr);
 
         for (auto device : device_map) {
             auto neighbors =
@@ -371,7 +374,7 @@ int main(int argc, char** argv) {
                 }
             }
 
-            log_info(LogTest, "Device {} router_mask = 0x{:04X}", device.first, router_mask);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Device {} router_mask = 0x{:04X}", device.first, router_mask);
             uint32_t sem_count = device_router_cores.size();
             device_router_map[device.first] = device_router_phys_cores;
 
@@ -410,7 +413,7 @@ int main(int argc, char** argv) {
                     device.second->ethernet_core_from_logical_core(logical_core));
             }
             // setup runtime args
-            log_info(LogTest, "run tt_fabric gatekeeper at x={},y={}", gk_core.x, gk_core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run tt_fabric gatekeeper at x={},y={}", gk_core.x, gk_core.y);
             std::vector<uint32_t> gk_compile_args = {
                 gk_interface_addr,   // 0:
                 socket_info_addr,    // 1:
@@ -494,7 +497,7 @@ int main(int argc, char** argv) {
                 runtime_args.push_back(target_address);
             }
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program_map[test_device_id_l],
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx.cpp",
@@ -512,7 +515,7 @@ int main(int argc, char** argv) {
             defines.erase("CHECK_TIMEOUT");
         }
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
 
@@ -535,7 +538,7 @@ int main(int argc, char** argv) {
         tt::llrt::write_hex_vec_to_core(test_device_id_l, tx_phys_core[0], zero_buf, test_results_addr);
 
         for (auto device : device_map) {
-            log_info(LogTest, "Launching on {}", device.first);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Launching on {}", device.first);
             tt_metal::detail::LaunchProgram(device.second, program_map[device.first], false);
         }
 
@@ -554,7 +557,7 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Tx Finished");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Tx Finished");
 
         // terminate gatekeeper.
         // Gatekeeper will signal all routers on the device to terminate.
@@ -570,14 +573,15 @@ int main(int argc, char** argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(tt::llrt::read_hex_vec_from_core(
                 device_map[test_device_id_l]->id(), tx_phys_core[i], test_results_addr, 128));
-            log_info(LogTest, "TX{} status = {}", i, tt_fabric_status_to_string(tx_results[i][TT_FABRIC_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "TX{} status = {}", i, tt_fabric_status_to_string(tx_results[i][TT_FABRIC_STATUS_INDEX]));
             pass &= (tx_results[i][TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
         }
         /*
@@ -586,14 +590,14 @@ int main(int argc, char** argv) {
                 vector<uint32_t> router_results =
                     tt::llrt::read_hex_vec_from_core(
                         device_map[test_device_id_l]->id(), tunneler_phys_core, tunneler_test_results_addr, 128);
-                log_info(LogTest, "L Router status = {}",
+                TT_LOG_INFO_WITH_CAT(LogTest, "L Router status = {}",
            tt_fabric_status_to_string(router_results[TT_FABRIC_STATUS_INDEX])); pass &=
            (router_results[TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
 
                 vector<uint32_t> r_router_results =
                     tt::llrt::read_hex_vec_from_core(
                         device_map[test_device_id_r]->id(), r_tunneler_phys_core, tunneler_test_results_addr, 128);
-                log_info(LogTest, "R Router status = {}",
+                TT_LOG_INFO_WITH_CAT(LogTest, "R Router status = {}",
            tt_fabric_status_to_string(r_router_results[TT_FABRIC_STATUS_INDEX])); pass &=
            (r_router_results[TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
         */
@@ -619,16 +623,16 @@ int main(int argc, char** argv) {
                 // double bytes_per_pkt = static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES /
                 // static_cast<double>(num_packets);
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
                     tx_words_sent,
                     tx_elapsed_cycles,
                     tx_bw);
-                // log_info(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent
-                // iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter,
-                // zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
+                // TT_LOG_INFO_WITH_CAT(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero
+                // data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets,
+                // bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
                 /*
                                 stat[fmt::format("tx_words_sent_{}", i)] = tx_words_sent;
                                 stat[fmt::format("tx_elapsed_cycles_{}", i)] = tx_elapsed_cycles;
@@ -640,7 +644,7 @@ int main(int argc, char** argv) {
                                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
                 */
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
         }
 
     } catch (const std::exception& e) {
@@ -651,7 +655,7 @@ int main(int argc, char** argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -959,7 +959,7 @@ typedef struct test_traffic {
             tt::llrt::write_hex_vec_to_core(
                 tx_device->physical_chip_id, controller_virtual_core, zero_buf, host_signal_address);
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "[Device: Phys: {}, Logical: {}] Controller running on: logical: x={},y={}; virtual: x={},y={}",
                 tx_device->physical_chip_id,
@@ -1009,7 +1009,7 @@ typedef struct test_traffic {
             tt::llrt::write_hex_vec_to_core(
                 tx_device->physical_chip_id, tx_virtual_cores[i], zero_buf, tx_signal_address);
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "[Device: Phys: {}, Logical: {}] TX running on: logical: x={},y={}; virtual: x={},y={}, Eth chan: {}",
                 tx_device->physical_chip_id,
@@ -1066,7 +1066,7 @@ typedef struct test_traffic {
                 tt::llrt::write_hex_vec_to_core(
                     rx_device->physical_chip_id, rx_virtual_cores[i], zero_buf, test_results_address);
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "[Device: Phys: {}, Logical: {}] RX kernel running on: logical: x={},y={}; virtual: x={},y={}",
                     rx_device->physical_chip_id,
@@ -1136,7 +1136,7 @@ typedef struct test_traffic {
         for (uint32_t i = 0; i < num_tx_workers; i++) {
             tx_results.push_back(tt::llrt::read_hex_vec_from_core(
                 tx_device->physical_chip_id, tx_virtual_cores[i], test_results_address, 128));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "[Device: Phys: {}, Logical: {}] TX{} status = {}",
                 tx_device->physical_chip_id,
@@ -1152,7 +1152,7 @@ typedef struct test_traffic {
             for (uint32_t i = 0; i < num_rx_workers; i++) {
                 rx_results[d].push_back(tt::llrt::read_hex_vec_from_core(
                     rx_devices[d]->physical_chip_id, rx_virtual_cores[i], test_results_address, 128));
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "[Device: Phys: {}, Logical: {}] RX{} status = {}",
                     rx_devices[d]->physical_chip_id,
@@ -1221,7 +1221,7 @@ typedef struct test_traffic {
             // double bytes_per_pkt = static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES /
             // static_cast<double>(num_packets);
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "[Device: Phys: {}, Logical: {}] TX {} words sent: {}, elapsed cycles: {} -> BW: {:.2f} B/cycle",
                 tx_device->physical_chip_id,
@@ -1230,7 +1230,8 @@ typedef struct test_traffic {
                 tx_words_sent,
                 tx_elapsed_cycles,
                 tx_bw);
-            // log_info(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter =
+            // TT_LOG_INFO_WITH_CAT(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data
+            // sent iter =
             // {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter,
             // zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
             /*
@@ -1256,7 +1257,7 @@ typedef struct test_traffic {
             for (uint32_t i = 0; i < num_rx_workers; i++) {
                 uint64_t words_received = get_64b_result(rx_results[d][i], TT_FABRIC_WORD_CNT_INDEX);
                 uint32_t num_tx = rx_to_tx_map[i].size();
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "[Device: Phys: {}, Logical: {}] RX {}, num producers = {}, words received = {}",
                     rx_devices[d]->physical_chip_id,
@@ -1266,8 +1267,8 @@ typedef struct test_traffic {
                     words_received);
             }
         }
-        // log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
-        log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw_2);
+        // TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw_2);
     }
 
     // generates mapping of tx core indices to rx core indices
@@ -1408,40 +1409,66 @@ int main(int argc, char **argv) {
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") ||
         test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --routing_table_start_addr: Routing Table start address, default = 0x{:x}",
             default_routing_table_start_addr);
-        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --disable_txrx_timeout: Disable timeout during tx & rx (enabled by default)");
-        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
-        log_info(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
-        log_info(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", false);
-        log_info(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
-        log_info(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
-        log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --disable_txrx_timeout: Disable timeout during tx & rx (enabled by default)");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest,
+            "  --rx_disable_data_check: Disable data check on RX, default = {}",
+            default_rx_disable_data_check);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest,
+            "  --rx_disable_header_check: Disable header check on RX, default = {}",
+            default_rx_disable_header_check);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", false);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest,
+            "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = "
+            "{}",
+            default_tx_pkt_dest_size_choice);  // pkt_dest_size_choices_t
+        TT_LOG_INFO_WITH_CAT(
+            LogTest,
+            "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low "
+            "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
+            default_tx_data_sent_per_iter_low);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest,
+            "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high "
+            "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
+            default_tx_data_sent_per_iter_high);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id_l);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --device_id_r: DDevice on which the test will be run, default = {}", default_test_device_id_r);
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --metal_fabric_init_level: use Metal runtime to load fabric, 0 is disable, 1 is enable", 0);
         return 0;
     }
@@ -1770,7 +1797,7 @@ int main(int argc, char **argv) {
             tt_metal::detail::LaunchProgram(test_device->device_handle, test_device->program_handle, false);
         }
 
-        log_info(LogTest, "Programs launched, waiting for router sync");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Programs launched, waiting for router sync");
 
         if (metal_fabric_init_level == 0) {
             // wait for all routers to handshake with master router
@@ -1779,28 +1806,28 @@ int main(int argc, char **argv) {
             }
         }
 
-        log_info(LogTest, "Routers sync done, notifying tx controllers");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Routers sync done, notifying tx controllers");
 
         // notify tx controller to signal the tx workers
         for (auto& traffic : fabric_traffic) {
             traffic.notify_tx_controller();
         }
 
-        log_info(LogTest, "Notified TX controllers, waiting for TX workers to finish");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Notified TX controllers, waiting for TX workers to finish");
 
         // wait for rx kernels to finish
         for (auto& traffic : fabric_traffic) {
             traffic.wait_for_tx_workers_to_finish();
         }
 
-        log_info(LogTest, "TX workers done, waiting for RX workers to finish");
+        TT_LOG_INFO_WITH_CAT(LogTest, "TX workers done, waiting for RX workers to finish");
 
         // wait for rx kernels to finish
         for (auto& traffic : fabric_traffic) {
             traffic.wait_for_rx_workers_to_finish();
         }
 
-        log_info(LogTest, "RX workers done, terminating routers");
+        TT_LOG_INFO_WITH_CAT(LogTest, "RX workers done, terminating routers");
 
         // terminate fabric routers if control plane is not managed by DevicePool
         if (metal_fabric_init_level == 0) {
@@ -1809,7 +1836,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        log_info(LogTest, "Terminated routers, waiting for program done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Terminated routers, waiting for program done");
 
         // wait for programs to exit
         for (auto& [chip_id, test_device] : test_devices) {
@@ -1818,9 +1845,9 @@ int main(int argc, char **argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
-        log_info(LogTest, "Programs done, collecting results");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Programs done, collecting results");
 
         // collect traffic results
         for (auto& traffic : fabric_traffic) {
@@ -1860,7 +1887,7 @@ int main(int argc, char **argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -118,70 +118,73 @@ int main(int argc, char** argv) {
 
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --max_packet_size_words: Max packet size in words, default = 0x{:x}",
             default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --routing_table_start_addr: Routing Table start address, default = 0x{:x}",
             default_routing_table_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be "
             "used), default = {}",
             default_check_txrx_timeout);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_data_check: Disable data check on RX, default = {}",
             default_rx_disable_data_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_header_check: Disable header check on RX, default = {}",
             default_rx_disable_header_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}",
             default_tx_skip_pkt_content_gen);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = "
             "{}",
             default_tx_pkt_dest_size_choice);  // pkt_dest_size_choices_t
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_low);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id_l);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --device_id_r: Device on which the test will be run, default = {}", default_test_device_id_r);
         return 0;
     }
@@ -268,7 +271,7 @@ int main(int argc, char** argv) {
 
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id_l >= num_devices) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id_l, num_devices - 1);
             throw std::runtime_error("Invalid Device Id.");
         }
@@ -281,7 +284,7 @@ int main(int argc, char** argv) {
         }
         device_map = tt::tt_metal::detail::CreateDevices(chip_ids);
 
-        log_info(LogTest, "Created {} Devices ...", device_map.size());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Created {} Devices ...", device_map.size());
 
         std::map<chip_id_t, tt_metal::Program> program_map;
 
@@ -289,14 +292,14 @@ int main(int argc, char** argv) {
             program_map[i] = tt_metal::CreateProgram();
         }
 
-        log_info(LogTest, "Created Programs ...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Created Programs ...");
 
         std::map<chip_id_t, std::vector<CoreCoord>> device_router_map;
 
         const auto& device_active_eth_cores = device_map[test_device_id_l]->get_active_ethernet_cores();
 
         if (device_active_eth_cores.size() == 0) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
                 test_device_id_l);
@@ -310,13 +313,13 @@ int main(int argc, char** argv) {
         auto [dev_l_mesh_id, dev_l_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_l);
         auto [dev_r_mesh_id, dev_r_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_r);
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Running on Left  Device {} : Fabric Mesh Id {} : Fabric Device Id {}",
             test_device_id_l,
             dev_l_mesh_id,
             dev_l_chip_id);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Running on Right Device {} : Fabric Mesh Id {} : Fabric Device Id {}",
             test_device_id_r,
@@ -334,9 +337,9 @@ int main(int argc, char** argv) {
         uint32_t client_interface_addr = routing_table_addr + sizeof(fabric_router_l1_config_t) * 4;
         uint32_t client_pull_req_buf_addr = client_interface_addr + sizeof(fabric_pull_client_interface_t);
         uint32_t socket_info_addr = gk_interface_addr + sizeof(gatekeeper_info_t);
-        log_info(LogTest, "GK Routing Table Addr = 0x{:08X}", routing_table_addr);
-        log_info(LogTest, "GK Info Addr = 0x{:08X}", gk_interface_addr);
-        log_info(LogTest, "GK Socket Info Addr = 0x{:08X}", socket_info_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "GK Routing Table Addr = 0x{:08X}", routing_table_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "GK Info Addr = 0x{:08X}", gk_interface_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "GK Socket Info Addr = 0x{:08X}", socket_info_addr);
 
         for (auto device : device_map) {
             auto neighbors =
@@ -375,7 +378,7 @@ int main(int argc, char** argv) {
                 }
             }
 
-            log_info(LogTest, "Device {} router_mask = 0x{:04X}", device.first, router_mask);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Device {} router_mask = 0x{:04X}", device.first, router_mask);
             uint32_t sem_count = device_router_cores.size();
             device_router_map[device.first] = device_router_phys_cores;
 
@@ -414,7 +417,7 @@ int main(int argc, char** argv) {
                     device.second->ethernet_core_from_logical_core(logical_core));
             }
             // setup runtime args
-            log_info(LogTest, "run tt_fabric gatekeeper at x={},y={}", gk_core.x, gk_core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run tt_fabric gatekeeper at x={},y={}", gk_core.x, gk_core.y);
             std::vector<uint32_t> gk_compile_args = {
                 gk_interface_addr,   // 0:
                 socket_info_addr,    // 1:
@@ -489,7 +492,7 @@ int main(int argc, char** argv) {
                 runtime_args.push_back(target_address);
             }
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program_map[test_device_id_l],
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_tx_socket.cpp",
@@ -528,7 +531,7 @@ int main(int argc, char** argv) {
 
             std::vector<uint32_t> runtime_args = {(dev_l_mesh_id << 16 | dev_l_chip_id)};
 
-            log_info(LogTest, "run socket rx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run socket rx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program_map[test_device_id_r],
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx_socket.cpp",
@@ -546,7 +549,7 @@ int main(int argc, char** argv) {
             defines.erase("CHECK_TIMEOUT");
         }
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
 
@@ -569,7 +572,7 @@ int main(int argc, char** argv) {
         tt::llrt::write_hex_vec_to_core(test_device_id_l, tx_phys_core[0], zero_buf, test_results_addr);
 
         for (auto device : device_map) {
-            log_info(LogTest, "Launching on {}", device.first);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Launching on {}", device.first);
             tt_metal::detail::LaunchProgram(device.second, program_map[device.first], false);
         }
 
@@ -588,7 +591,7 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Tx Finished");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Tx Finished");
 
         // terminate gatekeeper.
         // Gatekeeper will signal all routers on the device to terminate.
@@ -604,14 +607,15 @@ int main(int argc, char** argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
 
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(tt::llrt::read_hex_vec_from_core(
                 device_map[test_device_id_l]->id(), tx_phys_core[i], test_results_addr, 128));
-            log_info(LogTest, "TX{} status = {}", i, tt_fabric_status_to_string(tx_results[i][TT_FABRIC_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(
+                LogTest, "TX{} status = {}", i, tt_fabric_status_to_string(tx_results[i][TT_FABRIC_STATUS_INDEX]));
             pass &= (tx_results[i][TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
         }
         /*
@@ -620,14 +624,14 @@ int main(int argc, char** argv) {
                 vector<uint32_t> router_results =
                     tt::llrt::read_hex_vec_from_core(
                         device_map[test_device_id_l]->id(), tunneler_phys_core, tunneler_test_results_addr, 128);
-                log_info(LogTest, "L Router status = {}",
+                TT_LOG_INFO_WITH_CAT(LogTest, "L Router status = {}",
            tt_fabric_status_to_string(router_results[TT_FABRIC_STATUS_INDEX])); pass &=
            (router_results[TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
 
                 vector<uint32_t> r_router_results =
                     tt::llrt::read_hex_vec_from_core(
                         device_map[test_device_id_r]->id(), r_tunneler_phys_core, tunneler_test_results_addr, 128);
-                log_info(LogTest, "R Router status = {}",
+                TT_LOG_INFO_WITH_CAT(LogTest, "R Router status = {}",
            tt_fabric_status_to_string(r_router_results[TT_FABRIC_STATUS_INDEX])); pass &=
            (r_router_results[TT_FABRIC_STATUS_INDEX] == TT_FABRIC_STATUS_PASS);
         */
@@ -653,16 +657,16 @@ int main(int argc, char** argv) {
                 // double bytes_per_pkt = static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES /
                 // static_cast<double>(num_packets);
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
                     tx_words_sent,
                     tx_elapsed_cycles,
                     tx_bw);
-                // log_info(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent
-                // iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter,
-                // zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
+                // TT_LOG_INFO_WITH_CAT(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero
+                // data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets,
+                // bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
                 /*
                                 stat[fmt::format("tx_words_sent_{}", i)] = tx_words_sent;
                                 stat[fmt::format("tx_elapsed_cycles_{}", i)] = tx_elapsed_cycles;
@@ -674,7 +678,7 @@ int main(int argc, char** argv) {
                                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
                 */
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
         }
 
     } catch (const std::exception& e) {
@@ -685,7 +689,7 @@ int main(int argc, char** argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tx_rx.cpp
@@ -71,27 +71,27 @@ int main(int argc, char **argv) {
         std::vector<std::string> input_args(argv, argv + argc);
         if (test_args::has_command_option(input_args, "-h") ||
             test_args::has_command_option(input_args, "--help")) {
-            log_info(LogTest, "Usage:");
-            log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-            log_info(LogTest, "  --total_data_kb: Total data in KB, default = {}", default_total_data_kb);
-            log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
-            log_info(LogTest, "  --tx_x: X coordinate of the TX core, default = {}", default_tx_x);
-            log_info(LogTest, "  --tx_y: Y coordinate of the TX core, default = {}", default_tx_y);
-            log_info(LogTest, "  --rx_x: X coordinate of the RX core, default = {}", default_rx_x);
-            log_info(LogTest, "  --rx_y: Y coordinate of the RX core, default = {}", default_rx_y);
-            log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-            log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-            log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-            log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-            log_info(LogTest, "  --test_result_buf_addr: Test results buffer address, default = 0x{:x}", default_test_result_buf_addr);
-            log_info(LogTest, "  --test_result_buf_size: Test results buffer size, default = {} bytes", default_test_result_buf_size);
-            log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-            log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
-            log_info(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
-            log_info(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
-            log_info(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
-            log_info(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
-            log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --total_data_kb: Total data in KB, default = {}", default_total_data_kb);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the TX core, default = {}", default_tx_x);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the TX core, default = {}", default_tx_y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the RX core, default = {}", default_rx_x);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the RX core, default = {}", default_rx_y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --test_result_buf_addr: Test results buffer address, default = 0x{:x}", default_test_result_buf_addr);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --test_result_buf_size: Test results buffer size, default = {} bytes", default_test_result_buf_size);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
+            TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
             tt_metal::CloseDevice(device);
             return 0;
         }
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
             }
         );
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
 
@@ -214,7 +214,7 @@ int main(int argc, char **argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<uint32_t> tx_results =
             tt::llrt::read_hex_vec_from_core(
@@ -224,9 +224,9 @@ int main(int argc, char **argv) {
             tt::llrt::read_hex_vec_from_core(
                 device->id(), phys_traffic_gen_rx_core, test_result_buf_addr, test_result_buf_size);
 
-        log_info(LogTest, "TX status = {}",
+        TT_LOG_INFO_WITH_CAT(LogTest, "TX status = {}",
                 packet_queue_test_status_to_string(tx_results[PQ_TEST_STATUS_INDEX]));
-        log_info(LogTest, "RX status = {}",
+        TT_LOG_INFO_WITH_CAT(LogTest, "RX status = {}",
                 packet_queue_test_status_to_string(rx_results[PQ_TEST_STATUS_INDEX]));
 
         pass &= (tx_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
             uint64_t tx_words_sent = get_64b_result(tx_results, PQ_TEST_WORD_CNT_INDEX);
             uint64_t rx_words_checked = get_64b_result(rx_results, PQ_TEST_WORD_CNT_INDEX);
             if (tx_words_sent == rx_words_checked) {
-                log_info(LogTest, "TX words sent = {}, RX words checked = {} -> OK", tx_words_sent, rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "TX words sent = {}, RX words checked = {} -> OK", tx_words_sent, rx_words_checked);
                 if (tx_words_sent < total_data_words) {
                     log_error(LogTest, "TX words sent = {}, total_data_words = {}", tx_words_sent, total_data_words);
                 }
@@ -250,14 +250,14 @@ int main(int argc, char **argv) {
             }
             double elapsed_us = elapsed_seconds.count() * 1000.0 * 1000.0;
             double wall_clock_bw = ((double)total_data_bytes) / elapsed_us;
-            log_info(LogTest, "Wall clock time = {:.2f}us, bytes = {} -> wall clock BW = {:.2f} MB/s",
+            TT_LOG_INFO_WITH_CAT(LogTest, "Wall clock time = {:.2f}us, bytes = {} -> wall clock BW = {:.2f} MB/s",
                 elapsed_us, total_data_bytes, wall_clock_bw);
             uint64_t tx_elapsed_cycles = get_64b_result(tx_results, PQ_TEST_CYCLES_INDEX);
             uint64_t rx_elapsed_cycles = get_64b_result(rx_results, PQ_TEST_CYCLES_INDEX);
             double tx_bw = ((double)total_data_bytes) / tx_elapsed_cycles;
             double rx_bw = ((double)total_data_bytes) / rx_elapsed_cycles;
-            log_info(LogTest, "TX elapsed cycles = {} -> TX BW = {:.2f} B/cycle", tx_elapsed_cycles, tx_bw);
-            log_info(LogTest, "RX elapsed cycles = {} -> RX BW = {:.2f} B/cycle", rx_elapsed_cycles, rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "TX elapsed cycles = {} -> TX BW = {:.2f} B/cycle", tx_elapsed_cycles, tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "RX elapsed cycles = {} -> RX BW = {:.2f} B/cycle", rx_elapsed_cycles, rx_bw);
         }
 
     } catch (const std::exception& e) {
@@ -268,7 +268,7 @@ int main(int argc, char **argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_2ep.cpp
@@ -99,84 +99,84 @@ int main(int argc, char** argv) {
 
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --max_packet_size_words: Max packet size in words, default = 0x{:x}",
             default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
-        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
-        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
-        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}",
             default_mux_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}",
             default_mux_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}",
             default_demux_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}",
             default_demux_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be "
             "used), default = {}",
             default_check_txrx_timeout);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_data_check: Disable data check on RX, default = {}",
             default_rx_disable_data_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_header_check: Disable header check on RX, default = {}",
             default_rx_disable_header_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}",
             default_tx_skip_pkt_content_gen);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = "
             "{}",
             default_tx_pkt_dest_size_choice);  // pkt_dest_size_choices_t
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_low);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
         return 0;
     }
 
@@ -256,7 +256,7 @@ int main(int argc, char** argv) {
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id >= num_devices) {
-            log_info(LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id, num_devices - 1);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id, num_devices - 1);
             throw std::runtime_error("Invalid Device Id.");
         }
         int device_id_l = test_device_id;
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
         auto const& device_active_eth_cores = device->get_active_ethernet_cores();
 
         if (device_active_eth_cores.size() == 0) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
                 device_id_l);
@@ -284,9 +284,9 @@ int main(int argc, char** argv) {
         CoreCoord r_tunneler_logical_core = device_r->get_ethernet_sockets(device_id_l)[0];
         CoreCoord r_tunneler_phys_core = device_r->ethernet_core_from_logical_core(r_tunneler_logical_core);
 
-        log_info(LogTest, "Tx/Rx Device {}. Tunneling Ethernet core = {}.", device_id_l, tunneler_logical_core.str());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Tx/Rx Device {}. Tunneling Ethernet core = {}.", device_id_l, tunneler_logical_core.str());
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "Loopback Device {}. Tunneling Ethernet core = {}.", device_id_r, r_tunneler_logical_core.str());
 
         tt_metal::Program program = tt_metal::CreateProgram();
@@ -333,7 +333,7 @@ int main(int argc, char** argv) {
                 tx_data_sent_per_iter_high                                 // 21: data_sent_per_iter_high
             };
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -374,7 +374,7 @@ int main(int argc, char** argv) {
                 tx_data_sent_per_iter_high                                 // 21: data_sent_per_iter_high
             };
 
-            log_info(LogTest, "run traffic_gen_tx_r at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx_r at x={},y={}", core.x, core.y);
             auto kernel_r = tt_metal::CreateKernel(
                 program_r,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -412,7 +412,7 @@ int main(int argc, char** argv) {
                 rx_disable_header_check                     // 18: disable_header_check
             };
 
-            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -450,7 +450,7 @@ int main(int argc, char** argv) {
                 rx_disable_header_check                     // 18: disable_header_check
             };
 
-            log_info(LogTest, "run traffic_gen_rx_r at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx_r at x={},y={}", core.x, core.y);
             auto kernel_r = tt_metal::CreateKernel(
                 program_r,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -523,7 +523,7 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -590,7 +590,7 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel_r = tt_metal::CreateKernel(
             program_r,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -858,8 +858,8 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
-        log_info(LogTest, "run demux at physical x={},y={}", demux_phys_core.x, demux_phys_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at physical x={},y={}", demux_phys_core.x, demux_phys_core.y);
 
         auto demux_kernel = tt_metal::CreateKernel(
             program,
@@ -932,8 +932,8 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run remote demux at x={},y={}", demux_core.x, demux_core.y);
-        log_info(LogTest, "run remote demux at physical x={},y={}", demux_phys_core_r.x, demux_phys_core_r.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run remote demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run remote demux at physical x={},y={}", demux_phys_core_r.x, demux_phys_core_r.y);
 
         auto demux_kernel_r = tt_metal::CreateKernel(
             program_r,
@@ -945,7 +945,7 @@ int main(int argc, char** argv) {
                 .compile_args = demux_compile_args_r,
                 .defines = defines});
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
         tt_metal::detail::LaunchProgram(device, program, false);
@@ -955,7 +955,7 @@ int main(int argc, char** argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
         vector<vector<uint32_t>> tx_results_r;
@@ -965,7 +965,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(device->id(), tx_phys_core[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "TX{} status = {}",
                 i,
@@ -976,7 +976,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results_r.push_back(tt::llrt::read_hex_vec_from_core(
                 device_r->id(), tx_phys_core_r[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R TX{} status = {}",
                 i,
@@ -987,7 +987,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_dest_endpoints; i++) {
             rx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(device->id(), rx_phys_core[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "RX{} status = {}",
                 i,
@@ -997,7 +997,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_dest_endpoints; i++) {
             rx_results_r.push_back(tt::llrt::read_hex_vec_from_core(
                 device_r->id(), rx_phys_core_r[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R RX{} status = {}",
                 i,
@@ -1007,22 +1007,22 @@ int main(int argc, char** argv) {
 
         vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(device->id(), mux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> mux_results_r =
             tt::llrt::read_hex_vec_from_core(device_r->id(), mux_phys_core_r, test_results_addr, test_results_size);
-        log_info(LogTest, "R MUX status = {}", packet_queue_test_status_to_string(mux_results_r[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "R MUX status = {}", packet_queue_test_status_to_string(mux_results_r[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results_r[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(device->id(), demux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results_r =
             tt::llrt::read_hex_vec_from_core(device_r->id(), demux_phys_core_r, test_results_addr, test_results_size);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "R DEMUX status = {}", packet_queue_test_status_to_string(demux_results_r[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results_r[0] == PACKET_QUEUE_TEST_PASS);
 
@@ -1089,14 +1089,14 @@ int main(int argc, char** argv) {
                 double bytes_per_pkt =
                     static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
                     tx_words_sent,
                     tx_elapsed_cycles,
                     tx_bw);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few "
                     "data sent iter = {}, many data sent iter = {}",
@@ -1116,7 +1116,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["total_tx_bw (B/cycle)"] = total_tx_bw;
 
             double total_rx_bw = 0.0;
@@ -1127,7 +1127,7 @@ int main(int argc, char** argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
@@ -1138,7 +1138,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("r_rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("r_rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "R Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["r_total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(
@@ -1148,7 +1148,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R Total TX words sent = {} == Total RX words checked = {} -> OK",
                     total_tx_words_sent,
@@ -1172,14 +1172,14 @@ int main(int argc, char** argv) {
                 double bytes_per_pkt =
                     static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
                     tx_words_sent,
                     tx_elapsed_cycles,
                     tx_bw);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few "
                     "data sent iter = {}, many data sent iter = {}",
@@ -1199,7 +1199,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("r_tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("r_tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "R Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["r_total_tx_bw (B/cycle)"] = total_tx_bw;
 
             total_rx_bw = 0.0;
@@ -1210,7 +1210,7 @@ int main(int argc, char** argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
@@ -1221,7 +1221,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(
@@ -1231,7 +1231,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "Total TX words sent = {} == Total RX words checked = {} -> OK",
                     total_tx_words_sent,
@@ -1244,13 +1244,13 @@ int main(int argc, char** argv) {
             double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 mux_words_sent,
                 mux_elapsed_cycles,
                 mux_bw);
-            log_info(LogTest, "MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
             stat["mux_words_sent"] = mux_words_sent;
             stat["mux_elapsed_cycles"] = mux_elapsed_cycles;
             stat["mux_bw (B/cycle)"] = mux_bw;
@@ -1262,7 +1262,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "MUX words sent = {} == Total RX words checked = {} -> OK",
                     mux_words_sent,
@@ -1275,13 +1275,13 @@ int main(int argc, char** argv) {
             mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 mux_words_sent,
                 mux_elapsed_cycles,
                 mux_bw);
-            log_info(LogTest, "R MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
             stat["r_mux_words_sent"] = mux_words_sent;
             stat["r_mux_elapsed_cycles"] = mux_elapsed_cycles;
             stat["r_mux_bw (B/cycle)"] = mux_bw;
@@ -1293,7 +1293,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R MUX words sent = {} == Total RX words checked = {} -> OK",
                     mux_words_sent,
@@ -1306,13 +1306,13 @@ int main(int argc, char** argv) {
             uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
             double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 demux_words_sent,
                 demux_elapsed_cycles,
                 demux_bw);
-            log_info(LogTest, "DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
             stat["demux_words_sent"] = demux_words_sent;
             stat["demux_elapsed_cycles"] = demux_elapsed_cycles;
             stat["demux_bw (B/cycle)"] = demux_bw;
@@ -1324,7 +1324,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "DEMUX words sent = {} == Total RX words checked = {} -> OK",
                     demux_words_sent,
@@ -1337,13 +1337,13 @@ int main(int argc, char** argv) {
             demux_iter = get_64b_result(demux_results_r, PQ_TEST_ITER_INDEX);
             demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 demux_words_sent,
                 demux_elapsed_cycles,
                 demux_bw);
-            log_info(LogTest, "R DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
             stat["r_demux_words_sent"] = demux_words_sent;
             stat["r_demux_elapsed_cycles"] = demux_elapsed_cycles;
             stat["r_demux_bw (B/cycle)"] = demux_bw;
@@ -1355,7 +1355,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R DEMUX words sent = {} == Total RX words checked = {} -> OK",
                     demux_words_sent,
@@ -1403,16 +1403,16 @@ int main(int argc, char** argv) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 2048) {
                         target_bandwidth = 4.5;
-                        log_info(LogTest, "Perf check for pkt size >= 2048 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 2048 words");
                     } else if (max_packet_size_words >= 1024) {
                         target_bandwidth = 4.3;
-                        log_info(LogTest, "Perf check for pkt size >= 1024 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 512) {
                         target_bandwidth = 2.4;
-                        log_info(LogTest, "Perf check for pkt size >= 512 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 512 words");
                     } else if (max_packet_size_words >= 256) {
                         target_bandwidth = 1;
-                        log_info(LogTest, "Perf check for pkt size >= 256 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (demux_bw < target_bandwidth) {  // remote demux
                         pass = false;
@@ -1435,7 +1435,7 @@ int main(int argc, char** argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_bi_tunnel_4ep.cpp
@@ -99,84 +99,84 @@ int main(int argc, char** argv) {
 
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --max_packet_size_words: Max packet size in words, default = 0x{:x}",
             default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
-        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
-        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
-        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}",
             default_mux_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}",
             default_mux_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}",
             default_demux_queue_start_addr);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}",
             default_demux_queue_size_bytes);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be "
             "used), default = {}",
             default_check_txrx_timeout);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_data_check: Disable data check on RX, default = {}",
             default_rx_disable_data_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --rx_disable_header_check: Disable header check on RX, default = {}",
             default_rx_disable_header_check);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}",
             default_tx_skip_pkt_content_gen);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = "
             "{}",
             default_tx_pkt_dest_size_choice);  // pkt_dest_size_choices_t
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_low);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high "
             "(unit: words); if both 0, then disable counting it in tx kernel, default = {}",
             default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
         return 0;
     }
 
@@ -256,7 +256,7 @@ int main(int argc, char** argv) {
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id >= num_devices) {
-            log_info(LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id, num_devices - 1);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Device {} is not valid. Highest valid device id = {}.", test_device_id, num_devices - 1);
             throw std::runtime_error("Invalid Device Id.");
         }
         int device_id_l = test_device_id;
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
         auto const& device_active_eth_cores = device->get_active_ethernet_cores();
 
         if (device_active_eth_cores.size() == 0) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
                 device_id_l);
@@ -284,9 +284,9 @@ int main(int argc, char** argv) {
         CoreCoord r_tunneler_logical_core = device_r->get_ethernet_sockets(device_id_l)[0];
         CoreCoord r_tunneler_phys_core = device_r->ethernet_core_from_logical_core(r_tunneler_logical_core);
 
-        log_info(LogTest, "Tx/Rx Device {}. Tunneling Ethernet core = {}.", device_id_l, tunneler_logical_core.str());
+        TT_LOG_INFO_WITH_CAT(LogTest, "Tx/Rx Device {}. Tunneling Ethernet core = {}.", device_id_l, tunneler_logical_core.str());
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "Loopback Device {}. Tunneling Ethernet core = {}.", device_id_r, r_tunneler_logical_core.str());
 
         tt_metal::Program program = tt_metal::CreateProgram();
@@ -333,7 +333,7 @@ int main(int argc, char** argv) {
                 tx_data_sent_per_iter_high                                 // 21: data_sent_per_iter_high
             };
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -374,7 +374,7 @@ int main(int argc, char** argv) {
                 tx_data_sent_per_iter_high                                 // 21: data_sent_per_iter_high
             };
 
-            log_info(LogTest, "run traffic_gen_tx_r at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx_r at x={},y={}", core.x, core.y);
             auto kernel_r = tt_metal::CreateKernel(
                 program_r,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -412,7 +412,7 @@ int main(int argc, char** argv) {
                 rx_disable_header_check                     // 18: disable_header_check
             };
 
-            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -450,7 +450,7 @@ int main(int argc, char** argv) {
                 rx_disable_header_check                     // 18: disable_header_check
             };
 
-            log_info(LogTest, "run traffic_gen_rx_r at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx_r at x={},y={}", core.x, core.y);
             auto kernel_r = tt_metal::CreateKernel(
                 program_r,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -539,7 +539,7 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -622,7 +622,7 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel_r = tt_metal::CreateKernel(
             program_r,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -980,8 +980,8 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
-        log_info(LogTest, "run demux at physical x={},y={}", demux_phys_core.x, demux_phys_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at physical x={},y={}", demux_phys_core.x, demux_phys_core.y);
 
         auto demux_kernel = tt_metal::CreateKernel(
             program,
@@ -1070,8 +1070,8 @@ int main(int argc, char** argv) {
             0  // 25-35: packetize/depacketize settings
         };
 
-        log_info(LogTest, "run remote demux at x={},y={}", demux_core.x, demux_core.y);
-        log_info(LogTest, "run remote demux at physical x={},y={}", demux_phys_core_r.x, demux_phys_core_r.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run remote demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run remote demux at physical x={},y={}", demux_phys_core_r.x, demux_phys_core_r.y);
 
         auto demux_kernel_r = tt_metal::CreateKernel(
             program_r,
@@ -1083,7 +1083,7 @@ int main(int argc, char** argv) {
                 .compile_args = demux_compile_args_r,
                 .defines = defines});
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
         tt_metal::detail::LaunchProgram(device, program, false);
@@ -1093,7 +1093,7 @@ int main(int argc, char** argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
         vector<vector<uint32_t>> tx_results_r;
@@ -1103,7 +1103,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(device->id(), tx_phys_core[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "TX{} status = {}",
                 i,
@@ -1114,7 +1114,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_src_endpoints; i++) {
             tx_results_r.push_back(tt::llrt::read_hex_vec_from_core(
                 device_r->id(), tx_phys_core_r[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R TX{} status = {}",
                 i,
@@ -1125,7 +1125,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_dest_endpoints; i++) {
             rx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(device->id(), rx_phys_core[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "RX{} status = {}",
                 i,
@@ -1135,7 +1135,7 @@ int main(int argc, char** argv) {
         for (uint32_t i = 0; i < num_dest_endpoints; i++) {
             rx_results_r.push_back(tt::llrt::read_hex_vec_from_core(
                 device_r->id(), rx_phys_core_r[i], test_results_addr, test_results_size));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R RX{} status = {}",
                 i,
@@ -1145,22 +1145,22 @@ int main(int argc, char** argv) {
 
         vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(device->id(), mux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> mux_results_r =
             tt::llrt::read_hex_vec_from_core(device_r->id(), mux_phys_core_r, test_results_addr, test_results_size);
-        log_info(LogTest, "R MUX status = {}", packet_queue_test_status_to_string(mux_results_r[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "R MUX status = {}", packet_queue_test_status_to_string(mux_results_r[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results_r[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(device->id(), demux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results_r =
             tt::llrt::read_hex_vec_from_core(device_r->id(), demux_phys_core_r, test_results_addr, test_results_size);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest, "R DEMUX status = {}", packet_queue_test_status_to_string(demux_results_r[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results_r[0] == PACKET_QUEUE_TEST_PASS);
 
@@ -1227,14 +1227,14 @@ int main(int argc, char** argv) {
                 double bytes_per_pkt =
                     static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
                     tx_words_sent,
                     tx_elapsed_cycles,
                     tx_bw);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few "
                     "data sent iter = {}, many data sent iter = {}",
@@ -1254,7 +1254,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["total_tx_bw (B/cycle)"] = total_tx_bw;
 
             double total_rx_bw = 0.0;
@@ -1265,7 +1265,7 @@ int main(int argc, char** argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
@@ -1276,7 +1276,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("r_rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("r_rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "R Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["r_total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(
@@ -1286,7 +1286,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R Total TX words sent = {} == Total RX words checked = {} -> OK",
                     total_tx_words_sent,
@@ -1310,14 +1310,14 @@ int main(int argc, char** argv) {
                 double bytes_per_pkt =
                     static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
                     tx_words_sent,
                     tx_elapsed_cycles,
                     tx_bw);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few "
                     "data sent iter = {}, many data sent iter = {}",
@@ -1337,7 +1337,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("r_tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("r_tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "R Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["r_total_tx_bw (B/cycle)"] = total_tx_bw;
 
             total_rx_bw = 0.0;
@@ -1348,7 +1348,7 @@ int main(int argc, char** argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                     i,
@@ -1359,7 +1359,7 @@ int main(int argc, char** argv) {
                 stat[fmt::format("rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(
@@ -1369,7 +1369,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "Total TX words sent = {} == Total RX words checked = {} -> OK",
                     total_tx_words_sent,
@@ -1382,13 +1382,13 @@ int main(int argc, char** argv) {
             double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 mux_words_sent,
                 mux_elapsed_cycles,
                 mux_bw);
-            log_info(LogTest, "MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
             stat["mux_words_sent"] = mux_words_sent;
             stat["mux_elapsed_cycles"] = mux_elapsed_cycles;
             stat["mux_bw (B/cycle)"] = mux_bw;
@@ -1400,7 +1400,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "MUX words sent = {} == Total RX words checked = {} -> OK",
                     mux_words_sent,
@@ -1413,13 +1413,13 @@ int main(int argc, char** argv) {
             mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 mux_words_sent,
                 mux_elapsed_cycles,
                 mux_bw);
-            log_info(LogTest, "R MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R MUX iters = {} -> cycles/iter = {:.1f}", mux_iter, mux_cycles_per_iter);
             stat["r_mux_words_sent"] = mux_words_sent;
             stat["r_mux_elapsed_cycles"] = mux_elapsed_cycles;
             stat["r_mux_bw (B/cycle)"] = mux_bw;
@@ -1431,7 +1431,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R MUX words sent = {} == Total RX words checked = {} -> OK",
                     mux_words_sent,
@@ -1444,13 +1444,13 @@ int main(int argc, char** argv) {
             uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
             double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 demux_words_sent,
                 demux_elapsed_cycles,
                 demux_bw);
-            log_info(LogTest, "DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
             stat["demux_words_sent"] = demux_words_sent;
             stat["demux_elapsed_cycles"] = demux_elapsed_cycles;
             stat["demux_bw (B/cycle)"] = demux_bw;
@@ -1462,7 +1462,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "DEMUX words sent = {} == Total RX words checked = {} -> OK",
                     demux_words_sent,
@@ -1475,13 +1475,13 @@ int main(int argc, char** argv) {
             demux_iter = get_64b_result(demux_results_r, PQ_TEST_ITER_INDEX);
             demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "R DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                 demux_words_sent,
                 demux_elapsed_cycles,
                 demux_bw);
-            log_info(LogTest, "R DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
+            TT_LOG_INFO_WITH_CAT(LogTest, "R DEMUX iters = {} -> cycles/iter = {:.1f}", demux_iter, demux_cycles_per_iter);
             stat["r_demux_words_sent"] = demux_words_sent;
             stat["r_demux_elapsed_cycles"] = demux_elapsed_cycles;
             stat["r_demux_bw (B/cycle)"] = demux_bw;
@@ -1493,7 +1493,7 @@ int main(int argc, char** argv) {
                     total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogTest,
                     "R DEMUX words sent = {} == Total RX words checked = {} -> OK",
                     demux_words_sent,
@@ -1541,16 +1541,16 @@ int main(int argc, char** argv) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 2048) {
                         target_bandwidth = 3.8;
-                        log_info(LogTest, "Perf check for pkt size >= 2048 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 2048 words");
                     } else if (max_packet_size_words >= 1024) {
                         target_bandwidth = 3.9;
-                        log_info(LogTest, "Perf check for pkt size >= 1024 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 512) {
                         target_bandwidth = 2;
-                        log_info(LogTest, "Perf check for pkt size >= 512 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 512 words");
                     } else if (max_packet_size_words >= 256) {
                         target_bandwidth = 1;
-                        log_info(LogTest, "Perf check for pkt size >= 256 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (demux_bw < target_bandwidth) {
                         pass = false;
@@ -1573,7 +1573,7 @@ int main(int argc, char** argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_loopback_tunnel.cpp
@@ -99,39 +99,39 @@ int main(int argc, char **argv) {
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") ||
         test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
-        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
-        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
-        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
-        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
-        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
-        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
-        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
-        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
-        log_info(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
-        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
-        log_info(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
-        log_info(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
-        log_info(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
-        log_info(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
-        log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
         return 0;
     }
 
@@ -183,7 +183,7 @@ int main(int argc, char **argv) {
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id >= num_devices) {
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                 "Device {} is not valid. Highest valid device id = {}.",
                 test_device_id, num_devices-1);
             throw std::runtime_error("Invalid Device Id.");
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
         auto const& device_active_eth_cores = device->get_active_ethernet_cores();
 
         if (device_active_eth_cores.size() == 0) {
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                 "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
                 device_id_l);
             tt_metal::CloseDevice(device);
@@ -212,11 +212,11 @@ int main(int argc, char **argv) {
         CoreCoord r_tunneler_logical_core = device_r->get_ethernet_sockets(device_id_l)[0];
         CoreCoord r_tunneler_phys_core = device_r->ethernet_core_from_logical_core(r_tunneler_logical_core);
 
-        log_info(LogTest,
+        TT_LOG_INFO_WITH_CAT(LogTest,
             "Tx/Rx Device {}. Tunneling Ethernet core = {}.",
             device_id_l, tunneler_logical_core.str());
 
-        log_info(LogTest,
+        TT_LOG_INFO_WITH_CAT(LogTest,
             "Loopback Device {}. Tunneling Ethernet core = {}.",
             device_id_r, r_tunneler_logical_core.str());
 
@@ -268,7 +268,7 @@ int main(int argc, char **argv) {
                     tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
                 };
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -309,7 +309,7 @@ int main(int argc, char **argv) {
                     rx_disable_header_check // 18: disable_header_check
                 };
 
-            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -382,7 +382,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -680,7 +680,7 @@ int main(int argc, char **argv) {
             };
 
 
-        log_info(LogTest, "run loopback mux at x={},y={}", loopback_mux_core.x, loopback_mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run loopback mux at x={},y={}", loopback_mux_core.x, loopback_mux_core.y);
         auto loopback_mux_kernel = tt_metal::CreateKernel(
             program_r,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -758,9 +758,9 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
-        log_info(LogTest, "run demux at physical x={},y={}", demux_phys_core.x, demux_phys_core.y);
-        log_info(LogTest, "run demux at physical_r x={},y={}", demux_phys_core_r.x, demux_phys_core_r.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at physical x={},y={}", demux_phys_core.x, demux_phys_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at physical_r x={},y={}", demux_phys_core_r.x, demux_phys_core_r.y);
 
         auto demux_kernel = tt_metal::CreateKernel(
             program,
@@ -774,7 +774,7 @@ int main(int argc, char **argv) {
             }
         );
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
         tt_metal::detail::LaunchProgram(device, program, false);
@@ -784,7 +784,7 @@ int main(int argc, char **argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
         vector<vector<uint32_t>> rx_results;
@@ -793,7 +793,7 @@ int main(int argc, char **argv) {
             tx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), tx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
@@ -801,26 +801,26 @@ int main(int argc, char **argv) {
             rx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), rx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
         vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> loopback_mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device_r->id(), loopback_mux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "LOOPBACK MUX status = {}", packet_queue_test_status_to_string(loopback_mux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "LOOPBACK MUX status = {}", packet_queue_test_status_to_string(loopback_mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (loopback_mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
 
         pass &= tt_metal::CloseDevice(device);
@@ -874,10 +874,10 @@ int main(int argc, char **argv) {
                 uint64_t num_packets = get_64b_result(tx_results[i], TX_TEST_IDX_NPKT);
                 double bytes_per_pkt = static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, tx_words_sent, tx_elapsed_cycles, tx_bw);
-                log_info(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
+                TT_LOG_INFO_WITH_CAT(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
                 stat[fmt::format("tx_words_sent_{}", i)] = tx_words_sent;
                 stat[fmt::format("tx_elapsed_cycles_{}", i)] = tx_elapsed_cycles;
                 stat[fmt::format("tx_bw_{}", i)] = tx_bw;
@@ -887,7 +887,7 @@ int main(int argc, char **argv) {
                 stat[fmt::format("tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["total_tx_bw (B/cycle)"] = total_tx_bw;
 
             double total_rx_bw = 0.0;
@@ -898,20 +898,20 @@ int main(int argc, char **argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, rx_words_checked, rx_elapsed_cycles, rx_bw);
                 stat[fmt::format("rx_words_checked_{}", i)] = rx_words_checked;
                 stat[fmt::format("rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
             }
 
             uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -920,10 +920,10 @@ int main(int argc, char **argv) {
             double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      mux_words_sent, mux_elapsed_cycles, mux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                         "MUX iters = {} -> cycles/iter = {:.1f}",
                         mux_iter, mux_cycles_per_iter);
             stat["mux_words_sent"] = mux_words_sent;
@@ -933,7 +933,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
             }
 
             uint64_t loopback_mux_words_sent = get_64b_result(loopback_mux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -942,10 +942,10 @@ int main(int argc, char **argv) {
             double loopback_mux_bw = ((double)loopback_mux_words_sent) * PACKET_WORD_SIZE_BYTES / loopback_mux_elapsed_cycles;
             double loopback_mux_cycles_per_iter = ((double)loopback_mux_elapsed_cycles) / loopback_mux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "LOOPBACK MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      loopback_mux_words_sent, loopback_mux_elapsed_cycles, loopback_mux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                         "LOOPBACK MUX iters = {} -> cycles/iter = {:.1f}",
                         loopback_mux_iter, loopback_mux_cycles_per_iter);
             stat["loopback_mux_words_sent"] = loopback_mux_words_sent;
@@ -955,7 +955,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "LOOPBACK MUX words sent = {} != Total RX words checked = {}", loopback_mux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "LOOPBACK MUX words sent = {} == Total RX words checked = {} -> OK", loopback_mux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "LOOPBACK MUX words sent = {} == Total RX words checked = {} -> OK", loopback_mux_words_sent, total_rx_words_checked);
             }
 
             uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -964,10 +964,10 @@ int main(int argc, char **argv) {
             uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
             double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      demux_words_sent, demux_elapsed_cycles, demux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX iters = {} -> cycles/iter = {:.1f}",
                      demux_iter, demux_cycles_per_iter);
             stat["demux_words_sent"] = demux_words_sent;
@@ -977,7 +977,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
             }
 
             if (pass) {
@@ -1006,16 +1006,16 @@ int main(int argc, char **argv) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 2048) {
                         target_bandwidth = 4;
-                        log_info(LogTest, "Perf check for pkt size >= 2048 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 2048 words");
                     } else if (max_packet_size_words >= 1024) {
                         target_bandwidth = 4;
-                        log_info(LogTest, "Perf check for pkt size >= 1024 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 512) {
                         target_bandwidth = 2;
-                        log_info(LogTest, "Perf check for pkt size >= 512 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 512 words");
                     }else if (max_packet_size_words >= 256) {
                         target_bandwidth = 1;
-                        log_info(LogTest, "Perf check for pkt size >= 256 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (loopback_mux_bw < target_bandwidth) {
                         pass = false;
@@ -1039,7 +1039,7 @@ int main(int argc, char **argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_mux_demux.cpp
@@ -89,39 +89,39 @@ int main(int argc, char **argv) {
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") ||
         test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
-        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
-        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
-        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
-        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
-        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
-        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
-        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
-        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
-        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
-        log_info(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
-        log_info(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
-        log_info(LogTest, "  --num_endpoints: Number of endpoints, default = {}", default_num_endpoints);
-        log_info(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
-        log_info(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
-        log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --num_endpoints: Number of endpoints, default = {}", default_num_endpoints);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
         return 0;
     }
 
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
                     tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
                 };
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -256,7 +256,7 @@ int main(int argc, char **argv) {
                     rx_disable_header_check // 18: disable_header_check
                 };
 
-            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -329,7 +329,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -403,7 +403,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0, 0// 30-35: packetize settings
             };
 
-        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
         auto demux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -416,14 +416,14 @@ int main(int argc, char **argv) {
             }
         );
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
         tt_metal::detail::LaunchProgram(device, program);
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
         vector<vector<uint32_t>> rx_results;
@@ -432,7 +432,7 @@ int main(int argc, char **argv) {
             tx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), tx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
@@ -440,20 +440,20 @@ int main(int argc, char **argv) {
             rx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), rx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
         vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), demux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
 
         pass &= tt_metal::CloseDevice(device);
@@ -508,10 +508,10 @@ int main(int argc, char **argv) {
                 uint64_t num_packets = get_64b_result(tx_results[i], TX_TEST_IDX_NPKT);
                 double bytes_per_pkt = static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, tx_words_sent, tx_elapsed_cycles, tx_bw);
-                log_info(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
+                TT_LOG_INFO_WITH_CAT(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
                 stat[fmt::format("tx_words_sent_{}", i)] = tx_words_sent;
                 stat[fmt::format("tx_elapsed_cycles_{}", i)] = tx_elapsed_cycles;
                 stat[fmt::format("tx_bw_{}", i)] = tx_bw;
@@ -521,7 +521,7 @@ int main(int argc, char **argv) {
                 stat[fmt::format("tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["total_tx_bw (B/cycle)"] = total_tx_bw;
 
             double total_rx_bw = 0.0;
@@ -532,20 +532,20 @@ int main(int argc, char **argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, rx_words_checked, rx_elapsed_cycles, rx_bw);
                 stat[fmt::format("rx_words_checked_{}", i)] = rx_words_checked;
                 stat[fmt::format("rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
             }
 
             uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -554,10 +554,10 @@ int main(int argc, char **argv) {
             double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      mux_words_sent, mux_elapsed_cycles, mux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                         "MUX iters = {} -> cycles/iter = {:.1f}",
                         mux_iter, mux_cycles_per_iter);
             stat["mux_words_sent"] = mux_words_sent;
@@ -567,7 +567,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
             }
 
             uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -576,10 +576,10 @@ int main(int argc, char **argv) {
             uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
             double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      demux_words_sent, demux_elapsed_cycles, demux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX iters = {} -> cycles/iter = {:.1f}",
                      demux_iter, demux_cycles_per_iter);
             stat["demux_words_sent"] = demux_words_sent;
@@ -589,7 +589,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
             }
 
             if (pass) {
@@ -619,10 +619,10 @@ int main(int argc, char **argv) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 1024) {
                         target_bandwidth = 17;
-                        log_info(LogTest, "Perf check for pkt size >= 1024 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 256) {
                         target_bandwidth = 7;
-                        log_info(LogTest, "Perf check for pkt size >= 256 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (mux_bw < target_bandwidth) {
                         pass = false;
@@ -646,7 +646,7 @@ int main(int argc, char **argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_vc_uni_tunnel.cpp
@@ -100,39 +100,39 @@ int main(int argc, char **argv) {
     std::vector<std::string> input_args(argv, argv + argc);
     if (test_args::has_command_option(input_args, "-h") ||
         test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
-        log_info(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
-        log_info(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
-        log_info(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
-        log_info(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
-        log_info(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
-        log_info(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
-        log_info(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
-        log_info(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
-        log_info(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
-        log_info(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
-        log_info(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
-        log_info(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
-        log_info(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
-        log_info(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
-        log_info(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
-        log_info(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
-        log_info(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
-        log_info(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
-        log_info(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
-        log_info(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
-        log_info(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
-        log_info(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
-        log_info(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
-        log_info(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
-        log_info(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
-        log_info(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
-        log_info(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
-        log_info(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
-        log_info(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
-        log_info(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
-        log_info(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --prng_seed: PRNG seed, default = 0x{:x}", default_prng_seed);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --data_kb_per_tx: Total data in KB per TX endpoint, default = {}", default_data_kb_per_tx);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --max_packet_size_words: Max packet size in words, default = 0x{:x}", default_max_packet_size_words);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_x: X coordinate of the starting TX core, default = {}", default_tx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_y: Y coordinate of the starting TX core, default = {}", default_tx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_x: X coordinate of the starting RX core, default = {}", default_rx_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_y: Y coordinate of the starting RX core, default = {}", default_rx_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_x: X coordinate of the starting mux core, default = {}", default_mux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_y: Y coordinate of the starting mux core, default = {}", default_mux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_x: X coordinate of the starting demux core, default = {}", default_demux_x);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_y: Y coordinate of the starting demux core, default = {}", default_demux_y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_start_addr: TX queue start address, default = 0x{:x}", default_tx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_queue_size_bytes: TX queue size in bytes, default = 0x{:x}", default_tx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_start_addr: RX queue start address, default = 0x{:x}", default_rx_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_queue_size_bytes: RX queue size in bytes, default = 0x{:x}", default_rx_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_start_addr: MUX queue start address, default = 0x{:x}", default_mux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --mux_queue_size_bytes: MUX queue size in bytes, default = 0x{:x}", default_mux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_start_addr: DEMUX queue start address, default = 0x{:x}", default_demux_queue_start_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --demux_queue_size_bytes: DEMUX queue size in bytes, default = 0x{:x}", default_demux_queue_size_bytes);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_addr: test results buf address, default = 0x{:x}", default_test_results_addr);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --test_results_size: test results buf size, default = 0x{:x}", default_test_results_size);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --timeout_mcycles: Timeout in MCycles, default = {}", default_timeout_mcycles);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --check_txrx_timeout: Check if timeout happens during tx & rx (if enabled, timeout_mcycles will also be used), default = {}", default_check_txrx_timeout);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_data_check: Disable data check on RX, default = {}", default_rx_disable_data_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --rx_disable_header_check: Disable header check on RX, default = {}", default_rx_disable_header_check);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_skip_pkt_content_gen: Skip packet content generation during tx, default = {}", default_tx_skip_pkt_content_gen);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_pkt_dest_size_choice: choice for how packet destination and packet size are generated, default = {}", default_tx_pkt_dest_size_choice); // pkt_dest_size_choices_t
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_low: the criteria to determine the amount of tx data sent per iter is low (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_low);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --tx_data_sent_per_iter_high: the criteria to determine the amount of tx data sent per iter is high (unit: words); if both 0, then disable counting it in tx kernel, default = {}", default_tx_data_sent_per_iter_high);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --dump_stat_json: Dump stats in json to output_dir, default = {}", default_dump_stat_json);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --output_dir: Output directory, default = {}", default_output_dir);
+        TT_LOG_INFO_WITH_CAT(LogTest, "  --device_id: Device on which the test will be run, default = {}", default_test_device_id);
         return 0;
     }
 
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
     try {
         int num_devices = tt_metal::GetNumAvailableDevices();
         if (test_device_id >= num_devices) {
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                 "Device {} is not valid. Highest valid device id = {}.",
                 test_device_id, num_devices-1);
             throw std::runtime_error("Invalid Device Id.");
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
         auto const& device_active_eth_cores = device->get_active_ethernet_cores();
 
         if (device_active_eth_cores.size() == 0) {
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                 "Device {} does not have enough active cores. Need 1 active ethernet core for this test.",
                 device_id_l);
             tt_metal::CloseDevice(device);
@@ -262,7 +262,7 @@ int main(int argc, char **argv) {
                     tx_data_sent_per_iter_high // 21: data_sent_per_iter_high
                 };
 
-            log_info(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_tx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_tx.cpp",
@@ -303,7 +303,7 @@ int main(int argc, char **argv) {
                     rx_disable_header_check // 18: disable_header_check
                 };
 
-            log_info(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "run traffic_gen_rx at x={},y={}", core.x, core.y);
             auto kernel = tt_metal::CreateKernel(
                 program_r,
                 "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/traffic_gen_rx.cpp",
@@ -375,7 +375,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run mux at x={},y={}", mux_core.x, mux_core.y);
         auto mux_kernel = tt_metal::CreateKernel(
             program,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -589,7 +589,7 @@ int main(int argc, char **argv) {
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // 25-35: packetize/depacketize settings
             };
 
-        log_info(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "run demux at x={},y={}", demux_core.x, demux_core.y);
         auto demux_kernel = tt_metal::CreateKernel(
             program_r,
             "tt_metal/impl/dispatch/kernels/vc_packet_router.cpp",
@@ -602,7 +602,7 @@ int main(int argc, char **argv) {
             }
         );
 
-        log_info(LogTest, "Starting test...");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Starting test...");
 
         auto start = std::chrono::system_clock::now();
         tt_metal::detail::LaunchProgram(device, program, false);
@@ -612,7 +612,7 @@ int main(int argc, char **argv) {
         auto end = std::chrono::system_clock::now();
 
         std::chrono::duration<double> elapsed_seconds = (end-start);
-        log_info(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Ran in {:.2f}us", elapsed_seconds.count() * 1000 * 1000);
 
         vector<vector<uint32_t>> tx_results;
         vector<vector<uint32_t>> rx_results;
@@ -620,7 +620,7 @@ int main(int argc, char **argv) {
             tx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device->id(), tx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "TX{} status = {}", i, packet_queue_test_status_to_string(tx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (tx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
@@ -628,20 +628,20 @@ int main(int argc, char **argv) {
             rx_results.push_back(
                 tt::llrt::read_hex_vec_from_core(
                     device_r->id(), rx_phys_core[i], test_results_addr, test_results_size));
-            log_info(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
+            TT_LOG_INFO_WITH_CAT(LogTest, "RX{} status = {}", i, packet_queue_test_status_to_string(rx_results[i][PQ_TEST_STATUS_INDEX]));
             pass &= (rx_results[i][PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
         }
 
         vector<uint32_t> mux_results =
             tt::llrt::read_hex_vec_from_core(
                 device->id(), mux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "MUX status = {}", packet_queue_test_status_to_string(mux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (mux_results[PQ_TEST_STATUS_INDEX] == PACKET_QUEUE_TEST_PASS);
 
         vector<uint32_t> demux_results =
             tt::llrt::read_hex_vec_from_core(
                 device_r->id(), demux_phys_core, test_results_addr, test_results_size);
-        log_info(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
+        TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX status = {}", packet_queue_test_status_to_string(demux_results[PQ_TEST_STATUS_INDEX]));
         pass &= (demux_results[0] == PACKET_QUEUE_TEST_PASS);
 
         pass &= tt_metal::CloseDevice(device);
@@ -701,10 +701,10 @@ int main(int argc, char **argv) {
                 uint64_t num_packets = get_64b_result(tx_results[i], TX_TEST_IDX_NPKT);
                 double bytes_per_pkt = static_cast<double>(tx_words_sent) * PACKET_WORD_SIZE_BYTES / static_cast<double>(num_packets);
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "TX {} words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, tx_words_sent, tx_elapsed_cycles, tx_bw);
-                log_info(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
+                TT_LOG_INFO_WITH_CAT(LogTest, "TX {} packets sent = {}, bytes/packet = {:.2f}, total iter = {}, zero data sent iter = {}, few data sent iter = {}, many data sent iter = {}", i, num_packets, bytes_per_pkt, iter, zero_data_sent_iter, few_data_sent_iter, many_data_sent_iter);
                 stat[fmt::format("tx_words_sent_{}", i)] = tx_words_sent;
                 stat[fmt::format("tx_elapsed_cycles_{}", i)] = tx_elapsed_cycles;
                 stat[fmt::format("tx_bw_{}", i)] = tx_bw;
@@ -714,7 +714,7 @@ int main(int argc, char **argv) {
                 stat[fmt::format("tx_few_data_sent_iter_{}", i)] = few_data_sent_iter;
                 stat[fmt::format("tx_many_data_sent_iter_{}", i)] = many_data_sent_iter;
             }
-            log_info(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total TX BW = {:.2f} B/cycle", total_tx_bw);
             stat["total_tx_bw (B/cycle)"] = total_tx_bw;
 
             double total_rx_bw = 0.0;
@@ -725,20 +725,20 @@ int main(int argc, char **argv) {
                 double rx_bw = ((double)rx_words_checked) * PACKET_WORD_SIZE_BYTES / rx_elapsed_cycles;
                 total_rx_bw += rx_bw;
 
-                log_info(LogTest,
+                TT_LOG_INFO_WITH_CAT(LogTest,
                          "RX {} words checked = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                          i, rx_words_checked, rx_elapsed_cycles, rx_bw);
                 stat[fmt::format("rx_words_checked_{}", i)] = rx_words_checked;
                 stat[fmt::format("rx_elapsed_cycles_{}", i)] = rx_elapsed_cycles;
                 stat[fmt::format("rx_bw_{}", i)] = rx_bw;
             }
-            log_info(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Total RX BW = {:.2f} B/cycle", total_rx_bw);
             stat["total_rx_bw (B/cycle)"] = total_rx_bw;
             if (total_tx_words_sent != total_rx_words_checked) {
                 log_error(LogTest, "Total TX words sent = {} != Total RX words checked = {}", total_tx_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "Total TX words sent = {} == Total RX words checked = {} -> OK", total_tx_words_sent, total_rx_words_checked);
             }
 
             uint64_t mux_words_sent = get_64b_result(mux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -747,10 +747,10 @@ int main(int argc, char **argv) {
             double mux_bw = ((double)mux_words_sent) * PACKET_WORD_SIZE_BYTES / mux_elapsed_cycles;
             double mux_cycles_per_iter = ((double)mux_elapsed_cycles) / mux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "MUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      mux_words_sent, mux_elapsed_cycles, mux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                         "MUX iters = {} -> cycles/iter = {:.1f}",
                         mux_iter, mux_cycles_per_iter);
             stat["mux_words_sent"] = mux_words_sent;
@@ -760,7 +760,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "MUX words sent = {} != Total RX words checked = {}", mux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "MUX words sent = {} == Total RX words checked = {} -> OK", mux_words_sent, total_rx_words_checked);
             }
 
             uint64_t demux_words_sent = get_64b_result(demux_results, PQ_TEST_WORD_CNT_INDEX);
@@ -769,10 +769,10 @@ int main(int argc, char **argv) {
             uint64_t demux_iter = get_64b_result(demux_results, PQ_TEST_ITER_INDEX);
             double demux_cycles_per_iter = ((double)demux_elapsed_cycles) / demux_iter;
 
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX words sent = {}, elapsed cycles = {} -> BW = {:.2f} B/cycle",
                      demux_words_sent, demux_elapsed_cycles, demux_bw);
-            log_info(LogTest,
+            TT_LOG_INFO_WITH_CAT(LogTest,
                      "DEMUX iters = {} -> cycles/iter = {:.1f}",
                      demux_iter, demux_cycles_per_iter);
             stat["demux_words_sent"] = demux_words_sent;
@@ -782,7 +782,7 @@ int main(int argc, char **argv) {
                 log_error(LogTest, "DEMUX words sent = {} != Total RX words checked = {}", demux_words_sent, total_rx_words_checked);
                 pass = false;
             } else {
-                log_info(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
+                TT_LOG_INFO_WITH_CAT(LogTest, "DEMUX words sent = {} == Total RX words checked = {} -> OK", demux_words_sent, total_rx_words_checked);
             }
 
             if (pass) {
@@ -811,13 +811,13 @@ int main(int argc, char **argv) {
                     double target_bandwidth = 0;
                     if (max_packet_size_words >= 2048) {
                         target_bandwidth = 7;
-                        log_info(LogTest, "Perf check for pkt size >= 2048 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 2048 words");
                     } else if (max_packet_size_words >= 1024) {
                         target_bandwidth = 8.0;
-                        log_info(LogTest, "Perf check for pkt size >= 1024 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 1024 words");
                     } else if (max_packet_size_words >= 256) {
                         target_bandwidth = 2.5;
-                        log_info(LogTest, "Perf check for pkt size >= 256 words");
+                        TT_LOG_INFO_WITH_CAT(LogTest, "Perf check for pkt size >= 256 words");
                     }
                     if (demux_bw < target_bandwidth) {
                         pass = false;
@@ -841,7 +841,7 @@ int main(int argc, char **argv) {
     tt::tt_metal::MetalContext::instance().rtoptions().set_kernels_nullified(false);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
         return 0;
     } else {
         log_fatal(LogTest, "Test Failed\n");

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
 
         std::vector<uint32_t> first_kernel_result;
         tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, sizeof(int), first_kernel_result);
-        log_info(LogVerif, "first kernel result = {}", first_kernel_result[0]);
+        TT_LOG_INFO_WITH_CAT(LogVerif, "first kernel result = {}", first_kernel_result[0]);
 
         ////////////////////////////////////////////////////////////////////////////
         //                  Update Runtime Args and Re-run Application
@@ -84,14 +84,14 @@ int main(int argc, char** argv) {
 
         std::vector<uint32_t> second_kernel_result;
         tt_metal::detail::ReadFromDeviceL1(device, core, l1_unreserved_base, sizeof(int), second_kernel_result);
-        log_info(LogVerif, "second kernel result = {}", second_kernel_result[0]);
+        TT_LOG_INFO_WITH_CAT(LogVerif, "second kernel result = {}", second_kernel_result[0]);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         uint32_t first_expected_result = first_runtime_args[0] + first_runtime_args[1];
         uint32_t second_expected_result = second_runtime_args[0] + second_runtime_args[1];
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogVerif,
             "first expected result = {} second expected result = {}",
             first_expected_result,
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -104,8 +104,8 @@ int main(int argc, char** argv) {
     // ops = { BcastOp::MUL }; // TODO(AP): for debugging
     for (auto bcast_op : ops) {
         for (auto bcast_dim : bdims) {
-            log_info(LogTest, "=============================================================");
-            log_info(
+            TT_LOG_INFO_WITH_CAT(LogTest, "=============================================================");
+            TT_LOG_INFO_WITH_CAT(
                 LogTest,
                 "======= Running bcast test for bdim={}, op={}",
                 bdim_to_log_string[bcast_dim],
@@ -379,7 +379,7 @@ int main(int argc, char** argv) {
     }  // for bcast_mode loop
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_bfp4_conversion.cpp
+++ b/tests/tt_metal/tt_metal/test_bfp4_conversion.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
+++ b/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     auto slow_dispatch_mode = getenv("TT_METAL_SLOW_DISPATCH_MODE");
     TT_FATAL(slow_dispatch_mode, "This test only supports TT_METAL_SLOW_DISPATCH_MODE");
 
-    log_info(LogTest, "====================================================================");
+    TT_LOG_INFO_WITH_CAT(LogTest, "====================================================================");
     try {
         ////////////////////////////////////////////////////////////////////////////
         //                      Device Setup
@@ -217,7 +217,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -52,9 +52,9 @@ int main(int argc, char** argv) {
     // Any arg means that we shouldn't do teardown.
     bool skip_teardown = (argc > 1);
     if (skip_teardown) {
-        tt::log_info("Running loopback test with no teardown, to see if we can recover next run.");
+        TT_LOG_INFO("Running loopback test with no teardown, to see if we can recover next run.");
     } else {
-        tt::log_info("Running loopback test with proper teardown");
+        TT_LOG_INFO("Running loopback test with proper teardown");
     }
 
     bool pass = true;
@@ -139,9 +139,9 @@ int main(int argc, char** argv) {
             );
 
             EnqueueProgram(cq, program, false);
-            tt::log_info("Started program");
+            TT_LOG_INFO("Started program");
             Finish(cq);
-            tt::log_info("Finished program");
+            TT_LOG_INFO("Finished program");
 
             /*
             * Validation & Teardown
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
 
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled()) {
             // Test that the kernel_args.csv file was generated for both kernels
-            log_info(LogTest, "Test kernel args logging");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Test kernel args logging");
             auto kernel_args_path = binary_path.parent_path() / "kernel_args.csv";
             TT_FATAL(
                 std::filesystem::exists(kernel_args_path),
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -422,7 +422,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -321,7 +321,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -264,7 +264,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -177,7 +177,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -173,7 +173,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
@@ -201,39 +201,39 @@ bool write_runtime_args_to_device(
                 (std::uint32_t)N                                                       // dst_stride_y
             };
 
-            // log_info(LogTest, "Core = {}, {}", core.x, core.y);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "Core = {}, {}", core.x, core.y);
 
-            // log_info(LogTest, "Reader args");
-            // log_info(LogTest, "src0_addr = {}", src0_dram_addr);
-            // log_info(LogTest, "src0_start_tile_id = {}", K * per_core_M * core_idx_y);
-            // log_info(LogTest, "src0_block_x = {}", block_tile_dim);
-            // log_info(LogTest, "src0_block_y = {}", per_core_M);
-            // log_info(LogTest, "src0_stride_x = {}", 1);
-            // log_info(LogTest, "src0_stride_y = {}", K);
-            // log_info(LogTest, "src0_block_stride = {}", block_tile_dim);
-            // log_info(LogTest, "src0_block_num_tiles = {}", block_tile_dim * per_core_M);
-            // log_info(LogTest, "src1_addr = {}", src1_dram_addr);
-            // log_info(LogTest, "src1_start_tile_id = {}", per_core_N * core_idx_x);
-            // log_info(LogTest, "src1_sub_block_x = {}", num_tiles_per_sub_block_n);
-            // log_info(LogTest, "src1_sub_block_y = {}", block_tile_dim);
-            // log_info(LogTest, "src1_num_sub_blocks = {}", (per_core_N / num_tiles_per_sub_block_n));
-            // log_info(LogTest, "src1_stride_x = {}", 1);
-            // log_info(LogTest, "src1_stride_y = {}", N);
-            // log_info(LogTest, "src1_block_stride = {}", block_tile_dim * N);
-            // log_info(LogTest, "src1_block_num_tiles = {}", per_core_N * block_tile_dim);
-            // log_info(LogTest, "num_blocks = {}", K / block_tile_dim);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "Reader args");
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_addr = {}", src0_dram_addr);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_start_tile_id = {}", K * per_core_M * core_idx_y);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_block_x = {}", block_tile_dim);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_block_y = {}", per_core_M);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_stride_x = {}", 1);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_stride_y = {}", K);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_block_stride = {}", block_tile_dim);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src0_block_num_tiles = {}", block_tile_dim * per_core_M);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_addr = {}", src1_dram_addr);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_start_tile_id = {}", per_core_N * core_idx_x);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_sub_block_x = {}", num_tiles_per_sub_block_n);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_sub_block_y = {}", block_tile_dim);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_num_sub_blocks = {}", (per_core_N / num_tiles_per_sub_block_n));
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_stride_x = {}", 1);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_stride_y = {}", N);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_block_stride = {}", block_tile_dim * N);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "src1_block_num_tiles = {}", per_core_N * block_tile_dim);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "num_blocks = {}", K / block_tile_dim);
 
-            // log_info(LogTest, "Writer args");
-            // log_info(LogTest, "dst_addr = {}", dst_dram_addr);
-            // log_info(LogTest, "dst_start_tile_id = {}", core_idx_x * per_core_N + core_idx_y * per_core_M * N);
-            // log_info(LogTest, "dst_sub_block_x = {}", num_tiles_per_sub_block_n);
-            // log_info(LogTest, "dst_sub_block_y = {}", num_tiles_per_sub_block_m);
-            // log_info(LogTest, "dst_num_sub_blocks_x = {}", (per_core_N / num_tiles_per_sub_block_n));
-            // log_info(LogTest, "dst_num_sub_blocks_y = {}", (per_core_M / num_tiles_per_sub_block_m));
-            // log_info(LogTest, "dst_sb_stride_x = {}", num_tiles_per_sub_block_n);
-            // log_info(LogTest, "dst_sb_stride_y = {}", num_tiles_per_sub_block_m * N);
-            // log_info(LogTest, "dst_stride_x = {}", 1);
-            // log_info(LogTest, "dst_stride_y = {}", N);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "Writer args");
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_addr = {}", dst_dram_addr);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_start_tile_id = {}", core_idx_x * per_core_N + core_idx_y * per_core_M
+            // * N); TT_LOG_INFO_WITH_CAT(LogTest, "dst_sub_block_x = {}", num_tiles_per_sub_block_n);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_sub_block_y = {}", num_tiles_per_sub_block_m);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_num_sub_blocks_x = {}", (per_core_N / num_tiles_per_sub_block_n));
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_num_sub_blocks_y = {}", (per_core_M / num_tiles_per_sub_block_m));
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_sb_stride_x = {}", num_tiles_per_sub_block_n);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_sb_stride_y = {}", num_tiles_per_sub_block_m * N);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_stride_x = {}", 1);
+            // TT_LOG_INFO_WITH_CAT(LogTest, "dst_stride_y = {}", N);
 
             tt_metal::SetRuntimeArgs(program, mm_reader_kernel, core, mm_reader_args);
             tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_args);
@@ -308,17 +308,17 @@ int main(int argc, char** argv) {
         uint32_t src0_dram_addr = 0;
         uint32_t src1_dram_addr = 400 * 1024 * 1024;
         uint32_t dst_dram_addr = 800 * 1024 * 1024;
-        log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-        log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-        log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
             per_core_M,
             block_tile_dim,
             K / block_tile_dim,
             per_core_M / num_tiles_per_sub_block_m);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
             block_tile_dim,
@@ -364,7 +364,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
         auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
@@ -374,9 +374,9 @@ int main(int argc, char** argv) {
         auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         pass &= move_tiles_to_dram(device, weights, K, N, src1_dram_addr);
-        log_info(LogTest, "Copying inputs to dram complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Copying inputs to dram complete");
 
-        log_info(LogTest, "Writing kernel runtime args to device");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device");
         pass &= write_runtime_args_to_device(
             device,
             program,
@@ -395,14 +395,14 @@ int main(int argc, char** argv) {
             src0_dram_addr,
             src1_dram_addr,
             dst_dram_addr);
-        log_info(LogTest, "Writing kernel runtime args to device complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device complete");
 
-        log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
         tt_metal::detail::LaunchProgram(device, program);
 
-        log_info(LogTest, "Matmul test done");
-        log_info(LogTest, "Gathering data back from dram and checking against golden");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Matmul test done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Gathering data back from dram and checking against golden");
 
         for (int i = 0; i < M; i++) {
             auto row = get_row_slice(golden, M, i, M * 32, N * 32);
@@ -417,12 +417,12 @@ int main(int argc, char** argv) {
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                 auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
 
-                // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-                // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+                // TT_LOG_INFO_WITH_CAT(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank,
+                // dram_address); print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
                 pass &= (golden_tile == result_flat_layout);
             }
         }
-        log_info(LogTest, "Golden check complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Golden check complete");
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
@@ -438,7 +438,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -178,7 +178,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dataflow_cb.cpp
+++ b/tests/tt_metal/tt_metal/test_dataflow_cb.cpp
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -162,7 +162,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core.cpp
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_multi_core_db.cpp
@@ -184,7 +184,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -128,7 +128,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core_db.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core_db.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast.cpp
@@ -73,8 +73,8 @@ int main(int argc, char** argv) {
             (std::uint32_t)(grid_size.x * grid_size.y) -
                 1};  // Note: exclude src from acks, since we are not setting NOC_CMD_BRCST_SRC_INCLUDE
 
-        log_info(LogTest, "Start = {}, {}", core_start_physical.x, core_start_physical.y);
-        log_info(LogTest, "End = {}, {}", core_end_physical.x, core_end_physical.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Start = {}, {}", core_start_physical.x, core_start_physical.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "End = {}, {}", core_end_physical.x, core_end_physical.y);
         auto mcast_reader_kernel = tt_metal::CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_multicast.cpp",
@@ -101,9 +101,9 @@ int main(int argc, char** argv) {
 
         tt_metal::SetRuntimeArgs(program, mcast_reader_kernel, core, mcast_reader_args);
 
-        log_info(LogTest, "Launching kernels");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Launching kernels");
         tt_metal::detail::LaunchProgram(device, program);
-        log_info(LogTest, "Kernels done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Kernels done");
 
         for (int i = 0; i < grid_size.y; i++) {
             for (int j = 0; j < grid_size.x; j++) {
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
                 auto dest_core_data_unpacked = unpack_uint32_vec_into_bfloat16_vec(dest_core_data);
                 pass &= (dest_core_data_unpacked == tensor.get_values());
                 if (not(dest_core_data_unpacked == tensor.get_values())) {
-                    log_info(LogTest, "Mismatch on core {}, {}", dest_core.x, dest_core.y);
+                    TT_LOG_INFO_WITH_CAT(LogTest, "Mismatch on core {}, {}", dest_core.x, dest_core.y);
                     print_vec_of_bfloat16(dest_core_data_unpacked, 1, "Result");
                 }
             }
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_to_l1_multicast_loopback_src.cpp
@@ -68,8 +68,8 @@ int main(int argc, char** argv) {
             (std::uint32_t)core_start_physical.x,
             (std::uint32_t)core_start_physical.y,
             (std::uint32_t)(grid_size.x * grid_size.y)};
-        log_info(LogTest, "Start = {}, {}", core_start_physical.x, core_start_physical.y);
-        log_info(LogTest, "End = {}, {}", core_end_physical.x, core_end_physical.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Start = {}, {}", core_start_physical.x, core_start_physical.y);
+        TT_LOG_INFO_WITH_CAT(LogTest, "End = {}, {}", core_end_physical.x, core_end_physical.y);
         auto mcast_reader_kernel = tt_metal::CreateKernel(
             program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_multicast_include_src.cpp",
@@ -96,9 +96,9 @@ int main(int argc, char** argv) {
 
         tt_metal::SetRuntimeArgs(program, mcast_reader_kernel, core, mcast_reader_args);
 
-        log_info(LogTest, "Launching kernels");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Launching kernels");
         tt_metal::detail::LaunchProgram(device, program);
-        log_info(LogTest, "Kernels done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Kernels done");
 
         for (int i = 0; i < grid_size.y; i++) {
             for (int j = 0; j < grid_size.x; j++) {
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
                 auto dest_core_data_unpacked = unpack_uint32_vec_into_bfloat16_vec(dest_core_data);
                 pass &= (dest_core_data_unpacked == tensor.get_values());
                 if (not(dest_core_data_unpacked == tensor.get_values())) {
-                    log_info(LogTest, "Mismatch on core {}, {}", dest_core.x, dest_core.y);
+                    TT_LOG_INFO_WITH_CAT(LogTest, "Mismatch on core {}, {}", dest_core.x, dest_core.y);
                     print_vec_of_bfloat16(dest_core_data_unpacked, 1, "Result");
                 }
             }
@@ -129,7 +129,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -73,8 +73,8 @@ int main(int argc, char** argv) {
 
     auto ops = EltwiseOp::all();
     for (auto eltwise_op : ops) {
-        log_info(LogTest, "====================================================================");
-        log_info(LogTest, "======= Running eltwise_binary test for op={}", op_id_to_op_name[eltwise_op]);
+        TT_LOG_INFO_WITH_CAT(LogTest, "====================================================================");
+        TT_LOG_INFO_WITH_CAT(LogTest, "======= Running eltwise_binary test for op={}", op_id_to_op_name[eltwise_op]);
 
         try {
             ////////////////////////////////////////////////////////////////////////////
@@ -221,7 +221,7 @@ int main(int argc, char** argv) {
     pass &= tt_metal::CloseDevice(device);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/test_flatten.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -362,7 +362,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_gold_impls.hpp
+++ b/tests/tt_metal/tt_metal/test_gold_impls.hpp
@@ -41,7 +41,7 @@ inline std::vector<uint16_t> gold_transpose_hc(std::vector<uint16_t> src_vec, st
             }
         }
     }
-    // log_info(tt::LogVerif, "Prior size = {}", transposed.size());
+    // TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Prior size = {}", transposed.size());
     return transposed;
 };
 

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -565,7 +565,7 @@ int main(int argc, char** argv) {
     pass &= test_interleaved_l1_datacopy<false, false>(arch);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_l1_to_l1_multi_core.cpp
@@ -139,7 +139,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
@@ -411,39 +411,39 @@ int main(int argc, char** argv) {
     // Tilized input, Tilized output
     pass &= test_matmul_large_block(device, false, false);
     if (pass) {
-        log_info("Tilized input, Tilized output Passed");
+        TT_LOG_INFO("Tilized input, Tilized output Passed");
     } else {
-        log_info("Tilized input, Tilized output Failed");
+        TT_LOG_INFO("Tilized input, Tilized output Failed");
     }
 
     // Row major input, Tilized output
     pass &= test_matmul_large_block(device, true, false);
     if (pass) {
-        log_info("Row major input, Tilized output Passed");
+        TT_LOG_INFO("Row major input, Tilized output Passed");
     } else {
-        log_info("Row major input, Tilized output Failed");
+        TT_LOG_INFO("Row major input, Tilized output Failed");
     }
 
     // Tilized input, Row major output
     pass &= test_matmul_large_block(device, false, true);
     if (pass) {
-        log_info("Tilized input, Row major output Passed");
+        TT_LOG_INFO("Tilized input, Row major output Passed");
     } else {
-        log_info("Tilized input, Row major output Failed");
+        TT_LOG_INFO("Tilized input, Row major output Failed");
     }
 
     // Row major input, Row major output
     pass &= test_matmul_large_block(device, true, true);
     if (pass) {
-        log_info("Row major input, Row major output Passed");
+        TT_LOG_INFO("Row major input, Row major output Passed");
     } else {
-        log_info("Row major input, Row major output Failed");
+        TT_LOG_INFO("Row major input, Row major output Failed");
     }
 
     pass &= tt_metal::CloseDevice(device);
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
@@ -316,17 +316,17 @@ int main(int argc, char** argv) {
         int per_core_M = M / num_cores_r;
         int per_core_N = N / num_cores_c;
         uint32_t single_tile_size = 2 * 1024;
-        log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-        log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-        log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
             per_core_M,
             in0_block_w,
             K / in0_block_w,
             per_core_M / out_subblock_h);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
             in0_block_w,
@@ -371,7 +371,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
         auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
@@ -385,12 +385,12 @@ int main(int argc, char** argv) {
 
         Buffer weight_buffer(device, weights.size() * sizeof(uint32_t), 1024 * 2, BufferType::DRAM);
         pass &= move_tiles_to_dram(cq, weight_buffer, weights, K, N);
-        log_info(LogTest, "Copying inputs to dram complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Copying inputs to dram complete");
 
         Buffer out_buffer(device, M * N * sizeof(uint32_t) * 32 * 32, 1024 * 2, BufferType::DRAM);
         uint32_t out_dram_addr = out_buffer->address();
 
-        log_info(LogTest, "Writing kernel runtime args to device");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device");
         pass &= assign_runtime_args_to_program(
             device,
             program,
@@ -409,13 +409,13 @@ int main(int argc, char** argv) {
             activation_buffer->address(),
             weight_buffer->address(),
             out_dram_addr);
-        log_info(LogTest, "Writing kernel runtime args to device complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device complete");
 
-        log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
         EnqueueProgram(cq, program, false);
 
-        log_info(LogTest, "Matmul test done");
-        log_info(LogTest, "Gathering data back from dram and checking against golden");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Matmul test done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Gathering data back from dram and checking against golden");
 
         vector<uint32_t> result;
         EnqueueReadBuffer(cq, out_buffer, result, true);
@@ -438,7 +438,7 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Golden check complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Golden check complete");
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
@@ -454,7 +454,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
@@ -230,7 +230,7 @@ bool write_runtime_args_to_device(
     for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
             CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            log_info(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
 
             CoreCoord mcast_sender = {(std::size_t)start_core_x, core.y};
             CoreCoord core_start = {(std::size_t)start_core_x + 1, core.y};
@@ -370,17 +370,17 @@ int main(int argc, char** argv) {
         uint32_t in0_mcast_sender_semaphore_addr = 109600;
         uint32_t in0_mcast_receiver_semaphore_addr = 109632;
 
-        log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-        log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-        log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
             per_core_M,
             in0_block_w,
             K / in0_block_w,
             per_core_M / out_subblock_h);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
             in0_block_w,
@@ -426,7 +426,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
         auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
@@ -436,7 +436,7 @@ int main(int argc, char** argv) {
         auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
-        log_info(LogTest, "Copying inputs to dram complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Copying inputs to dram complete");
 
         for (int i = 0; i < num_cores_r; i++) {
             for (int j = 0; j < num_cores_c; j++) {
@@ -446,7 +446,7 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Writing kernel runtime args to device");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device");
         pass &= write_runtime_args_to_device(
             device,
             program,
@@ -470,14 +470,14 @@ int main(int argc, char** argv) {
             out_dram_addr,
             in0_mcast_sender_semaphore_addr,
             in0_mcast_receiver_semaphore_addr);
-        log_info(LogTest, "Writing kernel runtime args to device complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device complete");
 
-        log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
         tt_metal::detail::LaunchProgram(device, program);
-        log_info(LogTest, "Matmul test done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Matmul test done");
 
-        log_info(LogTest, "Gathering data back from dram and checking against golden");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Gathering data back from dram and checking against golden");
 
         for (int i = 0; i < M; i++) {
             auto row = get_row_slice(golden, M, i, M * 32, N * 32);
@@ -492,12 +492,12 @@ int main(int argc, char** argv) {
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                 auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
 
-                // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-                // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+                // TT_LOG_INFO_WITH_CAT(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank,
+                // dram_address); print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
                 pass &= (golden_tile == result_flat_layout);
             }
         }
-        log_info(LogTest, "Golden check complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Golden check complete");
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
@@ -513,7 +513,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
@@ -229,7 +229,7 @@ bool write_runtime_args_to_device(
     for (int core_idx_y = 0; core_idx_y < num_cores_r; core_idx_y++) {
         for (int core_idx_x = 0; core_idx_x < num_cores_c; core_idx_x++) {
             CoreCoord core = {(std::size_t)start_core_x + core_idx_x, (std::size_t)start_core_y + core_idx_y};
-            log_info(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
+            TT_LOG_INFO_WITH_CAT(LogTest, "Runtime kernel args for core {}, {}", core.x, core.y);
             CoreCoord mcast_sender = {core.x, (std::size_t)start_core_y};
             CoreCoord core_start = {core.x, (std::size_t)start_core_y + 1};
             CoreCoord core_end = {core.x, (std::size_t)start_core_y + (num_cores_r - 1)};
@@ -368,17 +368,17 @@ int main(int argc, char** argv) {
         uint32_t in1_mcast_sender_semaphore_addr = 109600;
         uint32_t in1_mcast_receiver_semaphore_addr = 109632;
 
-        log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-        log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-        log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
             per_core_M,
             in0_block_w,
             K / in0_block_w,
             per_core_M / out_subblock_h);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
             in0_block_w,
@@ -420,7 +420,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
         auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
@@ -430,7 +430,7 @@ int main(int argc, char** argv) {
         auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
-        log_info(LogTest, "Copying inputs to dram complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Copying inputs to dram complete");
 
         for (int i = 0; i < num_cores_r; i++) {
             for (int j = 0; j < num_cores_c; j++) {
@@ -440,7 +440,7 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Writing kernel runtime args to device");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device");
         pass &= write_runtime_args_to_device(
             device,
             program,
@@ -464,14 +464,14 @@ int main(int argc, char** argv) {
             out_dram_addr,
             in1_mcast_sender_semaphore_addr,
             in1_mcast_receiver_semaphore_addr);
-        log_info(LogTest, "Writing kernel runtime args to device complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Writing kernel runtime args to device complete");
 
-        log_info(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running Matmul {} core test", num_cores_r * num_cores_c);
 
         tt_metal::detail::LaunchProgram(device, program);
-        log_info(LogTest, "Matmul test done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Matmul test done");
 
-        log_info(LogTest, "Gathering data back from dram and checking against golden");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Gathering data back from dram and checking against golden");
 
         for (int i = 0; i < M; i++) {
             auto row = get_row_slice(golden, M, i, M * 32, N * 32);
@@ -486,12 +486,12 @@ int main(int argc, char** argv) {
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                 auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
 
-                // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
-                // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
+                // TT_LOG_INFO_WITH_CAT(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank,
+                // dram_address); print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));
                 pass &= (golden_tile == result_flat_layout);
             }
         }
-        log_info(LogTest, "Golden check complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Golden check complete");
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
@@ -507,7 +507,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
@@ -252,7 +252,7 @@ int main(int argc, char** argv) {
         CoreCoord compute_with_storage_grid_size = device->compute_with_storage_grid_size();
         int num_cores_r = compute_with_storage_grid_size.y;
         int num_cores_c = compute_with_storage_grid_size.x;
-        log_info(LogTest, "Num cores r = {}, Num cores c = {}", num_cores_r, num_cores_c);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Num cores r = {}, Num cores c = {}", num_cores_r, num_cores_c);
         uint32_t M = 16 * num_cores_r;
         uint32_t K = 16 * 12;
         uint32_t N = 16 * num_cores_c;
@@ -263,17 +263,17 @@ int main(int argc, char** argv) {
         int per_core_N = N / num_cores_c;
         uint32_t single_tile_size = 2 * 1024;
         uint32_t dram_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-        log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-        log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-        log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
             out_subblock_h,
             in0_block_w,
             K / in0_block_w,
             M / out_subblock_h);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
             out_subblock_w,
@@ -303,7 +303,8 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Execute Application
         ////////////////////////////////////////////////////////////////////////////
-        log_info(LogTest, "Slicing input tensors and copying them to dram along with sending runtime args to device");
+        TT_LOG_INFO_WITH_CAT(
+            LogTest, "Slicing input tensors and copying them to dram along with sending runtime args to device");
         for (int i = 0; i < num_cores_r; i++) {
             std::vector<bfloat16> activation_slice = get_row_slice(tensor.get_values(), num_cores_r, i, M * 32, K * 32);
             for (int j = 0; j < num_cores_c; j++) {
@@ -375,13 +376,13 @@ int main(int argc, char** argv) {
             }
         }
 
-        log_info(LogTest, "Copying inputs to dram and runtime args to cores complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Copying inputs to dram and runtime args to cores complete");
 
-        log_info(LogTest, "Running Matmul {} core test", num_cores_c * num_cores_r);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running Matmul {} core test", num_cores_c * num_cores_r);
 
         tt_metal::detail::LaunchProgram(device, program);
-        log_info(LogTest, "Matmul test done");
-        log_info(LogTest, "Gathering data back from dram and checking against golden");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Matmul test done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Gathering data back from dram and checking against golden");
         for (int i = 0; i < num_cores_r; i++) {
             auto golden_row = get_row_slice(golden, num_cores_r, i, M * 32, N * 32);
             for (int j = 0; j < num_cores_c; j++) {
@@ -403,7 +404,7 @@ int main(int argc, char** argv) {
                 pass &= (per_core_golden == result_untilized);
             }
         }
-        log_info(LogTest, "Golden check complete");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Golden check complete");
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
@@ -418,7 +419,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
@@ -258,7 +258,7 @@ bool run_matmul(const tt::ARCH& arch, const bool with_bias) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
@@ -118,17 +118,17 @@ int main(int argc, char** argv) {
         int out_subblock_h = 4;
         int out_subblock_w = 2;
         int in0_block_w = 2;
-        log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-        log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-        log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
             out_subblock_h,
             in0_block_w,
             K / in0_block_w,
             M / out_subblock_h);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
             out_subblock_w,
@@ -295,9 +295,9 @@ int main(int argc, char** argv) {
 
         tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_rt_args);
 
-        log_info(LogTest, "Launching kernels");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Launching kernels");
         tt_metal::detail::LaunchProgram(device, program);
-        log_info(LogTest, "Kernels done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Kernels done");
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
@@ -317,7 +317,7 @@ int main(int argc, char** argv) {
         // auto golden = tensor.get_values();
         pass &= (golden == result_untilized);
         pass &= tt_metal::CloseDevice(device);
-        log_info(LogTest, "Closing device");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Closing device");
 
     } catch (const std::exception& e) {
         pass = false;
@@ -328,7 +328,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
@@ -119,17 +119,17 @@ int main(int argc, char** argv) {
         int out_subblock_h = 4;
         int out_subblock_w = 4;
         int in0_block_w = 2;
-        log_info(LogTest, "M = {}, N = {}, K = {}", M, N, K);
-        log_info(LogTest, "Activation = {}x{}", M * 32, K * 32);
-        log_info(LogTest, "Weights = {}x{}", K * 32, N * 32);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(LogTest, "M = {}, N = {}, K = {}", M, N, K);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Activation = {}x{}", M * 32, K * 32);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Weights = {}x{}", K * 32, N * 32);
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Activation block = {}x{}, #blocks = {}, #sub-blocks = {}",
             out_subblock_h,
             in0_block_w,
             K / in0_block_w,
             M / out_subblock_h);
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "Weights block = {}x{}, #blocks = {}, #sub-blocks = {}",
             out_subblock_w,
@@ -297,9 +297,9 @@ int main(int argc, char** argv) {
 
         tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_rt_args);
 
-        log_info(LogTest, "Launching kernels");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Launching kernels");
         tt_metal::detail::LaunchProgram(device, program);
-        log_info(LogTest, "Kernels done");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Kernels done");
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
@@ -322,7 +322,7 @@ int main(int argc, char** argv) {
                 return tt::test_utils::is_close<bfloat16>(a, b, 0.015f);
             });
         pass &= tt_metal::CloseDevice(device);
-        log_info(LogTest, "Closing device");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Closing device");
 
     } catch (const std::exception& e) {
         pass = false;
@@ -333,7 +333,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -200,7 +200,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -380,7 +380,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -300,7 +300,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         pass &= (src0_activations == intermediate_result_vec);  // src1 is ZEROS
         if (pass) {
-            log_info(LogTest, "Eltwise binary ran successfully");
+            TT_LOG_INFO_WITH_CAT(LogTest, "Eltwise binary ran successfully");
         } else {
             log_error(LogTest, "Eltwise binary did not run sucessfully!");
         }
@@ -346,7 +346,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -64,22 +64,22 @@ void init(int argc, char** argv) {
     std::vector<std::string> input_args(argv, argv + argc);
 
     if (test_args::has_command_option(input_args, "-h") || test_args::has_command_option(input_args, "--help")) {
-        log_info(LogTest, "Usage:");
-        log_info(LogTest, "     -v: device number to run on (default 0) ", DEFAULT_SECONDS);
-        log_info(LogTest, "     -t: time in seconds (default {})", DEFAULT_SECONDS);
-        log_info(LogTest, "     -x: grid top left x");
-        log_info(LogTest, "     -y: grid top left y");
-        log_info(LogTest, "-width: unicast grid width (default {})", DEFAULT_TARGET_WIDTH);
-        log_info(LogTest, "-height: unicast grid height (default {})", DEFAULT_TARGET_HEIGHT);
-        log_info(LogTest, "    -mx: mcast core x");
-        log_info(LogTest, "    -my: mcast core y");
-        log_info(LogTest, "     -e: mcast from nth idle eth core (ignores -mx,-my)");
-        log_info(LogTest, "     -m: mcast packet size");
-        log_info(LogTest, "     -u: ucast packet size");
-        log_info(LogTest, "     -ucast-only: skip multicasting");
-        log_info(LogTest, "-rdelay: insert random delay between noc transactions");
-        log_info(LogTest, "     -n: noc to use (default 0)");
-        log_info(LogTest, "     -s: seed random number generator");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Usage:");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -v: device number to run on (default 0) ", DEFAULT_SECONDS);
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -t: time in seconds (default {})", DEFAULT_SECONDS);
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -x: grid top left x");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -y: grid top left y");
+        TT_LOG_INFO_WITH_CAT(LogTest, "-width: unicast grid width (default {})", DEFAULT_TARGET_WIDTH);
+        TT_LOG_INFO_WITH_CAT(LogTest, "-height: unicast grid height (default {})", DEFAULT_TARGET_HEIGHT);
+        TT_LOG_INFO_WITH_CAT(LogTest, "    -mx: mcast core x");
+        TT_LOG_INFO_WITH_CAT(LogTest, "    -my: mcast core y");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -e: mcast from nth idle eth core (ignores -mx,-my)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -m: mcast packet size");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -u: ucast packet size");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -ucast-only: skip multicasting");
+        TT_LOG_INFO_WITH_CAT(LogTest, "-rdelay: insert random delay between noc transactions");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -n: noc to use (default 0)");
+        TT_LOG_INFO_WITH_CAT(LogTest, "     -s: seed random number generator");
         exit(0);
     }
 
@@ -248,7 +248,7 @@ int main(int argc, char** argv) {
                                  .get_physical_tensix_core_from_logical(mcast_logical);
         }
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             LogTest,
             "MCast {} core: {}, virtual {}, physical {}, writing {} bytes per xfer",
             mcast_from_eth_g ? "ETH" : "TENSIX",
@@ -258,20 +258,20 @@ int main(int argc, char** argv) {
             mcast_size_g);
     }
 
-    log_info(LogTest, "Unicast grid: {}, writing {} bytes per xfer", workers_logical.str(), ucast_size_g);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Unicast grid: {}, writing {} bytes per xfer", workers_logical.str(), ucast_size_g);
 
     if (rnd_coord_g) {
-        log_info("Randomizing ucast noc write destinations");
+        TT_LOG_INFO("Randomizing ucast noc write destinations");
     } else {
-        log_info("Non-random ucast noc write destinations TBD");
+        TT_LOG_INFO("Non-random ucast noc write destinations TBD");
     }
 
-    log_info("Using NOC {}", (noc_g == tt_metal::NOC::NOC_0) ? 0 : 1);
+    TT_LOG_INFO("Using NOC {}", (noc_g == tt_metal::NOC::NOC_0) ? 0 : 1);
 
     if (rnd_delay_g) {
-        log_info("Randomizing delay");
+        TT_LOG_INFO("Randomizing delay");
     }
-    log_info(LogTest, "Running for {} seconds", time_secs_g);
+    TT_LOG_INFO_WITH_CAT(LogTest, "Running for {} seconds", time_secs_g);
 
     tt::tt_metal::detail::LaunchProgram(device, program, true);
     tt_metal::CloseDevice(device);

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -211,7 +211,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_untilize_eltwise_binary.cpp
@@ -107,8 +107,8 @@ int main(int argc, char** argv) {
     const char* op_id_to_op_name[] = {"ADD"};
 
     auto eltwise_op = EltwiseOp::ADD;
-    log_info(LogTest, "====================================================================");
-    log_info(LogTest, "======= Running eltwise_binary test for op={}", op_id_to_op_name[eltwise_op]);
+    TT_LOG_INFO_WITH_CAT(LogTest, "====================================================================");
+    TT_LOG_INFO_WITH_CAT(LogTest, "======= Running eltwise_binary test for op={}", op_id_to_op_name[eltwise_op]);
     try {
         ////////////////////////////////////////////////////////////////////////////
         //                      Device Setup
@@ -259,7 +259,7 @@ int main(int argc, char** argv) {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_1d_fabric_loopback_latency.cpp
@@ -45,7 +45,7 @@ inline void RunPersistent1dFabricLatencyTest(
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     bool is_6u = num_devices == 32 && tt::tt_metal::GetNumPCIeDevices() == num_devices;
     if (num_devices < 4 && !is_6u) {
-        log_info("This test can only be run on T3000 or 6u systems");
+        TT_LOG_INFO("This test can only be run on T3000 or 6u systems");
         return;
     }
 
@@ -99,7 +99,7 @@ inline void RunPersistent1dFabricLatencyTest(
         devices.push_back(devices_.at(i));
         TT_FATAL(devices_.at(i) != nullptr, "Device at index {} is null", i);
         if (writer_specs.size() > i && writer_specs.at(i).has_value()) {
-            log_info(tt::LogTest, "index: {} has worker", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "index: {} has worker", i);
             devices_with_workers.push_back(devices_.at(i));
         }
     }
@@ -144,7 +144,7 @@ inline void RunPersistent1dFabricLatencyTest(
 
     // Persistent Fabric Setup
     for (auto d : devices) {
-        log_info(tt::LogTest, "Launching fabric on device {}", d->id());
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Launching fabric on device {}", d->id());
     }
     std::optional<SubdeviceInfo> subdevice_managers = std::nullopt;
     std::optional<std::vector<Program>> fabric_programs;
@@ -242,9 +242,9 @@ inline void RunPersistent1dFabricLatencyTest(
         bool is_latency_packet_sender = std::holds_alternative<LatencyPacketTestWriterSpec>(writer_specs[i]->spec);
         bool is_datapath_busy_sender = std::holds_alternative<DatapathBusyDataWriterSpec>(writer_specs[i]->spec);
         if (is_latency_packet_sender) {
-            log_info(tt::LogTest, "index: {} has latency packet sender", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "index: {} has latency packet sender", i);
         } else if (is_datapath_busy_sender) {
-            log_info(tt::LogTest, "index: {} has datapath busy sender", i);
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "index: {} has datapath busy sender", i);
         }
 
         IDevice* backward_device = i == 0 ? is_ring ? devices.at(line_size - 1) : nullptr : devices.at(i - 1);
@@ -297,7 +297,7 @@ inline void RunPersistent1dFabricLatencyTest(
             bool sem_inc_only = writer_specs.at(i)->message_size_bytes == 0;
             worker_ct_args = {!sem_inc_only && enable_fused_payload_with_sync, payloads_are_mcast, sem_inc_only};
         } else {
-            log_info(tt::LogTest, "adding datapath busy writer");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "adding datapath busy writer");
             const auto& datapath_spec = std::get<DatapathBusyDataWriterSpec>(writer_specs[i]->spec);
             worker_ct_args.push_back(datapath_spec.mcast);
         }
@@ -322,7 +322,7 @@ inline void RunPersistent1dFabricLatencyTest(
                     const auto connection = local_device_fabric_handle->uniquely_connect_worker(device, direction);
                     const auto new_rt_args = ttnn::ccl::worker_detail::generate_edm_connection_rt_args(
                         connection, program, {worker_core_logical});
-                    log_info(
+                    TT_LOG_INFO_WITH_CAT(
                         tt::LogTest,
                         "On device: {}, connecting to EDM fabric in {} direction. EDM noc_x: {}, noc_y: {}",
                         device->id(),
@@ -444,24 +444,24 @@ inline void RunPersistent1dFabricLatencyTest(
     }
 
     for (auto d : devices_with_workers) {
-        log_info(tt::LogTest, "launch on Device {}", d->id());
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "launch on Device {}", d->id());
     }
     build_and_enqueue(devices_with_workers, programs);
 
-    log_info(tt::LogTest, "Waiting for Op finish on all devices");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Waiting for Op finish on all devices");
     wait_for_worker_program_completion(devices_with_workers, subdevice_managers);
-    log_info(tt::LogTest, "Main op done");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Main op done");
 
     TT_FATAL(
         is_ring || fabric_programs->size() == devices.size(),
         "Expected fabric programs size to be same as devices size");
-    log_info(tt::LogTest, "Fabric teardown");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Fabric teardown");
     if (!use_device_init_fabric) {
         persistent_fabric_teardown_sequence(
             devices, subdevice_managers, fabric_handle.value(), tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE);
     }
 
-    log_info(tt::LogTest, "Waiting for teardown completion");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Waiting for teardown completion");
     for (IDevice* d : devices) {
         tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
     }
@@ -470,7 +470,7 @@ inline void RunPersistent1dFabricLatencyTest(
         auto& program = programs.at(i);
         tt_metal::DumpDeviceProfileResults(d, program);
     }
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 }
 
 int main(int argc, char** argv) {

--- a/tests/ttnn/unit_tests/gtests/ccl/test_ccl_reduce_scatter_host_helpers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_ccl_reduce_scatter_host_helpers.cpp
@@ -63,9 +63,9 @@ TEST(LineReduceScatter, EmitCclSendSliceSequenceCommands_8Slices_1x1x32x2048Tens
 
     shape4d expected_tensor_slice_shape = shape4d(1, 1, 1, 8);
 
-    log_info(tt::LogOp, "Commands");
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "Commands");
     for (std::size_t i = 0; i < args.size(); i++) {
-        log_info(tt::LogOp, "arg {}: {}", i, args[i]);
+        TT_LOG_INFO_WITH_CAT(tt::LogOp, "arg {}: {}", i, args[i]);
     }
 
     {  // Validate the first command

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -74,7 +74,7 @@ void set_edm_runtime_args(
     for (auto const& s : edm_clockwise_kernel_rt_args) {
         ss << "\t" << s << "\n";
     }
-    log_info(tt::LogOp, "{}", ss.str());
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "{}", ss.str());
 }
 
 }  // namespace ccl
@@ -164,13 +164,13 @@ void generate_receiver_worker_kernels(
         page_size,
         num_pages_per_edm_buffer};
     std::vector<uint32_t> receiver_worker_writer_runtime_args{dram_output_buffer_base_addr};
-    log_info(tt::LogTest, "\tReceiverWriter CT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tReceiverWriter CT Args");
     for (auto const& arg : receiver_worker_writer_compile_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
-    log_info(tt::LogTest, "\tReceiverWriter RT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tReceiverWriter RT Args");
     for (auto const& arg : receiver_worker_writer_runtime_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
 
     std::vector<uint32_t> receiver_worker_receiver_compile_args{
@@ -186,13 +186,13 @@ void generate_receiver_worker_kernels(
         (uint32_t)device->ethernet_core_from_logical_core(edm_core).y,
         worker_semaphore_address,
         num_buffers_per_edm_channel};
-    log_info(tt::LogTest, "\tReceiverReader CT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tReceiverReader CT Args");
     for (auto const& arg : receiver_worker_receiver_compile_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
-    log_info(tt::LogTest, "\tReceiverReader RT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tReceiverReader RT Args");
     for (auto const& arg : receiver_worker_receiver_runtime_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
 
     auto receiver_worker_receiver_kernel = tt_metal::CreateKernel(
@@ -237,13 +237,13 @@ void generate_sender_worker_kernels(
         num_pages_per_edm_buffer};
     std::vector<uint32_t> sender_worker_reader_runtime_args{dram_output_buffer_base_addr};
 
-    log_info(tt::LogTest, "\tSenderReader CT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tSenderReader CT Args");
     for (auto const& arg : sender_worker_reader_compile_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
-    log_info(tt::LogTest, "\tSenderReader RT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tSenderReader RT Args");
     for (auto const& arg : sender_worker_reader_runtime_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
 
     std::vector<uint32_t> sender_worker_writer_compile_args{
@@ -256,13 +256,13 @@ void generate_sender_worker_kernels(
         (uint32_t)device->ethernet_core_from_logical_core(edm_core).y,
         num_buffers_per_edm_channel};
     uint32_t src0_cb_index = CBIndex::c_0;
-    log_info(tt::LogTest, "\tSenderWriter CT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tSenderWriter CT Args");
     for (auto const& arg : sender_worker_writer_compile_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
-    log_info(tt::LogTest, "\tSenderWriter RT Args");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "\tSenderWriter RT Args");
     for (auto const& arg : sender_worker_writer_runtime_args) {
-        log_info(tt::LogTest, "\t\t{}", arg);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "\t\t{}", arg);
     }
     // Just want a dummy DF
     tt::DataFormat df = page_size == 1024   ? tt::DataFormat::Bfp8
@@ -338,7 +338,7 @@ bool RunWriteBWTest(
     for (auto const& worker_core : worker_cores) {
         local_worker_semaphore_addresses.push_back(tt::tt_metal::CreateSemaphore(sender_program, worker_core, 0));
         remote_worker_semaphore_addresses.push_back(tt::tt_metal::CreateSemaphore(receiver_program, worker_core, 0));
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest,
             "worker_core=(x={},y={}), local_worker_semaphore_address={}, remote_worker_semaphore_address={}",
             worker_core.x,
@@ -430,10 +430,10 @@ bool RunWriteBWTest(
     TT_ASSERT(num_bytes_per_send >= page_size);
     TT_ASSERT(num_bytes_per_send >= page_size);
     const uint32_t num_messages_to_send = (((num_pages_total * page_size) - 1) / num_bytes_per_send) + 1;
-    log_info(tt::LogTest, "num_bytes_per_send={}", num_bytes_per_send);
-    log_info(tt::LogTest, "page_size={}", page_size);
-    log_info(tt::LogTest, "pages_per_send={}", pages_per_send);
-    log_info(tt::LogTest, "num_messages_to_send={}", num_messages_to_send);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "num_bytes_per_send={}", num_bytes_per_send);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "page_size={}", page_size);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "pages_per_send={}", pages_per_send);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "num_messages_to_send={}", num_messages_to_send);
     std::vector<uint32_t> num_messages_to_send_over_channel(num_edm_channels, num_messages_to_send);
 
     std::vector<CoreCoord> local_sender_workers;
@@ -488,10 +488,10 @@ bool RunWriteBWTest(
     ////////////////////////////////////////////////////////////////////////////
     // Build Workers
     ////////////////////////////////////////////////////////////////////////////
-    log_info(tt::LogTest, "Generating local_sender -> remote_receiver workers");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Generating local_sender -> remote_receiver workers");
     for (uint32_t i = 0; i < num_local_sender_channels; i++) {
         auto const& worker_core = worker_cores.at(i);
-        log_info(tt::LogTest, "Worker {}. On Core x={},y={}", i, worker_core.x, worker_core.y);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Worker {}. On Core x={},y={}", i, worker_core.x, worker_core.y);
         generate_sender_worker_kernels(
             sender_program,
             sender_device,
@@ -521,9 +521,9 @@ bool RunWriteBWTest(
             dest_is_dram,
             edm_termination_mode);
     }
-    log_info(tt::LogTest, "Generating remote_sender -> local_receiver workers");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Generating remote_sender -> local_receiver workers");
     for (uint32_t i = 0; i < num_remote_sender_channels; i++) {
-        log_info(tt::LogTest, "Worker {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Worker {}", i);
         auto const& worker_core = worker_cores.at(i + num_local_sender_channels);
         generate_sender_worker_kernels(
             receiver_program,
@@ -579,7 +579,7 @@ bool RunWriteBWTest(
         throw e;
     }
 
-    log_info(tt::LogTest, "Running...");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running...");
 
     if (std::getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
         std::thread th2 = std::thread([&] { tt_metal::detail::LaunchProgram(sender_device, sender_program); });
@@ -597,7 +597,7 @@ bool RunWriteBWTest(
     }
     // tt::tt_metal::detail::DumpDeviceProfileResults(receiver_device);
     // tt::tt_metal::detail::DumpDeviceProfileResults(sender_device);
-    log_info(tt::LogTest, "Reading back outputs");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Reading back outputs");
 
     auto is_output_correct = [&all_zeros, &inputs](const std::shared_ptr<tt_metal::Buffer>& output_buffer) {
         constexpr bool debug_mode = false;
@@ -606,7 +606,7 @@ bool RunWriteBWTest(
         std::fill(readback_data_vec.begin(), readback_data_vec.end(), 0);
 
         tt_metal::detail::ReadFromBuffer(output_buffer, readback_data_vec);
-        log_info(tt::LogTest, "Checking outputs");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Checking outputs");
         if (readback_data_vec.size() != inputs.size()) {
             log_error(tt::LogTest, "Output size mismatch: expected {} got {}", inputs.size(), readback_data_vec.size());
             return false;
@@ -665,11 +665,11 @@ int TestEntrypoint(
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 2) {
-        log_info("This test can only be run on n300 devices");
+        TT_LOG_INFO("This test can only be run on n300 devices");
         return 0;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return 0;
     }
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -226,7 +226,7 @@ template <typename CONTAINER_T>
 Correctness run_output_check(CONTAINER_T const& inputs, CONTAINER_T output_buffer) {
     constexpr bool debug_mode = true;
 
-    log_info(tt::LogTest, "Checking outputs");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Checking outputs");
     bool pass = true;
 
     std::size_t num_printed_mismatches = 0;
@@ -246,7 +246,7 @@ Correctness run_output_check(CONTAINER_T const& inputs, CONTAINER_T output_buffe
         log_error("... (remaining mismatches omitted)");
     }
 
-    log_info(tt::LogTest, "Output check: {}", pass ? "PASS" : "FAIL");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Output check: {}", pass ? "PASS" : "FAIL");
     return pass ? Correctness::Correct : Correctness::Incorrect;
 };
 
@@ -311,7 +311,7 @@ void run_programs(std::vector<Program>& programs, const std::vector<IDevice*>& d
         throw e;
     }
 
-    log_info(tt::LogTest, "Running...");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Running...");
 
     std::vector<std::thread> threads;
     threads.reserve(num_programs);
@@ -606,7 +606,7 @@ bool RunLoopbackTest(
     }
     log_trace(tt::LogTest, "{} programs, {} devices", programs.size(), devices.size());
     run_programs(programs, devices);
-    log_info(tt::LogTest, "Reading back outputs");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Reading back outputs");
 
     bool pass = true;
     constexpr bool enable_check = true;
@@ -833,7 +833,7 @@ bool RunLocalTestWithMultiInputReaders(
     const bool fabric_enabled = test_mode != TwoInputReaderKernelWriteMode::LOCAL_WRITEBACK;
     tt_metal::IDevice* device = devices.at(0);
     for (size_t i = 0; i < devices.size(); i++) {
-        log_info(tt::LogTest, "Device[{}] ID: {}", i, devices.at(i)->id());
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Device[{}] ID: {}", i, devices.at(i)->id());
     }
     auto program_ptrs = std::vector<Program*>();
     program_ptrs.reserve(devices.size());
@@ -842,7 +842,7 @@ bool RunLocalTestWithMultiInputReaders(
     size_t output_tensor_dest_device_index = 0;
     if (fabric_enabled) {
         if (std::holds_alternative<ttnn::ccl::cmd::UnicastCommandDestArgs>(dest_args)) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest,
                 "Unicast command dest args. Distance in hops: {}",
                 std::get<ttnn::ccl::cmd::UnicastCommandDestArgs>(dest_args).distance_in_hops);
@@ -851,7 +851,7 @@ bool RunLocalTestWithMultiInputReaders(
             TT_ASSERT(output_tensor_dest_device_index != 0, "Output tensor destination device index must be non-zero");
             TT_ASSERT(test_mode == TwoInputReaderKernelWriteMode::FABRIC_UNICAST);
         } else if (std::holds_alternative<ttnn::ccl::cmd::MulticastCommandDestArgs>(dest_args)) {
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest,
                 "Multicast command dest args. Number of targets forward direction: {}",
                 std::get<ttnn::ccl::cmd::MulticastCommandDestArgs>(dest_args).num_targets_forward_direction);
@@ -861,7 +861,7 @@ bool RunLocalTestWithMultiInputReaders(
             TT_ASSERT(test_mode == TwoInputReaderKernelWriteMode::FABRIC_MULTICAST);
         }
     } else {
-        log_info(tt::LogTest, "No fabric enabled");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "No fabric enabled");
         TT_ASSERT(
             std::holds_alternative<ttnn::ccl::cmd::DestTypeArgsNull>(dest_args), "Local command dest args expected");
     }
@@ -881,14 +881,14 @@ bool RunLocalTestWithMultiInputReaders(
     auto output_tensor0_device = output0_tensors.at(output_tensor_dest_device_index);
     auto output_tensor1_device = output1_tensors.at(output_tensor_dest_device_index);
 
-    log_info(tt::LogTest, "input_tensor0_device->address(): {}", input_tensor0_device.buffer()->address());
-    log_info(tt::LogTest, "input_tensor1_device->address(): {}", input_tensor1_device.buffer()->address());
-    log_info(
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "input_tensor0_device->address(): {}", input_tensor0_device.buffer()->address());
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "input_tensor1_device->address(): {}", input_tensor1_device.buffer()->address());
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "output_tensor0_device->address(): {} on device {}",
         output_tensor0_device.buffer()->address(),
         output_tensor_dest_device->id());
-    log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogTest,
         "output_tensor1_device->address(): {} on device {}",
         output_tensor1_device.buffer()->address(),
@@ -959,22 +959,22 @@ bool RunLocalTestWithMultiInputReaders(
         dest_args);
 
     if (!enable_persistent_fabric) {
-        log_info(tt::LogTest, "Building EDM kernels");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Building EDM kernels");
         line_fabric->build_kernels();
     }
 
-    log_info(tt::LogTest, "persistent_fabric: {}", enable_persistent_fabric);
-    log_info(tt::LogTest, "subdevice_managers.has_value(): {}", subdevice_managers.has_value());
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "persistent_fabric: {}", enable_persistent_fabric);
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "subdevice_managers.has_value(): {}", subdevice_managers.has_value());
     ////////////////////////////////////////////////////////////////////////////
     //                      Compile and Execute Application
     ////////////////////////////////////////////////////////////////////////////
     run_programs(programs, enable_persistent_fabric ? std::vector<IDevice*>{devices[0]} : devices);
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 
     bool pass = true;
     constexpr bool enable_check = true;
     if constexpr (enable_check) {
-        log_info(tt::LogTest, "Reading back outputs");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Reading back outputs");
         auto output0_cpu = output_tensor0_device.cpu(true, ttnn::DefaultQueueId);
         auto output1_cpu = output_tensor1_device.cpu(true, ttnn::DefaultQueueId);
 
@@ -996,16 +996,16 @@ bool RunLocalTestWithMultiInputReaders(
         TT_FATAL(input0_copyback_check_passed, "Input 0 copyback check failed");
         TT_FATAL(input1_copyback_check_passed, "Input 1 copyback check failed");
 
-        log_info(tt::LogTest, "Comparing outputs");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Comparing outputs");
         pass &= run_output_check(in0_tensor_data, out0_tensor_data) == Correctness::Correct;
         if (pass) {
-            log_info(tt::LogTest, "Output check passed for output 0");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Output check passed for output 0");
         } else {
             log_error(tt::LogTest, "Output check failed for output 0");
         }
         pass &= run_output_check(in1_tensor_data, out1_tensor_data) == Correctness::Correct;
         if (pass) {
-            log_info(tt::LogTest, "Output check passed for output 1");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Output check passed for output 1");
         } else {
             log_error(tt::LogTest, "Output check failed for output 1");
         }
@@ -1141,7 +1141,7 @@ bool RunLineFabricTest(
     ////////////////////////////////////////////////////////////////////////////
 
     run_programs(programs, devices);
-    log_info(tt::LogTest, "Reading back outputs");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Reading back outputs");
 
     bool pass = true;
     constexpr bool enable_check = true;
@@ -1166,7 +1166,7 @@ void persistent_fabric_teardown_sequence(
     std::optional<SubdeviceInfo>& subdevice_managers,
     ttnn::ccl::EdmLineFabricOpInterface& line_fabric,
     tt::tt_fabric::TerminationSignal termination_mode = tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE) {
-    log_info("Tearing down fabric");
+    TT_LOG_INFO("Tearing down fabric");
 
     // Wait for workers to finish
     auto d0_worker_subdevice = devices[0]->get_sub_device_ids()[TEST_WORKERS_SUBDEVICE_INDEX];
@@ -1195,7 +1195,7 @@ void setup_test_with_persistent_fabric(
     bool loopback_on_last_device = false,
     bool is_galaxy = false) {
     if (enable_persistent_fabric) {
-        log_info(tt::LogTest, "Enabling persistent fabric");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Enabling persistent fabric");
         fabric_programs = std::vector<Program>(devices.size());
         subdevice_managers = create_subdevices(devices);
         std::transform(
@@ -1226,7 +1226,7 @@ void setup_test_with_persistent_fabric(
         TT_FATAL(fabric_programs.has_value(), "Fabric programs must be set if fabric is enabled");
         TT_FATAL(devices.size() == fabric_programs->size(), "Number of devices must match number of programs");
 
-        log_info(tt::LogTest, "Building EDM kernels");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Building EDM kernels");
         line_fabric->build_kernels();
         build_and_enqueue(devices, *fabric_programs);
     }
@@ -1248,11 +1248,11 @@ int TestLineFabricEntrypoint(
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 4) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return 0;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return 0;
     }
 
@@ -1334,11 +1334,11 @@ int TestLoopbackEntrypoint(
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 4) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return 0;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return 0;
     }
 
@@ -1368,7 +1368,7 @@ int TestLoopbackEntrypoint(
     std::optional<std::vector<Program>> fabric_programs;
     auto& sender_program = programs.at(0);
     if (enable_persistent_fabric) {
-        log_info(tt::LogTest, "Enabling persistent fabric");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Enabling persistent fabric");
         fabric_programs = std::vector<Program>(2);
         subdevice_managers = create_subdevices({device_0, device_1});
     }
@@ -1511,11 +1511,11 @@ bool TestMultiInputReaderKernel(
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 4) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return true;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return true;
     }
     Fabric1DFixture test_fixture;
@@ -1611,7 +1611,7 @@ bool TestMultiInputReaderKernel(
         persistent_fabric_teardown_sequence(
             devices, subdevice_managers, line_fabric.value(), tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
 
-        log_info(tt::LogTest, "Finished");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
         for (auto d : devices) {
             tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
         }
@@ -1804,11 +1804,11 @@ bool RunPipelinedWorkersTest(
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     auto num_devices = tt::tt_metal::GetNumAvailableDevices();
     if (num_devices < 4) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return true;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return true;
     }
 
@@ -1867,7 +1867,7 @@ bool RunPipelinedWorkersTest(
     for (size_t i = 0; i < num_tensors; i++) {
         host_tensors[i].set_tensor_spec(tensor_specs[i]);
         device_tensors.push_back(host_tensors[i].to_device(device, mem_configs[i]));
-        log_info("Tensor[{}] allocated starting at address {}", i, device_tensors[i].buffer()->address());
+        TT_LOG_INFO("Tensor[{}] allocated starting at address {}", i, device_tensors[i].buffer()->address());
     }
     TT_ASSERT(device_tensors.size() == num_tensors);
     TT_ASSERT(device_tensors.size() == host_tensors.size());
@@ -2004,14 +2004,14 @@ bool RunPipelinedWorkersTest(
                 }
                 reader_cmd_stream.push_back(ttnn::ccl::cmd::uops::read_tensor_slice_to_cb(
                     per_stage_worker_reader_tensor_slices[stage][worker][slice_actual], cb_index));
-                log_info(tt::LogTest, "Worker {} reading/writing slice {}", worker, slice_actual);
+                TT_LOG_INFO_WITH_CAT(tt::LogTest, "Worker {} reading/writing slice {}", worker, slice_actual);
 
                 // writer
                 writer_cmd_stream.push_back(ttnn::ccl::cmd::uops::local_write_cb_to_tensor_slice(
                     per_stage_worker_writer_tensor_slices[stage][worker][slice_actual], cb_index));
                 if (not last_stage) {
                     for (auto next_worker_xy : next_worker_cores.value()) {
-                        log_info(
+                        TT_LOG_INFO_WITH_CAT(
                             tt::LogTest,
                             "Stage {} Worker {} noc seminc to core (logical) x={},y={}",
                             stage,
@@ -2060,7 +2060,7 @@ bool RunPipelinedWorkersTest(
     bool pass = true;
     constexpr bool enable_check = true;
     if constexpr (enable_check) {
-        log_info(tt::LogTest, "Reading back outputs");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Reading back outputs");
         auto input_cpu = device_tensors[0].cpu();
         auto final_out_cpu = device_tensors.back().cpu();
 
@@ -2072,11 +2072,11 @@ bool RunPipelinedWorkersTest(
         bool input_copyback_check_passed = run_output_check(in_tensor_data, in_tensor_copyback) == Correctness::Correct;
         TT_FATAL(input_copyback_check_passed, "Input 0 copyback check failed");
 
-        log_info(tt::LogTest, "Comparing outputs");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Comparing outputs");
 
         pass &= run_output_check(in_tensor_data, out_tensor_copyback) == Correctness::Correct;
         if (pass) {
-            log_info(tt::LogTest, "Output check passed for output 0");
+            TT_LOG_INFO_WITH_CAT(tt::LogTest, "Output check passed for output 0");
         } else {
             log_error(tt::LogTest, "Output check failed for output 0");
         }
@@ -2101,17 +2101,17 @@ static void wait_for_worker_program_completion(
 
 #include "ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/all_gather_async_op.hpp"
 void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_links, ttnn::Shape const& input_shape) {
-    log_info(tt::LogTest, "entering test");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "entering test");
     constexpr auto layout = Layout::TILE;
     // DEVICES setuip
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     constexpr size_t test_expected_num_devices = 4;
     if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return;
     }
     // Initialize MeshDevice with 1D Fabric
@@ -2134,7 +2134,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
     const auto num_elems = input_shape.volume();
 
     // INPUT TENSOR setup
-    log_info(tt::LogTest, "setting up input tensors");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "setting up input tensors");
     size_t page_size = tile_size(DataFormat::Float16);
     std::vector<Tensor> device_input_tensors;
     for (size_t i = 0; i < num_devices; i++) {
@@ -2149,7 +2149,7 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
                                          .to_device(test_fixture.mesh_device_.get());
     std::optional<SubdeviceInfo> subdevice_managers = create_worker_subdevices(devices);
 
-    log_info(tt::LogTest, "launching op");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "launching op");
 
     GlobalSemaphore multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore(
         test_fixture.mesh_device_.get(),
@@ -2169,22 +2169,22 @@ void run_all_gather_with_persistent_fabric(const size_t dim, const size_t num_li
 
     // wait for op completion
     wait_for_worker_program_completion(devices, subdevice_managers);
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 }
 
 void run_ring_all_gather_with_persistent_fabric(
     const size_t dim, const size_t num_links, const ttnn::Shape& input_shape) {
-    log_info(tt::LogTest, "entering test");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "entering test");
     constexpr auto layout = Layout::TILE;
     // DEVICES setuip
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     constexpr size_t test_expected_num_devices = 8;
     if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return;
     }
     // Initialize MeshDevice with 1D Fabric
@@ -2204,7 +2204,7 @@ void run_ring_all_gather_with_persistent_fabric(
     const auto num_elems = input_shape.volume();
 
     // INPUT TENSOR setup
-    log_info(tt::LogTest, "setting up input tensors");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "setting up input tensors");
     size_t page_size = tile_size(DataFormat::Float16);
     std::vector<Tensor> device_input_tensors;
     for (size_t i = 0; i < num_devices; i++) {
@@ -2221,7 +2221,7 @@ void run_ring_all_gather_with_persistent_fabric(
     std::optional<SubdeviceInfo> subdevice_managers = create_worker_subdevices(devices);
     ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear;
 
-    log_info(tt::LogTest, "launching op");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "launching op");
 
     GlobalSemaphore multi_device_global_semaphore = ttnn::global_semaphore::create_global_semaphore(
         test_fixture.mesh_device_.get(),
@@ -2484,11 +2484,11 @@ void Run1DFabricPacketSendTest(
     bool use_galaxy = num_devices == 32;
     bool use_tg = use_galaxy && tt::tt_metal::GetNumPCIeDevices() == 4;
     if (num_devices < 4) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return;
     }
 
@@ -2532,10 +2532,10 @@ void Run1DFabricPacketSendTest(
     size_t dest_buffer_size = max_packet_payload_size_bytes * 4;
     static constexpr tt::DataFormat cb_df = tt::DataFormat::Bfp8;
 
-    log_info("Device open and fabric init");
+    TT_LOG_INFO("Device open and fabric init");
     // MeshFabric1DLineDeviceInitFixture test_fixture;
     FABRIC_DEVICE_FIXTURE test_fixture;
-    log_info("\tDone");
+    TT_LOG_INFO("\tDone");
     auto view = *(test_fixture.view_);
 
     auto fabrics_under_test_devices =
@@ -2828,7 +2828,7 @@ void Run1DFabricPacketSendTest(
                         const auto connection = local_device_fabric_handle->uniquely_connect_worker(device, direction);
                         const auto new_rt_args = ttnn::ccl::worker_detail::generate_edm_connection_rt_args(
                             connection, program, {worker_core});
-                        log_info(
+                        TT_LOG_INFO_WITH_CAT(
                             tt::LogTest,
                             "On device: {}, connecting to EDM fabric in {} direction. EDM noc_x: {}, noc_y: {}",
                             device->id(),
@@ -2940,7 +2940,7 @@ void Run1DFabricPacketSendTest(
     }
 
     for (size_t i = 0; i < params.num_op_invocations; i++) {
-        log_info(tt::LogTest, "Iteration: {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Iteration: {}", i);
         if (i != 0 && params.line_sync) {
             for (size_t fabric_index = 0; fabric_index < fabrics_under_test_devices.size(); fabric_index++) {
                 auto& programs = programs_per_fabric[fabric_index];
@@ -2965,23 +2965,23 @@ void Run1DFabricPacketSendTest(
             build_and_enqueue(worker_devices, programs, i != 0);
         }
 
-        log_info(tt::LogTest, "Waiting for Op finish on all devices");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Waiting for Op finish on all devices");
         for (size_t fabric_index = 0; fabric_index < fabrics_under_test_devices.size(); fabric_index++) {
             auto& worker_devices = fabric_under_test_worker_devices[fabric_index];
             wait_for_worker_program_completion(worker_devices, subdevice_managers);
         }
-        log_info(tt::LogTest, "Main op done");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Main op done");
     }
 
     if (!use_device_init_fabric) {
         auto& devices = fabrics_under_test_devices[0];
         TT_FATAL(fabric_programs->size() == devices.size(), "Expected fabric programs size to be same as devices size");
-        log_info(tt::LogTest, "Fabric teardown");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Fabric teardown");
         persistent_fabric_teardown_sequence(
             devices, subdevice_managers, fabric_handle.value(), tt::tt_fabric::TerminationSignal::GRACEFULLY_TERMINATE);
     }
 
-    log_info(tt::LogTest, "Waiting for teardown completion");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Waiting for teardown completion");
     for (size_t fabric_index = 0; fabric_index < fabrics_under_test_devices.size(); fabric_index++) {
         auto& devices = fabrics_under_test_devices[fabric_index];
         for (IDevice* d : devices) {
@@ -2995,7 +2995,7 @@ void Run1DFabricPacketSendTest(
             tt_metal::detail::DumpDeviceProfileResults(d);
         }
     }
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 }
 
 void RunWriteThroughputStabilityTestWithPersistentFabric(
@@ -3040,17 +3040,17 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     switch (cluster_type) {
         case ClusterType::T3K:
             if (num_devices != 8) {
-                log_info(tt::LogTest, "This test can only be run 8 chips on T3000 devices");
+                TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test can only be run 8 chips on T3000 devices");
                 return;
             }
             break;
         case ClusterType::GALAXY:
             if (num_devices != 4 && num_devices != 8) {
-                log_info(tt::LogTest, "This test can only be run on 4 or 8 chips on Galaxy devices");
+                TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test can only be run on 4 or 8 chips on Galaxy devices");
                 return;
             }
             break;
-        default: log_info(tt::LogTest, "This test can only be run on T3000 or Galaxy devices"); return;
+        default: TT_LOG_INFO_WITH_CAT(tt::LogTest, "This test can only be run on T3000 or Galaxy devices"); return;
     }
 
     using namespace ttnn::ccl;
@@ -3302,7 +3302,7 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
     }
 
     for (size_t i = 0; i < num_op_invocations; i++) {
-        log_info(tt::LogTest, "Iteration: {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Iteration: {}", i);
         if (i != 0 && line_sync) {
             for (size_t k = 0; k < worker_kernel_ids.size(); k++) {
                 auto& worker_rt_args_by_core = GetRuntimeArgs(programs[k], worker_kernel_ids[k]);
@@ -3317,12 +3317,12 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
 
         build_and_enqueue(worker_devices, programs, i != 0);
 
-        log_info(tt::LogTest, "Waiting for Op finish on all devices");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Waiting for Op finish on all devices");
         for (IDevice* d : devices) {
             tt_metal::Synchronize(d, *ttnn::DefaultQueueId);
         }
-        log_info(tt::LogTest, "Main op done");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Main op done");
     }
 
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -815,7 +815,7 @@ TEST(
         for (auto& num_workers_per_stage : num_workers_per_stage_sweep) {
             for (size_t slices_per_stage : slices_per_stage_sweep) {
                 for (auto& mem_configs : mem_configs_sweep) {
-                    log_info(
+                    TT_LOG_INFO_WITH_CAT(
                         tt::LogTest,
                         "tensor shape {} and workers stage {} slices_per_stage {}",
                         tensor_shape,

--- a/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_persistent_fabric_ccl_ops.cpp
@@ -42,11 +42,11 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
     auto arch = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
     constexpr size_t test_expected_num_devices = 4;
     if (tt::tt_metal::GetNumAvailableDevices() < test_expected_num_devices) {
-        log_info("This test can only be run on T3000 devices");
+        TT_LOG_INFO("This test can only be run on T3000 devices");
         return;
     }
     if (arch == tt::ARCH::GRAYSKULL) {
-        log_info("Test must be run on WH");
+        TT_LOG_INFO("Test must be run on WH");
         return;
     }
     MeshFabric1DFixture test_fixture(tt::tt_metal::FabricConfig::FABRIC_1D);
@@ -114,12 +114,12 @@ TEST(CclAsyncOp, ReduceScatterSmall_PersistentFabric) {
         subdevice_managers->worker_subdevice_id.at(devices[0]->id()));
 
     // wait for op completion
-    log_info(tt::LogTest, "Waiting for Op finish");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Waiting for Op finish");
     std::ranges::for_each(devices, [&](IDevice* d) {
         tt_metal::Finish(d->command_queue(), {subdevice_managers->worker_subdevice_id.at(d->id())});
     });
 
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 }
 
 TEST(CclAsyncOp, AllGather_PersistentFabric_Dim3_Links1_Shape1_1_32_128) {

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -86,7 +86,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
         test_expected_num_devices,
         num_devices);
 
-    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Creating Global Semaphore for Ccl Ops");
     auto
         [from_remote_multi_device_global_semaphore,
          to_remote_multi_device_global_semaphore,
@@ -106,10 +106,10 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
     TensorSpec tensor_spec(input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
 
     for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
-        log_info(LogTest, "Running outer loop {}", outer_loop);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running outer loop {}", outer_loop);
         std::vector<Tensor> device_tensors(devices.size());
 
-        log_info(LogTest, "Enqueue Operations before AllGather");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Enqueue Operations before AllGather");
         std::vector<std::future<void>> futures;
         for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
             auto device = devices[dev_idx];
@@ -143,7 +143,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
         }
         futures.clear();
 
-        log_info(LogTest, "Enqueue AllGather");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Enqueue AllGather");
 
         // Enqueue the all_gather_async operation on each device.
         // It does not support command queue ID as a parameter and internally uses command queue 0.
@@ -156,7 +156,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
             ttnn::ccl::Topology::Linear,
             SubDeviceId(0));
 
-        log_info(LogTest, "Enqueue dummy ops");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Enqueue dummy ops");
         for (int dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
             auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
@@ -181,7 +181,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
         }
         futures.clear();
 
-        log_info(LogTest, "EnqueueReadBuffer");
+        TT_LOG_INFO_WITH_CAT(LogTest, "EnqueueReadBuffer");
         // Read the values from each device and compare them with the results calculated on the host
         for (size_t i = 0; i < devices.size(); ++i) {
             auto device = devices[i];
@@ -194,7 +194,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
                     int base = j / num_elems;  // dev_idx
                     ASSERT_EQ(output_data[j].to_float(), (-1.0 * base * 32.0 + 128));
                 }
-                log_info(LogTest, "Device{} Compare Success", device->id());
+                TT_LOG_INFO_WITH_CAT(LogTest, "Device{} Compare Success", device->id());
             });
         }
     }
@@ -205,7 +205,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
         ttnn::queue_synchronize(device->command_queue(op_cq_id));
     }
 
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 }
 
 TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
@@ -232,7 +232,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
         test_expected_num_devices,
         num_devices);
 
-    log_info(LogTest, "Creating Global Semaphore for Ccl Ops");
+    TT_LOG_INFO_WITH_CAT(LogTest, "Creating Global Semaphore for Ccl Ops");
     auto
         [from_remote_multi_device_global_semaphore,
          to_remote_multi_device_global_semaphore,
@@ -252,13 +252,13 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
     boost::asio::thread_pool pool(devices.size());
 
     for (int outer_loop = 0; outer_loop < 1; outer_loop++) {
-        log_info(LogTest, "Running outer loop {}", outer_loop);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running outer loop {}", outer_loop);
         std::vector<Tensor> device_tensors(devices.size());
 
         TensorSpec tensor_spec(
             input_shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), in_memory_config));
 
-        log_info(LogTest, "Enqueue Operations before AllGather");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Enqueue Operations before AllGather");
         std::vector<std::future<void>> futures;
         for (size_t dev_idx = 0; dev_idx < devices.size(); ++dev_idx) {
             auto device = devices[dev_idx];
@@ -298,7 +298,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
         }
         futures.clear();
 
-        log_info(LogTest, "Enqueue AllGather");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Enqueue AllGather");
 
         // Enqueue the all_gather_async operation on each device.
         // It does not support command queue ID as a parameter and internally uses command queue 0.
@@ -311,7 +311,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
             ttnn::ccl::Topology::Linear,
             SubDeviceId(0));
 
-        log_info(LogTest, "Enqueue dummy ops");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Enqueue dummy ops");
         for (size_t dev_idx = 0; dev_idx < devices.size(); dev_idx++) {
             auto device = devices[dev_idx];
             auto promise = std::make_shared<std::promise<void>>();
@@ -359,7 +359,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
         }
         futures.clear();
 
-        log_info(LogTest, "EnqueueReadBuffer");
+        TT_LOG_INFO_WITH_CAT(LogTest, "EnqueueReadBuffer");
         // Read the values from each device and compare them with the results calculated on the host
         for (size_t i = 0; i < devices.size(); ++i) {
             auto device = devices[i];
@@ -373,7 +373,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
                     int base = j / num_elems;  // dev_idx
                     ASSERT_EQ(output_data[j].to_float(), (-1.0 * base * 32.0 + 128));
                 }
-                log_info(LogTest, "Device{} Compare Success", device->id());
+                TT_LOG_INFO_WITH_CAT(LogTest, "Device{} Compare Success", device->id());
             });
         }
     }
@@ -384,7 +384,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
         ttnn::queue_synchronize(device->command_queue(op_cq_id));
     }
 
-    log_info(tt::LogTest, "Finished");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Finished");
 }
 
 }  // namespace ttnn::distributed::test

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_utils.cpp
@@ -110,7 +110,7 @@ void setup_test_with_persistent_fabric(
     bool enable_persistent_fabric,
     std::optional<size_t> num_links) {
     if (enable_persistent_fabric) {
-        log_info(tt::LogTest, "Enabling persistent fabric");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Enabling persistent fabric");
         fabric_programs = std::vector<Program>(devices.size());
         subdevice_managers = create_subdevices(devices);
         std::transform(
@@ -130,7 +130,7 @@ void setup_test_with_persistent_fabric(
         TT_FATAL(fabric_programs.has_value(), "Fabric programs must be set if fabric is enabled");
         TT_FATAL(devices.size() == fabric_programs->size(), "Number of devices must match number of programs");
 
-        log_info(tt::LogTest, "Building EDM kernels");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Building EDM kernels");
         line_fabric->build_kernels();
         build_and_enqueue(devices, *fabric_programs);
     }
@@ -141,7 +141,7 @@ void persistent_fabric_teardown_sequence(
     std::optional<SubdeviceInfo>& subdevice_managers,
     ttnn::ccl::EdmLineFabricOpInterface& line_fabric,
     tt::tt_fabric::TerminationSignal termination_mode) {
-    log_info("Tearing down fabric");
+    TT_LOG_INFO("Tearing down fabric");
 
     // Wait for workers to finish
     auto d0_worker_subdevice = devices[0]->get_sub_device_ids()[TEST_WORKERS_SUBDEVICE_INDEX];

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -121,7 +121,7 @@ TEST_P(EmptyTensorTest, Combinations) {
     auto dtype = std::get<1>(params);
     auto layout = std::get<2>(params);
     auto memory_config = std::get<3>(params);
-    tt::log_info(
+    TT_LOG_INFO(
         "Running test with shape={}, dtype={}, layout={}, memory_config={}", shape, dtype, layout, memory_config);
 
     if (layout == tt::tt_metal::Layout::ROW_MAJOR && dtype == tt::tt_metal::DataType::BFLOAT8_B) {

--- a/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_async_runtime.cpp
@@ -120,7 +120,7 @@ TEST_F(MultiCommandQueueSingleDeviceFixture, TestAsyncRuntimeAllocatedBuffers) {
     auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     for (int loop = 0; loop < 10; loop++) {
-        log_info(LogTest, "Running outer loop {}", loop);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running outer loop {}", loop);
         for (auto input_val : inputs) {
             for (int i = 0; i < buf_size_datums; i++) {
                 host_data[i] = bfloat16(static_cast<float>(input_val));

--- a/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_add.cpp
@@ -78,7 +78,7 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
 
         auto json_trace = graph::query_trace(call);
 
-        tt::log_info("Trace: {}", json_trace.dump(4));
+        TT_LOG_INFO("Trace: {}", json_trace.dump(4));
 
         // Direct calls
         {
@@ -115,19 +115,19 @@ TEST_P(AddOpGraphTestFixture, AddGraphTrace) {
             if (output_info.size() != params.expected_output_info.size()) {
                 auto print = [](const auto& infos) {
                     for (const auto& info : infos) {
-                        tt::log_info("{}", info);
+                        TT_LOG_INFO("{}", info);
                     }
                 };
 
-                tt::log_info(
+                TT_LOG_INFO(
                     "Output info size mismatch. Expected {} but got {}",
                     params.expected_output_info.size(),
                     output_info.size());
 
-                tt::log_info("Expected output info:");
+                TT_LOG_INFO("Expected output info:");
                 print(params.expected_output_info);
 
-                tt::log_info("Actual output info:");
+                TT_LOG_INFO("Actual output info:");
                 print(output_info);
                 ASSERT_TRUE(false);
             }

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -523,7 +523,7 @@ TEST_P(MatmulOpIfTest, Matmul) {
                 tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
                 ttnn::L1_MEMORY_CONFIG));
 
-        tt::log_info(
+        TT_LOG_INFO(
             "input_a_shape = {}, input_b_shape = {}, output_shape = {}",
             input_spec_a.logical_shape(),
             input_spec_b.logical_shape(),
@@ -540,7 +540,7 @@ TEST_P(MatmulOpIfTest, Matmul) {
             output_spec.data_type(),
             matmul_program_config);
 
-        tt::log_info("query status = {}, error_message = {}", query.status, query.error_message.value_or("none"));
+        TT_LOG_INFO("query status = {}, error_message = {}", query.status, query.error_message.value_or("none"));
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
         EXPECT_EQ(query.resource_usage.cb_peak_size_per_core, expected_resource_usage.cb_peak_size_per_core);

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_runtime.cpp
@@ -81,7 +81,7 @@ TEST_P(BinaryOpTraceRuntime, Add) {
         auto query = ttnn::graph::query_op_runtime(ttnn::add, device, input_spec_a, input_spec_b);
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Trace runtime: {} ns", query.runtime);
     }
 }
 
@@ -94,7 +94,7 @@ TEST_P(BinaryOpTraceRuntime, AddChain) {
         auto query = ttnn::graph::query_op_runtime(add_chain, device, input_spec_a, input_spec_b);
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        tt::log_info(tt::LogTest, "Trace runtime: {} ns", query.runtime);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Trace runtime: {} ns", query.runtime);
     }
 }
 

--- a/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_matmul_benchmark.cpp
@@ -199,7 +199,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
             "dtype,math_fidelity,inference_time_avg (ns),TFLOPs (avg),Utilization (vs user grid),Utilization (vs 8x8 "
             "full grid)\n";
 
-    tt::log_info("Running test with dtype: {}, math_fidelity: {}, use_trace: {}", dtype, math_fidelity, use_trace);
+    TT_LOG_INFO("Running test with dtype: {}, math_fidelity: {}, use_trace: {}", dtype, math_fidelity, use_trace);
 
     const int in0_block_w = k / grid_size.height() / 32 / in0_block_w_div;
     const int per_core_M = m / grid_size.width() / tile_h;
@@ -208,7 +208,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
     const int out_block_w = per_core_N / num_out_blocks_w;
     const Shape2D out_subblock = get_subblock_sizes(out_block_h, out_block_w, out_sharded);
 
-    tt::log_info(
+    TT_LOG_INFO(
         "M*K*N = {}*{}*{} out_subblock_h: {}, out_subblock_w: {}",
         m,
         k,
@@ -376,7 +376,7 @@ TEST_P(Matmul2DHostPerfTestFixture, Matmul2DHostPerfTest) {
     double utilization_user_grid = ideal_cycle_user_grid / inference_cycle;
     std::string utilization_full_grid_percentage = std::to_string(utilization_full_grid * 100);
     std::string utilization_user_grid_percentage = std::to_string(utilization_user_grid * 100);
-    tt::log_info(
+    TT_LOG_INFO(
         "M*K*N = {}*{}*{} == inference time (avg): {}, tflops (avg): {}, utilization (vs user grid): {}%, "
         "utilization (vs 8x8 grid): {}%",
         m,

--- a/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_cq_multi_dev.cpp
@@ -78,7 +78,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ1) {
     auto host_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
     for (int outer_loop = 0; outer_loop < 5; outer_loop++) {
-        log_info(LogTest, "Running outer loop {}", outer_loop);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running outer loop {}", outer_loop);
         for (int i = 0; i < 30; i++) {
             for (auto& dev : this->devs) {
                 auto dev_idx = dev.first;
@@ -138,7 +138,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceProgramsOnCQ0) {
     TensorSpec tensor_spec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), mem_cfg));
     ASSERT_EQ(buf_size_datums * datum_size_bytes, tensor_spec.compute_packed_buffer_size_bytes());
     for (int outer_loop = 0; outer_loop < 5; outer_loop++) {
-        log_info(LogTest, "Running outer loop {}", outer_loop);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running outer loop {}", outer_loop);
         for (int i = 0; i < 30; i++) {
             for (auto& dev : this->devs) {
                 auto dev_idx = dev.first;
@@ -194,7 +194,7 @@ TEST_F(MultiCommandQueueT3KFixture, Test2CQMultiDeviceWithCQ1Only) {
     auto readback_data = std::shared_ptr<bfloat16[]>(new bfloat16[buf_size_datums]);
 
     for (int outer_loop = 0; outer_loop < 5; outer_loop++) {
-        log_info(LogTest, "Running outer loop {}", outer_loop);
+        TT_LOG_INFO_WITH_CAT(LogTest, "Running outer loop {}", outer_loop);
         for (int i = 0; i < 30; i++) {
             for (auto& dev : this->devs) {
                 auto dev_idx = dev.first;

--- a/tests/ttnn/unit_tests/gtests/test_sliding_window_infra.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_sliding_window_infra.cpp
@@ -21,35 +21,45 @@ TEST_P(SlidingWindowTestFixture, SlidingWindowHash) {
 
     // start of same input
     auto sliding_window_b = sliding_window_a;
-    log_info(tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
-    log_info(tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
     EXPECT_EQ(sliding_window_a.get_hash(), sliding_window_b.get_hash());
 
     // flip snap_to_tile
     sliding_window_b.snap_to_tile = !sliding_window_a.snap_to_tile;
-    log_info(tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
-    log_info(tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
     EXPECT_NE(sliding_window_a.get_hash(), sliding_window_b.get_hash());
     sliding_window_b.snap_to_tile = !sliding_window_a.snap_to_tile;
 
     // flip is_bilinear
     sliding_window_b.is_bilinear = !sliding_window_a.is_bilinear;
-    log_info(tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
-    log_info(tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
     EXPECT_NE(sliding_window_a.get_hash(), sliding_window_b.get_hash());
     sliding_window_b.is_bilinear = !sliding_window_a.is_bilinear;
 
     // flip is_transpose
     sliding_window_b.is_transpose = !sliding_window_a.is_transpose;
-    log_info(tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
-    log_info(tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
     EXPECT_NE(sliding_window_a.get_hash(), sliding_window_b.get_hash());
     sliding_window_b.is_transpose = !sliding_window_a.is_transpose;
 
     // flip ceil_mode
     sliding_window_b.ceil_mode = !sliding_window_a.ceil_mode;
-    log_info(tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
-    log_info(tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_a:[{}] {}", sliding_window_a.get_hash(), sliding_window_a.to_string());
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogTest, "sliding_window_b:[{}] {}", sliding_window_b.get_hash(), sliding_window_b.to_string());
     EXPECT_NE(sliding_window_a.get_hash(), sliding_window_b.get_hash());
     sliding_window_b.ceil_mode = !sliding_window_a.ceil_mode;
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -260,4 +260,11 @@ endif()
 ############################################################################################################################
 # spdlog : https://github.com/gabime/spdlog
 ############################################################################################################################
-CPMAddPackage("gh:gabime/spdlog@1.15.2")
+CPMAddPackage(
+    NAME spdlog
+    GITHUB_REPOSITORY gabime/spdlog
+    GIT_TAG v1.15.2
+    OPTIONS
+        "BUILD_SHARED_LIBS OFF"
+        "SPDLOG_BUILD_SHARED OFF"
+)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -256,3 +256,8 @@ if(simd-everywhere_ADDED)
     add_library(simde::simde ALIAS simde)
     target_include_directories(simde SYSTEM INTERFACE ${simd-everywhere_SOURCE_DIR})
 endif()
+
+############################################################################################################################
+# spdlog : https://github.com/gabime/spdlog
+############################################################################################################################
+CPMAddPackage("gh:gabime/spdlog@1.15.2")

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -4,6 +4,8 @@ if(ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_link_options(--coverage)
 endif()
 
+link_libraries(spdlog::spdlog)
+
 add_library(tt_metal)
 add_library(TT::Metalium ALIAS tt_metal)
 add_library(Metalium::Metal ALIAS tt_metal) # For backwards compatibility
@@ -402,6 +404,7 @@ install(
         magic_enum
         TracyClient
         span
+        spdlog
         small_vector
     EXPORT Metalium
     FILE_SET

--- a/tt_metal/api/tt-metalium/logger.hpp
+++ b/tt_metal/api/tt-metalium/logger.hpp
@@ -300,7 +300,7 @@ static void log_fatal(char const* str) { log_fatal(LogAlways, "{}", str); }
 // Custom formatter for LogType
 namespace fmt {
 template <>
-struct fmt::formatter<tt::LogType> : fmt::formatter<std::string_view> {
+struct formatter<tt::LogType> : fmt::formatter<std::string_view> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 
     template <typename FormatContext>

--- a/tt_metal/common/scoped_timer.hpp
+++ b/tt_metal/common/scoped_timer.hpp
@@ -35,7 +35,8 @@ struct ScopedTimer {
         auto end = std::chrono::time_point_cast<std::chrono::nanoseconds>(Clock::now());
         this->elapsed = std::chrono::duration_cast<TimeUnit>(end - this->start);
         if (print_duration) {
-            tt::log_info(tt::LogTimer, "{} -- elapsed: {}{}", this->name, this->elapsed.count(), time_unit_to_string());
+            TT_LOG_INFO_WITH_CAT(
+                tt::LogTimer, "{} -- elapsed: {}{}", this->name, this->elapsed.count(), time_unit_to_string());
         }
     }
 

--- a/tt_metal/common/thread_pool.cpp
+++ b/tt_metal/common/thread_pool.cpp
@@ -97,7 +97,8 @@ void set_process_priority(int requested_priority) {
     // Set priority for calling process to user specified value
     int rc = setpriority(PRIO_PROCESS, 0, requested_priority);
     if (rc) {
-        log_warning(tt::LogMetal, "Unable to set process priority to {}, error code: {}", requested_priority, rc);
+        TT_LOG_WARN_WITH_CAT(
+            tt::LogMetal, "Unable to set process priority to {}, error code: {}", requested_priority, rc);
     }
 }
 

--- a/tt_metal/common/work_executor.hpp
+++ b/tt_metal/common/work_executor.hpp
@@ -52,7 +52,8 @@ inline void set_process_priority(int requested_priority) {
     // Set priority for calling process to user specified value
     int rc = setpriority(PRIO_PROCESS, 0, requested_priority);
     if (rc) {
-        log_warning(tt::LogMetal, "Unable to set process priority to {}, error code: {}", requested_priority, rc);
+        TT_LOG_WARN_WITH_CAT(
+            tt::LogMetal, "Unable to set process priority to {}, error code: {}", requested_priority, rc);
     }
 }
 

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -28,7 +28,7 @@ const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translat
         TT_FATAL(!mesh_ids.empty(), "There are no user physical meshes in the system found by control plane.");
 
         if (mesh_ids.size() > 1) {
-            tt::log_warning(LogMetal, "Only one user physical mesh is supported, using the first one");
+            TT_LOG_WARN_WITH_CAT(LogMetal, "Only one user physical mesh is supported, using the first one");
         }
 
         const auto mesh_id = mesh_ids.front();

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -515,12 +515,12 @@ std::vector<std::shared_ptr<MeshDevice>> MeshDevice::get_submeshes() const {
 std::ostream& operator<<(std::ostream& os, const MeshDevice& mesh_device) { return os << mesh_device.to_string(); }
 
 void MeshDevice::enable_program_cache() {
-    log_info(tt::LogMetal, "Enabling program cache on MeshDevice {}", this->id());
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Enabling program cache on MeshDevice {}", this->id());
     program_cache_->enable();
 }
 
 void MeshDevice::disable_and_clear_program_cache() {
-    log_info(tt::LogMetal, "Disabling and clearing program cache on MeshDevice {}", this->id());
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Disabling and clearing program cache on MeshDevice {}", this->id());
     program_cache_->clear();
 }
 

--- a/tt_metal/impl/allocator/bank_manager.cpp
+++ b/tt_metal/impl/allocator/bank_manager.cpp
@@ -199,7 +199,7 @@ MemoryBlockTable BankManager::get_memory_block_table() const {
         return allocator_->get_memory_block_table();
     }
 
-    log_warning("allocator is not initialized, cannot get block table for memory");
+    TT_LOG_WARN("allocator is not initialized, cannot get block table for memory");
     return {};
 }
 

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -21,7 +21,7 @@ void MetalContext::initialize(
     if (initialized_) {
         if (this->dispatch_core_config_ != dispatch_core_config or num_hw_cqs != this->num_hw_cqs_ or
             l1_bank_remap != this->l1_bank_remap_) {
-            log_warning("Closing and re-initializing MetalContext with new parameters.");
+            TT_LOG_WARN("Closing and re-initializing MetalContext with new parameters.");
         } else {
             // Re-init request with the same parameters, do nothing
             return;

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -56,7 +56,7 @@ static CoreDescriptorSet GetDispatchCores(chip_id_t device_id) {
     const auto& dispatch_core_config =
         tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_config();
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
-    tt::log_warning("Dispatch Core Type = {}", dispatch_core_type);
+    TT_LOG_WARN("Dispatch Core Type = {}", dispatch_core_type);
     for (auto logical_core : tt::get_logical_dispatch_cores(device_id, num_cqs, dispatch_core_config)) {
         dispatch_cores.insert({logical_core, dispatch_core_type});
     }

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -912,7 +912,7 @@ bool DebugPrintServerContext::PeekOneHartNonBlocking(
                     "DPRINT server timed out on {}, waiting on a RAISE signal: {}\n", core_str, wait_signal);
                 *intermediate_stream << error_str;
                 TransferToAndFlushOutputStream(risc_key, intermediate_stream);
-                log_warning(tt::LogMetal, "Debug Print Server encountered an error: {}", error_str);
+                TT_LOG_WARN_WITH_CAT(tt::LogMetal, "Debug Print Server encountered an error: {}", error_str);
                 raise_wait_lock_.unlock();
                 TT_THROW("{}", error_str);
                 server_killed_due_to_hang_ = true;

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -639,7 +639,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                     print_cores_sanitized.push_back(logical_core);
                 }
             }
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogMetal,
                 "DPRINT enabled on device {}, all {} cores.",
                 device_id,
@@ -652,7 +652,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                     print_cores_sanitized.push_back(logical_core);
                 }
             }
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogMetal,
                 "DPRINT enabled on device {}, {} dispatch cores.",
                 device_id,
@@ -668,7 +668,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                     }
                 }
             }
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogMetal,
                 "DPRINT enabled on device {}, {} worker cores.",
                 device_id,
@@ -694,7 +694,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
                 }
                 if (valid_logical_core && all_cores.count({logical_core, core_type}) > 0) {
                     print_cores_sanitized.push_back({logical_core, core_type});
-                    log_info(
+                    TT_LOG_INFO_WITH_CAT(
                         tt::LogMetal,
                         "DPRINT enabled on device {}, {} core {} (virtual {}).",
                         device_id,
@@ -744,7 +744,7 @@ void DebugPrintServerContext::AttachDevice(chip_id_t device_id) {
         device_to_core_range_.count(device_id) == 0, "Device {} added to DPRINT server more than once!", device_id);
     device_to_core_range_[device_id] = print_cores_sanitized;
     device_to_core_range_lock_.unlock();
-    log_info(tt::LogMetal, "DPRINT Server attached device {}", device_id);
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "DPRINT Server attached device {}", device_id);
 }  // AttachDevice
 
 void DebugPrintServerContext::DetachDevice(chip_id_t device_id) {
@@ -826,7 +826,7 @@ void DebugPrintServerContext::DetachDevice(chip_id_t device_id) {
         "Device {} not present in DPRINT server but tried removing it!",
         device_id);
     device_to_core_range_.erase(device_id);
-    log_info(tt::LogMetal, "DPRINT Server dettached device {}", device_id);
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "DPRINT Server dettached device {}", device_id);
 
     // When detaching a device, disable prints on it.
     tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(device_id);

--- a/tt_metal/impl/debug/noc_logging.cpp
+++ b/tt_metal/impl/debug/noc_logging.cpp
@@ -88,7 +88,7 @@ void DumpNocData(const std::vector<chip_id_t>& devices) {
 
     noc_data_t noc_data = {}, dispatch_noc_data = {};
     for (chip_id_t device_id : devices) {
-        log_info("Dumping noc data for Device {}...", device_id);
+        TT_LOG_INFO("Dumping noc data for Device {}...", device_id);
         DumpDeviceNocData(device_id, noc_data, dispatch_noc_data);
     }
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -603,8 +603,8 @@ void WatcherDeviceReader::DumpNocSanitizeStatus(
 
     // If we logged an error, print to stdout and throw.
     if (!error_msg.empty()) {
-        log_warning("Watcher detected NOC error and stopped device:");
-        log_warning("{}: {}", core_str, error_msg);
+        TT_LOG_WARN("Watcher detected NOC error and stopped device:");
+        TT_LOG_WARN("{}: {}", core_str, error_msg);
         DumpWaypoints(core, mbox_data, true);
         DumpRingBuffer(core, mbox_data, true);
         LogRunningKernels(core, launch_msg);
@@ -631,8 +631,8 @@ void WatcherDeviceReader::DumpAssertStatus(CoreDescriptor& core, const string& c
                 assert_status->line_num,
                 GetKernelName(core, launch_msg, assert_status->which).c_str(),
                 line_num_warning.c_str());
-            log_warning("Watcher stopped the device due to tripped assert, see watcher log for more details");
-            log_warning(error_msg.c_str());
+            TT_LOG_WARN("Watcher stopped the device due to tripped assert, see watcher log for more details");
+            TT_LOG_WARN(error_msg.c_str());
             DumpWaypoints(core, mbox_data, true);
             DumpRingBuffer(core, mbox_data, true);
             LogRunningKernels(core, launch_msg);
@@ -669,8 +669,8 @@ void WatcherDeviceReader::DumpPauseStatus(CoreDescriptor& core, const string& co
         } else if (pause > 1) {
             string error_reason = fmt::format(
                 "Watcher data corruption, pause state on core {} unknown code: {}.\n", core.coord.str(), pause);
-            log_warning(error_reason.c_str());
-            log_warning("{}: {}", core_str, error_reason);
+            TT_LOG_WARN(error_reason.c_str());
+            TT_LOG_WARN("{}: {}", core_str, error_reason);
             DumpWaypoints(core, mbox_data, true);
             DumpRingBuffer(core, mbox_data, true);
             LogRunningKernels(core, get_valid_launch_message(mbox_data));

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -247,7 +247,7 @@ void WatcherDeviceReader::Dump(FILE* file) {
     TT_ASSERT(this->f != nullptr);
 
     if (f != stdout && f != stderr) {
-        log_info(LogLLRuntime, "Watcher checking device {}", device_id);
+        TT_LOG_INFO_WITH_CAT(LogLLRuntime, "Watcher checking device {}", device_id);
     }
 
     // Clear per-dump info
@@ -342,7 +342,7 @@ void WatcherDeviceReader::Dump(FILE* file) {
         }
         paused_cores_str += "\n";
         fprintf(f, "%s", paused_cores_str.c_str());
-        log_info(LogLLRuntime, "{}Press ENTER to unpause core(s) and continue...", paused_cores_str);
+        TT_LOG_INFO_WITH_CAT(LogLLRuntime, "{}Press ENTER to unpause core(s) and continue...", paused_cores_str);
         if (!tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_auto_unpause()) {
             while (std::cin.get() != '\n') {
                 ;
@@ -712,7 +712,7 @@ void WatcherDeviceReader::DumpRingBuffer(CoreDescriptor& /*core*/, const mailbox
     if (to_stdout) {
         if (!out.empty()) {
             out = string("Last ring buffer status: ") + out;
-            log_info(out.c_str());
+            TT_LOG_INFO(out.c_str());
         }
     } else {
         fprintf(f, "%s", out.c_str());
@@ -878,7 +878,7 @@ void WatcherDeviceReader::DumpWaypoints(CoreDescriptor& core, const mailboxes_t*
     // This function can either log the waypoint to the log or stdout.
     if (to_stdout) {
         out = string("Last waypoint: ") + out;
-        log_info(out.c_str());
+        TT_LOG_INFO(out.c_str());
     } else {
         fprintf(f, "%s ", out.c_str());
     }
@@ -979,13 +979,15 @@ void WatcherDeviceReader::ValidateKernelIDs(CoreDescriptor& core, const launch_m
 }
 
 void WatcherDeviceReader::LogRunningKernels(CoreDescriptor& core, const launch_msg_t* launch_msg) {
-    log_info("While running kernels:");
+    TT_LOG_INFO("While running kernels:");
     if (core.type == CoreType::ETH) {
-        log_info(" erisc : {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_ETH_DM0]]);
+        TT_LOG_INFO(" erisc : {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_ETH_DM0]]);
     } else {
-        log_info(" brisc : {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]]);
-        log_info(" ncrisc: {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]]);
-        log_info(
+        TT_LOG_INFO(
+            " brisc : {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM0]]);
+        TT_LOG_INFO(
+            " ncrisc: {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_DM1]]);
+        TT_LOG_INFO(
             " triscs: {}", kernel_names[launch_msg->kernel_config.watcher_kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE]]);
     }
 }

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -102,7 +102,7 @@ void create_log_file() {
     if ((f = fopen(fname.c_str(), fmode)) == nullptr) {
         TT_THROW("Watcher failed to create log file\n");
     }
-    log_info(LogLLRuntime, "Watcher log file: {}", fname);
+    TT_LOG_INFO_WITH_CAT(LogLLRuntime, "Watcher log file: {}", fname);
 
     fprintf(f, "At %.3lfs starting\n", watcher::get_elapsed_secs());
     fprintf(f, "Legend:\n");
@@ -173,7 +173,7 @@ static void watcher_loop(int sleep_usecs) {
     } else {
         disabled_features = "None";
     }
-    log_info(LogLLRuntime, "Watcher server initialized, disabled features: {}", disabled_features);
+    TT_LOG_INFO_WITH_CAT(LogLLRuntime, "Watcher server initialized, disabled features: {}", disabled_features);
 
     while (true) {
         // Delay the amount of time specified by the user. Don't include watcher polling time to avoid the case where
@@ -223,7 +223,7 @@ static void watcher_loop(int sleep_usecs) {
         watcher::dump_count++;
     }
 
-    log_info(LogLLRuntime, "Watcher thread stopped watching...");
+    TT_LOG_INFO_WITH_CAT(LogLLRuntime, "Watcher thread stopped watching...");
     watcher::server_running = false;
 }
 
@@ -348,7 +348,7 @@ void watcher_init(chip_id_t device_id) {
 
     // Iterate over debug_delays_val and print what got configured where
     for (auto& delay : debug_delays_val) {
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogMetal,
             "Configured Watcher debug delays for device {}, core {}: read_delay_cores_mask=0x{:x}, "
             "write_delay_cores_mask=0x{:x}, atomic_delay_cores_mask=0x{:x}. Delay cycles: {}",
@@ -439,7 +439,7 @@ void watcher_attach(chip_id_t device_id) {
     }
 
     if (watcher::enabled) {
-        log_info(LogLLRuntime, "Watcher attached device {}", device_id);
+        TT_LOG_INFO_WITH_CAT(LogLLRuntime, "Watcher attached device {}", device_id);
     }
 
     // Always register the device w/ watcher, even if disabled
@@ -456,7 +456,7 @@ void watcher_detach(chip_id_t device_id) {
 
         TT_ASSERT(watcher::devices.find(device_id) != watcher::devices.end());
         if (watcher::enabled && watcher::logfile != nullptr) {
-            log_info(LogLLRuntime, "Watcher detached device {}", device_id);
+            TT_LOG_INFO_WITH_CAT(LogLLRuntime, "Watcher detached device {}", device_id);
             fprintf(watcher::logfile, "At %.3lfs detach device %d\n", watcher::get_elapsed_secs(), device_id);
         }
         watcher::devices.erase(device_id);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -338,7 +338,7 @@ void Device::initialize_cluster() {
         this->clear_l1_state();
     }
     int ai_clk = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(this->id_);
-    log_info(tt::LogMetal, "AI CLK for device {} is:   {} MHz", this->id_, ai_clk);
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "AI CLK for device {} is:   {} MHz", this->id_, ai_clk);
 }
 
 void Device::initialize_default_sub_device_state(
@@ -667,7 +667,7 @@ void Device::reset_cores() {
 
                 data = tt::llrt::read_hex_vec_from_core(this->id(), virtual_core, launch_addr, sizeof(launch_msg_t));
                 launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     tt::LogMetal,
                     "While initializing Device {}, active ethernet core {} on Device {} detected as still running, "
                     "issuing exit signal.",
@@ -704,7 +704,7 @@ void Device::reset_cores() {
                     virtual_core, id_and_cores.first)) {
                 // Ethernet cores won't be reset, so just signal the dispatch cores to early exit.
                 if (erisc_app_still_running(virtual_core)) {
-                    log_info(
+                    TT_LOG_INFO_WITH_CAT(
                         tt::LogMetal,
                         "While initializing device {}, idle ethernet dispatch core {} on Device {} detected as still "
                         "running, issuing exit signal.",
@@ -1165,7 +1165,11 @@ bool Device::initialize(
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool minimal) {
     ZoneScoped;
-    log_info(tt::LogMetal, "Initializing device {}. Program cache is {}enabled", this->id_, this->program_cache_.is_enabled() ? "": "NOT ");
+    TT_LOG_INFO_WITH_CAT(
+        tt::LogMetal,
+        "Initializing device {}. Program cache is {}enabled",
+        this->id_,
+        this->program_cache_.is_enabled() ? "" : "NOT ");
     log_debug(tt::LogMetal, "Running with {} cqs ", num_hw_cqs);
     TT_FATAL(num_hw_cqs > 0 and num_hw_cqs <= dispatch_core_manager::MAX_NUM_HW_CQS, "num_hw_cqs can be between 1 and {}", dispatch_core_manager::MAX_NUM_HW_CQS);
     this->using_fast_dispatch_ = false;
@@ -1227,7 +1231,7 @@ void Device::push_work(std::function<void()> work, bool blocking) {
 }
 
 bool Device::close() {
-    log_info(tt::LogMetal, "Closing device {}", this->id_);
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Closing device {}", this->id_);
     if (not this->initialized_) {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
@@ -1607,11 +1611,11 @@ std::shared_ptr<TraceBuffer> Device::get_trace(uint32_t tid) {
 }
 
 void Device::enable_program_cache() {
-    log_info(tt::LogMetal, "Enabling program cache on device {}", this->id_);
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Enabling program cache on device {}", this->id_);
     program_cache_.enable();
 }
 void Device::disable_and_clear_program_cache() {
-    log_info(tt::LogMetal, "Disabling and clearing program cache on device {}", this->id_);
+    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Disabling and clearing program cache on device {}", this->id_);
     if (this->program_cache_.is_enabled()) {
         program_cache_.disable();
     }

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -58,7 +58,7 @@ std::unordered_map<int, std::vector<uint32_t>> get_cpu_cores_per_numa_node(std::
         }
     } else {
         // Host does not have NUMA. Place all CPU Ids under a single node (0).
-        log_warning(tt::LogMetal, "Host does not use NUMA. May see reduced performance.");
+        TT_LOG_WARN_WITH_CAT(tt::LogMetal, "Host does not use NUMA. May see reduced performance.");
         for (int cpu = 0; cpu < sysconf(_SC_NPROCESSORS_ONLN); ++cpu) {
             free_cores.insert(cpu);
         }

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -190,7 +190,7 @@ void DevicePool::init_profiler() const {
         auto tunnels_from_mmio =
             tt::tt_metal::MetalContext::instance().get_cluster().get_tunnels_from_mmio_device(mmio_device_id);
         detail::InitDeviceProfiler(dev);
-        log_info(tt::LogMetal, "Profiler started on device {}", mmio_device_id);
+        TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Profiler started on device {}", mmio_device_id);
         if (not this->skip_remote_devices) {
             for (uint32_t t = 0; t < tunnels_from_mmio.size(); t++) {
                 // Need to create devices from farthest to the closest.
@@ -198,10 +198,7 @@ void DevicePool::init_profiler() const {
                     uint32_t mmio_controlled_device_id = tunnels_from_mmio[t][ts];
                     auto mmio_device = get_device(mmio_controlled_device_id);
                     detail::InitDeviceProfiler(mmio_device);
-                    log_info(
-                        tt::LogMetal,
-                        "Profiler started on remote device {}",
-                        mmio_device->id());
+                    TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Profiler started on remote device {}", mmio_device->id());
                 }
             }
         }
@@ -312,7 +309,7 @@ void DevicePool::initialize_active_devices() const {
     // Activate fabric (must be before FD)
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (tt_fabric::is_1d_fabric_config(fabric_config) || tt_fabric::is_2d_fabric_config(fabric_config)) {
-        log_info(tt::LogMetal, "Initializing Fabric");
+        TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Initializing Fabric");
         if (tt_fabric::is_2d_fabric_config(fabric_config)) {
             // write routing tables to all ethernet cores
             tt::tt_metal::MetalContext::instance()
@@ -325,7 +322,7 @@ void DevicePool::initialize_active_devices() const {
         for (const auto& dev : active_devices) {
             dev->init_fabric();
         }
-        log_info(tt::LogMetal, "Fabric Initialized");
+        TT_LOG_INFO_WITH_CAT(tt::LogMetal, "Fabric Initialized");
     }
 
     // Activate FD kernels

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -90,14 +90,14 @@ void match_device_program_data_with_host_program_data(const char* host_file, con
 
         for (const std::vector<string>& device_data : device_map) {
             if (host_data == device_data) {
-                tt::log_info("Matched on {}", type);
+                TT_LOG_INFO("Matched on {}", type);
                 match = true;
                 break;
             }
         }
 
         if (not match) {
-            tt::log_info("Mismatch between host and device program data on {}", type);
+            TT_LOG_INFO("Mismatch between host and device program data on {}", type);
         }
         all_match &= match;
     }
@@ -106,7 +106,7 @@ void match_device_program_data_with_host_program_data(const char* host_file, con
     device_dispatch_dump_file.close();
 
     if (all_match) {
-        tt::log_info("Full match between host and device program data");
+        TT_LOG_INFO("Full match between host and device program data");
     }
 }
 
@@ -327,7 +327,7 @@ void dump_completion_queue_entries(
     // Read out in pages, this is fine since all completion Q entries are page aligned.
     std::vector<uint8_t> read_data;
     read_data.resize(DispatchSettings::TRANSFER_PAGE_SIZE);
-    tt::log_info("Reading Device {} CQ {}, Completion Queue...", sysmem_manager.get_device_id(), cq_interface.id);
+    TT_LOG_INFO("Reading Device {} CQ {}, Completion Queue...", sysmem_manager.get_device_id(), cq_interface.id);
     cq_file << fmt::format(
         "Device {}, CQ {}, Completion Queue: write_ptr={:#010x}, read_ptr={:#010x}\n",
         sysmem_manager.get_device_id(),
@@ -423,7 +423,7 @@ void dump_issue_queue_entries(
     // Read out in 4K pages, could do ISSUE_Q_ALIGNMENT chunks to match the entries but this is ~2x faster.
     std::vector<uint8_t> read_data;
     read_data.resize(DispatchSettings::TRANSFER_PAGE_SIZE);
-    tt::log_info("Reading Device {} CQ {}, Issue Queue...", sysmem_manager.get_device_id(), cq_interface.id);
+    TT_LOG_INFO("Reading Device {} CQ {}, Issue Queue...", sysmem_manager.get_device_id(), cq_interface.id);
     iq_file << fmt::format(
         "Device {}, CQ {}, Issue Queue: write_ptr={:#010x}, read_ptr={:#010x} (read_ptr not currently implemented)\n",
         sysmem_manager.get_device_id(),
@@ -595,7 +595,7 @@ void dump_command_queue_raw_data(
                     cq_interface.id,
                     queue_type_name)
              << std::hex;
-    tt::log_info(
+    TT_LOG_INFO(
         "Reading Device {} CQ {}, {} Queue Raw Data...",
         sysmem_manager.get_device_id(),
         cq_interface.id,

--- a/tt_metal/impl/dispatch/worker_config_buffer.cpp
+++ b/tt_metal/impl/dispatch/worker_config_buffer.cpp
@@ -205,18 +205,18 @@ void WorkerConfigBufferMgr::PrintStatus() {
     size_t num_buffer_types = this->reservation_.size();
     for (size_t i = 0; i < num_buffer_types; i++) {
         fprintf(stderr, "Buffer type %zu\n", i);
-        log_info(tt::LogTest, "Buffer type {}", i);
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Buffer type {}", i);
 
         size_t free_index = this->alloc_index_[i];
         while (free_index != this->alloc_index_[i]) {
             auto& entry = this->entries_[free_index][i];
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogTest, "Free index {} has values {} {} {}", free_index, entry.addr, entry.size, entry.sync_count);
 
             free_index = (free_index + 1) % this->entries_.size();
         }
         auto& entry = this->entries_[free_index][i];
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogTest, "Alloc index {} has values {} {} {}", free_index, entry.addr, entry.size, entry.sync_count);
     }
 }

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -277,7 +277,12 @@ void Kernel::validate_runtime_args_size(
     uint32_t max_rt_args = is_idle_eth() ? idle_eth_max_runtime_args : max_runtime_args;
 
     if (total_rt_args > max_rt_args) {
-        log_warning(tt::LogMetal, "Too many runtime args, unique: {} common: {} on {}", num_unique_rt_args, num_common_rt_args, this->processor());
+        TT_LOG_WARN_WITH_CAT(
+            tt::LogMetal,
+            "Too many runtime args, unique: {} common: {} on {}",
+            num_unique_rt_args,
+            num_common_rt_args,
+            this->processor());
         TT_THROW("{} unique+common runtime args targeting kernel {} on {} are too large. Max allowable is {}", total_rt_args, this->name(), logical_core.str(), max_runtime_args);
     }
 }

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -28,25 +28,30 @@ void PrintHostDataType(const HostDataType& data) {
     std::visit(
         tt::stl::overloaded{
             [](const std::shared_ptr<std::vector<uint8_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint8_t>>");
+                TT_LOG_INFO_WITH_CAT(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint8_t>>");
             },
             [](const std::shared_ptr<std::vector<uint16_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint16_t>>");
+                TT_LOG_INFO_WITH_CAT(
+                    tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint16_t>>");
             },
             [](const std::shared_ptr<std::vector<int32_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<int32_t>>");
+                TT_LOG_INFO_WITH_CAT(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<int32_t>>");
             },
             [](const std::shared_ptr<std::vector<uint32_t>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint32_t>>");
+                TT_LOG_INFO_WITH_CAT(
+                    tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<uint32_t>>");
             },
             [](const std::shared_ptr<std::vector<float>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<float>>");
+                TT_LOG_INFO_WITH_CAT(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<float>>");
             },
             [](const std::shared_ptr<std::vector<bfloat16>>& /*value*/) {
-                log_info(tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<bfloat16>>");
+                TT_LOG_INFO_WITH_CAT(
+                    tt::LogMetalTrace, "HostDataType contains: std::shared_ptr<std::vector<bfloat16>>");
             },
-            [](const void* /*value*/) { log_info(tt::LogMetalTrace, "HostDataType contains: const void*"); },
-            [](auto&&) { log_info(tt::LogMetalTrace, "HostDataType contains: Unknown type"); }},
+            [](const void* /*value*/) {
+                TT_LOG_INFO_WITH_CAT(tt::LogMetalTrace, "HostDataType contains: const void*");
+            },
+            [](auto&&) { TT_LOG_INFO_WITH_CAT(tt::LogMetalTrace, "HostDataType contains: Unknown type"); }},
         data);
 }
 }  // namespace

--- a/tt_metal/impl/lightmetal/lightmetal_capture.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.cpp
@@ -85,7 +85,7 @@ uint32_t LightMetalCaptureContext::add_to_map(const Buffer* obj) {
 
 void LightMetalCaptureContext::remove_from_map(const Buffer* obj) {
     if (!is_in_map(obj)) {
-        log_warning(tt::LogMetalTrace, "Buffer not found in global_id map.");
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Buffer not found in global_id map.");
     }
     buffer_id_to_global_id_map_.erase(obj->unique_id());
 }
@@ -105,7 +105,7 @@ bool LightMetalCaptureContext::is_in_map(const Program* obj) {
 
 uint32_t LightMetalCaptureContext::add_to_map(const Program* obj) {
     if (is_in_map(obj)) {
-        log_warning(tt::LogMetalTrace, "Program id: {} already exists in global_id map.", obj->get_id());
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Program id: {} already exists in global_id map.", obj->get_id());
     }
     uint32_t global_id = next_global_id_++;
     program_id_to_global_id_map_[obj->get_id()] = global_id;
@@ -114,7 +114,7 @@ uint32_t LightMetalCaptureContext::add_to_map(const Program* obj) {
 
 void LightMetalCaptureContext::remove_from_map(const Program* obj) {
     if (!is_in_map(obj)) {
-        log_warning(tt::LogMetalTrace, "Program id: {} not found in global_id map.", obj->get_id());
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Program id: {} not found in global_id map.", obj->get_id());
     }
     program_id_to_global_id_map_.erase(obj->get_id());
 }
@@ -134,7 +134,7 @@ bool LightMetalCaptureContext::is_in_map(const Kernel* obj) {
 
 uint32_t LightMetalCaptureContext::add_to_map(const Kernel* obj) {
     if (is_in_map(obj)) {
-        log_warning(tt::LogMetalTrace, "Kernel already exists in global_id map.");
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Kernel already exists in global_id map.");
     }
     uint32_t global_id = next_global_id_++;
     kernel_to_global_id_map_[obj] = global_id;
@@ -143,7 +143,7 @@ uint32_t LightMetalCaptureContext::add_to_map(const Kernel* obj) {
 
 void LightMetalCaptureContext::remove_from_map(const Kernel* obj) {
     if (!is_in_map(obj)) {
-        log_warning(tt::LogMetalTrace, "Kernel not found in global_id map.");
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Kernel not found in global_id map.");
     }
     kernel_to_global_id_map_.erase(obj);
 }
@@ -163,7 +163,7 @@ bool LightMetalCaptureContext::is_in_map(const CBHandle handle) {
 
 uint32_t LightMetalCaptureContext::add_to_map(const CBHandle handle) {
     if (is_in_map(handle)) {
-        log_warning(tt::LogMetalTrace, "CBHandle already exists in global_id map.");
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "CBHandle already exists in global_id map.");
     }
     uint32_t global_id = next_global_id_++;
     cb_handle_to_global_id_map_[handle] = global_id;
@@ -172,7 +172,7 @@ uint32_t LightMetalCaptureContext::add_to_map(const CBHandle handle) {
 
 void LightMetalCaptureContext::remove_from_map(const CBHandle handle) {
     if (!is_in_map(handle)) {
-        log_warning(tt::LogMetalTrace, "CBHandle not found in global_id map.");
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "CBHandle not found in global_id map.");
     }
     cb_handle_to_global_id_map_.erase(handle);
 }

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -75,7 +75,7 @@ namespace detail {
 LightMetalReplayImpl::LightMetalReplayImpl(LightMetalBinary&& binary, IDevice* device) :
     binary_(std::move(binary)), fb_binary_(nullptr), device_(device) {
     if (binary_.is_empty()) {
-        log_warning(tt::LogMetalTrace, "Empty LightMetalBinary provided to LightMetalReplay.");
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Empty LightMetalBinary provided to LightMetalReplay.");
     }
 
     show_reads_ = parse_env("TT_LIGHT_METAL_SHOW_READS", false);
@@ -161,7 +161,7 @@ std::optional<TraceDescriptor> LightMetalReplayImpl::get_trace_by_id(uint32_t ta
 void LightMetalReplayImpl::add_buffer_to_map(
     uint32_t global_id, const std::shared_ptr<::tt::tt_metal::Buffer>& buffer) {
     if (buffer_map_.find(global_id) != buffer_map_.end()) {
-        log_warning(tt::LogMetalTrace, "Buffer with global_id: {} already exists in map.", global_id);
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Buffer with global_id: {} already exists in map.", global_id);
     }
     buffer_map_[global_id] = buffer;  // Shared ownership
 }
@@ -176,7 +176,7 @@ void LightMetalReplayImpl::remove_bufer_from_map(uint32_t global_id) { buffer_ma
 void LightMetalReplayImpl::add_program_to_map(
     uint32_t global_id, const std::shared_ptr<::tt::tt_metal::Program>& program) {
     if (program_map_.find(global_id) != program_map_.end()) {
-        log_warning(tt::LogMetalTrace, "Program with global_id: {} already exists in map.", global_id);
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Program with global_id: {} already exists in map.", global_id);
     }
     program_map_[global_id] = program;  // Shared ownership
 }
@@ -190,7 +190,7 @@ void LightMetalReplayImpl::remove_program_from_map(uint32_t global_id) { program
 
 void LightMetalReplayImpl::add_kernel_handle_to_map(uint32_t global_id, ::tt::tt_metal::KernelHandle kernel_id) {
     if (kernel_handle_map_.find(global_id) != kernel_handle_map_.end()) {
-        log_warning(tt::LogMetalTrace, "KernelHandle with global_id: {} already exists in map.", global_id);
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "KernelHandle with global_id: {} already exists in map.", global_id);
     }
     kernel_handle_map_[global_id] = kernel_id;  // Shared ownership
 }
@@ -205,7 +205,7 @@ void LightMetalReplayImpl::remove_kernel_handle_from_map(uint32_t global_id) { k
 void LightMetalReplayImpl::add_kernel_to_map(
     uint32_t global_id, const std::shared_ptr<::tt::tt_metal::Kernel>& kernel) {
     if (kernel_map_.find(global_id) != kernel_map_.end()) {
-        log_warning(tt::LogMetalTrace, "Kernel with global_id: {} already exists in map.", global_id);
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "Kernel with global_id: {} already exists in map.", global_id);
     }
     kernel_map_[global_id] = kernel;  // Shared ownership
 }
@@ -219,7 +219,7 @@ void LightMetalReplayImpl::remove_kernel_from_map(uint32_t global_id) { kernel_m
 
 void LightMetalReplayImpl::add_cb_handle_to_map(uint32_t global_id, ::tt::tt_metal::CBHandle cb_handle) {
     if (cb_handle_map_.find(global_id) != cb_handle_map_.end()) {
-        log_warning(tt::LogMetalTrace, "CBHandle with global_id: {} already exists in map.", global_id);
+        TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "CBHandle with global_id: {} already exists in map.", global_id);
     }
     cb_handle_map_[global_id] = cb_handle;  // Shared ownership
 }

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -506,7 +506,8 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::EnqueueReadBu
     // One idea is to store in map by global_read_id that caller can access.
     if (show_reads_) {
         for (size_t i = 0; i < readback_data.size(); i++) {
-            log_info(tt::LogMetalTrace, " rd_data i: {:3d} => data: {} ({:x})", i, readback_data[i], readback_data[i]);
+            TT_LOG_INFO_WITH_CAT(
+                tt::LogMetalTrace, " rd_data i: {:3d} => data: {} ({:x})", i, readback_data[i], readback_data[i]);
         }
     }
 }
@@ -691,7 +692,7 @@ void LightMetalReplayImpl::execute(const ::tt::tt_metal::flatbuffer::LightMetalC
         if (show_reads_) {
             for (size_t i = 0; i < rd_data.size(); i++) {
                 bool match = rd_data[i] == cmd->golden_data()->Get(i);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     tt::LogMetalTrace,
                     "LightMetalCompare i: {:3d} match: {} RdData: {:x} Golden: {:x}",
                     i,
@@ -725,7 +726,7 @@ bool LightMetalReplayImpl::run() {
             return false;
         }
 
-        log_info(
+        TT_LOG_INFO_WITH_CAT(
             tt::LogMetalTrace,
             "Running LightMetal Binary with {} cmds, {} traces. ManageDevice: {}",
             commands->size(),

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -168,7 +168,7 @@ void DeviceProfiler::readRiscProfilerResults(
                     tracy::riscName[riscEndIndex],
                     bufferEndIndex);
                 TracyMessageC(warningMsg.c_str(), warningMsg.size(), tracy::Color::Tomato3);
-                log_warning(warningMsg.c_str());
+                TT_LOG_WARN(warningMsg.c_str());
             }
 
             uint32_t riscNumRead = 0;
@@ -776,7 +776,7 @@ void DeviceProfiler::generateZoneSourceLocationsHashes() {
 
         auto did_insert = zone_src_locations.insert(zone_src_location);
         if (did_insert.second && (hash_to_zone_src_locations.find(hash_16bit) != hash_to_zone_src_locations.end())) {
-            log_warning("Source location hashes are colliding, two different locations are having the same hash");
+            TT_LOG_WARN("Source location hashes are colliding, two different locations are having the same hash");
         }
         hash_to_zone_src_locations.emplace(hash_16bit, zone_src_location);
     }
@@ -821,7 +821,7 @@ void DeviceProfiler::dumpResults(
         }
 
         if (rtoptions.get_profiler_noc_events_enabled()) {
-            log_warning("Profiler NoC events are enabled; this can add 1-15% cycle overhead to typical operations!");
+            TT_LOG_WARN("Profiler NoC events are enabled; this can add 1-15% cycle overhead to typical operations!");
         }
 
         // open CSV log file
@@ -857,7 +857,7 @@ void DeviceProfiler::dumpResults(
             }
         }
     } else {
-        log_warning("DRAM profiler buffer is not initialized");
+        TT_LOG_WARN("DRAM profiler buffer is not initialized");
     }
 #endif
 }

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -674,7 +674,7 @@ void DeviceProfiler::serializeJsonNocTraces(
         }
     }
 
-    log_info("Writing profiler noc traces to '{}'", output_dir);
+    TT_LOG_INFO("Writing profiler noc traces to '{}'", output_dir);
     for (auto& [runtime_id, events] : events_by_opname) {
         // dump events to a json file inside directory output_dir named after the opname
         std::filesystem::path rpt_path = output_dir;
@@ -886,7 +886,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
             cpuTime = get<0>(device_core_sync_info.at(worker_core));
             delay = get<1>(device_core_sync_info.at(worker_core));
             frequency = get<2>(device_core_sync_info.at(worker_core));
-            log_info(
+            TT_LOG_INFO_WITH_CAT(
                 "Device {} sync info are, frequency {} GHz,  delay {} cycles and, sync point {} seconds",
                 device_id,
                 frequency,

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -886,7 +886,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
             cpuTime = get<0>(device_core_sync_info.at(worker_core));
             delay = get<1>(device_core_sync_info.at(worker_core));
             frequency = get<2>(device_core_sync_info.at(worker_core));
-            TT_LOG_INFO_WITH_CAT(
+            TT_LOG_INFO(
                 "Device {} sync info are, frequency {} GHz,  delay {} cycles and, sync point {} seconds",
                 device_id,
                 frequency,

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -245,7 +245,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
         tt_metal::detail::WaitProgramDone(device, sync_program, false);
     }
 
-    log_info("SYNC PROGRAM FINISH IS DONE ON {}", device_id);
+    TT_LOG_INFO("SYNC PROGRAM FINISH IS DONE ON {}", device_id);
     if ((smallestHostime[device_id] == 0) || (smallestHostime[device_id] > hostStartTime)) {
         smallestHostime[device_id] = hostStartTime;
     }
@@ -357,7 +357,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
                  << std::endl;
     }
     log_file.close();
-    log_info(
+    TT_LOG_INFO(
         "Host sync data for device: {}, cpu_start:{}, delay:{}, freq:{} Hz",
         device_id,
         smallestHostime[device_id],
@@ -371,7 +371,7 @@ void setShift(int device_id, int64_t shift, double scale) {
     if (std::isnan(scale)) {
         return;
     }
-    log_info("Device sync data for device: {}, delay: {} ns, freq scale: {}", device_id, shift, scale);
+    TT_LOG_INFO("Device sync data for device: {}, delay: {} ns, freq scale: {}", device_id, shift, scale);
     if (tt_metal_device_profiler_map.find(device_id) != tt_metal_device_profiler_map.end()) {
         tt_metal_device_profiler_map.at(device_id).shift = shift;
         tt_metal_device_profiler_map.at(device_id).freqScale = scale;
@@ -429,7 +429,7 @@ void syncDeviceDevice(chip_id_t device_id_sender, chip_id_t device_id_receiver) 
         TT_FATAL(
             fabric_config != FabricConfig::DISABLED,
             "Cannot support device to device synchronization when TT-Fabric is disabled.");
-        log_info("Calling {} when TT-Fabric is enabled. This may take a while", __FUNCTION__);
+        TT_LOG_INFO("Calling {} when TT-Fabric is enabled. This may take a while", __FUNCTION__);
 
         constexpr std::uint16_t sample_count = 240;
         constexpr std::uint16_t sample_size = 16;

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -899,7 +899,7 @@ void DumpDeviceProfileResults(
                             curr_core.x,
                             curr_core.y);
                         TracyMessageC(msg.c_str(), msg.size(), tracy::Color::Tomato3);
-                        log_warning(msg.c_str());
+                        TT_LOG_WARN(msg.c_str());
                     }
                     dispatchCores.erase(dispatchCores.begin());
                 }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -104,7 +104,7 @@ void JitBuildEnv::init(
     this->aliased_arch_name_ = get_string_aliased_arch_lowercase(arch);
 
 #ifndef GIT_COMMIT_HASH
-    log_info(tt::LogBuildKernels, "GIT_COMMIT_HASH not found");
+    TT_LOG_INFO_WITH_CAT(tt::LogBuildKernels, "GIT_COMMIT_HASH not found");
 #else
     std::string git_hash(GIT_COMMIT_HASH);
 
@@ -115,7 +115,7 @@ void JitBuildEnv::init(
             std::filesystem::directory_iterator{root_path},
             [&git_hash_path](const auto& dir_entry) { check_built_dir(dir_entry.path(), git_hash_path); });
     } else {
-        log_info(tt::LogBuildKernels, "Skipping deleting built cache");
+        TT_LOG_INFO_WITH_CAT(tt::LogBuildKernels, "Skipping deleting built cache");
     }
 
     this->out_root_ = this->out_root_  + git_hash + "/";

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -6,7 +6,8 @@
 
 #include <core_coord.hpp>
 #include <dev_msgs.h>
-#include <logger.hpp>
+#include <tt-metalium/logger.hpp>
+// #include <logger.hpp>
 #include <metal_soc_descriptor.h>
 #include <algorithm>
 #include <cstdint>
@@ -91,7 +92,7 @@ namespace tt {
 
 Cluster::Cluster(const llrt::RunTimeOptions& rtoptions, const tt_metal::Hal& hal) : rtoptions_(rtoptions), hal_(hal) {
     ZoneScoped;
-    log_info(tt::LogDevice, "Opening user mode device driver");
+    TT_LOG_INFO_WITH_CAT(tt::LogDevice, "Opening user mode device driver");
 
     this->detect_arch_and_target();
 
@@ -338,7 +339,7 @@ void Cluster::start_driver(tt_device_params &device_params) const {
 }
 
 Cluster::~Cluster() {
-    log_info(tt::LogDevice, "Closing user mode device drivers");
+    TT_LOG_INFO_WITH_CAT(tt::LogDevice, "Closing user mode device drivers");
     this->driver_->close_device();
 
     this->sdesc_per_chip_.clear();
@@ -671,7 +672,7 @@ void Cluster::read_sysmem(
 void Cluster::verify_sw_fw_versions(
     int device_id, std::uint32_t sw_version, std::vector<std::uint32_t> &fw_versions) const {
     tt_version sw(sw_version), fw_first_eth_core(fw_versions.at(0));
-    tt::log_info(
+    TT_LOG_INFO_WITH_CAT(
         tt::LogDevice,
         "Software version {}, Ethernet FW version {} (Device {})",
         sw.str(),

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -308,7 +308,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -170,7 +170,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -108,7 +108,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul_multi_core/matmul_multi_core.cpp
@@ -313,10 +313,10 @@ int main() {
         matmul_multi_core(src0_vec, src1_vec, result_vec, false, M, N, K, B, device);
         result_vec = untilize_nfaces(result_vec, M, N);
 
-        log_info(tt::LogVerif, "Output vector of size {}", result_vec.size());
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Output vector of size {}", result_vec.size());
 
         float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
-        log_info(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
         TT_FATAL(pearson > 0.99, "PCC not high enough. Result PCC: {}, Expected PCC: 0.99", pearson);
 
         pass &= CloseDevice(device);
@@ -329,7 +329,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -103,8 +103,8 @@ void matmul_multicore_reuse(
     uint32_t out_subblock_h = std::get<2>(matmul_params);
     uint32_t out_subblock_w = std::get<3>(matmul_params);
 
-    log_info(tt::LogVerif, " -- Metalium Core Sizing --");
-    log_info(
+    TT_LOG_INFO_WITH_CAT(tt::LogVerif, " -- Metalium Core Sizing --");
+    TT_LOG_INFO_WITH_CAT(
         tt::LogVerif,
         " -- per_core_M= {} -- per_core_N= {} -- out_subblock_h= {} -- out_subblock_w= {} --",
         per_core_M,
@@ -400,10 +400,10 @@ int main() {
         matmul_multicore_reuse(src0_vec, src1_vec, result_vec, false, M, N, K, B, device);
         result_vec = untilize_nfaces(result_vec, M, N);
 
-        log_info(tt::LogVerif, "Output vector of size {}", result_vec.size());
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Output vector of size {}", result_vec.size());
 
         float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
-        log_info(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
         TT_FATAL(pearson > 0.99, "PCC not high enough. Result PCC: {}, Expected PCC: 0.99", pearson);
 
         pass &= CloseDevice(device);
@@ -416,7 +416,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -104,8 +104,8 @@ void matmul_multicore_reuse_mcast(
     uint32_t out_subblock_h = std::get<2>(matmul_params);
     uint32_t out_subblock_w = std::get<3>(matmul_params);
 
-    log_info(tt::LogVerif, " -- Metalium Core Sizing --");
-    log_info(
+    TT_LOG_INFO_WITH_CAT(tt::LogVerif, " -- Metalium Core Sizing --");
+    TT_LOG_INFO_WITH_CAT(
         tt::LogVerif,
         " -- per_core_M= {} -- per_core_N= {} -- out_subblock_h= {} -- out_subblock_w= {} --",
         per_core_M,
@@ -524,10 +524,10 @@ int main() {
         matmul_multicore_reuse_mcast(src0_vec, src1_vec, result_vec, false, M, N, K, B, device);
         result_vec = untilize_nfaces(result_vec, M, N);
 
-        log_info(tt::LogVerif, "Output vector of size {}", result_vec.size());
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Output vector of size {}", result_vec.size());
 
         float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
-        log_info(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
         TT_FATAL(pearson > 0.98, "PCC not high enough. Result PCC: {}, Expected PCC: 0.98", pearson);
 
         pass &= CloseDevice(device);
@@ -540,7 +540,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul_single_core/matmul_single_core.cpp
@@ -250,10 +250,10 @@ int main() {
         matmul_single_core(src0_vec, src1_vec, result_vec, false, M, N, K, B, device);
         result_vec = untilize_nfaces(result_vec, M, N);
 
-        log_info(tt::LogVerif, "Output vector of size {}", result_vec.size());
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Output vector of size {}", result_vec.size());
 
         float pearson = check_bfloat16_vector_pcc(golden_vec, result_vec);
-        log_info(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
+        TT_LOG_INFO_WITH_CAT(tt::LogVerif, "Metalium vs Golden -- PCC = {}", pearson);
         TT_FATAL(pearson > 0.97, "PCC not high enough. Result PCC: {}, Expected PCC: 0.97", pearson);
 
         pass &= CloseDevice(device);
@@ -266,7 +266,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count/test_custom_cycle_count.cpp
@@ -83,7 +83,7 @@ int main() {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
+++ b/tt_metal/programming_examples/profiler/test_custom_cycle_count_slow_dispatch/test_custom_cycle_count_slow_dispatch.cpp
@@ -85,7 +85,7 @@ int main() {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
+++ b/tt_metal/programming_examples/profiler/test_dispatch_cores/test_dispatch_cores.cpp
@@ -79,7 +79,7 @@ int main() {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -97,7 +97,7 @@ int main() {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -72,7 +72,7 @@ int main() {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -92,7 +92,7 @@ int main() {
     }
 
     if (pass) {
-        tt::log_info(tt::LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -97,7 +97,7 @@ int main() {
     }
 
     if (pass) {
-        log_info(LogTest, "Test Passed");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Test Passed");
     } else {
         TT_THROW("Test Failed");
     }

--- a/tt_metal/tools/lightmetal_runner/lightmetal_runner.cpp
+++ b/tt_metal/tools/lightmetal_runner/lightmetal_runner.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
         log_fatal("Light Metal Binary {} failed to execute or encountered errors.", binary_filename);
         return 1;
     } else {
-        log_info(tt::LogMetalTrace, "Light Metal Binary {} executed successfully", binary_filename);
+        TT_LOG_INFO_WITH_CAT(tt::LogMetalTrace, "Light Metal Binary {} executed successfully", binary_filename);
         return 0;
     }
 }

--- a/tt_metal/tools/memset.cpp
+++ b/tt_metal/tools/memset.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
     int num_user_provided_arguments = argc - 1;
 
     if (std::getenv("RUNNING_FROM_PYTHON") == nullptr) {
-        log_warning(tt::LogDevice, "It is recommended to run this script from 'memset.py'");
+        TT_LOG_WARN_WITH_CAT(tt::LogDevice, "It is recommended to run this script from 'memset.py'");
         sleep(2);
     }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1381,7 +1381,7 @@ void LightMetalBeginCapture() {
     lm_capture_ctx.reset();            // Clear previous traces if any, ensure tracing disabled
     lm_capture_ctx.set_tracing(true);  // Enable tracing
 #else
-    log_warning(tt::LogMetalTrace, "TT_ENABLE_LIGHT_METAL_TRACE!=1, ignoring LightMetalBeginCapture()");
+    TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "TT_ENABLE_LIGHT_METAL_TRACE!=1, ignoring LightMetalBeginCapture()");
 #endif
 }
 
@@ -1394,7 +1394,7 @@ LightMetalBinary LightMetalEndCapture() {
     lm_capture_ctx.set_tracing(false);  // Disable tracing
     return lm_capture_ctx.create_light_metal_binary();
 #else
-    log_warning(tt::LogMetalTrace, "TT_ENABLE_LIGHT_METAL_TRACE!=1, ignoring LightMetalEndCapture()");
+    TT_LOG_WARN_WITH_CAT(tt::LogMetalTrace, "TT_ENABLE_LIGHT_METAL_TRACE!=1, ignoring LightMetalEndCapture()");
     return {};
 #endif
 }

--- a/ttnn/cpp/ttnn/graph/graph_processor.cpp
+++ b/ttnn/cpp/ttnn/graph/graph_processor.cpp
@@ -182,7 +182,7 @@ void GraphProcessor::track_program(tt::tt_metal::Program* program, const tt::tt_
 
 void GraphProcessor::track_function_start(std::string_view function_name, std::span<std::any> input_parameters) {
     const std::lock_guard<std::mutex> lock(mutex);
-    tt::log_info("Begin op: {}", function_name);
+    TT_LOG_INFO("Begin op: {}", function_name);
     std::unordered_map<std::string, std::string> params = {
         {kInputs, std::to_string(input_parameters.size())},
         {kName, std::string(function_name)},
@@ -214,14 +214,14 @@ void GraphProcessor::track_function_start(std::string_view function_name, std::s
         if (it != begin_function_any_map.end()) {
             it->second(any);
         } else {
-            tt::log_info("input any type name ignored: {}", graph_demangle(any.type().name()));
+            TT_LOG_INFO("input any type name ignored: {}", graph_demangle(any.type().name()));
         }
     }
 }
 
 void GraphProcessor::track_function_end_impl() {
     auto name = graph[current_op_id.top()].params[kName];
-    tt::log_info("End op: {}", name);
+    TT_LOG_INFO("End op: {}", name);
 
     auto counter = graph.size();
     {
@@ -249,7 +249,7 @@ void GraphProcessor::track_function_end(const std::any& output_tensors) {
     if (it != end_function_any_map.end()) {
         it->second(output_tensors);
     } else {
-        tt::log_info("output any type name ignored: {}", graph_demangle(output_tensors.type().name()));
+        TT_LOG_INFO("output any type name ignored: {}", graph_demangle(output_tensors.type().name()));
     }
     TT_ASSERT(current_op_id.size() > 0);  // we should always have capture_start on top
     current_op_id.pop();
@@ -297,7 +297,7 @@ int GraphProcessor::add_tensor(const Tensor& t) {
     }
 
     if (buffers.empty()) {
-        tt::log_info(
+        TT_LOG_INFO(
             "Tensor doesn't have buffer, but storage is {}", graph_demangle(get_type_in_var(t.get_storage()).name()));
     }
 

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -214,7 +214,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                 }
                 if (enable_core_placement_opt) {
                     if (edm_fwd.my_noc_x < edm_bwd.my_noc_x) {
-                        log_info(
+                        TT_LOG_INFO_WITH_CAT(
                             tt::LogTest,
                             "device {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
                             edm_fwd.my_chip_id,
@@ -236,7 +236,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                             edm_bwd.config.sender_channel_ack_noc_ids[i] = 0;
                         }
                     } else if (edm_fwd.my_noc_x > edm_bwd.my_noc_x) {
-                        log_info(
+                        TT_LOG_INFO_WITH_CAT(
                             tt::LogTest,
                             "device {} edm_fwd {} {} is connecting to edm_bwd {} {} on link {}",
                             edm_fwd.my_chip_id,
@@ -639,7 +639,7 @@ void initialize_edm_fabric(
 
         for (size_t r = 0; r < num_rows; r++) {
             for (size_t c = 0; c < num_cols; c++) {
-                log_info(tt::LogAlways, "Compile EDM program");
+                TT_LOG_INFO_WITH_CAT(tt::LogAlways, "Compile EDM program");
                 tt::tt_metal::IDevice* device = mesh_device->get_device(r, c);
                 auto& program = programs.at(r).at(c);
                 device->push_work([&]() { tt::tt_metal::detail::CompileProgram(device, program); }, false);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -361,7 +361,7 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
             } else {
                 act_block_h_ntiles =
                     find_closest_largest_divisor(padded_output_height_ntiles_per_core, act_block_h_override_ntiles);
-                log_info(
+                TT_LOG_INFO_WITH_CAT(
                     LogOp,
                     "act_block_h_override {} is not a valid override for padded_output_height_ntiles_per_core {}, "
                     "instead {} was selected as closest valid option!",

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -397,14 +397,14 @@ operation::OpPerformanceModel OptimizedConvNew::create_op_performance_model(
     operation::OpPerformanceModel result(input_tensors, output_tensors, ideal_dev_clock_cycles);
 
 #if 0
-    tt::log_info(tt::LogOp, "OptimizedConv PerfModel:");
-    tt::log_info(tt::LogOp, "\t Batch: {}", batch_size);
-    tt::log_info(tt::LogOp, "\t In (H, W, C): ({}, {}, {})", conv_activation_h, conv_activation_w, conv_activation_c);
-    tt::log_info(tt::LogOp, "\t Filter (H, W): ({}, {})", filter_h, filter_w);
-    tt::log_info(tt::LogOp, "\t Filter Stride (H, W): ({}, {})", stride_h, stride_w);
-    tt::log_info(tt::LogOp, "\t Pad (H, W): ({}, {})", pad_h, pad_w);
-    tt::log_info(tt::LogOp, "\t Out (H, W, C): ({}, {}, {})", output_height, output_width, this->output_channels);
-    tt::log_info(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "OptimizedConv PerfModel:");
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Batch: {}", batch_size);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t In (H, W, C): ({}, {}, {})", conv_activation_h, conv_activation_w, conv_activation_c);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Filter (H, W): ({}, {})", filter_h, filter_w);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Filter Stride (H, W): ({}, {})", stride_h, stride_w);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Pad (H, W): ({}, {})", pad_h, pad_w);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Out (H, W, C): ({}, {}, {})", output_height, output_width, this->output_channels);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
 #endif
 
     return result;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/fold.cpp
@@ -48,11 +48,11 @@ std::vector<Tensor> fold_with_transpose_(
     auto padded_h32 = tt::round_up(padded_h, TILE_HEIGHT);
     auto padded_w32 = tt::round_up(padded_w, TILE_HEIGHT);
 
-    tt::log_info("padded_c: {}", padded_c);
-    tt::log_info("padded_h: {}", padded_h);
-    tt::log_info("padded_w: {}", padded_w);
-    tt::log_info("padded_h32: {}", padded_h32);
-    tt::log_info("padded_w32: {}", padded_w32);
+    TT_LOG_INFO("padded_c: {}", padded_c);
+    TT_LOG_INFO("padded_h: {}", padded_h);
+    TT_LOG_INFO("padded_w: {}", padded_w);
+    TT_LOG_INFO("padded_h32: {}", padded_h32);
+    TT_LOG_INFO("padded_w32: {}", padded_w32);
 
     auto L1_mem_config = tt::tt_metal::MemoryConfig{
         .memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::L1};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -186,7 +186,7 @@ Tensor ExecuteMaximum::invoke(
 }
 
 Tensor _atan2(const Tensor& input_b, const Tensor& input_a, const std::optional<MemoryConfig>& output_mem_config) {
-    tt::log_info(tt::LogOp, "Input arguments for the atan2 function are in the format (y, x)");
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "Input arguments for the atan2 function are in the format (y, x)");
     Tensor result(input_a);
     {
         Tensor atan_input =

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -339,9 +339,9 @@ operation::OpPerformanceModel BinaryDeviceOperation::create_op_performance_model
     // TODO: update OpPerformanceModel to work on variadic arguments
     operation::OpPerformanceModel result(input_tensors, {output_tensor}, ideal_eltwise_cycles);
 #if 0
-        tt::log_info(tt::LogOp, "BinaryDeviceOperation PerfModel:");
-        tt::log_info(tt::LogOp, "\t Data (Bytes): {}", total_bytes);
-        tt::log_info(tt::LogOp, "\t ideal_eltwise_cycles: {}", ideal_eltwise_cycles);
+        TT_LOG_INFO_WITH_CAT(tt::LogOp, "BinaryDeviceOperation PerfModel:");
+        TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Data (Bytes): {}", total_bytes);
+        TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t ideal_eltwise_cycles: {}", ideal_eltwise_cycles);
 #endif
     return result;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/slice_write.cpp
@@ -109,7 +109,7 @@ ttnn::Tensor SliceWriteOperation::invoke<uint32_t, 4>(
                                       tt::div_up(padded_output_shape[2], input.shard_spec().value().shape[0]);
             in_place_unpad &= begins[3] == 0 && ends[3] == padded_output_shape[3];
             if (in_place_unpad) {
-                tt::log_info("In-place unpad optimization via copy");
+                TT_LOG_INFO("In-place unpad optimization via copy");
                 ttnn::copy(DefaultQueueId, input_tensor, output_tensor);
                 return output_tensor;
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -131,14 +131,14 @@ operation::OpPerformanceModel create_op_performance_model_for_matmul(
 
     operation::OpPerformanceModel result(input_tensors, output_tensors, ideal_dev_clock_cycles);
 #if 0
-    tt::log_info(tt::LogOp, "Matmul PerfModel:");
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "Matmul PerfModel:");
     for (auto i = 0; i < out_shape.rank() - 2; i++) {
-        tt::log_info(tt::LogOp, "\t Batch Values: (Index: {}, Value: {})", i, out_shape[i]);
+        TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Batch Values: (Index: {}, Value: {})", i, out_shape[i]);
     }
-    tt::log_info(tt::LogOp, "\t In A (H, W): ({}, {})", in_a_shape[-2], in_a_shape[-1]);
-    tt::log_info(tt::LogOp, "\t In B (H, W): ({}, {})", in_b_shape[-2], in_b_shape[-1]);
-    tt::log_info(tt::LogOp, "\t Out (H, W): ({}, {})", out_shape[-2], out_shape[-1]);
-    tt::log_info(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t In A (H, W): ({}, {})", in_a_shape[-2], in_a_shape[-1]);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t In B (H, W): ({}, {})", in_b_shape[-2], in_b_shape[-1]);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t Out (H, W): ({}, {})", out_shape[-2], out_shape[-1]);
+    TT_LOG_INFO_WITH_CAT(tt::LogOp, "\t ideal_dev_clock_cycles: {}", ideal_dev_clock_cycles);
 #endif
     return result;
 }

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_program_factory.cpp
@@ -139,12 +139,12 @@ MorehGroupNormOperation::MorehGroupNormFactory::cached_program_t MorehGroupNormO
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {
-        log_info(LogTest, "Large moreh_group_norm algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Large moreh_group_norm algorithm is selected.");
         in0_t = block_size;
         im1_t = 2 * block_size;
         im2_t = 2 * block_size;
     } else {
-        log_info(LogTest, "Small moreh_group_norm algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Small moreh_group_norm algorithm is selected.");
     }
 
     CreateCircularBuffer(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/device/input_grad/moreh_group_norm_backward_input_grad_factory.cpp
@@ -112,12 +112,12 @@ MorehGroupNormBackwardInputGradOperation::MorehGroupNormBackwardInputGradFactory
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {
-        log_info(LogTest, "Large moreh_layer_norm_backward_input_grad algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Large moreh_layer_norm_backward_input_grad algorithm is selected.");
         im0_t = 1;
         im1_t = 1;
         im7_t = 0;
     } else {
-        log_info(LogTest, "Small moreh_layer_norm_backward_input_grad algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(LogTest, "Small moreh_layer_norm_backward_input_grad algorithm is selected.");
     }
 
     CreateCircularBuffer(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm/device/moreh_layer_norm_program_factory.cpp
@@ -160,12 +160,12 @@ MorehLayerNormOperation::ProgramFactory::cached_program_t MorehLayerNormOperatio
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {
-        log_info(tt::LogTest, "Large moreh_layer_norm algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large moreh_layer_norm algorithm is selected.");
         in0_t = 2 * block_size;
         im1_t = 2 * block_size;
         im2_t = 2 * block_size;
     } else {
-        log_info(tt::LogTest, "Small moreh_layer_norm algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Small moreh_layer_norm algorithm is selected.");
     }
 
     CreateCircularBuffer(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_layer_norm_backward/device/moreh_layer_norm_backward_input_grad_program_factory.cpp
@@ -122,12 +122,12 @@ MorehLayerNormBackwardInputGradOperation::ProgramFactory::create(
     const bool use_large_algorithm = cb_usage >= available_L1;
 
     if (use_large_algorithm) {
-        log_info(tt::LogTest, "Large moreh_layer_norm_backward_input_grad algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large moreh_layer_norm_backward_input_grad algorithm is selected.");
         im0_t = 1;
         im1_t = 1;
         im7_t = 0;
     } else {
-        log_info(tt::LogTest, "Small moreh_layer_norm_backward_input_grad algorithm is selected.");
+        TT_LOG_INFO_WITH_CAT(tt::LogTest, "Small moreh_layer_norm_backward_input_grad algorithm is selected.");
     }
 
     CreateCircularBuffer(

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_c_large/softmax_c_large.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxOperation::MorehSoftmaxCLargeFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto dim = operation_attributes.dim;
     const auto op = operation_attributes.op;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_large/softmax_h_large.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxOperation::MorehSoftmaxHLargeFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_h_small/softmax_h_small.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxOperation::MorehSoftmaxHSmallFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_large/softmax_w_large.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxOperation::MorehSoftmaxWLargeFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/softmax_w_small/softmax_w_small.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxOperation::MorehSoftmaxWSmallFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& input = tensor_args.input;
     const auto op = operation_attributes.op;
     const auto& compute_kernel_config = operation_attributes.compute_kernel_config;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_c_large/softmax_backward_c_large.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardCLargeFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
     const auto dim = operation_attributes.dim;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_large/softmax_backward_h_large.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHLargeFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
     const auto op = operation_attributes.op;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_h_small/softmax_backward_h_small.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardHSmallFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
-    log_info(tt::LogTest, "Small tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Small tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
     const auto op = operation_attributes.op;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_large/softmax_backward_w_large.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWLargeFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
-    log_info(tt::LogTest, "Large tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Large tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
     const auto op = operation_attributes.op;

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_softmax_backward/device/softmax_backward_w_small/softmax_backward_w_small.cpp
@@ -12,7 +12,7 @@ MorehSoftmaxBackwardOperation::MorehSoftmaxBackwardWSmallFactory::create(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& input_grad) {
-    log_info(tt::LogTest, "Small tensor algorithm selected");
+    TT_LOG_INFO_WITH_CAT(tt::LogTest, "Small tensor algorithm selected");
     const auto& output = tensor_args.output_tensor;
     const auto& output_grad = tensor_args.output_grad_tensor;
     const auto op = operation_attributes.op;

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -74,7 +74,7 @@ std::vector<TensorSpec> HaloDeviceOperation::compute_output_specs(const std::vec
     }
 
     if (this->in_place_) {
-        tt::log_info(tt::LogAlways, "halo_device_operation - Using in-place mode so deallocating input buffer");
+        TT_LOG_INFO_WITH_CAT(tt::LogAlways, "halo_device_operation - Using in-place mode so deallocating input buffer");
         // TODO: `input_tensor` is const qualified, but Tensor::deallocate() is not.
         // Find a nicer way to do this.
         input_tensor.mesh_buffer()->deallocate();
@@ -268,7 +268,7 @@ Tensor halo_op(
         p_config.shard_orientation = input_tensor.shard_spec().value().orientation;
 
         if (in_place && in_nsticks_per_core > max_out_nsticks_per_core) {
-            tt::log_info(
+            TT_LOG_INFO_WITH_CAT(
                 tt::LogAlways,
                 "halo_device_operation - in place operation is not supported for parameterizations with "
                 "input shard size larger than output shard size, falling back to normal operation");

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/joint_sdpa_op.cpp
@@ -13,7 +13,7 @@ using namespace tt::tt_metal;
 namespace ttnn::operations::transformer {
 
 void JointScaledDotProductAttention::validate(const std::vector<Tensor>& input_tensors) const {
-    tt::log_info("Validating Joint SDPA inputs");
+    TT_LOG_INFO("Validating Joint SDPA inputs");
     TT_FATAL(input_tensors.size() == 6, "Must have 6 input tensors (Q, K, V, joint_Q, joint_K, joint_V)");
 
     const auto& input_tensor_q = input_tensors.at(0);


### PR DESCRIPTION
### Problem description
Usually its better to use a mature logging library.
This could reduce our dependence on variadic template functions, ensure thread safety, bring in full spdlog feature set.

### What's changed
Define new macros to forward to spdlog macros. `TT_LOG_INFO` and related.
tt::LogType is passed as a string the the logger and formatted by spdlog/fmt.

See this commit to understand the slick approach to integration: https://github.com/tenstorrent/tt-metal/pull/21264/commits/758304bc48357c47a20630271455513bec863158

Default spdlog logger log message, with no configuration, looks like this:
```
[2025-04-26 16:39:28.272] [info] [device.cpp:1172] [Metal] | Initializing device 0. Program cache is NOT enabled
```

# SO FAR I HAVE ONLY DONE log_info replacements, need to do log_warning, log_debug. log_trace

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14684176941) CI passes
- [x] New/Existing tests provide coverage for changes
- [ ] 


Latest after WARN
https://github.com/tenstorrent/tt-metal/actions/runs/14685957980
