### PR TITLE
[skip ci] Restore unique name for test report

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
         with:
-          name: Metalium ${{ matrix.platform }} basic tests
+          name: Metalium ${{ inputs.runner }} basic tests
           path: /work/test-reports/*.xml
           reporter: jest-junit
           working-directory: /work

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -68,7 +68,7 @@ jobs:
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: phoenix-actions/test-reporting@f957cd93fc2d848d556fa0d03c57bc79127b6b5e # v15
         with:
-          name: Metalium ${{ matrix.platform }} smoke tests
+          name: Metalium ${{ inputs.runner }} smoke tests
           path: /work/test-reports/*.xml
           reporter: jest-junit
           working-directory: /work


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Test reports are using the obsolete ${{ matrix... }} to de-dupe the title.  Since then it was refactored and that's an empty string.

### What's changed
Used an existing variable to de-dupe the title.