### PR TITLE
[DM]: Enable regression checks for Data Movement tests

### DIFF
--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -65,15 +65,15 @@ jobs:
           }, # Sean Nijjar
           {
             arch: wormhole_b0,
-            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
+            runs-on: ["N150", "pipeline-perf", "bare-metal", "in-service"],
             name: "WH Data Movement Regressions",
-            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement --gtest-filter Directed",
+            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement --gtest-filter Directed --verbose-log",
           }, # Ata Tuzuner
           {
             arch: blackhole,
             runs-on: ["BH", "pipeline-perf", "in-service"],
             name: "BH Data Movement Regressions",
-            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement --gtest-filter Directed",
+            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement --gtest-filter Directed --verbose-log",
           } # Ata Tuzuner
         ]
     container:

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -67,13 +67,13 @@ jobs:
             arch: wormhole_b0,
             runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
             name: "WH Data Movement Regressions",
-            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement",
+            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement --gtest-filter Directed",
           }, # Ata Tuzuner
           {
             arch: blackhole,
             runs-on: ["BH", "pipeline-perf", "in-service"],
             name: "BH Data Movement Regressions",
-            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement",
+            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement --gtest-filter Directed",
           } # Ata Tuzuner
         ]
     container:

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -63,6 +63,18 @@ jobs:
             name: "T3K ubench - Fabric Latency",
             cmd: "pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_1d_fabric_latency.py",
           }, # Sean Nijjar
+          {
+            arch: wormhole_b0,
+            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
+            name: "WH Data Movement Regression",
+            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement",
+          }, # Ata Tuzuner
+          {
+            arch: blackhole,
+            runs-on: ["BH", "pipeline-perf", "in-service"],
+            name: "BH Data Movement Regression",
+            cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement",
+          } # Ata Tuzuner
         ]
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -66,13 +66,13 @@ jobs:
           {
             arch: wormhole_b0,
             runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
-            name: "WH Data Movement Regression",
+            name: "WH Data Movement Regressions",
             cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement",
           }, # Ata Tuzuner
           {
             arch: blackhole,
             runs-on: ["BH", "pipeline-perf", "in-service"],
-            name: "BH Data Movement Regression",
+            name: "BH Data Movement Regressions",
             cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement",
           } # Ata Tuzuner
         ]

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -65,7 +65,7 @@ jobs:
           }, # Sean Nijjar
           {
             arch: wormhole_b0,
-            runs-on: ["N150", "pipeline-perf", "bare-metal", "in-service"],
+            runs-on: ["N300", "pipeline-perf", "bare-metal", "in-service"],
             name: "WH Data Movement Regressions",
             cmd: "pytest -svv tests/tt_metal/tt_metal/data_movement --gtest-filter Directed --verbose-log",
           }, # Ata Tuzuner

--- a/tests/tt_metal/tt_metal/data_movement/conftest.py
+++ b/tests/tt_metal/tt_metal/data_movement/conftest.py
@@ -17,7 +17,7 @@ def no_profile(request):
 
 @pytest.fixture
 def verbose_log(request):
-    return request.config.getoption("--verbose_log")
+    return request.config.getoption("--verbose-log")
 
 
 @pytest.fixture
@@ -37,7 +37,7 @@ def pytest_addoption(parser):
         action="store_true",
         help="Use existing profiler logs. If not set, profile kernels and use those results.",
     )
-    parser.addoption("--verbose_log", action="store_true", help="Enable verbose logging of profiling results.")
+    parser.addoption("--verbose-log", action="store_true", help="Enable verbose logging of profiling results.")
     parser.addoption(
         "--gtest-filter",
         action="store",

--- a/tests/tt_metal/tt_metal/data_movement/conftest.py
+++ b/tests/tt_metal/tt_metal/data_movement/conftest.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+@pytest.fixture
+def gtest_filter(request):
+    return request.config.getoption("--gtest-filter")
+
+
+@pytest.fixture
+def no_profile(request):
+    return request.config.getoption("--no-profile")
+
+
+@pytest.fixture
+def verbose_log(request):
+    return request.config.getoption("--verbose_log")
+
+
+@pytest.fixture
+def plot(request):
+    return request.config.getoption("--plot")
+
+
+@pytest.fixture
+def report(request):
+    return request.config.getoption("--report")
+
+
+# These inputs override the default inputs used in data movement tests.
+def pytest_addoption(parser):
+    parser.addoption(
+        "--no-profile",
+        action="store_true",
+        help="Use existing profiler logs. If not set, profile kernels and use those results.",
+    )
+    parser.addoption("--verbose_log", action="store_true", help="Enable verbose logging of profiling results.")
+    parser.addoption(
+        "--gtest-filter",
+        action="store",
+        default=None,
+        help="Filter for gtest tests to run. If not set and profile flag is set, all tests are run.",
+    )
+    parser.addoption("--plot", action="store_true", help="Export profiling plots to a .png file.")
+    parser.addoption("--report", action="store_true", help="Export profiling results to a .csv file.")

--- a/tests/tt_metal/tt_metal/data_movement/conftest.py
+++ b/tests/tt_metal/tt_metal/data_movement/conftest.py
@@ -30,6 +30,11 @@ def report(request):
     return request.config.getoption("--report")
 
 
+@pytest.fixture
+def arch(request):
+    return request.config.getoption("--arch")
+
+
 # These inputs override the default inputs used in data movement tests.
 def pytest_addoption(parser):
     parser.addoption(
@@ -46,3 +51,9 @@ def pytest_addoption(parser):
     )
     parser.addoption("--plot", action="store_true", help="Export profiling plots to a .png file.")
     parser.addoption("--report", action="store_true", help="Export profiling results to a .csv file.")
+    parser.addoption(
+        "--arch",
+        action="store",
+        default=None,
+        help="Architecture the tests are run on.",
+    )

--- a/tests/tt_metal/tt_metal/data_movement/conftest.py
+++ b/tests/tt_metal/tt_metal/data_movement/conftest.py
@@ -47,7 +47,7 @@ def pytest_addoption(parser):
         "--gtest-filter",
         action="store",
         default=None,
-        help="Filter for gtest tests to run. If not set and profile flag is set, all tests are run.",
+        help="Filter for gtest tests to run. If not set, all tests are run.",
     )
     parser.addoption("--plot", action="store_true", help="Export profiling plots to a .png file.")
     parser.addoption("--report", action="store_true", help="Export profiling results to a .csv file.")
@@ -55,5 +55,28 @@ def pytest_addoption(parser):
         "--arch",
         action="store",
         default=None,
-        help="Architecture the tests are run on.",
+        help="Architecture the tests are run on. If not set, defaults to the ARCH_NAME variable, or if that is not set, to 'blackhole'.",
     )
+    parser.addoption(
+        "--dm-help",
+        action="store_true",
+        help="Display a personalized help message for data movement tests.",
+    )
+
+
+# Handle the custom --dm-help option
+def pytest_cmdline_main(config):
+    if config.getoption("--dm-help"):
+        print("\nData Movement Tests Help:")
+        print("  --no-profile       Use existing profiler logs instead of profiling kernels.")
+        print("  --verbose-log      Enable verbose logging of profiling results.")
+        print("  --gtest-filter     Filter for gtest tests to run. If not set, all tests are run.")
+        print("  --plot             Export profiling plots to a .png file.")
+        print("  --report           Export profiling results to a .csv file.")
+        print(
+            "  --arch             Specify the architecture the tests are run on. If not set, defaults to first the ARCH_NAME variable, then to 'blackhole'."
+        )
+        print("\nExample Usage:")
+        print("  pytest --no-profile --verbose-log --plot --report tests/tt_metal/tt_metal/data_movement")
+        print("  pytest --gtest-filter='Directed' --arch='wormhole_b0' tests/tt_metal/tt_metal/data_movement")
+        return 0

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -41,7 +41,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
         },
         3: {
-            "riscv_1": {"latency": {"lower": 33000, "upper": 34000}, "bandwidth": 22},
+            "riscv_1": {"latency": {"lower": 33000, "upper": 35000}, "bandwidth": 22},
             "riscv_0": {"latency": {"lower": 33000, "upper": 35000}, "bandwidth": 21},
         },
         4: {
@@ -64,7 +64,7 @@ test_bounds = {
         },
         3: {
             "riscv_1": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 33},
-            "riscv_0": {"latency": {"lower": 42000, "upper": 43000}, "bandwidth": 34},
+            "riscv_0": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 34},
         },
         4: {
             "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -7,6 +7,7 @@
 import os
 import sys
 import csv
+import pytest  # type: ignore
 from argparse import ArgumentParser
 from loguru import logger  # type: ignore
 import matplotlib.pyplot as plt  # type: ignore
@@ -50,6 +51,7 @@ test_bounds = {
 
 
 def run_dm_tests(profile, verbose, gtest_filter, plot, report):
+    logger.info("Starting data movement tests...")
     log_file_path = f"{PROFILER_LOGS_DIR}/{PROFILER_DEVICE_SIDE_LOG}"
 
     # Profile tests
@@ -256,10 +258,10 @@ def performance_check(dm_stats, verbose=False):
             else:
                 logger.info(f"RISCV 0 bandwidth within perf bounds.\n")
 
-        # assert riscv1_cycles_within_bounds
-        # assert riscv0_cycles_within_bounds
-        # assert riscv1_bw_within_bounds
-        # assert riscv0_bw_within_bounds
+        assert riscv1_cycles_within_bounds
+        assert riscv0_cycles_within_bounds
+        assert riscv1_bw_within_bounds
+        assert riscv0_bw_within_bounds
 
 
 def print_stats(dm_stats):
@@ -407,20 +409,11 @@ def export_dm_stats_to_csv(dm_stats, output_file="dm_stats.csv"):
     logger.info(f"dm_stats exported to {output_file}")
 
 
-if __name__ == "__main__":
-    parser = ArgumentParser(description="Generate profiling results for data movement tests.")
-    parser.add_argument(
-        "-p", "--profile", action="store_true", help="Profile the kernels. If not set, use existing profiler logs."
-    )
-    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging of profiling results.")
-    parser.add_argument(
-        "-g",
-        "--gtest-filter",
-        dest="gtest_filter",
-        help="Filter for gtest tests to run. If not set and profile flag is set, all tests are run.",
-    )
-    parser.add_argument("--plot", action="store_true", help="Export profiling plots to a .png file.")
-    parser.add_argument("-r", "--report", action="store_true", help="Export profiling results to a .csv file.")
-    args = parser.parse_args()
-
-    run_dm_tests(*vars(args).values())
+def test_data_movement(
+    no_profile: bool,
+    verbose_log: bool,
+    gtest_filter: str,
+    plot: bool,
+    report: bool,
+):
+    run_dm_tests(profile=not no_profile, verbose=verbose_log, gtest_filter=gtest_filter, plot=plot, report=report)

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -41,8 +41,8 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
         },
         3: {
-            "riscv_1": {"latency": {"lower": 149000, "upper": 150000}, "bandwidth": 9},
-            "riscv_0": {"latency": {"lower": 90000, "upper": 91000}, "bandwidth": 16},
+            "riscv_1": {"latency": {"lower": 33000, "upper": 34000}, "bandwidth": 22},
+            "riscv_0": {"latency": {"lower": 33000, "upper": 35000}, "bandwidth": 21},
         },
         4: {
             "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -44,8 +44,8 @@ test_bounds = {
         "riscv_0": {"latency": {"lower": 42000, "upper": 43000}, "bandwidth": 34},
     },
     4: {
-        "riscv_1": {"latency": {"lower": 4100, "upper": 4200}, "bandwidth": 0.06},
-        "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.59},
+        "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},
+        "riscv_0": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
     },
 }
 
@@ -258,10 +258,16 @@ def performance_check(dm_stats, verbose=False):
             else:
                 logger.info(f"RISCV 0 bandwidth within perf bounds.\n")
 
-        assert riscv1_cycles_within_bounds
-        assert riscv0_cycles_within_bounds
-        assert riscv1_bw_within_bounds
-        assert riscv0_bw_within_bounds
+        logger.info(f"Performance check for test id: {test_id}")
+        logger.info(f"  RISCV 1 cycles within bounds: {riscv1_cycles_within_bounds}")
+        logger.info(f"  RISCV 0 cycles within bounds: {riscv0_cycles_within_bounds}")
+        logger.info(f"  RISCV 1 bandwidth within bounds: {riscv1_bw_within_bounds}")
+        logger.info(f"  RISCV 0 bandwidth within bounds: {riscv0_bw_within_bounds}")
+
+        # assert riscv1_cycles_within_bounds
+        # assert riscv0_cycles_within_bounds
+        # assert riscv1_bw_within_bounds
+        # assert riscv0_bw_within_bounds
 
 
 def print_stats(dm_stats):

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -63,8 +63,8 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
         },
         3: {
-            "riscv_1": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 9},
-            "riscv_0": {"latency": {"lower": 42000, "upper": 43000}, "bandwidth": 16},
+            "riscv_1": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 33},
+            "riscv_0": {"latency": {"lower": 42000, "upper": 43000}, "bandwidth": 34},
         },
         4: {
             "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -63,8 +63,8 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
         },
         3: {
-            "riscv_1": {"latency": {"lower": 149000, "upper": 150000}, "bandwidth": 9},
-            "riscv_0": {"latency": {"lower": 90000, "upper": 91000}, "bandwidth": 16},
+            "riscv_1": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 9},
+            "riscv_0": {"latency": {"lower": 42000, "upper": 43000}, "bandwidth": 16},
         },
         4: {
             "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},
@@ -302,16 +302,10 @@ def performance_check(dm_stats, arch="blackhole", verbose=False):
             else:
                 logger.info(f"RISCV 0 bandwidth within perf bounds.\n")
 
-        logger.info(f"Performance check for test id: {test_id}")
-        logger.info(f"  RISCV 1 cycles within bounds: {riscv1_cycles_within_bounds}")
-        logger.info(f"  RISCV 0 cycles within bounds: {riscv0_cycles_within_bounds}")
-        logger.info(f"  RISCV 1 bandwidth within bounds: {riscv1_bw_within_bounds}")
-        logger.info(f"  RISCV 0 bandwidth within bounds: {riscv0_bw_within_bounds}")
-
-        # assert riscv1_cycles_within_bounds
-        # assert riscv0_cycles_within_bounds
-        # assert riscv1_bw_within_bounds
-        # assert riscv0_bw_within_bounds
+        assert riscv1_cycles_within_bounds
+        assert riscv0_cycles_within_bounds
+        assert riscv1_bw_within_bounds
+        assert riscv0_bw_within_bounds
 
 
 def print_stats(dm_stats):

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -26,6 +26,8 @@ test_id_to_name = {
 }
 
 # Correspondng test bounds for each arch, test id, riscv core
+# NOTE: These bounds are aggregated averages of large test sweeps and
+# are subject to change with new directed tests.
 test_bounds = {
     "wormhole_b0": {
         0: {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20344)

### Problem description
Add similar regression checks for data movement tests to models teams regressions.

### What's changed
Integrated the data movement pytest infrastructure into the 'metal - Run microbenchmarks' workflow. Our regression checks now run for both Wormhole and Blackhole. Current tests only check the performance of the DRAM directed ideal test, but more checks will be enabled as we determine appropriate test bounds.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14717503121) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14763759925) CI with demo tests passes
- [x] metal - Run microbenchmarks: [Wormhole regressions](https://github.com/tenstorrent/tt-metal/actions/runs/14761008626/attempts/2), [Blackhole regressions](https://github.com/tenstorrent/tt-metal/actions/runs/14734849907)