### PR TITLE
Stress tests for `matmul` and `eltwise`

### DIFF
--- a/tests/ttnn/stress_tests/test_data_movement.py
+++ b/tests/ttnn/stress_tests/test_data_movement.py
@@ -46,18 +46,6 @@ def reshape_input_shapes(test_case: str):
         raise RuntimeError("Unidentifiable device")
 
 
-if is_blackhole():
-    l1_input_shape, l1_output_shape = (L1_INPUT_SHAPE_BH, L1_OUTPUT_SHAPE_BH)
-    dram_input_shape, dram_output_shape = (DRAM_INPUT_SHAPE_BH, DRAM_OUTPUT_SHAPE_BH)
-    sharding_input_shape = SHARDING_INPUT_SHAPE_BH
-elif is_wormhole_b0():
-    l1_input_shape, l1_output_shape = (L1_INPUT_SHAPE_WH, L1_OUTPUT_SHAPE_WH)
-    dram_input_shape, dram_output_shape = (DRAM_INPUT_SHAPE_WH, DRAM_OUTPUT_SHAPE_WH)
-    sharding_input_shape = SHARDING_INPUT_SHAPE_WH
-else:
-    raise RuntimeError("Unidentifiable device")
-
-
 @pytest.mark.parametrize(
     "shapes_memory_config",
     [

--- a/tests/ttnn/stress_tests/test_eltwise.py
+++ b/tests/ttnn/stress_tests/test_eltwise.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+from ttnn.device import get_device_core_grid, is_blackhole, is_wormhole_b0
+
+NUM_REPEATS = 5
+
+##### WORMMHOLE #######
+L1_INPUT_SHAPE_WH = (10_000, 8, 8)
+
+DRAM_INPUT_SHAPE_WH = (1_500_000, 8, 8)
+
+##### BLACKHOLE #######
+L1_INPUT_SHAPE_BH = (60_000, 8, 8)
+
+DRAM_INPUT_SHAPE_BH = (7_500_000, 8, 8)
+
+
+def eltwise_input_shapes(test_case: str):
+    if is_blackhole():
+        return L1_INPUT_SHAPE_BH if test_case == "l1" else DRAM_INPUT_SHAPE_BH
+    elif is_wormhole_b0():
+        return L1_INPUT_SHAPE_WH if test_case == "l1" else DRAM_INPUT_SHAPE_WH
+    else:
+        raise RuntimeError("Unidentifiable device")
+
+
+@pytest.mark.parametrize(
+    "shape_memory_config",
+    [
+        (eltwise_input_shapes("l1"), ttnn.L1_MEMORY_CONFIG),
+        (eltwise_input_shapes("dram"), ttnn.DRAM_MEMORY_CONFIG),
+    ],
+)
+def test_stress_binary(device, use_program_cache, shape_memory_config):
+    input_shape, memory_config = shape_memory_config
+    for _ in range(NUM_REPEATS):
+        torch_input_tensor1 = torch.randn(input_shape, dtype=torch.bfloat16)
+        torch_input_tensor2 = torch.randn(input_shape, dtype=torch.bfloat16)
+        input_tensor1 = ttnn.from_torch(
+            torch_input_tensor1, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device
+        )
+        input_tensor2 = ttnn.from_torch(
+            torch_input_tensor2, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device
+        )
+
+        output_tensor = ttnn.add(input_tensor1, input_tensor2)
+
+        del torch_input_tensor1
+        del torch_input_tensor2
+        del input_tensor1
+        del input_tensor2
+        del output_tensor
+
+    assert True
+
+
+@pytest.mark.parametrize(
+    "shape_memory_config",
+    [
+        (eltwise_input_shapes("l1"), ttnn.L1_MEMORY_CONFIG),
+        (eltwise_input_shapes("dram"), ttnn.DRAM_MEMORY_CONFIG),
+    ],
+)
+def test_stress_unary(device, use_program_cache, shape_memory_config):
+    input_shape, memory_config = shape_memory_config
+    for _ in range(NUM_REPEATS):
+        torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
+        input_tensor = ttnn.from_torch(
+            torch_input_tensor, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device
+        )
+
+        output_tensor = ttnn.silu(input_tensor)
+
+        del torch_input_tensor
+        del input_tensor
+        del output_tensor
+
+    assert True

--- a/tests/ttnn/stress_tests/test_eltwise.py
+++ b/tests/ttnn/stress_tests/test_eltwise.py
@@ -16,9 +16,9 @@ L1_INPUT_SHAPE_WH = (10_000, 8, 8)
 DRAM_INPUT_SHAPE_WH = (1_500_000, 8, 8)
 
 ##### BLACKHOLE #######
-L1_INPUT_SHAPE_BH = (60_000, 8, 8)
+L1_INPUT_SHAPE_BH = (30_000, 8, 8)
 
-DRAM_INPUT_SHAPE_BH = (7_500_000, 8, 8)
+DRAM_INPUT_SHAPE_BH = (3_000_000, 8, 8)
 
 
 def eltwise_input_shapes(test_case: str):

--- a/tests/ttnn/stress_tests/test_matmul.py
+++ b/tests/ttnn/stress_tests/test_matmul.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+# test cases provided in https://github.com/tenstorrent/tt-metal/issues/21069
+
+TEST_CASES = [
+    "tests/ttnn/unit_tests/operations/matmul/test_matmul.py::test_matmul_2d_multiple_output_blocks_per_core",
+    "tests/ttnn/unit_tests/operations/matmul/test_matmul.py::test_matmul_in1_dram_sharded_tiny_tile",
+    "tests/ttnn/unit_tests/operations/matmul/test_matmul.py::test_padded_1d_matmul",
+]
+
+NUM_REPEATS = 5
+
+
+def test_matmul():
+    for _ in range(NUM_REPEATS):
+        pytest.main(TEST_CASES)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21069

### Problem description
NA

### What's changed
- stress test for matmul ops
- stress test for eltwise ops

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes