### PR TITLE
#21534: Disable test_sdpa_decode_paged_attention[paged_32-32-32-8-1024-128-grid_size3-True-kv_bfp8_q_bf16]

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_scaled_dot_product_attention_decode.py
@@ -1040,7 +1040,7 @@ def run_test_sdpa_decode_paged_attention_single_iter(
         [8, 16, 4, 4096, 128, (8, 2), True],  # llama 3.1 8b N300
         [1, 8, 1, 128 * 1024, 128, (8, 4), True],  # llama 3.1 8b N300
         [1, 32, 8, 32 * 1024, 128, (8, 8), True],  # llama3.1 8b (performance-batch-1 settings)
-        [32, 32, 8, 1024, 128, (8, 8), True],  # llama 3.1 8b (performance-batch-32 settings)
+        # [32, 32, 8, 1024, 128, (8, 8), True],  # llama 3.1 8b (performance-batch-32 settings) -- Issue 21534: Breaking blackhole post commit tests
         # [1, 8, 1, 32768, 128, (8, 1), True],  # Llama2-70B
         # [16, 8, 1, 32768, 128, (8, 6), False, False],  # Llama2-70B
         # [8, 8, 1, 32768, 128, (8, 6), True, False],  # Llama2-70B


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21534

### Problem description
Breaking blackhole post commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/14778741044/job/41501389775#step:5:2143
```
Error: test_sdpa_decode_paged_attention[paged_32-32-32-8-1024-128-grid_size3-True-kv_bfp8_q_bf16]

assert 3 == 4
 +  where 3 = <bound method PyCapsule.num_program_cache_entries of MeshDevice(1x1 grid, 1 devices)>()
 +    where <bound method PyCapsule.num_program_cache_entries of MeshDevice(1x1 grid, 1 devices)> = MeshDevice(1x1 grid, 1 devices).num_program_cache_entries
```

### What's changed
Disable test (partial revert of original commit)

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/14783040112