### PR TITLE
Remove _v2 postfix from halo program factory

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -378,7 +378,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize/device/untilize_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize/device/untilize_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize/untilize.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/sliding_window/halo/device/untilize_with_halo_v2_program_factory.hpp"
+#include "ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp"
@@ -146,7 +146,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
         int num_cores_c = conv::get_num_cores_channels_from_parallel_config(this->parallel_config_);
         int stick_size = input_tensor.get_padded_shape()[3] / num_cores_c;
 
-        return {data_movement::detail::inplace_untilize_with_halo_multi_core_v2(
+        return {data_movement::detail::inplace_untilize_with_halo_multi_core(
             program,
             input_tensor,
             pad_val_,
@@ -196,7 +196,7 @@ operation::ProgramWithCallbacks HaloDeviceOperation::create_program(
 
         Program program = CreateProgram();
 
-        return {data_movement::detail::untilize_with_halo_multi_core_v2(
+        return {data_movement::detail::untilize_with_halo_multi_core(
             program,
             input_tensor,
             pad_val_,
@@ -261,18 +261,19 @@ Tensor halo_op(
     }
 
     return operation::run(
-        HaloDeviceOperation{
-            .config_ = config,
-            .parallel_config_ = p_config,
-            .pad_val_ = pad_val,
-            .remote_read_ = remote_read,
-            .transpose_mcast_ = transpose_mcast,
-            .max_out_nsticks_per_core_ = max_out_nsticks_per_core,
-            .in_nsticks_per_core_ = in_nsticks_per_core,
-            .output_memory_config_ = output_memory_config,
-            .is_out_tiled_ = is_out_tiled,
-            .in_place_ = in_place},
-        {input_tensor}).at(0);
+               HaloDeviceOperation{
+                   .config_ = config,
+                   .parallel_config_ = p_config,
+                   .pad_val_ = pad_val,
+                   .remote_read_ = remote_read,
+                   .transpose_mcast_ = transpose_mcast,
+                   .max_out_nsticks_per_core_ = max_out_nsticks_per_core,
+                   .in_nsticks_per_core_ = in_nsticks_per_core,
+                   .output_memory_config_ = output_memory_config,
+                   .is_out_tiled_ = is_out_tiled,
+                   .in_place_ = in_place},
+               {input_tensor})
+        .at(0);
 }
 
 }  // namespace ttnn::operations::sliding_window::halo

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <tuple>
 
-// #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/run_operation.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -2,20 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "untilize_with_halo_v2_program_factory.hpp"
+#include "untilize_with_halo_program_factory.hpp"
 
-#include <math.h>
-
-// #include "lightmetal/lightmetal_capture.hpp"
-#include "ttnn/operations/cb_utils.hpp"
-#include "ttnn/operations/math.hpp"
 #include <cstdint>
 #include <optional>
+#include <cmath>
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
+
+#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/common/constants.hpp"
-#include "ttnn/operation.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -57,7 +55,7 @@ static inline CBHandle create_circular_buffer(
 
 constexpr bool ENABLE_UNTILIZE_DOUBLE_BUFFERING = true;
 
-operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
+operation::ProgramWithCallbacks untilize_with_halo_multi_core(
     Program& program,
     const Tensor& input_tensor,
     const uint32_t pad_val,
@@ -314,7 +312,7 @@ private:
     uint32_t next_cb_id = tt::CBIndex::c_0;
 };
 
-operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core_v2(
+operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     Program& program,
     const Tensor& input_tensor,
     const uint32_t pad_val,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
@@ -8,7 +8,7 @@
 
 namespace ttnn::operations::data_movement::detail {
 
-tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
+tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,
     const uint32_t pad_val,
@@ -23,9 +23,9 @@ tt::tt_metal::operation::ProgramWithCallbacks untilize_with_halo_multi_core_v2(
     Tensor& output_tensor,
     const int block_size,
     const bool capture_buffers);  // Used by halo op to cache internally created config buffers with the program
-                                  // Untilize with Halo V2 op takes them as inputs from the user, so doesn't capture
+                                  // Untilize with Halo takes them as inputs from the user, so doesn't capture
 
-tt::tt_metal::operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core_v2(
+tt::tt_metal::operation::ProgramWithCallbacks inplace_untilize_with_halo_multi_core(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor,
     const uint32_t pad_val,


### PR DESCRIPTION
### Ticket
Remove all references to _v2 in the halo program factory. This is motivated by the fact that there is no V1 in the repository so this is confusing for readers.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14739147325