### PR TITLE
Move program_device_map.hpp out of api/tt-metallium

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -80,7 +80,6 @@ target_sources(
             api/tt-metalium/persistent_kernel_cache.hpp
             api/tt-metalium/program.hpp
             api/tt-metalium/program_cache.hpp
-            api/tt-metalium/program_device_map.hpp
             api/tt-metalium/runtime_args_data.hpp
             api/tt-metalium/semaphore.hpp
             api/tt-metalium/shape.hpp

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -18,7 +18,6 @@
 #include <hostdevcommon/kernel_structs.h>  // Not used here, but leaked to programming examples
 #include <tt-metalium/work_executor_types.hpp>
 #include <tt-metalium/data_types.hpp>
-#include <tt-metalium/program_device_map.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/sub_device_types.hpp>
@@ -195,8 +194,6 @@ public:
     virtual HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core) const = 0;
 
     uint64_t get_dev_addr(CoreCoord virtual_core, HalL1MemAddrType addr_type) const;
-
-    virtual std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) = 0;
 
     virtual uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const = 0;
     virtual uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const = 0;

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -12,7 +12,6 @@
 #include <hostdevcommon/kernel_structs.h>  // Leaked up to ttnn level from here
 #include <tt-metalium/work_executor_types.hpp>
 #include <tt-metalium/data_types.hpp>
-#include <tt-metalium/program_device_map.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/command_queue.hpp>
@@ -166,8 +165,6 @@ public:
     std::size_t num_program_cache_entries() override;
 
     HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core) const override;
-
-    std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) override;
 
     uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const override;
     uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const override;

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -30,7 +30,6 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
-#include <tt-metalium/program_device_map.hpp>
 #include <tt-metalium/small_vector.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/trace_buffer.hpp>
@@ -238,8 +237,6 @@ public:
     program_cache::detail::ProgramCache& get_program_cache() override;
     std::size_t num_program_cache_entries() override;
     HalProgrammableCoreType get_programmable_core_type(CoreCoord virtual_core) const override;
-    std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(
-        const std::vector<CoreRange>& ranges, const CoreType core_type) override;
     uint8_t num_noc_mcast_txns(SubDeviceId sub_device_id) const override;
     uint8_t num_noc_unicast_txns(SubDeviceId sub_device_id) const override;
     uint8_t noc_data_start_index(SubDeviceId sub_device_id, bool mcast_data=true, bool unicast_data=true) const override;

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/circular_buffer_types.hpp>
 #include <tt-metalium/semaphore.hpp>
-#include <tt-metalium/program_device_map.hpp>
 #include <tt-metalium/worker_config_buffer.hpp>
 #include <tt-metalium/dev_msgs.h>
 #include <tt-metalium/program_descriptors.hpp>
@@ -27,6 +26,7 @@ class CircularBuffer;
 class IDevice;
 class Program;
 class CircularBufferConfig;
+class ProgramTransferInfo;
 
 struct ProgramCommandSequence;
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -848,10 +848,8 @@ void MeshDevice::push_work(std::function<void()> work, bool /*blocking*/) {
     work();
 }
 program_cache::detail::ProgramCache& MeshDevice::get_program_cache() { return *program_cache_; }
-HalProgrammableCoreType MeshDevice::get_programmable_core_type(CoreCoord virtual_core) const { return reference_device()->get_programmable_core_type(virtual_core); }
-std::vector<std::pair<transfer_info_cores, uint32_t>> MeshDevice::extract_dst_noc_multicast_info(
-    const std::vector<CoreRange>& ranges, const CoreType core_type) {
-    return reference_device()->extract_dst_noc_multicast_info(ranges, core_type);
+HalProgrammableCoreType MeshDevice::get_programmable_core_type(CoreCoord virtual_core) const {
+    return reference_device()->get_programmable_core_type(virtual_core);
 }
 
 // Methods for SubDevice Management

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -25,7 +25,7 @@
 #include "kernel_types.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_device.hpp"
-#include "program_device_map.hpp"
+#include "tt_metal/impl/program/program_device_map.hpp"
 #include "tt-metalium/program.hpp"
 #include "semaphore.hpp"
 #include "sub_device_types.hpp"

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -25,7 +25,7 @@
 #include "kernel_types.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_device.hpp"
-#include "tt_metal/impl/program/program_device_map.hpp"
+#include "program/program_device_map.hpp"
 #include "tt-metalium/program.hpp"
 #include "semaphore.hpp"
 #include "sub_device_types.hpp"

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -31,6 +31,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/program/program.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/program/dispatch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/program/program_descriptors.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/program/program_device_map.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler/profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/profiler/tt_metal_profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch/debug_tools.cpp

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -59,7 +59,6 @@
 #include "metal_soc_descriptor.h"
 #include "multi_producer_single_consumer_queue.hpp"
 #include "profiler_types.hpp"
-#include "program_device_map.hpp"
 #include "tt-metalium/program.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
@@ -1790,21 +1789,6 @@ HalProgrammableCoreType Device::get_programmable_core_type(CoreCoord virtual_cor
     }
 
     return HalProgrammableCoreType::IDLE_ETH;
-}
-
-// TODO: Find a better home for this function
-// Extracts all the pairs of noc multicast encodings given a set of core ranges
-std::vector<std::pair<transfer_info_cores, uint32_t>> Device::extract_dst_noc_multicast_info(const std::vector<CoreRange>& ranges, const CoreType core_type) {
-    std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
-    dst_noc_multicast_info.reserve(ranges.size());
-    for (const CoreRange& core_range : ranges) {
-        CoreCoord virtual_start = this->virtual_core_from_logical_core(core_range.start_coord, core_type);
-        CoreCoord virtual_end = this->virtual_core_from_logical_core(core_range.end_coord, core_type);
-
-        uint32_t num_receivers = core_range.size();
-        dst_noc_multicast_info.push_back(std::make_pair(CoreRange(virtual_start, virtual_end), num_receivers));
-    }
-    return dst_noc_multicast_info;
 }
 
 std::shared_ptr<distributed::MeshDevice> Device::get_mesh_device() { return mesh_device.lock(); }

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -31,7 +31,7 @@
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
 #include "logger.hpp"
-#include "program_device_map.hpp"
+#include "tt_metal/impl/program/program_device_map.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -31,7 +31,7 @@
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
 #include "logger.hpp"
-#include "tt_metal/impl/program/program_device_map.hpp"
+#include "program/program_device_map.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "system_memory_manager.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -806,7 +806,7 @@ BatchedTransfers assemble_runtime_args_commands(
                     uint32_t dispatch_class = kernel->dispatch_class();
                     const uint32_t crta_offset = program.get_program_config(index).crta_offsets[dispatch_class];
                     for (auto& [transfer_info, dests] :
-                         device->extract_dst_noc_multicast_info(kg->core_ranges.ranges(), CoreType::WORKER)) {
+                         extract_dst_noc_multicast_info(device, kg->core_ranges.ranges(), CoreType::WORKER)) {
                         auto noc_xy_addr =
                             device->get_noc_multicast_encoding(constants.noc_index, std::get<CoreRange>(transfer_info));
                         size_t size =
@@ -950,7 +950,7 @@ BatchedTransfers assemble_runtime_args_commands(
                         }
                     } else {
                         std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                            device->extract_dst_noc_multicast_info(kernel->logical_coreranges(), core_type);
+                            extract_dst_noc_multicast_info(device, kernel->logical_coreranges(), core_type);
                         common_sub_cmds.emplace<std::vector<CQDispatchWritePackedMulticastSubCmd>>(
                             std::vector<CQDispatchWritePackedMulticastSubCmd>());
                         auto& multicast_sub_cmd =
@@ -1048,7 +1048,7 @@ public:
             if (semaphore.core_type() == CoreType::WORKER) {
                 uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
                 std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                    device->extract_dst_noc_multicast_info(semaphore.core_range_set().ranges(), CoreType::WORKER);
+                    extract_dst_noc_multicast_info(device, semaphore.core_range_set().ranges(), CoreType::WORKER);
                 for (const auto& dst_noc_info : dst_noc_multicast_info) {
                     auto& [range, dests] = dst_noc_info;
                     auto noc_xy_addr =

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1120,8 +1120,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
             // TODO: add a bit in the hal that says if this core type is unicast/multicast
             if (core_type == CoreType::WORKER) {
                 std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
-                    device->extract_dst_noc_multicast_info(
-                       kernel_group->core_ranges.ranges(), core_type);
+                    extract_dst_noc_multicast_info(device, kernel_group->core_ranges.ranges(), core_type);
                 std::vector<KernelHandle> kernel_ids;
                 for (int dispatch_class = 0; dispatch_class < kernel_group->kernel_ids.size(); dispatch_class++) {
                     auto &optional_id = kernel_group->kernel_ids[dispatch_class];

--- a/tt_metal/impl/program/program_device_map.cpp
+++ b/tt_metal/impl/program/program_device_map.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "program_device_map.hpp"
+
+namespace tt::tt_metal {
+
+// Extracts all the pairs of noc multicast encodings given a set of core ranges
+std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(
+    IDevice* device, const std::vector<CoreRange>& ranges, const CoreType core_type) {
+    std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
+    dst_noc_multicast_info.reserve(ranges.size());
+    for (const CoreRange& core_range : ranges) {
+        CoreCoord virtual_start = device->virtual_core_from_logical_core(core_range.start_coord, core_type);
+        CoreCoord virtual_end = device->virtual_core_from_logical_core(core_range.end_coord, core_type);
+
+        uint32_t num_receivers = core_range.size();
+        dst_noc_multicast_info.push_back(std::make_pair(CoreRange(virtual_start, virtual_end), num_receivers));
+    }
+    return dst_noc_multicast_info;
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_device_map.hpp
+++ b/tt_metal/impl/program/program_device_map.hpp
@@ -5,17 +5,19 @@
 #pragma once
 
 #include <cstdint>
-#include <unordered_map>
 #include <variant>
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt::tt_metal {
 
 using transfer_info_cores = std::variant<CoreCoord, CoreRange>;
 
+std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(
+    IDevice* device, const std::vector<CoreRange>& ranges, const CoreType core_type);
 struct transfer_info {
     std::uint32_t dst_base_addr;
     std::vector<std::pair<transfer_info_cores, std::uint32_t>> dst_noc_info;  // noc_encoding, num_mcast_dests

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -14,7 +14,7 @@
 #include "tt-metalium/kernel.hpp"              // Kernel
 #include "tt-metalium/kernel_types.hpp"        // KernelHandle
 #include "tt-metalium/program.hpp"             // KernelGroup
-#include "tt-metalium/program_device_map.hpp"  // ProgramTransferInfo
+#include "program_device_map.hpp"              // ProgramTransferInfo
 #include "tt-metalium/semaphore.hpp"
 #include "tt-metalium/sub_device_types.hpp"
 


### PR DESCRIPTION
### Problem description
program_device_map.hpp is unnecessarily exposed in api/tt-metallium

### What's changed
Move it to tt_metal/impl/program/program_device_map.hpp. Device::extract_dst_noc_multicast_info depended on the transfer_info_cores struct but is only used in dispatch code, so move that into program_device_map.cpp.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes