### PR TITLE
Resolve profiler build issues due to missing arg in OpPerformanceModelGeneral

### DIFF
--- a/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp
@@ -166,7 +166,9 @@ struct MeshDeviceOperationAdapter {
                 // tensor_args_t for Op contains input_tensors attributes (mirror what's done in
                 // OldInfraDeviceOperation)
                 return tt::tt_metal::operation::OpPerformanceModelGeneral(
-                    tensor_args.input_tensors, tensor_return_value);
+                    tensor_args.input_tensors,
+                    tensor_return_value,
+                    1 /* ideal_compute_cycles: specify as 1, since op perf model is not provided*/);
             } else {
                 // tensor_args_t does not comply with interface used by OldInfraDeviceOperation, use default performance
                 // model


### PR DESCRIPTION
### Ticket
No ticket.

### Problem description
Profiler build fails on main when the following command is used:
`./build_metal.sh -e -c --build-tests --enable-profiler`
This was due to a missing arg in `OpPerformanceModelGeneral` called inside `ttnn/cpp/ttnn/mesh_device_operation_adapter.hpp`

### What's changed
Add back missing arg.

fyi @SeanNijjar @esmalTT @mo-tenstorrent 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes