### PR TITLE
Un-break build-static-libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,4 +310,7 @@ if(BUILD_TT_TRAIN)
     add_subdirectory(tt-train)
 endif()
 
-include(packaging)
+# If we've been asked to build static libs, packaging is left up to them to sort out.
+if(TT_INSTALL)
+    include(packaging)
+endif()

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -334,6 +334,7 @@ fi
 
 if [ "$build_static_libs" = "ON" ]; then
     cmake_args+=("-DBUILD_SHARED_LIBS=OFF")
+    cmake_args+=("-DTT_INSTALL=OFF")
 fi
 
 if [ "$unity_builds" = "ON" ]; then

--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -18,6 +18,7 @@ option(ENABLE_TTNN_SHARED_SUBLIBS "Use shared libraries for ttnn to speed up inc
 option(TT_ENABLE_LIGHT_METAL_TRACE "Enable Light Metal Trace" ON)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(TT_UMD_BUILD_SIMULATION "Force UMD to include its simulation harnessing" ON)
+option(TT_INSTALL "Define installation rules" ON)
 
 ###########################################################################################
 
@@ -38,4 +39,8 @@ if(TT_UNITY_BUILDS)
         message(STATUS "CMake 3.20 or newer is required for Unity builds, disabling")
         set(TT_UNITY_BUILDS OFF)
     endif()
+endif()
+
+if(TT_INSTALL AND NOT BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "Shared libs are required for installation rules.  Set TT_INSTALL=OFF or BUILD_SHARED_LIBS=ON.")
 endif()

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -370,42 +370,44 @@ if(TT_METAL_BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-install(
-    TARGETS
-        tt_metal
-    EXPORT Metalium
-    LIBRARY
-        COMPONENT metalium-runtime
-    FILE_SET
-    api
-        DESTINATION COMPONENT
-        metalium-dev
-)
-install(EXPORT Metalium NAMESPACE TT:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tt-metalium COMPONENT metalium-dev)
+if(TT_INSTALL)
+    install(
+        TARGETS
+            tt_metal
+        EXPORT Metalium
+        LIBRARY
+            COMPONENT metalium-runtime
+        FILE_SET
+        api
+            DESTINATION COMPONENT
+            metalium-dev
+    )
+    install(EXPORT Metalium NAMESPACE TT:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/tt-metalium COMPONENT metalium-dev)
 
-install(
-    TARGETS
-        jitapi
-    FILE_SET
-    jit_api
-        DESTINATION
-            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal # FIXME: fix the include paths for jit_build
-        COMPONENT metalium-runtime
-)
+    install(
+        TARGETS
+            jitapi
+        FILE_SET
+        jit_api
+            DESTINATION
+                ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/tt_metal # FIXME: fix the include paths for jit_build
+            COMPONENT metalium-runtime
+    )
 
-# 3rd party dependencies we export in our public API.
-# We must ship not only these libraries, but their public headers as well
-# ... or refactor our public API.
-install(
-    TARGETS
-        reflect
-        magic_enum
-        TracyClient
-        span
-        small_vector
-    EXPORT Metalium
-    FILE_SET
-    api
-        COMPONENT metalium-dev
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/metalium-thirdparty
-)
+    # 3rd party dependencies we export in our public API.
+    # We must ship not only these libraries, but their public headers as well
+    # ... or refactor our public API.
+    install(
+        TARGETS
+            reflect
+            magic_enum
+            TracyClient
+            span
+            small_vector
+        EXPORT Metalium
+        FILE_SET
+        api
+            COMPONENT metalium-dev
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/metalium-thirdparty
+    )
+endif()


### PR DESCRIPTION
### Ticket
#21262

### Problem description
We have a --build-static-libs option in our build_metal.sh script.  We shouldn't break it if we're going to keep it.

### What's changed
Disable packaging if the user has asked for static libs.
In the future we can consider making that work (will need to check whether OBJECT libs give us what we want there).  But we've got circular deps to sort out before we get that far.