### PR TITLE
#17536: Add output mem config checks to matmul validate

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2089,7 +2089,7 @@ def test_interleaved_input_sharded_output_matmul(device):
 
     out_mem_config = ttnn.create_sharded_memory_config(
         shape=(32, 256),
-        core_grid=ttnn.CoreGrid(x=1, y=8),
+        core_grid=ttnn.CoreGrid(x=8, y=1),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
     )
@@ -2100,8 +2100,8 @@ def test_interleaved_input_sharded_output_matmul(device):
 
     # Block sharded
     out_mem_config = ttnn.create_sharded_memory_config(
-        shape=(32, 256),
-        core_grid=ttnn.CoreGrid(x=1, y=8),
+        shape=(256, 256),
+        core_grid=ttnn.CoreGrid(x=1, y=1),
         strategy=ttnn.ShardStrategy.BLOCK,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
     )

--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -181,6 +181,13 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
         memory_config=in1_mem_config,
     )
 
+    # output shard config
+    out_shard_shape = (32, 128)
+    out_shard_spec = ttnn.ShardSpec(shard_grid, out_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    out_sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, out_shard_spec
+    )
+
     program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
         in0_block_w=32,
         per_core_M=1,
@@ -199,7 +206,7 @@ def test_ttnn_matmul_dram_sharded(device, m_size, k_size, n_size):
         input_tensor_in0,
         input_tensor_in1,
         program_config=program_config,
-        memory_config=sharded_mem_config,
+        memory_config=out_sharded_mem_config,
         dtype=ttnn.bfloat16,
         compute_kernel_config=compute_kernel_config,
     )

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1474,10 +1474,10 @@ void Matmul::validate(
 
     TT_FATAL(optional_input_tensors.size() == 1, "Error");
 
+    const auto output_tensor_spec = this->compute_output_specs(input_tensors, {}, optional_input_tensors).at(0);
     if (is_optional_output_tensor) {
         const auto& optional_output_tensor_c = optional_output_tensors.at(0);
         const auto& optional_output_tensor_shape = optional_output_tensor_c->get_logical_shape();
-        const auto output_tensor_spec = this->compute_output_specs(input_tensors, {}, optional_input_tensors).at(0);
         TT_FATAL(
             optional_output_tensor_shape == output_tensor_spec.logical_shape(),
             "Shape of Optional Output Tensor {} doesnt match Output Tensor {}",
@@ -1494,6 +1494,25 @@ void Matmul::validate(
             "tensor {}",
             optional_output_tensor_c->memory_config(),
             this->output_mem_config);
+    } else {
+        TT_FATAL(
+            output_tensor_spec.memory_config().memory_layout == this->output_mem_config.memory_layout,
+            "Mismatch between computed {} and provided {} mem config memory layout",
+            output_tensor_spec.memory_config().memory_layout,
+            this->output_mem_config.memory_layout);
+        TT_FATAL(
+            output_tensor_spec.memory_config().buffer_type == this->output_mem_config.buffer_type,
+            "Mismatch between computed {} and provided {} mem config buffer type",
+            output_tensor_spec.memory_config().buffer_type,
+            this->output_mem_config.buffer_type);
+        if (this->output_mem_config.shard_spec.has_value() &&
+            output_tensor_spec.memory_config() != this->output_mem_config) {
+            log_warning(
+                tt::LogOp,
+                "Mismatch between computed {} and provided {} mem config. Using computed config.",
+                output_tensor_spec.memory_config(),
+                this->output_mem_config);
+        }
     }
 
     TT_FATAL(this->bcast_batch.has_value(), "Error: bcast_batch field should have been automatically populated");


### PR DESCRIPTION
### Ticket
Link to Github Issue #17536

### Problem description
- upstream users need to know whether output memory configs are valid or not

### What's changed
- add checks for output memory config
- fix a couple of tests

This is based on PR https://github.com/tenstorrent/tt-metal/pull/18721 except that an alternative approach has been found that allows a warning to be printed instead of a fatal, and all models tests could not be fixed in terms of shard configs. Therefore a fatal does not occur if the shard config is specified, and a warning is printed instead.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14741045692
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) N/A
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) same failures as in main https://github.com/tenstorrent/tt-metal/actions/runs/14741048787
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) same failures as in main https://github.com/tenstorrent/tt-metal/actions/runs/14741050906
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes