### PR TITLE
#0: [skip ci] Only run blackhole demo tests on BH-baremetal + pipeline-perf labels

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -15,7 +15,7 @@ on:
       runner-label:
         required: false
         type: string
-        default: "BH"
+        default: "BH-baremetal"
 
 jobs:
   single-card-demo-tests:
@@ -37,7 +37,7 @@ jobs:
           }
         ]
     name: ${{ matrix.test-group.name }}
-    runs-on: ["in-service", "${{ inputs.runner-label }}"]
+    runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-perf"]
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
@@ -56,9 +56,8 @@ jobs:
         with:
           name: ${{ inputs.wheel-artifact-name }}
       - name: Enable Performance mode
-        # For now we're relying on runner-label == BH to target baremetal blackhole machines in order to confirm that the demo functionality works on blackhole VMs
-        # VMs will target a different runner label so they won't touch the perf governor but still run the models.
-        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH' }}
+        # Only touch the perf governor if we're running on a baremetal machine
+        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH-baremetal' }}
         run: |
           sudo cpupower frequency-set -g performance
       - name: Run demo regression tests
@@ -82,7 +81,7 @@ jobs:
           path: generated/test_reports/
           prefix: "test_reports_"
       - name: Disable Performance mode
-        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH' }}
+        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH-baremetal' }}
         run: |
           sudo cpupower frequency-set -g ondemand
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: BH
+      runner-label: BH-baremetal
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -145,7 +145,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: BH-baremetal
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Right now for VM testing we're running blackhole demos without the `pipeline-perf` label

### What's changed
Re-add `pipeline-perf` label, add `BH-baremetal` label to target BMs only

### Checklist

- [x] None