### PR TITLE
#14955: OpenPDN Mnist model Trace 2CQ implementation

### DIFF
--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -86,6 +86,7 @@ jobs:
           WH_ARCH_YAML=$MAGIC_ENV pytest models/demos/segformer/tests/perf -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/ufld_v2/tests -m models_device_performance_bare_metal
           WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/yolov10/tests -m models_device_performance_bare_metal
+          WH_ARCH_YAML=$MAGIC_ENV pytest models/experimental/openpdn_mnist/tests -m models_device_performance_bare_metal
           python3 models/perf/merge_device_perf_results.py
 
       - name: Check device perf report exists

--- a/models/experimental/openpdn_mnist/tests/openpdn_mnist_e2e_performant.py
+++ b/models/experimental/openpdn_mnist/tests/openpdn_mnist_e2e_performant.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+from models.experimental.openpdn_mnist.tests.openpdn_mnist_test_infra import create_test_infra
+
+try:
+    pass
+
+    use_signpost = True
+except ModuleNotFoundError:
+    use_signpost = False
+
+
+def buffer_address(tensor):
+    addr = []
+    for ten in ttnn.get_device_tensors(tensor):
+        addr.append(ten.buffer_address())
+    return addr
+
+
+# TODO: Create ttnn APIs for this
+ttnn.buffer_address = buffer_address
+
+
+class OpenPDNMnistTrace2CQ:
+    def __init__(self):
+        ...
+
+    def initialize_openpdn_mnist_trace_2cqs_inference(
+        self,
+        device,
+        model_location_generator,
+    ):
+        self.test_infra = create_test_infra(
+            device,
+            model_location_generator,
+        )
+        self.device = device
+        self.tt_inputs_host, sharded_mem_config_DRAM, self.input_mem_config = self.test_infra.setup_dram_sharded_input(
+            device
+        )
+        self.tt_image_res = self.tt_inputs_host.to(device, sharded_mem_config_DRAM)
+        self.op_event = ttnn.record_event(device, 0)
+
+        # First run configures convs JIT
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        spec = self.test_infra.input_tensor.spec
+        self.op_event = ttnn.record_event(device, 0)
+        self.test_infra.run()
+        self.test_infra.validate()
+        self.test_infra.output_tensor.deallocate(force=True)
+
+        # Optimized run
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(device, 0)
+        self.test_infra.run()
+        self.test_infra.validate()
+
+        # Capture
+        ttnn.wait_for_event(1, self.op_event)
+        ttnn.copy_host_to_device_tensor(self.tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
+        self.op_event = ttnn.record_event(device, 0)
+        self.test_infra.output_tensor.deallocate(force=True)
+        trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
+        self.tid = ttnn.begin_trace_capture(device, cq_id=0)
+        self.test_infra.run()
+        self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
+        ttnn.end_trace_capture(device, self.tid, cq_id=0)
+        assert trace_input_addr == ttnn.buffer_address(self.input_tensor)
+
+    def execute_openpdn_mnist_trace_2cqs_inference(self, tt_inputs_host=None):
+        ttnn.wait_for_event(1, self.op_event)
+
+        ttnn.copy_host_to_device_tensor(tt_inputs_host, self.tt_image_res, 1)
+        self.write_event = ttnn.record_event(self.device, 1)
+        ttnn.wait_for_event(0, self.write_event)
+        # TODO: Add in place support to ttnn to_memory_config
+        self.input_tensor = ttnn.reshard(self.tt_image_res, self.input_mem_config, self.input_tensor)
+        self.op_event = ttnn.record_event(self.device, 0)
+        ttnn.execute_trace(self.device, self.tid, cq_id=0, blocking=False)
+        outputs = ttnn.from_device(self.test_infra.output_tensor, blocking=True)
+
+        return outputs
+
+    def release_openpdn_mnist_trace_2cqs_inference(self):
+        ttnn.release_trace(self.device, self.tid)

--- a/models/experimental/openpdn_mnist/tests/openpdn_mnist_performant.py
+++ b/models/experimental/openpdn_mnist/tests/openpdn_mnist_performant.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import ttnn
+from models.experimental.openpdn_mnist.tests.openpdn_mnist_test_infra import create_test_infra
+
+try:
+    from tracy import signpost
+
+    use_signpost = True
+except ModuleNotFoundError:
+    use_signpost = False
+
+
+def buffer_address(tensor):
+    addr = []
+    for ten in ttnn.get_device_tensors(tensor):
+        addr.append(ten.buffer_address())
+    return addr
+
+
+def dump_device_profiler(device):
+    if isinstance(device, ttnn.Device):
+        ttnn.DumpDeviceProfiler(device)
+    else:
+        for dev in device.get_device_ids():
+            ttnn.DumpDeviceProfiler(device.get_device(dev))
+
+
+ttnn.dump_device_profiler = dump_device_profiler
+
+ttnn.buffer_address = buffer_address
+
+
+def run_openpdn_mnist_inference(
+    device,
+    model_location_generator,
+):
+    test_infra = create_test_infra(
+        device,
+        model_location_generator=model_location_generator,
+    )
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+
+    # First run configures convs JIT
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+
+    test_infra.run()
+    test_infra.validate()
+    test_infra.dealloc_output()
+
+    # Optimized run
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    test_infra.validate()
+    test_infra.dealloc_output()
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    if use_signpost:
+        signpost(header="stop")
+    test_infra.validate()
+    test_infra.dealloc_output()
+
+
+def run_openpdn_mnist_trace_inference(
+    device,
+    model_location_generator,
+):
+    test_infra = create_test_infra(
+        device,
+        model_location_generator=model_location_generator,
+    )
+    tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(device)
+
+    # First run configures convs JIT
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    spec = test_infra.input_tensor.spec
+
+    test_infra.run()
+    test_infra.validate()
+    test_infra.dealloc_output()
+
+    # Optimized run
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.run()
+    test_infra.validate()
+
+    # Capture
+    test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+    test_infra.dealloc_output()
+    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    tid = ttnn.begin_trace_capture(device, cq_id=0)
+    test_infra.run()
+    tt_image_res = ttnn.allocate_tensor_on_device(spec, device)
+    ttnn.end_trace_capture(device, tid, cq_id=0)
+    assert trace_input_addr == ttnn.buffer_address(tt_image_res)
+
+    # More optimized run with caching
+    if use_signpost:
+        signpost(header="start")
+    ttnn.copy_host_to_device_tensor(tt_inputs_host, tt_image_res, 0)
+    ttnn.execute_trace(device, tid, cq_id=0, blocking=True)
+    if use_signpost:
+        signpost(header="stop")
+    test_infra.validate()
+
+    ttnn.release_trace(device, tid)
+    test_infra.dealloc_output()

--- a/models/experimental/openpdn_mnist/tests/openpdn_mnist_test_infra.py
+++ b/models/experimental/openpdn_mnist/tests/openpdn_mnist_test_infra.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+import torch
+from tests.ttnn.utils_for_testing import assert_with_pcc
+import ttnn
+
+from models.experimental.openpdn_mnist.reference import openpdn_mnist
+from models.experimental.openpdn_mnist.ttnn import ttnn_openpdn_mnist
+from models.experimental.openpdn_mnist.ttnn.model_preprocessing import (
+    create_openpdn_mnist_model_model_parameters,
+)
+
+from models.utility_functions import (
+    is_wormhole_b0,
+    divup,
+)
+
+
+class OpenPDNMnistTestInfra:
+    def __init__(
+        self,
+        device,
+        model_location_generator=None,
+    ):
+        super().__init__()
+        torch.manual_seed(0)
+        self.pcc_passed = False
+        self.pcc_message = "Did you forget to call validate()?"
+        self.device = device
+        self.model_location_generator = model_location_generator
+        self.torch_input = torch.randn((1, 5, 78, 78), dtype=torch.bfloat16)
+        self.torch_input = self.torch_input.float()
+        # torch_input_permuted = self.torch_input.permute(0, 2, 3, 1)
+        # self.input_tensor = ttnn.from_torch(torch_input_permuted, dtype=ttnn.bfloat16)
+        torch_model = openpdn_mnist.OpenPDNMnist(11)
+        parameters = create_openpdn_mnist_model_model_parameters(torch_model, self.torch_input, device=device)
+        self.torch_output = torch_model(self.torch_input)
+        self.ttnn_openpdn_mnist_model = ttnn_openpdn_mnist.TtOpenPDNMnist(device, parameters)
+
+    def run(self):
+        self.output_tensor = self.ttnn_openpdn_mnist_model(self.input_tensor)
+
+    def setup_l1_sharded_input(self, device, torch_input_tensor=None):
+        if is_wormhole_b0():
+            core_grid = ttnn.CoreGrid(y=8, x=8)
+        else:
+            exit("Unsupported device")
+        num_devices = 1 if isinstance(device, ttnn.Device) else device.get_num_devices()
+        # torch tensor
+        torch_input_tensor = self.torch_input if self.torch_input is None else self.torch_input
+
+        n, c, h, w = torch_input_tensor.shape
+        # sharded mem config for fold input
+        num_cores = core_grid.x * core_grid.y
+        shard_h = (n * w * h + num_cores - 1) // num_cores
+        grid_size = core_grid
+        grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+        shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+        shard_spec = ttnn.ShardSpec(shard_grid, (shard_h, 16), ttnn.ShardOrientation.ROW_MAJOR)
+        input_mem_config = ttnn.MemoryConfig(
+            ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+        )
+        torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+        torch_input_tensor = torch_input_tensor.reshape(1, 1, h * w * n, c)
+        tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+        tt_inputs_host = ttnn.pad(tt_inputs_host, [1, 1, n * h * w, 16], [0, 0, 0, 0], 0)
+        return tt_inputs_host, input_mem_config
+
+    def setup_dram_sharded_input(self, device, torch_input_tensor=None, mesh_mapper=None, mesh_composer=None):
+        tt_inputs_host, input_mem_config = self.setup_l1_sharded_input(device)
+        dram_grid_size = device.dram_grid_size()
+        dram_shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+            ),
+            [
+                divup(tt_inputs_host.volume() // tt_inputs_host.shape[-1], (dram_grid_size.x * dram_grid_size.y)),
+                16,
+            ],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        sharded_mem_config_DRAM = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, dram_shard_spec
+        )
+
+        return tt_inputs_host, sharded_mem_config_DRAM, input_mem_config
+
+    def validate(self, output_tensor=None):
+        output_tensor = self.output_tensor if output_tensor is None else output_tensor
+        output_tensor = ttnn.to_torch(self.output_tensor)
+
+        valid_pcc = 0.99
+        self.pcc_passed, self.pcc_message = assert_with_pcc(self.torch_output, output_tensor, pcc=valid_pcc)
+
+        logger.info(f"OpenPDNMnist, PCC={self.pcc_message}")
+
+    def dealloc_output(self):
+        ttnn.deallocate(self.output_tensor)
+
+
+def create_test_infra(
+    device,
+    model_location_generator=None,
+):
+    return OpenPDNMnistTestInfra(
+        device,
+        model_location_generator,
+    )

--- a/models/experimental/openpdn_mnist/tests/test_e2e_performant.py
+++ b/models/experimental/openpdn_mnist/tests/test_e2e_performant.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import time
+import torch
+from loguru import logger
+
+from models.utility_functions import run_for_wormhole_b0
+from models.experimental.openpdn_mnist.tests.openpdn_mnist_e2e_performant import OpenPDNMnistTrace2CQ
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size",
+    ((1),),
+)
+def test_run_openpdn_mnist_trace_2cqs_inference(
+    device,
+    use_program_cache,
+    batch_size,
+    model_location_generator,
+):
+    openpdn_mnist_trace_2cq = OpenPDNMnistTrace2CQ()
+
+    openpdn_mnist_trace_2cq.initialize_openpdn_mnist_trace_2cqs_inference(
+        device,
+        model_location_generator,
+    )
+
+    input_shape = (batch_size, 5, 78, 78)
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    n, c, h, w = torch_input_tensor.shape
+    torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+    torch_input_tensor = torch_input_tensor.reshape(1, 1, h * w * n, c)
+    tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_inputs_host = ttnn.pad(tt_inputs_host, [1, 1, n * h * w, 16], [0, 0, 0, 0], 0)
+    inference_iter_count = 10
+    inference_time_iter = []
+    for iter in range(0, inference_iter_count):
+        t0 = time.time()
+        output = openpdn_mnist_trace_2cq.execute_openpdn_mnist_trace_2cqs_inference(tt_inputs_host)
+        t1 = time.time()
+        inference_time_iter.append(t1 - t0)
+    openpdn_mnist_trace_2cq.release_openpdn_mnist_trace_2cqs_inference()
+    inference_time_avg = round(sum(inference_time_iter) / len(inference_time_iter), 6)
+    logger.info(
+        f"ttnn_openpdn_mnist_78x78_batch_size_{batch_size}. One inference iteration time (sec): {inference_time_avg}, FPS: {round(batch_size/inference_time_avg)}"
+    )

--- a/models/experimental/openpdn_mnist/tests/test_openpdn_mnist_performant.py
+++ b/models/experimental/openpdn_mnist/tests/test_openpdn_mnist_performant.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+import pytest
+from models.utility_functions import run_for_wormhole_b0
+from models.experimental.openpdn_mnist.tests.openpdn_mnist_e2e_performant import OpenPDNMnistTrace2CQ
+from models.experimental.openpdn_mnist.tests.openpdn_mnist_performant import (
+    run_openpdn_mnist_inference,
+    run_openpdn_mnist_trace_inference,
+)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_run_openpdn_mnist_inference(device, use_program_cache, model_location_generator):
+    run_openpdn_mnist_inference(device, model_location_generator)
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768, "trace_region_size": 1843200}], indirect=True)
+def test_run_openpdn_mnist_trace_inference(
+    device,
+    use_program_cache,
+    model_location_generator,
+):
+    run_openpdn_mnist_trace_inference(
+        device,
+        model_location_generator,
+    )
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "trace_region_size": 3686400, "num_command_queues": 2}], indirect=True
+)
+def test_run_openpdn_mnist_trace_2cqs_inference(
+    device,
+    use_program_cache,
+    model_location_generator,
+):
+    openpdn_mnist_trace_2cq = OpenPDNMnistTrace2CQ()
+
+    openpdn_mnist_trace_2cq.initialize_openpdn_mnist_trace_2cqs_inference(
+        device,
+        model_location_generator,
+    )
+
+    input_shape = (1, 5, 78, 78)
+    batch_size = input_shape[0]
+    torch_input_tensor = torch.randn(input_shape, dtype=torch.float32)
+    n, c, h, w = torch_input_tensor.shape
+    torch_input_tensor = torch_input_tensor.permute(0, 2, 3, 1)
+    torch_input_tensor = torch_input_tensor.reshape(1, 1, h * w * n, c)
+    tt_inputs_host = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_inputs_host = ttnn.pad(tt_inputs_host, [1, 1, n * h * w, 16], [0, 0, 0, 0], 0)
+    inference_iter_count = 10
+    inference_time_iter = []
+    for iter in range(0, inference_iter_count):
+        output = openpdn_mnist_trace_2cq.execute_openpdn_mnist_trace_2cqs_inference(tt_inputs_host)
+    openpdn_mnist_trace_2cq.release_openpdn_mnist_trace_2cqs_inference()

--- a/models/experimental/openpdn_mnist/tests/test_perf_openpdn_mnist.py
+++ b/models/experimental/openpdn_mnist/tests/test_perf_openpdn_mnist.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch
+import pytest
+from loguru import logger
+from models.perf.perf_utils import prep_perf_report
+from models.perf.device_perf_utils import run_device_perf, check_device_perf, prep_device_perf_report
+from models.utility_functions import (
+    profiler,
+)
+from models.utility_functions import run_for_wormhole_b0
+
+from models.experimental.openpdn_mnist.reference import openpdn_mnist
+from models.experimental.openpdn_mnist.ttnn import ttnn_openpdn_mnist
+from models.experimental.openpdn_mnist.ttnn.model_preprocessing import (
+    create_openpdn_mnist_model_model_parameters,
+    create_openpdn_mnist_model_input_tensors,
+)
+
+
+def get_expected_times(name):
+    base = {"openpdn_mnist": (12.2, 0.035)}
+    return base[name]
+
+
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
+@run_for_wormhole_b0()
+# Using random weights as pretrained ones aren't available in open-source; real weights were manually trained and uploaded to Drive
+@pytest.mark.parametrize(
+    "use_pretrained_weight",
+    [
+        False,
+        # True,
+    ],
+    ids=[
+        "pretrained_weight_false",
+        # "pretrained_weight_true",
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True, ids=["0"])
+def test_openpdn_mnist(device, reset_seeds, model_location_generator, use_pretrained_weight):
+    torch.manual_seed(0)
+
+    torch_model = openpdn_mnist.OpenPDNMnist(11)
+    torch_model.eval()
+    torch_input, ttnn_input = create_openpdn_mnist_model_input_tensors()
+    batch_size = torch_input.shape[0]
+    torch_output = torch_model(torch_input)
+    parameters = create_openpdn_mnist_model_model_parameters(torch_model, torch_input, device=device)
+
+    ttnn_model = ttnn_openpdn_mnist.TtOpenPDNMnist(device, parameters)
+    logger.info(f"Compiling model with warmup run")
+    profiler.start(f"inference_and_compile_time")
+    result = ttnn_model(ttnn_input)
+    ttnn.deallocate(result)
+
+    profiler.end(f"inference_and_compile_time")
+
+    inference_and_compile_time = profiler.get("inference_and_compile_time")
+    logger.info(f"Model compiled with warmup run in {(inference_and_compile_time):.2f} s")
+
+    iterations = 16
+    outputs = []
+    logger.info(f"Running inference for {iterations} iterations")
+    for idx in range(iterations):
+        profiler.start("inference_time")
+        profiler.start(f"inference_time_{idx}")
+        result = ttnn_model(ttnn_input)
+        ttnn.deallocate(result)
+        profiler.end(f"inference_time_{idx}")
+        profiler.end("inference_time")
+
+    mean_inference_time = profiler.get("inference_time")
+    inference_time = profiler.get(f"inference_time_{iterations - 1}")
+    compile_time = inference_and_compile_time - inference_time
+    logger.info(f"Model compilation took {compile_time:.1f} s")
+    logger.info(f"Inference time on last iterations was completed in {(inference_time * 1000.0):.2f} ms")
+    logger.info(
+        f"Mean inference time for {batch_size} (batch) images was {(mean_inference_time * 1000.0):.2f} ms ({batch_size / mean_inference_time:.2f} fps)"
+    )
+
+    expected_compile_time, expected_inference_time = get_expected_times("openpdn_mnist")
+
+    prep_perf_report(
+        model_name="models/experimental/functional_openpdn_mnist",
+        batch_size=batch_size,
+        inference_and_compile_time=inference_and_compile_time,
+        inference_time=inference_time,
+        expected_compile_time=expected_compile_time,
+        expected_inference_time=expected_inference_time,
+        comments="",
+        inference_time_cpu=0.0,
+    )
+
+    logger.info(f"Compile time: {inference_and_compile_time - inference_time}")
+    logger.info(f"Inference time: {inference_time}")
+    logger.info(f"Samples per second: {1 / inference_time * batch_size}")
+    assert (
+        inference_time < expected_inference_time
+    ), f"Expected inference time: {expected_inference_time} Actual inference time: {inference_time}"
+    logger.info("Exit openpdn_mnist perf test")
+
+
+@pytest.mark.parametrize(
+    "batch_size, expected_perf",
+    [
+        [2, 92.738],
+    ],
+)
+@pytest.mark.models_device_performance_bare_metal
+def test_perf_device_bare_metal_openpdn_mnist(batch_size, expected_perf):
+    subdir = "ttnn_openpdn_mnist"
+    num_iterations = 1
+    margin = 0.03
+    command = f"pytest tests/ttnn/integration_tests/openpdn_mnist/test_ttnn_openpdn_mnist.py"
+    cols = ["DEVICE FW", "DEVICE KERNEL", "DEVICE BRISC KERNEL"]
+
+    inference_time_key = "AVG DEVICE KERNEL SAMPLES/S"
+    expected_perf_cols = {inference_time_key: expected_perf}
+
+    post_processed_results = run_device_perf(command, subdir, num_iterations, cols, batch_size)
+    expected_results = check_device_perf(post_processed_results, margin, expected_perf_cols, assert_on_fail=True)
+
+    logger.info(f"{expected_results}")
+
+    prep_device_perf_report(
+        model_name=f"ttnn_functional_openpdn_mnist{batch_size}",
+        batch_size=batch_size,
+        post_processed_results=post_processed_results,
+        expected_results=expected_results,
+        comments="",
+    )

--- a/tests/scripts/run_performance.sh
+++ b/tests/scripts/run_performance.sh
@@ -46,6 +46,8 @@ run_perf_models_other() {
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov8x/tests -m $test_marker
         env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/yolov10/tests -m $test_marker
 
+
+        env WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml pytest -n auto models/experimental/openpdn_mnist/tests -m $test_marker
     fi
 
     env pytest -n auto tests/ttnn/integration_tests/bert/test_performance.py -m $test_marker


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/14954
### Problem description
- Add test perf with trace and 2 CQs for the OpenPDN Mnist model.

### What's changed
- Added  openpdn_mnist_perfomant with trace and 2CQs.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14750224966) CI passes
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)