### PR TITLE
Preserve input dtype in conv2d mm

### DIFF
--- a/models/demos/mnist/tests/test_perf_mnist.py
+++ b/models/demos/mnist/tests/test_perf_mnist.py
@@ -114,7 +114,7 @@ def test_perf_device_bare_metal(batch_size, reset_seeds):
     if is_grayskull():
         expected_perf = 402500.0
     elif is_wormhole_b0():
-        expected_perf = 900000.0
+        expected_perf = 932965.0
 
     command = f"pytest tests/ttnn/integration_tests/mnist/test_mnist.py::test_mnist"
     cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]

--- a/models/experimental/yolov10/tt/attention.py
+++ b/models/experimental/yolov10/tt/attention.py
@@ -19,17 +19,9 @@ class TtnnAttention:
         nh_kd = self.key_dim * num_heads
         h = dim + nh_kd * 2
 
-        self.qkv = Conv(
-            device,
-            parameters.qkv,
-            self.conv_pt.qkv,
-            enable_identity=True,
-        )
+        self.qkv = Conv(device, parameters.qkv, self.conv_pt.qkv, enable_identity=True, activation_dtype=ttnn.bfloat16)
         self.proj = Conv(
-            device,
-            parameters.proj,
-            self.conv_pt.proj,
-            enable_identity=True,
+            device, parameters.proj, self.conv_pt.proj, enable_identity=True, activation_dtype=ttnn.bfloat16
         )
 
         self.pe = Conv(

--- a/models/experimental/yolov10/tt/common.py
+++ b/models/experimental/yolov10/tt/common.py
@@ -146,6 +146,7 @@ class Conv:
         shard_layout=None,
         activation="",
         deallocate_activation=False,
+        activation_dtype=ttnn.bfloat8_b,
     ):
         self.enable_identity = enable_identity
         self.enable_act = enable_act
@@ -163,6 +164,7 @@ class Conv:
             shard_layout=shard_layout,
             activation=activation,
             deallocate_activation=deallocate_activation,
+            activation_dtype=activation_dtype,
         )
 
     def __call__(self, x):


### PR DESCRIPTION
Issue #21109

In case conv2d maps to matmul as a micro op, and
user has passed in a row-major tensor, we need to
tilize it.

Current we set output data format of tilized tensor to the output data format of the conv2d op.

This way we potentially lose precision on input.

Proper thing to do is to preserve input dtype during tilization, and set proper output data format on
matmul device op.

Fixing this triggered a issue in yolov10 where model relied on conv2d op not really output data format which was specified in Conv2dConfig as dtype.

To resolve this yolov10 model was adjusted.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14696516024)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/14696516887)
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14695966769)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14706135963)