### PR TITLE
Send linked multicast before multicasting go

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -632,6 +632,10 @@ int main(int argc, char** argv) {
             {"NUM_WORKER_CORES_TO_MCAST", "0"},
             {"IS_D_VARIANT", "1"},
             {"IS_H_VARIANT", "1"},
+            {"DISPATCH_SHARED_REGION",
+             std::to_string(MetalContext::instance()
+                                .dispatch_mem_map(CoreType::WORKER)
+                                .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_SHARED_REGION))},
         };
 
         std::vector<uint32_t> spoof_prefetch_compile_args = {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2245,6 +2245,10 @@ void configure_for_single_chip(
         {"FABRIC_2D", "0"},
         {"WORKER_MCAST_GRID", "0"},
         {"NUM_WORKER_CORES_TO_MCAST", "0"},
+        {"DISPATCH_SHARED_REGION",
+         std::to_string(MetalContext::instance()
+                            .dispatch_mem_map(CoreType::WORKER)
+                            .get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_SHARED_REGION))},
     };
 
     CoreCoord phys_upstream_from_dispatch_core = split_prefetcher_g ? phys_prefetch_d_core : phys_prefetch_core_g;

--- a/tt_metal/hw/inc/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/blackhole/dev_mem_map.h
@@ -69,6 +69,8 @@
 
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_NOC_ATOMIC_RET_VAL_ADDR 4
+// An address that can be written to with no consequences.
+#define MEM_DISPATCH_NOOP 8
 #define MEM_L1_BARRIER 12
 
 // Used by ARC FW and LLKs to store power throttling state

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -73,6 +73,7 @@
 
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_NOC_ATOMIC_RET_VAL_ADDR 4
+#define MEM_DISPATCH_NOOP 8
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small

--- a/tt_metal/hw/inc/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/wormhole/dev_mem_map.h
@@ -73,6 +73,7 @@
 
 #define MEM_BOOT_CODE_BASE 0
 #define MEM_NOC_ATOMIC_RET_VAL_ADDR 4
+// An address that can be written to with no consequences.
 #define MEM_DISPATCH_NOOP 8
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -25,7 +25,9 @@ enum class CommandQueueDeviceAddrType : uint8_t {
     DISPATCH_S_SYNC_SEM = 6,
     FABRIC_HEADER_RB = 7,
     FABRIC_SYNC_STATUS = 8,
-    UNRESERVED = 9,
+    // Region shared between dispatch_s and dispatch_d if they're on the same core.
+    DISPATCH_SHARED_REGION = 9,
+    UNRESERVED = 10,
 };
 
 // likely only used in impl

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -190,6 +190,8 @@ void DispatchKernel::GenerateStaticConfigs() {
         static_config_.is_2d_fabric = false;
         static_config_.is_2d_fabric_dynamic = false;
     }
+    static_config_.dispatch_shared_region =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_SHARED_REGION);
 }
 
 void DispatchKernel::GenerateDependentConfigs() {
@@ -407,6 +409,8 @@ void DispatchKernel::CreateKernel() {
         {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual_noc_coords.y)},
         {"DOWNSTREAM_SUBORDINATE_NOC_X", std::to_string(downstream_s_virtual_noc_coords.x)},
         {"DOWNSTREAM_SUBORDINATE_NOC_Y", std::to_string(downstream_s_virtual_noc_coords.y)},
+
+        {"DISPATCH_SHARED_REGION", std::to_string(static_config_.dispatch_shared_region.value())},
 
         // Add all the dispatch-specific defines
         {"DISPATCH_CB_BASE", std::to_string(static_config_.dispatch_cb_base.value())},

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -47,6 +47,7 @@ struct dispatch_static_config_t {
     std::optional<uint32_t> host_completion_q_wr_ptr;  // 26
     std::optional<uint32_t> dev_completion_q_wr_ptr;
     std::optional<uint32_t> dev_completion_q_rd_ptr;
+    std::optional<uint32_t> dispatch_shared_region;
 
     std::optional<uint32_t> fabric_header_rb_base;
     std::optional<uint32_t> fabric_header_rb_entries;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -63,6 +63,9 @@ void DispatchSKernel::GenerateStaticConfigs() {
     static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
     static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
     static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
+
+    static_config_.dispatch_shared_region =
+        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_SHARED_REGION);
 }
 
 void DispatchSKernel::GenerateDependentConfigs() {
@@ -127,6 +130,8 @@ void DispatchSKernel::CreateKernel() {
         {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual_noc_coords.y)},
         {"DOWNSTREAM_SUBORDINATE_NOC_X", std::to_string(downstream_s_virtual_noc_coords.x)},  // Unused, remove later
         {"DOWNSTREAM_SUBORDINATE_NOC_Y", std::to_string(downstream_s_virtual_noc_coords.y)},  // Unused, remove later
+
+        {"DISPATCH_SHARED_REGION", std::to_string(static_config_.dispatch_shared_region.value())},
         {"CB_BASE", std::to_string(static_config_.cb_base.value())},
         {"CB_LOG_PAGE_SIZE", std::to_string(static_config_.cb_log_page_size.value())},
         {"CB_SIZE", std::to_string(static_config_.cb_size.value())},

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -25,6 +25,7 @@ struct dispatch_s_static_config_t {
     std::optional<uint32_t> first_stream_used;
     std::optional<uint32_t> max_num_worker_sems;
     std::optional<uint32_t> max_num_go_signal_noc_data_entries;
+    std::optional<uint32_t> dispatch_shared_region;
 };
 
 struct dispatch_s_dependent_config_t {

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -57,6 +57,28 @@ uint32_t wrap_gt(uint32_t a, uint32_t b) {
 
 constexpr bool use_fabric(uint64_t fabric_router_xy) { return fabric_router_xy != 0; }
 
+#if defined(ARCH_WORMHOLE)
+constexpr uint32_t dispatch_lock_index = 0;
+constexpr uint32_t dispatch_s_lock_index = 1;
+// TODO: Use real atomics on blackhole. Making these implementation work there wouldn't be efficient.
+FORCE_INLINE void lock_no_atomic(volatile tt_l1_ptr uint32_t* addr, uint32_t i) {
+    auto byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(addr);
+    // Peterson's lock implementation.
+    uint32_t j = 1 - i;
+    byte_ptr[i] = 1;
+    auto turn = byte_ptr + 2;
+    *turn = j;  // Let the other one go first.
+    while (byte_ptr[j] && *turn == j) {
+        // Wait until it's my turn or the other one isn't trying to lock.
+    }
+}
+
+FORCE_INLINE void unlock_no_atomic(volatile tt_l1_ptr uint32_t* addr, uint32_t i) {
+    auto byte_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(addr);
+    byte_ptr[i] = 0;
+}
+#endif
+
 template <
     enum CQNocFlags flags,
     enum CQNocWait wait = CQ_NOC_WAIT,
@@ -334,10 +356,22 @@ FORCE_INLINE void move_rd_to_next_block(uint32_t& rd_block_idx) {
     rd_block_idx &= cb_blocks - 1;
 }
 
-template <uint8_t noc_idx, uint32_t noc_xy, uint32_t sem_id, uint32_t cb_pages_per_block, uint32_t cb_blocks>
+template <
+    uint8_t noc_idx,
+    uint32_t noc_xy,
+    uint32_t sem_id,
+    uint32_t cb_pages_per_block,
+    uint32_t cb_blocks,
+    typename LockCallbackType = void>
 FORCE_INLINE void move_rd_to_next_block_and_release_pages(
     uint32_t& block_noc_writes_to_clear, uint32_t& rd_block_idx, uint8_t noc = noc_index) {
+    if constexpr (!std::is_void_v<LockCallbackType>) {
+        LockCallbackType::lock();
+    }
     cb_block_release_pages<noc_idx, noc_xy, sem_id, cb_pages_per_block>(block_noc_writes_to_clear, noc);
+    if constexpr (!std::is_void_v<LockCallbackType>) {
+        LockCallbackType::unlock();
+    }
     move_rd_to_next_block<cb_blocks>(rd_block_idx);
 }
 
@@ -347,11 +381,18 @@ template <
     uint32_t sem_id,
     uint32_t cb_pages_per_block,
     uint32_t cb_blocks,
+    typename LockCallbackType = void,
     typename T>
 FORCE_INLINE void move_rd_to_next_block_and_release_pages_remote(
     T& relay_client, uint32_t& block_noc_writes_to_clear, uint32_t& rd_block_idx, uint8_t noc = noc_index) {
+    if constexpr (!std::is_void_v<LockCallbackType>) {
+        LockCallbackType::lock();
+    }
     cb_block_release_pages_remote<noc_idx, noc_xy, sem_id, cb_pages_per_block>(
         relay_client, block_noc_writes_to_clear, noc);
+    if constexpr (!std::is_void_v<LockCallbackType>) {
+        LockCallbackType::unlock();
+    }
     move_rd_to_next_block<cb_blocks>(rd_block_idx);
 }
 
@@ -363,7 +404,8 @@ template <
     uint8_t upstream_noc_idx,
     uint32_t upstream_noc_xy,
     uint32_t upstream_cb_sem,
-    uint32_t cb_pages_per_block>
+    uint32_t cb_pages_per_block,
+    typename LockCallbackType = void>
 FORCE_INLINE uint32_t get_cb_page_and_release_pages(
     uint32_t& cmd_ptr,
     uint32_t& cb_fence,
@@ -383,7 +425,8 @@ FORCE_INLINE uint32_t get_cb_page_and_release_pages(
             upstream_noc_xy,
             upstream_cb_sem,
             cb_pages_per_block,
-            cb_blocks>(block_noc_writes_to_clear, rd_block_idx, noc);
+            cb_blocks,
+            LockCallbackType>(block_noc_writes_to_clear, rd_block_idx, noc);
     }
 
     // Wait for dispatcher to supply a page
@@ -403,6 +446,7 @@ template <
     uint32_t upstream_noc_xy,
     uint32_t upstream_cb_sem,
     uint32_t cb_pages_per_block,
+    typename LockCallbackType = void,
     typename T>
 FORCE_INLINE uint32_t get_cb_page_and_release_pages_remote(
     T& relay_client,
@@ -424,7 +468,8 @@ FORCE_INLINE uint32_t get_cb_page_and_release_pages_remote(
             upstream_noc_xy,
             upstream_cb_sem,
             cb_pages_per_block,
-            cb_blocks>(relay_client, block_noc_writes_to_clear, rd_block_idx, noc);
+            cb_blocks,
+            LockCallbackType>(relay_client, block_noc_writes_to_clear, rd_block_idx, noc);
     }
 
     // Wait for dispatcher to supply a page

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -287,7 +287,7 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
                             upstream_dispatch_cb_sem_id,
                             dispatch_cb_pages_per_block,
                             dispatch_cb_blocks,
-                        LockUpstreamNocAtomicCallback>(block_noc_writes_to_clear, rd_block_idx);
+                            LockUpstreamNocAtomicCallback>(block_noc_writes_to_clear, rd_block_idx);
                     } else {
                         move_rd_to_next_block_and_release_pages_remote<
                             upstream_noc_index,
@@ -295,7 +295,7 @@ void process_write_host_h(uint32_t& block_noc_writes_to_clear, uint32_t block_ne
                             upstream_dispatch_cb_sem_id,
                             dispatch_cb_pages_per_block,
                             dispatch_cb_blocks,
-                        LockUpstreamNocAtomicCallback>(relay_client, block_noc_writes_to_clear, rd_block_idx);
+                            LockUpstreamNocAtomicCallback>(relay_client, block_noc_writes_to_clear, rd_block_idx);
                     }
                 }
                 // Wait for dispatcher to supply a page (this won't go beyond the buffer end)
@@ -442,7 +442,7 @@ void relay_to_next_cb(
                         upstream_dispatch_cb_sem_id,
                         dispatch_cb_pages_per_block,
                         dispatch_cb_blocks,
-                    LockUpstreamNocAtomicCallback>(block_noc_writes_to_clear, rd_block_idx);
+                        LockUpstreamNocAtomicCallback>(block_noc_writes_to_clear, rd_block_idx);
                 }
 
                 // Wait for dispatcher to supply a page (this won't go beyond the buffer end)

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -15,6 +15,7 @@
 #include "debug/dprint.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_common.hpp"
+#include "debug/ring_buffer.h"
 
 // dispatch_s has a customized command buffer allocation for NOC 1.
 // Cmd Buf 0 is used for regular writes.
@@ -44,6 +45,8 @@ constexpr uint32_t num_physical_unicast_cores = NUM_PHYSICAL_UNICAST_CORES;
 constexpr uint32_t worker_mcast_grid = WORKER_MCAST_GRID;
 constexpr uint32_t num_worker_cores_to_mcast = NUM_WORKER_CORES_TO_MCAST;
 
+constexpr uint32_t dispatch_shared_region = DISPATCH_SHARED_REGION;
+
 constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
 constexpr uint32_t dispatch_d_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
@@ -63,6 +66,8 @@ static uint32_t worker_count_update_for_dispatch_d[max_num_worker_sems] = {0};
 static uint32_t go_signal_noc_data[max_num_go_signal_noc_data_entries];
 
 static uint32_t num_worker_sems = 1;
+
+static volatile tt_l1_ptr uint32_t* const noc_atomic_ptr = (volatile tt_l1_ptr uint32_t*)(dispatch_shared_region);
 
 FORCE_INLINE
 void dispatch_s_wr_reg_cmd_buf_init() {
@@ -223,10 +228,40 @@ void process_go_signal_mcast_cmd() {
     uint32_t wait_stream = cmd->mcast.wait_stream;
 
     if (multicast_go_offset != CQ_DISPATCH_CMD_GO_NO_MULTICAST_OFFSET) {
+        uint32_t dst_noc = worker_mcast_grid;
+        uint32_t num_dests = num_worker_cores_to_mcast;
+        // lock_no_atomic is only supported on wormhole. TODO: use real atomics and support this on blackhole.
+#if defined(ARCH_WORMHOLE)
+        volatile uint32_t* worker_sem =
+            (volatile uint32_t*)STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
+        // Check if we're currently waiting for workers.  Also if we're on the same core as cq_dispatch.cpp, check if
+        // the next kernel (after this) is already ready to go, as the lock around cmdbuf 3 can slow down dispatching
+        // future kernels.
+        if (stream_wrap_gt(wait_count, *worker_sem) &&
+            (distributed_dispatcher || !wrap_ge(mcasts_sent, *sync_sem_addr))) {
+            // We're currently waiting for workers. Send a linked multicast to the first group of workers so the first
+            // multicast once the workers are ready doesn't need to do a path reservation. Normally keeping a path
+            // reservation open arbitrarily long could cause deadlocks or poor performance, but this code is the only
+            // user of NOC_DISPATCH_MULTICAST_WRITE_VC on this NOC (NOC 1).
+            uint64_t fake_noc_addr_multicast = get_noc_addr_helper(dst_noc, MEM_DISPATCH_NOOP);
+            constexpr bool linked = true;
+            cq_noc_async_write_init_state<CQ_NOC_SNDL, true, linked>(
+                ((uint32_t)aligned_go_signal_storage) + MEM_DISPATCH_NOOP, fake_noc_addr_multicast, sizeof(uint32_t));
+
+            if constexpr (!distributed_dispatcher) {
+                // Prevent dispatch_d from submitting commands to cmdbuf 3 while we have a path reservation, as a
+                // hardware issue would cause both those commands and the later multicast to hang.
+                lock_no_atomic(noc_atomic_ptr, dispatch_s_lock_index);
+            }
+            cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
+            noc_nonposted_writes_acked[noc_index] += num_dests;
+            noc_nonposted_writes_num_issued[noc_index]++;
+        }
+#endif
+
         // Setup registers before waiting for workers so only the NOC_CMD_CTRL register needs to be touched after.
         uint64_t dst_noc_addr_multicast =
             get_noc_addr_helper(worker_mcast_grid, mcast_go_signal_addr + sizeof(uint32_t) * multicast_go_offset);
-        uint32_t num_dests = num_worker_cores_to_mcast;
         // Ensure the offset with respect to L1_ALIGNMENT is the same for the source and destination.
         uint32_t storage_offset = multicast_go_offset % (L1_ALIGNMENT / sizeof(uint32_t));
         aligned_go_signal_storage[storage_offset] = go_signal_value;
@@ -239,6 +274,13 @@ void process_go_signal_mcast_cmd() {
         wait_for_workers(wait_count, wait_stream);
         cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);
         noc_nonposted_writes_num_issued[noc_index] += 1;
+
+        if constexpr (!distributed_dispatcher) {
+#if defined(ARCH_WORMHOLE)
+            // This is safe to do even if the lock wasn't taken.
+            unlock_no_atomic(noc_atomic_ptr, dispatch_s_lock_index);
+#endif
+        }
     } else {
         wait_for_workers(wait_count, wait_stream);
     }

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -235,8 +235,8 @@ void process_go_signal_mcast_cmd() {
         volatile uint32_t* worker_sem =
             (volatile uint32_t*)STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
         // Check if we're currently waiting for workers.  Also if we're on the same core as cq_dispatch.cpp, check if
-        // the next kernel (after this) is already ready to go, as the lock around NCRISC_AT_CMD_BUF can slow down dispatching
-        // future kernels.
+        // the next kernel (after this) is already ready to go, as the lock around NCRISC_AT_CMD_BUF can slow down
+        // dispatching future kernels.
         if (stream_wrap_gt(wait_count, *worker_sem) &&
             (distributed_dispatcher || !wrap_ge(mcasts_sent, *sync_sem_addr))) {
             // We're currently waiting for workers. Send a linked multicast to the workers so the first multicast once
@@ -249,8 +249,8 @@ void process_go_signal_mcast_cmd() {
                 ((uint32_t)aligned_go_signal_storage) + MEM_DISPATCH_NOOP, fake_noc_addr_multicast, sizeof(uint32_t));
 
             if constexpr (!distributed_dispatcher) {
-                // Prevent dispatch_d from submitting commands to NCRISC_AT_CMD_BUF while we have a path reservation, as a
-                // hardware issue would cause both those commands and the later multicast to hang.
+                // Prevent dispatch_d from submitting commands to NCRISC_AT_CMD_BUF while we have a path reservation, as
+                // a hardware issue would cause both those commands and the later multicast to hang.
                 lock_no_atomic(noc_atomic_ptr, dispatch_s_lock_index);
             }
             cq_noc_async_write_with_state<CQ_NOC_sndl, CQ_NOC_wait>(0, 0, 0);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -239,10 +239,10 @@ void process_go_signal_mcast_cmd() {
         // future kernels.
         if (stream_wrap_gt(wait_count, *worker_sem) &&
             (distributed_dispatcher || !wrap_ge(mcasts_sent, *sync_sem_addr))) {
-            // We're currently waiting for workers. Send a linked multicast to the first group of workers so the first
-            // multicast once the workers are ready doesn't need to do a path reservation. Normally keeping a path
-            // reservation open arbitrarily long could cause deadlocks or poor performance, but this code is the only
-            // user of NOC_DISPATCH_MULTICAST_WRITE_VC on this NOC (NOC 1).
+            // We're currently waiting for workers. Send a linked multicast to the workers so the first multicast once
+            // the workers are ready doesn't need to do a path reservation. Normally keeping a path reservation open
+            // arbitrarily long could cause deadlocks or poor performance, but this code is the only user of
+            // NOC_DISPATCH_MULTICAST_WRITE_VC on this NOC (NOC 1).
             uint64_t fake_noc_addr_multicast = get_noc_addr_helper(dst_noc, MEM_DISPATCH_NOOP);
             constexpr bool linked = true;
             cq_noc_async_write_init_state<CQ_NOC_SNDL, true, linked>(

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -235,7 +235,7 @@ void process_go_signal_mcast_cmd() {
         volatile uint32_t* worker_sem =
             (volatile uint32_t*)STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
         // Check if we're currently waiting for workers.  Also if we're on the same core as cq_dispatch.cpp, check if
-        // the next kernel (after this) is already ready to go, as the lock around cmdbuf 3 can slow down dispatching
+        // the next kernel (after this) is already ready to go, as the lock around NCRISC_AT_CMD_BUF can slow down dispatching
         // future kernels.
         if (stream_wrap_gt(wait_count, *worker_sem) &&
             (distributed_dispatcher || !wrap_ge(mcasts_sent, *sync_sem_addr))) {
@@ -249,7 +249,7 @@ void process_go_signal_mcast_cmd() {
                 ((uint32_t)aligned_go_signal_storage) + MEM_DISPATCH_NOOP, fake_noc_addr_multicast, sizeof(uint32_t));
 
             if constexpr (!distributed_dispatcher) {
-                // Prevent dispatch_d from submitting commands to cmdbuf 3 while we have a path reservation, as a
+                // Prevent dispatch_d from submitting commands to NCRISC_AT_CMD_BUF while we have a path reservation, as a
                 // hardware issue would cause both those commands and the later multicast to hang.
                 lock_no_atomic(noc_atomic_ptr, dispatch_s_lock_index);
             }


### PR DESCRIPTION
### Problem description
Currently we have a large delay between done of one kernel and go of the next, partly because GO is a multicast and needs a path reservation.

### What's changed
If we send a linked multicast transaction to the same NOC address before the go, the go can reuse its path reservation and not need to do its own multicast.

Because of a hardware bug, NOC 1 can't have any other transactions started on it while a path reservation exists. We use cmdbuf 3 of NOC 1 to do upstream atomics from the dispatcher, so we need a lock to prevent the dispatcher from creating atomics in that critical section. To reduce the impact of that lock, we should only create this linked transaction if the next kernel is already ready to launch, as that shows there's plenty of margin even if the dispatcher is slowed down.

This change improves the op-to-op latency of a lot of llama operations by 200ns.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes