### PR TITLE
Reserve space in dev_mem_map for ARC FW power throttling state

### DIFF
--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -68,16 +68,21 @@
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_NOC_ATOMIC_RET_VAL_ADDR 4
 #define MEM_L1_BARRIER 12
+
+// Used by ARC FW and LLKs to store power throttling state
+#define MEM_L1_ARC_FW_SCRATCH 16
+#define MEM_L1_ARC_FW_SCRATCH_SIZE 16
+
 // On Blackhole issuing inline writes and atomics requires all 4 memory ports to accept the transaction at the same
 // time. If one port on the receipient has no back-pressure then the transaction will hang because there is no mechanism
 // to allow one memory port to move ahead of another. To workaround this hang, we emulate inline writes on Blackhole by
 // writing the value to be written to local L1 first and then issue a noc async write.
-#define MEM_L1_INLINE_BASE 16
+#define MEM_L1_INLINE_BASE 32  // MEM_L1_ARC_FW_SCRATCH + MEM_L1_ARC_FW_SCRATCH_SIZE
 // Each noc has 16B to store value written out by inline writes.
 // Base address for each noc to store the value to be written will be `MEM_L1_INLINE_BASE + (noc_index * 16)`
 #define MEM_L1_INLINE_SIZE_PER_NOC 16
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
-#define MEM_MAILBOX_BASE 48  // (MEM_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
+#define MEM_MAILBOX_BASE 64  // (MEM_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2))  // 2 nocs
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
 #define MEM_MAILBOX_SIZE 12640
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Reserve space in L1 for ARC FW and LLK to sync on power throttling requirements

### What's changed
- Reserve 16 bytes at L1[16]

### Checklist