### PR TITLE
Add test return code check option to python tracy

### DIFF
--- a/tt_metal/tools/profiler/process_model_log.py
+++ b/tt_metal/tools/profiler/process_model_log.py
@@ -44,9 +44,12 @@ def post_process_ops_log(output_logs_subdir, columns, sum_vals=True, op_name="",
     return results
 
 
-def run_device_profiler(command, output_logs_subdir):
+def run_device_profiler(command, output_logs_subdir, check_test_return_code=True):
     output_profiler_dir = get_profiler_folder(output_logs_subdir)
-    profiler_cmd = f"python3 -m tracy -p -r -o {output_profiler_dir} -t 5000 -m {command}"
+    check_return_code = ""
+    if check_test_return_code:
+        check_return_code = "--check-exit-code"
+    profiler_cmd = f"python3 -m tracy -p -r -o {output_profiler_dir} {check_return_code} -t 5000 -m {command}"
     subprocess.run([profiler_cmd], shell=True, check=True)
 
 

--- a/ttnn/tracy/__main__.py
+++ b/ttnn/tracy/__main__.py
@@ -84,6 +84,13 @@ def main():
         help="Collect noc event traces when profiling",
         default=False,
     )
+    parser.add_option(
+        "--check-exit-code",
+        dest="check_exit_code",
+        action="store_true",
+        help="Exit the run and do not attempt post processing if the test command fails",
+        default=False,
+    )
 
     if not sys.argv[1:]:
         parser.print_usage()
@@ -214,6 +221,9 @@ def main():
             signal.signal(signal.SIGTERM, signal_handler)
 
             testProcess.communicate()
+            if options.check_exit_code and testProcess.returncode != 0:
+                logger.error(f"{testCommand} exited with a non-zero return code")
+                sys.exit(4)
 
             try:
                 captureProcess.communicate(timeout=15)


### PR DESCRIPTION
### Ticket
#21208 

### Problem description
If the test called by the tracy module fails, we still attempt to generate the analysis csv for the run. This is good for dev but for CI it is not ideal as it masks failures from the underlying tests.

### What's changed
cli option `--check-exit-code` is added to python tracy module to catch test runs that fail

### Checklist
- [x] [All post commit profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14716713418)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14716706593)
- [x] [Device perf](https://github.com/tenstorrent/tt-metal/actions/runs/14716689746)
- [x] [TG profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14733241283)
- [x] [uBenchmark](https://github.com/tenstorrent/tt-metal/actions/runs/14733263389/job/41353284774)