### PR TITLE
Add blackhole support for Shallow UNet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,6 +97,7 @@ ttnn/cpp/ttnn/operations/data_movement/fold/ @tenstorrent/metalium-developers-co
 ttnn/cpp/ttnn/operations/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT
 ttnn/cpp/ttnn/operations/experimental/ccl/ @SeanNijjar @jvegaTT @tt-aho @sjameelTT @ntarafdar @nardoTT @llongTT @amorrisonTT
 ttnn/cpp/ttnn/operations/experimental/conv3d/ @tenstorrent/metalium-developers-convolutions
+ttnn/cpp/ttnn/operations/experimental/cnn/ @tenstorrent/metalium-developers-convolutions @esmalTT
 ttnn/cpp/ttnn/operations/experimental/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT
 ttnn/cpp/ttnn/operations/experimental/slice_write/ @tenstorrent/metalium-developers-convolutions @sjameelTT @ntarafdar @amorrisonTT
 ttnn/cpp/ttnn/operations/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -78,8 +78,6 @@ jobs:
           prefix: "test_reports_"
 
   models-tests-slow-runtime-mode:
-    # BH runs only FD tests to avoid using too many CI resources
-    if: ${{ inputs.arch != 'blackhole' }}
     strategy:
       fail-fast: false
       matrix:

--- a/models/experimental/functional_unet/tests/common.py
+++ b/models/experimental/functional_unet/tests/common.py
@@ -10,6 +10,8 @@ from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 UNET_FULL_MODEL_PCC = 0.99840
+UNET_FULL_MODEL_PCC_BH = 0.99780
+
 UNET_TRACE_REGION_SIZE = 483328
 
 

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -24,6 +24,12 @@ from models.experimental.functional_unet.tests.common import (
 @pytest.mark.parametrize("groups", [4])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 79104}], indirect=True)
 def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
+    if (
+        not is_wormhole_b0(device)
+        and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 110
+    ):
+        pytest.skip(f"Shallow UNet only support 110 cores on BH (was {device.compute_with_storage_grid_size()})")
+
     torch_input, ttnn_input = create_unet_input_tensors(batch, groups, channel_order="first", pad=False, fold=False)
     model = unet_shallow_torch.UNet.from_random_weights(groups=groups)
 

--- a/models/experimental/functional_unet/tests/test_unet_model.py
+++ b/models/experimental/functional_unet/tests/test_unet_model.py
@@ -5,13 +5,19 @@
 import pytest
 import ttnn
 
+from ttnn.device import is_wormhole_b0
+
 from models.experimental.functional_unet.tt.model_preprocessing import (
     create_unet_input_tensors,
     create_unet_model_parameters,
 )
 from models.experimental.functional_unet.tt import unet_shallow_torch
 from models.experimental.functional_unet.tt import unet_shallow_ttnn
-from models.experimental.functional_unet.tests.common import verify_with_pcc, UNET_FULL_MODEL_PCC
+from models.experimental.functional_unet.tests.common import (
+    verify_with_pcc,
+    UNET_FULL_MODEL_PCC,
+    UNET_FULL_MODEL_PCC_BH,
+)
 
 
 @pytest.mark.parametrize("batch", [1])
@@ -29,4 +35,8 @@ def test_unet_model(batch, groups, device, use_program_cache, reset_seeds):
 
     B, C, H, W = torch_output_tensor.shape
     ttnn_output_tensor = ttnn.to_torch(output_tensor).reshape(B, C, H, W)
-    verify_with_pcc(torch_output_tensor, ttnn_output_tensor, UNET_FULL_MODEL_PCC)
+    verify_with_pcc(
+        torch_output_tensor,
+        ttnn_output_tensor,
+        UNET_FULL_MODEL_PCC if is_wormhole_b0(device) else UNET_FULL_MODEL_PCC_BH,
+    )

--- a/tests/scripts/run_python_model_tests.sh
+++ b/tests/scripts/run_python_model_tests.sh
@@ -91,4 +91,16 @@ run_python_model_tests_blackhole() {
 
     pytest tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
     pytest models/demos/yolov4/tests/pcc/test_ttnn_yolov4_bh.py
+    pytest models/experimental/functional_unet/tests/test_unet_model.py
+}
+
+run_python_model_tests_slow_runtime_mode_blackhole() {
+    # Unet Shallow
+    export TTNN_CONFIG_OVERRIDES='{
+        "enable_fast_runtime_mode": false,
+        "enable_comparison_mode": true,
+        "comparison_mode_should_raise_exception": true,
+        "comparison_mode_pcc": 0.998
+    }'
+    pytest -svv models/experimental/functional_unet/tests/test_unet_model.py
 }

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
@@ -16,8 +16,8 @@ tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_chw(
 
     const auto input_shape = a.get_logical_shape();
     const auto input_core_grid = a.shard_spec()->grid;
-    std::vector<CoreCoord> input_cores = grid_to_cores(
-        input_core_grid.num_cores(), compute_with_storage_grid_size.x, compute_with_storage_grid_size.y, true);
+    const auto input_cores = corerange_to_cores(
+        input_core_grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
 
     const auto HW = input_shape[2];
     const auto C = input_shape[3];


### PR DESCRIPTION
### Summary
Adds blackhole support to Shallow UNet. This commit also includes a small fix for `ttnn.convert_to_chw` where the incorrect grid was being selected.

This change includes the following tests:
- Single card full model test
- Single card full model test using comparison mode

Future work should add the full nightly test suite to CI.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14778005178
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes: https://github.com/tenstorrent/tt-metal/actions/runs/14778854068