### PR TITLE
Refactoring 1d tests

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -34,6 +34,10 @@
 #include "tt_metal/fabric/hw/inc/tt_fabric_status.h"
 #include "umd/device/tt_core_coordinates.h"
 
+static const char* SENDER_KERNEL_PATH =
+    "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp";
+static const char* RECEIVER_KERNEL_PATH =
+    "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp";
 namespace tt::tt_fabric {
 namespace fabric_router_tests {
 struct TestParameters {
@@ -50,7 +54,6 @@ struct TestParameters {
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
     bool is_mcast = false;
 };
-
 struct ProgramInfo {
     tt::tt_metal::IDevice* device;
     tt::tt_metal::Program& program;
@@ -170,7 +173,7 @@ void CreateRx(
         params.packet_payload_size_bytes, params.num_packets, params.time_seed};
     auto receiver_kernel = tt_metal::CreateKernel(
         receiver_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
+        RECEIVER_KERNEL_PATH,
         {params.receiver_logical_core},
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
@@ -198,11 +201,9 @@ void CreateTx(
         /* mcast_bwd_hops for mcast */
         sender_runtime_args.push_back(params.num_hops);
     }
-    // Dynamically allocate the sender program.
-    // auto* sender_program = new tt::tt_metal::Program(tt_metal::CreateProgram());
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
+        SENDER_KERNEL_PATH,
         {params.sender_logical_core},
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
@@ -267,7 +268,7 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     auto sender_program = tt_metal::CreateProgram();
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
+        SENDER_KERNEL_PATH,
         {params.sender_logical_core},
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -36,47 +36,9 @@
 
 namespace tt::tt_fabric {
 namespace fabric_router_tests {
-
-TEST_F(Fabric1DFixture, TestUnicastRaw) {
+struct TestParameters {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
-
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-
-    std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
-    std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
-    chip_id_t not_used_1;
-    chip_id_t not_used_2;
-    // Find a device with a neighbour in the East direction
-    bool connection_found = find_device_with_neighbor_in_direction(
-        src_mesh_chip_id, dst_mesh_chip_id, not_used_1, not_used_2, RoutingDirection::E);
-    if (!connection_found) {
-        GTEST_SKIP() << "No path found between sender and receivers";
-    }
-
-    chip_id_t src_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(src_mesh_chip_id);
-    chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
-
-    // get a port to connect to
-    std::set<chan_id_t> eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
-        src_mesh_chip_id.first, src_mesh_chip_id.second, RoutingDirection::E);
-    if (eth_chans.size() == 0) {
-        GTEST_SKIP() << "No active eth chans to connect to";
-    }
-
-    auto edm_port = *(eth_chans.begin());
-    CoreCoord edm_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
-        src_physical_device_id, edm_port);
-
-    auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
-    auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
-    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
-
-    auto receiver_noc_encoding =
-        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
-
-    // test parameters
     uint32_t packet_header_address = 0x25000;
     uint32_t source_l1_buffer_address = 0x30000;
     uint32_t packet_payload_size_bytes = 4096;
@@ -86,10 +48,226 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     uint32_t test_results_size_bytes = 128;
     uint32_t target_address = 0x30000;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
+    bool is_mcast = false;
+};
+
+struct ProgramInfo {
+    tt::tt_metal::IDevice* device;
+    tt::tt_metal::Program& program;
+    CoreCoord core;
+};
+
+void LaunchAndSyncPhase(Fabric1DFixture* fixture, std::vector<ProgramInfo>& devices) {
+    for (auto& device : devices) {
+        fixture->RunProgramNonblocking(device.device, device.program);
+    }
+    for (auto& device : devices) {
+        fixture->WaitForSingleProgramDone(device.device, device.program);
+    }
+}
+
+void ValidationPhase(std::vector<ProgramInfo>& devices, TestParameters& params) {
+    uint64_t prev_bytes;
+    for (uint32_t i = 0; i < devices.size(); i++) {
+        auto& device = devices[i];
+        std::vector<uint32_t> status;
+        tt_metal::detail::ReadFromDeviceL1(
+            device.device,
+            device.core,
+            params.test_results_address,
+            params.test_results_size_bytes,
+            status,
+            CoreType::WORKER);
+
+        EXPECT_EQ(status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
+        uint64_t next_bytes = ((uint64_t)status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | status[TT_FABRIC_WORD_CNT_INDEX];
+        if (i > 0) {
+            EXPECT_EQ(prev_bytes, next_bytes);
+        }
+        prev_bytes = next_bytes;
+    }
+}
+
+std::tuple<chip_id_t, std::vector<chip_id_t>, uint32_t, CoreCoord> GetConnectedDeviceInfo(
+    Fabric1DFixture* fixture,
+    CoreCoord sender_logical_core,
+    CoreCoord receiver_logical_core,
+    bool is_mcast = false,
+    bool get_active_eth_core = false) {
+    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+
+    chip_id_t src_physical_device_id = 0, left_physical_device_id = 0, right_physical_device_id = 0;
+    std::vector<chip_id_t> dest_chip_ids;
+    CoreCoord edm_eth_core = {0, 0};
+    if (!is_mcast) {
+        std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
+        std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
+        chip_id_t not_used_1;
+        chip_id_t not_used_2;
+        // Find a device with a neighbour in the East direction
+        bool connection_found = fixture->find_device_with_neighbor_in_direction(
+            src_mesh_chip_id, dst_mesh_chip_id, not_used_1, not_used_2, RoutingDirection::E);
+        if (!connection_found) {
+            return std::make_tuple(0, dest_chip_ids, 0, CoreCoord{0, 0});
+        }
+
+        src_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(src_mesh_chip_id);
+        left_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
+
+        if (get_active_eth_core) {
+            std::set<chan_id_t> eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
+                src_mesh_chip_id.first, src_mesh_chip_id.second, RoutingDirection::E);
+            if (eth_chans.size() == 0) {
+                return std::make_tuple(0, dest_chip_ids, 0, CoreCoord{0, 0});
+            }
+            auto edm_port = *(eth_chans.begin());
+            edm_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                src_physical_device_id, edm_port);
+        }
+        dest_chip_ids.push_back(left_physical_device_id);
+    } else {
+        // use control plane to find a mesh with 3 devices
+        auto user_meshes = control_plane->get_user_physical_mesh_ids();
+        std::optional<mesh_id_t> mesh_id;
+        for (const auto& mesh : user_meshes) {
+            auto mesh_shape = control_plane->get_physical_mesh_shape(mesh);
+            if (mesh_shape.mesh_size() >= 3) {
+                mesh_id = mesh;
+                break;
+            }
+        }
+        if (!mesh_id.has_value()) {
+            return std::make_tuple(0, dest_chip_ids, 0, CoreCoord{0, 0});
+        }
+
+        // for this test, logical chip id 1 is the sender, 0 is the left receiver and 1 is the right receiver
+        auto src_physical_device_id =
+            control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 1));
+        auto left_physical_device_id =
+            control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 0));
+        auto right_physical_device_id =
+            control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 2));
+        dest_chip_ids.push_back(left_physical_device_id);
+        dest_chip_ids.push_back(right_physical_device_id);
+    }
+
+    auto sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
+    auto receiver_l_device = DevicePool::instance().get_active_device(left_physical_device_id);
+    auto receiver_r_device = DevicePool::instance().get_active_device(right_physical_device_id);
+    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+    CoreCoord receiver_virtual_core = receiver_l_device->worker_core_from_logical_core(receiver_logical_core);
+
+    auto receiver_noc_encoding = tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(
+        receiver_virtual_core.x, receiver_virtual_core.y);  //
+
+    // return tuple
+    return std::make_tuple(src_physical_device_id, dest_chip_ids, receiver_noc_encoding, edm_eth_core);
+}
+
+void CreateRx(
+    TestParameters& params, tt::tt_metal::Program& receiver_program, std::vector<uint32_t>& compile_time_args) {
+    std::vector<uint32_t> receiver_runtime_args = {
+        params.packet_payload_size_bytes, params.num_packets, params.time_seed};
+    auto receiver_kernel = tt_metal::CreateKernel(
+        receiver_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
+        {params.receiver_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, params.receiver_logical_core, receiver_runtime_args);
+}
+
+void CreateTx(
+    TestParameters& params,
+    tt::tt_metal::Program& sender_program,
+    std::vector<uint32_t>& compile_time_args,
+    uint32_t receiver_noc_encoding,
+    chip_id_t src_chip_id,
+    std::vector<chip_id_t>& dest_chip_ids) {
+    std::vector<uint32_t> sender_runtime_args = {
+        params.packet_header_address,
+        params.source_l1_buffer_address,
+        params.packet_payload_size_bytes,
+        params.num_packets,
+        receiver_noc_encoding,
+        params.time_seed};
+    sender_runtime_args.push_back(params.num_hops);
+    if (dest_chip_ids.size() > 1) {
+        /* mcast_bwd_hops for mcast */
+        sender_runtime_args.push_back(params.num_hops);
+    }
+    // Dynamically allocate the sender program.
+    // auto* sender_program = new tt::tt_metal::Program(tt_metal::CreateProgram());
+    auto sender_kernel = tt_metal::CreateKernel(
+        sender_program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
+        {params.sender_logical_core},
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0,
+            .noc = tt_metal::NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+    for (auto dest_chip_id : dest_chip_ids) {
+        append_fabric_connection_rt_args(
+            src_chip_id, dest_chip_id, 0, sender_program, {params.sender_logical_core}, sender_runtime_args);
+    }
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, params.sender_logical_core, sender_runtime_args);
+}
+
+void ExecuteFabricTest(Fabric1DFixture* fixture, TestParameters params) {
+    auto [src_physical_device_id, dst_chip_ids, receiver_noc_encoding, edm_eth_core] = GetConnectedDeviceInfo(
+        fixture, params.sender_logical_core, params.receiver_logical_core, params.is_mcast, false);
+    if (src_physical_device_id == 0 && dst_chip_ids.empty() && receiver_noc_encoding == 0) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+    std::vector<uint32_t> compile_time_args = {
+        params.test_results_address,
+        params.test_results_size_bytes,
+        params.target_address,
+        params.is_mcast ? 1 : 0,
+    };
+
+    auto sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
+    std::vector<ProgramInfo> program_infos;
+    auto sender_program = tt_metal::CreateProgram();
+    auto receiver_program = tt_metal::CreateProgram();
+    if (params.is_mcast) {
+        auto left_recv_device = DevicePool::instance().get_active_device(dst_chip_ids[0]);
+        auto right_recv_device = DevicePool::instance().get_active_device(dst_chip_ids[1]);
+        CreateTx(
+            params, sender_program, compile_time_args, receiver_noc_encoding, src_physical_device_id, dst_chip_ids);
+        CreateRx(params, receiver_program, compile_time_args);
+        program_infos.emplace_back(sender_device, sender_program, params.sender_logical_core);
+        program_infos.emplace_back(left_recv_device, receiver_program, params.receiver_logical_core);
+        program_infos.emplace_back(right_recv_device, receiver_program, params.receiver_logical_core);
+    } else {
+        auto receiver_device = DevicePool::instance().get_active_device(dst_chip_ids[0]);
+        CreateTx(
+            params, sender_program, compile_time_args, receiver_noc_encoding, src_physical_device_id, dst_chip_ids);
+        CreateRx(params, receiver_program, compile_time_args);
+        program_infos.emplace_back(sender_device, sender_program, params.sender_logical_core);
+        program_infos.emplace_back(receiver_device, receiver_program, params.receiver_logical_core);
+    }
+    LaunchAndSyncPhase(fixture, program_infos);
+    ValidationPhase(program_infos, params);
+}
+
+TEST_F(Fabric1DFixture, TestUnicastRaw) {
+    // test parameters (default)
+    TestParameters params;
+
+    auto [src_physical_device_id, dst_physical_device_ids, receiver_noc_encoding, edm_eth_core] =
+        GetConnectedDeviceInfo(this, params.sender_logical_core, params.receiver_logical_core, false, true);
+    if (src_physical_device_id == 0 && dst_physical_device_ids.size() == 0 && receiver_noc_encoding == 0) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+    auto sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
+    auto receiver_device = DevicePool::instance().get_active_device(dst_physical_device_ids[0]);
 
     // common compile time args for sender and receiver
     std::vector<uint32_t> compile_time_args = {
-        test_results_address, test_results_size_bytes, target_address, 0 /* mcast_mode */
+        params.test_results_address, params.test_results_size_bytes, params.target_address, 0 /* mcast_mode */
     };
 
     // Create the sender program
@@ -97,20 +275,20 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
     auto sender_kernel = tt_metal::CreateKernel(
         sender_program,
         "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
-        {sender_logical_core},
+        {params.sender_logical_core},
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0,
             .noc = tt_metal::NOC::RISCV_0_default,
             .compile_args = compile_time_args});
 
     std::vector<uint32_t> sender_runtime_args = {
-        packet_header_address,
-        source_l1_buffer_address,
-        packet_payload_size_bytes,
-        num_packets,
+        params.packet_header_address,
+        params.source_l1_buffer_address,
+        params.packet_payload_size_bytes,
+        params.num_packets,
         receiver_noc_encoding,
-        time_seed,
-        num_hops};
+        params.time_seed,
+        params.num_hops};
 
     // append the EDM connection rt args
     const auto edm_config = get_1d_fabric_config();
@@ -127,9 +305,9 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
         .buffer_index_semaphore_id = edm_config.sender_channels_buffer_index_semaphore_address[0],
         .persistent_fabric = true};
 
-    auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(sender_program, sender_logical_core, 0);
-    auto worker_teardown_semaphore_id = tt_metal::CreateSemaphore(sender_program, sender_logical_core, 0);
-    auto worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(sender_program, sender_logical_core, 0);
+    auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(sender_program, params.sender_logical_core, 0);
+    auto worker_teardown_semaphore_id = tt_metal::CreateSemaphore(sender_program, params.sender_logical_core, 0);
+    auto worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(sender_program, params.sender_logical_core, 0);
 
     append_worker_to_fabric_edm_sender_rt_args(
         edm_connection,
@@ -138,327 +316,31 @@ TEST_F(Fabric1DFixture, TestUnicastRaw) {
         worker_buffer_index_semaphore_id,
         sender_runtime_args);
 
-    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
+    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, params.sender_logical_core, sender_runtime_args);
 
-    std::vector<uint32_t> receiver_runtime_args = {packet_payload_size_bytes, num_packets, time_seed};
-
-    // Create the receiver program for validation
     auto receiver_program = tt_metal::CreateProgram();
-    auto receiver_kernel = tt_metal::CreateKernel(
-        receiver_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
-        {receiver_logical_core},
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args});
+    CreateRx(params, receiver_program, compile_time_args);
 
-    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
+    std::vector<ProgramInfo> program_infos;
+    program_infos.emplace_back(sender_device, sender_program, params.sender_logical_core);
+    program_infos.emplace_back(receiver_device, receiver_program, params.receiver_logical_core);
 
-    // Launch sender and receiver programs and wait for them to finish
-    this->RunProgramNonblocking(receiver_device, receiver_program);
-    this->RunProgramNonblocking(sender_device, sender_program);
-    this->WaitForSingleProgramDone(sender_device, sender_program);
-    this->WaitForSingleProgramDone(receiver_device, receiver_program);
-
-    // Validate the status and packets processed by sender and receiver
-    std::vector<uint32_t> sender_status;
-    std::vector<uint32_t> receiver_status;
-
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device,
-        sender_logical_core,
-        test_results_address,
-        test_results_size_bytes,
-        sender_status,
-        CoreType::WORKER);
-
-    tt_metal::detail::ReadFromDeviceL1(
-        receiver_device,
-        receiver_logical_core,
-        test_results_address,
-        test_results_size_bytes,
-        receiver_status,
-        CoreType::WORKER);
-
-    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
-    EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
-
-    uint64_t sender_bytes =
-        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
-    uint64_t receiver_bytes =
-        ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
-    EXPECT_EQ(sender_bytes, receiver_bytes);
+    LaunchAndSyncPhase(this, program_infos);
+    ValidationPhase(program_infos, params);
 }
 
 TEST_F(Fabric1DFixture, TestUnicastConnAPI) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
-
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-
-    std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
-    std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
-    chip_id_t not_used_1;
-    chip_id_t not_used_2;
-    // Find a device with a neighbour in the East direction
-    bool connection_found = find_device_with_neighbor_in_direction(
-        src_mesh_chip_id, dst_mesh_chip_id, not_used_1, not_used_2, RoutingDirection::E);
-    if (!connection_found) {
-        GTEST_SKIP() << "No path found between sender and receivers";
-    }
-
-    chip_id_t src_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(src_mesh_chip_id);
-    chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
-
-    auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
-    auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
-    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
-
-    auto receiver_noc_encoding =
-        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
-
-    // test parameters
-    uint32_t packet_header_address = 0x25000;
-    uint32_t source_l1_buffer_address = 0x30000;
-    uint32_t packet_payload_size_bytes = 4096;
-    uint32_t num_packets = 10;
-    uint32_t num_hops = 1;
-    uint32_t test_results_address = 0x100000;
-    uint32_t test_results_size_bytes = 128;
-    uint32_t target_address = 0x30000;
-    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
-
-    // common compile time args for sender and receiver
-    std::vector<uint32_t> compile_time_args = {
-        test_results_address, test_results_size_bytes, target_address, 0 /* mcast_mode */
-    };
-
-    // Create the sender program
-    auto sender_program = tt_metal::CreateProgram();
-    auto sender_kernel = tt_metal::CreateKernel(
-        sender_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
-        {sender_logical_core},
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args});
-
-    std::vector<uint32_t> sender_runtime_args = {
-        packet_header_address,
-        source_l1_buffer_address,
-        packet_payload_size_bytes,
-        num_packets,
-        receiver_noc_encoding,
-        time_seed,
-        num_hops};
-
-    // append the EDM connection rt args
-    append_fabric_connection_rt_args(
-        src_physical_device_id, dst_physical_device_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
-
-    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
-
-    std::vector<uint32_t> receiver_runtime_args = {packet_payload_size_bytes, num_packets, time_seed};
-
-    // Create the receiver program for validation
-    auto receiver_program = tt_metal::CreateProgram();
-    auto receiver_kernel = tt_metal::CreateKernel(
-        receiver_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
-        {receiver_logical_core},
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args});
-
-    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-
-    // Launch sender and receiver programs and wait for them to finish
-    this->RunProgramNonblocking(receiver_device, receiver_program);
-    this->RunProgramNonblocking(sender_device, sender_program);
-    this->WaitForSingleProgramDone(sender_device, sender_program);
-    this->WaitForSingleProgramDone(receiver_device, receiver_program);
-
-    // Validate the status and packets processed by sender and receiver
-    std::vector<uint32_t> sender_status;
-    std::vector<uint32_t> receiver_status;
-
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device,
-        sender_logical_core,
-        test_results_address,
-        test_results_size_bytes,
-        sender_status,
-        CoreType::WORKER);
-
-    tt_metal::detail::ReadFromDeviceL1(
-        receiver_device,
-        receiver_logical_core,
-        test_results_address,
-        test_results_size_bytes,
-        receiver_status,
-        CoreType::WORKER);
-
-    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
-    EXPECT_EQ(receiver_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
-
-    uint64_t sender_bytes =
-        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
-    uint64_t receiver_bytes =
-        ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
-    EXPECT_EQ(sender_bytes, receiver_bytes);
+    // Test parameters for unicast (default).
+    TestParameters params;
+    ExecuteFabricTest(this, params);
 }
 
 TEST_F(Fabric1DFixture, TestMCastConnAPI) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
-
-    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-
-    // use control plane to find a mesh with 3 devices
-    auto user_meshes = control_plane->get_user_physical_mesh_ids();
-    std::optional<mesh_id_t> mesh_id;
-    for (const auto& mesh : user_meshes) {
-        auto mesh_shape = control_plane->get_physical_mesh_shape(mesh);
-        if (mesh_shape.mesh_size() >= 3) {
-            mesh_id = mesh;
-            break;
-        }
-    }
-    if (!mesh_id.has_value()) {
-        GTEST_SKIP() << "No mesh found for 3 chip mcast test";
-    }
-
-    // for this test, logical chip id 1 is the sender, 0 is the left receiver and 1 is the right receiver
-    auto src_phys_chip_id = control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 1));
-    auto left_recv_phys_chip_id =
-        control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 0));
-    auto right_recv_phys_chip_id =
-        control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id.value(), 2));
-
-    auto* sender_device = DevicePool::instance().get_active_device(src_phys_chip_id);
-    auto* left_recv_device = DevicePool::instance().get_active_device(left_recv_phys_chip_id);
-    auto* right_recv_device = DevicePool::instance().get_active_device(right_recv_phys_chip_id);
-
-    CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
-    CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
-
-    auto receiver_noc_encoding =
-        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
-
-    // test parameters
-    uint32_t packet_header_address = 0x25000;
-    uint32_t source_l1_buffer_address = 0x30000;
-    uint32_t packet_payload_size_bytes = 4096;
-    uint32_t num_packets = 100;
-    uint32_t test_results_address = 0x100000;
-    uint32_t test_results_size_bytes = 128;
-    uint32_t target_address = 0x30000;
-    uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
-
-    // common compile time args for sender and receiver
-    std::vector<uint32_t> compile_time_args = {
-        test_results_address, test_results_size_bytes, target_address, 1 /* mcast_mode */
-    };
-
-    // Create the sender program
-    auto sender_program = tt_metal::CreateProgram();
-    auto sender_kernel = tt_metal::CreateKernel(
-        sender_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_tx.cpp",
-        {sender_logical_core},
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args});
-
-    std::vector<uint32_t> sender_runtime_args = {
-        packet_header_address,
-        source_l1_buffer_address,
-        packet_payload_size_bytes,
-        num_packets,
-        receiver_noc_encoding,
-        time_seed,
-        1, /* mcast_fwd_hops */
-        1, /* mcast_bwd_hops */
-    };
-
-    // append the EDM connection rt args for fwd connection
-    append_fabric_connection_rt_args(
-        src_phys_chip_id, right_recv_phys_chip_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
-    append_fabric_connection_rt_args(
-        src_phys_chip_id, left_recv_phys_chip_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
-
-    tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
-
-    std::vector<uint32_t> receiver_runtime_args = {packet_payload_size_bytes, num_packets, time_seed};
-
-    // Create the receiver program for validation
-    auto receiver_program = tt_metal::CreateProgram();
-    auto receiver_kernel = tt_metal::CreateKernel(
-        receiver_program,
-        "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_1d_rx.cpp",
-        {receiver_logical_core},
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .compile_args = compile_time_args});
-
-    tt_metal::SetRuntimeArgs(receiver_program, receiver_kernel, receiver_logical_core, receiver_runtime_args);
-
-    // Launch sender and receiver programs and wait for them to finish
-    this->RunProgramNonblocking(left_recv_device, receiver_program);
-    this->RunProgramNonblocking(right_recv_device, receiver_program);
-    this->RunProgramNonblocking(sender_device, sender_program);
-    this->WaitForSingleProgramDone(sender_device, sender_program);
-    this->WaitForSingleProgramDone(right_recv_device, receiver_program);
-    this->WaitForSingleProgramDone(left_recv_device, receiver_program);
-
-    // Validate the status and packets processed by sender and receiver
-    std::vector<uint32_t> sender_status;
-    std::vector<uint32_t> left_recv_status;
-    std::vector<uint32_t> right_recv_status;
-
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device,
-        sender_logical_core,
-        test_results_address,
-        test_results_size_bytes,
-        sender_status,
-        CoreType::WORKER);
-
-    tt_metal::detail::ReadFromDeviceL1(
-        left_recv_device,
-        receiver_logical_core,
-        test_results_address,
-        test_results_size_bytes,
-        left_recv_status,
-        CoreType::WORKER);
-
-    tt_metal::detail::ReadFromDeviceL1(
-        right_recv_device,
-        receiver_logical_core,
-        test_results_address,
-        test_results_size_bytes,
-        right_recv_status,
-        CoreType::WORKER);
-
-    EXPECT_EQ(sender_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
-    EXPECT_EQ(left_recv_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
-    EXPECT_EQ(right_recv_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
-
-    uint64_t sender_bytes =
-        ((uint64_t)sender_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | sender_status[TT_FABRIC_WORD_CNT_INDEX];
-    uint64_t left_recv_bytes =
-        ((uint64_t)left_recv_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | left_recv_status[TT_FABRIC_WORD_CNT_INDEX];
-    uint64_t right_recv_bytes =
-        ((uint64_t)right_recv_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | right_recv_status[TT_FABRIC_WORD_CNT_INDEX];
-
-    EXPECT_EQ(sender_bytes, left_recv_bytes);
-    EXPECT_EQ(left_recv_bytes, right_recv_bytes);
+    // Test parameters for mcast.
+    TestParameters params = {
+        .num_packets = 100,  // mcast test uses more packets
+        .is_mcast = true};
+    ExecuteFabricTest(this, params);
 }
 
 }  // namespace fabric_router_tests


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21218

### Problem description
There are a lot of copy & paste which is hard to identify what differs between each tests and make it harder for further extension

### What's changed
Create common functions and each gtest entry just changes test parameter.
Raw send/recv tests is refactored a little as it has many differences from others

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes