### PR TITLE
#20979: Update and cleanup ttnn.add uint16 ckernels

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_uint16.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_uint16.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
+#include "ckernel_addrmod.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
@@ -19,14 +16,14 @@ inline void add_uint16(const uint dst_offset) {
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
         // operand A - uint16
-        TTI_SFPLOAD(p_sfpu::LREG0, 6, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_7, 0);
         // operand B - uint16
-        TT_SFPLOAD(p_sfpu::LREG1, 6, ADDR_MOD_7, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG1, LO16, ADDR_MOD_7, dst_offset * dst_tile_size);
 
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
-        TTI_SFPSTORE(p_sfpu::LREG0, 6, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, LO16, ADDR_MOD_7, 0);
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_uint16.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_add_uint16.h
@@ -4,11 +4,8 @@
 
 #pragma once
 
-#include "ckernel.h"
-#include "ckernel_defs.h"
+#include "ckernel_addrmod.h"
 #include "sfpi.h"
-
-using namespace sfpi;
 
 namespace ckernel {
 namespace sfpu {
@@ -19,14 +16,14 @@ inline void add_uint16(const uint dst_offset) {
     for (int d = 0; d < ITERATIONS; d++) {
         constexpr uint dst_tile_size = 64;
         // operand A - uint16
-        TTI_SFPLOAD(p_sfpu::LREG0, 6, ADDR_MOD_3, 0);
+        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_3, 0);
         // operand B - uint16
-        TT_SFPLOAD(p_sfpu::LREG1, 6, ADDR_MOD_3, dst_offset * dst_tile_size);
+        TT_SFPLOAD(p_sfpu::LREG1, LO16, ADDR_MOD_3, dst_offset * dst_tile_size);
 
         TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, 4);
-        TTI_SFPSTORE(p_sfpu::LREG0, 6, ADDR_MOD_3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, LO16, ADDR_MOD_3, 0);
 
-        dst_reg++;
+        sfpi::dst_reg++;
     }
 }
 


### PR DESCRIPTION
### Problem description
With respect to the [comment](https://github.com/tenstorrent/tt-metal/pull/21356#discussion_r2066110178), remove `using namespace sfpi;`. Also use load/store instr mode names instead of numbers.

### What's changed

- Remove `using namespace sfpi;`
- Update load/store instr mode from `6` to `LO16`
- Cleanup includes

### Checklist
- [x] BH Test passes
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14735195483) - PASSED
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14735211754) - same as main