### PR TITLE
Update sweep_rw_buffer.sh to use device 1

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/sweep_rw_buffer.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/sweep_rw_buffer.sh
@@ -38,15 +38,15 @@ echo "###" write bw 512M buffer
 run_set --transfer-size 536870912 --skip-read
 
 echo "###" read bw 32K buffer remote device
-run_set --transfer-size 32768 --skip-write --device 2
+run_set --transfer-size 32768 --skip-write --device 1
 
 echo "###" read bw 512M buffer remote device
-run_set --transfer-size 536870912 --skip-write --device 2
+run_set --transfer-size 536870912 --skip-write --device 1
 
 echo "###" write bw 32K buffer remote device
-run_set --transfer-size 32768 --skip-read --device 2
+run_set --transfer-size 32768 --skip-read --device 1
 
 echo "###" write bw 512M buffer remote device
-run_set --transfer-size 536870912 --skip-read --device 2
+run_set --transfer-size 536870912 --skip-read --device 1
 
 echo "###" done


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Usually there is no device 2

### What's changed
Use device 1 instead of device 2 for the remote device sweeps

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes