### PR TITLE
#19177: Clean up utility mesh APIs for checking Tensor storage type

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -88,7 +88,6 @@ TEST_F(MeshTensorTest, ReplicateOwnedTensor) {
     // Write host tensor to device.
     Tensor device_tensor =
         tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
-    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor));
     EXPECT_EQ(device_tensor.get_tensor_spec().logical_shape(), shape);
 
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
@@ -122,7 +121,6 @@ TEST_F(MeshTensorTest, GetDeviceTensors) {
 
     Tensor device_tensor =
         tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
-    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor));
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
     ASSERT_NE(device_storage, nullptr);
     EXPECT_NE(device_storage->mesh_buffer, nullptr);
@@ -161,10 +159,8 @@ TEST_F(MeshTensorTestT3K, AggregateAsTensor) {
 
     Tensor device_tensor1 =
         tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
-    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor1));
     Tensor device_tensor2 =
         tensor_impl::to_device_mesh_tensor_wrapper(input_host_tensor, mesh_device_.get(), MemoryConfig{});
-    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor2));
 
     auto device_tensors1 = get_device_tensors(device_tensor1);
     auto device_tensors2 = get_device_tensors(device_tensor2);
@@ -259,8 +255,6 @@ TEST_P(MeshTensorWriteTest, WriteMultiDeviceHostTensor) {
                 input_host_tensor_sharded, mesh_device_.get(), MemoryConfig{});
         }
     }();
-
-    EXPECT_TRUE(distributed::is_mesh_buffer_tensor(device_tensor));
 
     auto* device_storage = std::get_if<tt::tt_metal::DeviceStorage>(&device_tensor.get_storage());
     ASSERT_NE(device_storage, nullptr);

--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -35,7 +35,7 @@ namespace {
 using ::testing::Eq;
 using ::testing::FloatEq;
 using ::testing::Pointwise;
-using ::tt::tt_metal::is_tensor_on_device;
+using ::tt::tt_metal::is_device_tensor;
 
 using MultiProducerCommandQueueTest = ttnn::MultiCommandQueueSingleDeviceFixture;
 
@@ -69,7 +69,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     std::thread t0([&]() {
         for (int j = 0; j < kNumIterations; j++) {
             Tensor t0_tensor = t0_host_tensor.to_device(device, mem_cfg, t0_io_cq);
-            EXPECT_TRUE(is_tensor_on_device(t0_tensor));
+            EXPECT_TRUE(is_device_tensor(t0_tensor));
             EXPECT_THAT(t0_tensor.to_vector<float>(t0_io_cq), Pointwise(FloatEq(), t0_host_data));
         }
     });
@@ -77,7 +77,7 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     std::thread t1([&]() {
         for (int j = 0; j < kNumIterations; j++) {
             Tensor t1_tensor = t1_host_tensor.to_device(device, mem_cfg, t1_io_cq);
-            EXPECT_TRUE(is_tensor_on_device(t1_tensor));
+            EXPECT_TRUE(is_device_tensor(t1_tensor));
             EXPECT_THAT(t1_tensor.to_vector<float>(t1_io_cq), Pointwise(FloatEq(), t1_host_data));
         }
     });
@@ -136,7 +136,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
             std::iota(host_data.begin(), host_data.end(), j);
             const Tensor host_tensor = Tensor::from_vector(host_data, tensor_spec);
             memcpy(device->mesh_command_queue(*write_cq), device_tensor, host_tensor);
-            EXPECT_TRUE(is_tensor_on_device(device_tensor));
+            EXPECT_TRUE(is_device_tensor(device_tensor));
 
             {
                 std::unique_lock<std::mutex> lock(event_mutex);
@@ -164,7 +164,7 @@ TEST_F(MultiProducerCommandQueueTest, EventSync) {
 
             // Read back from device and verify
             const Tensor readback_tensor = device_tensor.cpu(/*blocking=*/true, read_cq);
-            EXPECT_FALSE(is_tensor_on_device(readback_tensor));
+            EXPECT_FALSE(is_device_tensor(readback_tensor));
             std::iota(expected_readback_data.begin(), expected_readback_data.end(), j);
             EXPECT_THAT(readback_tensor.to_vector<uint32_t>(), Pointwise(Eq(), expected_readback_data))
                 << "At iteration " << j;

--- a/ttnn/cpp/pybind11/pytensor.cpp
+++ b/ttnn/cpp/pybind11/pytensor.cpp
@@ -389,7 +389,7 @@ HostBuffer create_row_major_host_buffer(
 }
 
 HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padded_output) {
-    TT_ASSERT(tt_tensor.is_host_tensor());
+    TT_ASSERT(is_cpu_tensor(tt_tensor) || is_multi_device_host_tensor(tt_tensor), "Tensor must be on host for padding");
 
     const auto& tensor_spec = tt_tensor.get_tensor_spec();
     auto convert_to_logical = [&tensor_spec, padded_output](const HostBuffer& buffer) {

--- a/ttnn/cpp/ttnn/core.cpp
+++ b/ttnn/cpp/ttnn/core.cpp
@@ -13,7 +13,7 @@ bool has_storage_type_of(const ttnn::Tensor& tensor, const ttnn::StorageType& st
 }
 
 std::optional<ttnn::MemoryConfig> get_memory_config(const ttnn::Tensor& tensor) {
-    if (not tensor.is_allocated() or not is_tensor_on_device_or_multidevice(tensor)) {
+    if (not tensor.is_allocated() or not is_device_tensor(tensor)) {
         return std::nullopt;
     }
     return tensor.memory_config();

--- a/ttnn/cpp/ttnn/core.hpp
+++ b/ttnn/cpp/ttnn/core.hpp
@@ -21,8 +21,6 @@ using OptionalConstTensors = std::vector<std::optional<const Tensor>>;
 using OptionalTensors = std::vector<std::optional<Tensor>>;
 using Tensors = std::vector<Tensor>;
 
-using tt::tt_metal::is_tensor_on_device;
-using tt::tt_metal::is_tensor_on_device_or_multidevice;
 }  // namespace ttnn
 
 namespace ttnn {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -192,13 +192,4 @@ DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& 
     }
 }
 
-bool is_multi_device_host_tensor(const Tensor& tensor) {
-    return tensor.storage_type() == StorageType::MULTI_DEVICE_HOST;
-}
-
-bool is_mesh_buffer_tensor(const Tensor& tensor) {
-    const auto* device_storage = std::get_if<DeviceStorage>(&tensor.get_storage());
-    return device_storage != nullptr && device_storage->mesh_buffer != nullptr;
-}
-
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -39,11 +39,4 @@ std::vector<tt::tt_metal::IDevice*> get_mapped_devices(const Tensor& tensor, Mes
 // Returns the distributed tensor config from a tensor.
 tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
 
-// Returns true if tensor has MultiDeviceHost storage.
-bool is_multi_device_host_tensor(const Tensor& tensor);
-
-// Returns true if tensor has MultiDevice storage type and is allocated on a mesh buffer.
-// TODO: remove when the infrastructure uniformly works with mesh buffer backed tensors.
-bool is_mesh_buffer_tensor(const Tensor& tensor);
-
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -149,7 +149,7 @@ Result conv2d_DRAM(
         " Number of slices should be less than the dimension being sliced in Conv2D DRAM Slicing");
 
     ttnn::Tensor input_tensor_on_device;
-    if (!is_tensor_on_device_or_multidevice(input_tensor)) {
+    if (!is_device_tensor(input_tensor)) {
         input_tensor_on_device = ttnn::operations::core::to_device(input_tensor, device, ttnn::DRAM_MEMORY_CONFIG);
     } else {
         input_tensor_on_device = input_tensor;
@@ -389,8 +389,8 @@ Result conv2d_L1(
             input_width,
             compute_grid_size,
             input_tensor.layout(),
-            ttnn::is_tensor_on_device_or_multidevice(input_tensor) ? std::make_optional(input_tensor.memory_config())
-                                                                   : std::nullopt,
+            tt::tt_metal::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config())
+                                                         : std::nullopt,
             kernel_size,
             groups,
             bias_tensor.has_value(),
@@ -426,7 +426,7 @@ Result conv2d_L1(
         kernel_size,
         compute_grid_size);
 
-    bool weight_is_on_device = ttnn::is_tensor_on_device_or_multidevice(weight_tensor);
+    bool weight_is_on_device = tt::tt_metal::is_device_tensor(weight_tensor);
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
     if (!weight_is_on_device || conv_config.always_preprocess_weights) {
@@ -468,7 +468,7 @@ Result conv2d_L1(
     }
 
     // call optimized conv op or matmul micro op
-    bool input_is_on_device = ttnn::is_tensor_on_device_or_multidevice(input_tensor_post_tm);
+    bool input_is_on_device = tt::tt_metal::is_device_tensor(input_tensor_post_tm);
     TT_ASSERT(input_is_on_device);
 
     if (!mm_conv) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -440,7 +440,7 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_s
     uint32_t out_channels,
     bool is_mm_conv) {
     ttnn::Tensor input_tensor = input_tensor_;  // tensor to return
-    bool input_tensor_on_device = ttnn::is_tensor_on_device_or_multidevice(input_tensor_);
+    bool input_tensor_on_device = tt::tt_metal::is_device_tensor(input_tensor_);
     bool needs_shard_or_reshard = false;
     if (conv_config.override_sharding_config && conv_config.reshard_if_not_optimal) {
         TT_ASSERT(
@@ -592,7 +592,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
     bool is_mm_conv,
     bool auto_shard) {
     ttnn::Tensor input_tensor = input_tensor_;  // tensor to return
-    bool input_tensor_on_device = ttnn::is_tensor_on_device_or_multidevice(input_tensor_);
+    bool input_tensor_on_device = tt::tt_metal::is_device_tensor(input_tensor_);
     auto compute_grid_size = device->compute_with_storage_grid_size();
 
     auto [input_padded_shape, input_tensor_sharded_memory_config, needs_shard_or_reshard] =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -88,7 +88,7 @@ Tensor optimized_conv_new(
             .pad_shape = bias.value().get_padded_shape(), .pad_value = 0, .target_layout = Layout::TILE};
     }
     auto output_layout = untilize_out ? Layout::ROW_MAJOR : Layout::TILE;
-    auto arch = is_tensor_on_device_or_multidevice(a)
+    auto arch = is_device_tensor(a)
                     ? a.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     bool fp32_accum =

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -43,8 +43,8 @@ Tensor convert_tensor(const Tensor& input_tensor, compute_& compute) {
     TT_FATAL(!is_device_tensor(input_tensor), "convert_tensor only supports host tensors");
 
     // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    return ttnn::distributed::is_multi_device_host_tensor(input_tensor) ? transform(input_tensor, convert_tensor)
-                                                                        : convert_tensor(input_tensor);
+    return is_multi_device_host_tensor(input_tensor) ? transform(input_tensor, convert_tensor)
+                                                     : convert_tensor(input_tensor);
 }
 
 template <typename Func, typename... Args>
@@ -681,7 +681,7 @@ ttnn::Tensor prepare_bias_on_device(
     uint32_t out_channel_padding = out_channels_padded - out_channels;
 
     ttnn::Tensor bias_tensor_ = bias_tensor;
-    bool is_bias_tensor_is_on_device = ttnn::is_tensor_on_device_or_multidevice(bias_tensor_);
+    bool is_bias_tensor_is_on_device = tt::tt_metal::is_device_tensor(bias_tensor_);
     if (!is_bias_tensor_is_on_device) {
         bias_tensor_ = ttnn::operations::core::to_device(bias_tensor_, device, std::nullopt);
     }
@@ -784,7 +784,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
         has_bias);
 
     // Convert weight tensor to 0 padded shape if groups > 1
-    if (groups > 1 and is_tensor_on_device_or_multidevice(weight_tensor_)) {
+    if (groups > 1 and is_device_tensor(weight_tensor_)) {
         TT_THROW(
             "Grouped Convolution not supported when weights are on device. Please move the weights tensor to host");
     }
@@ -1004,7 +1004,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
         input_width,
         has_bias);
     TT_FATAL(
-        !is_tensor_on_device_or_multidevice(weight_tensor_),
+        !is_device_tensor(weight_tensor_),
         "prepare_conv_weights_biases_and_move_to_device is not supported when the weights tensor is on the device");
     // Convert weight tensor to 0 padded shape if groups > 1
     if (!is_conv1d and groups > 1) {
@@ -1072,7 +1072,7 @@ std::pair<ttnn::Tensor, std::optional<ttnn::Tensor>> prepare_conv_weights_biases
 
     if (bias_tensor.has_value()) {
         bias_tensor_ = bias_tensor.value();
-        bool is_bias_tensor_is_on_device = ttnn::is_tensor_on_device_or_multidevice(bias_tensor_);
+        bool is_bias_tensor_is_on_device = tt::tt_metal::is_device_tensor(bias_tensor_);
         if (!is_bias_tensor_is_on_device) {
             TT_FATAL(
                 bias_tensor_.get_logical_shape()[3] == out_channels,
@@ -1174,7 +1174,7 @@ ttnn::Tensor prepare_conv_weights(
     std::optional<const ttnn::Tensor> bias_tensor = std::nullopt;
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
-    if (weight_tensor.is_device_tensor() || conv_config.preprocess_weights_on_device) {
+    if (is_device_tensor(weight_tensor) || conv_config.preprocess_weights_on_device) {
         if (!conv_config.preprocess_weights_on_device) {
             log_warning(
                 tt::LogOp,
@@ -1304,7 +1304,7 @@ ttnn::Tensor prepare_conv_bias(
     ttnn::Tensor bias_tensor_ = bias_tensor;
     TT_FATAL(bias_tensor_.get_logical_shape()[3] == out_channels, "Bias must have the same length as output channels");
 
-    if (bias_tensor_.is_device_tensor()) {
+    if (tt::tt_metal::is_device_tensor(bias_tensor_)) {
         bias_tensor_ = prepare_bias_on_device(
             bias_tensor_,
             conv_config.weights_dtype,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -87,9 +87,8 @@ Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor,
         !is_device_tensor(conv_weight_tensor), "transform_weights_for_conv_transpose2d only supports host tensors");
 
     // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    return ttnn::distributed::is_multi_device_host_tensor(conv_weight_tensor)
-               ? transform(conv_weight_tensor, convert_tensor)
-               : convert_tensor(conv_weight_tensor);
+    return tt::tt_metal::is_multi_device_host_tensor(conv_weight_tensor) ? transform(conv_weight_tensor, convert_tensor)
+                                                                         : convert_tensor(conv_weight_tensor);
 }
 
 Tensor transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel) {
@@ -200,8 +199,8 @@ Result conv_transpose2d(
             full_input_width,
             compute_grid_size,
             input_tensor.layout(),
-            ttnn::is_tensor_on_device_or_multidevice(input_tensor) ? std::make_optional(input_tensor.memory_config())
-                                                                   : std::nullopt,
+            tt::tt_metal::is_device_tensor(input_tensor) ? std::make_optional(input_tensor.memory_config())
+                                                         : std::nullopt,
             kernel_size,
             groups,
             bias_tensor.has_value(),
@@ -282,7 +281,7 @@ Result conv_transpose2d(
         get_fp32_dest_acc_en(compute_config),
         conv_config.enable_split_reader);
 
-    bool weight_is_on_device = ttnn::is_tensor_on_device_or_multidevice(weight_tensor);
+    bool weight_is_on_device = tt::tt_metal::is_device_tensor(weight_tensor);
     ttnn::Tensor weight_tensor_on_device = weight_tensor;
     std::optional<ttnn::Tensor> bias_tensor_on_device = bias_tensor;
     if (!weight_is_on_device) {

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -19,7 +19,7 @@
 namespace ttnn::operations::core {
 
 ttnn::Tensor unsqueeze_to_4D(const ttnn::Tensor& tensor) {
-    if (distributed::is_multi_device_host_tensor(tensor)) {
+    if (tt::tt_metal::is_multi_device_host_tensor(tensor)) {
         return transform(tensor, [&](const Tensor& device_tensor) { return unsqueeze_to_4D(device_tensor); });
     }
 

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
@@ -200,8 +200,8 @@ inline Tensor convert_to_dtype(const Tensor& input_tensor, const Layout& input_l
     TT_FATAL(!is_device_tensor(input_tensor), "to_dtype only supports host tensors");
 
     // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    return distributed::is_multi_device_host_tensor(input_tensor) ? transform(input_tensor, convert_dtype)
-                                                                  : convert_dtype(input_tensor);
+    return tt::tt_metal::is_multi_device_host_tensor(input_tensor) ? transform(input_tensor, convert_dtype)
+                                                                   : convert_dtype(input_tensor);
 }
 
 }  // namespace detail
@@ -221,7 +221,7 @@ struct ToDtype {
         auto row_major_input_tensor = input_tensor.to_layout(ttnn::ROW_MAJOR_LAYOUT);
 
         // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-        auto intermediate_tensor = distributed::is_multi_device_host_tensor(row_major_input_tensor)
+        auto intermediate_tensor = tt::tt_metal::is_multi_device_host_tensor(row_major_input_tensor)
                                        ? transform(row_major_input_tensor, detail::convert_to_cpp_supported_dtype)
                                        : detail::convert_to_cpp_supported_dtype(row_major_input_tensor);
         return detail::convert_to_dtype(intermediate_tensor, input_layout, dtype);

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -95,7 +95,7 @@ Tensor to_layout_impl(
         }
     }
 
-    if (ttnn::is_tensor_on_device_or_multidevice(tensor_arg)) {
+    if (tt::tt_metal::is_device_tensor(tensor_arg)) {
         bool use_multicore_untilize = true;
         bool use_multicore_tilize = true;
 

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -262,7 +262,7 @@ inline ttnn::Tensor full_like_impl(
                                                               : dtype.value_or(tensor.get_dtype());
     auto arch = tensor.device()->arch();
     bool is_TILE = (tensor.get_layout() == Layout::TILE) && (layout_value == Layout::TILE);
-    if (ttnn::is_tensor_on_device_or_multidevice(tensor)) {
+    if (tt::tt_metal::is_device_tensor(tensor)) {
         // requires reference tensor to be in TILE for device operation fill - this will be changed later
         if (is_TILE &&
             (dtype_value == DataType::BFLOAT8_B || dtype_value == DataType::BFLOAT16 ||

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/concat.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttnn/common/queue_id.hpp"
+#include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include <tt-metalium/math.hpp>
@@ -46,8 +47,10 @@ using MassagedConcatParams = MassagedOperationParams<ttnn::Tensor, const std::ve
 MassagedConcat build_unsqueeze_concat(int input_rank, const MemoryConfig& output_memory_config) {
     return MassagedConcat(MassagedConcatParams{
         .predicate = [input_rank](const std::vector<ttnn::Tensor>& tensors, int dim, unsigned int groups) -> bool {
-            bool inputs_are_device_tensors = std::all_of(
-                tensors.begin(), tensors.end(), [](const ttnn::Tensor& tensor) { return tensor.is_device_tensor(); });
+            bool inputs_are_device_tensors =
+                std::all_of(tensors.begin(), tensors.end(), [](const ttnn::Tensor& tensor) {
+                    return tt::tt_metal::is_device_tensor(tensor);
+                });
             bool res = input_rank < 4 && inputs_are_device_tensors;  // pad only rejects rank != 4 for device tensors
             concat_db_print(res, "unsqueeze to 4D required");
             return res;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -168,7 +168,7 @@ ttnn::Tensor ExecutePermute::invoke(
     TT_FATAL(
         input_rank == dims.size(),
         "The number of dimensions in the tensor input does not match the length of the desired ordering");
-    TT_FATAL(is_tensor_on_device_or_multidevice(input_tensor), "Tensor must already be on device");
+    TT_FATAL(is_device_tensor(input_tensor), "Tensor must already be on device");
 
     SmallVector<uint32_t> normalized_dims(dims.size());
     std::transform(dims.begin(), dims.end(), normalized_dims.begin(), [input_tensor](std::int64_t idx) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -309,7 +309,7 @@ ttnn::Tensor ReshapeViewOperation::invoke(
     }
     TT_FATAL(logical_shape.volume() != 0, "Tensor volume is not 0, but shape volume is 0");
 
-    if (!is_tensor_on_device_or_multidevice(tensor)) {
+    if (!is_device_tensor(tensor)) {
         // This case has been allowed in the past though it means introducing padding values to the data
         return ttnn::experimental::view(tensor, logical_shape, padded_shape);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.cpp
@@ -25,7 +25,7 @@ ttnn::Tensor ExecuteFusedRMSNorm::invoke(
     const std::optional<const ttnn::Tensor>& weight,
     const std::optional<const ttnn::Tensor>& stats,
     bool is_pre) {
-    auto arch = is_tensor_on_device_or_multidevice(input_tensor)
+    auto arch = is_device_tensor(input_tensor)
                     ? input_tensor.device()->arch()
                     : ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice()->arch();
     auto kernel_config_val =

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -447,7 +447,7 @@ void dump_tensor(
     auto storage_type = tensor.storage_type();
     safe_fwrite(&storage_type, sizeof(storage_type), 1, output_file);
 
-    bool is_on_device = is_tensor_on_device_or_multidevice(tensor);
+    bool is_on_device = is_device_tensor(tensor);
     Tensor tensor_to_dump = tensor;
     if (is_on_device) {
         tensor_to_dump = tensor_to_dump.cpu();

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -631,7 +631,7 @@ Tensor Tensor::unpad_from_tile(const ttnn::Shape& output_tensor_shape) const {
 }
 
 bool Tensor::is_sharded() const {
-    return is_tensor_on_device_or_multidevice(*this) ? this->memory_config().is_sharded() : false;
+    return tt::tt_metal::is_device_tensor(*this) ? this->memory_config().is_sharded() : false;
 }
 
 uint32_t Tensor::element_size() const { return tensor_impl::element_size_bytes(this->get_dtype()); }
@@ -673,13 +673,6 @@ StorageType Tensor::storage_type() const {
         },
         this->get_storage());
 }
-
-bool Tensor::is_host_tensor() const {
-    auto type = storage_type();
-    return type == StorageType::HOST || type == StorageType::MULTI_DEVICE_HOST;
-}
-
-bool Tensor::is_device_tensor() const { return !is_host_tensor(); }
 
 ttnn::Shape Tensor::strides() const { return ttnn::Shape(tt::tt_metal::compute_strides(this->get_padded_shape())); }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -238,8 +238,6 @@ public:
     //                                      Extra Helper Functions
     // ======================================================================================
     StorageType storage_type() const;
-    bool is_host_tensor() const;
-    bool is_device_tensor() const;
     ttnn::Shape strides() const;
     uint32_t volume() const;
 

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -580,7 +580,6 @@ Tensor to_host<bfloat8_b>(const Tensor& tensor, bool blocking, ttnn::QueueId cq_
 
 template <typename T>
 Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id) {
-    // TT_FATAL(ttnn::distributed::is_mesh_buffer_tensor(tensor), "Tensor is not a mesh buffer tensor!");
     TT_FATAL(tt::tt_metal::detail::InMainThread(), "to_host_mesh_tensor must be called from the main thread");
     TT_ASSERT(tensor.is_allocated(), "Buffer must be allocated on device!");
     const auto& storage = std::get<DeviceStorage>(tensor.get_storage());
@@ -1303,7 +1302,7 @@ Tensor pad(
     TT_FATAL(!is_device_tensor(tensor), "pad only supports host tensors");
 
     // TODO: #15840 - Treat multi-device host vs owned/borrowed tensors uniformly.
-    if (ttnn::distributed::is_multi_device_host_tensor(tensor)) {
+    if (is_multi_device_host_tensor(tensor)) {
         return transform(tensor, [&](const Tensor& device_tensor) {
             return pad<T>(device_tensor, output_padded_shape, input_tensor_start, pad_value);
         });

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.hpp
@@ -83,7 +83,7 @@ constexpr size_t packed_buffer_size_bytes<bfloat4_b>(size_t volume_unpacked_data
 //                                  Layout converters
 // ======================================================================================
 template <typename T>
-inline std::vector<T> convert_layout_row_major_to_tile(
+std::vector<T> convert_layout_row_major_to_tile(
     const Shape2D& shape, const Tile& tile, tt::stl::Span<const T> data_to_convert) {
     if (shape.width() * shape.height() == 0) {
         return std::vector<T>();
@@ -113,7 +113,7 @@ inline std::vector<T> convert_layout_row_major_to_tile(
 }
 
 template <typename T>
-inline std::vector<T> convert_layout_tile_to_row_major(
+std::vector<T> convert_layout_tile_to_row_major(
     const Shape2D& shape, const Tile& tile, tt::stl::Span<const T> data_to_convert) {
     auto tile_shape = tile.get_tile_shape();
     auto face_shape = tile.get_face_shape();

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -152,7 +152,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevic
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device) {
     ZoneScoped;
     TT_ASSERT(
-        input_tensor.is_host_tensor(),
+        is_cpu_tensor(input_tensor) || is_multi_device_host_tensor(input_tensor),
         "to(layout) must be called on host tensors with MULTI_DEVICE_HOST_STORAGE when multiple "
         "workers "
         "are specified");
@@ -215,7 +215,8 @@ Tensor tensor_pad(
     ZoneScoped;
     GraphTracker::instance().track_function_start(
         "Tensor::pad", input_tensor, output_padded_shape, input_tensor_start, pad_value);
-    TT_ASSERT(input_tensor.is_host_tensor(), "Tensor must be on host for padding");
+    TT_ASSERT(
+        is_cpu_tensor(input_tensor) || is_multi_device_host_tensor(input_tensor), "Tensor must be on host for padding");
     // TODO: Flip to assert when we remove use cases in python and c++
     if (input_tensor.get_layout() != Layout::ROW_MAJOR) {
         log_warning(


### PR DESCRIPTION
### Ticket
#19177

### Problem description
Existing APIs that check storage types are repeated multiple times in various shapes forms.

### What's changed
1. Delete `is_mesh_buffer_tensor` - was not used.
2. Move `is_multi_device_host_tensor` next to `is_cpu_tensor` and `is_device_tensor`. This will be eventually removed upon unification of the multi device host / host storage.
3. Remove `is_tensor_on_device_or_multidevice`. This is now `is_device_tensor`.
4. Remove `is_tensor_on_device`. This is now `is_device_tensor`.
5. Remove `Tensor::is_device_tensor`. This is now `is_device_tensor`.
6. Remove `Tensor::is_host_tensor`. This is now `is_cpu_tensor(t) || is_multi_device_host_tensor(t)`. Note `is_multi_device_host_tensor` will be eventually removed.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14718734620)
- [X] New/Existing tests provide coverage for changes