### PR TITLE
Conv2d remove redundant ttnn::to_memory_config

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -659,18 +659,6 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
         } else {
             input_tensor = ttnn::to_device(
                 input_tensor, device, (auto_shard_mm ? ttnn::DRAM_MEMORY_CONFIG : input_tensor_sharded_memory_config));
-            log_debug(
-                tt::LogOp,
-                "Input Tensor Memory Config is {}, expected {}",
-                input_tensor.memory_config(),
-                (auto_shard_mm ? ttnn::DRAM_MEMORY_CONFIG : input_tensor_sharded_memory_config));
-
-            // to_device doesn't respect the memory config that's passed.
-            // So to_memory_config is needed to ensure the memory config is set correctly.
-            input_tensor = ttnn::to_memory_config(
-                input_tensor,
-                (auto_shard_mm ? ttnn::DRAM_MEMORY_CONFIG : input_tensor_sharded_memory_config),
-                std::nullopt);
         }
     }
     return {input_tensor, parallel_config, output_parallel_config};


### PR DESCRIPTION
Conv2d remove redundant ttnn::to_memory_config

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14695864134)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14695867958) CI with demo tests passes (if applicable)