### PR TITLE
Fix bug in tt_transformer's `load_sharded_checkpoints` function

### DIFF
--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -23,6 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
+          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 45, owner_id: U07RY6B5FLJ}, #Gongyu Wang
           { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
           { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 30, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich

--- a/.github/workflows/t3000-demo-tests-impl.yaml
+++ b/.github/workflows/t3000-demo-tests-impl.yaml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 45, owner_id: U07RY6B5FLJ}, #Gongyu Wang
+          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_llama3_load_checkpoints_tests, timeout: 10, owner_id: U07RY6B5FLJ}, #Gongyu Wang
           { name: "t3k_falcon40b_tests", arch: wormhole_b0, cmd: run_t3000_falcon40b_tests, timeout: 50, owner_id: U053W15B6JF}, #Djordje Ivanovic
           { name: "t3k_llama3_tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 30, owner_id: U03PUAKE719}, # Miguel Tairum
           { name: "t3k_llama3_vision_tests", arch: wormhole_b0, cmd: run_t3000_llama3_vision_tests, timeout: 30, owner_id: U03FJB5TM5Y}, #Colman Glagovich

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -34,7 +34,6 @@ jobs:
           { name: "t3k llama3 accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_accuracy_tests, timeout: 45, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
           { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
           { name: "t3k llama3_90b tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_tests, timeout: 45, owner_id: U07RY6B5FLJ}, #Gongyu Wang
-          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_load_checkpoints_tests, timeout: 45, owner_id: U07RY6B5FLJ}, #Gongyu Wang
           # { name: "t3k llama3_70b tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich  # FIXME issue #14934
           { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
           { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 30, owner_id: U052J2QDDKQ}, #Pavle Josipovic

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -33,7 +33,8 @@ jobs:
           { name: "t3k llama3 tests", arch: wormhole_b0, cmd: run_t3000_llama3_tests, timeout: 45, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
           { name: "t3k llama3 accuracy tests", arch: wormhole_b0, cmd: run_t3000_llama3_accuracy_tests, timeout: 45, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
           { name: "t3k llama2_70b tests", arch: wormhole_b0, cmd: run_t3000_llama2_70b_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich
-          { name: "t3k llama3_90b tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_tests, timeout: 45, owner_id: U07RY6B5FLJ},  #Gongyu Wang
+          { name: "t3k llama3_90b tests", arch: wormhole_b0, cmd: run_t3000_llama3_90b_tests, timeout: 45, owner_id: U07RY6B5FLJ}, #Gongyu Wang
+          { name: "t3k llama3_load_checkpoints tests", arch: wormhole_b0, cmd: run_t3000_load_checkpoints_tests, timeout: 45, owner_id: U07RY6B5FLJ}, #Gongyu Wang
           # { name: "t3k llama3_70b tests", arch: wormhole_b0, cmd: run_t3000_llama3_70b_tests, timeout: 45, owner_id: U03FJB5TM5Y}, #Colman Glagovich  # FIXME issue #14934
           { name: "t3k mixtral tests", arch: wormhole_b0, cmd: run_t3000_mixtral_tests, timeout: 60, owner_id: U03PUAKE719}, #Miguel Tairum Cruz
           { name: "t3k resnet tests", arch: wormhole_b0, cmd: run_t3000_resnet_tests, timeout: 30, owner_id: U052J2QDDKQ}, #Pavle Josipovic

--- a/models/tt_transformers/model_params/Llama3.1-70B-Instruct/tensor_states.json
+++ b/models/tt_transformers/model_params/Llama3.1-70B-Instruct/tensor_states.json
@@ -1,0 +1,4179 @@
+{
+    "tok_embeddings.weight": {
+        "full_shape": [
+            128256,
+            8192
+        ]
+    },
+    "layers.0.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.0.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.0.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.0.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.0.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.0.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.0.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.0.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.0.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.1.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.1.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.1.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.1.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.1.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.1.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.1.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.1.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.1.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.2.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.2.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.2.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.2.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.2.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.2.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.2.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.2.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.2.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.3.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.3.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.3.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.3.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.3.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.3.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.3.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.3.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.3.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.4.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.4.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.4.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.4.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.4.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.4.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.4.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.4.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.4.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.5.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.5.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.5.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.5.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.5.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.5.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.5.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.5.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.5.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.6.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.6.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.6.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.6.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.6.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.6.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.6.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.6.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.6.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.7.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.7.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.7.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.7.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.7.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.7.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.7.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.7.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.7.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.8.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.8.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.8.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.8.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.8.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.8.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.8.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.8.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.8.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.9.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.9.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.9.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.9.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.9.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.9.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.9.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.9.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.9.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.10.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.10.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.10.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.10.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.10.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.10.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.10.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.10.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.10.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.11.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.11.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.11.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.11.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.11.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.11.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.11.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.11.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.11.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.12.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.12.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.12.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.12.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.12.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.12.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.12.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.12.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.12.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.13.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.13.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.13.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.13.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.13.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.13.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.13.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.13.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.13.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.14.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.14.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.14.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.14.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.14.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.14.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.14.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.14.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.14.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.15.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.15.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.15.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.15.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.15.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.15.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.15.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.15.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.15.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.16.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.16.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.16.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.16.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.16.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.16.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.16.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.16.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.16.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.17.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.17.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.17.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.17.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.17.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.17.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.17.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.17.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.17.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.18.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.18.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.18.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.18.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.18.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.18.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.18.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.18.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.18.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.19.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.19.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.19.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.19.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.19.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.19.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.19.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.19.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.19.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.20.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.20.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.20.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.20.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.20.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.20.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.20.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.20.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.20.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.21.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.21.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.21.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.21.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.21.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.21.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.21.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.21.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.21.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.22.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.22.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.22.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.22.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.22.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.22.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.22.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.22.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.22.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.23.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.23.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.23.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.23.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.23.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.23.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.23.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.23.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.23.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.24.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.24.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.24.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.24.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.24.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.24.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.24.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.24.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.24.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.25.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.25.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.25.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.25.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.25.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.25.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.25.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.25.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.25.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.26.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.26.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.26.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.26.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.26.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.26.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.26.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.26.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.26.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.27.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.27.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.27.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.27.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.27.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.27.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.27.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.27.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.27.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.28.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.28.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.28.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.28.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.28.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.28.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.28.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.28.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.28.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.29.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.29.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.29.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.29.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.29.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.29.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.29.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.29.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.29.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.30.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.30.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.30.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.30.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.30.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.30.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.30.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.30.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.30.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.31.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.31.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.31.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.31.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.31.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.31.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.31.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.31.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.31.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.32.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.32.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.32.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.32.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.32.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.32.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.32.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.32.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.32.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.33.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.33.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.33.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.33.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.33.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.33.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.33.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.33.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.33.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.34.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.34.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.34.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.34.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.34.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.34.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.34.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.34.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.34.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.35.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.35.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.35.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.35.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.35.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.35.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.35.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.35.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.35.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.36.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.36.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.36.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.36.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.36.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.36.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.36.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.36.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.36.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.37.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.37.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.37.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.37.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.37.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.37.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.37.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.37.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.37.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.38.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.38.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.38.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.38.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.38.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.38.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.38.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.38.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.38.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.39.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.39.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.39.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.39.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.39.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.39.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.39.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.39.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.39.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.40.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.40.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.40.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.40.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.40.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.40.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.40.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.40.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.40.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.41.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.41.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.41.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.41.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.41.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.41.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.41.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.41.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.41.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.42.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.42.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.42.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.42.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.42.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.42.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.42.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.42.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.42.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.43.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.43.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.43.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.43.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.43.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.43.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.43.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.43.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.43.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.44.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.44.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.44.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.44.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.44.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.44.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.44.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.44.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.44.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.45.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.45.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.45.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.45.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.45.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.45.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.45.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.45.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.45.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.46.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.46.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.46.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.46.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.46.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.46.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.46.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.46.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.46.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.47.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.47.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.47.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.47.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.47.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.47.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.47.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.47.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.47.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.48.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.48.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.48.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.48.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.48.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.48.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.48.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.48.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.48.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.49.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.49.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.49.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.49.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.49.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.49.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.49.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.49.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.49.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.50.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.50.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.50.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.50.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.50.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.50.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.50.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.50.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.50.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.51.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.51.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.51.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.51.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.51.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.51.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.51.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.51.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.51.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.52.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.52.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.52.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.52.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.52.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.52.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.52.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.52.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.52.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.53.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.53.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.53.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.53.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.53.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.53.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.53.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.53.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.53.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.54.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.54.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.54.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.54.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.54.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.54.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.54.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.54.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.54.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.55.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.55.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.55.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.55.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.55.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.55.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.55.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.55.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.55.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.56.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.56.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.56.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.56.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.56.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.56.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.56.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.56.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.56.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.57.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.57.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.57.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.57.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.57.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.57.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.57.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.57.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.57.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.58.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.58.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.58.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.58.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.58.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.58.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.58.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.58.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.58.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.59.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.59.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.59.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.59.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.59.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.59.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.59.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.59.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.59.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.60.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.60.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.60.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.60.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.60.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.60.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.60.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.60.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.60.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.61.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.61.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.61.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.61.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.61.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.61.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.61.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.61.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.61.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.62.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.62.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.62.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.62.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.62.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.62.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.62.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.62.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.62.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.63.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.63.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.63.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.63.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.63.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.63.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.63.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.63.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.63.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.64.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.64.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.64.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.64.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.64.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.64.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.64.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.64.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.64.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.65.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.65.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.65.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.65.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.65.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.65.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.65.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.65.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.65.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.66.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.66.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.66.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.66.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.66.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.66.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.66.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.66.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.66.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.67.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.67.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.67.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.67.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.67.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.67.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.67.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.67.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.67.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.68.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.68.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.68.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.68.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.68.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.68.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.68.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.68.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.68.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.69.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.69.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.69.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.69.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.69.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.69.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.69.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.69.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.69.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.70.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.70.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.70.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.70.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.70.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.70.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.70.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.70.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.70.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.71.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.71.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.71.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.71.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.71.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.71.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.71.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.71.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.71.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.72.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.72.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.72.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.72.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.72.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.72.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.72.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.72.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.72.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.73.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.73.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.73.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.73.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.73.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.73.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.73.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.73.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.73.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.74.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.74.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.74.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.74.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.74.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.74.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.74.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.74.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.74.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.75.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.75.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.75.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.75.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.75.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.75.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.75.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.75.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.75.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.76.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.76.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.76.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.76.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.76.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.76.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.76.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.76.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.76.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.77.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.77.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.77.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.77.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.77.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.77.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.77.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.77.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.77.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.78.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.78.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.78.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.78.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.78.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.78.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.78.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.78.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.78.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.79.attention.wq.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.79.attention.wk.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.79.attention.wv.weight": {
+        "full_shape": [
+            1024,
+            8192
+        ]
+    },
+    "layers.79.attention.wo.weight": {
+        "full_shape": [
+            8192,
+            8192
+        ]
+    },
+    "layers.79.feed_forward.w1.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.79.feed_forward.w3.weight": {
+        "full_shape": [
+            28672,
+            8192
+        ]
+    },
+    "layers.79.feed_forward.w2.weight": {
+        "full_shape": [
+            8192,
+            28672
+        ]
+    },
+    "layers.79.attention_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "layers.79.ffn_norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "norm.weight": {
+        "full_shape": [
+            8192
+        ]
+    },
+    "output.weight": {
+        "full_shape": [
+            128256,
+            8192
+        ]
+    }
+}

--- a/models/tt_transformers/tests/test_load_checkpoints.py
+++ b/models/tt_transformers/tests/test_load_checkpoints.py
@@ -20,7 +20,7 @@ from models.tt_transformers.tt.load_checkpoints import load_sharded_checkpoints
 # get the absolute path to this file
 _file_abs_path = os.path.abspath(__file__)
 
-# NOTE: because HF does not export convert_mllama_weight_to_hf.py (the line below fails), we need to copy the functions here
+# [INFO]: because HF does not export convert_mllama_weight_to_hf.py (the line below fails), we need to copy the functions here
 # from transformers.models.mllama.convert_mllama_weight_to_hf import is_param_different_across_shards, convert_old_keys_to_new_keys, get_concat_dim, cross_attention_layers_shift, self_attention_layers_shift
 
 # fmt: off
@@ -120,7 +120,7 @@ def get_concat_dim(key):
 
 
 def hf_mllama_save_tensor_states(loaded: list, model_name: str, params: dict, tensor_states_path: str) -> None:
-    # copied just enough code from transformers.models.mllama.convert_mllama_weight_to_hf.write_model to get the tensor states
+    # [INFO] copied just enough code from transformers.models.mllama.convert_mllama_weight_to_hf.write_model to get the tensor states
     text_num_layers = params["n_layers"]
     cross_attention_num_layers = params["vision_num_cross_attention_layers"]
 
@@ -170,16 +170,12 @@ def hf_mllama_save_tensor_states(loaded: list, model_name: str, params: dict, te
         json.dump(tensor_states, f, indent=4)
 
 
-# NOTE: end of copied functions from transformers.models.mllama.convert_mllama_weight_to_hf
-
-# NOTE: start of copied function from known good implementation of load_sharded_checkpoints for the following models:
+# [INFO]: start of copied function from known good implementation of load_sharded_checkpoints for the following models:
 # "Llama3.2-1B"
 # "Llama3.2-3B"
 # "Llama3.1-8B"
 # "Llama3.2-11B"
 # "Llama3.1-70B"
-
-
 def load_sharded_checkpoints_orig(checkpoints, n_layers):
     checkpoint = {}
     logger.info(f"Loading {len(checkpoints)} checkpoint files")
@@ -216,7 +212,7 @@ def load_sharded_checkpoints_orig(checkpoints, n_layers):
     return checkpoint
 
 
-# NOTE: end of copied function from known good implementation of load_sharded_checkpoints
+# [INFO]: end of copied function from known good implementation of load_sharded_checkpoints
 
 
 def write_tensor_states(loaded: dict, tensor_states_path: str) -> None:
@@ -240,6 +236,7 @@ def test_load_checkpoints():
     # make ModelArgs object with empty mesh_device for its ability to recognize the model name
     input_base_path = os.getenv("LLAMA_DIR")
     assert input_base_path, "LLAMA_DIR must be set to indicate the path to the model checkpoints"
+    logger.info(f"Checkpoint directory: {input_base_path}")
     # [INFO] we can hardcode this check because we only test 70B and 90B models atm
     is_70b = "Llama" in input_base_path and "70B" in input_base_path
     is_90b = "Llama" in input_base_path and "90B" in input_base_path and "Vision" in input_base_path

--- a/models/tt_transformers/tests/test_load_checkpoints.py
+++ b/models/tt_transformers/tests/test_load_checkpoints.py
@@ -16,7 +16,6 @@ import torch
 
 ##### TTNN imports #####
 from models.tt_transformers.tt.load_checkpoints import load_sharded_checkpoints
-from models.tt_transformers.tt.model_config import ModelArgs
 
 # get the absolute path to this file
 _file_abs_path = os.path.abspath(__file__)
@@ -239,12 +238,15 @@ def write_tensor_states(loaded: dict, tensor_states_path: str) -> None:
 # [INFO] Focus on testing 70B and 90B models because they are the only ones that require shared checkpoints
 def test_load_checkpoints():
     # make ModelArgs object with empty mesh_device for its ability to recognize the model name
-    model_args = ModelArgs(None)
-    input_base_path = model_args.CKPT_DIR
+    input_base_path = os.getenv("LLAMA_DIR")
+    assert input_base_path, "LLAMA_DIR must be set to indicate the path to the model checkpoints"
+    # [INFO] we can hardcode this check because we only test 70B and 90B models atm
+    is_70b = "Llama" in input_base_path and "70B" in input_base_path
+    is_90b = "Llama" in input_base_path and "90B" in input_base_path and "Vision" in input_base_path
     assert (
-        model_args.is_70b or model_args.is_90b
+        is_70b or is_90b
     ), "this test is only needed for models with sharded checkpoints (only 70B and 90B models atm)"
-    model_name = "Llama3.1-70B-Instruct" if model_args.is_70b else "Llama3.2-90B-Vision-Instruct"
+    model_name = "Llama3.1-70B-Instruct" if is_70b else "Llama3.2-90B-Vision-Instruct"
     model_names_with_hf_golden_func = ("Llama3.2-90B-Vision-Instruct",)
     model_names_with_orig_golden_func = ("Llama3.1-70B-Instruct",)
 

--- a/models/tt_transformers/tests/test_load_checkpoints.py
+++ b/models/tt_transformers/tests/test_load_checkpoints.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ##### Python imports #####
-import pytest
 from loguru import logger
 import os
 from pathlib import Path
@@ -17,6 +16,7 @@ import torch
 
 ##### TTNN imports #####
 from models.tt_transformers.tt.load_checkpoints import load_sharded_checkpoints
+from models.tt_transformers.tt.model_config import ModelArgs
 
 # get the absolute path to this file
 _file_abs_path = os.path.abspath(__file__)
@@ -181,7 +181,7 @@ def hf_mllama_save_tensor_states(loaded: list, model_name: str, params: dict, te
 # "Llama3.1-70B"
 
 
-def load_sharded_checkpoints(checkpoints, n_layers):
+def load_sharded_checkpoints_orig(checkpoints, n_layers):
     checkpoint = {}
     logger.info(f"Loading {len(checkpoints)} checkpoint files")
     for ckpt in tqdm(checkpoints):
@@ -236,26 +236,18 @@ def write_tensor_states(loaded: dict, tensor_states_path: str) -> None:
         json.dump(tensor_states, f, indent=4)
 
 
-@pytest.mark.parametrize(
-    "input_base_path, model_name",
-    [
-        # ("/proj_sw/user_dev/llama32-data/Llama3.2-1B-Instruct", "Llama3.2-1B-Instruct"),
-        # ("/proj_sw/user_dev/llama32-data/Llama3.2-3B-Instruct", "Llama3.2-3B-Instruct"),
-        # ("/proj_sw/user_dev/llama31-8b-data/Meta-Llama-3.1-8B-Instruct", "Llama3.1-8B-Instruct"),
-        # ("/proj_sw/user_dev/llama32-data/Llama3.2-11B-Vision-Instruct", "Llama3.2-11B-Vision-Instruct"),
-        # ("/proj_sw/user_dev/llama33-data/Llama3.1-70B-Instruct/", "Llama3.1-70B-Instruct"),
-        ("/proj_sw/user_dev/llama32-data/Llama3.2-90B-Vision-Instruct", "Llama3.2-90B-Vision-Instruct"),
-    ],
-    ids=[
-        # "3.2-1B",
-        # "3.2-3B",
-        # "3.1-8B",
-        # "3.2-11B",
-        # "3.1-70B",
-        "3.2-90B",
-    ],
-)
-def test_class_embedding_inference(input_base_path, model_name):
+# [INFO] Focus on testing 70B and 90B models because they are the only ones that require shared checkpoints
+def test_load_checkpoints():
+    # make ModelArgs object with empty mesh_device for its ability to recognize the model name
+    model_args = ModelArgs(None)
+    input_base_path = model_args.CKPT_DIR
+    assert (
+        model_args.is_70b or model_args.is_90b
+    ), "this test is only needed for models with sharded checkpoints (only 70B and 90B models atm)"
+    model_name = "Llama3.1-70B-Instruct" if model_args.is_70b else "Llama3.2-90B-Vision-Instruct"
+    model_names_with_hf_golden_func = ("Llama3.2-90B-Vision-Instruct",)
+    model_names_with_orig_golden_func = ("Llama3.1-70B-Instruct",)
+
     with open(os.path.join(input_base_path, "params.json"), "r") as f:
         params = json.load(f)
 
@@ -263,25 +255,28 @@ def test_class_embedding_inference(input_base_path, model_name):
     assert len(checkpoints) > 0, f"no checkpoint files found in {input_base_path}"
     print(f"\nFetching all parameters from the checkpoint at {input_base_path}...")
 
-    tensor_states_path = Path(_file_abs_path).parent.parent.parent / "model_params" / model_name / "tensor_states.json"
+    tensor_states_path = Path(_file_abs_path).parent.parent / "model_params" / model_name / "tensor_states.json"
     if not os.path.exists(tensor_states_path):
         print(f"tensor states not found at {tensor_states_path}. Generating...")
         num_shards = len(checkpoints)
-        if model_name in ("Llama3.2-90B-Vision-Instruct",):
+        if model_name in model_names_with_hf_golden_func:
             loaded = [
                 torch.load(os.path.join(input_base_path, f"consolidated.{i:02d}.pth"), map_location="cpu", mmap=True)
                 for i in range(num_shards)
             ]
             hf_mllama_save_tensor_states(loaded, model_name, params, tensor_states_path)
         else:
-            loaded = load_sharded_checkpoints(checkpoints, n_layers=None)
+            assert (
+                model_name in model_names_with_orig_golden_func
+            ), f"model {model_name} must have a golden function implemented"
+            loaded = load_sharded_checkpoints_orig(checkpoints, n_layers=None)
             write_tensor_states(loaded, tensor_states_path)
 
     assert os.path.exists(tensor_states_path), f"tensor states must now be available at {tensor_states_path}"
     print(f"loading tensor states from {tensor_states_path}")
     tensor_states = json.load(open(tensor_states_path, "r"))
 
-    # use our load_sharded_checkpoints function to load the model
+    # use tt-transformers' load_sharded_checkpoints function to load the model
     state_dict = load_sharded_checkpoints(checkpoints, n_layers=None)  # n_layers=None will load all layers
 
     assert len(state_dict) == len(

--- a/models/tt_transformers/tt/load_checkpoints.py
+++ b/models/tt_transformers/tt/load_checkpoints.py
@@ -156,10 +156,9 @@ def is_param_replicated_across_shards(key: str) -> bool:
     """
     if key.startswith("vision_model."):
         return any(keyword in key for keyword in ("ln", "gate", "embed", "c_proj.bias"))
-    elif key.startswith("text_model."):
-        return any(keyword in key for keyword in ("norm", "gate"))
     else:
-        raise ValueError(f"Unknown model parameter name: {key}")
+        # for Meta checkpoint keys, key either starts with "text_model." or contains no such prefix; both cases are handled here
+        return any(keyword in key for keyword in ("norm", "gate"))
 
 
 def load_sharded_checkpoints(checkpoints, n_layers):

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -199,7 +199,7 @@ run_t3000_llama3_load_checkpoints_tests() {
   llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct/
 
   for llama_dir in "$llama70b" "$llama90b"; do
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_load_checkpoints.py ; fail+=$?
+    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_load_checkpoints.py --timeout=600; fail+=$?
     echo "LOG_METAL: Llama3 load checkpoints tests for $llama_dir completed"
   done
 

--- a/tests/scripts/t3000/run_t3000_demo_tests.sh
+++ b/tests/scripts/t3000/run_t3000_demo_tests.sh
@@ -185,7 +185,36 @@ run_t3000_resnet50_tests() {
   fi
 }
 
+run_t3000_llama3_load_checkpoints_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_load_checkpoints_tests"
+
+  wh_arch_yaml=wormhole_b0_80_arch_eth_dispatch.yaml
+  # Llama3.1-70B weights
+  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/original_weights/
+  # Llama3.2-90B weights
+  llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct/
+
+  for llama_dir in "$llama70b" "$llama90b"; do
+    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_load_checkpoints.py ; fail+=$?
+    echo "LOG_METAL: Llama3 load checkpoints tests for $llama_dir completed"
+  done
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_load_checkpoints_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_tests() {
+  # Run llama3 load checkpoints tests
+  run_t3000_llama3_load_checkpoints_tests
 
   # Run llama3 smaller tests (1B, 3B, 8B, 11B)
   run_t3000_llama3_tests

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -336,6 +336,33 @@ run_t3000_resnet_tests() {
   fi
 }
 
+run_t3000_load_checkpoints_tests() {
+  # Record the start time
+  fail=0
+  start_time=$(date +%s)
+
+  echo "LOG_METAL: Running run_t3000_load_checkpoints_tests"
+
+  wh_arch_yaml=wormhole_b0_80_arch_eth_dispatch.yaml
+  # Llama3.1-70B weights
+  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/original_weights/
+  # Llama3.2-90B weights
+  llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct/
+
+  for llama_dir in "$llama70b" "$llama90b"; do
+    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_load_checkpoints.py ; fail+=$?
+    echo "LOG_METAL: Llama3 load checkpoints tests for $llama_dir completed"
+  done
+
+  # Record the end time
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "LOG_METAL: run_t3000_load_checkpoints_tests $duration seconds to complete"
+  if [[ $fail -ne 0 ]]; then
+    exit 1
+  fi
+}
+
 run_t3000_tests() {
   # Run ethernet tests
   run_t3000_ethernet_tests

--- a/tests/scripts/t3000/run_t3000_frequent_tests.sh
+++ b/tests/scripts/t3000/run_t3000_frequent_tests.sh
@@ -336,33 +336,6 @@ run_t3000_resnet_tests() {
   fi
 }
 
-run_t3000_load_checkpoints_tests() {
-  # Record the start time
-  fail=0
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_load_checkpoints_tests"
-
-  wh_arch_yaml=wormhole_b0_80_arch_eth_dispatch.yaml
-  # Llama3.1-70B weights
-  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/original_weights/
-  # Llama3.2-90B weights
-  llama90b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.2-90B-Vision-Instruct/
-
-  for llama_dir in "$llama70b" "$llama90b"; do
-    LLAMA_DIR=$llama_dir WH_ARCH_YAML=$wh_arch_yaml pytest -n auto models/tt_transformers/tests/test_load_checkpoints.py ; fail+=$?
-    echo "LOG_METAL: Llama3 load checkpoints tests for $llama_dir completed"
-  done
-
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_load_checkpoints_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
-
 run_t3000_tests() {
   # Run ethernet tests
   run_t3000_ethernet_tests


### PR DESCRIPTION
### Problem description
#20069 added Llama90B model, which is a vision model. Like Llama70B, Meta's checkpoint of the 90B model weights are sharded across multiple files. Furthermore, Meta's checkpoint of vision models contain additional prefix in tensor names to differentiate the vision and text parts of the model. The prefixes are `vision_model.` and `text_model.`. Text-only model such as Llama70B does not have this prefix in its tensor names from Meta's checkpoint.

#20069 made changes to the `load_sharded_checkpoint` function in order to deal with the additional prefixes. However, a bug was introduced to loading sharded checkpoints for Llama70B model. Existing CI tests do not use Meta checkpoints (instead CI tests use repacked weights which are loaded through a different function) and thus did not catch this bug. Thanks, @avoraTT, for uncovering the bug!  

### What's changed
- Made a simple modification to combine the conditionals to handle the text model part of 90B and the whole of 70B together.
- Added `test_load_checkpoint.py` to make sure any future changes to `load_sharded_checkpoint.py` is tested in CI.
- Added a small JSON file that contains the expected tensor shapes of Llama70B model to save time on CI runs.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14776486169) CI passes
  - on [90cecbe](https://github.com/tenstorrent/tt-metal/pull/21516/commits/90cecbee67d0f55ef05bd3e0737eab38abfeacc7)
  - with single unrelated-to-this-PR failure on N300 profiler test case
- [X] ~~Any TG test that @avoraTT suggests to run~~ Ammar and team recommends the separation of checkpoint loading code between tt_transformer and Llama TG (which is done through #21484). So, we just need to make sure CI run of `test_load_checkpoint.py` is successful:
  - [x] [CI run](https://github.com/tenstorrent/tt-metal/actions/runs/14797221997) of `test_load_checkpoint.py`.
    - on [998f5aa](https://github.com/tenstorrent/tt-metal/pull/21516/commits/998f5aadeeaa13466caa140b575e04df0ee3f4c4)
    - with unrelated 70b test failure -- test case timed out after many successful iterations