### PR TITLE
#21067: [skip ci] Add initial unit tests that require cached HF weights for Llama

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -1,6 +1,9 @@
 name: Build test and publish upstream tests
 
 on:
+  push:
+    branches:
+      - rkim/21067-add-llama-dir
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'
@@ -118,7 +121,8 @@ jobs:
           tags: ${{ matrix.image-config.image-tag }}
           context: ${{ github.workspace }}
       - name: Tag and push latest
-        if: ${{ github.ref == 'refs/heads/main' }}
+        # TODO - get rid of my branch and make this generic for both images
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rkim/21067-add-llama-dir' }}
         run: |
           IMAGE_NAME="${{ matrix.image-config.image-base-name }}"
           LATEST_TAG="${IMAGE_NAME}:latest"
@@ -142,8 +146,11 @@ jobs:
         timeout-minutes: 10
         run: docker pull ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run image
-        timeout-minutes: 10
-        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
+        timeout-minutes: 15
+        env:
+          SOURCE_LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct
+          LLAMA_DIR: /model_weights/llama/Llama3.1-70B-Instruct
+        run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent -v $SOURCE_LLAMA_DIR:$LLAMA_DIR:ro -e LLAMA_DIR ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -1,9 +1,6 @@
 name: Build test and publish upstream tests
 
 on:
-  push:
-    branches:
-      - rkim/21067-add-llama-dir
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * *'
@@ -121,8 +118,7 @@ jobs:
           tags: ${{ matrix.image-config.image-tag }}
           context: ${{ github.workspace }}
       - name: Tag and push latest
-        # TODO - get rid of my branch and make this generic for both images
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/rkim/21067-add-llama-dir' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           IMAGE_NAME="${{ matrix.image-config.image-base-name }}"
           LATEST_TAG="${IMAGE_NAME}:latest"

--- a/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "[upstream-tests] running metalium section. Note that skips should be treated as failures"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="ControlPlaneFixture.TestQuantaGalaxyControlPlaneInit"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
+TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+
+echo "[upstream-tests] Running minimal model unit tests"
+pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
+pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py::test_matmul_1d_ring_llama_perf
+pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
+# pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py hang???
+
 if [ -z "${LLAMA_DIR}" ]; then
   echo "Error: LLAMA_DIR environment variable not detected. Please set this environment variable to tell the tests where to find the downloaded Llama weights." >&2
   exit 1
@@ -15,20 +29,7 @@ fi
 
 echo "[upstream-tests] Running validation model tests with weights"
 pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick"
+pytest models/demos/llama3_subdevices/tests/unit_tests/test_llama_model_prefill.py
 
 echo "[upstream-tests] Unsetting LLAMA_DIR to ensure later tests can't use it"
 unset LLAMA_DIR
-
-echo "[upstream-tests] Running minimal model unit tests"
-pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
-pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
-pytest tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_1d_gather_in0.py::test_matmul_1d_ring_llama_perf
-pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
-# pytest tests/ttnn/unit_tests/operations/ccl/test_minimals.py hang???
-
-echo "[upstream-tests] running metalium section. Note that skips should be treated as failures"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="ControlPlaneFixture.TestQuantaGalaxyControlPlaneInit"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardFixture.*"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardProgramFixture.*"
-TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="CommandQueueSingleCardBufferFixture.ShardedBufferLarge*ReadWrites"
-TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"

--- a/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_tests.sh
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ -z "${LLAMA_DIR}" ]; then
+  echo "Error: LLAMA_DIR environment variable not detected. Please set this environment variable to tell the tests where to find the downloaded Llama weights." >&2
+  exit 1
+fi
+
+if [ -d "$LLAMA_DIR" ] && [ "$(ls -A $LLAMA_DIR)" ]; then
+  echo "[upstream-tests] Llama weights exist, continuing"
+else
+  echo "[upstream-tests] Error: Llama weights do not seem to exist in $LLAMA_DIR, exiting" >&2
+  exit 1
+fi
+
+echo "[upstream-tests] Running validation model tests with weights"
+pytest models/demos/llama3_subdevices/tests/test_llama_model.py -k "quick"
+
+echo "[upstream-tests] Unsetting LLAMA_DIR to ensure later tests can't use it"
+unset LLAMA_DIR
+
 echo "[upstream-tests] Running minimal model unit tests"
 pytest tests/ttnn/unit_tests/operations/ccl/test_ccl_async_TG_llama.py
 pytest tests/ttnn/unit_tests/operations/test_prefetcher_TG.py


### PR DESCRIPTION
### Ticket

#21067


### Problem description

Certain tests require `LLAMA_DIR`. Other tests like Falcon7b include this.

### What's changed

- Mount our existing MLPerf directories into the test container as ro
- Add tests that use weights
- Need to ensure documentation is up to date

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes