### PR TITLE
#16067: Delete legacy and very legacy implementations of serialization

### DIFF
--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -25,6 +25,20 @@ using MeshDevice = distributed::MeshDevice;
 
 namespace {
 
+void validate_version(uint8_t version_id) {
+    TT_FATAL(
+        version_id >= 5,
+        "Version {} is no longer supported. Please update your saved data to the supported version (5).",
+        version_id);
+    TT_FATAL(
+        version_id <= VERSION_ID,
+        "Version mismatch: the serialized tensor was created with version {} but is "
+        "being loaded by a loader with version {}. Please update your saved data or your "
+        "loader so that both versions match.",
+        version_id,
+        VERSION_ID);
+}
+
 struct FileCloser {
     void operator()(FILE* file) const {
         if (file) {
@@ -32,54 +46,6 @@ struct FileCloser {
                 log_warning("Failed to close file");
             }
         }
-    }
-};
-
-struct Padding {
-    enum class PadValue { Any, Zero, Infinity, NegativeInfinity };
-    struct PadDimension {
-        std::size_t front;
-        std::size_t back;
-    };
-    std::size_t rank_;
-    std::array<PadDimension, MAX_NUM_DIMENSIONS> pad_dimensions_;
-    PadValue pad_value_ = PadValue::Any;
-};
-
-struct LegacyShape {
-    std::size_t rank_;
-    std::array<uint32_t, MAX_NUM_DIMENSIONS> dimensions_;
-    Padding padding_;
-
-    LegacyShape() = default;
-    LegacyShape(const ttnn::Shape& logical_shape, const ttnn::Shape& padded_shape) {
-        rank_ = padded_shape.rank();
-        padding_.rank_ = padded_shape.rank();
-        for (int index = 0; index < padded_shape.rank(); index++) {
-            int shape_index = index + static_cast<int>(logical_shape.size()) - static_cast<int>(padded_shape.size());
-            int dimension = shape_index >= 0 ? logical_shape[shape_index] : 1;
-            int padded_dimension = padded_shape[index];
-            this->dimensions_[index] = padded_dimension;
-            this->padding_.pad_dimensions_[index] = {
-                .front = 0, .back = static_cast<size_t>(padded_dimension - dimension)};
-        }
-    }
-
-    ttnn::Shape logical_shape() const {
-        ttnn::SmallVector<uint32_t> values(rank_);
-        for (size_t i = 0; i < values.size(); i++) {
-            auto [front_pad, back_pad] = padding_.pad_dimensions_[i];
-            values[i] = dimensions_[i] - front_pad - back_pad;
-        }
-        return ttnn::Shape(std::move(values));
-    }
-
-    ttnn::Shape padded_shape() const {
-        ttnn::SmallVector<uint32_t> values(rank_);
-        for (size_t i = 0; i < values.size(); i++) {
-            values[i] = dimensions_[i];
-        }
-        return ttnn::Shape(std::move(values));
     }
 };
 
@@ -178,7 +144,7 @@ HostStorage load_host_storage(FILE* input_file) {
 
 template <typename T>
 MultiDeviceHostStorage load_multi_device_host_storage(
-    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
+    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device) {
     uint64_t num_buffers = 0;
     DistributedTensorConfig strategy;
     safe_fread(&num_buffers, sizeof(num_buffers), 1, input_file);
@@ -193,18 +159,7 @@ MultiDeviceHostStorage load_multi_device_host_storage(
         safe_fread(data.data(), sizeof(T) * size, 1, input_file);
         HostBuffer buffer = host_buffer::create<T>(std::move(data));
         buffers.push_back(std::move(buffer));
-
-        auto spec = [&] {
-            if (version_id >= 5) {
-                return load_tensor_spec(input_file);
-            }
-            auto shape = LegacyShape{};
-            safe_fread(&shape, sizeof(shape), 1, input_file);
-            return TensorSpec(
-                shape.logical_shape(),
-                TensorLayout::fromPaddedShape(
-                    data_type, PageConfig(layout), MemoryConfig{}, shape.logical_shape(), shape.padded_shape()));
-        }();
+        auto spec = load_tensor_spec(input_file);
         specs.push_back(spec);
 
         auto num_devices = mesh_device ? mesh_device->num_devices() : 1;
@@ -223,17 +178,7 @@ MultiDeviceHostStorage load_multi_device_host_storage(
             buffers.push_back(std::move(buffer));
         }
         for (std::size_t i = 0; i < num_buffers; ++i) {
-            if (version_id >= 5) {
-                specs.push_back(load_tensor_spec(input_file));
-            } else {
-                auto shape = LegacyShape{};
-                safe_fread(&shape, sizeof(shape), 1, input_file);
-                TensorSpec spec(
-                    shape.logical_shape(),
-                    TensorLayout::fromPaddedShape(
-                        data_type, PageConfig(layout), MemoryConfig{}, shape.logical_shape(), shape.padded_shape()));
-                specs.push_back(spec);
-            }
+            specs.push_back(load_tensor_spec(input_file));
         }
     }
 
@@ -265,128 +210,32 @@ HostStorage load_host_storage(FILE* input_file, DataType data_type) {
 }
 
 MultiDeviceHostStorage load_multi_device_host_storage(
-    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device, uint8_t version_id) {
+    FILE* input_file, DataType data_type, Layout layout, MeshDevice* mesh_device) {
     if (data_type == DataType::UINT32 or data_type == DataType::BFLOAT8_B or data_type == DataType::BFLOAT4_B) {
         using T = std::uint32_t;
-        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device);
     } else if (data_type == DataType::UINT16) {
         using T = std::uint16_t;
-        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device);
     } else if (data_type == DataType::FLOAT32) {
         using T = float;
-        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device);
     } else if (data_type == DataType::BFLOAT16) {
         using T = bfloat16;
-        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device, version_id);
+        return load_multi_device_host_storage<T>(input_file, data_type, layout, mesh_device);
     } else {
         TT_THROW("Unsupported DataType");
     }
 }
 
 template <typename T>
-Storage load_storage(
-    FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, T device, uint8_t version_id) {
+Storage load_storage(FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, T device) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::DEVICE) {
         if constexpr (std::is_same_v<T, MeshDevice*>) {
-            return load_multi_device_host_storage(input_file, data_type, layout, device, version_id);
+            return load_multi_device_host_storage(input_file, data_type, layout, device);
         }
     }
     return load_host_storage(input_file, data_type);
-}
-
-template <typename T>
-Tensor load_tensor_helper_legacy_impl(FILE* input_file, T device, uint8_t version_id) {
-    auto shape = LegacyShape{};
-    DataType data_type;
-    Layout layout;
-    StorageType storage_type;
-    safe_fread(&shape, sizeof(shape), 1, input_file);
-    safe_fread(&data_type, sizeof(data_type), 1, input_file);
-    safe_fread(&layout, sizeof(layout), 1, input_file);
-    safe_fread(&storage_type, sizeof(storage_type), 1, input_file);
-
-    bool has_memory_config = false;
-    MemoryConfig memory_config =
-        MemoryConfig{.memory_layout = tt::tt_metal::TensorMemoryLayout::INTERLEAVED, .buffer_type = BufferType::DRAM};
-
-    if (version_id >= 2) {
-        safe_fread(&has_memory_config, sizeof(has_memory_config), 1, input_file);
-        if (has_memory_config) {
-            memory_config = tt::tt_metal::load_memory_config(input_file);
-        }
-    }
-
-    auto storage = load_storage(input_file, data_type, layout, storage_type, device, version_id);
-
-    auto tensor = Tensor(
-        std::move(storage),
-        TensorSpec(
-            shape.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
-    if (device != nullptr) {
-        tensor = tensor.to_device(device, memory_config);
-    } else if (has_memory_config) {
-        tt::log_warning("Memory config is ignored when loading the tensor because device is not provided");
-    }
-    return tensor;
-}
-
-// Used before VERSION_ID was introduced
-template <typename T>
-Tensor load_tensor_helper_very_legacy_impl(FILE* input_file, T device) {
-    auto shape = LegacyShape{};
-    DataType data_type;
-    Layout layout;
-    safe_fread(&shape, sizeof(shape), 1, input_file);
-    safe_fread(&data_type, sizeof(data_type), 1, input_file);
-    safe_fread(&layout, sizeof(layout), 1, input_file);
-
-    auto storage = load_host_storage(input_file, data_type);
-    auto tensor = Tensor(
-        std::move(storage),
-        TensorSpec(
-            shape.logical_shape(),
-            TensorLayout::fromPaddedShape(
-                data_type, layout, MemoryConfig{}, shape.logical_shape(), shape.padded_shape())));
-    if (device != nullptr) {
-        tensor = tensor.to_device(device);
-    }
-    return tensor;
-}
-
-// Used before flatbuffer serialization, aka VERSION_ID < 5
-MemoryConfig load_memory_config_legacy_impl(FILE* input_file, uint8_t version_id) {
-    TensorMemoryLayout memory_layout;
-    BufferType buffer_type;
-    bool has_shard_spec;
-    safe_fread(&memory_layout, sizeof(memory_layout), 1, input_file);
-    safe_fread(&buffer_type, sizeof(buffer_type), 1, input_file);
-    safe_fread(&has_shard_spec, sizeof(has_shard_spec), 1, input_file);
-
-    std::optional<ShardSpec> shard_spec = std::nullopt;
-    if (has_shard_spec) {
-        uint64_t num_core_ranges;
-        std::set<CoreRange> core_ranges;
-        std::array<uint32_t, 2> shape;
-        ShardOrientation orientation;
-
-        safe_fread(&num_core_ranges, sizeof(num_core_ranges), 1, input_file);
-        for (auto index = 0; index < num_core_ranges; index++) {
-            CoreRange core_range{{}, {}};
-            safe_fread(&core_range, sizeof(core_range), 1, input_file);
-            core_ranges.insert(core_range);
-        }
-        safe_fread(&shape, sizeof(shape), 1, input_file);
-        safe_fread(&orientation, sizeof(orientation), 1, input_file);
-        if (version_id <= 3) {
-            // Read halo for backward compatibility.
-            bool halo;
-            safe_fread(&halo, sizeof(halo), 1, input_file);
-        }
-        shard_spec = {CoreRangeSet{core_ranges}, shape, orientation};
-    }
-    return MemoryConfig{memory_layout, buffer_type, shard_spec};
 }
 
 template <typename T>
@@ -399,29 +248,19 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
 
     std::size_t read_sentinel;
     safe_fread(&read_sentinel, sizeof(read_sentinel), 1, input_file);
-    if (read_sentinel != SENTINEL_VALUE) {
-        fseek(input_file, 0, SEEK_SET);
-        return load_tensor_helper_very_legacy_impl(input_file, device);
-    }
+    TT_FATAL(
+        read_sentinel == SENTINEL_VALUE,
+        "Sentinel value is not valid. The tensor data in {} is corrupted and cannot be loaded.",
+        file_name);
 
     std::uint8_t version_id = 0;
     safe_fread(&version_id, sizeof(version_id), 1, input_file);
-    if (version_id > VERSION_ID) {
-        TT_THROW(
-            "Version mismatch: the serialized tensor was created with version {} but is being loaded by a loader with "
-            "version {}. Please update your saved data or your loader so that both versions match.",
-            version_id,
-            VERSION_ID);
-    }
-
-    if (version_id < 5) {
-        return load_tensor_helper_legacy_impl(input_file, device, version_id);
-    }
+    validate_version(version_id);
 
     auto spec = load_tensor_spec(input_file);
     StorageType storage_type = StorageType::HOST;
     safe_fread(&storage_type, sizeof(storage_type), 1, input_file);
-    auto storage = load_storage(input_file, spec.data_type(), spec.layout(), storage_type, device, version_id);
+    auto storage = load_storage(input_file, spec.data_type(), spec.layout(), storage_type, device);
     Tensor tensor(std::move(storage), spec);
     if (device != nullptr) {
         tensor = tensor.to_device(device, spec.memory_config());
@@ -500,19 +339,7 @@ void dump_memory_config(const std::string& file_name, const MemoryConfig& memory
 MemoryConfig load_memory_config(FILE* input_file) {
     std::uint8_t version_id;
     safe_fread(&version_id, sizeof(version_id), 1, input_file);
-
-    // Allow only backward compatible versions
-    if (version_id > VERSION_ID) {
-        TT_THROW(
-            "Version mismatch: the serialized memory config was created with version {} but is being loaded by a "
-            "loader with version {}. Please update your saved data or your loader so that both versions match.",
-            version_id,
-            VERSION_ID);
-    }
-
-    if (version_id < 5) {
-        return load_memory_config_legacy_impl(input_file, version_id);
-    }
+    validate_version(version_id);
 
     uint64_t bin_size = 0;
     safe_fread(&bin_size, sizeof(bin_size), 1, input_file);


### PR DESCRIPTION
### Ticket
#16067

### Problem description
Caches were re-generated as part of TT-mesh migration. This code is stale, likely doesn't work, and shouldn't be needed.

### What's changed
Delete processing of tensor caches before sentinel value was introduced, and before "version 5" is introduced.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14715263068)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14717911813)
- [X] New/Existing tests provide coverage for changes