### PR TITLE
Update 4xP150 mesh graph desc to specify valid N/E/S/W eth ports

### DIFF
--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
@@ -1,10 +1,10 @@
 ChipSpec: {
   arch: blackhole,
   ethernet_ports: {
-    N: 7,
-    E: 7,
-    S: 7,
-    W: 7,
+    N: 4,
+    E: 4,
+    S: 4,
+    W: 4,
   }
 }
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
original 4x P150 mesh graph desc was based on invalid machine config. No 4x P150 on BH CI but validated this on BH-31. 

FYI @mtairum 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14761930210) CI passes