### PR TITLE
Revert getting pcie virtual coordinates

### DIFF
--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -94,12 +94,9 @@ std::map<std::string, std::string> initialize_device_kernel_defines(chip_id_t de
 
     auto pcie_cores = soc_d.get_cores(CoreType::PCIE, soc_d.get_umd_coord_system());
     CoreCoord pcie_core = pcie_cores.empty() ? soc_d.grid_size : pcie_cores[0];
-    auto virtual_pcie_core =
-        tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_physical_coordinates(
-            device_id, {pcie_core.x, pcie_core.y});
 
-    device_kernel_defines.emplace("PCIE_NOC_X", std::to_string(virtual_pcie_core.x));
-    device_kernel_defines.emplace("PCIE_NOC_Y", std::to_string(virtual_pcie_core.y));
+    device_kernel_defines.emplace("PCIE_NOC_X", std::to_string(pcie_core.x));
+    device_kernel_defines.emplace("PCIE_NOC_Y", std::to_string(pcie_core.y));
 
     return device_kernel_defines;
 }

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -92,7 +92,7 @@ std::map<std::string, std::string> initialize_device_kernel_defines(chip_id_t de
         device_kernel_defines.emplace("IS_NOT_POW2_NUM_L1_BANKS", "1");
     }
 
-    auto pcie_cores = soc_d.get_cores(CoreType::PCIE, soc_d.get_umd_coord_system());
+    auto pcie_cores = soc_d.get_cores(CoreType::PCIE, CoordSystem::TRANSLATED);
     CoreCoord pcie_core = pcie_cores.empty() ? soc_d.grid_size : pcie_cores[0];
 
     device_kernel_defines.emplace("PCIE_NOC_X", std::to_string(pcie_core.x));


### PR DESCRIPTION
### Problem description
A runtime exception `No core type found for system PHYSICAL at location: (2, 2)` occurs when running tt-metal tests on the Simulator. 
After investigation, it was observed that the previous [change](https://github.com/tenstorrent/tt-metal/pull/18131/files#diff-2482ce7044642423d58391d5b8c9dd93a2fa7d8508f0b4ac80e51348da3f1ad5) attempts to derive virtual coordinates from an already virtual coordinate.
Explanation: `get_umd_coord_system` already returns virtual coordinates.

### What's changed
This [change](https://github.com/tenstorrent/tt-metal/pull/18131/files#diff-2482ce7044642423d58391d5b8c9dd93a2fa7d8508f0b4ac80e51348da3f1ad5) has been reverted.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14837585748) CI passes
- [x] Blackhole post-commit tests : https://github.com/tenstorrent/tt-metal/actions/runs/14879999834
