### PR TITLE
Enable -Wbool-operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,6 @@ add_compile_options(
     -Werror
     # The following list is not indicative of what we _desire_ only the status quo to build.
     -Wno-deprecated-declarations
-    -Wno-bool-operation
     -Wno-pessimizing-move
     -Wno-range-loop-construct
     -Wno-unused-but-set-variable

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -241,7 +241,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
             TT_ASSERT(found_dispatch && found_dispatch_s);
         } else {
             // No dispatch_s, just write 0s to the configs dependent on it
-            TT_ASSERT(found_dispatch && ~found_dispatch_s);
+            TT_ASSERT(found_dispatch && !found_dispatch_s);
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
             dependent_config_.downstream_dispatch_s_cb_sem_id = UNUSED_SEM_ID;
         }
@@ -341,7 +341,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
             TT_ASSERT(found_dispatch && found_dispatch_s);
         } else {
             // No dispatch_s, just write 0s to the configs dependent on it
-            TT_ASSERT(found_dispatch && ~found_dispatch_s);
+            TT_ASSERT(found_dispatch && !found_dispatch_s);
             dependent_config_.downstream_s_logical_core = UNUSED_LOGICAL_CORE;
             dependent_config_.downstream_dispatch_s_cb_sem_id =
                 MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
-Wbool-operation has been disabled because we had a couple places in code that get flagged.

```
error: bitwise negation of a boolean expression always evaluates to 'true'; did you mean logical negation? [-Werror,-Wbool-operation]
  244 |             TT_ASSERT(found_dispatch && ~found_dispatch_s);
      |                                         ^~~~~~~~~~~~~~~~~
      |                                         !
tt_metal/api/tt-metalium/assert.hpp:161:17: note: expanded from macro 'TT_ASSERT'
  161 |         if (not(condition)) [[unlikely]]                                                                    \
      |                 ^~~~~~~~~
```

### What's changed
Fixed the code
Enabled the warning