### PR TITLE
Skip tt-smi reset on any galaxy system

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,11 @@ from loguru import logger
 from tests.scripts.common import run_process_and_get_result
 from tests.scripts.common import get_updated_device_params
 
+# Constants for device configurations
+GALAXY_NUM_DEVICES = 32
+TG_NUM_PCIE_DEVICES = 4
+SIX_U_NUM_PCIE_DEVICES = 32
+
 
 @pytest.fixture(scope="function")
 def reset_seeds():
@@ -69,30 +74,23 @@ def is_galaxy():
 
     num_devices = ttnn.GetNumAvailableDevices()
     # Galaxy systems have 32 devices
-    return num_devices == 32
+    return num_devices == GALAXY_NUM_DEVICES
 
 
 # TODO: Remove this when TG clusters are deprecated.
 def is_6u():
     import ttnn
 
-    num_pcie = ttnn.GetNumPCIeDevices()
-    num_devices = ttnn.GetNumAvailableDevices()
-    NUM_PCIE_DEVICES = 32
-    NUM_DEVICES = 32
-    return num_pcie == NUM_PCIE_DEVICES and num_devices == NUM_DEVICES
+    # 6U has 32 PCIe devices
+    return is_galaxy() and ttnn.GetNumPCIeDevices() == SIX_U_NUM_PCIE_DEVICES
 
 
 # TODO: Remove this when TG clusters are deprecated.
 def is_tg_cluster():
     import ttnn
 
-    num_pcie = ttnn.GetNumPCIeDevices()
-    num_devices = ttnn.GetNumAvailableDevices()
-    # TG has 32 available chips and 4 PCIe mapped chips (not exposed to the user)
-    TG_NUM_PCIE_DEVICES = 4
-    TG_NUM_DEVICES = 32
-    return num_pcie == TG_NUM_PCIE_DEVICES and num_devices == TG_NUM_DEVICES
+    # TG has 4 PCIe devices
+    return is_galaxy() and ttnn.GetNumPCIeDevices() == TG_NUM_PCIE_DEVICES
 
 
 def first_available_tg_device():

--- a/conftest.py
+++ b/conftest.py
@@ -64,6 +64,14 @@ def galaxy_type():
         return None
 
 
+def is_galaxy():
+    import ttnn
+
+    num_devices = ttnn.GetNumAvailableDevices()
+    # Galaxy systems have 32 devices
+    return num_devices == 32
+
+
 # TODO: Remove this when TG clusters are deprecated.
 def is_6u():
     import ttnn
@@ -697,6 +705,10 @@ def pytest_handlecrashitem(crashitem, report, sched):
 
 def reset_tensix(tt_open_devices=None):
     import shutil
+
+    if is_galaxy():
+        logger.info("Skipping reset for Galaxy systems, need a new reset.json scheme")
+        return
 
     # Check if tt-smi exists
     if not shutil.which("tt-smi"):


### PR DESCRIPTION
### Ticket
Maybe helps https://github.com/tenstorrent/tt-metal/issues/21237
@skhorasganiTT @roseli-TT @ttmchiou please let me know what you think on this.

### Problem description
tt-smi -r 0,1,2,3 
Hangs on galaxy.

### What's changed
Skip the automatic inter test reset for galaxy.
We need to figure out a scheme to use a reset.json

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14742213582) CI passes
- [ ] [TG Demo](https://github.com/tenstorrent/tt-metal/actions/runs/14742198474l) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes