### PR TITLE
[skip ci] Delete dangling CMake files

### DIFF
--- a/ttnn/cpp/ttnn/deprecated/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/deprecated/CMakeLists.txt
@@ -1,5 +1,0 @@
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_dnn)
-
-if(WITH_PYTHON_BINDINGS)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tt_lib)
-endif()

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/op_library)

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/op_library/CMakeLists.txt
@@ -1,2 +1,0 @@
-# We do not use GLOB here since build system won't be able to pick up changes to the file list generated
-set(TT_DNN_SRCS CACHE INTERNAL "tt_dnn sources to reuse in ttnn build")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Unreferenced CMakeLists.txt files are dead code.  Dead code is noise and misleading.

### What's changed
rm -rf