### PR TITLE
Include kernel content as a part of persistent cache key

### DIFF
--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -118,7 +118,7 @@ class Kernel : public JitBuildSettings {
 
     virtual Config config() const = 0;
 
-    std::string compute_hash() const;
+    std::string compute_hash(bool lightweight = true) const;
     virtual void set_build_options(JitBuildOptions &build_options) const {}
     virtual void generate_binaries(IDevice* device, JitBuildOptions &build_options) const = 0;
     uint32_t get_binary_packed_size(IDevice* device, int index) const;

--- a/tt_metal/api/tt-metalium/persistent_kernel_cache.hpp
+++ b/tt_metal/api/tt-metalium/persistent_kernel_cache.hpp
@@ -12,6 +12,9 @@ namespace tt::tt_metal::detail {
  * Enable kernel compilation cache to be persistent across runs. When this is called, kernels will not be compiled if
  * the output binary path exists.
  *
+ * @note The persistent kernel cache is keyed by the Metal build ID, the content of the kernel and build options
+ * (including the core type and command queue). Included files changing _will not_ invalidate the cache.
+ *
  * Return value: void
  */
 void EnablePersistentKernelCache();

--- a/tt_metal/detail/kernel_cache.hpp
+++ b/tt_metal/detail/kernel_cache.hpp
@@ -19,29 +19,10 @@ struct HashLookup {
 
     bool exists(size_t khash) {
         std::unique_lock<std::mutex> lock(mutex_);
-        return hashes_.find(khash) != hashes_.end();
-    }
-    bool add(size_t khash) {
-        std::unique_lock<std::mutex> lock(mutex_);
-        bool ret = false;
-        if (hashes_.find(khash) == hashes_.end()) {
-            hashes_.insert(khash);
-            ret = true;
-        }
-        return ret;
+        return map_key_to_generated_bin_.find(khash) != map_key_to_generated_bin_.end();
     }
 
-    bool is_bin_generated(size_t khash) {
-        std::unique_lock<std::mutex> lock(mutex_);
-        return generated_bins_.find(khash) != generated_bins_.end();
-    }
-
-    void add_generated_bin(size_t khash) {
-        std::unique_lock<std::mutex> lock(mutex_);
-        generated_bins_.insert(khash);
-    }
-
-    bool add_key_to_generated_bin(size_t khash, size_t key) {
+    bool add(size_t khash, size_t key) {
         std::unique_lock<std::mutex> lock(mutex_);
         auto it = map_key_to_generated_bin_.find(key);
         if (it == map_key_to_generated_bin_.end()) {
@@ -51,7 +32,7 @@ struct HashLookup {
         return false;
     }
 
-    std::optional<size_t> get_generated_bin(size_t key) {
+    std::optional<size_t> get(size_t key) {
         std::unique_lock<std::mutex> lock(mutex_);
         auto it = map_key_to_generated_bin_.find(key);
         if (it != map_key_to_generated_bin_.end()) {
@@ -62,15 +43,11 @@ struct HashLookup {
 
     void clear() {
         std::unique_lock<std::mutex> lock(mutex_);
-        hashes_.clear();
-        generated_bins_.clear();
         map_key_to_generated_bin_.clear();
     }
 
 private:
     std::mutex mutex_;
-    std::unordered_set<size_t> hashes_;
-    std::unordered_set<size_t> generated_bins_;
     std::unordered_map<size_t, size_t> map_key_to_generated_bin_;
 };
 

--- a/tt_metal/detail/kernel_cache.hpp
+++ b/tt_metal/detail/kernel_cache.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <stdint.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <optional>
 
 namespace tt::tt_metal::detail {
@@ -40,14 +41,32 @@ struct HashLookup {
         return std::nullopt;
     }
 
+    bool add_generated_bin(size_t khash) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        auto it = generated_bin_.find(khash);
+        if (it == generated_bin_.end()) {
+            generated_bin_.insert(khash);
+            return true;
+        }
+        return false;
+    }
+
+    bool is_bin_generated(size_t khash) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        auto it = generated_bin_.find(khash);
+        return it != generated_bin_.end();
+    }
+
     void clear() {
         std::unique_lock<std::mutex> lock(mutex_);
         map_key_to_generated_bin_.clear();
+        generated_bin_.clear();
     }
 
 private:
     std::mutex mutex_;
     std::unordered_map<size_t, size_t> map_key_to_generated_bin_;
+    std::unordered_set<size_t> generated_bin_;
 };
 
 /**

--- a/tt_metal/detail/kernel_cache.hpp
+++ b/tt_metal/detail/kernel_cache.hpp
@@ -6,7 +6,6 @@
 
 #include <mutex>
 #include <stdint.h>
-#include <unordered_set>
 #include <unordered_map>
 #include <optional>
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -226,9 +226,9 @@ std::string ComputeKernel::config_hash() const {
         this->config_.dst_full_sync_en);
 }
 
-std::string Kernel::compute_hash() const {
+std::string Kernel::compute_hash(bool lightweight) const {
     std::string source = this->kernel_src_.source_;
-    if (this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
+    if (!lightweight && this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
         std::ifstream file(jit_build_get_absolute_path(this->kernel_src_.source_));
         TT_ASSERT(file.is_open(), "Failed to open kernel source file: {}", this->kernel_src_.source_);
         std::stringstream buffer;
@@ -237,7 +237,7 @@ std::string Kernel::compute_hash() const {
     }
     return fmt::format(
         "{}_{}_{}_{}",
-        std::hash<std::string>{}(this->kernel_src_.source_),
+        std::hash<std::string>{}(source),
         fmt::join(this->compile_time_args_, "_"),
         tt::utils::DefinesHash{}(this->defines_),
         this->config_hash());

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -230,7 +230,7 @@ std::string Kernel::compute_hash(bool lightweight) const {
     std::string source = this->kernel_src_.source_;
     if (!lightweight && this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
         std::ifstream file(jit_build_get_absolute_path(this->kernel_src_.source_));
-        TT_ASSERT(file.is_open(), "Failed to open kernel source file: {}", this->kernel_src_.source_);
+        TT_FATAL(file.is_open(), "Failed to open kernel source file: {}", this->kernel_src_.source_);
         std::stringstream buffer;
         buffer << file.rdbuf();
         source = buffer.str();

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -233,7 +233,7 @@ std::string Kernel::compute_hash(bool lightweight) const {
         TT_FATAL(file.is_open(), "Failed to open kernel source file: {}", this->kernel_src_.source_);
         std::stringstream buffer;
         buffer << file.rdbuf();
-        source = buffer.str();
+        source += "_" + buffer.str();
     }
     return fmt::format(
         "{}_{}_{}_{}",

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -5,9 +5,11 @@
 #include <core_coord.hpp>
 #include <device.hpp>
 #include <fmt/ranges.h>
+#include <fstream>
 #include <kernel.hpp>
 #include <kernel_types.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <sstream>
 #include <utils.hpp>
 #include <algorithm>
 #include <cstring>
@@ -38,10 +40,10 @@ namespace tt {
 namespace tt_metal {
 
 Kernel::Kernel(
-    const KernelSource &kernel_src,
-    const CoreRangeSet &core_range_set,
-    const std::vector<uint32_t> &compile_args,
-    const std::map<std::string, std::string> &defines) :
+    const KernelSource& kernel_src,
+    const CoreRangeSet& core_range_set,
+    const std::vector<uint32_t>& compile_args,
+    const std::map<std::string, std::string>& defines) :
     kernel_src_(kernel_src),
     core_range_set_(core_range_set),
     max_runtime_args_per_core_(0),
@@ -65,8 +67,8 @@ Kernel::Kernel(
     }
     this->core_to_runtime_args_ = {max_x + 1, std::vector<std::vector<uint32_t>>(max_y + 1, std::vector<uint32_t>())};
     this->core_to_runtime_args_data_ = {max_x + 1, std::vector<RuntimeArgsData>(max_y + 1, RuntimeArgsData{})};
-    for (auto &runtime_args_data_x : this->core_to_runtime_args_data_) {
-        for (auto &runtime_args_data : runtime_args_data_x) {
+    for (auto& runtime_args_data_x : this->core_to_runtime_args_data_) {
+        for (auto& runtime_args_data : runtime_args_data_x) {
             runtime_args_data.rt_args_data = nullptr;
             runtime_args_data.rt_args_count = 0;
         }
@@ -85,14 +87,14 @@ void Kernel::register_kernel_with_watcher() {
 
 std::string Kernel::name() const { return this->kernel_src_.name(); }
 
-const std::set<CoreCoord> &Kernel::logical_cores() const { return this->logical_cores_; }
+const std::set<CoreCoord>& Kernel::logical_cores() const { return this->logical_cores_; }
 
 std::vector<CoreRange> Kernel::logical_coreranges() const {
     auto crs = this->core_range_set_.ranges();
     return {crs.begin(), crs.end()};
 }
 
-bool Kernel::is_on_logical_core(const CoreCoord &logical_core) const {
+bool Kernel::is_on_logical_core(const CoreCoord& logical_core) const {
     return this->core_range_set_.contains(logical_core);
 }
 
@@ -102,7 +104,8 @@ HalProgrammableCoreType Kernel::get_kernel_programmable_core_type() const {
         case RISCV::BRISC:
         case RISCV::NCRISC:
         case RISCV::COMPUTE: return HalProgrammableCoreType::TENSIX;
-        case RISCV::ERISC: return this->is_idle_eth() ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
+        case RISCV::ERISC:
+            return this->is_idle_eth() ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH;
         default: TT_ASSERT(false, "Unsupported kernel processor!");
     }
     return HalProgrammableCoreType::TENSIX;
@@ -126,22 +129,22 @@ void Kernel::add_defines(const std::map<std::string, std::string>& defines) {
     this->defines_.insert(defines.begin(), defines.end());
 }
 
-void Kernel::process_defines(const std::function<void(const string &define, const string &value)> callback) const {
-    for (const auto &[define, value] : this->defines_) {
+void Kernel::process_defines(const std::function<void(const string& define, const string& value)> callback) const {
+    for (const auto& [define, value] : this->defines_) {
         callback(define, value);
     }
 }
 
 void DataMovementKernel::process_defines(
-    const std::function<void(const string &define, const string &value)> callback) const {
+    const std::function<void(const string& define, const string& value)> callback) const {
     Kernel::process_defines(callback);
     callback("NOC_INDEX", std::to_string(this->config_.noc));
     callback("NOC_MODE", std::to_string(this->config_.noc_mode));
 }
 
 void ComputeKernel::process_defines(
-    const std::function<void(const string &define, const string &value)> callback) const {
-    for (const auto &[define, value] : this->defines_) {
+    const std::function<void(const string& define, const string& value)> callback) const {
+    for (const auto& [define, value] : this->defines_) {
         callback(define, value);
     }
     // pass default noc mode as compute does not need it, just for compile to pass
@@ -149,7 +152,7 @@ void ComputeKernel::process_defines(
 }
 
 void EthernetKernel::process_defines(
-    const std::function<void(const string &define, const string &value)> callback) const {
+    const std::function<void(const string& define, const string& value)> callback) const {
     Kernel::process_defines(callback);
     callback("NOC_INDEX", std::to_string(this->config_.noc));
     // pass default noc mode as eth does not need it, just for compile to pass
@@ -187,7 +190,7 @@ uint8_t ComputeKernel::expected_num_binaries() const {
     return 3;
 }
 
-std::vector<ll_api::memory const*> const& Kernel::binaries(uint32_t build_key) const {
+const std::vector<const ll_api::memory*>& Kernel::binaries(uint32_t build_key) const {
     auto iter = binaries_.find(build_key);
     TT_ASSERT(iter != binaries_.end(), "binary not found");
     if (iter->second.size() != expected_num_binaries()) {
@@ -210,10 +213,8 @@ std::string DataMovementKernel::config_hash() const {
 
 // Add "eth_" to the hash to differentiate between erisc and brisc.
 std::string EthernetKernel::config_hash() const {
-    return fmt::format("eth_{}_{}_{}",
-        magic_enum::enum_name(this->config_.noc),
-        this->config_.eth_mode,
-        this->config_.processor);
+    return fmt::format(
+        "eth_{}_{}_{}", magic_enum::enum_name(this->config_.noc), this->config_.eth_mode, this->config_.processor);
 }
 
 std::string ComputeKernel::config_hash() const {
@@ -226,6 +227,14 @@ std::string ComputeKernel::config_hash() const {
 }
 
 std::string Kernel::compute_hash() const {
+    std::string source = this->kernel_src_.source_;
+    if (this->kernel_src_.source_type_ == KernelSource::FILE_PATH) {
+        std::ifstream file(jit_build_get_absolute_path(this->kernel_src_.source_));
+        TT_ASSERT(file.is_open(), "Failed to open kernel source file: {}", this->kernel_src_.source_);
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        source = buffer.str();
+    }
     return fmt::format(
         "{}_{}_{}_{}",
         std::hash<std::string>{}(this->kernel_src_.source_),
@@ -234,7 +243,7 @@ std::string Kernel::compute_hash() const {
         this->config_hash());
 }
 
-std::vector<uint32_t> &Kernel::runtime_args(const CoreCoord &logical_core) {
+std::vector<uint32_t>& Kernel::runtime_args(const CoreCoord& logical_core) {
     // TODO (abhullar): Should this check only be enabled in debug mode?
     TT_FATAL(
         logical_core.x < this->core_to_runtime_args_.size() &&
@@ -245,7 +254,7 @@ std::vector<uint32_t> &Kernel::runtime_args(const CoreCoord &logical_core) {
     return this->core_to_runtime_args_[logical_core.x][logical_core.y];
 }
 
-RuntimeArgsData &Kernel::runtime_args_data(const CoreCoord &logical_core) {
+RuntimeArgsData& Kernel::runtime_args_data(const CoreCoord& logical_core) {
     // TODO (abhullar): Should this check only be enabled in debug mode?
     TT_FATAL(
         logical_core.x < this->core_to_runtime_args_.size() &&
@@ -256,17 +265,17 @@ RuntimeArgsData &Kernel::runtime_args_data(const CoreCoord &logical_core) {
     return this->core_to_runtime_args_data_[logical_core.x][logical_core.y];
 }
 
-std::vector<std::vector<std::vector<uint32_t>>> &Kernel::runtime_args() { return this->core_to_runtime_args_; }
+std::vector<std::vector<std::vector<uint32_t>>>& Kernel::runtime_args() { return this->core_to_runtime_args_; }
 
-std::vector<std::vector<RuntimeArgsData>> &Kernel::runtime_args_data() { return this->core_to_runtime_args_data_; }
+std::vector<std::vector<RuntimeArgsData>>& Kernel::runtime_args_data() { return this->core_to_runtime_args_data_; }
 
-std::vector<uint32_t> &Kernel::common_runtime_args() { return this->common_runtime_args_; }
+std::vector<uint32_t>& Kernel::common_runtime_args() { return this->common_runtime_args_; }
 
-RuntimeArgsData &Kernel::common_runtime_args_data() { return this->common_runtime_args_data_; }
+RuntimeArgsData& Kernel::common_runtime_args_data() { return this->common_runtime_args_data_; }
 
 // Ensure that unique and common runtime args do not overflow reserved region in L1.
 void Kernel::validate_runtime_args_size(
-    size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord &logical_core) {
+    size_t num_unique_rt_args, size_t num_common_rt_args, const CoreCoord& logical_core) {
     uint32_t total_rt_args = (num_unique_rt_args + num_common_rt_args);
     auto arch = MetalContext::instance().hal().get_arch();
     uint32_t idle_eth_max_runtime_args =
@@ -277,12 +286,22 @@ void Kernel::validate_runtime_args_size(
     uint32_t max_rt_args = is_idle_eth() ? idle_eth_max_runtime_args : max_runtime_args;
 
     if (total_rt_args > max_rt_args) {
-        log_warning(tt::LogMetal, "Too many runtime args, unique: {} common: {} on {}", num_unique_rt_args, num_common_rt_args, this->processor());
-        TT_THROW("{} unique+common runtime args targeting kernel {} on {} are too large. Max allowable is {}", total_rt_args, this->name(), logical_core.str(), max_runtime_args);
+        log_warning(
+            tt::LogMetal,
+            "Too many runtime args, unique: {} common: {} on {}",
+            num_unique_rt_args,
+            num_common_rt_args,
+            this->processor());
+        TT_THROW(
+            "{} unique+common runtime args targeting kernel {} on {} are too large. Max allowable is {}",
+            total_rt_args,
+            this->name(),
+            logical_core.str(),
+            max_runtime_args);
     }
 }
 
-void Kernel::set_runtime_args(const CoreCoord &logical_core, stl::Span<const uint32_t> runtime_args) {
+void Kernel::set_runtime_args(const CoreCoord& logical_core, stl::Span<const uint32_t> runtime_args) {
     // TODO (abhullar): If we don't include this check then user can write runtime args to a core that the kernel is not
     // placed on.
     //                  Should this check only be enabled in debug mode?
@@ -294,7 +313,7 @@ void Kernel::set_runtime_args(const CoreCoord &logical_core, stl::Span<const uin
 
     // Keep state for validation, to be able to check from both set_runtime_args() and set_common_runtime_args() APIs.
 
-    auto &set_rt_args = this->core_to_runtime_args_[logical_core.x][logical_core.y];
+    auto& set_rt_args = this->core_to_runtime_args_[logical_core.x][logical_core.y];
     // TODO: Only allow setting once
     if (set_rt_args.empty()) {
         if (runtime_args.size() > max_runtime_args_per_core_) {
@@ -309,7 +328,10 @@ void Kernel::set_runtime_args(const CoreCoord &logical_core, stl::Span<const uin
     } else {
         TT_FATAL(
             set_rt_args.size() == runtime_args.size(),
-            "Illegal Runtime Args on {}: Number of runtime args cannot be modified from {} to {}!", logical_core.str(), set_rt_args.size(), runtime_args.size());
+            "Illegal Runtime Args on {}: Number of runtime args cannot be modified from {} to {}!",
+            logical_core.str(),
+            set_rt_args.size(),
+            runtime_args.size());
         std::memcpy(
             this->core_to_runtime_args_data_[logical_core.x][logical_core.y].rt_args_data,
             runtime_args.data(),
@@ -318,7 +340,7 @@ void Kernel::set_runtime_args(const CoreCoord &logical_core, stl::Span<const uin
 }
 
 void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_args) {
-    auto &set_rt_args = this->common_runtime_args_;
+    auto& set_rt_args = this->common_runtime_args_;
     TT_FATAL(
         set_rt_args.empty(),
         "Illegal Common Runtime Args: Can only set common runtime args once. Get and modify args in place instead.");
@@ -330,12 +352,13 @@ void Kernel::set_common_runtime_args(stl::Span<const uint32_t> common_runtime_ar
 
 // Pads runtime args to count
 void Kernel::set_runtime_args_count(CoreRangeSet& core_ranges, uint32_t count) {
-
-    for (const CoreRange &core_range : core_ranges.ranges()) {
+    for (const CoreRange& core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                auto &set_rt_args = this->core_to_runtime_args_[x][y];
-                if (set_rt_args.empty()) continue;
+                auto& set_rt_args = this->core_to_runtime_args_[x][y];
+                if (set_rt_args.empty()) {
+                    continue;
+                }
 
                 TT_ASSERT(count >= core_to_runtime_args_data_[x][y].size());
                 core_to_runtime_args_data_[x][y].rt_args_count = count;
@@ -352,7 +375,8 @@ void Kernel::set_common_runtime_args_count(uint32_t count) {
 }
 
 bool Kernel::is_idle_eth() const {
-    return std::holds_alternative<EthernetConfig>(this->config()) && std::get<EthernetConfig>(this->config()).eth_mode == Eth::IDLE;
+    return std::holds_alternative<EthernetConfig>(this->config()) &&
+           std::get<EthernetConfig>(this->config()).eth_mode == Eth::IDLE;
 }
 
 uint32_t Kernel::get_binary_packed_size(IDevice* device, int index) const {
@@ -367,7 +391,7 @@ uint32_t Kernel::get_binary_text_size(IDevice* device, int index) const {
     return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
 }
 
-void ComputeKernel::set_build_options(JitBuildOptions &build_options) const {
+void ComputeKernel::set_build_options(JitBuildOptions& build_options) const {
     build_options.set_hlk_math_fidelity_all_cores(this->config_.math_fidelity);
     build_options.set_hlk_math_approx_mode_all_cores(this->config_.math_approx_mode);
     build_options.fp32_dest_acc_en = this->config_.fp32_dest_acc_en;
@@ -413,14 +437,15 @@ void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_
     jit_build_subset(build_states, this);
 }
 
-void Kernel::set_binaries(uint32_t build_key, std::vector<ll_api::memory const*>&& binaries) {
+void Kernel::set_binaries(uint32_t build_key, std::vector<const ll_api::memory*>&& binaries) {
     // Try inserting an empry vector, as that is cheap to construct
     // and avoids an additonal move.
     auto pair = binaries_.insert({build_key, {}});
-    if (pair.second)
+    if (pair.second) {
         pair.first->second = std::move(binaries);
-    else
+    } else {
         TT_ASSERT(pair.first->second == binaries);
+    }
 }
 
 bool DataMovementKernel::binaries_exist_on_disk(const IDevice* device) const {
@@ -437,7 +462,7 @@ bool DataMovementKernel::binaries_exist_on_disk(const IDevice* device) const {
 
 void DataMovementKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
-    std::vector<ll_api::memory const*> binaries;
+    std::vector<const ll_api::memory*> binaries;
 
     // TODO(pgk): move the procssor types into the build system.  or just use integer indicies
     // TODO(pgk): consolidate read_binaries where possible
@@ -452,9 +477,8 @@ void DataMovementKernel::read_binaries(IDevice* device) {
         (riscv_id == 1 && (device->arch() == tt::ARCH::GRAYSKULL || device->arch() == tt::ARCH::WORMHOLE_B0))
             ? ll_api::memory::Loading::CONTIGUOUS
             : ll_api::memory::Loading::CONTIGUOUS_XIP;
-    ll_api::memory const& binary_mem = llrt::get_risc_binary(
-        build_state.get_target_out_path(this->kernel_full_name_),
-        load_type);
+    const ll_api::memory& binary_mem =
+        llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
     binaries.push_back(&binary_mem);
     uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", riscv_id, this->name(), binary_size);
@@ -477,7 +501,7 @@ bool EthernetKernel::binaries_exist_on_disk(const IDevice* device) const {
 void EthernetKernel::read_binaries(IDevice* device) {
     // untested
     TT_ASSERT(this->binaries_exist_on_disk(device));
-    std::vector<ll_api::memory const*> binaries;
+    std::vector<const ll_api::memory*> binaries;
     uint32_t erisc_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
@@ -485,11 +509,10 @@ void EthernetKernel::read_binaries(IDevice* device) {
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
         device->build_id(), erisc_core_type, dm_class_idx, erisc_id);
     // TODO: fix when active eth supports relo
-    auto load_type = (this->config_.eth_mode == Eth::IDLE) ?
-        ll_api::memory::Loading::CONTIGUOUS_XIP : ll_api::memory::Loading::DISCRETE;
-    ll_api::memory const& binary_mem = llrt::get_risc_binary(
-        build_state.get_target_out_path(this->kernel_full_name_),
-        load_type);
+    auto load_type = (this->config_.eth_mode == Eth::IDLE) ? ll_api::memory::Loading::CONTIGUOUS_XIP
+                                                           : ll_api::memory::Loading::DISCRETE;
+    const ll_api::memory& binary_mem =
+        llrt::get_risc_binary(build_state.get_target_out_path(this->kernel_full_name_), load_type);
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
         this->config_.eth_mode != Eth::IDLE) {
         // text_addr and some of span's addr point to IRAM base address.
@@ -529,16 +552,15 @@ bool ComputeKernel::binaries_exist_on_disk(const IDevice* device) const {
 
 void ComputeKernel::read_binaries(IDevice* device) {
     TT_ASSERT(this->binaries_exist_on_disk(device));
-    std::vector<ll_api::memory const*> binaries;
+    std::vector<const ll_api::memory*> binaries;
     uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
             device->build_id(), tensix_core_type, compute_class_idx, trisc_id);
-        ll_api::memory const& binary_mem = llrt::get_risc_binary(
-            build_state.get_target_out_path(this->kernel_full_name_),
-            ll_api::memory::Loading::CONTIGUOUS_XIP);
+        const ll_api::memory& binary_mem = llrt::get_risc_binary(
+            build_state.get_target_out_path(this->kernel_full_name_), ll_api::memory::Loading::CONTIGUOUS_XIP);
         binaries.push_back(&binary_mem);
         uint32_t binary_size = binary_mem.get_packed_size();
     }
@@ -559,7 +581,8 @@ RISCV EthernetKernel::processor() const { return RISCV::ERISC; }
 
 RISCV ComputeKernel::processor() const { return RISCV::COMPUTE; }
 
-bool DataMovementKernel::configure(IDevice* device, const CoreCoord &logical_core, uint32_t base_address, const uint32_t offsets[]) const {
+bool DataMovementKernel::configure(
+    IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const {
     if (not is_on_logical_core(logical_core)) {
         TT_THROW("Cannot configure kernel because it is not on core {}", logical_core.str());
     }
@@ -573,27 +596,31 @@ bool DataMovementKernel::configure(IDevice* device, const CoreCoord &logical_cor
     return true;
 }
 
-bool EthernetKernel::configure(IDevice* device, const CoreCoord &logical_core, uint32_t base_address, const uint32_t offsets[]) const {
+bool EthernetKernel::configure(
+    IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const {
     auto device_id = device->id();
     auto ethernet_core = device->ethernet_core_from_logical_core(logical_core);
     const ll_api::memory& binary_mem =
         *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)[0];
 
     if (this->config_.eth_mode == Eth::IDLE) {
-        uint32_t offset_idx = magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
+        uint32_t offset_idx =
+            magic_enum::enum_integer(HalProcessorClassType::DM) + magic_enum::enum_integer(this->config_.processor);
         llrt::write_binary_to_address(binary_mem, device_id, ethernet_core, base_address + offsets[offset_idx]);
     } else {
         uint32_t erisc_core_type =
             MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
         uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
         int erisc_id = magic_enum::enum_integer(this->config_.processor);
-        tt::llrt::test_load_write_read_risc_binary(binary_mem, device_id, ethernet_core, erisc_core_type, dm_class_idx, erisc_id);
+        tt::llrt::test_load_write_read_risc_binary(
+            binary_mem, device_id, ethernet_core, erisc_core_type, dm_class_idx, erisc_id);
     }
 
     return true;
 }
 
-bool ComputeKernel::configure(IDevice* device, const CoreCoord &logical_core, uint32_t base_address, const uint32_t offsets[]) const {
+bool ComputeKernel::configure(
+    IDevice* device, const CoreCoord& logical_core, uint32_t base_address, const uint32_t offsets[]) const {
     bool pass = true;
     if (not is_on_logical_core(logical_core)) {
         TT_THROW("Cannot configure kernel because it is not on core {}", logical_core.str());
@@ -610,7 +637,7 @@ bool ComputeKernel::configure(IDevice* device, const CoreCoord &logical_core, ui
     return pass;
 }
 
-std::ostream &operator<<(std::ostream &os, const DataMovementProcessor &processor) {
+std::ostream& operator<<(std::ostream& os, const DataMovementProcessor& processor) {
     switch (processor) {
         case DataMovementProcessor::RISCV_0: os << "RISCV_0"; break;
         case DataMovementProcessor::RISCV_1: os << "RISCV_1"; break;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1386,11 +1386,11 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);
 
-                    if (enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
+                    const bool exist_in_cache = !detail::HashLookup::inst().add(key_hash, kernel_hash);
+                    if (!exist_in_cache && enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
                         // No need to check as the function itself will check if the kernel is already cached
-                        detail::HashLookup::inst().add(key_hash, kernel_hash);
                         detail::HashLookup::inst().add_generated_bin(kernel_hash);
-                    } else if (detail::HashLookup::inst().add(key_hash, kernel_hash)) {
+                    } else if (!exist_in_cache) {
                         GenerateBinaries(device, build_options, kernel);
                         detail::HashLookup::inst().add_generated_bin(kernel_hash);
                     }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1389,9 +1389,12 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     if (enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
                         // No need to check as the function itself will check if the kernel is already cached
                         detail::HashLookup::inst().add(key_hash, kernel_hash);
-                    } else if (not detail::HashLookup::inst().exists(key_hash)) {
+                        detail::HashLookup::inst().add_generated_bin(kernel_hash);
+                    } else if (detail::HashLookup::inst().add(key_hash, kernel_hash)) {
                         GenerateBinaries(device, build_options, kernel);
-                        detail::HashLookup::inst().add(key_hash, kernel_hash);
+                        detail::HashLookup::inst().add_generated_bin(kernel_hash);
+                    }
+                    while (not detail::HashLookup::inst().is_bin_generated(kernel_hash)) {
                     }
                 },
                 events);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1387,9 +1387,8 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     build_options.set_name(kernel_path_suffix);
 
                     if (enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
-                        if (not detail::HashLookup::inst().exists(key_hash)) {
-                            detail::HashLookup::inst().add(key_hash, kernel_hash);
-                        }
+                        // No need to check as the function itself will check if the kernel is already cached
+                        detail::HashLookup::inst().add(key_hash, kernel_hash);
                     } else if (not detail::HashLookup::inst().exists(key_hash)) {
                         GenerateBinaries(device, build_options, kernel);
                         detail::HashLookup::inst().add(key_hash, kernel_hash);

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -89,7 +89,7 @@ static fs::path get_file_path_relative_to_src(const fs::path& file_path) {
     return file_path_relative_to_src;
 }
 
-static string get_absolute_path(const string& file_path_string) {
+string jit_build_get_absolute_path(const string& file_path_string) {
     const fs::path& file_path = get_file_path_relative_to_src(file_path_string);
 
     const bool does_file_exist = fs::exists(file_path);
@@ -101,7 +101,7 @@ static string get_absolute_path(const string& file_path_string) {
 
 static string get_kernel_source_to_include(const KernelSource& kernel_src) {
     switch (kernel_src.source_type_) {
-        case KernelSource::FILE_PATH: return "#include \"" + get_absolute_path(kernel_src.source_) + "\"\n";
+        case KernelSource::FILE_PATH: return "#include \"" + jit_build_get_absolute_path(kernel_src.source_) + "\"\n";
         case KernelSource::SOURCE_CODE: return kernel_src.source_;
         default: {
             TT_THROW("Unsupported kernel source type!");

--- a/tt_metal/jit_build/genfiles.hpp
+++ b/tt_metal/jit_build/genfiles.hpp
@@ -27,5 +27,6 @@ void jit_build_genfiles_triscs_src(
     const JitBuildEnv& env, const JitBuildSettings& settings, const KernelSource& kernel_src);
 
 void jit_build_genfiles_descriptors(const JitBuildEnv& env, JitBuildOptions& options);
+std::string jit_build_get_absolute_path(const std::string& file_path_string);
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/pybind11/device.cpp
+++ b/ttnn/cpp/pybind11/device.cpp
@@ -568,6 +568,8 @@ void device_module(py::module& m_device) {
 
     m_device.def("EnablePersistentKernelCache", &tt::tt_metal::detail::EnablePersistentKernelCache, R"doc(
         Enable kernel compilation cache to be persistent across runs. When this is called, kernels will not be compiled if the output binary path exists.
+
+        The persistent kernel cache is keyed by the Metal build ID, the content of the kernel and build options (including the core type and command queue). Included files changing _will not_ invalidate the cache.
     )doc");
     m_device.def("DisablePersistentKernelCache", &tt::tt_metal::detail::DisablePersistentKernelCache, R"doc(
         Disables kernel compilation cache from being persistent across runs


### PR DESCRIPTION
### Ticket
#21266

This PR likely will be my last contribution as a community member. See you on the other side :)

### Problem description

The persistent cache is keyed only on path, build config and core. Which is very annoying for kernel writers as they have to disable the persistent cache. Remembering to turn the persistent cache back on only when modifying the host program, and off when changing the kernel, is a major mental load and thus unfeasible. Leading to low iteration speed.

### What's changed

1. The caching logic has been updated to take the content of the kernel into account
2. Simplify cache lookup logic
3. Add documentation around cache keying (what counts and what doesn't)

Pseudo code for the cache logic is as follows:

```python
kernel_hash = hash(kernel_path, build_cfg, build_param, metal_hash)
if not kernel_hash in kernel_cache and enable_persistent_kernel_cache and find_on_disk(kernel_hash):
    kernel_cache.insert(kernel_hash)
else if not kernel_hash in kernel_cache:
    build_kernel()
    kernel_cache.insert(kernel_hash)
```

The PR changes the logic to

```python
path_hash = hash(kernel_path, build_cfg, build_param, metal_hash)
# Avoid repeated FS access which can be slow
content_hash = kernel_cache[path_hash] if path_hash in kernel_cache else hash(read(kernel_path), build_cfg, build_param, metal_hash)
if not kernel_hash in kernel_cache and enable_persistent_kernel_cache and find_on_disk(content_hash):
    kernel_cache[path_hash] = content_hash
else if not kernel_hash in kernel_cache:
    build_kernel()
    kernel_cache[path_hash] = content_hash
```

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes