### PR TITLE
Add llama3 8B/70B data-parellel demo tests for TG

### DIFF
--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -27,8 +27,9 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          # Deleting for now - LLM team will put in a new version soon
           { name: "Galaxy Llama3 demo tests", arch: wormhole_b0, model: llama3, timeout: 30, owner_id: U053W15B6JF}, # Djordje Ivanovic
+          { name: "Galaxy Llama3 8B data-parallel demo tests", arch: wormhole_b0, model: llama3_8b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
+          { name: "Galaxy Llama3 70B data-parallel demo tests", arch: wormhole_b0, model: llama3_70b_dp, timeout: 30, owner_id: U08BH66EXAL}, # Radoica Draskic
           { name: "Galaxy Falcon7b demo tests", arch: wormhole_b0, model: falcon7b, timeout: 30, owner_id: U05RWH3QUPM}, # Salar Hosseini
         ]
     runs-on:

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -337,31 +337,31 @@ def prepare_generator_args(
             False,  # ci_only
             4,  # data_parallel
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
+        (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
             8192,  # max_seq_len
             1,  # batch_size
-            200,  # max_generated_tokens
+            4096,  # max_generated_tokens
             True,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
-            True,  # stop_at_eos
+            False,  # stop_at_eos
             True,  # ci_only
             4,  # data_parallel
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
+        (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
             8192,  # max_seq_len
             1,  # batch_size
-            200,  # max_generated_tokens
+            4096,  # max_generated_tokens
             True,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
-            True,  # stop_at_eos
+            False,  # stop_at_eos
             True,  # ci_only
             8,  # data_parallel
         ),

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -523,11 +523,10 @@ def test_demo_text(
         is_31_8b = "3.1-8B" in llama_dir
 
         tg_enabled = (data_parallel == 4 and is_33_70b) or (data_parallel in [4, 16, 32] and is_31_8b)
-        t3k_enabled = data_parallel == 1 and (is_32_1b or is_31_8b)
 
         if num_devices == 32 and not tg_enabled:
             pytest.skip("CI only runs Llama3 70b DP = 4, TP = 8 or Llama3 8b DP = 4/16/32, TP = 8/2/1 on TG")
-        if num_devices == 8 and not t3k_enabled:
+        if num_devices == 8 and data_parallel > 1 and not (is_32_1b or is_31_8b):
             pytest.skip("CI only runs hybrid Llama3 1b and 8b on T3K")
         if data_parallel > 1 and batch_size > 1:
             pytest.skip("CI only runs hybrid with batch 1 per submesh")

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -337,33 +337,61 @@ def prepare_generator_args(
             False,  # ci_only
             4,  # data_parallel
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
+        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
             8192,  # max_seq_len
             1,  # batch_size
-            4096,  # max_generated_tokens
+            200,  # max_generated_tokens
             True,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
-            False,  # stop_at_eos
+            True,  # stop_at_eos
             True,  # ci_only
             4,  # data_parallel
         ),
-        (  # CI Batch-1 run - Measures the performance of a single user over 4096 iterations
+        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
             True,  # instruct mode
             1,  # repeat_batches
             8192,  # max_seq_len
             1,  # batch_size
-            4096,  # max_generated_tokens
+            200,  # max_generated_tokens
             True,  # paged_attention
             {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
-            False,  # stop_at_eos
+            True,  # stop_at_eos
             True,  # ci_only
             8,  # data_parallel
+        ),
+        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            8192,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            16,  # data_parallel
+        ),
+        (  # CI Batch-1 run - Measures the performance of a single user over 200 iterations
+            "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
+            True,  # instruct mode
+            1,  # repeat_batches
+            8192,  # max_seq_len
+            1,  # batch_size
+            200,  # max_generated_tokens
+            True,  # paged_attention
+            {"page_block_size": 32, "page_max_num_blocks_per_dp": 1024},  # page_params
+            {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
+            True,  # stop_at_eos
+            True,  # ci_only
+            32,  # data_parallel
         ),
         (  # CI stress test batch-1 run - Runs a short prefill (128) and exhaust the KV cache (128K), by running 50000 iterations
             "models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json",  # input_prompts
@@ -394,6 +422,8 @@ def prepare_generator_args(
         "DP-4-b32",  # DP 4 throughput
         "ci-b1-DP-4",  # CI DP 4 batch 1
         "ci-b1-DP-8",  # CI DP 8 batch 1
+        "ci-b1-DP-16",  # CI DP 16 batch 1
+        "ci-b1-DP-32",  # CI DP 32 batch 1
         "ci-stress-1",  # CI Stress test batch-1
     ],
 )
@@ -405,7 +435,7 @@ def prepare_generator_args(
     ],
     ids=["performance", "accuracy"],
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872, "num_command_queues": 1}], indirect=True)
 @pytest.mark.parametrize(
     "mesh_device",
     [
@@ -488,12 +518,16 @@ def test_demo_text(
 
     if is_ci_env:
         llama_dir = os.getenv("LLAMA_DIR", "")
-        is_31_70b = "3.1-70B" in llama_dir
+        is_33_70b = "3.3-70B" in llama_dir
         is_32_1b = "3.2-1B" in llama_dir
         is_31_8b = "3.1-8B" in llama_dir
-        if num_devices == 32 and (data_parallel > 4 or (data_parallel == 4 and not is_31_70b)):
-            pytest.skip("CI only runs Llama3 70b DP = 4, TP = 8 on TG")
-        if num_devices == 8 and data_parallel > 1 and not (is_32_1b or is_31_8b):
+
+        tg_enabled = (data_parallel == 4 and is_33_70b) or (data_parallel in [4, 16, 32] and is_31_8b)
+        t3k_enabled = data_parallel == 1 and (is_32_1b or is_31_8b)
+
+        if num_devices == 32 and not tg_enabled:
+            pytest.skip("CI only runs Llama3 70b DP = 4, TP = 8 or Llama3 8b DP = 4/16/32, TP = 8/2/1 on TG")
+        if num_devices == 8 and not t3k_enabled:
             pytest.skip("CI only runs hybrid Llama3 1b and 8b on T3K")
         if data_parallel > 1 and batch_size > 1:
             pytest.skip("CI only runs hybrid with batch 1 per submesh")

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -29,17 +29,13 @@ run_tg_llama3_tests() {
 
 run_tg_llama3_8b_dp_tests() {
   fail=0
-  start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_tg_llama3_8b_dp_tests"
 
   llama8b=/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/
-  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
+  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
   echo "LOG_METAL: Llama3 8B tests for $llama_dir completed"
 
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_tg_llama3_8b_dp_tests $duration seconds to complete"
   if [[ $fail -ne 0 ]]; then
     exit 1
   fi
@@ -47,17 +43,13 @@ run_tg_llama3_8b_dp_tests() {
 
 run_tg_llama3_70b_dp_tests() {
   fail=0
-  start_time=$(date +%s)
 
   echo "LOG_METAL: Running run_tg_llama3_70b_dp_tests"
 
   llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
-  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
+  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
   echo "LOG_METAL: Llama3 70B tests for $llama_dir completed"
 
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_tg_llama3_70b_dp_tests $duration seconds to complete"
   if [[ $fail -ne 0 ]]; then
     exit 1
   fi

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -10,8 +10,6 @@ run_tg_llama3_tests() {
   # Llama3.3-70B
   llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
 
-  # Run all Llama3 tests for 1B, 3B, 8B, 11B and 70B weights
-  # for llama_dir in "$llama1b" "$llama3b" "$llama8b" "$llama11b" "$llama70b"; do
   for llama_dir in "$llama70b"; do
     LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/demo_decode.py -k "full" --timeout 1000; fail+=$?;
     LLAMA_DIR=$llama_dir TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG pytest -n auto models/demos/llama3_subdevices/demo/text_demo.py -k "repeat" --timeout 1000; fail+=$?;
@@ -24,6 +22,42 @@ run_tg_llama3_tests() {
   end_time=$(date +%s)
   duration=$((end_time - start_time))
   echo "LOG_METAL: run_tg_llama3_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+run_tg_llama3_8b_dp_tests() {
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_tg_llama3_8b_dp_tests"
+
+  llama8b=/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/
+  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
+  echo "LOG_METAL: Llama3 8B tests for $llama_dir completed"
+
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_tg_llama3_8b_dp_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
+run_tg_llama3_70b_dp_tests() {
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_tg_llama3_70b_dp_tests"
+
+  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
+  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest -n auto models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
+  echo "LOG_METAL: Llama3 70B tests for $llama_dir completed"
+
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_tg_llama3_70b_dp_tests $duration seconds to complete"
   if [[ $fail -ne 0 ]]; then
     exit 1
   fi
@@ -45,8 +79,12 @@ run_tg_demo_tests() {
 
   if [[ "$1" == "falcon7b" ]]; then
     run_tg_falcon7b_tests
-  elif  [[ "$1" == "llama3" ]]; then
+  elif [[ "$1" == "llama3" ]]; then
     run_tg_llama3_tests
+  elif [[ "$1" == "llama3_8b_dp" ]]; then
+    run_tg_llama3_8b_dp_tests
+  elif [[ "$1" == "llama3_70b_dp" ]]; then
+    run_tg_llama3_70b_dp_tests
   else
     echo "LOG_METAL: Unknown model type: $1"
     return 1

--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -33,8 +33,8 @@ run_tg_llama3_8b_dp_tests() {
   echo "LOG_METAL: Running run_tg_llama3_8b_dp_tests"
 
   llama8b=/mnt/MLPerf/tt_dnn-models/llama/Meta-Llama-3.1-8B-Instruct/
-  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
-  echo "LOG_METAL: Llama3 8B tests for $llama_dir completed"
+  LLAMA_DIR=$llama8b MESH_DEVICE=TG pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
+  echo "LOG_METAL: Llama3 8B tests for $llama8b completed"
 
   if [[ $fail -ne 0 ]]; then
     exit 1
@@ -47,8 +47,8 @@ run_tg_llama3_70b_dp_tests() {
   echo "LOG_METAL: Running run_tg_llama3_70b_dp_tests"
 
   llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
-  LLAMA_DIR=$llama_dir MESH_DEVICE=TG pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
-  echo "LOG_METAL: Llama3 70B tests for $llama_dir completed"
+  LLAMA_DIR=$llama70b MESH_DEVICE=TG pytest models/tt_transformers/demo/simple_text_demo.py --timeout 1000; fail+=$?
+  echo "LOG_METAL: Llama3 70B tests for $llama70b completed"
 
   if [[ $fail -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21835
We want to have the following tests in TG demo CI

- Llama3 8B TP=1 DP=32
- Llama3 8B TP=2 DP=16
- Llama3 8B TP=8 DP=4
- Llama3 70B TP=8 DP=4

Reducing the number of iterations for data-parallel configurations to reduce run time. We are already running other configurations with more iterations to stress-test the model.

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15156572301) CI passes
- [x] [TG demo CI](https://github.com/tenstorrent/tt-metal/actions/runs/15272426269)
- [ ] [T3K demo CI](https://github.com/tenstorrent/tt-metal/actions/runs/15260923565)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes