### PR TITLE
Disable reflect selftest during compilation

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -106,6 +106,7 @@ if(reflect_ADDED)
             BASE_DIRS ${reflect_SOURCE_DIR}
             FILES ${reflect_SOURCE_DIR}/reflect
     )
+    target_compile_definitions(reflect INTERFACE DISABLE_STATIC_ASSERT_TESTS)
 endif()
 
 ############################################################################################################################


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
tt-metal/TTNN takes a long time to build

### What's changed
The reflect library always runs it's internal tests on each compilation (stored within the header itself). Defining the `DISABLE_STATIC_ASSERT_TESTS` macro disables the self test and saves about 3 seconds in a clean build on a QuietBox.

This change leads to not testing reflect itself each time. But IMO it's stable enough and we'd see other problems from the library if something broke anyway.

Before
ninja  17735.66s user 633.52s system 2435% cpu 12:34.29 total

After
ninja  17635.17s user 623.80s system 2431% cpu 12:31.06 total

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
