### PR TITLE
Fix TT_FATAL fail in HostBuffer::view_as when used in external project

### DIFF
--- a/ttnn/cpp/ttnn/tensor/host_buffer/host_buffer.hpp
+++ b/ttnn/cpp/ttnn/tensor/host_buffer/host_buffer.hpp
@@ -113,13 +113,13 @@ HostBuffer::HostBuffer(tt::stl::Span<T> borrowed_data, MemoryPin pin) :
 
 template <typename T>
 tt::stl::Span<T> HostBuffer::view_as() & {
-    TT_FATAL(type_info_ == &typeid(T), "Requested type T does not match the underlying buffer type.");
+    TT_FATAL(*type_info_ == typeid(T), "Requested type T does not match the underlying buffer type.");
     return tt::stl::Span<T>(reinterpret_cast<T*>(view_.data()), view_.size() / sizeof(T));
 }
 
 template <typename T>
 tt::stl::Span<const T> HostBuffer::view_as() const& {
-    TT_FATAL(type_info_ == &typeid(T), "Requested type T does not match the underlying buffer type.");
+    TT_FATAL(*type_info_ == typeid(T), "Requested type T does not match the underlying buffer type.");
     return tt::stl::Span<const T>(reinterpret_cast<const T*>(view_.data()), view_.size() / sizeof(T));
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/21452 

### Problem description
We should compare typeids directly not pointers, since pointer might change when consuming tt-metal repo in other project

### What's changed
 `type_info_ == &typeid(T),` ==> `*type_info_ == typeid(T)`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes