### PR TITLE
[skip ci] Fallback to a dummy version when we have nothing to go on

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -30,9 +30,15 @@ function(ParseGitDescribe)
             ERROR_QUIET
         )
     endif()
+    if(NOT VERSION_HASH)
+        set(VERSION_HASH ${fallbackHash})
+    endif()
     if(NOT version)
         set(version ${fallbackVersion})
-        set(VERSION_HASH ${fallbackHash})
+        # A shallow Git clone will fail a git describe, but also will not have substitued the fallbackVersion
+        if(version MATCHES "Format")
+            set(version "0.0-alpha0-1-g${VERSION_HASH}-dirty")
+        endif()
     endif()
 
     # Local modifications (dirty), or not


### PR DESCRIPTION
### Ticket
Closes #21399

### Problem description
There's no version information with a shallow clone.  This fails to write a version file for packaging.

### What's changed
Fallback to a dummy version when we have nothing better to use.