### PR TITLE
Added skip for harvested blackhole machine case

### DIFF
--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
@@ -6,7 +6,7 @@ import pytest
 import ttnn
 
 from models.demos.ttnn_resnet.tests.resnet50_test_infra import create_test_infra
-from models.utility_functions import is_blackhole, skip_for_blackhole
+from models.utility_functions import is_blackhole
 
 
 def run_resnet_50(
@@ -26,7 +26,7 @@ def run_resnet_50(
         pytest.skip("Batch size > 16 is not supported on non-blackhole devices")
 
     if is_blackhole() and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130:
-        pytest.skip("Expected to run only on blackhole devices with 130 cores (unharvested grid)")
+        pytest.skip("Expected to run only on blackhole devices with 130 cores (unharvested grid), see #21319")
 
     test_infra = create_test_infra(
         device,
@@ -51,7 +51,6 @@ def run_resnet_50(
     assert passed, message
 
 
-@skip_for_blackhole("Failing on harvested BH, see #21319")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, act_dtype, weight_dtype, math_fidelity",

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
@@ -25,6 +25,9 @@ def run_resnet_50(
     if batch_size > 16 and not is_blackhole():
         pytest.skip("Batch size > 16 is not supported on non-blackhole devices")
 
+    if is_blackhole() and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130:
+        pytest.skip("Expected to run only on blackhole devices with 130 cores (unharvested grid)")
+
     test_infra = create_test_infra(
         device,
         batch_size,


### PR DESCRIPTION
### Ticket
#21319

### Problem description
Resnet50 model doesn't work on harvested BH machines, but it works on unharvested machines. Reason is resnet50 implementation - 130 cores are expected, but 1 column harvested machine has 120 cores.

### What's changed
For now skip is added, until it is decided how the implementation of the model can be handled.

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14834544164)