### PR TITLE
removed unused torch import in transpose_conv2d.py

### DIFF
--- a/ttnn/ttnn/operations/transpose_conv2d.py
+++ b/ttnn/ttnn/operations/transpose_conv2d.py
@@ -5,7 +5,6 @@
 from loguru import logger
 
 from typing import Tuple, Union, Dict, Optional
-import torch
 import warnings
 import math
 import ttnn


### PR DESCRIPTION
### Ticket
[#21143](https://github.com/tenstorrent/tt-metal/issues/21143)

### Problem description
Torch shouldn't be imported globally in `transpose_conv2d.py`

### What's changed
Removed unused import

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14703265990)