### PR TITLE
#15874: Enable global circular buffer size check in release mode

### DIFF
--- a/tt_metal/impl/buffers/circular_buffer_types.cpp
+++ b/tt_metal/impl/buffers/circular_buffer_types.cpp
@@ -123,30 +123,12 @@ CircularBufferConfig& CircularBufferConfig::set_page_size(uint8_t buffer_index, 
 
 CircularBufferConfig& CircularBufferConfig::set_total_size(uint32_t total_size) {
     if (dynamic_cb_) {
-        if (total_size > this->max_size_) {
-            TT_ASSERT(
-                false,
-                "Cannot set circular buffer size to {}. This is larger than the associated dynamically allocated "
-                "L1 buffer bank size of {} B",
-                total_size,
-                this->max_size_);
-#ifndef DEBUG
-            log_warning(
-                "Cannot set circular buffer size to {}. This is larger than the associated dynamically allocated "
-                "L1 buffer bank size of {} B and may allow this circular buffer to write outside the allocated "
-                "buffer space.",
-                total_size,
-                this->max_size_);
-            if (total_size > this->buffer_size_) {
-                TT_THROW(
-                    "Cannot set circular buffer size to {}. This is larger than the associated dynamically "
-                    "allocated L1 buffer size"
-                    "of {} B",
-                    total_size,
-                    this->buffer_size_);
-            }
-#endif
-        }
+        TT_FATAL(
+            total_size <= this->max_size_,
+            "Cannot set circular buffer size to {}. This is larger than the associated dynamically allocated "
+            "L1 buffer bank size of {} B",
+            total_size,
+            this->max_size_);
     }
     this->total_size_ = total_size;
     return *this;
@@ -166,29 +148,7 @@ CircularBufferConfig& CircularBufferConfig::set_globally_allocated_address_and_t
     this->max_size_ = buffer.aligned_size_per_bank();
     this->buffer_size_ = buffer.aligned_size();
     this->shadow_global_buffer = &buffer;
-    if (total_size > this->max_size_) {
-        TT_ASSERT(
-            false,
-            "Cannot set to globally allocated buffer. Circular buffer size {} B exceeds allocated L1 buffer bank "
-            "size of {} B",
-            total_size,
-            this->max_size_);
-#ifndef DEBUG
-        log_warning(
-            "Circular buffer size {} B exceeds allocated L1 buffer bank size of {} B. This may allow this circular "
-            "buffer to write outside the allocated buffer space.",
-            total_size,
-            this->max_size_);
-        if (total_size > this->buffer_size_) {
-            TT_THROW(
-                "Cannot set to globally allocated buffer. Circular buffer size {} B exceeds allocated L1 buffer "
-                "size of {} B",
-                total_size,
-                this->buffer_size_);
-        }
-#endif
-    }
-    this->total_size_ = total_size;
+    this->set_total_size(total_size);
     return *this;
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #15874

### Problem description
- a CB size check was made as a TT_ASSERT to avoid breaking our main pipelines, which use release build

### What's changed
- the APC debug build pipeline is now green
- to prevent future code from setting CB sizes incorrectly the code should be changed to use TT_FATAL, and the additional logging is not required

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14801338926
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14801341756/job/41560895294 unrelated errors
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14782970584
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14782973393
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes

- T3k fast tests https://github.com/tenstorrent/tt-metal/actions/runs/14783003839
- T3k frequent tests https://github.com/tenstorrent/tt-metal/actions/runs/14783005374
- TG frequent tests https://github.com/tenstorrent/tt-metal/actions/runs/14783006966
- Galaxy quick on this branch https://github.com/tenstorrent/tt-metal/actions/runs/14804252167 has the same behaviour as main https://github.com/tenstorrent/tt-metal/actions/runs/14804441405