### PR TITLE
#19201: remove a cb_wait_front tried for a workaround from sdpa decode

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -346,7 +346,6 @@ ALWI void cb_matmul_blocks(
         in0_cb, in1_cb, transpose /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
 
     reconfig_data_format(in1_cb, in0_cb);
-    cb_wait_front(in0_cb, M * K);  // #19201 BH hang workaround
     cb_wait_front(in1_cb, K * N);
 
     uint32_t output_num_tiles = M * N;


### PR DESCRIPTION
### Ticket
Link to Github Issue #19201

### Problem description
A workaround that was tried to fix a BH hang seems to be causing a different BH hang:
http://github.com/tenstorrent/tt-metal/actions/runs/14716830669/job/41318659040

### What's changed
- remove this workaround

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes - https://github.com/tenstorrent/tt-metal/actions/runs/14732136747 fails in the same way as main https://github.com/tenstorrent/tt-metal/actions/runs/14730591175 that's unrelated to the changes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) N/A this is just reverting part of an earlier change
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes