### PR TITLE
[skip ci] Bump Docker timeout

### DIFF
--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -121,7 +121,7 @@ jobs:
     name: "🐳️ Build images"
     needs: check-docker-images
     if: needs.check-docker-images.outputs.dev-exists != 'true' || needs.check-docker-images.outputs.basic-dev-exists != 'true'
-    timeout-minutes: 45
+    timeout-minutes: 60
     runs-on: tt-beta-ubuntu-2204-large
     steps:
       - name: ⬇️ Checkout


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Sometimes we take >45m to build all our Docker images.  It doesn't appear that we're CPU bound in general, so consuming a larger image won't buy us much (but will hog more resources).  For now just bump the timeout.  We can revisit the images themselves another day.

### What's changed
Increased the timeout.