### PR TITLE
Re-enable static HAL asserts

### DIFF
--- a/tt_metal/llrt/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal.cpp
@@ -11,6 +11,7 @@
 #include "blackhole/bh_hal.hpp"
 #include "core_config.h"  // ProgrammableCoreType
 #include "dev_mem_map.h"
+#include "hal_asserts.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
 #include "noc/noc_overlay_parameters.h"

--- a/tt_metal/llrt/hal_asserts.hpp
+++ b/tt_metal/llrt/hal_asserts.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+// This header provides static asserts. Consumers really do want it even if they don't use any symbol from it.
+// IWYU pragma: always_keep
+
 #include "dev_mem_map.h"
 #include <dev_msgs.h>
 #include "noc/noc_parameters.h"

--- a/tt_metal/llrt/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal.cpp
@@ -11,6 +11,7 @@
 #include "core_config.h"  // ProgrammableCoreType
 #include "dev_mem_map.h"  // MEM_LOCAL_BASE
 #include "hal_types.hpp"
+#include "hal_asserts.hpp"
 #include "hw/inc/wormhole/eth_l1_address_map.h"
 #include "llrt/hal.hpp"
 #include "noc/noc_overlay_parameters.h"


### PR DESCRIPTION
### Ticket
#21321

### Problem description
HAL static asserts got lost.  They help keep brittle code less brittle.  And we lost them.

### What's changed
* Include hal_asserts in the HAL of each arch
* Add an IWYU pragma so that future cleanup won't have a tool suggesting it get removed.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14768317331)