### PR TITLE
Add cluster type for simulator

### DIFF
--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -92,7 +92,7 @@ namespace tt {
 ClusterType Cluster::get_cluster_type_from_cluster_desc(
     const llrt::RunTimeOptions& rtoptions, const tt_ClusterDescriptor* cluster_desc) {
     if (rtoptions.get_simulator_enabled()) {
-        return ClusterType::INVALID;
+        return ClusterType::SIMULATOR;
     }
     if (cluster_desc == nullptr) {
         return Cluster::get_cluster_type_from_cluster_desc(
@@ -205,6 +205,7 @@ void Cluster::generate_cluster_descriptor() {
         this->mock_cluster_desc_ptr_ =
             tt_ClusterDescriptor::create_mock_cluster(tt_SimulationDevice::detect_available_device_ids(), this->arch_);
         this->cluster_desc_ = this->mock_cluster_desc_ptr_.get();
+        this->cluster_type_ = ClusterType::SIMULATOR;
     } else {
         this->cluster_desc_ = this->driver_->get_cluster_description();
     }
@@ -1384,6 +1385,7 @@ void Cluster::initialize_control_plane() {
         case tt::ClusterType::P150: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::P150_X2: mesh_graph_descriptor = "p150_x2_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::P150_X4: mesh_graph_descriptor = "p150_x4_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::SIMULATOR: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
         default: TT_THROW("Unknown cluster type"); // TODO: we could expose this as a custom mesh graph option
     }
     const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -92,7 +92,14 @@ namespace tt {
 ClusterType Cluster::get_cluster_type_from_cluster_desc(
     const llrt::RunTimeOptions& rtoptions, const tt_ClusterDescriptor* cluster_desc) {
     if (rtoptions.get_simulator_enabled()) {
-        return ClusterType::SIMULATOR;
+        tt_SimulationDeviceInit init(rtoptions.get_simulator_path());
+        auto arch = init.get_arch_name();
+        if (arch == tt::ARCH::WORMHOLE_B0) {
+            return ClusterType::SIMULATOR_WORMHOLE_B0;
+        } else if (arch == tt::ARCH::BLACKHOLE) {
+            return ClusterType::SIMULATOR_BLACKHOLE;
+        }
+        return ClusterType::INVALID;
     }
     if (cluster_desc == nullptr) {
         return Cluster::get_cluster_type_from_cluster_desc(
@@ -205,7 +212,6 @@ void Cluster::generate_cluster_descriptor() {
         this->mock_cluster_desc_ptr_ =
             tt_ClusterDescriptor::create_mock_cluster(tt_SimulationDevice::detect_available_device_ids(), this->arch_);
         this->cluster_desc_ = this->mock_cluster_desc_ptr_.get();
-        this->cluster_type_ = ClusterType::SIMULATOR;
     } else {
         this->cluster_desc_ = this->driver_->get_cluster_description();
     }
@@ -1385,7 +1391,8 @@ void Cluster::initialize_control_plane() {
         case tt::ClusterType::P150: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::P150_X2: mesh_graph_descriptor = "p150_x2_mesh_graph_descriptor.yaml"; break;
         case tt::ClusterType::P150_X4: mesh_graph_descriptor = "p150_x4_mesh_graph_descriptor.yaml"; break;
-        case tt::ClusterType::SIMULATOR: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::SIMULATOR_WORMHOLE_B0: mesh_graph_descriptor = "n150_mesh_graph_descriptor.yaml"; break;
+        case tt::ClusterType::SIMULATOR_BLACKHOLE: mesh_graph_descriptor = "p150_mesh_graph_descriptor.yaml"; break;
         default: TT_THROW("Unknown cluster type"); // TODO: we could expose this as a custom mesh graph option
     }
     const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -63,15 +63,16 @@ enum class TargetDevice : std::uint8_t {
 
 enum class ClusterType : std::uint8_t {
     INVALID = 0,
-    N150 = 1,     // Production N150
-    N300 = 2,     // Production N300
-    T3K = 3,      // Production T3K, built with 4 N300s
-    GALAXY = 4,   // Production Galaxy, all chips with mmio
-    TG = 5,       // Will be deprecated
-    P100 = 6,     // Blackhole single card, ethernet disabled
-    P150 = 7,     // Blackhole single card, ethernet enabled
-    P150_X2 = 8,  // 2 Blackhole single card, ethernet connected
-    P150_X4 = 9,  // 4 Blackhole single card, ethernet connected
+    N150 = 1,        // Production N150
+    N300 = 2,        // Production N300
+    T3K = 3,         // Production T3K, built with 4 N300s
+    GALAXY = 4,      // Production Galaxy, all chips with mmio
+    TG = 5,          // Will be deprecated
+    P100 = 6,        // Blackhole single card, ethernet disabled
+    P150 = 7,        // Blackhole single card, ethernet enabled
+    P150_X2 = 8,     // 2 Blackhole single card, ethernet connected
+    P150_X4 = 9,     // 4 Blackhole single card, ethernet connected
+    SIMULATOR = 10,  // Simulator
 };
 
 enum class EthRouterMode : uint32_t {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -63,16 +63,17 @@ enum class TargetDevice : std::uint8_t {
 
 enum class ClusterType : std::uint8_t {
     INVALID = 0,
-    N150 = 1,        // Production N150
-    N300 = 2,        // Production N300
-    T3K = 3,         // Production T3K, built with 4 N300s
-    GALAXY = 4,      // Production Galaxy, all chips with mmio
-    TG = 5,          // Will be deprecated
-    P100 = 6,        // Blackhole single card, ethernet disabled
-    P150 = 7,        // Blackhole single card, ethernet enabled
-    P150_X2 = 8,     // 2 Blackhole single card, ethernet connected
-    P150_X4 = 9,     // 4 Blackhole single card, ethernet connected
-    SIMULATOR = 10,  // Simulator
+    N150 = 1,                    // Production N150
+    N300 = 2,                    // Production N300
+    T3K = 3,                     // Production T3K, built with 4 N300s
+    GALAXY = 4,                  // Production Galaxy, all chips with mmio
+    TG = 5,                      // Will be deprecated
+    P100 = 6,                    // Blackhole single card, ethernet disabled
+    P150 = 7,                    // Blackhole single card, ethernet enabled
+    P150_X2 = 8,                 // 2 Blackhole single card, ethernet connected
+    P150_X4 = 9,                 // 4 Blackhole single card, ethernet connected
+    SIMULATOR_WORMHOLE_B0 = 10,  // Simulator Wormhole B0
+    SIMULATOR_BLACKHOLE = 11,    // Simulator Blackhole
 };
 
 enum class EthRouterMode : uint32_t {


### PR DESCRIPTION
### Problem description
A runtime exception `Unknown cluster type` occurs when running tt-metal tests on the Simulator. This happens because the cluster type is not initialized for the Simulator target.
Reference to test: https://yyz-gitlab.local.tenstorrent.com/tenstorrent/tt-umd-simulators/-/jobs/10197480

### What's changed
A new cluster type for the Simulator target has been added, and the cluster_type is now properly initialized for this target. This ensures that tt-metal tests on the Simulator no longer raise the Unknown cluster type exception.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14840588363) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14840595075) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes