### PR TITLE
Fix sweep infra for BH

### DIFF
--- a/tests/sweep_framework/framework/tt_smi_util.py
+++ b/tests/sweep_framework/framework/tt_smi_util.py
@@ -16,7 +16,7 @@ class ResetUtil:
         self.arch = arch
         self.command = os.getenv("TT_SMI_RESET_COMMAND")
         self.args = []
-        if arch not in ["grayskull", "wormhole_b0"]:
+        if arch not in ["grayskull", "wormhole_b0", "blackhole"]:
             raise Exception(f"SWEEPS: Unsupported Architecture for TT-SMI Reset: {arch}")
         if self.command is not None:
             return
@@ -53,6 +53,8 @@ class ResetUtil:
                                 raise Exception(f"SWEEPS: TT-SMI Reset Failed to Find Card ID.")
                             args.append(str(card_id[0]))
                         subprocess.run(["rm", "-f", ".reset.json"])
+                elif arch == "blackhole":
+                    args = ["-r", "0"]
                 smi_process = subprocess.run([executable, *args])
                 if smi_process.returncode == 0:
                     self.command = executable


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Sweeps not running in BH
devs are running sweeps in blackhole, they are manually changing this every time they needs to run

### What's changed
Add BH arch to run in sweep infra

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes