### PR TITLE
Fix non tile multiple input shard

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -509,7 +509,6 @@ Result conv2d_L1(
                 0,
                 false,
                 parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-                0,
                 input_tensor_post_tm.memory_config(),
                 true,
                 conv_config.in_place);

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -236,7 +236,6 @@ Result conv_transpose2d(
             0,
             false,
             parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-            0,
             input_tensor_post_tm.memory_config());
 
         if (conv_config.deallocate_activation) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/generic_pools.cpp
@@ -145,7 +145,6 @@ Tensor Pool2DOp<pool_type>::invoke(
         get_bf16_pool_init_value(pool_type),  // pad_val
         false,
         parallel_config.shard_orientation == ShardOrientation::COL_MAJOR,
-        0,
         input_tensor_sharded.memory_config(),
         is_out_tiled,
         in_place_halo);

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -57,7 +57,7 @@ Tensor HaloTensorCreation(const Tensor& input) {
     input_tensor = ttnn::reshape(input_tensor, new_shape);
 
     auto halo_output = ttnn::halo(
-        DefaultQueueId, input_tensor, sliding_window_config, 0, false, false, 0, input_tensor.memory_config(), false);
+        DefaultQueueId, input_tensor, sliding_window_config, 0, false, false, input_tensor.memory_config(), false);
 
     return halo_output;
 }

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -21,7 +21,6 @@ struct HaloDeviceOperation {
     uint32_t pad_val_;
     bool remote_read_;
     bool transpose_mcast_;
-    uint32_t reshard_num_cores_nhw_;
     uint32_t max_out_nsticks_per_core_;
     uint32_t in_nsticks_per_core_;
     tt::tt_metal::MemoryConfig output_memory_config_;
@@ -40,7 +39,6 @@ struct HaloDeviceOperation {
         "pad_val_",
         "remote_read_",
         "transpose_mcast_",
-        "reshard_num_cores_nhw_",
         "max_out_nsticks_per_core_",
         "output_memory_config_",
         "is_out_tiled_",
@@ -52,7 +50,6 @@ struct HaloDeviceOperation {
             std::cref(pad_val_),
             std::cref(remote_read_),
             std::cref(transpose_mcast_),
-            std::cref(reshard_num_cores_nhw_),
             std::cref(max_out_nsticks_per_core_),
             std::cref(output_memory_config_),
             std::cref(is_out_tiled_),
@@ -66,7 +63,6 @@ Tensor halo_op(
     uint32_t pad_val = 0x0,
     bool remote_read = false,
     bool transpose_mcast = true,
-    uint32_t reshard_num_cores_nhw = 0,
     const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
     bool is_out_tiled = true,
     bool in_place = false);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.cpp
@@ -14,7 +14,6 @@ Tensor HaloOperation::invoke(
     uint32_t pad_val,
     bool remote_read,
     bool transpose_mcast,
-    uint32_t reshard_num_cores_nhw,
     const MemoryConfig& output_memory_config,
     bool is_out_tiled,
     bool in_place) {
@@ -24,7 +23,6 @@ Tensor HaloOperation::invoke(
         pad_val,
         remote_read,
         transpose_mcast,
-        reshard_num_cores_nhw,
         std::move(output_memory_config),
         is_out_tiled,
         in_place);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/halo.hpp
@@ -18,7 +18,6 @@ struct HaloOperation {
         uint32_t pad_val = 0x0,
         bool remote_read = false,
         bool transpose_mcast = true,
-        uint32_t reshard_num_cores_nhw = 0,
         const tt::tt_metal::MemoryConfig& output_memory_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG,
         bool is_out_tiled = true,
         bool in_place = false);

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.hpp
@@ -112,10 +112,7 @@ std::vector<ShardBoundary> generate_shard_boundaries(
     const SlidingWindowConfig& config, const std::vector<uint32_t>& op_trace_metadata);
 
 std::vector<PixelMetadata> generate_tensor_metadata(
-    const std::vector<bool>& pad_metadata,
-    const SlidingWindowConfig& config,
-    uint32_t reshard_num_cores_nhw = 0,
-    bool is_in_tiled = true);
+    const std::vector<bool>& pad_metadata, const SlidingWindowConfig& config, uint32_t shard_height);
 
 uint32_t generate_max_out_nsticks_per_core(const std::vector<ShardBoundary>& shard_boundaries);
 


### PR DESCRIPTION
Conv2d is failing in case when input shard
is not a multiple of tile size. Bug is in
sliding windows infra which is trying to deduce the shard height. Instead of deducing the shard height just pass in actual shard height.

Motivation for this change comes from work of
improving device perf on unet shallow model, where changing the core count of the model exposed this
problem. max_pool2d on higher core count is producing shard height of 671 which isn't multiple of 32 and subsequent conv2d has pcc issues.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14695761557)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14695767142)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14695773119)