### PR TITLE
[skip ci] added conv team to codeowners for specific python ops files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,6 +83,10 @@ tt_metal/impl/flatbuffer/ @kmabeeTT @nsmithtt @omilyutin-tt
 ttnn/ @ayerofieiev-tt @dmakoviichuk-tt @cfjchu @TT-BrianLiu @omilyutin-tt
 ttnn/ttnn/library_tweaks.py @ayerofieiev-tt @tenstorrent/metalium-developers-infra
 ttnn/ttnn/operations/moreh.py @razorback3 @dongjin-na @cfjchu @ayerofieiev-tt @dmakoviichuk-tt
+ttnn/ttnn/operations/conv2d.py @tenstorrent/metalium-developers-convolutions
+ttnn/ttnn/operations/transpose_conv2d.py @tenstorrent/metalium-developers-convolutions
+ttnn/ttnn/operations/pool.py @tenstorrent/metalium-developers-convolutions
+ttnn/ttnn/operations/downsample.py @tenstorrent/metalium-developers-convolutions
 ttnn/**/kernels/ # Removes the owners above from owning kernels unless specified afterwards
 ttnn/**/CMakeLists.txt @ayerofieiev-tt @dmakoviichuk-tt @sminakov-tt
 ttnn/cpp/ttnn/tensor/ @cfjchu @ayerofieiev-tt @dmakoviichuk-tt @omilyutin-tt


### PR DESCRIPTION
### What's changed
Adding conv team to CODEOWNERS for conv, pool and downsample files.