### PR TITLE
#0: Fix race in worker to fabric connection and minor test updates/fixes

### DIFF
--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2188,7 +2188,7 @@ void run_ring_all_gather_with_persistent_fabric(
         return;
     }
     // Initialize MeshDevice with 1D Fabric
-    MeshFabric1DFixture test_fixture(tt::tt_metal::FabricConfig::FABRIC_1D);
+    MeshFabric1DFixture test_fixture(tt::tt_metal::FabricConfig::FABRIC_1D_RING);
     test_fixture.mesh_device_->reshape(MeshShape(1, 8));
     auto view = test_fixture.mesh_device_->get_view();
 
@@ -2219,7 +2219,7 @@ void run_ring_all_gather_with_persistent_fabric(
                                          .to_device(test_fixture.mesh_device_.get());
 
     std::optional<SubdeviceInfo> subdevice_managers = create_worker_subdevices(devices);
-    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Linear;
+    ttnn::ccl::Topology topology = ttnn::ccl::Topology::Ring;
 
     log_info(tt::LogTest, "launching op");
 
@@ -3055,10 +3055,10 @@ void RunRingDeadlockStabilityTestWithPersistentFabric(
 
     using namespace ttnn::ccl;
     auto topology = ttnn::ccl::Topology::Ring;
-    size_t num_unicasts = 0;
+    constexpr size_t num_unicasts = 0;
     size_t line_size = num_devices;
     size_t num_devices_with_workers = line_size;
-    bool line_sync = true;
+    constexpr bool line_sync = false;
 
     auto worker_core_logical = [](size_t link) { return CoreCoord(link, 0); };
 

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
@@ -1399,6 +1399,7 @@ TEST(EdmFabric, RingDeadlockStabilityTest) {
     auto cluster_type = tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type();
     if (cluster_type == tt::ClusterType::GALAXY) {
         num_devices = {4, 8};
+        num_links = 4;
     } else {
         num_devices = {8};
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
There is a race in worker to sender connection, where worker will read a cached rd ptr value, and edm will also write back the updated ptr value. If the write from edm lands first, then worker will end up using the stale value. This is fine if there is at least one slot available as sender will eventually send back the latest value after processing the newest packet, but we will hang if there are no slots available when we read the cached value.

### What's changed
Move the start msg to sender to be after read has completed. This guarantees we will eventually get an updated value even if we don't send any packets.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14717469604
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/14717474306
T3K Nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14720062157