### PR TITLE
Add missing doc for quantization ops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -101,7 +101,7 @@ ttnn/cpp/ttnn/operations/experimental/cnn/ @tenstorrent/metalium-developers-conv
 ttnn/cpp/ttnn/operations/experimental/matmul/ @TT-BrianLiu @bbradelTT @yugaoTT @vsureshTT @edwinleeTT @nsorabaTT
 ttnn/cpp/ttnn/operations/experimental/slice_write/ @tenstorrent/metalium-developers-convolutions @sjameelTT @ntarafdar @amorrisonTT
 ttnn/cpp/ttnn/operations/eltwise/ @patrickroberts @sjameelTT @ntarafdar @dchenTT
-ttnn/cpp/ttnn/operations/eltwise/quantization @wenbinlyuTT @patrickroberts @sjameelTT
+ttnn/cpp/ttnn/operations/eltwise/quantization/ @wenbinlyuTT @patrickroberts @sjameelTT
 ttnn/cpp/ttnn/operations/reduction/ @bbradelTT @sjameelTT @vsureshTT @edwinleeTT @nsorabaTT
 ttnn/cpp/ttnn/operations/normalization/ @yugaoTT @tt-aho @bbradelTT @vsureshTT @edwinleeTT @nsorabaTT
 ttnn/cpp/ttnn/operations/embedding/ @ntarafdar @tt-aho @TT-BrianLiu @yugi957 @sjameelTT @jaykru-tt @llongTT @nardoTT

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -944,6 +944,7 @@ INPUT                  = tt_metal/hw/inc/compile_time_args.h \
                          tt_metal/include/compute_kernel_api/eltwise_binary.h \
                          tt_metal/include/compute_kernel_api/matmul.h \
                          tt_metal/include/compute_kernel_api/pack.h \
+                         tt_metal/include/compute_kernel_api/quantization.h \
                          tt_metal/include/compute_kernel_api/reconfig_data_format.h \
                          tt_metal/include/compute_kernel_api/reduce.h \
                          tt_metal/include/compute_kernel_api/reg_api.h \

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/compute.rst
@@ -58,6 +58,10 @@ Compute APIs
   atan_tile
   acos_tile
 
+  quant_tile
+  requant_tile
+  dequant_tile
+
   ltz_tile
   eqz_tile
   lez_tile

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/dequant_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/dequant_tile.rst
@@ -1,0 +1,5 @@
+dequant_tile
+============
+
+.. doxygenfunction:: dequant_tile_init(const uint32_t zero_point)
+.. doxygenfunction:: dequant_tile(uint32_t idst0, uint32_t idst1)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/quant_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/quant_tile.rst
@@ -1,0 +1,5 @@
+quant_tile
+==========
+
+.. doxygenfunction:: quant_tile_init(const uint32_t zero_point)
+.. doxygenfunction:: quant_tile(uint32_t idst0, uint32_t idst1)

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/requant_tile.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/requant_tile.rst
@@ -1,0 +1,5 @@
+requant_tile
+============
+
+.. doxygenfunction:: requant_tile_init(const uint32_t zero_point)
+.. doxygenfunction:: requant_tile(uint32_t idst0, uint32_t idst1)

--- a/tt_metal/include/compute_kernel_api/quantization.h
+++ b/tt_metal/include/compute_kernel_api/quantization.h
@@ -32,10 +32,36 @@ ALWI void quant_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_quant_int32<APPROX>(idst0, idst1)));
 }
 
+// clang-format off
+/**
+ * Performs an elementwise per-tensor affine re-quantization operation on the first operand using the scaling factor in the second operand.
+ * Output overwrites first operand in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
 ALWI void requant_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_requant_int32<APPROX>(idst0, idst1)));
 }
 
+// clang-format off
+/**
+ * Performs an elementwise per-tensor affine de-quantization operation on the first operand using the scaling factor in the second operand.
+ * Output overwrites first operand in DST.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
 ALWI void dequant_tile(uint32_t idst0, uint32_t idst1) {
     MATH((llk_math_eltwise_binary_sfpu_dequant_int32<APPROX>(idst0, idst1)));
 }
@@ -55,9 +81,35 @@ ALWI void dequant_tile(uint32_t idst0, uint32_t idst1) {
 ALWI void quant_tile_init(const uint32_t zero_point) {
     MATH((llk_math_eltwise_binary_sfpu_quant_int32_init<APPROX>(zero_point)));
 }
+
+// clang-format off
+/**
+ * Initialize the sfpu with the zero point argument of the re-quantization Op.
+ * To be called once at beginning of a kernel.
+ *
+ * Return value: None
+ *
+ * | Argument   | Description                              | Data type | Valid range | Required |
+ * |------------|------------------------------------------|-----------|-------------|----------|
+ * | zero_point | The zero point of the re-quantization Op | uint32_t  | Any number  | Yes      |
+ * */
+// clang-format on
 ALWI void requant_tile_init(const uint32_t zero_point) {
     MATH((llk_math_eltwise_binary_sfpu_requant_int32_init<APPROX>(zero_point)));
 }
+
+// clang-format off
+/**
+ * Initialize the sfpu with the zero point argument of the de-quantization Op.
+ * To be called once at beginning of a kernel.
+ *
+ * Return value: None
+ *
+ * | Argument   | Description                              | Data type | Valid range | Required |
+ * |------------|------------------------------------------|-----------|-------------|----------|
+ * | zero_point | The zero point of the de-quantization Op | uint32_t  | Any number  | Yes      |
+ * */
+// clang-format on
 ALWI void dequant_tile_init(const uint32_t zero_point) {
     MATH((llk_math_eltwise_binary_sfpu_dequant_int32_init<APPROX>(zero_point)));
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Forgot to tell doxygen to generate docs for quantization ops

### What's changed
Tell doxygen to generate docs for quantization ops
Also fix the missing trailing '/' in the codeowner file for the quantization API

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14850740527