### PR TITLE
[TT-Transformers] Fix rot mat indexing bug causing bad outputs for long sequences using chunked prefill, refactor prefill model test to use Generator and fill testing gaps

### DIFF
--- a/models/tt_transformers/lt
+++ b/models/tt_transformers/lt
@@ -930,7 +930,7 @@ def run_entry_command(entry, screen_lock, output_entries, screen_needs_update):
         "lm-head": "pytest models/tt_transformers/tests/test_lm_head.py",
         "model": "pytest models/tt_transformers/tests/test_model.py -k 'performance-256 and full'",
         "model-quick": "pytest models/tt_transformers/tests/test_model.py -k 'performance-256 and quick'",
-        "model-prefill": "pytest models/tt_transformers/tests/test_model_prefill.py -k performance-4096",
+        "model-prefill": "pytest models/tt_transformers/tests/test_model_prefill.py -k 'all_layers and performance- and 4k'",
         # Precision and Math Fidelity tests for Pareto analysis
         **pareto_commands,
         **pareto_commands_from_json,

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -9,10 +9,10 @@ import os
 import ttnn
 from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
+    create_tt_model,
 )
 from models.tt_transformers.tt.model_config import DecodersPrecision
 from models.tt_transformers.tt.generator import Generator
-from models.tt_transformers.demo.simple_text_demo import create_tt_model  # TODO move to common util dir
 from models.utility_functions import (
     comp_pcc,
 )

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -106,7 +106,7 @@ def test_model_inference(
 
     # This sets the minimum PCC for each iteration based on optimization mode
     if num_layers == 1:
-        expec_out_pcc = 0.98
+        expec_out_pcc = 0.97
         expec_kv_cache_pcc = 0.99
     else:
         if "accuracy" in test_id:

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -133,10 +133,6 @@ def test_model_inference(
         dtype=dtype,
         num_layers=num_layers,
     )
-    
-    if is_ci_env and model_args.is_90b:
-        logger.info("Loading single layer of 90B model for fast CI testing...")
-        model_args.n_layers = 1
     tokenizer = model_args.tokenizer
     generator = Generator([tt_model], [model_args], mesh_device, tokenizer=tokenizer)
     logger.info("Finished loading TT model.")

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -12,10 +12,8 @@ from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
 )
 from models.tt_transformers.tt.model_config import DecodersPrecision
-from models.tt_transformers.demo.simple_text_demo import (
-    create_tt_model,
-    create_tt_page_table,
-)  # TODO move to common util dir
+from models.tt_transformers.tt.generator import Generator
+from models.tt_transformers.demo.simple_text_demo import create_tt_model  # TODO move to common util dir
 from models.utility_functions import (
     comp_pcc,
     comp_allclose,
@@ -99,20 +97,22 @@ def test_model_inference(
 
     # model_args = ModelArgs(mesh_device, max_batch_size=batch_size, optimizations=optimizations, max_seq_len=(128 * 1024))
     # model_args.n_layers = 2
-    model_args, tt_model, tt_kv_cache_i, state_dict = create_tt_model(
+    model_args, tt_model, tt_kv_cache, state_dict = create_tt_model(
         mesh_device,
         instruct=instruct,
         max_batch_size=batch_size,
         optimizations=optimizations,
         max_seq_len=seq_len,
         page_params=page_params,
-        dtype=ttnn.bfloat8_b,
+        dtype=dtype,
         use_paged_kv_cache=paged_attention,
     )
     
     if is_ci_env and model_args.is_90b:
         logger.info("Loading single layer of 90B model for fast CI testing...")
         model_args.n_layers = 1
+    tokenizer = model_args.tokenizer
+    generator = Generator([tt_model], [model_args], mesh_device, tokenizer=tokenizer)
 
     logger.info("Loading weights...")
     state_dict_prefix = model_args.get_state_dict_prefix("", None)
@@ -177,13 +177,13 @@ def test_model_inference(
         page_table = reverse_permutation.reshape(
             model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
         )
-        page_table_tt = ttnn.from_torch(
-            page_table,
-            device=mesh_device,
-            dtype=ttnn.int32,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
-        )
+        # page_table_tt = ttnn.from_torch(
+        #     page_table,
+        #     device=mesh_device,
+        #     dtype=ttnn.int32,
+        #     layout=ttnn.ROW_MAJOR_LAYOUT,
+        #     mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        # )
 
     # Load TTNN model
     # tt_model = Transformer(
@@ -202,38 +202,48 @@ def test_model_inference(
 
     # Select the first token from the prompt for initial decoding
     encoded_prompt_tensor = torch.tensor(encoded_prompt)  # [:,0]
+    tt_prefill_input = encoded_prompt_tensor.unsqueeze(0)
+    prompt_lens = [seq_len]
     pt_prefill_input = embd(encoded_prompt_tensor).view(batch_size, seq_len, -1)
 
-    tt_prefill_input = pt_prefill_input
+    # tt_prefill_input = pt_prefill_input
 
-    tt_prefill_input = model_args.prepare_residual_tensor_prefill(
-        pt_prefill_input,
-    )
+    # tt_prefill_input = model_args.prepare_residual_tensor_prefill(
+    #     pt_prefill_input,
+    # )
 
     start_pos = 0
     # Run TT model
     logger.info(f"Running TT model...")
-    tt_out = tt_model(
+    # tt_out = tt_model(
+    #     tt_prefill_input,
+    #     current_pos=None,
+    #     rot_mats=rot_mats,
+    #     user_id=0,
+    #     mode="prefill",
+    #     page_table=page_table_tt,
+    # )
+    # # Convert ttnn tensor to torch tensor
+    # tt_out = ttnn.to_torch(
+    #     tt_out,
+    #     mesh_composer=ttnn.ConcatMesh2dToTensor(
+    #         mesh_device, dims=(1, 3) if model_args.is_galaxy else (1, 3), mesh_shape=model_args.cluster_shape
+    #     ),
+    # )
+    # tt_output_torch = tt_out[:, 0:1, :, : model_args.dim].view(batch_size, seq_len, -1)  # [ batch, seq, hidden_dim]
+    tt_output_torch = generator.prefill_forward_text(
         tt_prefill_input,
-        current_pos=None,
-        rot_mats=rot_mats,
-        user_id=0,
-        mode="prefill",
-        page_table=page_table_tt,
+        page_table=page_table,
+        kv_cache=[tt_kv_cache],
+        prompt_lens=prompt_lens,
     )
-    # Convert ttnn tensor to torch tensor
-    tt_out = ttnn.to_torch(
-        tt_out,
-        mesh_composer=ttnn.ConcatMesh2dToTensor(
-            mesh_device, dims=(1, 3) if model_args.is_galaxy else (1, 3), mesh_shape=model_args.cluster_shape
-        ),
-    )
-    tt_output_torch = tt_out[:, 0:1, :, : model_args.dim].view(batch_size, seq_len, -1)  # [ batch, seq, hidden_dim]
     logger.info(f"Finished running TT model.")
 
     if run_ref_pt:  # Run reference model
         logger.info(f"Running reference model...")
-        ref_output = reference_model(pt_prefill_input, start_pos, mode="prefill")
+        # ref_output = reference_model(pt_prefill_input, start_pos, mode="prefill")  # previously was returning out before lm head?
+        ref_output = reference_model(pt_prefill_input, start_pos)
+        ref_output = ref_output[:, -1:, :]  # Get last token since TT model only returns the last token
         logger.info(f"Finished running reference model.")
 
     # Measure PCC if also running reference model

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -54,6 +54,13 @@ from models.utility_functions import skip_for_grayskull
     ids=["128", "3k", "4k", "8k", "16k", "32k"],
 )
 @pytest.mark.parametrize(
+    "max_seq_len",
+    (128 * 1024,),
+    ids=[
+        "max128k",
+    ],
+)
+@pytest.mark.parametrize(
     "optimizations",
     [
         lambda model_args: DecodersPrecision.performance(model_args.n_layers, model_args.model_name),
@@ -67,10 +74,11 @@ from models.utility_functions import skip_for_grayskull
     ids=["1layer", "all_layers"],
 )
 def test_model_inference(
-    seq_len,
     paged_attention,
     page_params,
     optimizations,
+    seq_len,
+    max_seq_len,
     num_layers,
     mesh_device,
     use_program_cache,
@@ -128,7 +136,7 @@ def test_model_inference(
         instruct=instruct,
         max_batch_size=batch_size,
         optimizations=optimizations,
-        max_seq_len=seq_len,
+        max_seq_len=max_seq_len,
         paged_attention_config=paged_attention_config,
         dtype=dtype,
         num_layers=num_layers,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -120,6 +120,9 @@ class Transformer(LightweightModule):
         tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
 
         # Slice the rot mats to the prefill seqlen
+        assert (
+            self.rope_setup.cos_matrix.shape[2] >= start_pos + S
+        ), f"Padded prefill end idx {start_pos + S} exceeds max seq len {self.rope_setup.cos_matrix.shape[2]}"
         tt_rot_mats_prefill = [
             self.rope_setup.cos_matrix[:, :, start_pos : start_pos + S, :],
             self.rope_setup.sin_matrix[:, :, start_pos : start_pos + S, :],

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -120,7 +120,10 @@ class Transformer(LightweightModule):
         tokens_embd = ttnn.unsqueeze_to_4D(tokens_embd)
 
         # Slice the rot mats to the prefill seqlen
-        tt_rot_mats_prefill = [self.rope_setup.cos_matrix[:, :, :S, :], self.rope_setup.sin_matrix[:, :, :S, :]]
+        tt_rot_mats_prefill = [
+            self.rope_setup.cos_matrix[:, :, start_pos : start_pos + S, :],
+            self.rope_setup.sin_matrix[:, :, start_pos : start_pos + S, :],
+        ]
 
         if page_table is not None:
             tt_page_table = ttnn.from_torch(

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -112,7 +112,7 @@ run_t3000_llama3_90b_tests() {
   wh_arch_yaml=wormhole_b0_80_arch_eth_dispatch.yaml
   llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Instruct/
   LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model.py -k quick ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model_prefill.py -k accuracy ; fail+=$?
+  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model_prefill.py -k "accuracy and 1layer" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -112,7 +112,7 @@ run_t3000_llama3_90b_tests() {
   wh_arch_yaml=wormhole_b0_80_arch_eth_dispatch.yaml
   llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Instruct/
   LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model.py -k quick ; fail+=$?
-  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model_prefill.py -k "accuracy and 1layer" ; fail+=$?
+  LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model_prefill.py -k "performance and 1layer" ; fail+=$?
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -110,7 +110,7 @@ run_t3000_llama3_90b_tests() {
 
   # Run test_model (decode and prefill) for llama3 70B
   wh_arch_yaml=wormhole_b0_80_arch_eth_dispatch.yaml
-  llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Instruct/
+  llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct/
   LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model.py -k quick ; fail+=$?
   LLAMA_DIR=$llama90b WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_model_prefill.py -k "performance and 1layer" ; fail+=$?
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/18932
https://github.com/tenstorrent/tt-metal/issues/20191

### Problem description
- Llama models were generating bad outputs when prefilling long sequences via chunked prefill due to a bug in the rotation matrix indexing (introduced in #16753) where the chunk start pos was being ignored
- The prefill model test was not executing models the same way as `simple_text_demo.py` using the `Generator` class, was not checking kv cache pcc, and was not testing varying sequence lengths, resulting in this regression to not be caught and making debugging previously very difficult

### What's changed
- Fixed `tt_rot_mats_prefill` in `model.py::prepare_inputs_prefill` to properly index the cos/sin rot matrices using `start_pos` and fix the bad outputs for chunked prefill
- Refactored `test_model_prefill.py` to use Generator for model execution similar to the demo, check kv cache pcc, test 1 layer, and test additional seq lens
- Moved `create_tt_model` out of `simple_text_demo.py` and into `common.py` so it can be used in `test_model_prefill.py` and other unit tests in the future

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes