### PR TITLE
Fold Op program cache bug

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.hpp
@@ -51,8 +51,8 @@ struct Fold {
             tt::tt_metal::KernelHandle writer_kernel_id;
             uint32_t stride_h;
             uint32_t stride_w;
-            uint32_t cb_src0;
-            uint32_t cb_dst0;
+            tt::tt_metal::CBHandle cb_src0;
+            tt::tt_metal::CBHandle cb_dst0;
         };
 
         using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_multi_core_program_factory.cpp
@@ -123,7 +123,7 @@ void Fold::MultiCore::override_runtime_arguments(
     uint32_t dst_pixel_size = stride_h * chunk_size;
     uint32_t dst_row_size = stride_h * row_size;
     uint32_t num_dst_rows = num_pixels / (width * stride_h);
-    uint32_t cb_pages_per_dst_row = stride_h * width;
+    uint32_t pixels_per_dst_row = stride_h * width;
 
     uint32_t aligned_pixel_size = round_up_to_mul32(pixel_size);
     uint32_t aligned_dst_pixel_size = round_up_to_mul32(dst_pixel_size);
@@ -150,7 +150,7 @@ void Fold::MultiCore::override_runtime_arguments(
             stride_w,
             num_dst_rows,
             width / stride_w,
-            cb_pages_per_dst_row,
+            pixels_per_dst_row * aligned_pixel_size,
         });
 }
 


### PR DESCRIPTION
### Ticket
#19372 

### Problem description
Program cache was broken with fold multicore sharded op.
And one of the kernel runtime parameters was wrongly calculated. 

### What's changed
CB handles in shared variables are now CBhandle (64bit value, instead of previously defined 32bit value)
Runtime argument is properly adjusted. 

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) [CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/14725429820)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) [CI passes ](https://github.com/tenstorrent/tt-metal/actions/runs/14730302470)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes