### PR TITLE
#19177: Separate TensorAttributes in its own header

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -218,6 +218,7 @@ set(TTNN_BASE_SRCS
 )
 
 set(TENSOR_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/tensor_attributes.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/tensor_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/tensor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/tensor/tensor_ops.cpp

--- a/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
@@ -37,7 +37,8 @@ void filter_tensor_shards(
     const std::vector<ttnn::MeshCoordinate>& tensor_coordinates, TensorReturnValue& tensor_return_value) {
     tt::stl::reflection::visit_object_of_type<Tensor>(
         [&](const Tensor& tensor_to_return) {
-            auto& tensor_storage = std::get<tt::tt_metal::DeviceStorage>(tensor_to_return.tensor_attributes->storage);
+            auto& tensor_storage =
+                std::get<tt::tt_metal::DeviceStorage>(tensor_to_return.tensor_attributes->get_storage());
 
             auto coord_it = tensor_coordinates.cbegin();
             auto storage_it = tensor_storage.specs.begin();

--- a/ttnn/cpp/ttnn/run_operation.cpp
+++ b/ttnn/cpp/ttnn/run_operation.cpp
@@ -25,13 +25,13 @@ namespace detail {
 
 IDevice* get_device(const Tensors& input_tensors, const OptionalConstTensors& optional_input_tensors) {
     for (auto& input_tensor : input_tensors) {
-        if (std::holds_alternative<DeviceStorage>(input_tensor.tensor_attributes->storage)) {
+        if (std::holds_alternative<DeviceStorage>(input_tensor.tensor_attributes->get_storage())) {
             return input_tensor.workers.at(0);
         }
     }
     for (auto& optional_input_tensor : optional_input_tensors) {
         if (optional_input_tensor.has_value() and
-            std::holds_alternative<DeviceStorage>(optional_input_tensor.value().tensor_attributes->storage)) {
+            std::holds_alternative<DeviceStorage>(optional_input_tensor.value().tensor_attributes->get_storage())) {
             return optional_input_tensor.value().workers.at(0);
         }
     }

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -11,7 +11,8 @@
 
 #include <flatbuffers/flatbuffers.h>
 
-#include "tt_stl/overloaded.hpp"
+#include <tt_stl/overloaded.hpp>
+
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -11,6 +11,7 @@
 
 #include <flatbuffers/flatbuffers.h>
 
+#include "tt_stl/overloaded.hpp"
 #include "ttnn/tensor/host_buffer/functions.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
@@ -454,18 +455,17 @@ void dump_tensor(
     }
 
     std::visit(
-        [output_file, &strategy, dtype = tensor.get_dtype()](const auto& storage) {
-            using StorageType = std::decay_t<decltype(storage)>;
-            if constexpr (std::is_same_v<StorageType, HostStorage>) {
+        tt::stl::overloaded{
+            [output_file, dtype = tensor.get_dtype()](const HostStorage& storage) {
                 dump_host_storage(output_file, storage, dtype);
-            } else if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
+            },
+            [output_file, dtype = tensor.get_dtype()](const DeviceStorage& storage) {
                 TT_THROW("Device storage isn't supported");
-            } else if constexpr (std::is_same_v<StorageType, MultiDeviceHostStorage>) {
+            },
+            [output_file, &strategy, dtype = tensor.get_dtype()](const MultiDeviceHostStorage& storage) {
                 auto distribute_config = get_distributed_tensor_config(strategy);
                 dump_multi_device_host_storage(output_file, storage, distribute_config, dtype);
-            } else {
-                raise_unsupported_storage<StorageType>();
-            }
+            },
         },
         tensor_to_dump.get_storage());
 }

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -148,9 +148,4 @@ struct MultiDeviceHostStorage {
 
 using Storage = std::variant<HostStorage, DeviceStorage, MultiDeviceHostStorage>;
 
-template <typename T>
-constexpr void raise_unsupported_storage() {
-    static_assert(tt::stl::concepts::always_false_v<T>, "Unsupported Storage");
-}
-
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/tensor_attributes.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_attributes.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <utility>
+
+#include "ttnn/tensor/storage.hpp"
+#include "ttnn/tensor/tensor_attributes.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+
+namespace tt::tt_metal {
+
+TensorAttributes::TensorAttributes() :
+    storage_(Storage(HostStorage())),
+    tensor_spec_(
+        ttnn::Shape(std::array<uint32_t, 4>{0xff, 0xff, 0xff, 0xff}),
+        TensorLayout(DataType::INVALID, PageConfig(Layout::INVALID), MemoryConfig{})) {}
+
+TensorAttributes::TensorAttributes(Storage storage, TensorSpec tensor_spec) :
+    storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)) {}
+
+const Storage& TensorAttributes::get_storage() const { return storage_; }
+const TensorSpec& TensorAttributes::get_tensor_spec() const { return tensor_spec_; }
+Storage& TensorAttributes::get_storage() { return storage_; }
+TensorSpec& TensorAttributes::get_tensor_spec() { return tensor_spec_; }
+void TensorAttributes::set_storage(const Storage& storage) { storage_ = storage; }
+void TensorAttributes::set_tensor_spec(const TensorSpec& tensor_spec) { tensor_spec_ = tensor_spec; }
+
+}  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_attributes.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "ttnn/tensor/storage.hpp"
+#include "ttnn/tensor/tensor_spec.hpp"
+
+namespace tt::tt_metal {
+
+class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
+public:
+    TensorAttributes(Storage storage, TensorSpec tensor_spec);
+
+    // Creates `TensorAttributes` with default values.
+    // TODO: remove the ability to do this. Tensor attributes should always be well-formed at creation time.
+    TensorAttributes();
+
+    // Getters and setters.
+    const Storage& get_storage() const;
+    const TensorSpec& get_tensor_spec() const;
+    Storage& get_storage();
+    TensorSpec& get_tensor_spec();
+    void set_storage(const Storage& storage);
+    void set_tensor_spec(const TensorSpec& tensor_spec);
+
+private:
+    Storage storage_;
+    TensorSpec tensor_spec_;
+};
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#19177

### Problem description
`TensorAttributes` should be separated for better modularity.

Subsequently, `TensorAttributes` will be responsible for tracking heterogenous tensors (tensors that have different shapes across devices).

### What's changed
Moved `TensorAttributes` in its own lib.

Made it a `class`.

Removed `raise_unsupported_storage` - unrelated minor cleanup.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14738554157)
- [x] New/Existing tests provide coverage for changes