### PR TITLE
Move dispatch_settings.hpp from api/tt-metallium

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -9,7 +9,6 @@
 #include <sys/types.h>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
@@ -38,6 +37,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/dispatch_core_common.hpp>
 #include "dispatch_test_utils.hpp"
+#include "impl/dispatch/dispatch_settings.hpp"
 #include "gtest/gtest.h"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/math.hpp>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -20,7 +20,7 @@
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/command_queue.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
+#include "impl/dispatch/dispatch_settings.hpp"
 #include "dispatch_test_utils.hpp"
 #include "gtest/gtest.h"
 #include "multi_command_queue_fixture.hpp"

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -20,7 +20,7 @@
 #include <tt-metalium/buffer_types.hpp>
 #include "command_queue_fixture.hpp"
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
+#include "impl/dispatch/dispatch_settings.hpp"
 #include "gtest/gtest.h"
 #include "impl/debug/watcher_server.hpp"
 #include <tt-metalium/logger.hpp>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_settings.cpp
@@ -4,7 +4,6 @@
 
 #include <fmt/base.h>
 #include <stdint.h>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/logger.hpp>
 #include <array>
 #include <functional>
@@ -15,6 +14,7 @@
 #include <tt-metalium/hal_types.hpp>
 #include "impl/context/metal_context.hpp"
 #include "umd/device/tt_core_coordinates.h"
+#include "impl/dispatch/dispatch_settings.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -30,7 +30,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/data_types.hpp>
 #include <tt-metalium/device.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
+#include "impl/dispatch/dispatch_settings.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include "llrt.hpp"
 #include <tt-metalium/logger.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -7,7 +7,6 @@
 #include <fmt/base.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -45,6 +44,7 @@
 #include "noc/noc_parameters.h"
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/system_memory_manager.hpp>
+#include "impl/dispatch/dispatch_settings.hpp"
 #include "test_common.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -55,7 +55,6 @@ target_sources(
             api/tt-metalium/device_impl.hpp
             api/tt-metalium/device_pool.hpp
             api/tt-metalium/dispatch_core_common.hpp
-            api/tt-metalium/dispatch_settings.hpp
             api/tt-metalium/event.hpp
             api/tt-metalium/fabric_host_interface.h
             api/tt-metalium/global_circular_buffer.hpp

--- a/tt_metal/api/tt-metalium/command_queue_interface.hpp
+++ b/tt_metal/api/tt-metalium/command_queue_interface.hpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/fabric_host_interface.h>
 
 #include <tt-metalium/launch_message_ring_buffer_state.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <umd/device/tt_core_coordinates.h>
 

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -22,7 +22,6 @@
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/command_queue_interface.hpp>
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/launch_message_ring_buffer_state.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_coord.hpp>

--- a/tt_metal/api/tt-metalium/system_memory_manager.hpp
+++ b/tt_metal/api/tt-metalium/system_memory_manager.hpp
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include <tt-metalium/dispatch_settings.hpp>
 // needed for private members
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/launch_message_ring_buffer_state.hpp>
 #include <tt-metalium/system_memory_cq_interface.hpp>
 #include <umd/device/chip_helpers/tlb_manager.h>  // needed because tt_io.hpp requires needs TLBManager

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -7,7 +7,6 @@
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <array>
@@ -23,6 +22,7 @@
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "event/dispatch.hpp"
 #include "hal_types.hpp"
 #include "mesh_config.hpp"

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -9,6 +9,8 @@
 #include <tt-metalium/command_queue.hpp>
 #include <tt-metalium/multi_producer_single_consumer_queue.hpp>
 
+#include "dispatch/dispatch_settings.hpp"
+
 namespace tt::tt_metal::distributed {
 
 struct MeshReadEventDescriptor;

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -7,7 +7,6 @@
 #include <mesh_device.hpp>
 #include <mesh_event.hpp>
 #include <optional>
-#include <tt-metalium/dispatch_settings.hpp>
 
 #include "buffer.hpp"
 #include "mesh_coord.hpp"
@@ -18,6 +17,7 @@
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/common/thread_pool.hpp"
 #include "tt_cluster.hpp"
+#include "dispatch/dispatch_settings.hpp"
 
 namespace tt::tt_metal::distributed {
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -25,7 +25,7 @@
 
 #include "allocator.hpp"
 #include "assert.hpp"
-#include "dispatch_settings.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "launch_message_ring_buffer_state.hpp"
 #include "mesh_trace.hpp"
 #include "shape_base.hpp"

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -5,7 +5,6 @@
 #include <boost/core/span.hpp>
 #include <device.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <algorithm>
 #include <array>
 #include <optional>
@@ -18,6 +17,7 @@
 #include "dispatch.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "hal_types.hpp"
 #include "logger.hpp"
 #include "math.hpp"

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "metal_context.hpp"
-#include <tt-metalium/dispatch_settings.hpp>
+#include "dispatch/dispatch_settings.hpp"
 #include "tt_metal/impl/allocator/l1_banking_allocator.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
 #include "tt_metal/impl/debug/dprint_server.hpp"

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -47,7 +47,7 @@
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch_core_common.hpp"
-#include "dispatch_settings.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dprint_server.hpp"
 #include "hal_types.hpp"
 #include "jit_build/build.hpp"

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -17,7 +17,7 @@
 
 #include "control_plane.hpp"
 #include "core_coord.hpp"
-#include "dispatch_settings.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dprint_server.hpp"
 #include "env_lib.hpp"
 #include "erisc_datamover_builder.hpp"

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/command_queue_common.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
+#include "dispatch_settings.hpp"
 
 #include "impl/context/metal_context.hpp"
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -6,11 +6,11 @@
 
 #include <stdint.h>
 #include <tt-metalium/command_queue_common.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <utility>
 #include <vector>
 
 #include <umd/device/tt_core_coordinates.h>
+#include "dispatch_settings.hpp"
 
 namespace tt {
 namespace tt_metal {

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -135,9 +135,9 @@ public:
     // page size is padded appropriately.
     static constexpr uint32_t BASE_PARTIAL_PAGE_SIZE_DISPATCH = 4096;
 
-    static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30;                                        // 1GB
-    static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                     // 256 MB;
-    static constexpr uint32_t DEVICES_PER_UMD_CHANNEL = MAX_HUGEPAGE_SIZE / MAX_DEV_CHANNEL_SIZE; // 256 MB;
+    static constexpr uint32_t MAX_HUGEPAGE_SIZE = 1 << 30;                                         // 1GB
+    static constexpr uint32_t MAX_DEV_CHANNEL_SIZE = 1 << 28;                                      // 256 MB;
+    static constexpr uint32_t DEVICES_PER_UMD_CHANNEL = MAX_HUGEPAGE_SIZE / MAX_DEV_CHANNEL_SIZE;  // 256 MB;
 
     //
     // Configurable Settings

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -12,7 +12,6 @@
 #include <trace_buffer.hpp>
 #include <tracy/Tracy.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt_stl/overloaded.hpp>
 #include <algorithm>
 #include <array>
@@ -25,6 +24,7 @@
 #include "buffers/dispatch.hpp"
 #include "device/dispatch.hpp"
 #include "dispatch/device_command.hpp"
+#include "dispatch_settings.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/host_runtime_commands.hpp"
 #include "dprint_server.hpp"

--- a/tt_metal/impl/dispatch/host_runtime_commands.hpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
@@ -21,6 +20,7 @@
 #include "device_command.hpp"
 #include "env_lib.hpp"
 #include "multi_producer_single_consumer_queue.hpp"
+#include "dispatch_settings.hpp"
 #include "tt-metalium/program.hpp"
 #include "sub_device_types.hpp"
 #include "trace_buffer.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -4,7 +4,6 @@
 #include "demux.hpp"
 
 #include <host_api.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <map>
 #include <string>
 #include <utility>
@@ -17,6 +16,7 @@
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch_core_common.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "eth_tunneler.hpp"
 #include "hal.hpp"
 #include <umd/device/tt_xy_pair.h>

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -4,7 +4,6 @@
 #include "dispatch.hpp"
 
 #include <host_api.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt_metal.hpp>
 #include <array>
 #include <map>
@@ -19,6 +18,7 @@
 #include "device.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch/kernels/packet_queue_ctrl.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_s.hpp"
 #include "hal_types.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -4,7 +4,6 @@
 #include "dispatch_s.hpp"
 
 #include <host_api.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt_metal.hpp>
 #include <map>
 #include <string>
@@ -18,6 +17,7 @@
 #include "dispatch.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
 #include "dispatch_core_common.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "hal.hpp"
 #include "hal_types.hpp"
 #include "prefetch.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -4,7 +4,6 @@
 #include "eth_router.hpp"
 
 #include <host_api.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <map>
 #include <string>
 #include <utility>
@@ -15,6 +14,7 @@
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
 #include "eth_tunneler.hpp"
 #include "hal.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -4,7 +4,6 @@
 #include "mux.hpp"
 
 #include <host_api.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <map>
 #include <string>
 #include <utility>
@@ -16,6 +15,7 @@
 #include "dispatch.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
 #include "eth_tunneler.hpp"
 #include "hal.hpp"

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -4,7 +4,6 @@
 #include "prefetch.hpp"
 
 #include <host_api.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt_metal.hpp>
 #include <array>
 #include <map>
@@ -18,6 +17,7 @@
 #include "device.hpp"
 #include "dispatch.hpp"
 #include "dispatch/kernel_config/fd_kernel.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
 #include "dispatch_s.hpp"
 #include "eth_router.hpp"

--- a/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
+++ b/tt_metal/impl/dispatch/system_memory_cq_interface.cpp
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/command_queue_common.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/system_memory_cq_interface.hpp>
 
 #include "assert.hpp"
 #include "impl/context/metal_context.hpp"
+#include "dispatch_settings.hpp"
 
 namespace tt::tt_metal {
 

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <dispatch_settings.hpp>
 #include <limits.h>
 #include <tt-metalium/dev_msgs.h>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -17,6 +15,7 @@
 #include "fmt/base.h"
 #include "hal_types.hpp"
 #include "impl/context/metal_context.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "magic_enum/magic_enum.hpp"
 #include "size_literals.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"

--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -5,7 +5,6 @@
 #include "tt_metal/impl/event/dispatch.hpp"
 
 #include <boost/core/span.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt_align.hpp>
 #include <utility>
 #include <vector>
@@ -16,6 +15,7 @@
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
 #include "hal_types.hpp"
 #include "logger.hpp"

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -11,7 +11,6 @@
 #include <sub_device_types.hpp>
 #include <tracy/Tracy.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/dispatch_settings.hpp>
 #include <tt-metalium/mesh_command_queue.hpp>
 #include <tt_align.hpp>
 #include <algorithm>
@@ -39,6 +38,7 @@
 #include "dispatch/device_command.hpp"
 #include "impl/context/metal_context.hpp"
 #include "dispatch/kernels/cq_commands.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
 #include "hal_types.hpp"
 #include "kernel.hpp"

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -19,7 +19,7 @@
 
 #include "core_coord.hpp"
 #include "dev_msgs.h"
-#include "dispatch_settings.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "kernel_types.hpp"
 #include "sub_device_types.hpp"
 

--- a/tt_metal/impl/sub_device/sub_device_manager.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager.cpp
@@ -20,7 +20,7 @@
 #include "allocator_types.hpp"
 #include "buffer_types.hpp"
 #include "core_coord.hpp"
-#include "dispatch_settings.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "hal.hpp"
 #include <tt_stl/strong_type.hpp>
 #include "sub_device_manager.hpp"

--- a/tt_metal/impl/trace/dispatch.hpp
+++ b/tt_metal/impl/trace/dispatch.hpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include "core_coord.hpp"
-#include "dispatch_settings.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "sub_device_types.hpp"
 
 namespace tt {

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -36,7 +36,7 @@
 #include "data_types.hpp"
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
-#include "dispatch_settings.hpp"
+#include "dispatch/dispatch_settings.hpp"
 #include "hal_types.hpp"
 #include "kernel_types.hpp"
 #include "lightmetal/host_api_capture_helpers.hpp"


### PR DESCRIPTION
### Problem description
DispatchSettings is a fast-dispatch internal concept, so it doesn't belong in api.

### What's changed
Move it to tt_metal/impl/dispatch.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes