### PR TITLE
Optimize Tracy profiler runtime

### DIFF
--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1099,9 +1099,11 @@ void DeviceProfiler::pushTracyDeviceResults() {
     for (auto& event : device_events_vec) {
         std::reference_wrapper<const tracy::TTDeviceEvent> event_to_push = event;
 
+        // Using std::optional to avoid calling the default constructor of tracy::TTDeviceEvent
+        std::optional<tracy::TTDeviceEvent> event_with_adjusted_timestamp;
         const uint64_t adjusted_timestamp = event.get().timestamp * this->freqScale + this->shift;
         if (adjusted_timestamp != event.get().timestamp) {
-            tracy::TTDeviceEvent new_event(
+            event_with_adjusted_timestamp.emplace(
                 event.get().run_num,
                 event.get().chip_id,
                 event.get().core_x,
@@ -1113,7 +1115,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
                 event.get().file,
                 event.get().zone_name,
                 event.get().zone_phase);
-            event_to_push = std::cref(new_event);
+            event_to_push = std::cref(event_with_adjusted_timestamp.value());
         }
 
         std::pair<chip_id_t, CoreCoord> device_core = {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1064,6 +1064,7 @@ void DeviceProfiler::pushTracyDeviceResults() {
 
     sortDeviceEvents(device_events_vec);
 
+    // Tracy contexts must be updated in order of their first timestamps
     for (auto& event : device_events_vec) {
         auto device_core_it = device_cores.find({event.get().chip_id, {event.get().core_x, event.get().core_y}});
         if (device_core_it != device_cores.end()) {

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -48,6 +48,10 @@ using std::chrono::duration_cast;
 using std::chrono::nanoseconds;
 using std::chrono::steady_clock;
 
+namespace tt {
+
+namespace tt_metal {
+
 template <typename T1, typename T2>
 struct pair_hash {
     size_t operator()(const std::pair<T1, T2>& p) const {
@@ -57,10 +61,6 @@ struct pair_hash {
         return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
     }
 };
-
-namespace tt {
-
-namespace tt_metal {
 
 struct DisptachMetaData {
     // Dispatch command queue command type
@@ -219,7 +219,7 @@ public:
     std::vector<uint32_t> profile_buffer;
 
     // (Device ID, Core Coord) pairs that keep track of cores which need to have their Tracy contexts updated
-    std::unordered_set<std::pair<uint32_t, CoreCoord>, pair_hash<uint32_t, CoreCoord>> device_cores;
+    std::unordered_set<std::pair<chip_id_t, CoreCoord>, pair_hash<chip_id_t, CoreCoord>> device_cores;
 
     // Device events
     std::unordered_set<tracy::TTDeviceEvent> device_events;

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -80,7 +80,7 @@ struct ZoneDetails {
     bool is_zone_in_brisc_or_erisc;
 };
 
-const ZoneDetails InvalidZoneDetails = ZoneDetails{"", "", 0, false};
+const ZoneDetails UnidentifiedZoneDetails = ZoneDetails{"", "", 0, false};
 
 class DeviceProfiler {
 private:
@@ -136,6 +136,8 @@ private:
 
     // translates potentially-virtual coordinates recorded on Device into physical coordinates
     CoreCoord getPhysicalAddressFromVirtual(chip_id_t device_id, const CoreCoord& c) const;
+
+    ZoneDetails getZoneDetails(uint16_t timer_id) const;
 
     // Dumping profile result to file
     void logPacketData(

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <cstddef>
 #include <filesystem>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <optional>
@@ -214,10 +213,13 @@ public:
     std::shared_ptr<tt::tt_metal::Program> sync_program = nullptr;
 
     // Device-core Syncdata
-    std::unordered_map<CoreCoord, std::tuple<double, double, double>> device_core_sync_info;
+    std::map<CoreCoord, std::tuple<double, double, double>> device_core_sync_info;
 
     // DRAM Vector
     std::vector<uint32_t> profile_buffer;
+
+    // (Device ID, Core Coord) pairs that keep track of cores which need to have their Tracy contexts updated
+    std::unordered_set<std::pair<uint32_t, CoreCoord>, pair_hash<uint32_t, CoreCoord>> device_cores;
 
     // Device events
     std::unordered_set<tracy::TTDeviceEvent> device_events;
@@ -252,7 +254,7 @@ public:
     void pushTracyDeviceResults();
 
     // Update sync info for this device
-    void setSyncInfo(std::tuple<double, double, double> sync_info);
+    void setSyncInfo(const std::tuple<double, double, double>& sync_info);
 };
 
 void issue_fd_write_to_profiler_buffer(distributed::AnyBuffer& buffer, IDevice* device, std::vector<uint32_t>& data);

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -57,8 +57,8 @@ struct pair_hash {
     size_t operator()(const std::pair<T1, T2>& p) const {
         auto h1 = std::hash<T1>{}(p.first);
         auto h2 = std::hash<T2>{}(p.second);
-        // The magic number 0x9e3779b9 is from Boost's hash_combine
-        return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+        constexpr std::size_t hash_combine_prime = 0x9e3779b9;
+        return h1 ^ (h2 + hash_combine_prime + (h1 << 6) + (h1 >> 2));
     }
 };
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -373,7 +373,6 @@ void setShift(int device_id, int64_t shift, double scale, std::tuple<double, dou
 
 void peekDeviceData(IDevice* device, std::vector<CoreCoord>& worker_cores) {
     ZoneScoped;
-    tt::log_info("peekDeviceData");
     auto device_id = device->id();
     std::string zoneName = fmt::format("peek {}", device_id);
     ZoneName(zoneName.c_str(), zoneName.size());

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -111,6 +111,7 @@ constexpr CoreCoord SYNC_CORE = {0, 0};
 
 void setControlBuffer(IDevice* device, std::vector<uint32_t>& control_buffer) {
 #if defined(TRACY_ENABLE)
+    ZoneScoped;
     chip_id_t device_id = device->id();
     const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
 
@@ -371,6 +372,7 @@ void setShift(int device_id, int64_t shift, double scale, std::tuple<double, dou
 
 void peekDeviceData(IDevice* device, std::vector<CoreCoord>& worker_cores) {
     ZoneScoped;
+    tt::log_info("peekDeviceData");
     auto device_id = device->id();
     std::string zoneName = fmt::format("peek {}", device_id);
     ZoneName(zoneName.c_str(), zoneName.size());
@@ -702,9 +704,9 @@ void InitDeviceProfiler(IDevice* device) {
 
         if (tt_metal_device_profiler_map.find(device_id) == tt_metal_device_profiler_map.end()) {
             if (firstInit.exchange(false)) {
-                tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(true));
+                tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(device, true));
             } else {
-                tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(false));
+                tt_metal_device_profiler_map.emplace(device_id, DeviceProfiler(device, false));
             }
         }
 

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -111,7 +111,6 @@ constexpr CoreCoord SYNC_CORE = {0, 0};
 
 void setControlBuffer(IDevice* device, std::vector<uint32_t>& control_buffer) {
 #if defined(TRACY_ENABLE)
-    ZoneScoped;
     chip_id_t device_id = device->id();
     const metal_SocDescriptor& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device_id);
 
@@ -347,7 +346,6 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
 }
 
 void setShift(int device_id, int64_t shift, double scale, std::tuple<double, double, double>& root_sync_info) {
-    ZoneScoped;
     if (std::isnan(scale)) {
         return;
     }

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -347,6 +347,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
 }
 
 void setShift(int device_id, int64_t shift, double scale, std::tuple<double, double, double>& root_sync_info) {
+    ZoneScoped;
     if (std::isnan(scale)) {
         return;
     }


### PR DESCRIPTION
### Ticket
#20574 

This PR makes several optimizations to the profiler to enable it to run faster.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14936157869)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (https://github.com/tenstorrent/tt-metal/actions/runs/14863695158)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14863707470)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/14863703557)
- [x] [T3K Model performance tests] (https://github.com/tenstorrent/tt-metal/actions/runs/14863736422)
- [x] [T3K profiler tests] (https://github.com/tenstorrent/tt-metal/actions/runs/14863711460)
- [x] [Metal microbenchmarks tests] (https://github.com/tenstorrent/tt-metal/actions/runs/14863698283)
- [x] New/Existing tests provide coverage for changes