### PR TITLE
Fix segfault in mem_bench

### DIFF
--- a/tt_metal/tools/mem_bench/context.hpp
+++ b/tt_metal/tools/mem_bench/context.hpp
@@ -59,12 +59,15 @@ struct Context {
         int writers_,
         bool enable_host_copy_with_kernels_,
         int iterations_) {
-        auto l1_alignment = hal::get_l1_alignment();
-        auto l1_base = devices_.begin()->second->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
-        device_address.cycles = l1_base;
-        device_address.rd_bytes = align(device_address.cycles + sizeof(uint32_t), l1_alignment);
-        device_address.wr_bytes = align(device_address.rd_bytes + sizeof(uint32_t), l1_alignment);
-        device_address.unreserved = align(device_address.wr_bytes + sizeof(uint32_t), l1_alignment);
+        // Devices can be empty if it's a host only test
+        if (!devices_.empty()) {
+            auto l1_alignment = hal::get_l1_alignment();
+            auto l1_base = devices_.begin()->second->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+            device_address.cycles = l1_base;
+            device_address.rd_bytes = align(device_address.cycles + sizeof(uint32_t), l1_alignment);
+            device_address.wr_bytes = align(device_address.rd_bytes + sizeof(uint32_t), l1_alignment);
+            device_address.unreserved = align(device_address.wr_bytes + sizeof(uint32_t), l1_alignment);
+        }
         devices = devices_;
         total_size = total_size_;
         page_size = page_size_;

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -507,6 +507,7 @@ void register_full_benchmark_suite() {
             {32_KB},
             {1, 2},
             {1, 2},
+            {true},
         });
     ::benchmark::RegisterBenchmark(
         "Multiple MMIO Devices Reading (Same NUMA node)", mem_bench_multi_mmio_devices_reading_same_node)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
This was trying to access devices on host only tests


### What's changed
Don't access it if no devices.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes