### PR TITLE
Fixed TTT sharded specs for rot mats on BH

### DIFF
--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -397,8 +397,9 @@ class Attention(LightweightModule):
             xqkv_fused,
             num_heads=self.n_local_heads,
             num_kv_heads=self.n_local_kv_heads,
-            # memory_config=self.model_config["CREATE_QKV_DECODE_SHARD"] if self.arch_name == "blackhole" else ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
-            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+            memory_config=self.model_config["CREATE_QKV_DECODE_SHARD"]
+            if self.arch_name == "blackhole"
+            else ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         )
 
         ttnn.deallocate(xqkv_fused)

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -397,9 +397,7 @@ class Attention(LightweightModule):
             xqkv_fused,
             num_heads=self.n_local_heads,
             num_kv_heads=self.n_local_kv_heads,
-            memory_config=self.model_config["CREATE_QKV_DECODE_SHARD"]
-            if self.arch_name == "blackhole"
-            else ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+            memory_config=self.model_config["CREATE_QKV_DECODE_SHARD"],
         )
 
         ttnn.deallocate(xqkv_fused)

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -52,6 +52,7 @@ class Attention(LightweightModule):
         self.n_local_heads = self.n_heads // self.num_devices_per_group
         self.n_local_kv_heads = self.n_kv_heads // self.num_devices_per_group
 
+        self.arch_name = configuration.arch_name
         # TODO: Fix this once all-gather supports < tile_size
         if self.TG:
             weight = torch.zeros(1, 32, 8, 32)
@@ -396,6 +397,7 @@ class Attention(LightweightModule):
             xqkv_fused,
             num_heads=self.n_local_heads,
             num_kv_heads=self.n_local_kv_heads,
+            # memory_config=self.model_config["CREATE_QKV_DECODE_SHARD"] if self.arch_name == "blackhole" else ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
             memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
         )
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -744,12 +744,16 @@ class ModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
 
-            self.model_config["CREATE_QKV_DECODE_SHARD"] = ttnn.create_sharded_memory_config(
-                shape=(ttnn.TILE_SIZE, self.head_dim),
-                core_grid=ttnn.CoreGrid(y=4, x=8),
-                strategy=ttnn.ShardStrategy.HEIGHT,
-                orientation=ttnn.ShardOrientation.ROW_MAJOR,
-                use_height_and_width_as_shard_shape=True,
+            self.model_config["CREATE_QKV_DECODE_SHARD"] = (
+                ttnn.create_sharded_memory_config(
+                    shape=(ttnn.TILE_SIZE, self.head_dim),
+                    core_grid=ttnn.CoreGrid(y=4, x=8),
+                    strategy=ttnn.ShardStrategy.HEIGHT,
+                    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                    use_height_and_width_as_shard_shape=True,
+                )
+                if self.arch_name == "blackhole"
+                else ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
             )
 
             self.model_config["SDPA_DECODE_PROGCFG"] = ttnn.SDPAProgramConfig(

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -745,7 +745,7 @@ class ModelArgs:
             )
 
             self.model_config["CREATE_QKV_DECODE_SHARD"] = ttnn.create_sharded_memory_config(
-                shape=(32, 128),
+                shape=(ttnn.TILE_SIZE, self.head_dim),
                 core_grid=ttnn.CoreGrid(y=4, x=8),
                 strategy=ttnn.ShardStrategy.HEIGHT,
                 orientation=ttnn.ShardOrientation.ROW_MAJOR,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -744,6 +744,14 @@ class ModelArgs:
                 use_height_and_width_as_shard_shape=True,
             )
 
+            self.model_config["CREATE_QKV_DECODE_SHARD"] = ttnn.create_sharded_memory_config(
+                shape=(32, 128),
+                core_grid=ttnn.CoreGrid(y=4, x=8),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
             self.model_config["SDPA_DECODE_PROGCFG"] = ttnn.SDPAProgramConfig(
                 compute_with_storage_grid_size=(8, 8),
                 exp_approx_mode=False,

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -65,7 +65,7 @@ class RotarySetup(LightweightModule):
             mesh_mapper=ReplicateTensorToMesh(device) if self.is_mesh_device else None,
         )
 
-        batch_grid = ttnn.num_cores_to_corerangeset(batch_size, self.core_grid, row_wise=True)
+        batch_grid_wh = ttnn.num_cores_to_corerangeset(batch_size, self.core_grid, row_wise=True)
         # Generate the transformation matrix
         trans_mat = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE).repeat(
             1,
@@ -76,7 +76,7 @@ class RotarySetup(LightweightModule):
         )  # Repeat across all cores on device
         trans_mat_mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, ttnn.TILE_SIZE),
-            core_grid=batch_grid,
+            core_grid=ttnn.CoreGrid(y=4, x=8) if ttnn.get_arch_name() == "blackhole" else batch_grid_wh,
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
             use_height_and_width_as_shard_shape=True,
@@ -174,10 +174,10 @@ class RotarySetup(LightweightModule):
             cos = cos[:, : self.batch_size_per_device_group, :, :]
             sin = sin[:, : self.batch_size_per_device_group, :, :]
 
-        grid = ttnn.num_cores_to_corerangeset(self.batch_size, self.core_grid, row_wise=True)
+        grid_wh = ttnn.num_cores_to_corerangeset(self.batch_size, self.core_grid, row_wise=True)
         mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, self.head_dim),
-            core_grid=grid,
+            core_grid=ttnn.CoreGrid(y=4, x=8) if ttnn.get_arch_name() == "blackhole" else grid_wh,
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
             use_height_and_width_as_shard_shape=True,

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -65,7 +65,7 @@ class RotarySetup(LightweightModule):
             mesh_mapper=ReplicateTensorToMesh(device) if self.is_mesh_device else None,
         )
 
-        batch_grid = (
+        self.batch_grid = (
             ttnn.CoreGrid(y=4, x=8)
             if ttnn.get_arch_name() == "blackhole"
             else ttnn.num_cores_to_corerangeset(batch_size, self.core_grid, row_wise=True)
@@ -80,7 +80,7 @@ class RotarySetup(LightweightModule):
         )  # Repeat across all cores on device
         trans_mat_mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, ttnn.TILE_SIZE),
-            core_grid=batch_grid,
+            core_grid=self.batch_grid,
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
             use_height_and_width_as_shard_shape=True,
@@ -178,15 +178,9 @@ class RotarySetup(LightweightModule):
             cos = cos[:, : self.batch_size_per_device_group, :, :]
             sin = sin[:, : self.batch_size_per_device_group, :, :]
 
-        grid = (
-            ttnn.CoreGrid(y=4, x=8)
-            if ttnn.get_arch_name() == "blackhole"
-            else ttnn.num_cores_to_corerangeset(self.batch_size, self.core_grid, row_wise=True)
-        )
-
         mem_config = ttnn.create_sharded_memory_config(
             shape=(ttnn.TILE_SIZE, self.head_dim),
-            core_grid=grid,
+            core_grid=self.batch_grid,
             strategy=ttnn.ShardStrategy.HEIGHT,
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
             use_height_and_width_as_shard_shape=True,

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -1040,6 +1040,7 @@ def run_test_sdpa_decode_paged_attention_single_iter(
         [8, 16, 4, 4096, 128, (8, 2), True],  # llama 3.1 8b N300
         [1, 8, 1, 128 * 1024, 128, (8, 4), True],  # llama 3.1 8b N300
         [1, 32, 8, 32 * 1024, 128, (8, 8), True],  # llama3.1 8b (performance-batch-1 settings)
+        [32, 32, 8, 1024, 128, (8, 8), True],  # llama 3.1 8b (performance-batch-32 settings)
         # [1, 8, 1, 32768, 128, (8, 1), True],  # Llama2-70B
         # [16, 8, 1, 32768, 128, (8, 6), False, False],  # Llama2-70B
         # [8, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B


### PR DESCRIPTION
And also added a new parametrized unit test to SDPA decode with batch-32 config.

### Ticket
https://github.com/tenstorrent/tt-metal/issues/19798

### Problem description
On blackhole, long batch numbers were giving bad outputs due to a misconfiguration of the shard specs on the decode side. 

### Checklist
- [ ] [All-post-commit](https://github.com/tenstorrent/tt-metal/actions/runs/14714265696)
- [ ] [T3K](https://github.com/tenstorrent/tt-metal/actions/runs/14714258543)
- [ ] [Single-device](https://github.com/tenstorrent/tt-metal/actions/runs/14714291337)
- [x] [BH nightly](https://github.com/tenstorrent/tt-metal/actions/runs/14714282126)
- [x] [BH Demo](https://github.com/tenstorrent/tt-metal/actions/runs/14714284480)