### PR TITLE
Fix CSR bit to disable periodic HW cache flush and add ability to disable relaxed mem ordering on BH

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -311,4 +311,48 @@ TEST_F(DeviceFixture, TensixTestL1ToPCIeAt16BAlignedAddress) {
     EXPECT_EQ(src, result);
 }
 
+// One risc caches L1 address then polls for expected value that other risc on same core writes after some delay
+// Expected test scenarios:
+// 1. `invalidate_cache` is true: pass
+// 2. `invalidate_cache` is false: hang because periodic HW cache flush is default disabled
+// 3. `invalidate_cache` is false and env var `TT_METAL_ENABLE_HW_CACHE_INVALIDATION` is set: pass
+TEST_F(BlackholeSingleCardFixture, TensixL1DataCache) {
+    CoreCoord core{0, 0};
+
+    uint32_t l1_unreserved_base = device_->allocator()->get_base_allocator_addr(HalMemType::L1);
+    std::vector<uint32_t> random_vec(1, 0xDEADBEEF);
+    tt_metal::detail::WriteToDeviceL1(device_, core, l1_unreserved_base, random_vec);
+
+    uint32_t value_to_write = 39;
+    bool invalidate_cache =
+        true;  // To make sure this test passes on CI set this to true but can be modified for local debug
+    tt_metal::Program program = tt_metal::CreateProgram();
+
+    uint32_t sem0_id = tt_metal::CreateSemaphore(program, core, 0);
+
+    tt_metal::KernelHandle kernel0 = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/poll_l1.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::NOC_0});
+
+    tt_metal::SetRuntimeArgs(
+        program, kernel0, core, {l1_unreserved_base, value_to_write, sem0_id, (uint32_t)invalidate_cache});
+
+    tt_metal::KernelHandle kernel1 = tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/write_to_break_poll.cpp",
+        core,
+        tt_metal::DataMovementConfig{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::NOC_1});
+
+    tt_metal::SetRuntimeArgs(program, kernel1, core, {l1_unreserved_base, value_to_write, sem0_id});
+
+    tt_metal::detail::LaunchProgram(device_, program);
+
+    tt_metal::detail::ReadFromDeviceL1(device_, core, l1_unreserved_base, sizeof(uint32_t), random_vec);
+    EXPECT_EQ(random_vec[0], value_to_write);
+}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/poll_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/poll_l1.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/dprint.h"
+
+void kernel_main() {
+    uint32_t poll_addr = get_arg_val<uint32_t>(0);
+    uint32_t expected_value = get_arg_val<uint32_t>(1);
+    auto sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(2)));
+    uint32_t invalidate_cache =
+        get_arg_val<uint32_t>(3);  // For CI this will be true but for debug this can be modified
+
+    volatile tt_l1_ptr uint32_t* poll_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(poll_addr);
+    uint32_t base_value = *poll_addr_ptr;  // Read once to cache it
+
+    noc_semaphore_set(sem_addr, 1);
+
+    while (*poll_addr_ptr != expected_value) {
+        if (invalidate_cache) {
+            invalidate_l1_cache();
+        }
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/write_to_break_poll.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/write_to_break_poll.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "debug/dprint.h"
+
+void kernel_main() {
+    uint32_t poll_addr = get_arg_val<uint32_t>(0);
+    uint32_t value_to_write = get_arg_val<uint32_t>(1);
+    auto sem_addr = reinterpret_cast<volatile uint32_t*>(get_semaphore(get_arg_val<uint32_t>(2)));
+
+    volatile tt_l1_ptr uint32_t* poll_addr_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(poll_addr);
+
+    // don't call noc_semaphore_wait here because this kernel is run with `poll_l1.cpp` and it is meant to test the l1
+    // cache invalidation from pov of the polling kernel
+    while (*sem_addr != 1) {
+        invalidate_l1_cache();
+    }
+
+    poll_addr_ptr[0] = value_to_write;
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_waypoints.cpp
@@ -17,7 +17,9 @@ void hacky_sync(uint32_t sync_num, uint32_t wait_cycles, uint32_t sync_addr) {
     *(sync_ptr) = sync_num;
 #endif
 #else
-    while (*(sync_ptr) != sync_num) { ; }
+    while (*(sync_ptr) != sync_num) {
+        invalidate_l1_cache();
+    }
 #endif
 }
 

--- a/tt_metal/hw/firmware/src/active_erisc.cc
+++ b/tt_metal/hw/firmware/src/active_erisc.cc
@@ -65,7 +65,7 @@ uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 #endif
 
 int main() {
-    configure_l1_data_cache();
+    configure_csr();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t*)eth_l1_mem::address_map::MEM_ERISC_INIT_LOCAL_L1_BASE_SCRATCH);

--- a/tt_metal/hw/firmware/src/brisc.cc
+++ b/tt_metal/hw/firmware/src/brisc.cc
@@ -324,12 +324,7 @@ inline void barrier_remote_cb_interface_setup(uint8_t noc_index, uint32_t end_cb
 }
 
 int main() {
-    // Workaround for tt-metal#16439, making sure gathering multiple instructions issued to Tensix is disabled
-    // Brisc does not issue Tensix instructions but to be consistent for all riscs around Tensix we disable it
-#ifdef ARCH_BLACKHOLE
-    disable_gathering();
-#endif
-    configure_l1_data_cache();
+    configure_csr();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 

--- a/tt_metal/hw/firmware/src/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/idle_erisc.cc
@@ -105,7 +105,7 @@ inline void wait_slave_eriscs(uint32_t &heartbeat) {
 }
 
 int main() {
-    configure_l1_data_cache();
+    configure_csr();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t *)MEM_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);

--- a/tt_metal/hw/firmware/src/ncrisc.cc
+++ b/tt_metal/hw/firmware/src/ncrisc.cc
@@ -97,12 +97,7 @@ void l1_to_ncrisc_iram_copy_wait() {
 #endif
 
 int main(int argc, char *argv[]) {
-    // Workaround for tt-metal#16439, making sure gathering multiple instructions issued to Tensix is disabled
-    // Ncrisc does not issue Tensix instructions but to be consistent for all riscs around Tensix we disable it
-#ifdef ARCH_BLACKHOLE
-    disable_gathering();
-#endif
-    configure_l1_data_cache();
+    configure_csr();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 

--- a/tt_metal/hw/firmware/src/slave_idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/slave_idle_erisc.cc
@@ -64,7 +64,7 @@ inline __attribute__((always_inline)) void signal_slave_idle_erisc_completion() 
 }
 
 int main(int argc, char *argv[]) {
-    configure_l1_data_cache();
+    configure_csr();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
     do_crt1((uint32_t *)MEM_SLAVE_IERISC_INIT_LOCAL_L1_BASE_SCRATCH);

--- a/tt_metal/hw/firmware/src/trisc.cc
+++ b/tt_metal/hw/firmware/src/trisc.cc
@@ -93,11 +93,7 @@ void init_sync_registers() {
 }
 
 int main(int argc, char *argv[]) {
-    // Workaround for tt-metal#16439, making sure gathering multiple instructions issued to Tensix is disabled
-#ifdef ARCH_BLACKHOLE
-    disable_gathering();
-#endif
-    configure_l1_data_cache();
+    configure_csr();
     DIRTY_STACK_MEMORY();
     WAYPOINT("I");
 

--- a/tt_metal/hw/inc/debug/dprint.h
+++ b/tt_metal/hw/inc/debug/dprint.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "risc_common.h"
+
 /*
  * Device-side debug print API for device kernels.
  * Works on either one of NC/BR/TR threads.
@@ -350,6 +352,7 @@ __attribute__((__noinline__)) void debug_print(DebugPrinter& dp, DebugPrintData 
         // buffer is full - wait for the host reader to flush+update rpos
         WAYPOINT("DPW");
         while (dprint_buffer->aux.rpos < dprint_buffer->aux.wpos) {
+            invalidate_l1_cache();
 #if defined(COMPILE_FOR_ERISC)
             internal_::risc_context_switch();
 #endif
@@ -392,6 +395,7 @@ __attribute__((__noinline__)) void debug_print(DebugPrinter& dp, DebugPrintData 
                 dprint_buffer->aux.wpos = wpos;
                 WAYPOINT("DPW");
                 while (dprint_buffer->aux.rpos < dprint_buffer->aux.wpos) {
+                    invalidate_l1_cache();
 #if defined(COMPILE_FOR_ERISC)
                     internal_::risc_context_switch();
 #endif

--- a/tt_metal/hw/inc/debug/pause.h
+++ b/tt_metal/hw/inc/debug/pause.h
@@ -18,6 +18,7 @@ void watcher_pause() {
     // Wait for the pause flag to be cleared.
     WAYPOINT("PASW");
     while (pause_msg->flags[debug_get_which_riscv()]) {
+        invalidate_l1_cache();
 #if defined(COMPILE_FOR_ERISC)
         internal_::risc_context_switch();
 #endif

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -241,6 +241,10 @@ void JitBuildEnv::init(
         this->defines_ += "-DENABLE_HW_CACHE_INVALIDATION ";
     }
 
+    if (rtoptions.get_relaxed_memory_ordering_disabled()) {
+        this->defines_ += "-DDISABLE_RELAXED_MEMORY_ORDERING ";
+    }
+
     if (tt::tt_metal::MetalContext::instance().get_cluster().is_base_routing_fw_enabled()) {
         this->defines_ += "-DROUTING_FW_ENABLED ";
     }

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -175,7 +175,9 @@ RunTimeOptions::RunTimeOptions() {
         this->skip_deleting_built_cache = true;
     }
 
-    this->enable_hw_cache_invalidation = (std::getenv("TT_METAL_ENABLE_HW_CACHE_INVALIDATION") != nullptr);
+    if (getenv("TT_METAL_ENABLE_HW_CACHE_INVALIDATION")) {
+        this->enable_hw_cache_invalidation = true;
+    }
 
     if (std::getenv("TT_METAL_SIMULATOR")) {
         this->simulator_enabled = true;
@@ -184,6 +186,10 @@ RunTimeOptions::RunTimeOptions() {
 
     if (getenv("TT_METAL_ENABLE_ERISC_IRAM")) {
         this->erisc_iram_enabled = true;
+    }
+
+    if (getenv("TT_METAL_DISABLE_RELAXED_MEM_ORDERING")) {
+        this->disable_relaxed_memory_ordering = true;
     }
 }
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -148,6 +148,11 @@ class RunTimeOptions {
 
     bool skip_eth_cores_with_retrain = false;
 
+    // Relaxed ordering on BH allows loads to bypass stores when going to separate addresses
+    // e.g. Store A followed by Load A will be unchanges but Store A followed by Load B may return B before A is written
+    // This option will disable the relaxed ordering
+    bool disable_relaxed_memory_ordering = false;
+
 public:
     RunTimeOptions();
     RunTimeOptions(const RunTimeOptions&) = delete;
@@ -333,6 +338,8 @@ public:
     inline void set_dispatch_data_collection_enabled(bool enable) { enable_dispatch_data_collection = enable; }
 
     inline bool get_hw_cache_invalidation_enabled() const { return this->enable_hw_cache_invalidation; }
+
+    inline bool get_relaxed_memory_ordering_disabled() const { return this->disable_relaxed_memory_ordering; }
 
     tt_metal::DispatchCoreConfig get_dispatch_core_config() const;
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1141,6 +1141,9 @@ std::set<tt_fabric::chan_id_t> Cluster::get_fabric_ethernet_channels(chip_id_t c
     std::set<tt_fabric::chan_id_t> fabric_ethernet_channels;
     const auto& active_eth_cores = this->get_active_ethernet_cores(chip_id, false);
     for (const auto& eth_core : active_eth_cores) {
+        if (!this->is_ethernet_link_up(chip_id, eth_core)) {
+            continue;
+        }
         if (this->device_eth_routing_info_.at(chip_id).at(eth_core) == EthRouterMode::FABRIC_ROUTER) {
             fabric_ethernet_channels.insert(this->get_soc_desc(chip_id).logical_eth_core_to_chan_map.at(eth_core));
         }

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -252,7 +252,9 @@ __attribute__((noinline)) void finish_profiler() {
     if (profiler_control_buffer[PROFILER_DONE] == 1) {
         return;
     }
-    while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
+    while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]) {
+        invalidate_l1_cache();
+    }
     uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
     uint32_t profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
 
@@ -321,7 +323,9 @@ __attribute__((noinline)) void quick_push() {
     mark_time_at_index_inlined(wIndex, hash);
     wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
 
-    while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]);
+    while (!profiler_control_buffer[DRAM_PROFILER_ADDRESS]) {
+        invalidate_l1_cache();
+    }
     uint32_t core_flat_id = profiler_control_buffer[FLAT_ID];
     uint32_t profiler_core_count_per_dram = profiler_control_buffer[CORE_COUNT_PER_DRAM];
 

--- a/tt_metal/tools/profiler/sync/sync_device_kernel_receiver.cpp
+++ b/tt_metal/tools/profiler/sync/sync_device_kernel_receiver.cpp
@@ -30,10 +30,12 @@ FORCE_INLINE void run_loop_iteration(
     std::array<volatile eth_channel_sync_t*, NUM_CHANNELS> const& channel_sync_addrs) {
     if constexpr (MEASURE) {
         while (channel_sync_addrs[0]->bytes_sent == 0) {
+            invalidate_l1_cache();
         }
 
         for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
             while (channel_sync_addrs[i]->bytes_sent == 0) {
+                invalidate_l1_cache();
             }
             DeviceZoneScopedN("SYNC-ZONE-RECEIVER");
 
@@ -51,11 +53,13 @@ FORCE_INLINE void run_loop_iteration(
         }
     } else {
         while (channel_sync_addrs[0]->bytes_sent == 0) {
+            invalidate_l1_cache();
         }
 
         {
             for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
                 while (channel_sync_addrs[i]->bytes_sent == 0) {
+                    invalidate_l1_cache();
                 }
 
                 channel_sync_addrs[i]->bytes_sent = 0;

--- a/tt_metal/tools/profiler/sync/sync_device_kernel_sender.cpp
+++ b/tt_metal/tools/profiler/sync/sync_device_kernel_sender.cpp
@@ -42,6 +42,7 @@ FORCE_INLINE void run_loop_iteration(
         }
         for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
             while (channel_sync_addrs[i]->bytes_sent != 0) {
+                invalidate_l1_cache();
             }
         }
     } else {
@@ -53,6 +54,7 @@ FORCE_INLINE void run_loop_iteration(
         }
         for (uint32_t i = 0; i < NUM_CHANNELS; i++) {
             while (channel_sync_addrs[i]->bytes_sent != 0) {
+                invalidate_l1_cache();
             }
         }
     }

--- a/tt_metal/tools/profiler/sync/sync_kernel.cpp
+++ b/tt_metal/tools/profiler/sync/sync_kernel.cpp
@@ -20,6 +20,7 @@ void kernel_main() {
     constexpr int FIRST_READ_COUNT = 2;
 
     while (syncTimeBufferIndex < FIRST_READ_COUNT) {
+        invalidate_l1_cache();
         uint32_t deviceTime = p_reg[kernel_profiler::WALL_CLOCK_LOW_INDEX];
 
         uint32_t hostTime = profiler_control_buffer[kernel_profiler::FW_RESET_L];
@@ -35,6 +36,7 @@ void kernel_main() {
     {
         DeviceZoneScopedMainChildN("SYNC-LOOP");
         while (syncTimeBufferIndex < ((SAMPLE_COUNT + 1) * 2)) {
+            invalidate_l1_cache();
             uint32_t deviceTime = p_reg[kernel_profiler::WALL_CLOCK_LOW_INDEX];
 
             uint32_t hostTime = profiler_control_buffer[kernel_profiler::FW_RESET_L];


### PR DESCRIPTION
### Ticket
N/A

### Problem description
CSR bit 24 should be set to disable periodic HW cache flush but we were setting bit 18 (which was disabling gathering of 4 TTIs) 

### What's changed
Set correct bit to disable HW cache flush and also expose ability to disable relaxed memory ordering through env var `TT_METAL_DISABLE_RELAXED_MEM_ORDERING`
Added a test that can be modified to demonstrate hang with l1 data cache. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14828773757) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14829347942) CI with demo tests passes (if applicable)