### PR TITLE
#0: Extend bert model to support re-generating caches

### DIFF
--- a/models/demos/metal_BERT_large_11/tt/bert_encoder.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_encoder.py
@@ -10,6 +10,7 @@ import ttnn
 from models.demos.metal_BERT_large_11.tt.mha import TtMultiHeadAttentionModel
 from models.demos.metal_BERT_large_11.tt.ffn import TtFeedForwardModel
 from models.demos.metal_BERT_large_11.tt import custom_matmuls
+from models.demos.metal_BERT_large_11.tt.tensor_utils import load_or_compute_and_cache
 from tt_lib.utils import pad_weight
 
 
@@ -24,112 +25,149 @@ class TtBertEncoder:
         attn_layer_name = f"bert.encoder.layer.{encoder_idx}.attention.output"
         layer_name = f"bert.encoder.layer.{encoder_idx}.output"
 
+        attention_output_weight_path = None
+        attention_output_bias_path = None
+        mha_gamma_path = None
+        mha_beta_path = None
+        ffn_gamma_path = None
+        ffn_beta_path = None
+
         if tt_cache_path is not None:
-            self.attention_output_weight = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{attn_layer_name}.dense.weight_{self.model_config['OP7_SELFOUT_WEIGHTS_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["OP7_SELFOUT_WEIGHTS_MEMCFG"])
-            self.attention_output_bias = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{attn_layer_name}.dense.bias_{self.model_config['OP7_SELFOUT_BIAS_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["OP7_SELFOUT_BIAS_MEMCFG"])
-            self.mha_gamma = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{attn_layer_name}.LayerNorm.weight_{self.model_config['OP8_LAYERNORM_GAMMA_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["OP8_LAYERNORM_GAMMA_MEMCFG"])
-            self.mha_beta = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{attn_layer_name}.LayerNorm.bias_{self.model_config['OP8_LAYERNORM_BETA_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["OP8_LAYERNORM_BETA_MEMCFG"])
-            self.ffn_gamma = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{layer_name}.LayerNorm.weight_{self.model_config['OP11_LAYERNORM_GAMMA_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["OP8_LAYERNORM_GAMMA_MEMCFG"])
-            self.ffn_beta = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{layer_name}.LayerNorm.bias_{self.model_config['OP11_LAYERNORM_BETA_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["OP8_LAYERNORM_BETA_MEMCFG"])
-        else:
-            attention_output_weight = pad_weight(
+            attention_output_weight_path = str(
+                f"{tt_cache_path}/"
+                f"{attn_layer_name}.dense.weight_{self.model_config['OP7_SELFOUT_WEIGHTS_DTYPE'].name}.bin"
+            )
+            attention_output_bias_path = str(
+                f"{tt_cache_path}/"
+                f"{attn_layer_name}.dense.bias_{self.model_config['OP7_SELFOUT_BIAS_DTYPE'].name}.bin"
+            )
+            mha_gamma_path = str(
+                f"{tt_cache_path}/"
+                f"{attn_layer_name}.LayerNorm.weight_{self.model_config['OP8_LAYERNORM_GAMMA_DTYPE'].name}.bin"
+            )
+            mha_beta_path = str(
+                f"{tt_cache_path}/"
+                f"{attn_layer_name}.LayerNorm.bias_{self.model_config['OP8_LAYERNORM_BETA_DTYPE'].name}.bin"
+            )
+            ffn_gamma_path = str(
+                f"{tt_cache_path}/"
+                f"{layer_name}.LayerNorm.weight_{self.model_config['OP11_LAYERNORM_GAMMA_DTYPE'].name}.bin"
+            )
+            ffn_beta_path = str(
+                f"{tt_cache_path}/"
+                f"{layer_name}.LayerNorm.bias_{self.model_config['OP11_LAYERNORM_BETA_DTYPE'].name}.bin"
+            )
+
+        # Define memory configs to be captured by nested functions
+        attn_out_w_mem_config = model_config["OP7_SELFOUT_WEIGHTS_MEMCFG"]
+        attn_out_b_mem_config = model_config["OP7_SELFOUT_BIAS_MEMCFG"]
+        mha_ln_g_mem_config = model_config["OP8_LAYERNORM_GAMMA_MEMCFG"]
+        mha_ln_b_mem_config = model_config["OP8_LAYERNORM_BETA_MEMCFG"]
+        ffn_ln_g_mem_config = model_config["OP11_LAYERNORM_GAMMA_MEMCFG"]  # Assuming same memcfg as OP8
+        ffn_ln_b_mem_config = model_config["OP11_LAYERNORM_BETA_MEMCFG"]  # Assuming same memcfg as OP8
+
+        def compute_attention_output_weight():
+            weight_torch = pad_weight(
                 torch.transpose(
                     state_dict[f"{attn_layer_name}.dense.weight"],
                     -2,
                     -1,
                 )
             )
-            self.attention_output_weight = ttnn.from_torch(
-                attention_output_weight,
+            return ttnn.from_torch(
+                weight_torch,
                 model_config["OP7_SELFOUT_WEIGHTS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
-                memory_config=model_config["OP7_SELFOUT_WEIGHTS_MEMCFG"],
+                memory_config=attn_out_w_mem_config,
             )
-            attention_output_bias = pad_weight(state_dict[f"{attn_layer_name}.dense.bias"])
-            self.attention_output_bias = ttnn.from_torch(
-                attention_output_bias,
+
+        def compute_attention_output_bias():
+            bias_torch = pad_weight(state_dict[f"{attn_layer_name}.dense.bias"])
+            return ttnn.from_torch(
+                bias_torch,
                 model_config["OP7_SELFOUT_BIAS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
-                memory_config=model_config["OP7_SELFOUT_BIAS_MEMCFG"],
+                memory_config=attn_out_b_mem_config,
             )
 
-            # Weights pre-transposed on host​. No on-the fly transpose of W.
-            # self.attention_output_weight = ttnn.transpose(
-            #     self.attention_output_weight,
-            #     -2, -1,
-            # )
-
-            # MHA layernorm
-            gamma0 = state_dict[f"{attn_layer_name}.LayerNorm.weight"]
-            beta0 = state_dict[f"{attn_layer_name}.LayerNorm.bias"]
-            mha_gamma = gamma0.reshape(1, 1, -1, 32)
-            self.mha_gamma = ttnn.from_torch(
-                mha_gamma,
+        def compute_mha_gamma():
+            gamma_torch = state_dict[f"{attn_layer_name}.LayerNorm.weight"].reshape(1, 1, -1, 32)
+            return ttnn.from_torch(
+                gamma_torch,
                 model_config["OP8_LAYERNORM_GAMMA_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["OP8_LAYERNORM_GAMMA_MEMCFG"],
+                memory_config=mha_ln_g_mem_config,
             )
-            mha_beta = beta0.reshape(1, 1, -1, 32)
-            self.mha_beta = ttnn.from_torch(
-                mha_beta,
+
+        def compute_mha_beta():
+            beta_torch = state_dict[f"{attn_layer_name}.LayerNorm.bias"].reshape(1, 1, -1, 32)
+            return ttnn.from_torch(
+                beta_torch,
                 model_config["OP8_LAYERNORM_BETA_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["OP8_LAYERNORM_BETA_MEMCFG"],
+                memory_config=mha_ln_b_mem_config,
             )
 
-            # FFN layernorm
-            gamma1 = state_dict[f"{layer_name}.LayerNorm.weight"]
-            beta1 = state_dict[f"{layer_name}.LayerNorm.bias"]
-            ffn_gamma = gamma1.reshape(1, 1, -1, 32)
-            self.ffn_gamma = ttnn.from_torch(
-                ffn_gamma,
+        def compute_ffn_gamma():
+            gamma_torch = state_dict[f"{layer_name}.LayerNorm.weight"].reshape(1, 1, -1, 32)
+            return ttnn.from_torch(
+                gamma_torch,
                 model_config["OP11_LAYERNORM_GAMMA_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["OP11_LAYERNORM_GAMMA_MEMCFG"],
+                memory_config=ffn_ln_g_mem_config,
             )
-            ffn_beta = beta1.reshape(1, 1, -1, 32)
-            self.ffn_beta = ttnn.from_torch(
-                ffn_beta,
+
+        def compute_ffn_beta():
+            beta_torch = state_dict[f"{layer_name}.LayerNorm.bias"].reshape(1, 1, -1, 32)
+            return ttnn.from_torch(
+                beta_torch,
                 model_config["OP11_LAYERNORM_BETA_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["OP11_LAYERNORM_BETA_MEMCFG"],
+                memory_config=ffn_ln_b_mem_config,
             )
+
+        self.attention_output_weight = load_or_compute_and_cache(
+            attention_output_weight_path,
+            compute_attention_output_weight,
+            device=device,
+            mem_config=attn_out_w_mem_config,
+        )
+        self.attention_output_bias = load_or_compute_and_cache(
+            attention_output_bias_path,
+            compute_attention_output_bias,
+            device=device,
+            mem_config=attn_out_b_mem_config,
+        )
+        self.mha_gamma = load_or_compute_and_cache(
+            mha_gamma_path,
+            compute_mha_gamma,
+            device=device,
+            mem_config=mha_ln_g_mem_config,
+        )
+        self.mha_beta = load_or_compute_and_cache(
+            mha_beta_path,
+            compute_mha_beta,
+            device=device,
+            mem_config=mha_ln_b_mem_config,
+        )
+        self.ffn_gamma = load_or_compute_and_cache(
+            ffn_gamma_path,
+            compute_ffn_gamma,
+            device=device,
+            mem_config=ffn_ln_g_mem_config,
+        )
+        self.ffn_beta = load_or_compute_and_cache(
+            ffn_beta_path,
+            compute_ffn_beta,
+            device=device,
+            mem_config=ffn_ln_b_mem_config,
+        )
 
         # FFN sub-graph
         self.ffn = TtFeedForwardModel(encoder_idx, state_dict, device, model_config, tt_cache_path)

--- a/models/demos/metal_BERT_large_11/tt/bert_model.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_model.py
@@ -11,6 +11,7 @@ import ttnn
 
 from models.demos.metal_BERT_large_11.tt.embeddings import TtEmbeddings
 from models.demos.metal_BERT_large_11.tt.bert_encoder import TtBertEncoder
+from models.demos.metal_BERT_large_11.tt.tensor_utils import load_or_compute_and_cache
 
 from tt_lib.utils import pad_activation, pad_weight
 
@@ -43,30 +44,49 @@ class TtBertBatchDram:
 
         num_classes, hidden_size = state_dict["qa_outputs.weight"].shape
 
+        qa_weight_path = None
+        qa_bias_path = None
         if tt_cache_path is not None:
-            weight = ttnn.load_tensor(
-                str(tt_cache_path / f"qa_outputs.weight_{self.model_config['QA_LINEAR_WEIGHTS_DTYPE'].name}.bin")
-            ).to(device, self.model_config["QA_LINEAR_WEIGHTS_MEMCFG"])
-            bias = ttnn.load_tensor(
-                str(tt_cache_path / f"qa_outputs.bias_{self.model_config['QA_LINEAR_BIAS_DTYPE'].name}.bin")
-            ).to(device, self.model_config["QA_LINEAR_BIAS_MEMCFG"])
-        else:
-            weight = pad_weight(torch.transpose(state_dict["qa_outputs.weight"], -2, -1))
-            weight = ttnn.from_torch(
-                weight,
-                model_config["QA_LINEAR_WEIGHTS_DTYPE"],
+            qa_weight_path = str(
+                f"{tt_cache_path}/qa_outputs.weight_{self.model_config['QA_LINEAR_WEIGHTS_DTYPE'].name}.bin"
+            )
+            qa_bias_path = str(f"{tt_cache_path}/qa_outputs.bias_{self.model_config['QA_LINEAR_BIAS_DTYPE'].name}.bin")
+
+        qa_weight_mem_config = self.model_config["QA_LINEAR_WEIGHTS_MEMCFG"]
+        qa_bias_mem_config = self.model_config["QA_LINEAR_BIAS_MEMCFG"]
+
+        def compute_qa_weight():
+            weight_torch = pad_weight(torch.transpose(state_dict["qa_outputs.weight"], -2, -1))
+            return ttnn.from_torch(
+                weight_torch,
+                dtype=model_config["QA_LINEAR_WEIGHTS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
-                memory_config=model_config["QA_LINEAR_WEIGHTS_MEMCFG"],
+                memory_config=qa_weight_mem_config,
             )
-            bias = pad_weight(state_dict["qa_outputs.bias"])
-            bias = ttnn.from_torch(
-                bias,
-                model_config["QA_LINEAR_BIAS_DTYPE"],
+
+        def compute_qa_bias():
+            bias_torch = pad_weight(state_dict["qa_outputs.bias"])
+            return ttnn.from_torch(
+                bias_torch,
+                dtype=model_config["QA_LINEAR_BIAS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
-                memory_config=model_config["QA_LINEAR_BIAS_MEMCFG"],
+                memory_config=qa_bias_mem_config,
             )
+
+        weight = load_or_compute_and_cache(
+            qa_weight_path,
+            compute_qa_weight,
+            device=device,
+            mem_config=qa_weight_mem_config,
+        )
+        bias = load_or_compute_and_cache(
+            qa_bias_path,
+            compute_qa_bias,
+            device=device,
+            mem_config=qa_bias_mem_config,
+        )
 
         # QA linear
         # TODO: Replace with custom op with fused bias?

--- a/models/demos/metal_BERT_large_11/tt/bert_model.py
+++ b/models/demos/metal_BERT_large_11/tt/bert_model.py
@@ -52,17 +52,12 @@ class TtBertBatchDram:
             )
             qa_bias_path = str(f"{tt_cache_path}/qa_outputs.bias_{self.model_config['QA_LINEAR_BIAS_DTYPE'].name}.bin")
 
-        qa_weight_mem_config = self.model_config["QA_LINEAR_WEIGHTS_MEMCFG"]
-        qa_bias_mem_config = self.model_config["QA_LINEAR_BIAS_MEMCFG"]
-
         def compute_qa_weight():
             weight_torch = pad_weight(torch.transpose(state_dict["qa_outputs.weight"], -2, -1))
             return ttnn.from_torch(
                 weight_torch,
                 dtype=model_config["QA_LINEAR_WEIGHTS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=qa_weight_mem_config,
             )
 
         def compute_qa_bias():
@@ -71,21 +66,19 @@ class TtBertBatchDram:
                 bias_torch,
                 dtype=model_config["QA_LINEAR_BIAS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=qa_bias_mem_config,
             )
 
         weight = load_or_compute_and_cache(
             qa_weight_path,
             compute_qa_weight,
             device=device,
-            mem_config=qa_weight_mem_config,
+            mem_config=self.model_config["QA_LINEAR_WEIGHTS_MEMCFG"],
         )
         bias = load_or_compute_and_cache(
             qa_bias_path,
             compute_qa_bias,
             device=device,
-            mem_config=qa_bias_mem_config,
+            mem_config=self.model_config["QA_LINEAR_BIAS_MEMCFG"],
         )
 
         # QA linear

--- a/models/demos/metal_BERT_large_11/tt/embeddings.py
+++ b/models/demos/metal_BERT_large_11/tt/embeddings.py
@@ -5,6 +5,7 @@
 from typing import Optional
 import torch
 import ttnn
+from models.demos.metal_BERT_large_11.tt.tensor_utils import load_or_compute_and_cache
 
 
 class TtEmbeddings:
@@ -17,77 +18,119 @@ class TtEmbeddings:
         self.pad_token = config.pad_token_id
 
         base_address = "bert.embeddings"
+
+        word_embeddings_path = None
+        position_embeddings_path = None
+        token_type_embeddings_path = None
+        layerNorm_gamma_path = None
+        layerNorm_beta_path = None
+
         if tt_cache_path is not None:
-            self.word_embeddings_weight = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{base_address}.word_embeddings.weight_{self.model_config['INPUT_EMBEDDINGS_WEIGHTS_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"])
-            self.position_embeddings_weight = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{base_address}.position_embeddings.weight_{self.model_config['INPUT_EMBEDDINGS_WEIGHTS_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"])
-            self.token_type_embeddings_weight = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{base_address}.token_type_embeddings.weight_{self.model_config['INPUT_EMBEDDINGS_WEIGHTS_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"])
-            self.layerNorm_gamma = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{base_address}.LayerNorm.weight_{self.model_config['EMBEDDINGS_LAYERNORM_GAMMA_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["EMBEDDINGS_LAYERNORM_GAMMA_MEMCFG"])
-            self.layerNorm_beta = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{base_address}.LayerNorm.beta_{self.model_config['EMBEDDINGS_LAYERNORM_BETA_DTYPE'].name}.bin"
-                )
-            ).to(device, self.model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"])
-        else:
-            self.word_embeddings_weight = ttnn.from_torch(
-                state_dict[f"{base_address}.word_embeddings.weight"],
-                model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
-                layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=device,
-                memory_config=model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
+            word_embeddings_path = str(
+                f"{tt_cache_path}/"
+                f"{base_address}.word_embeddings.weight_{self.model_config['INPUT_EMBEDDINGS_WEIGHTS_DTYPE'].name}.bin"
+            )
+            position_embeddings_path = str(
+                f"{tt_cache_path}/"
+                f"{base_address}.position_embeddings.weight_{self.model_config['INPUT_EMBEDDINGS_WEIGHTS_DTYPE'].name}.bin"
+            )
+            token_type_embeddings_path = str(
+                f"{tt_cache_path}/"
+                f"{base_address}.token_type_embeddings.weight_{self.model_config['INPUT_EMBEDDINGS_WEIGHTS_DTYPE'].name}.bin"
+            )
+            layerNorm_gamma_path = str(
+                f"{tt_cache_path}/"
+                f"{base_address}.LayerNorm.weight_{self.model_config['EMBEDDINGS_LAYERNORM_GAMMA_DTYPE'].name}.bin"
+            )
+            layerNorm_beta_path = str(
+                f"{tt_cache_path}/"
+                f"{base_address}.LayerNorm.beta_{self.model_config['EMBEDDINGS_LAYERNORM_BETA_DTYPE'].name}.bin"
             )
 
-            self.position_embeddings_weight = ttnn.from_torch(
-                state_dict[f"{base_address}.position_embeddings.weight"],
-                model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
+        input_weights_mem_config = self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"]
+        ln_gamma_mem_config = self.model_config["EMBEDDINGS_LAYERNORM_GAMMA_MEMCFG"]
+        ln_beta_mem_config = self.model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"]
+
+        def compute_word_embeddings():
+            weight_torch = state_dict[f"{base_address}.word_embeddings.weight"]
+            return ttnn.from_torch(
+                weight_torch,
+                dtype=model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
+                memory_config=input_weights_mem_config,
             )
 
-            self.token_type_embeddings_weight = ttnn.from_torch(
-                state_dict[f"{base_address}.token_type_embeddings.weight"],
-                model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
+        def compute_position_embeddings():
+            weight_torch = state_dict[f"{base_address}.position_embeddings.weight"]
+            return ttnn.from_torch(
+                weight_torch,
+                dtype=model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
+                memory_config=input_weights_mem_config,
             )
 
-            self.layerNorm_gamma = ttnn.from_torch(
-                state_dict[f"{base_address}.LayerNorm.weight"].reshape([1, 1, -1, 32]),
-                model_config["EMBEDDINGS_LAYERNORM_GAMMA_DTYPE"],
+        def compute_token_type_embeddings():
+            weight_torch = state_dict[f"{base_address}.token_type_embeddings.weight"]
+            return ttnn.from_torch(
+                weight_torch,
+                dtype=model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["EMBEDDINGS_LAYERNORM_GAMMA_MEMCFG"],
+                memory_config=input_weights_mem_config,
             )
 
-            self.layerNorm_beta = ttnn.from_torch(
-                state_dict[f"{base_address}.LayerNorm.bias"].reshape([1, 1, -1, 32]),
-                model_config["EMBEDDINGS_LAYERNORM_BETA_DTYPE"],
+        def compute_layerNorm_gamma():
+            gamma_torch = state_dict[f"{base_address}.LayerNorm.weight"].reshape([1, 1, -1, 32])
+            return ttnn.from_torch(
+                gamma_torch,
+                dtype=model_config["EMBEDDINGS_LAYERNORM_GAMMA_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
                 device=device,
-                memory_config=model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"],
+                memory_config=ln_gamma_mem_config,
             )
+
+        def compute_layerNorm_beta():
+            beta_torch = state_dict[f"{base_address}.LayerNorm.bias"].reshape([1, 1, -1, 32])
+            return ttnn.from_torch(
+                beta_torch,
+                dtype=model_config["EMBEDDINGS_LAYERNORM_BETA_DTYPE"],
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=device,
+                memory_config=ln_beta_mem_config,
+            )
+
+        self.word_embeddings_weight = load_or_compute_and_cache(
+            word_embeddings_path,
+            compute_word_embeddings,
+            device=device,
+            mem_config=input_weights_mem_config,
+        )
+        self.position_embeddings_weight = load_or_compute_and_cache(
+            position_embeddings_path,
+            compute_position_embeddings,
+            device=device,
+            mem_config=input_weights_mem_config,
+        )
+        self.token_type_embeddings_weight = load_or_compute_and_cache(
+            token_type_embeddings_path,
+            compute_token_type_embeddings,
+            device=device,
+            mem_config=input_weights_mem_config,
+        )
+        self.layerNorm_gamma = load_or_compute_and_cache(
+            layerNorm_gamma_path,
+            compute_layerNorm_gamma,
+            device=device,
+            mem_config=ln_gamma_mem_config,
+        )
+        self.layerNorm_beta = load_or_compute_and_cache(
+            layerNorm_beta_path,
+            compute_layerNorm_beta,
+            device=device,
+            mem_config=ln_beta_mem_config,
+        )
 
         self.layerNorm_eps = config.layer_norm_eps
 

--- a/models/demos/metal_BERT_large_11/tt/embeddings.py
+++ b/models/demos/metal_BERT_large_11/tt/embeddings.py
@@ -47,18 +47,12 @@ class TtEmbeddings:
                 f"{base_address}.LayerNorm.beta_{self.model_config['EMBEDDINGS_LAYERNORM_BETA_DTYPE'].name}.bin"
             )
 
-        input_weights_mem_config = self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"]
-        ln_gamma_mem_config = self.model_config["EMBEDDINGS_LAYERNORM_GAMMA_MEMCFG"]
-        ln_beta_mem_config = self.model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"]
-
         def compute_word_embeddings():
             weight_torch = state_dict[f"{base_address}.word_embeddings.weight"]
             return ttnn.from_torch(
                 weight_torch,
                 dtype=model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=device,
-                memory_config=input_weights_mem_config,
             )
 
         def compute_position_embeddings():
@@ -67,8 +61,6 @@ class TtEmbeddings:
                 weight_torch,
                 dtype=model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=device,
-                memory_config=input_weights_mem_config,
             )
 
         def compute_token_type_embeddings():
@@ -77,8 +69,6 @@ class TtEmbeddings:
                 weight_torch,
                 dtype=model_config["INPUT_EMBEDDINGS_WEIGHTS_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=device,
-                memory_config=input_weights_mem_config,
             )
 
         def compute_layerNorm_gamma():
@@ -87,8 +77,6 @@ class TtEmbeddings:
                 gamma_torch,
                 dtype=model_config["EMBEDDINGS_LAYERNORM_GAMMA_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=device,
-                memory_config=ln_gamma_mem_config,
             )
 
         def compute_layerNorm_beta():
@@ -97,39 +85,37 @@ class TtEmbeddings:
                 beta_torch,
                 dtype=model_config["EMBEDDINGS_LAYERNORM_BETA_DTYPE"],
                 layout=ttnn.ROW_MAJOR_LAYOUT,
-                device=device,
-                memory_config=ln_beta_mem_config,
             )
 
         self.word_embeddings_weight = load_or_compute_and_cache(
             word_embeddings_path,
             compute_word_embeddings,
             device=device,
-            mem_config=input_weights_mem_config,
+            mem_config=self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
         )
         self.position_embeddings_weight = load_or_compute_and_cache(
             position_embeddings_path,
             compute_position_embeddings,
             device=device,
-            mem_config=input_weights_mem_config,
+            mem_config=self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
         )
         self.token_type_embeddings_weight = load_or_compute_and_cache(
             token_type_embeddings_path,
             compute_token_type_embeddings,
             device=device,
-            mem_config=input_weights_mem_config,
+            mem_config=self.model_config["INPUT_EMBEDDINGS_WEIGHTS_MEMCFG"],
         )
         self.layerNorm_gamma = load_or_compute_and_cache(
             layerNorm_gamma_path,
             compute_layerNorm_gamma,
             device=device,
-            mem_config=ln_gamma_mem_config,
+            mem_config=self.model_config["EMBEDDINGS_LAYERNORM_GAMMA_MEMCFG"],
         )
         self.layerNorm_beta = load_or_compute_and_cache(
             layerNorm_beta_path,
             compute_layerNorm_beta,
             device=device,
-            mem_config=ln_beta_mem_config,
+            mem_config=self.model_config["EMBEDDINGS_LAYERNORM_BETA_MEMCFG"],
         )
 
         self.layerNorm_eps = config.layer_norm_eps

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -99,6 +99,7 @@ class TtFeedForwardModel:
         ff1_bias_path = None
         ff2_weight_path = None
         ff2_bias_path = None
+
         if tt_cache_path is not None:
             ff1_weight_path = str(
                 f"{tt_cache_path}/" f"{encoder_ff1_str}.weight_{model_config['OP9_FF1_MM_WEIGHTS_DTYPE'].name}.bin"
@@ -113,11 +114,6 @@ class TtFeedForwardModel:
                 f"{tt_cache_path}/" f"{encoder_ff2_str}.bias_{model_config['OP10_FF2_MM_BIAS_DTYPE'].name}.bin"
             )
 
-        ff1_weight_mem_config = model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"]
-        ff1_bias_mem_config = model_config["OP9_FF1_MM_BIAS_MEMCFG"]
-        ff2_weight_mem_config = model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"]
-        ff2_bias_mem_config = model_config["OP10_FF2_MM_BIAS_MEMCFG"]
-
         def compute_ff1_weight():
             ff1_weight_torch = pad_weight(
                 torch.transpose(
@@ -130,8 +126,6 @@ class TtFeedForwardModel:
                 ff1_weight_torch,
                 dtype=model_config["OP9_FF1_MM_WEIGHTS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=ff1_weight_mem_config,
             )
 
         def compute_ff1_bias():
@@ -140,8 +134,6 @@ class TtFeedForwardModel:
                 ff1_bias_torch,
                 dtype=model_config["OP9_FF1_MM_BIAS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=ff1_bias_mem_config,
             )
 
         def compute_ff2_weight():
@@ -156,8 +148,6 @@ class TtFeedForwardModel:
                 ff2_weight_torch,
                 dtype=model_config["OP10_FF2_MM_WEIGHTS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=ff2_weight_mem_config,
             )
 
         def compute_ff2_bias():
@@ -166,33 +156,31 @@ class TtFeedForwardModel:
                 ff2_bias_torch,
                 dtype=model_config["OP10_FF2_MM_BIAS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=ff2_bias_mem_config,
             )
 
         encoder0_ff1_weight = load_or_compute_and_cache(
             ff1_weight_path,
             compute_ff1_weight,
             device=device,
-            mem_config=ff1_weight_mem_config,
+            mem_config=model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"],
         )
         encoder0_ff1_bias = load_or_compute_and_cache(
             ff1_bias_path,
             compute_ff1_bias,
             device=device,
-            mem_config=ff1_bias_mem_config,
+            mem_config=model_config["OP9_FF1_MM_BIAS_MEMCFG"],
         )
         encoder0_ff2_weight = load_or_compute_and_cache(
             ff2_weight_path,
             compute_ff2_weight,
             device=device,
-            mem_config=ff2_weight_mem_config,
+            mem_config=model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"],
         )
         encoder0_ff2_bias = load_or_compute_and_cache(
             ff2_bias_path,
             compute_ff2_bias,
             device=device,
-            mem_config=ff2_bias_mem_config,
+            mem_config=model_config["OP10_FF2_MM_BIAS_MEMCFG"],
         )
 
         encoder0_ff1_weight_shape = encoder0_ff1_weight.padded_shape

--- a/models/demos/metal_BERT_large_11/tt/ffn.py
+++ b/models/demos/metal_BERT_large_11/tt/ffn.py
@@ -8,6 +8,7 @@ import torch
 import ttnn
 from tt_lib.utils import pad_weight
 from models.demos.metal_BERT_large_11.tt import custom_matmuls
+from models.demos.metal_BERT_large_11.tt.tensor_utils import load_or_compute_and_cache
 
 
 def feed_forward(
@@ -90,80 +91,111 @@ def feed_forward(
 
 class TtFeedForwardModel:
     def __init__(self, encoder_idx, state_dict, device, model_config, tt_cache_path):
-        # FF1 params
         layer_name = f"bert.encoder.layer.{encoder_idx}"
         encoder_ff1_str = f"{layer_name}.intermediate.dense"
         encoder_ff2_str = f"{layer_name}.output.dense"
-        if tt_cache_path is not None:
-            encoder0_ff1_weight = ttnn.load_tensor(
-                str(tt_cache_path / f"{encoder_ff1_str}.weight_{model_config['OP9_FF1_MM_WEIGHTS_DTYPE'].name}.bin")
-            ).to(device, model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"])
-            encoder0_ff1_bias = ttnn.load_tensor(
-                str(tt_cache_path / f"{encoder_ff1_str}.bias_{model_config['OP9_FF1_MM_BIAS_DTYPE'].name}.bin")
-            ).to(device, model_config["OP9_FF1_MM_BIAS_MEMCFG"])
-            encoder0_ff1_weight_shape = encoder0_ff1_weight.padded_shape
 
-            encoder0_ff2_weight = ttnn.load_tensor(
-                str(tt_cache_path / f"{encoder_ff2_str}.weight_{model_config['OP10_FF2_MM_WEIGHTS_DTYPE'].name}.bin")
-            ).to(device, model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"])
-            encoder0_ff2_bias = ttnn.load_tensor(
-                str(tt_cache_path / f"{encoder_ff2_str}.bias_{model_config['OP10_FF2_MM_BIAS_DTYPE'].name}.bin")
-            ).to(device, model_config["OP10_FF2_MM_BIAS_MEMCFG"])
-        else:
-            encoder0_ff1_weight = pad_weight(
+        ff1_weight_path = None
+        ff1_bias_path = None
+        ff2_weight_path = None
+        ff2_bias_path = None
+        if tt_cache_path is not None:
+            ff1_weight_path = str(
+                f"{tt_cache_path}/" f"{encoder_ff1_str}.weight_{model_config['OP9_FF1_MM_WEIGHTS_DTYPE'].name}.bin"
+            )
+            ff1_bias_path = str(
+                f"{tt_cache_path}/" f"{encoder_ff1_str}.bias_{model_config['OP9_FF1_MM_BIAS_DTYPE'].name}.bin"
+            )
+            ff2_weight_path = str(
+                f"{tt_cache_path}/" f"{encoder_ff2_str}.weight_{model_config['OP10_FF2_MM_WEIGHTS_DTYPE'].name}.bin"
+            )
+            ff2_bias_path = str(
+                f"{tt_cache_path}/" f"{encoder_ff2_str}.bias_{model_config['OP10_FF2_MM_BIAS_DTYPE'].name}.bin"
+            )
+
+        ff1_weight_mem_config = model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"]
+        ff1_bias_mem_config = model_config["OP9_FF1_MM_BIAS_MEMCFG"]
+        ff2_weight_mem_config = model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"]
+        ff2_bias_mem_config = model_config["OP10_FF2_MM_BIAS_MEMCFG"]
+
+        def compute_ff1_weight():
+            ff1_weight_torch = pad_weight(
                 torch.transpose(
                     state_dict[f"{encoder_ff1_str}.weight"],
                     -2,
                     -1,
                 )
             )
-            encoder0_ff1_bias = pad_weight(state_dict[f"{encoder_ff1_str}.bias"])
-
-            encoder0_ff1_weight_shape = encoder0_ff1_weight.shape
-            encoder0_ff1_bias_shape = encoder0_ff1_bias.shape
-
-            encoder0_ff1_weight = ttnn.from_torch(
-                encoder0_ff1_weight,
-                model_config["OP9_FF1_MM_WEIGHTS_DTYPE"],
+            return ttnn.from_torch(
+                ff1_weight_torch,
+                dtype=model_config["OP9_FF1_MM_WEIGHTS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
-                memory_config=model_config["OP9_FF1_MM_WEIGHTS_MEMCFG"],
-            )
-            encoder0_ff1_bias = ttnn.from_torch(
-                encoder0_ff1_bias,
-                model_config["OP9_FF1_MM_BIAS_DTYPE"],
-                layout=ttnn.TILE_LAYOUT,
-                device=device,
-                memory_config=model_config["OP9_FF1_MM_BIAS_MEMCFG"],
+                memory_config=ff1_weight_mem_config,
             )
 
-            # FF2 params
-            encoder0_ff2_weight = pad_weight(
+        def compute_ff1_bias():
+            ff1_bias_torch = pad_weight(state_dict[f"{encoder_ff1_str}.bias"])
+            return ttnn.from_torch(
+                ff1_bias_torch,
+                dtype=model_config["OP9_FF1_MM_BIAS_DTYPE"],
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ff1_bias_mem_config,
+            )
+
+        def compute_ff2_weight():
+            ff2_weight_torch = pad_weight(
                 torch.transpose(
                     state_dict[f"{encoder_ff2_str}.weight"],
                     -2,
                     -1,
                 )
             )
-            encoder0_ff2_bias = pad_weight(state_dict[f"{encoder_ff2_str}.bias"])
-
-            encoder0_ff2_weight_shape = encoder0_ff2_weight.shape
-            encoder0_ff2_bias_shape = encoder0_ff2_bias.shape
-
-            encoder0_ff2_weight = ttnn.from_torch(
-                encoder0_ff2_weight,
-                model_config["OP10_FF2_MM_WEIGHTS_DTYPE"],
+            return ttnn.from_torch(
+                ff2_weight_torch,
+                dtype=model_config["OP10_FF2_MM_WEIGHTS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
-                memory_config=model_config["OP10_FF2_MM_WEIGHTS_MEMCFG"],
+                memory_config=ff2_weight_mem_config,
             )
-            encoder0_ff2_bias = ttnn.from_torch(
-                encoder0_ff2_bias,
-                model_config["OP10_FF2_MM_BIAS_DTYPE"],
+
+        def compute_ff2_bias():
+            ff2_bias_torch = pad_weight(state_dict[f"{encoder_ff2_str}.bias"])
+            return ttnn.from_torch(
+                ff2_bias_torch,
+                dtype=model_config["OP10_FF2_MM_BIAS_DTYPE"],
                 layout=ttnn.TILE_LAYOUT,
                 device=device,
-                memory_config=model_config["OP10_FF2_MM_BIAS_MEMCFG"],
+                memory_config=ff2_bias_mem_config,
             )
+
+        encoder0_ff1_weight = load_or_compute_and_cache(
+            ff1_weight_path,
+            compute_ff1_weight,
+            device=device,
+            mem_config=ff1_weight_mem_config,
+        )
+        encoder0_ff1_bias = load_or_compute_and_cache(
+            ff1_bias_path,
+            compute_ff1_bias,
+            device=device,
+            mem_config=ff1_bias_mem_config,
+        )
+        encoder0_ff2_weight = load_or_compute_and_cache(
+            ff2_weight_path,
+            compute_ff2_weight,
+            device=device,
+            mem_config=ff2_weight_mem_config,
+        )
+        encoder0_ff2_bias = load_or_compute_and_cache(
+            ff2_bias_path,
+            compute_ff2_bias,
+            device=device,
+            mem_config=ff2_bias_mem_config,
+        )
+
+        encoder0_ff1_weight_shape = encoder0_ff1_weight.padded_shape
 
         self.ffn = feed_forward(
             *tuple(encoder0_ff1_weight_shape)[-2:],

--- a/models/demos/metal_BERT_large_11/tt/mha.py
+++ b/models/demos/metal_BERT_large_11/tt/mha.py
@@ -10,6 +10,7 @@ from typing import Optional
 import ttnn
 from tt_lib.utils import pad_weight
 from models.demos.metal_BERT_large_11.tt import custom_matmuls
+from models.demos.metal_BERT_large_11.tt.tensor_utils import load_or_compute_and_cache
 
 
 def mha(qkv_weight, qkv_bias, hidden_dim, num_heads, device, model_config):
@@ -176,67 +177,89 @@ class TtMultiHeadAttentionModel:
     def __init__(self, config, encoder_idx, state_dict, device, model_config=None, tt_cache_path=None):
         layer_name = f"bert.encoder.layer.{encoder_idx}.attention.self"
 
+        qkv_weight_cache_path = None
+        qkv_bias_cache_path = None
         if tt_cache_path is not None:
             interleaved_str = ""
             if "QKV_INTERLEAVED" in model_config:
                 interleaved_str = f"interleaved_{model_config['QKV_INTERLEAVED']}_"
-            qkv_weight = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{layer_name}.qkv.weight_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_WEIGHTS_DTYPE'].name}.bin"
-                )
-            ).to(device, model_config["OP1_FUSED_QKV_MM_WEIGHTS_MEMCFG"])
-            qkv_bias = ttnn.load_tensor(
-                str(
-                    tt_cache_path
-                    / f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}.bin"
-                )
-            ).to(device, model_config["OP1_FUSED_QKV_MM_BIAS_MEMCFG"])
-        else:
-            qw = state_dict[f"{layer_name}.query.weight"]
-            qb = state_dict[f"{layer_name}.query.bias"]
-            kw = state_dict[f"{layer_name}.key.weight"]
-            kb = state_dict[f"{layer_name}.key.bias"]
-            vw = state_dict[f"{layer_name}.value.weight"]
-            vb = state_dict[f"{layer_name}.value.bias"]
+            qkv_weight_cache_path = str(
+                f"{tt_cache_path}/"
+                f"{layer_name}.qkv.weight_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_WEIGHTS_DTYPE'].name}.bin"
+            )
+            qkv_bias_cache_path = str(
+                f"{tt_cache_path}/"
+                f"{layer_name}.qkv.bias_{interleaved_str}{model_config['OP1_FUSED_QKV_MM_BIAS_DTYPE'].name}.bin"
+            )
 
-            # Weights pre-transposed on host​. No on-the fly transpose of W​
+        qkv_weight_mem_config = model_config["OP1_FUSED_QKV_MM_WEIGHTS_MEMCFG"]
+        qkv_bias_mem_config = model_config["OP1_FUSED_QKV_MM_BIAS_MEMCFG"]
+
+        def compute_qkv_weight():
+            qw = state_dict[f"{layer_name}.query.weight"]
+            kw = state_dict[f"{layer_name}.key.weight"]
+            vw = state_dict[f"{layer_name}.value.weight"]
+
             qw = torch.transpose(qw, -1, -2)
             kw = torch.transpose(kw, -1, -2)
             vw = torch.transpose(vw, -1, -2)
+
             if "QKV_INTERLEAVED" in model_config:
                 const_w_dims = qw.shape[:-1]
-                const_b_dims = qb.shape[:-1]
                 qw = qw.reshape([*const_w_dims, model_config["QKV_INTERLEAVED"], -1])
-                qb = qb.reshape([*const_b_dims, model_config["QKV_INTERLEAVED"], -1])
                 kw = kw.reshape(qw.shape)
-                kb = kb.reshape(qb.shape)
                 vw = vw.reshape(qw.shape)
-                vb = vb.reshape(qb.shape)
-                qkv_weight = torch.cat((qw, kw, vw), -1).reshape([*const_w_dims, -1])
-                qkv_bias = torch.cat((qb, kb, vb), -1).reshape([*const_b_dims, -1])
+                qkv_weight_torch = torch.cat((qw, kw, vw), -1).reshape([*const_w_dims, -1])
             else:
-                qkv_weight = torch.cat((qw, kw, vw), -1)
-                qkv_bias = torch.cat((qb, kb, vb), -1)
+                qkv_weight_torch = torch.cat((qw, kw, vw), -1)
 
-            qkv_weight = pad_weight(qkv_weight)
-            qkv_bias = pad_weight(qkv_bias)
+            qkv_weight_torch = pad_weight(qkv_weight_torch)
 
-            qkv_weight = ttnn.from_torch(
-                qkv_weight,
-                model_config["OP1_FUSED_QKV_MM_WEIGHTS_DTYPE"],
+            return ttnn.from_torch(
+                qkv_weight_torch,
+                dtype=model_config["OP1_FUSED_QKV_MM_WEIGHTS_DTYPE"],
                 layout=ttnn.Layout.TILE,
                 device=device,
-                memory_config=model_config["OP1_FUSED_QKV_MM_WEIGHTS_MEMCFG"],
+                memory_config=qkv_weight_mem_config,
             )
 
-            qkv_bias = ttnn.from_torch(
-                qkv_bias,
-                model_config["OP1_FUSED_QKV_MM_BIAS_DTYPE"],
+        def compute_qkv_bias():
+            qb = state_dict[f"{layer_name}.query.bias"]
+            kb = state_dict[f"{layer_name}.key.bias"]
+            vb = state_dict[f"{layer_name}.value.bias"]
+
+            if "QKV_INTERLEAVED" in model_config:
+                const_b_dims = qb.shape[:-1]
+                qb = qb.reshape([*const_b_dims, model_config["QKV_INTERLEAVED"], -1])
+                kb = kb.reshape(qb.shape)
+                vb = vb.reshape(qb.shape)
+                qkv_bias_torch = torch.cat((qb, kb, vb), -1).reshape([*const_b_dims, -1])
+            else:
+                qkv_bias_torch = torch.cat((qb, kb, vb), -1)
+
+            qkv_bias_torch = pad_weight(qkv_bias_torch)
+
+            return ttnn.from_torch(
+                qkv_bias_torch,
+                dtype=model_config["OP1_FUSED_QKV_MM_BIAS_DTYPE"],
                 layout=ttnn.Layout.TILE,
                 device=device,
-                memory_config=model_config["OP1_FUSED_QKV_MM_BIAS_MEMCFG"],
+                memory_config=qkv_bias_mem_config,
             )
+
+        qkv_weight = load_or_compute_and_cache(
+            qkv_weight_cache_path,
+            compute_qkv_weight,
+            device=device,
+            mem_config=qkv_weight_mem_config,
+        )
+
+        qkv_bias = load_or_compute_and_cache(
+            qkv_bias_cache_path,
+            compute_qkv_bias,
+            device=device,
+            mem_config=qkv_bias_mem_config,
+        )
 
         # Hidden dim
         hidden_dim = qkv_weight.padded_shape[-1] // 3

--- a/models/demos/metal_BERT_large_11/tt/tensor_utils.py
+++ b/models/demos/metal_BERT_large_11/tt/tensor_utils.py
@@ -32,7 +32,7 @@ def load_or_compute_and_cache(
     tensor = None
     if cache_path:
         try:
-            tensor = ttnn.load_tensor(cache_path).to(device, mem_config)
+            tensor = ttnn.load_tensor(cache_path)
             logger.info(f"Loaded tensor from cache: {cache_path}")
         except Exception as e:
             logger.warning(f"Failed to load tensor from cache: {cache_path}. Error: {e}")
@@ -44,4 +44,4 @@ def load_or_compute_and_cache(
             logger.info(f"Dumping tensor to cache: {cache_path}")
             ttnn.dump_tensor(cache_path, tensor)
 
-    return tensor
+    return tensor.to(device, mem_config)

--- a/models/demos/metal_BERT_large_11/tt/tensor_utils.py
+++ b/models/demos/metal_BERT_large_11/tt/tensor_utils.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional, Callable
+import ttnn
+from loguru import logger
+
+
+def load_or_compute_and_cache(
+    cache_path: Optional[str],
+    compute_func: Callable[[], ttnn.Tensor],
+    device: ttnn.Device,
+    mem_config: ttnn.MemoryConfig,
+) -> ttnn.Tensor:
+    """
+    Attempts to load a tensor from cache_path using ttnn.load_tensor.
+    If cache_path is None or loading fails, it calls compute_func,
+    converts the result using convert_func, places it on the specified device and mem_config,
+    and caches the result if cache_path was provided.
+
+    Args:
+        cache_path (Optional[str]): Path (as string) to load from/save to.
+        compute_func (Callable[[], ttnn.Tensor]): Function that computes and returns the tensor as a ttnn.Tensor
+                                                  (handling dtype and layout).
+        device (ttnn.Device): Target device for the final ttnn.Tensor.
+        mem_config (ttnn.MemoryConfig): Target memory config for the final ttnn.Tensor.
+
+    Returns:
+        ttnn.Tensor: The loaded or computed tensor on the specified device and memory configuration.
+    """
+    tensor = None
+    if cache_path:
+        try:
+            tensor = ttnn.load_tensor(cache_path).to(device, mem_config)
+            logger.info(f"Loaded tensor from cache: {cache_path}")
+        except Exception as e:
+            logger.warning(f"Failed to load tensor from cache: {cache_path}. Error: {e}")
+            tensor = None
+
+    if tensor is None:
+        tensor = compute_func()
+        if cache_path:
+            logger.info(f"Dumping tensor to cache: {cache_path}")
+            ttnn.dump_tensor(cache_path, tensor)
+
+    return tensor


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent-metal/metal-internal-workflows/issues/499

### Problem description
Stale weights caches lead to serialization failures.

Existing code needs to be adjusted to detect and re-generate caches in this case.

### What's changed
Added special handling of cache loading failures.

### Checklist
- [X] [Single card perf](https://github.com/tenstorrent/tt-metal/actions/runs/14787116165)

With re-generated caches, `main` is now fixed: https://github.com/tenstorrent/tt-metal/actions/runs/14783530676

Tested locally with
```
pytest -n auto --disable-warnings models/demos/metal_BERT_large_11/demo/demo.py -k batch_7
```