### PR TITLE
ttnn.embedding returns incorrect result for tiled input (specifically with output specified as tiled) #17643

### DIFF
--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -61,7 +61,7 @@ std::vector<TensorSpec> Embeddings::compute_output_specs(const std::vector<Tenso
     auto num_embedding_dims = weight_tensor.logical_shape()[-1];
 
     ttnn::Shape output_shape({batch_num, 1, num_output_embeddings, num_embedding_dims});
-    auto output_layout = tilized ? Layout::TILE : Layout::ROW_MAJOR;
+    auto output_layout = (tilized && input_tensors.at(0).get_layout() != Layout::TILE)? Layout::TILE : Layout::ROW_MAJOR;
     return {TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(output_layout), output_mem_config))};
 }
 


### PR DESCRIPTION
### Ticket
[17643](https://github.com/tenstorrent/tt-metal/issues/17643)

### Problem description
Customer had some failing cases with tiled inputs

### What's changed
Tiled input embedding was already supported, the problem lied in the fact that tiled input embedding outputs an RM tensor, therefore we need to make sure the output tensor being created is RM before being converted to Tile after the kernel is finished.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14764843130) CI passes
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/14764854490) CI passes (if applicable)