### PR TITLE
Use static library for libfmt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(
         gmock_main
         nlohmann_json::nlohmann_json
         magic_enum::magic_enum
-        fmt::fmt-header-only
+        fmt::fmt
         span
         small_vector
         Boost::algorithm

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -120,7 +120,14 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME ${DEFAULT_COMPONENT_NAME})
 # fmt : https://github.com/fmtlib/fmt
 ############################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4 OPTIONS "CMAKE_MESSAGE_LOG_LEVEL NOTICE")
+CPMAddPackage(
+    NAME fmt
+    GITHUB_REPOSITORY fmtlib/fmt
+    GIT_TAG 11.1.4
+    OPTIONS
+        "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+        "BUILD_SHARED_LIBS OFF"
+)
 
 ############################################################################################################################
 # range-v3 : https://github.com/ericniebler/range-v3

--- a/tt-train/cmake/dependencies.cmake
+++ b/tt-train/cmake/dependencies.cmake
@@ -58,7 +58,14 @@ CPMAddPackage(NAME reflect GITHUB_REPOSITORY boost-ext/reflect GIT_TAG v1.1.1)
 # fmt : https://github.com/fmtlib/fmt
 ############################################################################################################################
 
-CPMAddPackage(NAME fmt GITHUB_REPOSITORY fmtlib/fmt GIT_TAG 11.1.4)
+CPMAddPackage(
+    NAME fmt
+    GITHUB_REPOSITORY fmtlib/fmt
+    GIT_TAG 11.1.4
+    OPTIONS
+        "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+        "BUILD_SHARED_LIBS OFF"
+)
 
 ############################################################################################################################
 # magic_enum : https://github.com/Neargye/magic_enum

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -139,7 +139,7 @@ target_link_libraries(
         Metalium::Metal
         Metalium::TTNN
         Python3::Python
-        fmt::fmt-header-only
+        fmt::fmt
         magic_enum::magic_enum
         yaml-cpp::yaml-cpp
         xtensor

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -292,7 +292,7 @@ target_link_libraries(
     PUBLIC
         umd::device
         magic_enum::magic_enum
-        fmt::fmt-header-only
+        fmt::fmt
         span
         small_vector
         TracyClient

--- a/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
+++ b/tt_metal/api/tt-metalium/tt_backend_api_types.hpp
@@ -15,6 +15,7 @@
 
 #include <fmt/base.h>
 #include <umd/device/types/arch.h>
+#include <magic_enum/magic_enum.hpp>
 
 namespace tt {
 
@@ -177,5 +178,11 @@ struct std::hash<tt::DataFormat> {
 
 template <>
 struct fmt::formatter<tt::DataFormat> : formatter<string_view> {
-    auto format(tt::DataFormat df, format_context& ctx) const -> format_context::iterator;
+    auto format(tt::DataFormat df, format_context& ctx) const -> format_context::iterator {
+        const auto name = magic_enum::enum_name(df);
+        if (name.empty()) {
+            throw std::invalid_argument("Unknown format");
+        }
+        return formatter<string_view>::format(name, ctx);
+    }
 };

--- a/tt_metal/common/CMakeLists.txt
+++ b/tt_metal/common/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(
     PUBLIC
         nlohmann_json::nlohmann_json
         magic_enum::magic_enum
-        fmt::fmt-header-only
+        fmt::fmt
         span
         small_vector
         TT:STL

--- a/tt_metal/common/tt_backend_api_types.cpp
+++ b/tt_metal/common/tt_backend_api_types.cpp
@@ -53,12 +53,3 @@ tt::ARCH tt::get_arch_from_string(const std::string& arch_str) {
 
     return arch;
 }
-
-auto fmt::formatter<tt::DataFormat>::format(tt::DataFormat df, format_context& ctx) const -> format_context::iterator {
-    const auto name = magic_enum::enum_name(df);
-
-    if (name.empty()) {
-        throw std::invalid_argument("Unknown format");
-    }
-    return formatter<string_view>::format(name, ctx);
-}

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(
         umd::device
         metal_common_libs
         magic_enum::magic_enum
-        fmt::fmt-header-only
+        fmt::fmt
         yaml-cpp::yaml-cpp
         Metalium::Metal::Impl
         TT::Metalium::HostDevCommon

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
     PRIVATE
         hw
         fmt::fmt
+        magic_enum::magic_enum
         umd::device
 )
 
@@ -58,6 +59,7 @@ target_link_libraries(
     PRIVATE
         hw
         fmt::fmt
+        magic_enum::magic_enum
         umd::device
 )
 

--- a/tt_metal/llrt/CMakeLists.txt
+++ b/tt_metal/llrt/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(
     wh_hal
     PRIVATE
         hw
-        fmt::fmt-header-only
+        fmt::fmt
         umd::device
 )
 
@@ -57,7 +57,7 @@ target_link_libraries(
     bh_hal
     PRIVATE
         hw
-        fmt::fmt-header-only
+        fmt::fmt
         umd::device
 )
 


### PR DESCRIPTION
### Problem description
Compilation is slow. Can we make it a bit better by using libfmt as a static library?

### What's changed
Stop using header only target.

After this PR, the following hot spots are removed from the compilation profiler:
```
char const* fmt::v11::detail::parse_format_specs<$>(char const*, cha... (962 times, avg 10 ms)
decltype(fp(0)) fmt::v11::basic_format_arg<$>::visit<$>(fmt::v11::de... (963 times, avg 12 ms)
decltype(fp(0)) fmt::v11::basic_format_arg<$>::visit<$>(fmt::v11::de... (963 times, avg 6 ms)
fmt::detail::default_arg_formatter<char>::operator()<float, 0> (1384 times, avg 44 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::digit_grouping<$>::app... (963 times, avg 10 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::do_write_float<$>(fmt:... (1924 times, avg 11 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::do_write_float<$>(fmt:... (962 times, avg 11 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::fill<$>(fmt::v11::basi... (963 times, avg 7 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write<$>(fmt::v11::bas... (964 times, avg 12 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_codepoint<$>(fmt... (2892 times, avg 3 ms)
fmt::detail::write<char, fmt::basic_appender<char>, float, 0> (2770 times, avg 37 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_escaped_string<$... (964 times, avg 23 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_int<$>(fmt::v11:... (2886 times, avg 14 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_int<$>(fmt::v11:... (963 times, avg 10 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_int<$>(fmt::v11:... (963 times, avg 13 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_padded<$>(fmt::v... (1926 times, avg 6 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_padded<$>(fmt::v... (962 times, avg 7 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_padded<$>(fmt::v... (964 times, avg 7 ms)
fmt::v11::basic_appender<$> fmt::v11::detail::write_significand<$>(f... (963 times, avg 13 ms)
fmt::v11::basic_appender<char> fmt::v11::detail::do_write_float<char... (962 times, avg 7 ms)
fmt::v11::basic_appender<char> fmt::v11::detail::write_int<char, fmt... (962 times, avg 6 ms)
fmt::v11::basic_appender<char> fmt::v11::detail::write_int<char, fmt... (962 times, avg 6 ms)
fmt::v11::basic_appender<char> fmt::v11::detail::write_int<char, fmt... (962 times, avg 6 ms)
fmt::v11::detail::dragonbox::decimal_fp<$> fmt::v11::detail::dragonb... (963 times, avg 6 ms)
fmt::v11::detail::dragonbox::decimal_fp<$> fmt::v11::detail::write_p... (1924 times, avg 3 ms)
int fmt::v11::detail::format_float<$>(double, int, fmt::v11::format_... (962 times, avg 15 ms)
void fmt::v11::detail::format_hexfloat<$>(double, fmt::v11::format_s... (963 times, avg 12 ms)
void fmt::v11::detail::format_hexfloat<$>(long double, fmt::v11::for... (963 times, avg 13 ms)
```

The following is introduced:
```
fmt::v11::detail::ansi_color_escape<$>::ansi_color_escape(fmt::v11::... (897 times, avg 2 ms)
fmt::v11::detail::ansi_color_escape<$>::ansi_color_escape(fmt::v11::... (897 times, avg 4 ms)
fmt::v11::formatter<$>::format(tt::tt_metal::StorageType const&, fmt... (497 times, avg 3 ms)
```

The following is the same:
```
fmt::detail::value<$>::format_custom<$> (2947 times, avg 73 ms)
fmt::detail::value<fmt::context>::format_custom<tt::tt_metal::Storag... (852 times, avg 167 ms)
fmt::formatter<$>::format (2935 times, avg 73 ms)
fmt::formatter<tt::tt_metal::StorageType>::format (852 times, avg 167 ms)
fmt::print<$> (12854 times, avg 15 ms)
fmt::print<const tt::tt_metal::StorageType &> (852 times, avg 171 ms)
fmt::v11::detail::format_dragon(fmt::v11::detail::basic_fp<$>, unsig... (29 times, avg 76 ms)
tt::assert::tt_throw_impl<fmt::fstring<const tt::tt_metal::StorageTy... (852 times, avg 177 ms)
void fmt::v11::detail::vformat_to<$>(fmt::v11::detail::buffer<$>&, f... (897 times, avg 20 ms)
```

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14749469648) CI passes
- [x] New/Existing tests provide coverage for changes
