### PR TITLE
#19609: Update unary backward ops 

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_elu.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_elu.py
@@ -27,8 +27,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_elu(input_shapes, alpha, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.elu_bw(grad_tensor, input_tensor, alpha=alpha)
 
@@ -47,8 +47,8 @@ def test_bw_elu(input_shapes, alpha, device):
     ),
 )
 def test_bw_elu_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.elu_bw(grad_tensor, input_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_exp.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_exp.py
@@ -17,14 +17,13 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_exp(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -199, 200, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -80, 80, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.exp_bw(grad_tensor, input_tensor)
 
     golden_function = ttnn.get_golden_function(ttnn.exp_bw)
     golden_tensor = golden_function(grad_data, in_data)
-
     comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass
 
@@ -38,8 +37,8 @@ def test_bw_exp(input_shapes, device):
     ),
 )
 def test_bw_exp_output(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -199, 200, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -200, 200, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -80, 80, device, True)
     input_grad = None
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_xlogy.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_xlogy.py
@@ -17,15 +17,14 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data
     ),
 )
 def test_bw_xlogy(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -2, 5, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=0)
+    other_data, other_tensor = data_gen_with_range(input_shapes, 1, 5, device, True, seed=1)
 
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=3)
 
     tt_output_tensor_on_device = ttnn.xlogy_bw(grad_tensor, input_tensor, other_tensor)
 
     golden_function = ttnn.get_golden_function(ttnn.xlogy_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data)
-
     status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -48,9 +48,9 @@ def data_gen_pt_tt(input_shapes, device, required_grad=False):
     return pt_tensor, tt_tensor
 
 
-def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is_row_major=False):
+def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is_row_major=False, seed=213919):
     assert high > low, "Incorrect range provided"
-    torch.manual_seed(213919)
+    torch.manual_seed(seed)
     pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
     if is_row_major:
         tt_tensor = ttnn.Tensor(pt_tensor, ttnn.bfloat16).to(ttnn.ROW_MAJOR_LAYOUT).to(device)


### PR DESCRIPTION
### Ticket
Link to Github Issue #19609 

### Problem description
Tests failing on backward exp, elu, logy after adding seeding.

### What's changed

- backward_exp: Updated the logic by removing special handling for inf, which was needed for GS but not for WH. This operation uses the forward exp, which supports a limited input range, so the input range was adjusted to avoid issues with large values.

- backward_elu: Fixed the logic by changing the condition from "greater than or equal to zero" to "greater than zero", which correctly resolves the issue.

- backward_xlogy: Since this operation uses log, which doesn't support negative values, the input range was updated to prevent errors.

### Checklist
- [ ] [All post commit cI](https://github.com/tenstorrent/tt-metal/actions/runs/14747153135)