### PR TITLE
Add option to clear DRAM memory at device initialization via TT_METAL_CLEAR_DRAM env var

### DIFF
--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -216,6 +216,7 @@ private:
     void compile_command_queue_programs();
     void configure_command_queue_programs();
     void clear_l1_state();
+    void clear_dram_state();
     void clear_launch_messages_on_eth_cores();
     void get_associated_dispatch_virtual_cores(
         std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>>& my_dispatch_cores,

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1026,6 +1026,8 @@ void Device::clear_dram_state() {
     for (int channel = 0; channel < num_dram_channels; ++channel) {
         detail::WriteToDeviceDRAMChannel(this, channel, start_address, zero_vec);
     }
+
+    tt::tt_metal::MetalContext::instance().get_cluster().dram_barrier(this->id());
 }
 
 void Device::compile_command_queue_programs() {

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -119,24 +119,14 @@ RunTimeOptions::RunTimeOptions() {
 
     this->clear_l1 = false;
     const char* clear_l1_enabled_str = std::getenv("TT_METAL_CLEAR_L1");
-    if (clear_l1_enabled_str != nullptr) {
-        if (clear_l1_enabled_str[0] == '0') {
-            this->clear_l1 = false;
-        }
-        if (clear_l1_enabled_str[0] == '1') {
-            this->clear_l1 = true;
-        }
+    if (clear_l1_enabled_str != nullptr && clear_l1_enabled_str[0] == '1') {
+        this->clear_l1 = true;
     }
 
     this->clear_dram = false;
     const char* clear_dram_enabled_str = std::getenv("TT_METAL_CLEAR_DRAM");
-    if (clear_dram_enabled_str != nullptr) {
-        if (clear_dram_enabled_str[0] == '0') {
-            this->clear_dram = false;
-        }
-        if (clear_dram_enabled_str[0] == '1') {
-            this->clear_dram = true;
-        }
+    if (clear_dram_enabled_str != nullptr && clear_dram_enabled_str[0] == '1') {
+        this->clear_dram = true;
     }
 
     const char* skip_eth_cores_with_retrain_str = std::getenv("TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN");

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -117,14 +117,25 @@ RunTimeOptions::RunTimeOptions() {
 
     kernels_early_return = (std::getenv("TT_METAL_KERNELS_EARLY_RETURN") != nullptr);
 
-    clear_l1 = false;
+    this->clear_l1 = false;
     const char* clear_l1_enabled_str = std::getenv("TT_METAL_CLEAR_L1");
     if (clear_l1_enabled_str != nullptr) {
         if (clear_l1_enabled_str[0] == '0') {
-            clear_l1 = false;
+            this->clear_l1 = false;
         }
         if (clear_l1_enabled_str[0] == '1') {
-            clear_l1 = true;
+            this->clear_l1 = true;
+        }
+    }
+
+    this->clear_dram = false;
+    const char* clear_dram_enabled_str = std::getenv("TT_METAL_CLEAR_DRAM");
+    if (clear_dram_enabled_str != nullptr) {
+        if (clear_dram_enabled_str[0] == '0') {
+            this->clear_dram = false;
+        }
+        if (clear_dram_enabled_str[0] == '1') {
+            this->clear_dram = true;
         }
     }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -117,6 +117,7 @@ class RunTimeOptions {
     bool kernels_early_return = false;
 
     bool clear_l1 = false;
+    bool clear_dram = false;
 
     bool skip_loading_fw = false;
     bool skip_reset_cores_on_init = false;
@@ -306,6 +307,9 @@ public:
 
     inline bool get_clear_l1() const { return clear_l1; }
     inline void set_clear_l1(bool clear) { clear_l1 = clear; }
+
+    inline bool get_clear_dram() const { return clear_dram; }
+    inline void set_clear_dram(bool clear) { clear_dram = clear; }
 
     inline bool get_skip_loading_fw() const { return skip_loading_fw; }
     inline bool get_skip_reset_cores_on_init() const { return skip_reset_cores_on_init; }


### PR DESCRIPTION
#21261

This PR adds an env var `TT_METAL_CLEAR_DRAM` which clears DRAM memory during device initialization if it is enabled.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14758463461/attempts/1)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/14758479739)