### PR TITLE
#21329 Move both read to reader when there is no subtile broadcast for binary_ng

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1894,14 +1894,18 @@ def test_binary_sharded_row_major_layout(
     "a_shape, b_shape",
     [
         [[1, 1, 7, 7], [1, 1, 7, 7]],
-        [[1, 71, 7, 7], [1, 71, 7, 7]],
-        [[71, 1, 7, 7], [71, 1, 7, 7]],
-        [[7, 71, 7, 7], [7, 71, 7, 7]],
-        [[7, 71, 7, 7], [7, 7]],
+        [[7, 71, 71, 7], [7, 71, 71, 7]],
+        [[1, 1, 7, 7], [1, 71, 7, 7]],
+        [[1, 71, 7, 7], [1, 1, 7, 7]],
+        [[71, 1, 7, 7], [1, 1, 7, 7]],
+        [[1, 1, 7, 7], [71, 1, 7, 7]],
+        [[1, 1, 7, 7], [7, 71, 7, 7]],
+        [[7, 71, 7, 7], [1, 1, 7, 7]],
         [[920, 1, 256], [256]],
+        [[256], [920, 1, 256]],
     ],
 )
-def test_binary_no_bcast(a_shape, b_shape, device):
+def test_binary_no_subtile_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1894,6 +1894,7 @@ def test_binary_sharded_row_major_layout(
     "a_shape, b_shape",
     [
         [[1, 1, 7, 7], [1, 1, 7, 7]],
+        [[1, 1, 71, 71], [1, 1, 71, 71]],
         [[7, 71, 71, 7], [7, 71, 71, 7]],
         [[1, 1, 7, 7], [1, 71, 7, 7]],
         [[1, 71, 7, 7], [1, 1, 7, 7]],
@@ -1905,7 +1906,7 @@ def test_binary_sharded_row_major_layout(
         [[256], [920, 1, 256]],
     ],
 )
-def test_binary_no_subtile_bcast(a_shape, b_shape, device):
+def test_binary_subtile_no_bcast(a_shape, b_shape, device):
     torch.manual_seed(0)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -1942,7 +1942,7 @@ profile_a_b_shape_pairs = [
 )
 @pytest.mark.parametrize("a_and_b_shape", profile_a_b_shape_pairs)
 def test_binary_bcast_profile(device, dtype_pt, dtype_tt, a_and_b_shape, memory_config_input):
-    ttnn.enable_program_cache(device)
+    device.enable_program_cache()
     torch.manual_seed(0)
     a_shape, b_shape = a_and_b_shape
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -111,6 +111,10 @@ std::string get_kernel_file_path(KernelName kernel_name, bool is_sfpu) {
     constexpr std::string_view compute = "{}/compute/{}";
 
     switch (kernel_name) {
+        case KernelName::ReaderNoBcastSplit:
+            return fmt::format(dataflow, root, "reader_interleaved_no_bcast_split.cpp");
+        case KernelName::WriterNoBcastSplit:
+            return fmt::format(dataflow, root, "writer_interleaved_no_bcast_split.cpp");
         case KernelName::ReaderNoBcast: return fmt::format(dataflow, root, "reader_interleaved_no_bcast.cpp");
         case KernelName::ReaderRowBcast: return fmt::format(dataflow, root, "reader_interleaved_row_bcast.cpp");
         case KernelName::ReaderColBcast: return fmt::format(dataflow, root, "reader_interleaved_col_bcast.cpp");

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -25,7 +25,9 @@ enum class KernelName {
     WriterScalar,
     ComputeNoBcast,
     ComputeBcast,
-    ComputeScalar
+    ComputeScalar,
+    ReaderNoBcastSplit,
+    WriterNoBcastSplit,
 };
 
 struct BinaryNgKernelConfig {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_split.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_split.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "dataflow_api.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(1);
+    const uint32_t src_num_tiles = get_arg_val<uint32_t>(2);
+    const uint32_t dst_num_tiles = get_arg_val<uint32_t>(3);
+    const uint32_t dst_shard_width = get_arg_val<uint32_t>(4);
+    const uint32_t nD_stride = get_arg_val<uint32_t>(5);
+    const uint32_t n_stride = get_arg_val<uint32_t>(6);
+    const uint32_t c_stride = get_arg_val<uint32_t>(7);
+    const uint32_t N = get_arg_val<uint32_t>(8);
+    const uint32_t C = get_arg_val<uint32_t>(9);
+    const uint32_t Ht = get_arg_val<uint32_t>(10);
+    const uint32_t Wt = get_arg_val<uint32_t>(11);
+    const uint32_t cND = get_arg_val<uint32_t>(12);  // collapsed dims > 4
+    const uint32_t src_addr_b = get_arg_val<uint32_t>(13);
+
+    constexpr auto cb_id_src = tt::CBIndex::c_0;
+    constexpr auto cb_id_src_b = tt::CBIndex::c_1;
+
+#if SRC_SHARDED && SRC_SHARDED_B
+    cb_reserve_back(cb_id_src, src_num_tiles);
+    cb_push_back(cb_id_src, src_num_tiles);
+
+    cb_reserve_back(cb_id_src_b, src_num_tiles);
+    cb_push_back(cb_id_src_b, src_num_tiles);
+#else
+#if SRC_SHARDED
+    cb_reserve_back(cb_id_src, src_num_tiles);
+    cb_push_back(cb_id_src, src_num_tiles);
+#endif
+#if SRC_SHARDED_B
+    cb_reserve_back(cb_id_src_b, src_num_tiles);
+    cb_push_back(cb_id_src_b, src_num_tiles);
+#endif
+    constexpr uint32_t onetile = 1;
+#if !SRC_SHARDED
+    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
+    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
+    const DataFormat src_data_format = get_dataformat(cb_id_src);
+    const InterleavedAddrGenFast<src_is_dram> src = {
+        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
+#endif
+#if !SRC_SHARDED_B
+    constexpr bool src_is_dram_b = get_compile_time_arg_val(2) == 1;
+    const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
+    const DataFormat src_data_format_b = get_dataformat(cb_id_src_b);
+
+    const InterleavedAddrGenFast<src_is_dram_b> src_b = {
+        .bank_base_address = src_addr_b, .page_size = src_tile_bytes_b, .data_format = src_data_format_b};
+#endif
+    constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_depth = N * C * HtWt;
+    uint32_t start_d = start_tile_id / tiles_per_depth;  // ND index
+    uint32_t start_remaining_1 = start_tile_id % tiles_per_depth;
+    uint32_t tiles_per_batch = HtWt * C;
+    uint32_t start_n = start_remaining_1 / tiles_per_batch;  // N index
+    uint32_t start_remaining_2 = start_remaining_1 % tiles_per_batch;
+    uint32_t tiles_per_channel = HtWt;
+    uint32_t start_c = start_remaining_2 / tiles_per_channel;  // C index
+    uint32_t start_t = start_remaining_2 % tiles_per_channel;  // tile index within HtWt
+    uint32_t start_th = start_t / Wt;                          // H index
+    uint32_t start_tw = start_t % Wt;                          // W index
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_channel_shift = c_stride - HtWt;
+    uint32_t next_batch_shift = n_stride - c_stride * C;
+    uint32_t next_depth_shift = nD_stride - (n_stride * N);
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_d; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_n = 0) {
+        for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+            for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th, tile_offset += Wt) {
+                    for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                         ++tw, ++num_tiles_read) {
+#if !SRC_SHARDED
+                        cb_reserve_back(cb_id_src, onetile);
+                        uint32_t l1_write_addr_src = get_write_ptr(cb_id_src);
+                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr_src);
+#endif
+#if !SRC_SHARDED_B
+                        // read a tile from src_b
+                        cb_reserve_back(cb_id_src_b, onetile);
+                        uint32_t l1_write_addr_b = get_write_ptr(cb_id_src_b);
+                        noc_async_read_tile(tile_offset + tw, src_b, l1_write_addr_b);
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+                        noc_async_read_barrier();
+#endif
+#if !SRC_SHARDED
+                        cb_push_back(cb_id_src, onetile);
+#endif
+#if !SRC_SHARDED_B
+                        cb_push_back(cb_id_src_b, onetile);
+#endif
+                    }
+                    if constexpr (!has_sharding) {
+                        // next row of tiles should start at the first column
+                        start_tw = 0;
+                    }
+                }
+                tile_offset += next_channel_shift;
+            }
+            tile_offset += next_batch_shift;
+        }
+        tile_offset += next_depth_shift;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_split.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_split.cpp
@@ -24,6 +24,7 @@ void kernel_main() {
     const uint32_t nD_stride_b = get_arg_val<uint32_t>(14);
     const uint32_t n_stride_b = get_arg_val<uint32_t>(15);
     const uint32_t c_stride_b = get_arg_val<uint32_t>(16);
+    const uint32_t src_num_tiles_b = get_arg_val<uint32_t>(17);
 
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
@@ -32,16 +33,16 @@ void kernel_main() {
     cb_reserve_back(cb_id_src, src_num_tiles);
     cb_push_back(cb_id_src, src_num_tiles);
 
-    cb_reserve_back(cb_id_src_b, src_num_tiles);
-    cb_push_back(cb_id_src_b, src_num_tiles);
+    cb_reserve_back(cb_id_src_b, src_num_tiles_b);
+    cb_push_back(cb_id_src_b, src_num_tiles_b);
 #else
 #if SRC_SHARDED
     cb_reserve_back(cb_id_src, src_num_tiles);
     cb_push_back(cb_id_src, src_num_tiles);
 #endif
 #if SRC_SHARDED_B
-    cb_reserve_back(cb_id_src_b, src_num_tiles);
-    cb_push_back(cb_id_src_b, src_num_tiles);
+    cb_reserve_back(cb_id_src_b, src_num_tiles_b);
+    cb_push_back(cb_id_src_b, src_num_tiles_b);
 #endif
     constexpr uint32_t onetile = 1;
 #if !SRC_SHARDED

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_split.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_split.cpp
@@ -29,30 +29,20 @@ void kernel_main() {
     constexpr auto cb_id_src = tt::CBIndex::c_0;
     constexpr auto cb_id_src_b = tt::CBIndex::c_1;
 
-#if SRC_SHARDED && SRC_SHARDED_B
-    cb_reserve_back(cb_id_src, src_num_tiles);
-    cb_push_back(cb_id_src, src_num_tiles);
-
-    cb_reserve_back(cb_id_src_b, src_num_tiles_b);
-    cb_push_back(cb_id_src_b, src_num_tiles_b);
-#else
 #if SRC_SHARDED
     cb_reserve_back(cb_id_src, src_num_tiles);
     cb_push_back(cb_id_src, src_num_tiles);
-#endif
-#if SRC_SHARDED_B
-    cb_reserve_back(cb_id_src_b, src_num_tiles_b);
-    cb_push_back(cb_id_src_b, src_num_tiles_b);
-#endif
-    constexpr uint32_t onetile = 1;
-#if !SRC_SHARDED
+#else
     constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
     const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
     const DataFormat src_data_format = get_dataformat(cb_id_src);
     const InterleavedAddrGenFast<src_is_dram> src = {
         .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
 #endif
-#if !SRC_SHARDED_B
+#if SRC_SHARDED_B
+    cb_reserve_back(cb_id_src_b, src_num_tiles_b);
+    cb_push_back(cb_id_src_b, src_num_tiles_b);
+#else
     constexpr bool src_is_dram_b = get_compile_time_arg_val(2) == 1;
     const uint32_t src_tile_bytes_b = get_tile_size(cb_id_src_b);
     const DataFormat src_data_format_b = get_dataformat(cb_id_src_b);
@@ -60,6 +50,8 @@ void kernel_main() {
     const InterleavedAddrGenFast<src_is_dram_b> src_b = {
         .bank_base_address = src_addr_b, .page_size = src_tile_bytes_b, .data_format = src_data_format_b};
 #endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+    constexpr uint32_t onetile = 1;
     constexpr bool has_sharding = get_compile_time_arg_val(1) == 1;
     const uint32_t HtWt = Ht * Wt;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast_split.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast_split.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,19 +24,6 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    constexpr auto cb_id_src = tt::CBIndex::c_1;
-#if SRC_SHARDED
-    cb_reserve_back(cb_id_src, src_num_tiles);
-    cb_push_back(cb_id_src, src_num_tiles);
-#else
-    constexpr bool src_is_dram = get_compile_time_arg_val(0) == 1;
-    const uint32_t src_tile_bytes = get_tile_size(cb_id_src);
-    const DataFormat src_data_format = get_dataformat(cb_id_src);
-
-    const InterleavedAddrGenFast<src_is_dram> src = {
-        .bank_base_address = src_addr, .page_size = src_tile_bytes, .data_format = src_data_format};
-#endif
-
     constexpr auto cb_id_dst = tt::CBIndex::c_2;
 #if !DST_SHARDED
     constexpr bool dst_is_dram = get_compile_time_arg_val(1) == 1;
@@ -47,7 +34,7 @@ void kernel_main() {
         .bank_base_address = dst_addr, .page_size = dst_tile_bytes, .data_format = dst_data_format};
 #endif
 
-#if !SRC_SHARDED || !DST_SHARDED
+#if !DST_SHARDED
     constexpr bool has_sharding = get_compile_time_arg_val(2) == 1;
     const uint32_t HtWt = Ht * Wt;
 
@@ -79,17 +66,8 @@ void kernel_main() {
                 for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
                     for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
                          ++tw, ++num_tiles_written) {
-#if !SRC_SHARDED
-                        // read a tile from src
-                        cb_reserve_back(cb_id_src, onetile);
-                        uint32_t l1_write_addr = get_write_ptr(cb_id_src);
-                        noc_async_read_tile(tile_offset + tw, src, l1_write_addr);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_id_src, onetile);
-#endif
-
 #if !DST_SHARDED
-                        // write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                        //  write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
                         cb_wait_front(cb_id_dst, onetile);
                         uint32_t l1_read_addr = get_read_ptr(cb_id_dst);
                         noc_async_write_tile(dst_tile_offset + num_tiles_written, dst, l1_read_addr);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast_split.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_no_bcast_split.cpp
@@ -51,12 +51,6 @@ void kernel_main() {
     uint32_t start_tw = start_t % Wt;                          // W index
     uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
 
-    // this is the INPUT tile offset
-    uint32_t tile_offset = start_d * nD_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
-    uint32_t next_channel_shift = c_stride - HtWt;
-    uint32_t next_batch_shift = n_stride - c_stride * C;
-    uint32_t next_depth_shift = nD_stride - (n_stride * N);
-
     uint32_t num_tiles_written = 0;
     uint32_t dst_tile_offset = start_tile_id;
 
@@ -75,7 +69,6 @@ void kernel_main() {
                         cb_pop_front(cb_id_dst, onetile);
 #endif
                     }
-                    tile_offset += Wt;
                     if constexpr (has_sharding) {
                         // adjust the output tile offset since we had to skip parts of the row
                         dst_tile_offset += (Wt - dst_shard_width);
@@ -84,11 +77,8 @@ void kernel_main() {
                         start_tw = 0;
                     }
                 }
-                tile_offset += next_channel_shift;
             }
-            tile_offset += next_batch_shift;
         }
-        tile_offset += next_depth_shift;
     }
 #endif
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21329)

### Problem description
There is about 15% performance overhead if writer does both read b and write. Move the read to reader, starting with the case of when there is no subtile broadcast. Note N and C dimension can still broadcast.

### What's changed
To co-exist with other subtile broadcast cases, two new kernels are created for this issue for now.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes