### PR TITLE
Remove topk_replay_init global.

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -13,9 +13,6 @@
 
 #include "debug/dprint.h"
 
-// topk llk needs a global variable atm
-// this can only be removed once that's fixed
-int32_t topk_replay_init = 0;
 namespace NAMESPACE {
 /*
 The sorting algorithm is based on Bitonic Merge Sort.

--- a/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/moe/device/kernels/compute/moe.cpp
@@ -18,9 +18,6 @@
 #include "debug/dprint.h"
 #include "ckernel_sfpu.h"
 using namespace ckernel;
-// topk llk needs a global variable atm
-// this can only be removed once that's fixed
-int32_t topk_replay_init = 0;
 
 namespace NAMESPACE {
 template <uint32_t in0_cb, uint32_t in1_cb, uint32_t rows, uint32_t cols>

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -22,9 +22,6 @@
 
 #define DEBUG_PRINT 0
 using namespace ckernel;
-// topk llk needs a global variable atm
-// this can only be removed once that's fixed
-int32_t topk_replay_init = 0;
 
 namespace NAMESPACE {
 void generate_rand_tile(const uint32_t cb_id, const uint32_t seed) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk.cpp
@@ -10,7 +10,6 @@
 #include "compute_kernel_api/reconfig_data_format.h"
 #include "compute_kernel_api/pack.h"
 
-int32_t topk_replay_init = 0;
 namespace NAMESPACE {
 
 FORCE_INLINE void transpose_and_pack(uint32_t input_cb_index, uint32_t dest_cb_index, uint32_t total_tiles) {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp
@@ -13,10 +13,6 @@
 
 #include "topk_common_funcs.hpp"
 
-// topk llk needs a global variable atm
-// this can only be removed once that's fixed
-int32_t topk_replay_init = 0;
-
 namespace NAMESPACE {
 
 void MAIN {

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp
@@ -12,10 +12,6 @@
 
 #include "topk_common_funcs.hpp"
 
-// topk llk needs a global variable atm
-// this can only be removed once that's fixed
-int32_t topk_replay_init = 0;
-
 namespace NAMESPACE {
 
 void MAIN {


### PR DESCRIPTION
### Ticket

#21301

### Problem description

The `topk_replay_init` variable should be internal to the LLK.

### What's changed

Remove all topk_replay_init globals in ttnn operations.

Relies on this LLK change: tenstorrent/tt-llk#142

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes