### PR TITLE
Llama MLP prefill perf improvement

### DIFF
--- a/models/demos/llama3_subdevices/tests/perf_targets/prefill_4096.json
+++ b/models/demos/llama3_subdevices/tests/perf_targets/prefill_4096.json
@@ -226,7 +226,7 @@
     },
     "Matmul_2": {
         "op_name": "matmul_ffn_1",
-        "kernel_duration": 866238,
+        "kernel_duration": 670000,
         "op_to_op": 1.0,
         "non-overlapped-dispatch-time": 0.0,
         "kernel_duration_relative_margin": 0.05,
@@ -244,7 +244,7 @@
     },
     "Matmul_3": {
         "op_name": "matmul_ffn_3",
-        "kernel_duration": 869943,
+        "kernel_duration": 670000,
         "op_to_op": 1.0,
         "non-overlapped-dispatch-time": 0.0,
         "kernel_duration_relative_margin": 0.05,
@@ -280,7 +280,7 @@
     },
     "Matmul_4": {
         "op_name": "matmul_ffn_2",
-        "kernel_duration": 1521752,
+        "kernel_duration": 1000000,
         "op_to_op": 1.0,
         "non-overlapped-dispatch-time": 0.0,
         "kernel_duration_relative_margin": 0.05,

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
+++ b/models/demos/llama3_subdevices/tests/unit_tests/test_llama_mlp_prefill.py
@@ -32,7 +32,7 @@ from models.demos.llama3_subdevices.tt.llama_ccl import TT_CCL
 )
 @pytest.mark.parametrize(
     "seq_len",
-    (128,),
+    (128, 4096),
 )
 @pytest.mark.parametrize(
     "batch_size",

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -262,26 +262,15 @@ class TtLlamaMLP(LightweightModule):
         # ttnn.deallocate(w3_out)
         # ttnn.deallocate(w1_out)
 
-        if seq_len in [128, 512, 65536]:
-            w2_out = ttnn.linear(
-                w2_in_gathered,
-                self.w2,
-                compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
-                dtype=ttnn.bfloat8_b,
-                program_config=pc_2,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
-            )
-        else:
-            w2_out = ttnn.linear(
-                w2_in_gathered,
-                self.w2_interleaved,
-                compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
-                dtype=ttnn.bfloat8_b,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                core_grid=ttnn.CoreGrid(y=7, x=7),
-                # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
-            )
+        w2_out = ttnn.linear(
+            w2_in_gathered,
+            self.w2_interleaved,
+            compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
+            dtype=ttnn.bfloat8_b,
+            program_config=pc_2,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
+        )
 
         ttnn.deallocate(w2_in)
         w2_out_reduced = self.tt_ccl.line_all_reduce(

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -71,6 +71,16 @@ class TtLlamaMLP(LightweightModule):
             cache_file_name=cache_name(name),
         )
 
+        as_interleaved_tensor = lambda name, type, dim: ttnn.as_tensor(
+            torch_weight(name[:2]).unsqueeze(0).unsqueeze(0),  # Grab only the wX part of the name
+            dtype=type,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dim, mesh_shape=args.cluster_shape),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_file_name=cache_name(name),
+        )
+
         self.four_bit_mlp = args.optimizations.bfp4_mlp
 
         # Sharded weights
@@ -83,6 +93,14 @@ class TtLlamaMLP(LightweightModule):
         )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
         self.w2 = as_sharded_tensor("w2_sharded", ttnn.bfloat8_b, dim=w2_dim)
         self.w3 = as_sharded_tensor("w3_sharded", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim)
+
+        self.w1_prefill = as_interleaved_tensor(
+            "w1_prefill", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim
+        )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
+        self.w2_prefill = as_interleaved_tensor("w2_prefill", ttnn.bfloat8_b, dim=w2_dim)
+        self.w3_prefill = as_interleaved_tensor(
+            "w3_prefill", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim
+        )
 
         if tt_ccl.mode == "decode":
             self.prefetch(prefetcher_setup, tt_ccl)
@@ -198,39 +216,32 @@ class TtLlamaMLP(LightweightModule):
         HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         """
         seq_len = x.shape[-2]
-        if seq_len >= 1024:
+        if seq_len > 2048:
             # Reshape input to to fit on device and parallelize computation
-            x = ttnn.reshape(x, [1, seq_len // 1024, 1024, -1])
-        pc_1 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
-        pc_2 = self.model_config["PREFILL_MLP_W2_PRG_CONFIG"](seq_len)
-        pc_3 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
+            x = ttnn.reshape(x, [1, seq_len // 2048, 2048, -1])
 
         w1_out = ttnn.linear(
             x,
-            self.w1,
+            self.w1_prefill,
             compute_kernel_config=(
-                self.args.compute_kernel_config_lofi
-                if self.four_bit_mlp
-                else self.args.compute_kernel_config_hifi2_fp16
+                self.args.compute_kernel_config_lofi if self.four_bit_mlp else self.args.compute_kernel_config_hifi2_fp1
             ),
             dtype=ttnn.bfloat8_b,
-            program_config=pc_1,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            core_grid=ttnn.CoreGrid(y=7, x=7),
         )
         w1_out_reduced = self.tt_ccl.line_reduce_scatter(
             w1_out, cluster_axis=1, num_links=3, memory_config=w1_out.memory_config(), buffer_key="FF1", dim=3
         )
         w3_out = ttnn.linear(
             x,
-            self.w3,
+            self.w3_prefill,
             compute_kernel_config=(
                 self.args.compute_kernel_config_lofi
                 if self.four_bit_mlp
                 else self.args.compute_kernel_config_hifi2_fp16
             ),
             dtype=ttnn.bfloat8_b,
-            program_config=pc_3,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            core_grid=ttnn.CoreGrid(y=7, x=7),
         )
         # ttnn.deallocate(x)
         w3_out_reduced = self.tt_ccl.line_reduce_scatter(
@@ -251,11 +262,10 @@ class TtLlamaMLP(LightweightModule):
         # ttnn.deallocate(w1_out)
         w2_out = ttnn.linear(
             w2_in_gathered,
-            self.w2,
+            self.w2_prefill,
             compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
             dtype=ttnn.bfloat8_b,
-            program_config=pc_2,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            core_grid=ttnn.CoreGrid(y=7, x=7),
             # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
         )
         ttnn.deallocate(w2_in)

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -94,13 +94,7 @@ class TtLlamaMLP(LightweightModule):
         self.w2 = as_sharded_tensor("w2_sharded", ttnn.bfloat8_b, dim=w2_dim)
         self.w3 = as_sharded_tensor("w3_sharded", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim)
 
-        self.w1_prefill = as_interleaved_tensor(
-            "w1_prefill", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim
-        )  # bfp4 normally ok here but sub .99 pcc for llama 3.1 weights
-        self.w2_prefill = as_interleaved_tensor("w2_prefill", ttnn.bfloat8_b, dim=w2_dim)
-        self.w3_prefill = as_interleaved_tensor(
-            "w3_prefill", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim
-        )
+        self.w2_interleaved = as_interleaved_tensor("w2_interleaved", ttnn.bfloat8_b, dim=w2_dim)
 
         if tt_ccl.mode == "decode":
             self.prefetch(prefetcher_setup, tt_ccl)
@@ -216,32 +210,39 @@ class TtLlamaMLP(LightweightModule):
         HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         """
         seq_len = x.shape[-2]
-        if seq_len > 2048:
+        if seq_len >= 1024:
             # Reshape input to to fit on device and parallelize computation
-            x = ttnn.reshape(x, [1, seq_len // 2048, 2048, -1])
+            x = ttnn.reshape(x, [1, seq_len // 1024, 1024, -1])
+        pc_1 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
+        pc_2 = self.model_config["PREFILL_MLP_W2_PRG_CONFIG"](seq_len)
+        pc_3 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
 
         w1_out = ttnn.linear(
             x,
-            self.w1_prefill,
-            compute_kernel_config=(
-                self.args.compute_kernel_config_lofi if self.four_bit_mlp else self.args.compute_kernel_config_hifi2_fp1
-            ),
-            dtype=ttnn.bfloat8_b,
-            core_grid=ttnn.CoreGrid(y=7, x=7),
-        )
-        w1_out_reduced = self.tt_ccl.line_reduce_scatter(
-            w1_out, cluster_axis=1, num_links=3, memory_config=w1_out.memory_config(), buffer_key="FF1", dim=3
-        )
-        w3_out = ttnn.linear(
-            x,
-            self.w3_prefill,
+            self.w1,
             compute_kernel_config=(
                 self.args.compute_kernel_config_lofi
                 if self.four_bit_mlp
                 else self.args.compute_kernel_config_hifi2_fp16
             ),
             dtype=ttnn.bfloat8_b,
-            core_grid=ttnn.CoreGrid(y=7, x=7),
+            program_config=pc_1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        w1_out_reduced = self.tt_ccl.line_reduce_scatter(
+            w1_out, cluster_axis=1, num_links=3, memory_config=w1_out.memory_config(), buffer_key="FF1", dim=3
+        )
+        w3_out = ttnn.linear(
+            x,
+            self.w3,
+            compute_kernel_config=(
+                self.args.compute_kernel_config_lofi
+                if self.four_bit_mlp
+                else self.args.compute_kernel_config_hifi2_fp16
+            ),
+            dtype=ttnn.bfloat8_b,
+            program_config=pc_3,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         # ttnn.deallocate(x)
         w3_out_reduced = self.tt_ccl.line_reduce_scatter(
@@ -260,14 +261,28 @@ class TtLlamaMLP(LightweightModule):
         )
         # ttnn.deallocate(w3_out)
         # ttnn.deallocate(w1_out)
-        w2_out = ttnn.linear(
-            w2_in_gathered,
-            self.w2_prefill,
-            compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
-            dtype=ttnn.bfloat8_b,
-            core_grid=ttnn.CoreGrid(y=7, x=7),
-            # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
-        )
+
+        if seq_len in [128, 512, 65536]:
+            w2_out = ttnn.linear(
+                w2_in_gathered,
+                self.w2,
+                compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
+                dtype=ttnn.bfloat8_b,
+                program_config=pc_2,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
+            )
+        else:
+            w2_out = ttnn.linear(
+                w2_in_gathered,
+                self.w2_interleaved,
+                compute_kernel_config=self.args.compute_kernel_config_hifi2_fp16,
+                dtype=ttnn.bfloat8_b,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                core_grid=ttnn.CoreGrid(y=7, x=7),
+                # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
+            )
+
         ttnn.deallocate(w2_in)
         w2_out_reduced = self.tt_ccl.line_all_reduce(
             w2_out, cluster_axis=0, num_links=3, memory_config=ttnn.DRAM_MEMORY_CONFIG, buffer_key="FF2"

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -78,7 +78,8 @@ class TtLlamaMLP(LightweightModule):
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dim, mesh_shape=args.cluster_shape),
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            cache_file_name=cache_name(name),
+            # Temporarily disable caching this weight for CI
+            # cache_file_name=cache_name(name),
         )
 
         self.four_bit_mlp = args.optimizations.bfp4_mlp

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -78,7 +78,6 @@ class TtLlamaMLP(LightweightModule):
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=dim, mesh_shape=args.cluster_shape),
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            # Temporarily disable caching this weight for CI
             cache_file_name=cache_name(name),
         )
 
@@ -95,7 +94,13 @@ class TtLlamaMLP(LightweightModule):
         self.w2 = as_sharded_tensor("w2_sharded", ttnn.bfloat8_b, dim=w2_dim)
         self.w3 = as_sharded_tensor("w3_sharded", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim)
 
+        self.w1_interleaved = as_interleaved_tensor(
+            "w1_interleaved", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim
+        )
         self.w2_interleaved = as_interleaved_tensor("w2_interleaved", ttnn.bfloat8_b, dim=w2_dim)
+        self.w3_interleaved = as_interleaved_tensor(
+            "w3_interleaved", ttnn.bfloat4_b if self.four_bit_mlp else ttnn.bfloat8_b, dim=w1_dim
+        )
 
         if tt_ccl.mode == "decode":
             self.prefetch(prefetcher_setup, tt_ccl)
@@ -211,16 +216,17 @@ class TtLlamaMLP(LightweightModule):
         HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         """
         seq_len = x.shape[-2]
-        if seq_len >= 1024:
-            # Reshape input to to fit on device and parallelize computation
-            x = ttnn.reshape(x, [1, seq_len // 1024, 1024, -1])
-        pc_1 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
+        use_w1_w3_interleaved = seq_len >= 4096
+        pc_1 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len, use_w1_w3_interleaved)
         pc_2 = self.model_config["PREFILL_MLP_W2_PRG_CONFIG"](seq_len)
-        pc_3 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len)
+        pc_3 = self.model_config["PREFILL_MLP_W1_W3_PRG_CONFIG"](seq_len, use_w1_w3_interleaved)
+
+        if 1024 <= seq_len < 4096:
+            x = ttnn.reshape(x, (1, seq_len // 1024, 1024, -1))
 
         w1_out = ttnn.linear(
             x,
-            self.w1,
+            self.w1_interleaved if use_w1_w3_interleaved else self.w1,
             compute_kernel_config=(
                 self.args.compute_kernel_config_lofi
                 if self.four_bit_mlp
@@ -235,7 +241,7 @@ class TtLlamaMLP(LightweightModule):
         )
         w3_out = ttnn.linear(
             x,
-            self.w3,
+            self.w3_interleaved if use_w1_w3_interleaved else self.w3,
             compute_kernel_config=(
                 self.args.compute_kernel_config_lofi
                 if self.four_bit_mlp
@@ -263,7 +269,6 @@ class TtLlamaMLP(LightweightModule):
         # ttnn.deallocate(w3_out)
         # ttnn.deallocate(w1_out)
 
-        w2_in_gathered = ttnn.reshape(w2_in_gathered, (1, 1, seq_len, -1))
         w2_out = ttnn.linear(
             w2_in_gathered,
             self.w2_interleaved,
@@ -271,17 +276,11 @@ class TtLlamaMLP(LightweightModule):
             dtype=ttnn.bfloat8_b,
             program_config=pc_2,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            # core_grid=ttnn.CoreGrid(y=8, x=4),  # FIXME: validate on TG ttnn.CoreGrid(y=8, x=8) if not pc_2 else None,
         )
 
         ttnn.deallocate(w2_in)
         w2_out_reduced = self.tt_ccl.line_all_reduce(
             w2_out, cluster_axis=0, num_links=3, memory_config=ttnn.DRAM_MEMORY_CONFIG, buffer_key="FF2"
-        )
-
-        original_shape = w2_out_reduced.shape
-        w2_out_reduced = ttnn.reshape(
-            w2_out_reduced, (1, 1, original_shape[-4] * original_shape[-3] * original_shape[-2], original_shape[-1])
         )
 
         # ttnn.deallocate(w2_out)

--- a/models/demos/llama3_subdevices/tt/llama_mlp.py
+++ b/models/demos/llama3_subdevices/tt/llama_mlp.py
@@ -79,7 +79,7 @@ class TtLlamaMLP(LightweightModule):
             layout=ttnn.TILE_LAYOUT,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             # Temporarily disable caching this weight for CI
-            # cache_file_name=cache_name(name),
+            cache_file_name=cache_name(name),
         )
 
         self.four_bit_mlp = args.optimizations.bfp4_mlp
@@ -263,6 +263,7 @@ class TtLlamaMLP(LightweightModule):
         # ttnn.deallocate(w3_out)
         # ttnn.deallocate(w1_out)
 
+        w2_in_gathered = ttnn.reshape(w2_in_gathered, (1, 1, seq_len, -1))
         w2_out = ttnn.linear(
             w2_in_gathered,
             self.w2_interleaved,

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -718,7 +718,7 @@ class TtModelArgs:
                         out_subblock_h=1,  # Must be divisible by per_core_M
                         out_subblock_w=4,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
                         per_core_M=max(
-                            1, 8 if seq_len >= 2048 else seq_len // TILE_SIZE // 8  # 8 rows
+                            1, 8 if seq_len >= 2048 else seq_len // self.tile_size // 8  # 8 rows
                         ),  # M / TILE_HEIGHT / Grid_Size (dynamic based on seqlen)
                         per_core_N=math.ceil(28672 / 8 / 32 / 7),  # N / TILE_WIDTH / grid width
                         transpose_mcast=False,

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -726,229 +726,104 @@ class TtModelArgs:
                 fuse_batch=seq_len <= 2048,
             )
 
-            def w2_prg_config(seq_len):
-                if seq_len == 128:
-                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=2,
-                        out_subblock_h=4,
-                        out_subblock_w=2,
-                        out_block_h=4,
-                        out_block_w=2,
-                        per_core_M=4,
-                        per_core_N=2,
-                        fuse_batch=True,
-                        fused_activation=None,
-                        mcast_in0=True,
-                        gather_in0=False,
-                        num_global_cb_receivers=0,
-                    )
-                elif seq_len == 4096:
-                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=4,
-                        out_subblock_h=1,
-                        out_subblock_w=5,
-                        out_block_h=19,
-                        out_block_w=10,
-                        per_core_M=19,
-                        per_core_N=10,
-                        transpose_mcast=False,
-                        fused_activation=None,
-                        fuse_batch=True,
-                    )
-                elif seq_len == 6144:
-                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=4,
-                        out_subblock_h=1,
-                        out_subblock_w=2,
-                        out_block_h=28,
-                        out_block_w=10,
-                        per_core_M=28,
-                        per_core_N=10,
-                        transpose_mcast=False,
-                        fused_activation=None,
-                        fuse_batch=True,
-                    )
-                elif seq_len == 8192:
-                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=4,
-                        out_subblock_h=1,
-                        out_subblock_w=5,
-                        out_block_h=37,
-                        out_block_w=5,
-                        per_core_M=37,
-                        per_core_N=10,
-                        transpose_mcast=False,
-                        fused_activation=None,
-                        fuse_batch=True,
-                    )
-                elif seq_len == 10240:
-                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=4,
-                        out_subblock_h=1,
-                        out_subblock_w=5,
-                        out_block_h=23,
-                        out_block_w=10,
-                        per_core_M=46,
-                        per_core_N=10,
-                        transpose_mcast=False,
-                        fused_activation=None,
-                        fuse_batch=True,
-                    )
-                elif seq_len == 12288:
-                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=4,
-                        out_subblock_h=1,
-                        out_subblock_w=5,
-                        out_block_h=55,
-                        out_block_w=5,
-                        per_core_M=55,
-                        per_core_N=10,
-                        transpose_mcast=False,
-                        fused_activation=None,
-                        fuse_batch=True,
-                    )
-                elif seq_len == 14336:
-                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=4,
-                        out_subblock_h=1,
-                        out_subblock_w=2,
-                        out_block_h=32,
-                        out_block_w=10,
-                        per_core_M=64,
-                        per_core_N=10,
-                        transpose_mcast=False,
-                        fused_activation=None,
-                        fuse_batch=True,
-                    )
-                elif seq_len == 16384:
-                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=4,
-                        out_subblock_h=1,
-                        out_subblock_w=5,
-                        out_block_h=37,
-                        out_block_w=5,
-                        per_core_M=74,
-                        per_core_N=10,
-                        transpose_mcast=False,
-                        fused_activation=None,
-                        fuse_batch=True,
-                    )
-                elif seq_len == 24576:
-                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=2,
-                        out_subblock_h=2,
-                        out_subblock_w=4,
-                        out_block_h=16,
-                        out_block_w=16,
-                        per_core_M=16,
-                        per_core_N=64,
-                        fuse_batch=True,
-                        fused_activation=None,
-                        mcast_in0=False,
-                        gather_in0=False,
-                        num_global_cb_receivers=0,
-                    )
-                elif seq_len == 32768:
-                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=2,
-                        out_subblock_h=1,
-                        out_subblock_w=8,
-                        out_block_h=21,
-                        out_block_w=16,
-                        per_core_M=21,
-                        per_core_N=64,
-                        fuse_batch=True,
-                        fused_activation=None,
-                        mcast_in0=False,
-                        gather_in0=False,
-                        num_global_cb_receivers=0,
-                    )
-                elif seq_len == 51200:
-                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=2,
-                        out_subblock_h=1,
-                        out_subblock_w=8,
-                        out_block_h=11,
-                        out_block_w=32,
-                        per_core_M=33,
-                        per_core_N=64,
-                        fuse_batch=True,
-                        fused_activation=None,
-                        mcast_in0=False,
-                        gather_in0=False,
-                        num_global_cb_receivers=0,
-                    )
-                elif seq_len == 65536:
-                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=2,
-                        out_subblock_h=1,
-                        out_subblock_w=8,
-                        out_block_h=21,
-                        out_block_w=16,
-                        per_core_M=42,
-                        per_core_N=64,
-                        fuse_batch=True,
-                        fused_activation=None,
-                        mcast_in0=False,
-                        gather_in0=False,
-                        num_global_cb_receivers=0,
-                    )
-                elif seq_len == 86106:
-                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=2,
-                        out_subblock_h=1,
-                        out_subblock_w=8,
-                        out_block_h=11,
-                        out_block_w=32,
-                        per_core_M=55,
-                        per_core_N=64,
-                        fuse_batch=True,
-                        fused_activation=None,
-                        mcast_in0=False,
-                        gather_in0=False,
-                        num_global_cb_receivers=0,
-                    )
-                elif seq_len == 131072:
-                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                        compute_with_storage_grid_size=(7, 7),
-                        in0_block_w=2,
-                        out_subblock_h=2,
-                        out_subblock_w=4,
-                        out_block_h=12,
-                        out_block_w=32,
-                        per_core_M=84,
-                        per_core_N=64,
-                        fuse_batch=True,
-                        fused_activation=None,
-                        mcast_in0=False,
-                        gather_in0=False,
-                        num_global_cb_receivers=0,
-                    )
-                else:
+            def w2_prg_config(activation_height):
+                # For sequence lengths < 4096, we use this config as it performs better that what would be generated below
+                if activation_height < 4096:
                     return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                         compute_with_storage_grid_size=(7, 10),
                         in0_block_w=8,  # FIXME: optimize this config for prefill, careful use DI_DT_WORKAROUND if necessary
                         out_subblock_h=1,  # Must be divisible by per_core_M
                         out_subblock_w=2,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
-                        per_core_M=max(1, 8 if seq_len >= 2048 else seq_len // self.tile_size // 8),  # 8~10 rows
+                        per_core_M=max(
+                            1, 8 if activation_height >= 2048 else activation_height // self.tile_size // 8
+                        ),  # 8~10 rows
                         per_core_N=math.ceil(2048 / 32 / 7),  # N / TILE_WIDTH / grid width
                         transpose_mcast=False,
                         fused_activation=None,
-                        fuse_batch=seq_len <= 2048,
+                        fuse_batch=activation_height <= 2048,
                     )
+
+                # For very large activation heights (arbitrarily chosen to be > 320) we want the per_core_M to have many divisors
+                # so that there are many options for out_block_h and out_block_w. Padding to the next multiple of 8 ensures that
+                # per_core_M can at least be divisible by 2, 4, and 8 in addition to 1 and itself.
+                #
+                # If the number is less than or equal to 320 we still wouldn't want it to be prime so we'll add one if thats the case.
+                next_multiple_of_8 = lambda x: int(x + (8 - x % 8) % 8)
+                add_one_if_prime = (
+                    lambda n: n + 1 if n > 1 and all(n % i != 0 for i in range(2, int(n**0.5) + 1)) else n
+                )
+                total_per_core_out_M = add_one_if_prime(math.ceil(activation_height / (7 * self.tile_size)))
+                per_core_M = (
+                    next_multiple_of_8(total_per_core_out_M) if total_per_core_out_M > 320 else total_per_core_out_M
+                )
+                per_core_N = 10
+
+                # Want out_block_h and out_block_w such that:
+                # out_block_h * out block_w <= 320
+                # out_block_h % per_core_M == 0
+                # out_block_w % per_core_N == 0
+                # Since we're fixing per_core_N = 10, out_block_w can only be 5 or 10
+
+                def find_out_block_h(out_block_w):
+                    max_out_block_h = -1
+                    for i in range(1, per_core_M + 1):
+                        if i * out_block_w > 320:
+                            break
+                        if per_core_M % i == 0:
+                            if i > max_out_block_h:
+                                max_out_block_h = i
+                    if max_out_block_h == -1:
+                        return None
+                    return max_out_block_h
+
+                out_block_h_if_w_5 = find_out_block_h(5)
+                out_block_h_if_w_10 = find_out_block_h(10)
+
+                if out_block_h_if_w_5 is None and out_block_h_if_w_10 is None:
+                    assert False, "This should never happen"
+
+                # Pick the configuration that exists if one of them does not
+                if out_block_h_if_w_5 is None:
+                    out_block_w = 10
+                    out_block_h = out_block_h_if_w_10
+                elif out_block_h_if_w_10 is None:
+                    out_block_w = 5
+                    out_block_h = out_block_h_if_w_5
+                # If both exist, pick the one that is larger in volume
+                elif out_block_h_if_w_5 * 5 > out_block_h_if_w_10 * 10:
+                    out_block_h = out_block_h_if_w_5
+                    out_block_w = 5
+                elif out_block_h_if_w_10 * 10 > out_block_h_if_w_5 * 5:
+                    out_block_h = out_block_h_if_w_10
+                    out_block_w = 10
+                # If both have the same volume, pick the configuration that is more "square"
+                else:
+                    # Want to use the out_block_h/w combination which is the most "square"
+                    # This calculates the height/width ratio of the blocks and then gets their
+                    # distance from 1 (1 is the ideal ratio) to determine which is more square
+                    squareness_5 = abs(1 - (max(out_block_h_if_w_5, 5) / min(out_block_h_if_w_5, 5)))
+                    squareness_10 = abs(1 - (max(out_block_h_if_w_10, 10) / min(out_block_h_if_w_10, 10)))
+
+                    if squareness_5 < squareness_10:
+                        out_block_w = 5
+                        out_block_h = out_block_h_if_w_5
+                    else:
+                        out_block_w = 10
+                        out_block_h = out_block_h_if_w_10
+
+                return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=(7, 7),
+                    in0_block_w=4,
+                    out_subblock_h=1,
+                    out_subblock_w=5,
+                    out_block_h=out_block_h,
+                    out_block_w=out_block_w,
+                    per_core_M=per_core_M,
+                    per_core_N=per_core_N,
+                    transpose_mcast=False,
+                    fused_activation=None,
+                    fuse_batch=False,
+                )
 
             self.model_config["PREFILL_MLP_W2_PRG_CONFIG"] = w2_prg_config
 

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -725,19 +725,239 @@ class TtModelArgs:
                 fused_activation=None,
                 fuse_batch=seq_len <= 2048,
             )
-            self.model_config[
-                "PREFILL_MLP_W2_PRG_CONFIG"
-            ] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                compute_with_storage_grid_size=(7, 10),
-                in0_block_w=8,  # FIXME: optimize this config for prefill, careful use DI_DT_WORKAROUND if necessary
-                out_subblock_h=1,  # Must be divisible by per_core_M
-                out_subblock_w=2,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
-                per_core_M=max(1, 8 if seq_len >= 2048 else seq_len // self.tile_size // 8),  # 8~10 rows
-                per_core_N=math.ceil(2048 / 32 / 7),  # N / TILE_WIDTH / grid width
-                transpose_mcast=False,
-                fused_activation=None,
-                fuse_batch=seq_len <= 2048,
-            )
+
+            def w2_prg_config(seq_len):
+                if seq_len == 128:
+                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=2,
+                        out_subblock_h=4,
+                        out_subblock_w=2,
+                        out_block_h=4,
+                        out_block_w=2,
+                        per_core_M=4,
+                        per_core_N=2,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=True,
+                        gather_in0=True,
+                        hop_cores={},
+                        num_global_cb_receivers=0,
+                    )
+                elif seq_len == 4096:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=4,
+                        out_subblock_h=1,
+                        out_subblock_w=5,
+                        out_block_h=19,
+                        out_block_w=10,
+                        per_core_M=19,
+                        per_core_N=10,
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=True,
+                    )
+                elif seq_len == 6144:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=4,
+                        out_subblock_h=1,
+                        out_subblock_w=2,
+                        out_block_h=28,
+                        out_block_w=10,
+                        per_core_M=28,
+                        per_core_N=10,
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=True,
+                    )
+                elif seq_len == 8192:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=4,
+                        out_subblock_h=1,
+                        out_subblock_w=5,
+                        out_block_h=37,
+                        out_block_w=5,
+                        per_core_M=37,
+                        per_core_N=10,
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=True,
+                    )
+                elif seq_len == 10240:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=4,
+                        out_subblock_h=1,
+                        out_subblock_w=5,
+                        out_block_h=23,
+                        out_block_w=10,
+                        per_core_M=46,
+                        per_core_N=10,
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=True,
+                    )
+                elif seq_len == 12288:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=4,
+                        out_subblock_h=1,
+                        out_subblock_w=5,
+                        out_block_h=55,
+                        out_block_w=5,
+                        per_core_M=55,
+                        per_core_N=10,
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=True,
+                    )
+                elif seq_len == 14336:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=4,
+                        out_subblock_h=1,
+                        out_subblock_w=2,
+                        out_block_h=32,
+                        out_block_w=10,
+                        per_core_M=64,
+                        per_core_N=10,
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=True,
+                    )
+                elif seq_len == 16384:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=4,
+                        out_subblock_h=1,
+                        out_subblock_w=5,
+                        out_block_h=37,
+                        out_block_w=5,
+                        per_core_M=74,
+                        per_core_N=10,
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=True,
+                    )
+                elif seq_len == 24576:
+                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=2,
+                        out_subblock_h=2,
+                        out_subblock_w=4,
+                        out_block_h=16,
+                        out_block_w=16,
+                        per_core_M=16,
+                        per_core_N=64,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=False,
+                        gather_in0=False,
+                        hop_cores={},
+                        num_global_cb_receivers=0,
+                    )
+                elif seq_len == 32768:
+                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=2,
+                        out_subblock_h=1,
+                        out_subblock_w=8,
+                        out_block_h=21,
+                        out_block_w=16,
+                        per_core_M=21,
+                        per_core_N=64,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=False,
+                        gather_in0=False,
+                        hop_cores={},
+                        num_global_cb_receivers=0,
+                    )
+                elif seq_len == 51200:
+                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=2,
+                        out_subblock_h=1,
+                        out_subblock_w=8,
+                        out_block_h=11,
+                        out_block_w=32,
+                        per_core_M=33,
+                        per_core_N=64,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=False,
+                        gather_in0=False,
+                        hop_cores={},
+                        num_global_cb_receivers=0,
+                    )
+                elif seq_len == 65536:
+                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=2,
+                        out_subblock_h=1,
+                        out_subblock_w=8,
+                        out_block_h=21,
+                        out_block_w=16,
+                        per_core_M=42,
+                        per_core_N=64,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=False,
+                        gather_in0=False,
+                        hop_cores={},
+                        num_global_cb_receivers=0,
+                    )
+                elif seq_len == 86106:
+                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=2,
+                        out_subblock_h=1,
+                        out_subblock_w=8,
+                        out_block_h=11,
+                        out_block_w=32,
+                        per_core_M=55,
+                        per_core_N=64,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=False,
+                        gather_in0=False,
+                        hop_cores={},
+                        num_global_cb_receivers=0,
+                    )
+                elif seq_len == 131072:
+                    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=(7, 7),
+                        in0_block_w=2,
+                        out_subblock_h=2,
+                        out_subblock_w=4,
+                        out_block_h=12,
+                        out_block_w=32,
+                        per_core_M=84,
+                        per_core_N=64,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=False,
+                        gather_in0=False,
+                        hop_cores={},
+                        num_global_cb_receivers=0,
+                    )
+                else:
+                    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=(7, 10),
+                        in0_block_w=8,  # FIXME: optimize this config for prefill, careful use DI_DT_WORKAROUND if necessary
+                        out_subblock_h=1,  # Must be divisible by per_core_M
+                        out_subblock_w=2,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
+                        per_core_M=max(1, 8 if seq_len >= 2048 else seq_len // self.tile_size // 8),  # 8~10 rows
+                        per_core_N=math.ceil(2048 / 32 / 7),  # N / TILE_WIDTH / grid width
+                        transpose_mcast=False,
+                        fused_activation=None,
+                        fuse_batch=seq_len <= 2048,
+                    )
+
+            self.model_config["PREFILL_MLP_W2_PRG_CONFIG"] = w2_prg_config
 
             self.model_config["WO_PREFILL_PROGCFG"] = lambda seq_len: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=(7, 10),

--- a/models/demos/llama3_subdevices/tt/model_config.py
+++ b/models/demos/llama3_subdevices/tt/model_config.py
@@ -740,8 +740,7 @@ class TtModelArgs:
                         fuse_batch=True,
                         fused_activation=None,
                         mcast_in0=True,
-                        gather_in0=True,
-                        hop_cores={},
+                        gather_in0=False,
                         num_global_cb_receivers=0,
                     )
                 elif seq_len == 4096:
@@ -856,7 +855,6 @@ class TtModelArgs:
                         fused_activation=None,
                         mcast_in0=False,
                         gather_in0=False,
-                        hop_cores={},
                         num_global_cb_receivers=0,
                     )
                 elif seq_len == 32768:
@@ -873,7 +871,6 @@ class TtModelArgs:
                         fused_activation=None,
                         mcast_in0=False,
                         gather_in0=False,
-                        hop_cores={},
                         num_global_cb_receivers=0,
                     )
                 elif seq_len == 51200:
@@ -890,7 +887,6 @@ class TtModelArgs:
                         fused_activation=None,
                         mcast_in0=False,
                         gather_in0=False,
-                        hop_cores={},
                         num_global_cb_receivers=0,
                     )
                 elif seq_len == 65536:
@@ -907,7 +903,6 @@ class TtModelArgs:
                         fused_activation=None,
                         mcast_in0=False,
                         gather_in0=False,
-                        hop_cores={},
                         num_global_cb_receivers=0,
                     )
                 elif seq_len == 86106:
@@ -924,7 +919,6 @@ class TtModelArgs:
                         fused_activation=None,
                         mcast_in0=False,
                         gather_in0=False,
-                        hop_cores={},
                         num_global_cb_receivers=0,
                     )
                 elif seq_len == 131072:
@@ -941,7 +935,6 @@ class TtModelArgs:
                         fused_activation=None,
                         mcast_in0=False,
                         gather_in0=False,
-                        hop_cores={},
                         num_global_cb_receivers=0,
                     )
                 else:


### PR DESCRIPTION
### What's changed
Optimized program configs for all matmuls in the MLP layer for seq_len >= 4k. These changes require an interleaved weight tensor. So, each MLP layer will now have width-shared weights AND interleaved weights with identical data. The interleaved weights will be used during prefill if the sequence length >= 4k.

On 4U, these changes will save ~80ms during prefill at a 4k sequence length.

Perf difference **W1/W3** by sequence length (% reduction in device kernel duration):
- 128: 0%
- 256: 0%
- 512: 0%
- 1024 0%
- 2048 0%
- 4096: 28%
- 6144: 28%
- 8192: 28%
- 10240: 28%
- 12288: 28%
- 14336: 28%
- 16384: 28%
- 24576: 28%
- 32768: 28%
- 51200: 28%
- 65536: 28%
- 86016: 28%
- 131072: 28%

Perf difference **W2** by sequence length (% reduction in device kernel duration):
- 128: ~2%
- 256: 0%
- 512: ~2%
- 1024: 0%
- 2048: 0%
- 4096: 37%
- 6144: 38%
- 8192: 38%
- 10240: 39%
- 12288: 39%
- 14336: 40%
- 16384: 38%
- 24576: 39%
- 32768: 38%
- 51200: 39%
- 65536: 38%
- 86016: 40%
- 131072: 38%

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes