### PR TITLE
Increase device profiler regression timeout

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -54,14 +54,14 @@ permissions:
   packages: write
 
 jobs:
-  build-artifact:
-    uses: ./.github/workflows/build-artifact.yaml
-    secrets: inherit
-    with:
-      build-type: ${{ inputs.build-type || 'Release' }}
-      build-wheel: true
-      version: "22.04"
-      build-umd-tests: true
+  # build-artifact:
+  #   uses: ./.github/workflows/build-artifact.yaml
+  #   secrets: inherit
+  #   with:
+  #     build-type: ${{ inputs.build-type || 'Release' }}
+  #     build-wheel: true
+  #     version: "22.04"
+  #     build-umd-tests: true
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
@@ -82,73 +82,73 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
-  umd-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/umd-unit-tests.yaml
-    with:
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  sd-unit-tests:
-    needs: build-artifact
-    uses: ./.github/workflows/build-and-unit-tests.yaml
-    secrets: inherit
-    with:
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 15
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  fd-unit-tests:
-    needs: build-artifact
-    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-    secrets: inherit
-    with:
-      timeout: 40
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  # FD C++ Unit Tests
-  cpp-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/cpp-post-commit.yaml
-    with:
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 20
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  models-unit-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/models-post-commit.yaml
-    with:
-      arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
-      timeout: 20
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enable-watcher: ${{ inputs.enable-watcher || false }}
-  blackhole-demo-tests:
-    # Issue 20998: Due to capacity constraints, only run blackhole demo tests on workflow_dispatch events
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-demo-tests == true }}
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
-    with:
-      runner-label: BH-baremetal
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # umd-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/umd-unit-tests.yaml
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  # sd-unit-tests:
+  #   needs: build-artifact
+  #   uses: ./.github/workflows/build-and-unit-tests.yaml
+  #   secrets: inherit
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     timeout: 15
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # fd-unit-tests:
+  #   needs: build-artifact
+  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+  #   secrets: inherit
+  #   with:
+  #     timeout: 40
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # # FD C++ Unit Tests
+  # cpp-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/cpp-post-commit.yaml
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     timeout: 20
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # models-unit-tests:
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/models-post-commit.yaml
+  #   with:
+  #     arch: blackhole
+  #     runner-label: ${{ inputs.runner-label || 'BH' }}
+  #     timeout: 20
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  #     enable-watcher: ${{ inputs.enable-watcher || false }}
+  # blackhole-demo-tests:
+  #   # Issue 20998: Due to capacity constraints, only run blackhole demo tests on workflow_dispatch events
+  #   if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-demo-tests == true }}
+  #   needs: build-artifact
+  #   secrets: inherit
+  #   uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
+  #   with:
+  #     runner-label: BH-baremetal
+  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 #   profiler-regression:
 #     needs: build-artifact-profiler
 #     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -54,14 +54,14 @@ permissions:
   packages: write
 
 jobs:
-  # build-artifact:
-  #   uses: ./.github/workflows/build-artifact.yaml
-  #   secrets: inherit
-  #   with:
-  #     build-type: ${{ inputs.build-type || 'Release' }}
-  #     build-wheel: true
-  #     version: "22.04"
-  #     build-umd-tests: true
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      build-wheel: true
+      version: "22.04"
+      build-umd-tests: true
   build-artifact-profiler:
     uses: ./.github/workflows/build-artifact.yaml
     secrets: inherit
@@ -82,73 +82,73 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
-  # umd-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/umd-unit-tests.yaml
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  # sd-unit-tests:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/build-and-unit-tests.yaml
-  #   secrets: inherit
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     timeout: 15
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # fd-unit-tests:
-  #   needs: build-artifact
-  #   uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
-  #   secrets: inherit
-  #   with:
-  #     timeout: 40
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # # FD C++ Unit Tests
-  # cpp-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/cpp-post-commit.yaml
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     timeout: 20
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # models-unit-tests:
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/models-post-commit.yaml
-  #   with:
-  #     arch: blackhole
-  #     runner-label: ${{ inputs.runner-label || 'BH' }}
-  #     timeout: 20
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  #     enable-watcher: ${{ inputs.enable-watcher || false }}
-  # blackhole-demo-tests:
-  #   # Issue 20998: Due to capacity constraints, only run blackhole demo tests on workflow_dispatch events
-  #   if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-demo-tests == true }}
-  #   needs: build-artifact
-  #   secrets: inherit
-  #   uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
-  #   with:
-  #     runner-label: BH-baremetal
-  #     docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-  #     build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-  #     wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  umd-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/umd-unit-tests.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+  sd-unit-tests:
+    needs: build-artifact
+    uses: ./.github/workflows/build-and-unit-tests.yaml
+    secrets: inherit
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      timeout: 15
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  fd-unit-tests:
+    needs: build-artifact
+    uses: ./.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+    secrets: inherit
+    with:
+      timeout: 40
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  # FD C++ Unit Tests
+  cpp-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/cpp-post-commit.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      timeout: 20
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  models-unit-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/models-post-commit.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      timeout: 20
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
+  blackhole-demo-tests:
+    # Issue 20998: Due to capacity constraints, only run blackhole demo tests on workflow_dispatch events
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-demo-tests == true }}
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
+    with:
+      runner-label: BH-baremetal
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
 #   profiler-regression:
 #     needs: build-artifact-profiler
 #     uses: ./.github/workflows/run-profiler-regression.yaml

--- a/tests/scripts/run_profiler_regressions.sh
+++ b/tests/scripts/run_profiler_regressions.sh
@@ -118,7 +118,7 @@ run_profiling_test() {
 
     run_mid_run_tracy_push
 
-    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py --noconftest
+    TT_METAL_DEVICE_PROFILER=1 pytest $PROFILER_TEST_SCRIPTS_ROOT/test_device_profiler.py --noconftest --timeout 360
 
     pytest tests/ttnn/tracy/test_perf_op_report.py --noconftest
 


### PR DESCRIPTION
### Ticket
[21522](https://github.com/tenstorrent/tt-metal/issues/21522#issuecomment-2845598385)
### Problem description
On P150a because of high number of cores. Test full buffer for profiler was timing out during its post proc

### What's changed
Increase the timeout time for device profiler regression

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14783199508/job/41506756192)