### PR TITLE
#21521: Update all link eth test to skip links that are not up

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -276,6 +276,10 @@ private:
                 tt::tt_metal::MetalContext::instance().get_cluster().get_active_ethernet_cores(
                     sender_chip_id, !slow_dispath_mode);
             for (auto logical_active_eth : non_tunneling_eth_cores) {
+                if (!tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_link_up(
+                        sender_chip_id, logical_active_eth)) {
+                    continue;
+                }
                 auto sender_eth = tt_cxy_pair(sender_chip_id, logical_active_eth);
                 auto receiver_eth_tuple =
                     tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(


### PR DESCRIPTION
### Ticket
#21521 

### Problem description
for single chip systems with active eth cores, all links eth ubench was trying to query remote eth info even though links are not active

### What's changed
skip querying remote eth if eth link is not up

### Checklist
- [ ] [eth ubenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/14785203890) CI passes