### PR TITLE
[DM]: Testing for "One from one" primitive

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -2,6 +2,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/dm_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dram_unary/test_unary_dram.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/one_to_one/test_one_to_one.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/one_from_one/test_one_from_one.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -3,10 +3,11 @@
 This test suite addresses the functionality and performance (i.e. bandwidth) of various data movement scenarios.
 
 ## Tests in the Test Suite
-| Name       | ID(s) | Description                                          |
-| ---------- | ----- | ---------------------------------------------------- |
-| DRAM Unary | 0-3   | Transactions between DRAM and a single Tensix core.  |
-| One to One | 4     | Transactions between two Tensix cores.               |
+| Name          | ID(s) | Description                                          |
+| ----------    | ----- | ---------------------------------------------------- |
+| DRAM Unary    | 0-3   | Transactions between DRAM and a single Tensix core.  |
+| One to One    | 4     | Write transactions between two Tensix cores.         |
+| One From One  | 5     | Read transactions between two Tensix cores.          |
 
 ## Running Tests
 Before running any tests, build the repo with tests: ```./build_metal.sh --build-tests```

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -1,0 +1,29 @@
+# One From One Core Data Movement Tests
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
+
+## Test Flow
+Sharded L1 buffers are created on two Tensix cores: one requestor and one responder core. Data is written into the L1 buffer on the responder core. The requestor kernel issues read NOC transactions to request a transfer of this data from the L1 buffer of the responder core to the L1 buffer of its core. A read barrier is placed after these transactions in order to ensure data validity.
+
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+
+Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Test Parameters
+| Parameter                 | Data Type             | Description |
+| ------------------------- | --------------------- | ----------- |
+| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
+| transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
+| page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format            | DataFormat            | Data format data that will be moved. |
+| master_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
+| slave_core_coord          | CoreCoord             | Logical coordinates for the receiver core. |
+| virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
+| noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
+
+## Test Cases
+Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+
+1. One From One Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. Sweeps values that are multiples of 2 (including 1) in the range [1, 64] for both parameters.

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/README.md
@@ -17,8 +17,8 @@ Test expectations are that pcc checks pass and sufficient test attribute data is
 | transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
 | page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
 | l1_data_format            | DataFormat            | Data format data that will be moved. |
-| master_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
-| slave_core_coord          | CoreCoord             | Logical coordinates for the receiver core. |
+| master_core_coord         | CoreCoord             | Logical coordinates for the requestor core. |
+| subordinate_core_coord    | CoreCoord             | Logical coordinates for the responder core. |
 | virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
 | noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+// L1 to L1 request
+void kernel_main() {
+    uint32_t src_addr = get_compile_time_arg_val(0);
+    uint32_t dst_addr = get_compile_time_arg_val(1);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(2);
+    constexpr uint32_t transaction_num_pages = get_compile_time_arg_val(3);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(4);
+    constexpr uint32_t test_id = get_compile_time_arg_val(5);
+
+    uint32_t responder_x_coord = get_arg_val<uint32_t>(0);
+    uint32_t responder_y_coord = get_arg_val<uint32_t>(1);
+
+    constexpr uint32_t transaction_size_bytes = transaction_num_pages * page_size_bytes;
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes);
+    DeviceTimestampedData("Test id", test_id);
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            uint64_t src_noc_addr = get_noc_addr(responder_x_coord, responder_y_coord, src_addr);
+
+            noc_async_read(src_noc_addr, dst_addr, transaction_size_bytes);
+
+            src_addr += transaction_size_bytes;
+            dst_addr += transaction_size_bytes;
+        }
+        noc_async_read_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::dm::core_to_core {
+// Test config, i.e. test parameters
+struct OneFromOneConfig {
+    uint32_t test_id = 0;
+    CoreCoord master_core_coord = CoreCoord();
+    CoreCoord slave_core_coord = CoreCoord();
+    uint32_t num_of_transactions = 0;
+    uint32_t transaction_size_pages = 0;
+    uint32_t page_size_bytes = 0;
+    DataFormat l1_data_format = DataFormat::Invalid;
+
+    // TODO: Add the following parameters
+    //  1. Virtual Channel
+    //  2. Which NOC to use
+    //  3. Posted flag
+};
+
+/// @brief Does Requestor Core --> L1 Responder Core --> L1 Requestor Core
+/// @param device
+/// @param test_config - Configuration of the test -- see struct
+/// @return
+bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
+    // Program
+    Program program = CreateProgram();
+
+    // Sharded L1 buffers
+    const size_t total_size_bytes =
+        test_config.num_of_transactions * test_config.transaction_size_pages * test_config.page_size_bytes;
+    const size_t total_size_pages = test_config.num_of_transactions * test_config.transaction_size_pages;
+
+    CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
+    CoreRangeSet slave_core_set({CoreRange(test_config.slave_core_coord)});
+
+    auto master_shard_parameters = ShardSpecBuffer(
+        master_core_set,
+        {1, total_size_bytes / 2},
+        ShardOrientation::ROW_MAJOR,
+        {1, test_config.page_size_bytes / 2},
+        {1, total_size_pages});
+    auto master_l1_buffer = CreateBuffer(ShardedBufferConfig{
+        .device = device,
+        .size = total_size_bytes,
+        .page_size = test_config.page_size_bytes,
+        .buffer_type = BufferType::L1,
+        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
+        .shard_parameters = std::move(master_shard_parameters),
+    });
+    uint32_t master_l1_byte_address = master_l1_buffer->address();
+
+    auto slave_shard_parameters = ShardSpecBuffer(
+        slave_core_set,
+        {1, total_size_bytes / 2},
+        ShardOrientation::ROW_MAJOR,
+        {1, test_config.page_size_bytes / 2},
+        {1, total_size_pages});
+    auto slave_l1_buffer = CreateBuffer(ShardedBufferConfig{
+        .device = device,
+        .size = total_size_bytes,
+        .page_size = test_config.page_size_bytes,
+        .buffer_type = BufferType::L1,
+        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
+        .shard_parameters = std::move(slave_shard_parameters),
+    });
+    uint32_t slave_l1_byte_address = slave_l1_buffer->address();
+
+    // Compile-time arguments for kernels
+    vector<uint32_t> requestor_compile_args = {
+        (uint32_t)slave_l1_byte_address,
+        (uint32_t)master_l1_byte_address,
+        (uint32_t)test_config.num_of_transactions,
+        (uint32_t)test_config.transaction_size_pages,
+        (uint32_t)test_config.page_size_bytes,
+        (uint32_t)test_config.test_id};
+
+    // Kernels
+    auto requestor_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor.cpp",
+        master_core_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = requestor_compile_args});
+
+    // Runtime Arguments
+    CoreCoord physical_slave_core = device->worker_core_from_logical_core(test_config.slave_core_coord);
+    SetRuntimeArgs(program, requestor_kernel, master_core_set, {physical_slave_core.x, physical_slave_core.y});
+
+    // Assign unique id
+    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, runtime_host_id);
+    program.set_runtime_id(runtime_host_id++);
+
+    // Input
+    vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -100.0f, 100.0f, total_size_bytes / bfloat16::SIZEOF, chrono::system_clock::now().time_since_epoch().count());
+
+    // Golden output
+    vector<uint32_t> packed_golden = packed_input;
+
+    // Launch program and record outputs
+    vector<uint32_t> packed_output;
+    detail::WriteToBuffer(slave_l1_buffer, packed_input);
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+    detail::LaunchProgram(device, program);
+    detail::ReadFromBuffer(master_l1_buffer, packed_output);
+
+    // Results comparison
+    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
+        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+
+    if (!pcc) {
+        log_error("PCC Check failed");
+        log_info("Golden vector");
+        print_vector<uint32_t>(packed_golden);
+        log_info("Output vector");
+        print_vector<uint32_t>(packed_output);
+    }
+
+    return pcc;
+}
+}  // namespace unit_tests::dm::core_to_core
+
+/* ========== Test case for one from one data movement; Test id = 5 ========== */
+TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
+    // Parameters
+    uint32_t max_transactions = 64;
+    uint32_t max_transaction_size_pages = 64;
+    uint32_t page_size_bytes = 32;  // =Flit size: 32 bytes for WH, 64 for BH
+    if (arch_ == tt::ARCH::BLACKHOLE) {
+        page_size_bytes *= 2;
+    }
+
+    // Cores
+    CoreCoord master_core_coord = {0, 0};
+    CoreCoord slave_core_coord = {1, 1};
+
+    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 2) {
+        for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
+             transaction_size_pages *= 2) {
+            // Test config
+            unit_tests::dm::core_to_core::OneFromOneConfig test_config = {
+                .test_id = 5,
+                .master_core_coord = master_core_coord,
+                .slave_core_coord = slave_core_coord,
+                .num_of_transactions = num_of_transactions,
+                .transaction_size_pages = transaction_size_pages,
+                .page_size_bytes = page_size_bytes,
+                .l1_data_format = DataFormat::Float16_b,
+            };
+
+            // Run
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+            }
+        }
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -102,8 +102,8 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
         program, requestor_kernel, master_core_set, {physical_subordinate_core.x, physical_subordinate_core.y});
 
     // Assign unique id
-    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, runtime_host_id);
-    program.set_runtime_id(runtime_host_id++);
+    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Input
     vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -6,6 +6,7 @@
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
+#include "dm_common.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/README.md
@@ -18,7 +18,7 @@ Test expectations are that pcc checks pass and sufficient test attribute data is
 | page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
 | l1_data_format            | DataFormat            | Data format data that will be moved. |
 | master_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
-| slave_core_coord          | CoreCoord             | Logical coordinates for the receiver core. |
+| subordinate_core_coord    | CoreCoord             | Logical coordinates for the receiver core. |
 | virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
 | noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
 | posted                    | N/A                   | Posted flag. Determines if write is posted or non-posted (TODO)|

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -5,12 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import sys
 import csv
-import pytest  # type: ignore
-from argparse import ArgumentParser
 from loguru import logger  # type: ignore
 import matplotlib.pyplot as plt  # type: ignore
+import itertools
 
 from tt_metal.tools.profiler.process_device_log import import_log_run_stats
 import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
@@ -23,6 +21,7 @@ test_id_to_name = {
     2: "DRAM Sharded",
     3: "DRAM Directed Ideal",
     4: "One to One Packet Sizes",
+    5: "One from One Packet Sizes",
 }
 
 # Correspondng test bounds for each arch, test id, riscv core
@@ -72,6 +71,9 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},
             "riscv_0": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
         },
+    },
+    5: {
+        "riscv_1": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
     },
 }
 
@@ -195,12 +197,12 @@ def gather_stats_from_csv(file_path, verbose=False):
             "start": {"risc": "ANY", "zone_name": "RISCV0"},
             "end": {"risc": "ANY", "zone_name": "RISCV0"},
         },
-        "riscv_1_events": {
+        "riscv_0_events": {
             "across": "device",
             "type": "event",
             "marker": {"risc": "BRISC"},
         },
-        "riscv_0_events": {
+        "riscv_1_events": {
             "across": "device",
             "type": "event",
             "marker": {"risc": "NCRISC"},
@@ -217,9 +219,15 @@ def gather_stats_from_csv(file_path, verbose=False):
 def performance_check(dm_stats, arch="blackhole", verbose=False):
     # Tidy results' ranges
     results_bounds = {}
-    for i in range(len(dm_stats["riscv_1"]["analysis"]["series"])):
-        run_host_id = dm_stats["riscv_1"]["analysis"]["series"][i]["duration_type"][0]["run_host_id"]
-        test_id = dm_stats["riscv_1"]["attributes"][run_host_id]["Test id"]
+    for riscv1_run, riscv0_run in itertools.zip_longest(
+        dm_stats["riscv_1"]["analysis"]["series"], dm_stats["riscv_0"]["analysis"]["series"], fillvalue=None
+    ):
+        if riscv1_run:
+            run_host_id = riscv1_run["duration_type"][0]["run_host_id"]
+            test_id = dm_stats["riscv_1"]["attributes"][run_host_id]["Test id"]
+        else:
+            run_host_id = riscv0_run["duration_type"][0]["run_host_id"]
+            test_id = dm_stats["riscv_0"]["attributes"][run_host_id]["Test id"]
 
         if not test_id in results_bounds.keys():
             results_bounds[test_id] = {
@@ -227,52 +235,46 @@ def performance_check(dm_stats, arch="blackhole", verbose=False):
                 "riscv_0": {"latency": {"lower": float("inf"), "upper": 0}, "bandwidth": float("inf")},
             }
 
-        riscv1_cycles = dm_stats["riscv_1"]["analysis"]["series"][i]["duration_cycles"]
-        riscv0_cycles = dm_stats["riscv_0"]["analysis"]["series"][i]["duration_cycles"]
+        if riscv1_run:
+            riscv1_cycles = riscv1_run["duration_cycles"]
+            results_bounds[test_id]["riscv_1"]["latency"]["lower"] = min(
+                results_bounds[test_id]["riscv_1"]["latency"]["lower"], riscv1_cycles
+            )
+            results_bounds[test_id]["riscv_1"]["latency"]["upper"] = max(
+                results_bounds[test_id]["riscv_1"]["latency"]["upper"], riscv1_cycles
+            )
 
-        results_bounds[test_id]["riscv_1"]["latency"]["lower"] = min(
-            results_bounds[test_id]["riscv_1"]["latency"]["lower"], riscv1_cycles
-        )
-        results_bounds[test_id]["riscv_0"]["latency"]["lower"] = min(
-            results_bounds[test_id]["riscv_0"]["latency"]["lower"], riscv0_cycles
-        )
-        results_bounds[test_id]["riscv_1"]["latency"]["upper"] = max(
-            results_bounds[test_id]["riscv_1"]["latency"]["upper"], riscv1_cycles
-        )
-        results_bounds[test_id]["riscv_0"]["latency"]["upper"] = max(
-            results_bounds[test_id]["riscv_0"]["latency"]["upper"], riscv0_cycles
-        )
+            riscv1_attributes = dm_stats["riscv_1"]["attributes"][run_host_id]
+            riscv1_bw = (
+                riscv1_attributes["Number of transactions"]
+                * riscv1_attributes["Transaction size in bytes"]
+                / riscv1_cycles
+            )
+            results_bounds[test_id]["riscv_1"]["bandwidth"] = min(
+                results_bounds[test_id]["riscv_1"]["bandwidth"], riscv1_bw
+            )
 
-        riscv1_attributes = dm_stats["riscv_1"]["attributes"][run_host_id]
-        riscv1_bw = (
-            riscv1_attributes["Number of transactions"] * riscv1_attributes["Transaction size in bytes"] / riscv1_cycles
-        )
-        results_bounds[test_id]["riscv_1"]["bandwidth"] = min(
-            results_bounds[test_id]["riscv_1"]["bandwidth"], riscv1_bw
-        )
+        if riscv0_run:
+            riscv0_cycles = riscv0_run["duration_cycles"]
+            results_bounds[test_id]["riscv_0"]["latency"]["lower"] = min(
+                results_bounds[test_id]["riscv_0"]["latency"]["lower"], riscv0_cycles
+            )
+            results_bounds[test_id]["riscv_0"]["latency"]["upper"] = max(
+                results_bounds[test_id]["riscv_0"]["latency"]["upper"], riscv0_cycles
+            )
 
-        riscv0_attributes = dm_stats["riscv_0"]["attributes"][run_host_id]
-        riscv0_bw = (
-            riscv0_attributes["Number of transactions"] * riscv0_attributes["Transaction size in bytes"] / riscv0_cycles
-        )
-        results_bounds[test_id]["riscv_0"]["bandwidth"] = min(
-            results_bounds[test_id]["riscv_0"]["bandwidth"], riscv0_bw
-        )
+            riscv0_attributes = dm_stats["riscv_0"]["attributes"][run_host_id]
+            riscv0_bw = (
+                riscv0_attributes["Number of transactions"]
+                * riscv0_attributes["Transaction size in bytes"]
+                / riscv0_cycles
+            )
+            results_bounds[test_id]["riscv_0"]["bandwidth"] = min(
+                results_bounds[test_id]["riscv_0"]["bandwidth"], riscv0_bw
+            )
 
     # Performance checks per test
     for test_id, bounds in results_bounds.items():
-        # Bounds check
-        riscv1_cycles_within_bounds = (
-            test_bounds[arch][test_id]["riscv_1"]["latency"]["lower"] <= bounds["riscv_1"]["latency"]["lower"]
-            and bounds["riscv_1"]["latency"]["upper"] <= test_bounds[arch][test_id]["riscv_1"]["latency"]["upper"]
-        )
-        riscv0_cycles_within_bounds = (
-            test_bounds[arch][test_id]["riscv_0"]["latency"]["lower"] <= bounds["riscv_0"]["latency"]["lower"]
-            and bounds["riscv_0"]["latency"]["upper"] <= test_bounds[arch][test_id]["riscv_0"]["latency"]["upper"]
-        )
-        riscv1_bw_within_bounds = test_bounds[arch][test_id]["riscv_1"]["bandwidth"] <= bounds["riscv_1"]["bandwidth"]
-        riscv0_bw_within_bounds = test_bounds[arch][test_id]["riscv_0"]["bandwidth"] <= bounds["riscv_0"]["bandwidth"]
-
         # Print latency and bandwidth perf results
         if verbose:
             logger.info(f"Perf results for test id: {test_id}")
@@ -287,27 +289,33 @@ def performance_check(dm_stats, arch="blackhole", verbose=False):
             logger.info(f"  RISCV 1: {bounds['riscv_1']['bandwidth']} Bytes/cycle")
             logger.info(f"  RISCV 0: {bounds['riscv_0']['bandwidth']} Bytes/cycle")
 
-            if not riscv1_cycles_within_bounds:
-                logger.warning(f"RISCV 1 cycles not within perf bounds.")
-            else:
-                logger.info(f"RISCV 1 cycles within perf bounds.")
-            if not riscv0_cycles_within_bounds:
-                logger.warning(f"RISCV 0 cycles not within perf bounds.")
-            else:
-                logger.info(f"RISCV 0 cycles within perf bounds.")
-            if not riscv1_bw_within_bounds:
-                logger.warning(f"RISCV 1 bandwidth not within perf bounds.")
-            else:
-                logger.info(f"RISCV 1 bandwidth within perf bounds.")
-            if not riscv0_bw_within_bounds:
-                logger.warning(f"RISCV 0 bandwidth not within perf bounds.\n")
-            else:
-                logger.info(f"RISCV 0 bandwidth within perf bounds.\n")
+        if test_id not in test_bounds.keys():
+            logger.warning(f"Test id {test_id} not found in test bounds.")
+            continue
 
-        assert riscv1_cycles_within_bounds
-        assert riscv0_cycles_within_bounds
-        assert riscv1_bw_within_bounds
-        assert riscv0_bw_within_bounds
+
+        for riscv in bounds.keys():
+            if riscv not in test_bounds[test_id].keys():
+                continue
+            cycles_within_bounds = (
+                test_bounds[test_id][riscv]["latency"]["lower"] <= bounds[riscv]["latency"]["lower"]
+                and bounds[riscv]["latency"]["upper"] <= test_bounds[test_id][riscv]["latency"]["upper"]
+            )
+            bw_within_bounds = test_bounds[test_id][riscv]["bandwidth"] <= bounds[riscv]["bandwidth"]
+
+            # Print bounds check results
+            if verbose:
+                if not cycles_within_bounds:
+                    logger.warning(f"{riscv} cycles not within perf bounds.")
+                else:
+                    logger.info(f"{riscv} cycles within perf bounds.")
+                if not bw_within_bounds:
+                    logger.warning(f"{riscv} bandwidth not within perf bounds.")
+                else:
+                    logger.info(f"{riscv} bandwidth within perf bounds.")
+
+            assert cycles_within_bounds
+            assert bw_within_bounds
 
 
 def print_stats(dm_stats):
@@ -315,11 +323,21 @@ def print_stats(dm_stats):
     for i in range(len(dm_stats["riscv_1"]["analysis"]["series"])):
         run_host_id = dm_stats["riscv_1"]["analysis"]["series"][i]["duration_type"][0]["run_host_id"]
 
+    for riscv1_run, riscv0_run in itertools.zip_longest(
+        dm_stats["riscv_1"]["analysis"]["series"], dm_stats["riscv_0"]["analysis"]["series"], fillvalue=None
+    ):
+        run_host_id = (riscv1_run if riscv1_run else riscv0_run)["duration_type"][0]["run_host_id"]
+
         logger.info(f"Run host id: {run_host_id}")
-        logger.info(f'RISCV 1 duration: {dm_stats["riscv_1"]["analysis"]["series"][i]["duration_cycles"]}')
-        logger.info(f'RISCV 0 duration: {dm_stats["riscv_0"]["analysis"]["series"][i]["duration_cycles"]}')
+
+        if riscv1_run:
+            logger.info(f'RISCV 1 duration: {riscv1_run["duration_cycles"]}')
+
+        if riscv0_run:
+            logger.info(f'RISCV 0 duration: {riscv0_run["duration_cycles"]}')
+
         logger.info(f"Attributes:")
-        for attr, val in dm_stats["riscv_1"]["attributes"][run_host_id].items():
+        for attr, val in dm_stats["riscv_1" if riscv1_run else "riscv_0"]["attributes"][run_host_id].items():
             logger.info(f"  {attr}: {val}")
         logger.info(f"\n")
 

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -50,7 +50,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
         },
         5: {
-            "riscv_1": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
+            "riscv_1": {"latency": {"lower": 200, "upper": 5000}, "bandwidth": 0.1},
         },
     },
     "blackhole": {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19277)

### Problem description
Add a “one‑from‑one” primitive data‑movement test that exercises one core reading data from another remote core. Determine the effective read bandwidth between two cores, representing the simplest scenario of one core (reader) retrieving data from another core (writer).

### What's changed
Enabled one core from one core testing in the data movement test suite. Further generalization of parameters (i.e. VC and NOC) as well as test sweeps for these parameters are required.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14777180510) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14777185147) CI with demo tests passes (if applicable)
- [x] [metal - Run microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/14803021746)
- [x] New/Existing tests provide coverage for changes