### PR TITLE
SDPA - enable fp32 inputs and fp32 matmul intermediates

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -216,7 +216,6 @@ void MAIN {
                         false /*transpose*/);
 
                     cb_pop_front(cb_qk_im, qk_chunk_tiles);
-                    // reconfig_data_format(alias_prev_max, alias_cur_max);
 
                     /* OUT_ACC += OUT_IM */
                     if (k_chunk > 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -139,6 +139,7 @@ void MAIN {
                         true /*transpose*/);
 
                     /* QK *= SCALE */
+                    reconfig_data_format(cb_qk_im, cb_scale_in);
                     mul_block_bcast_scalar_inplace<cb_qk_im, cb_scale_in, qk_chunk_tiles>();
 
                     // Finding the diagonal is harder now that q_chunk_size and k_chunk_size can differ
@@ -166,6 +167,7 @@ void MAIN {
                     }
 
                     reconfig_data_format(cb_qk_im, cb_identity_scale_in);
+                    pack_reconfig_data_format(alias_cur_max);
                     reduce_c<
                         PoolType::MAX,
                         ReduceDim::REDUCE_ROW,
@@ -175,13 +177,18 @@ void MAIN {
                         Sk_chunk_t>(alias_cur_max);
 
                     if (k_chunk > 0) {
+                        reconfig_data_format(alias_cur_max, alias_prev_max);
                         max_block_inplace<Sq_chunk_t>(alias_cur_max, alias_prev_max);
                     }
 
                     /* QK -= cb_cur_max */
                     /* QK = exp(QK)*/
+                    reconfig_data_format(cb_qk_im, alias_cur_max);
+                    pack_reconfig_data_format(cb_qk_im);
                     sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, Sk_chunk_t>(alias_cur_max);
 
+                    reconfig_data_format(cb_qk_im, cb_identity_scale_in);
+                    pack_reconfig_data_format(alias_cur_sum);
                     /* cb_cur_sum = sum(cb_qk_im, dim=-1) */
                     reduce_c<
                         PoolType::SUM,
@@ -192,6 +199,7 @@ void MAIN {
                         Sk_chunk_t>(alias_cur_sum);
 
                     /* OUT_IM = QK @ V_CHUNK */
+                    pack_reconfig_data_format(alias_mm2_cur_out);
                     matmul_blocks(
                         cb_qk_im,
                         cb_v_in,
@@ -208,11 +216,13 @@ void MAIN {
                         false /*transpose*/);
 
                     cb_pop_front(cb_qk_im, qk_chunk_tiles);
-                    reconfig_data_format(alias_prev_max, alias_cur_max);
+                    // reconfig_data_format(alias_prev_max, alias_cur_max);
 
                     /* OUT_ACC += OUT_IM */
                     if (k_chunk > 0) {
                         /* cb_exp_max_diff = torch.exp(cb_prev_max - cb_cur_max) */
+                        reconfig_data_format(alias_prev_max, alias_cur_max);
+                        pack_reconfig_data_format(cb_exp_max_diff);
                         sub_exp_block(alias_prev_max, alias_cur_max, cb_exp_max_diff, Sq_chunk_t);
                         cb_pop_front(alias_prev_max, Sq_chunk_t);
 
@@ -222,7 +232,10 @@ void MAIN {
                         add_block_inplace(alias_cur_sum, alias_prev_sum, Sq_chunk_t);
 
                         /* cb_out_accumulate_im *= cb_exp_max_diff */
+                        reconfig_data_format(alias_mm2_prev_out, cb_exp_max_diff);
+                        pack_reconfig_data_format(alias_mm2_prev_out);
                         mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_mm2_prev_out, cb_exp_max_diff);
+                        reconfig_data_format(alias_mm2_cur_out, alias_mm2_prev_out);
                         add_block_inplace(alias_mm2_cur_out, alias_mm2_prev_out, out_chunk_tiles);
                     }
 
@@ -233,11 +246,16 @@ void MAIN {
                 }
 
                 /* cb_cur_sum = 1.0 / cb_cur_sum */
+                reconfig_data_format(alias_prev_sum, alias_prev_sum);
+                pack_reconfig_data_format(alias_prev_sum);
                 recip_block_inplace(alias_prev_sum, Sq_chunk_t);
 
                 /* cb_out_accumulate_im *= cb_cur_sum */
                 // NOTE: PCC bug if we modify below function to directy output to cb_out.
+                reconfig_data_format(alias_mm2_prev_out, alias_prev_sum);
+                pack_reconfig_data_format(alias_mm2_prev_out);
                 mul_block_bcast_cols_inplace<Sq_chunk_t, DHt>(alias_mm2_prev_out, alias_prev_sum);
+                reconfig_data_format(alias_mm2_prev_out, alias_mm2_prev_out);
                 pack_reconfig_data_format(cb_out);
                 copy_block(alias_mm2_prev_out, cb_out, out_chunk_tiles);
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_op.cpp
@@ -26,8 +26,8 @@ void ScaledDotProductAttention::validate(
         TT_FATAL(input_tensor.buffer() != nullptr, "Operands to SDPA need to be allocated in buffers on device");
         TT_FATAL((input_tensor.get_layout() == Layout::TILE), "Inputs to SDPA must be tilized");
         TT_FATAL(
-            input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::BFLOAT8_B ||
-                input_tensor.get_dtype() == DataType::BFLOAT4_B,
+            input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16 ||
+                input_tensor.get_dtype() == DataType::BFLOAT8_B || input_tensor.get_dtype() == DataType::BFLOAT4_B,
             "Data type of input tensor must be BFLOAT16, BFLOAT8_B, or BFLOAT4_B and is {}",
             input_tensor.get_dtype());
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -439,16 +439,20 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                                  ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().get_dtype())
                                  : tt::DataFormat::Bfp4_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
+    // tt::DataFormat out_df = tt::DataFormat::Float16_b;
+    tt::DataFormat identity_df = tt::DataFormat::Float16_b;
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
-    tt::DataFormat im_df = tt::DataFormat::Float16_b;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
-                                                       // tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    tt::DataFormat stats_df = im_df;
+    // TODO (cjg): add option to program factory for im df
+    tt::DataFormat im_df = tt::DataFormat::Float32;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
+                                                     // tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+    tt::DataFormat stats_df = tt::DataFormat::Float16_b;
 
     uint32_t q_tile_size = tt::tt_metal::detail::TileSize(q_df);
     uint32_t k_tile_size = tt::tt_metal::detail::TileSize(k_df);
     uint32_t v_tile_size = tt::tt_metal::detail::TileSize(v_df);
     uint32_t mask_tile_size = tt::tt_metal::detail::TileSize(mask_df);
     uint32_t out_tile_size = tt::tt_metal::detail::TileSize(out_df);
+    uint32_t identity_tile_size = tt::tt_metal::detail::TileSize(identity_df);
     uint32_t scalar_tile_size = tt::tt_metal::detail::TileSize(scalar_df);
     uint32_t im_tile_size = tt::tt_metal::detail::TileSize(im_df);
     uint32_t stats_tile_size = tt::tt_metal::detail::TileSize(stats_df);
@@ -490,8 +494,8 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     auto cb_in4_id = CreateCircularBuffer(program, core_grid, c_in4_config);
 
     // identity scale input
-    auto c_in5_config = CircularBufferConfig(scale_tiles * scalar_tile_size, {{tt::CBIndex::c_5, scalar_df}})
-                            .set_page_size(tt::CBIndex::c_5, scalar_tile_size);
+    auto c_in5_config = CircularBufferConfig(scale_tiles * identity_tile_size, {{tt::CBIndex::c_5, identity_df}})
+                            .set_page_size(tt::CBIndex::c_5, identity_tile_size);
     auto cb_in5_id = CreateCircularBuffer(program, core_grid, c_in5_config);
 
     if (is_chunked) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -442,9 +442,9 @@ operation::ProgramWithCallbacks sdpa_multi_core(
     // tt::DataFormat out_df = tt::DataFormat::Float16_b;
     tt::DataFormat identity_df = tt::DataFormat::Float16_b;
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
-    // TODO (cjg): add option to program factory for im df
-    tt::DataFormat im_df = tt::DataFormat::Float32;  // need to disable fp32 cbs (Issue #13364) fp32_dest_acc_en ?
-                                                     // tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+
+    tt::DataFormat im_df =
+        program_config->fp32_matmul_intermediates ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     tt::DataFormat stats_df = tt::DataFormat::Float16_b;
 
     uint32_t q_tile_size = tt::tt_metal::detail::TileSize(q_df);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -439,7 +439,7 @@ operation::ProgramWithCallbacks sdpa_multi_core(
                                  ? tt::tt_metal::datatype_to_dataformat_converter(attn_mask.value().get_dtype())
                                  : tt::DataFormat::Bfp4_b;
     tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output_tensor.get_dtype());
-    // tt::DataFormat out_df = tt::DataFormat::Float16_b;
+
     tt::DataFormat identity_df = tt::DataFormat::Float16_b;
     tt::DataFormat scalar_df = tt::DataFormat::Float16_b;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
@@ -15,6 +15,7 @@ struct SDPAProgramConfig {
     std::size_t q_chunk_size;
     std::size_t k_chunk_size;
     std::optional<bool> exp_approx_mode;
+    bool fp32_matmul_intermediates = false;
     uint32_t max_cores_per_head_batch = 16;
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_pybind.cpp
@@ -21,18 +21,20 @@ namespace py = pybind11;
 void py_module(py::module& module) {
     py::class_<SDPAProgramConfig>(module, "SDPAProgramConfig")
         .def(
-            py::init<CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>>(),
+            py::init<CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>, bool>(),
             py::kw_only(),
             py::arg("compute_with_storage_grid_size"),
             py::arg("sub_core_grids") = std::nullopt,
             py::arg("q_chunk_size").noconvert(),
             py::arg("k_chunk_size").noconvert(),
-            py::arg("exp_approx_mode") = std::nullopt)
+            py::arg("exp_approx_mode") = std::nullopt,
+            py::arg("fp32_matmul_intermediates").noconvert())
         .def_readwrite("compute_with_storage_grid_size", &SDPAProgramConfig::compute_with_storage_grid_size)
         .def_readwrite("sub_core_grids", &SDPAProgramConfig::sub_core_grids)
         .def_readwrite("q_chunk_size", &SDPAProgramConfig::q_chunk_size)
         .def_readwrite("k_chunk_size", &SDPAProgramConfig::k_chunk_size)
-        .def_readwrite("exp_approx_mode", &SDPAProgramConfig::exp_approx_mode);
+        .def_readwrite("exp_approx_mode", &SDPAProgramConfig::exp_approx_mode)
+        .def_readwrite("fp32_matmul_intermediates", &SDPAProgramConfig::fp32_matmul_intermediates);
 
     py_bind_attention_softmax(module);
     py_bind_concatenate_heads(module);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21199

### Problem description
Qwen SDPA tests had low (.968) PCC with bf16 inputs and bf16 matmul intermediates.

### What's changed
This PR enables fp32 inputs (Q input must be fp32 in Qwen tests for correctess) and allows the user to select fp32 CB dataformat for matmul intermediates (also required for Qwen).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes