### PR TITLE
Re-add lower level eth tests so we can see if it passes now on latest main on 6U WH

### DIFF
--- a/tests/scripts/wh_6u/run_wh_6u_upstream_profiler_tests.sh
+++ b/tests/scripts/wh_6u/run_wh_6u_upstream_profiler_tests.sh
@@ -6,6 +6,5 @@ echo "[upstream-profiler-tests] Running sanity fabric tests"
 
 echo "[upstream-profiler-tests] Running Ethernet API tests"
 eth_api_iterations=5
-# shit still broke on main
-# ARCH_NAME=wormhole_b0 pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py::test_erisc_latency_uni_dir --num-iterations $eth_api_iterations
-# ARCH_NAME=wormhole_b0 pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py::test_erisc_bw_uni_dir --num-iterations $eth_api_iterations
+ARCH_NAME=wormhole_b0 pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py::test_erisc_latency_uni_dir --num-iterations $eth_api_iterations
+ARCH_NAME=wormhole_b0 pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py::test_erisc_bw_uni_dir --num-iterations $eth_api_iterations


### PR DESCRIPTION
… 

### Ticket

#21067 

### Problem description

Lower-level eth tests were broken while Queen Bhullar was gone.

### What's changed

Should be fixed now !!!

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes