### PR TITLE
Loop through programmable core types to generate launch message

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -765,7 +765,7 @@ SystemMemoryManager& FDMeshCommandQueue::reference_sysmem_manager() {
 void FDMeshCommandQueue::update_launch_messages_for_device_profiler(
     ProgramCommandSequence& program_cmd_seq, uint32_t program_runtime_id, IDevice* device) {
 #if defined(TRACY_ENABLE)
-    for (auto& launch_msg : program_cmd_seq.go_signals) {
+    for (auto& launch_msg : program_cmd_seq.launch_messages) {
         launch_msg->kernel_config.host_assigned_id =
             tt_metal::detail::EncodePerDeviceProgramID(program_runtime_id, device->id());
     }

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -34,6 +34,7 @@
 #include "circular_buffer.hpp"
 #include "circular_buffer_constants.h"
 #include "core_coord.hpp"
+#include "dev_msgs.h"
 #include "device.hpp"
 #include "dispatch/device_command.hpp"
 #include "impl/context/metal_context.hpp"
@@ -1500,97 +1501,72 @@ public:
         DeviceCommandCalculator& calculator,
         const CommandConstants& constants,
         SubDeviceId sub_device_id) {
-        const auto& hal = MetalContext::instance().hal();
-        constexpr uint32_t go_signal_sizeB = sizeof(launch_msg_t);
-        uint32_t aligned_go_signal_sizeB = tt::align(go_signal_sizeB, hal.get_alignment(HalMemType::L1));
-        uint32_t go_signal_size_words = aligned_go_signal_sizeB / sizeof(uint32_t);
-
-        // TODO: eventually the code below could be structured to loop over programmable_indices
-        /* *****************
-         *
-         *   TENSIX
-         *
-         *******************
-         */
-        // and check for mcast/unicast
-        uint32_t programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-        for (auto& kernel_group : program.get_kernel_groups(programmable_core_index)) {
-            kernel_group->launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
-            kernel_group->launch_msg.kernel_config.preload = DISPATCH_ENABLE_FLAG_PRELOAD;
-            for (uint32_t i = 0; i < NUM_PROGRAMMABLE_CORE_TYPES; i++) {
-                kernel_group->launch_msg.kernel_config.kernel_config_base[i] = 0;
-            }
-            kernel_group->launch_msg.kernel_config.host_assigned_id = program.get_runtime_id();
-
-            const auto& origin = get_sub_device_worker_origin(device, sub_device_id, HalProgrammableCoreType::TENSIX);
-            kernel_group->launch_msg.kernel_config.sub_device_origin_x = origin.x;
-            kernel_group->launch_msg.kernel_config.sub_device_origin_y = origin.y;
-
-            const void* launch_message_data = (const void*)(&(kernel_group->launch_msg));
-            for (const CoreRange& core_range : kernel_group->core_ranges.ranges()) {
-                CoreCoord virtual_start =
-                    device->virtual_core_from_logical_core(core_range.start_coord, kernel_group->get_core_type());
-                CoreCoord virtual_end =
-                    device->virtual_core_from_logical_core(core_range.end_coord, kernel_group->get_core_type());
-
-                multicast_cmds.sub_cmds.emplace_back(CQDispatchWritePackedMulticastSubCmd{
-                    .noc_xy_addr =
-                        device->get_noc_multicast_encoding(constants.noc_index, CoreRange(virtual_start, virtual_end)),
-                    .num_mcast_dests = (uint32_t)core_range.size()});
-                multicast_cmds.data.emplace_back(launch_message_data, go_signal_sizeB);
-            }
-        }
-        if (multicast_cmds.sub_cmds.size() > 0) {
-            calculator.insert_write_packed_payloads<CQDispatchWritePackedMulticastSubCmd>(
-                multicast_cmds.sub_cmds.size(),
-                go_signal_sizeB,
-                constants.max_prefetch_command_size,
-                constants.packed_write_max_unicast_sub_cmds,
-                multicast_cmds.payload);
-        }
-
-        /* *****************
-         *
-         *   ETH
-         *
-         *******************
-         */
-        programmable_core_index = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
-        // TODO: ugly, can be fixed by looping over indices w/ some work
-        if (programmable_core_index != -1) {
-            for (auto& kernel_group : program.get_kernel_groups(programmable_core_index)) {
+        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+        for (uint32_t programmable_core_type_index = 0;
+             programmable_core_type_index < tt::tt_metal::NumHalProgrammableCoreTypes;
+             ++programmable_core_type_index) {
+            for (auto& kernel_group : program.get_kernel_groups(programmable_core_type_index)) {
                 kernel_group->launch_msg.kernel_config.mode = DISPATCH_MODE_DEV;
                 kernel_group->launch_msg.kernel_config.preload = DISPATCH_ENABLE_FLAG_PRELOAD;
-                // Set the kernel_config_base addrs to 0 when generating the dispatch commands for the program
-                // Will be resolved at runtime
+
                 for (uint32_t i = 0; i < NUM_PROGRAMMABLE_CORE_TYPES; i++) {
                     kernel_group->launch_msg.kernel_config.kernel_config_base[i] = 0;
                 }
                 kernel_group->launch_msg.kernel_config.host_assigned_id = program.get_runtime_id();
-                const auto& origin =
-                    get_sub_device_worker_origin(device, sub_device_id, HalProgrammableCoreType::ACTIVE_ETH);
+
+                // Setup values for dataflow kernel APIs for getting logical and relative coordinates
+                const auto& origin = get_sub_device_worker_origin(
+                    device,
+                    sub_device_id,
+                    static_cast<tt::tt_metal::HalProgrammableCoreType>(programmable_core_type_index));
                 kernel_group->launch_msg.kernel_config.sub_device_origin_x = origin.x;
                 kernel_group->launch_msg.kernel_config.sub_device_origin_y = origin.y;
 
-                const void* launch_message_data = (const launch_msg_t*)(&(kernel_group->launch_msg));
-                for (const CoreRange& core_range : kernel_group->core_ranges.ranges()) {
-                    for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
-                        for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                            CoreCoord virtual_coord = device->virtual_core_from_logical_core(
-                                CoreCoord({x, y}), kernel_group->get_core_type());
-                            unicast_cmds.sub_cmds.emplace_back(CQDispatchWritePackedUnicastSubCmd{
-                                .noc_xy_addr = device->get_noc_unicast_encoding(constants.noc_index, virtual_coord)});
-                            unicast_cmds.data.emplace_back(launch_message_data, go_signal_sizeB);
+                const void* launch_message_data = (const void*)(&(kernel_group->launch_msg));
+                if (hal.get_supports_receiving_multicasts(programmable_core_type_index)) {
+                    for (const CoreRange& core_range : kernel_group->core_ranges.ranges()) {
+                        CoreCoord virtual_start = device->virtual_core_from_logical_core(
+                            core_range.start_coord, kernel_group->get_core_type());
+                        CoreCoord virtual_end =
+                            device->virtual_core_from_logical_core(core_range.end_coord, kernel_group->get_core_type());
+
+                        multicast_cmds.sub_cmds.emplace_back(CQDispatchWritePackedMulticastSubCmd{
+                            .noc_xy_addr = device->get_noc_multicast_encoding(
+                                constants.noc_index, CoreRange(virtual_start, virtual_end)),
+                            .num_mcast_dests = (uint32_t)core_range.size()});
+                        multicast_cmds.data.emplace_back(launch_message_data, launch_msg_sizeB);
+                    }
+                } else {
+                    // Need to unicast to each core in the kernel group
+                    for (const CoreRange& core_range : kernel_group->core_ranges.ranges()) {
+                        for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
+                            for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
+                                CoreCoord virtual_coord = device->virtual_core_from_logical_core(
+                                    CoreCoord({x, y}), kernel_group->get_core_type());
+                                unicast_cmds.sub_cmds.emplace_back(CQDispatchWritePackedUnicastSubCmd{
+                                    .noc_xy_addr =
+                                        device->get_noc_unicast_encoding(constants.noc_index, virtual_coord)});
+                                unicast_cmds.data.emplace_back(launch_message_data, launch_msg_sizeB);
+                            }
                         }
                     }
                 }
             }
         }
 
-        if (unicast_cmds.sub_cmds.size() > 0) {
+        if (!multicast_cmds.sub_cmds.empty()) {
+            calculator.insert_write_packed_payloads<CQDispatchWritePackedMulticastSubCmd>(
+                multicast_cmds.sub_cmds.size(),
+                launch_msg_sizeB,
+                constants.max_prefetch_command_size,
+                constants.packed_write_max_unicast_sub_cmds,
+                multicast_cmds.payload);
+        }
+
+        if (!unicast_cmds.sub_cmds.empty()) {
             calculator.insert_write_packed_payloads<CQDispatchWritePackedUnicastSubCmd>(
                 unicast_cmds.sub_cmds.size(),
-                go_signal_sizeB,
+                launch_msg_sizeB,
                 constants.max_prefetch_command_size,
                 constants.packed_write_max_unicast_sub_cmds,
                 unicast_cmds.payload);
@@ -1602,27 +1578,26 @@ public:
         ProgramCommandSequence& program_command_sequence,
         HostMemDeviceCommand& device_command_sequence,
         const CommandConstants& constants) const {
-        const auto& hal = MetalContext::instance().hal();
-        constexpr uint32_t go_signal_sizeB = sizeof(launch_msg_t);
-        uint32_t aligned_go_signal_sizeB = tt::align(go_signal_sizeB, hal.get_alignment(HalMemType::L1));
-        uint32_t go_signal_size_words = aligned_go_signal_sizeB / sizeof(uint32_t);
+        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
         uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+        uint32_t aligned_launch_msg_sizeB = tt::align(launch_msg_sizeB, l1_alignment);
+        uint32_t launch_msg_size_words = aligned_launch_msg_sizeB / sizeof(uint32_t);
 
-        program_command_sequence.go_signals.reserve(multicast_cmds.sub_cmds.size() + unicast_cmds.sub_cmds.size());
+        program_command_sequence.launch_messages.reserve(multicast_cmds.sub_cmds.size() + unicast_cmds.sub_cmds.size());
 
         // Launch Message address is resolved when the program is enqueued
-        uint32_t multicast_launch_msg_addr = 0;
+        constexpr uint32_t unresolved_launch_msg_addr = 0;
 
         if (multicast_cmds.sub_cmds.size() > 0) {
             uint32_t curr_sub_cmd_idx = 0;
-            for (const auto& [num_sub_cmds_in_cmd, multicast_go_signal_payload_sizeB] : multicast_cmds.payload) {
+            for (const auto& [num_sub_cmds_in_cmd, multicast_launch_msg_payload_sizeB] : multicast_cmds.payload) {
                 uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
                 device_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedMulticastSubCmd>(
                     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_LAUNCH,
                     num_sub_cmds_in_cmd,
-                    multicast_launch_msg_addr,
-                    go_signal_sizeB,
-                    multicast_go_signal_payload_sizeB,
+                    unresolved_launch_msg_addr,
+                    aligned_launch_msg_sizeB,
+                    multicast_launch_msg_payload_sizeB,
                     multicast_cmds.sub_cmds,
                     multicast_cmds.data,
                     constants.packed_write_max_unicast_sub_cmds,
@@ -1637,25 +1612,23 @@ public:
                      tt::align(num_sub_cmds_in_cmd * sizeof(CQDispatchWritePackedMulticastSubCmd), l1_alignment)) /
                     sizeof(uint32_t);
                 for (uint32_t i = 0; i < num_sub_cmds_in_cmd; ++i) {
-                    program_command_sequence.go_signals.push_back(
+                    program_command_sequence.launch_messages.push_back(
                         (launch_msg_t*)((uint32_t*)device_command_sequence.data() + curr_sub_cmd_data_offset_words));
-                    curr_sub_cmd_data_offset_words += go_signal_size_words;
+                    curr_sub_cmd_data_offset_words += launch_msg_size_words;
                 }
             }
         }
 
         if (unicast_cmds.sub_cmds.size() > 0) {
-            // Launch Message address is resolved when the program is enqueued
-            uint32_t unicast_launch_msg_addr = 0;
             uint32_t curr_sub_cmd_idx = 0;
-            for (const auto& [num_sub_cmds_in_cmd, unicast_go_signal_payload_sizeB] : unicast_cmds.payload) {
+            for (const auto& [num_sub_cmds_in_cmd, unicast_launch_msg_payload_sizeB] : unicast_cmds.payload) {
                 uint32_t write_offset_bytes = device_command_sequence.write_offset_bytes();
                 device_command_sequence.add_dispatch_write_packed<CQDispatchWritePackedUnicastSubCmd>(
                     CQ_DISPATCH_CMD_PACKED_WRITE_FLAG_TYPE_LAUNCH,
                     num_sub_cmds_in_cmd,
-                    unicast_launch_msg_addr,
-                    go_signal_sizeB,
-                    unicast_go_signal_payload_sizeB,
+                    unresolved_launch_msg_addr,
+                    aligned_launch_msg_sizeB,
+                    unicast_launch_msg_payload_sizeB,
                     unicast_cmds.sub_cmds,
                     unicast_cmds.data,
                     constants.packed_write_max_unicast_sub_cmds,
@@ -1670,9 +1643,9 @@ public:
                      tt::align(num_sub_cmds_in_cmd * sizeof(CQDispatchWritePackedUnicastSubCmd), l1_alignment)) /
                     sizeof(uint32_t);
                 for (uint32_t i = 0; i < num_sub_cmds_in_cmd; ++i) {
-                    program_command_sequence.go_signals.push_back(
+                    program_command_sequence.launch_messages.push_back(
                         (launch_msg_t*)((uint32_t*)device_command_sequence.data() + curr_sub_cmd_data_offset_words));
-                    curr_sub_cmd_data_offset_words += go_signal_size_words;
+                    curr_sub_cmd_data_offset_words += launch_msg_size_words;
                 }
             }
         }
@@ -1688,6 +1661,8 @@ private:
         std::vector<T> sub_cmds;
         std::vector<std::pair<uint32_t, uint32_t>> payload;
     };
+
+    static constexpr uint32_t launch_msg_sizeB = sizeof(launch_msg_t);
 
     LaunchMessageCmds<CQDispatchWritePackedMulticastSubCmd> multicast_cmds;
     LaunchMessageCmds<CQDispatchWritePackedUnicastSubCmd> unicast_cmds;
@@ -2039,11 +2014,11 @@ void update_program_dispatch_commands(
     }
 
     // Update launch messages
-    for (auto& go_signal : cached_program_command_sequence.go_signals) {
+    for (auto& launch_msg : cached_program_command_sequence.launch_messages) {
         for (uint32_t i = 0; i < dispatch_md.kernel_config_addrs.size(); i++) {
-            go_signal->kernel_config.kernel_config_base[i] = dispatch_md.kernel_config_addrs[i].addr;
+            launch_msg->kernel_config.kernel_config_base[i] = dispatch_md.kernel_config_addrs[i].addr;
         }
-        go_signal->kernel_config.host_assigned_id = program.get_runtime_id();
+        launch_msg->kernel_config.host_assigned_id = program.get_runtime_id();
     }
     // Update launch message addresses to reflect new launch_msg slot in ring buffer
     uint32_t multicast_cores_launch_msg_addr =

--- a/tt_metal/impl/program/program_command_sequence.hpp
+++ b/tt_metal/impl/program/program_command_sequence.hpp
@@ -38,7 +38,7 @@ struct ProgramCommandSequence {
     // Note: some RTAs may be have their RuntimeArgsData modified so the source-of-truth of their data is the command
     // sequence. They won't be listed in rta_updates.
     std::vector<RtaUpdate> rta_updates;
-    std::vector<launch_msg_t*> go_signals;
+    std::vector<launch_msg_t*> launch_messages;
     std::vector<CQDispatchWritePackedCmd*> launch_msg_write_packed_cmd_ptrs;
     std::vector<CQDispatchWritePackedCmd*> unicast_launch_msg_write_packed_cmd_ptrs;
     CQDispatchGoSignalMcastCmd* mcast_go_signal_cmd_ptr;


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Launch message generator doesn't need separate loops anymore for tensix and ethernet. The only difference is for ethernet it's using unicast rather than multicast.

### What's changed
- Rename "go signals" to "launch messages" because they are actually holding launch messages. not go signals.
- Combined the TENSIX and ETH code in construct commands to loop over programmable core type. This should help clean up this part of program dispatch.

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14721109159
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14722292369
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14722291117
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14758624626