### PR TITLE
Fix Conv2d bug affecting block float format computations when in_channels * kernel_w % 16 != 0

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/height_sharded_reader_common.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Zero out all tiles for a given circular buffer.
+template <uint32_t cb_id>
+FORCE_INLINE void zero_out_tiles() {
+    constexpr uint32_t tile_size = get_tile_size(cb_id);
+    static_assert(
+        tile_size % MEM_ZEROS_SIZE == 0, "Tile size must be a multiple of MEM_ZEROS_BASE for zeroing out tiles");
+    const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_num_pages;
+    const uint32_t num_zeros_reads = (tile_size / MEM_ZEROS_SIZE) * num_tiles;
+    uint64_t zeros_noc_addr = get_noc_addr(MEM_ZEROS_BASE);
+    uint32_t write_addr = get_write_ptr(cb_id);
+
+    noc_async_read_one_packet_set_state(zeros_noc_addr, MEM_ZEROS_SIZE);
+    for (uint32_t i = 0; i < num_zeros_reads; ++i) {
+        noc_async_read_one_packet_with_state(zeros_noc_addr, write_addr);
+        write_addr += MEM_ZEROS_SIZE;
+    }
+    noc_async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp
@@ -12,8 +12,8 @@
 #include "debug/dprint_pages.h"
 #endif
 
-constexpr uint32_t weight_size_w = get_compile_time_arg_val(11);  // Input filter window width
-constexpr uint32_t weight_size_h = get_compile_time_arg_val(14);  // Input filter window width
+constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);  // Input filter window width
+constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);  // Input filter window width
 
 template <int window_height, int window_width>
 FORCE_INLINE void read_dilated_channels(
@@ -59,33 +59,30 @@ void read_channels(
     }
 }
 
-constexpr uint32_t DILATION_W = get_compile_time_arg_val(3);
+constexpr uint32_t DILATION_W = get_compile_time_arg_val(1);
 void kernel_main() {
-    constexpr uint32_t stride_h = get_compile_time_arg_val(0);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(1);
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(2);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(3);
-    constexpr uint32_t conv_act_size_w = get_compile_time_arg_val(4);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(6);
-    constexpr uint32_t window_inner = get_compile_time_arg_val(8);
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(9);
-    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(12);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(13);
-    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(15);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(16);
-    constexpr uint32_t act_w_num_outer = get_compile_time_arg_val(17);
-    constexpr uint32_t act_mcast_num_dests = get_compile_time_arg_val(18);
-    constexpr uint32_t act_mcast_num_cores = get_compile_time_arg_val(19);
-    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(20));
-    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(21));
-    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(22);
-    constexpr bool transpose_mcast = get_compile_time_arg_val(23) == 1;
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(26);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(27);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(28);
-    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(29);
-    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(30);
-    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(31);
+    constexpr uint32_t dilation_h = get_compile_time_arg_val(0);
+    constexpr uint32_t dilation_w = get_compile_time_arg_val(1);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t window_inner = get_compile_time_arg_val(4);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(5);
+    constexpr uint32_t padded_conv_act_size_w = get_compile_time_arg_val(9);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(12);
+    constexpr uint32_t act_w_num_outer = get_compile_time_arg_val(13);
+    constexpr uint32_t act_mcast_num_dests = get_compile_time_arg_val(14);
+    constexpr uint32_t act_mcast_num_cores = get_compile_time_arg_val(15);
+    const uint32_t act_mcast_sender_semaphore_addr = get_semaphore(get_compile_time_arg_val(16));
+    const uint32_t act_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(17));
+    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(18);
+    constexpr bool transpose_mcast = get_compile_time_arg_val(19) == 1;
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
+    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(26);
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(27);
+    constexpr uint32_t cb_l1_array = get_compile_time_arg_val(28);
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp
@@ -11,28 +11,21 @@ void kernel_main() {
     constexpr uint32_t LOCAL_PACKED_READER_INDICES_MAX_SIZE = 128;
     uint32_t local_packed_reader_indices[LOCAL_PACKED_READER_INDICES_MAX_SIZE];
 
-    constexpr uint32_t stride_h = get_compile_time_arg_val(0);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(1);
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(2);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(3);
-    constexpr uint32_t conv_act_size_w_ = get_compile_time_arg_val(4);
-    constexpr uint32_t conv_output_w_last_index = get_compile_time_arg_val(5) - 1;
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(2);
     // need to have these as compile-time, they are inner loop bouds / unroll loops / constexpr conditionals based on
     // them
-    constexpr uint32_t window_outer = get_compile_time_arg_val(7);
-    constexpr uint32_t window_inner = get_compile_time_arg_val(8);
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(9);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(10);
-    constexpr uint32_t weight_size_w = get_compile_time_arg_val(11);
-    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(12);
-    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(13);
-    constexpr uint32_t weight_size_h = get_compile_time_arg_val(14);
-    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(17);
-
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(26);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(27);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(28);
+    constexpr uint32_t window_outer = get_compile_time_arg_val(3);
+    constexpr uint32_t window_inner = get_compile_time_arg_val(4);
+    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(5);
+    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(6);
+    constexpr uint32_t weight_size_h = get_compile_time_arg_val(7);
+    constexpr uint32_t weight_size_w = get_compile_time_arg_val(8);
+    constexpr uint32_t conv_act_size_w_padded = get_compile_time_arg_val(9);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_id_act = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(24);
+    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(25);
 
     uint32_t i = 0;
     uint32_t noop = get_arg_val<uint32_t>(i);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "dataflow_api.h"
+#include "height_sharded_reader_common.hpp"
 
 void kernel_main() {
     // This writer is for output tensor in tile format
@@ -33,6 +34,7 @@ void kernel_main() {
     constexpr uint32_t act_block_w_extra_align_bytes = get_compile_time_arg_val(24);
     constexpr uint32_t act_block_h_datums_first_reader = get_compile_time_arg_val(25);
     constexpr uint32_t act_block_h_datums_last_block = get_compile_time_arg_val(26);
+    constexpr bool needs_act_block_zero_out = get_compile_time_arg_val(27) == 1;
 
     constexpr uint32_t act_block_h_datums_read_last_block =
         act_block_h_datums_last_block > act_block_h_datums
@@ -51,6 +53,10 @@ void kernel_main() {
         return;
     }
 
+    if constexpr (split_reader && needs_act_block_zero_out) {
+        zero_out_tiles<cb_id_act_second_reader>();
+    }
+
     // mcast args
     const uint32_t weights_mcast_sender_noc_x = get_arg_val<uint32_t>(i++);
     const uint32_t weights_mcast_sender_noc_y = get_arg_val<uint32_t>(i++);
@@ -63,7 +69,6 @@ void kernel_main() {
         get_noc_addr(weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, weights_mcast_sender_semaphore_addr);
 
     constexpr uint32_t act_block_h_datums_read = act_block_h_datums / 2;
-    constexpr uint32_t act_block_num_tiles_read = act_block_num_tiles;
 
     volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr;
     uint32_t reader_idx;
@@ -106,7 +111,7 @@ void kernel_main() {
                         // Do the second half of the reads for act
                         noc_async_read_one_packet_set_state(get_noc_addr(act_l1_read_addr), coalesced_read_bytes);
                         reader_idx = start_reader_idx;
-                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles_read);
+                        cb_reserve_back(cb_id_act_second_reader, act_block_num_tiles);
                         uint32_t l1_write_addr_act = get_write_ptr(cb_id_act_second_reader);
                         uint32_t act_block_h_datums_read_curr =
                             bh == out_num_blocks_h - 1 ? act_block_h_datums_read_last_block : act_block_h_datums_read;
@@ -127,7 +132,7 @@ void kernel_main() {
                             reader_idx++;
                         }
                         noc_async_read_barrier();
-                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles_read);
+                        cb_push_back(cb_id_act_second_reader, act_block_num_tiles);
 
                         reader_offset += window_outer_offset;
                     }


### PR DESCRIPTION
When using output block float formats (like bfp8) with Conv2d, our input tilizing algorithm corrupts valid data if the input dimensions don't align with the 16-scalar boundary required for block format conversion. This happens specifically when (in_channels * kernel_width) is not divisible by 16.

The corruption occurs because our compute kernel tilizes input with random uninitialized data surrounding the valid data, which affects the block float conversion process.

Solution: Zero-initialize the temporary circular buffer used for input tilizing to prevent data corruption in these edge cases.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14701898818)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14701895605)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14696462164) 
- [x] [(Single-card) Device perf regressions](https://github.com/tenstorrent/tt-metal/actions/runs/14707016479)