### PR TITLE
Use struct instead of pair in return of extract_dst_noc_multicast_info

### DIFF
--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -805,19 +805,20 @@ BatchedTransfers assemble_runtime_args_commands(
                     }
                     uint32_t dispatch_class = kernel->dispatch_class();
                     const uint32_t crta_offset = program.get_program_config(index).crta_offsets[dispatch_class];
-                    for (auto& [transfer_info, dests] :
+                    for (auto& transfer_info :
                          extract_dst_noc_multicast_info(device, kg->core_ranges.ranges(), CoreType::WORKER)) {
-                        auto noc_xy_addr =
-                            device->get_noc_multicast_encoding(constants.noc_index, std::get<CoreRange>(transfer_info));
+                        auto noc_xy_addr = device->get_noc_multicast_encoding(
+                            constants.noc_index, std::get<CoreRange>(transfer_info.cores));
                         size_t size =
                             kernel->common_runtime_args().size() * sizeof(*kernel->common_runtime_args().data());
                         RecordDispatchData(program, DISPATCH_DATA_RTARGS, size);
-                        transfers[std::make_pair(noc_xy_addr, dests)][crta_offset] = std::vector<Transfer>{Transfer{
-                            .start = crta_offset,
-                            .data =
-                                tt::stl::Span(reinterpret_cast<uint8_t*>(kernel->common_runtime_args().data()), size),
-                            .cbs = {},
-                            .rta_data = &kernel->common_runtime_args_data()}};
+                        transfers[std::make_pair(noc_xy_addr, transfer_info.num_dests)][crta_offset] =
+                            std::vector<Transfer>{Transfer{
+                                .start = crta_offset,
+                                .data = tt::stl::Span(
+                                    reinterpret_cast<uint8_t*>(kernel->common_runtime_args().data()), size),
+                                .cbs = {},
+                                .rta_data = &kernel->common_runtime_args_data()}};
                     }
                 }
             }
@@ -949,7 +950,7 @@ BatchedTransfers assemble_runtime_args_commands(
                                     device->get_noc_unicast_encoding(constants.noc_index, virtual_core_coords)});
                         }
                     } else {
-                        std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
+                        std::vector<multicast_transfer_info> dst_noc_multicast_info =
                             extract_dst_noc_multicast_info(device, kernel->logical_coreranges(), core_type);
                         common_sub_cmds.emplace<std::vector<CQDispatchWritePackedMulticastSubCmd>>(
                             std::vector<CQDispatchWritePackedMulticastSubCmd>());
@@ -959,8 +960,8 @@ BatchedTransfers assemble_runtime_args_commands(
                         for (const auto& mcast_dests : dst_noc_multicast_info) {
                             multicast_sub_cmd.emplace_back(CQDispatchWritePackedMulticastSubCmd{
                                 .noc_xy_addr = device->get_noc_multicast_encoding(
-                                    constants.noc_index, std::get<CoreRange>(mcast_dests.first)),
-                                .num_mcast_dests = mcast_dests.second});
+                                    constants.noc_index, std::get<CoreRange>(mcast_dests.cores)),
+                                .num_mcast_dests = mcast_dests.num_dests});
                         }
                     }
 
@@ -1041,18 +1042,18 @@ public:
 
             if (semaphore.core_type() == CoreType::WORKER) {
                 uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
-                std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
+                std::vector<multicast_transfer_info> dst_noc_multicast_info =
                     extract_dst_noc_multicast_info(device, semaphore.core_range_set().ranges(), CoreType::WORKER);
                 for (const auto& dst_noc_info : dst_noc_multicast_info) {
-                    auto& [range, dests] = dst_noc_info;
-                    auto noc_xy_addr =
-                        device->get_noc_multicast_encoding(constants.noc_index, std::get<CoreRange>(range));
+                    auto noc_xy_addr = device->get_noc_multicast_encoding(
+                        constants.noc_index, std::get<CoreRange>(dst_noc_info.cores));
                     uint32_t start_addr = semaphore.offset() + program.get_program_config(index).sem_offset;
                     RecordDispatchData(program, DISPATCH_DATA_SEMAPHORE, sizeof(uint32_t));
-                    batched_transfers[std::make_pair(noc_xy_addr, dests)][start_addr] = std::vector<Transfer>{
-                        {{.start = start_addr,
-                          .data = tt::stl::Span(
-                              reinterpret_cast<const uint8_t*>(&semaphore_data.back()), sizeof(uint32_t))}}};
+                    batched_transfers[std::make_pair(noc_xy_addr, dst_noc_info.num_dests)][start_addr] =
+                        std::vector<Transfer>{
+                            {{.start = start_addr,
+                              .data = tt::stl::Span(
+                                  reinterpret_cast<const uint8_t*>(&semaphore_data.back()), sizeof(uint32_t))}}};
                 }
             } else if (semaphore.core_type() == CoreType::ETH) {
                 unicast_semaphore_cmds.push_back({.dst = semaphore.offset(), .size = sizeof(uint32_t)});

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1119,7 +1119,7 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
         for (const auto& kernel_group : this->get_kernel_groups(index)) {
             // TODO: add a bit in the hal that says if this core type is unicast/multicast
             if (core_type == CoreType::WORKER) {
-                std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info =
+                std::vector<multicast_transfer_info> dst_noc_multicast_info =
                     extract_dst_noc_multicast_info(device, kernel_group->core_ranges.ranges(), core_type);
                 std::vector<KernelHandle> kernel_ids;
                 for (int dispatch_class = 0; dispatch_class < kernel_group->kernel_ids.size(); dispatch_class++) {
@@ -1136,10 +1136,10 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
                     }
                 }
 
-                for (const auto &[cores, num_mcast_dsts] : dst_noc_multicast_info) {
+                for (const auto& transfer_info : dst_noc_multicast_info) {
                     for (const auto &kernel_id : kernel_ids) {
                         this->program_transfer_info.kernel_bins.emplace_back(
-                            cores, num_mcast_dsts, kernel_transfer_info.at(kernel_id));
+                            transfer_info.cores, transfer_info.num_dests, kernel_transfer_info.at(kernel_id));
                     }
                 }
             } else {

--- a/tt_metal/impl/program/program_device_map.cpp
+++ b/tt_metal/impl/program/program_device_map.cpp
@@ -7,16 +7,16 @@
 namespace tt::tt_metal {
 
 // Extracts all the pairs of noc multicast encodings given a set of core ranges
-std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(
+std::vector<multicast_transfer_info> extract_dst_noc_multicast_info(
     IDevice* device, const std::vector<CoreRange>& ranges, const CoreType core_type) {
-    std::vector<std::pair<transfer_info_cores, uint32_t>> dst_noc_multicast_info;
+    std::vector<multicast_transfer_info> dst_noc_multicast_info;
     dst_noc_multicast_info.reserve(ranges.size());
     for (const CoreRange& core_range : ranges) {
         CoreCoord virtual_start = device->virtual_core_from_logical_core(core_range.start_coord, core_type);
         CoreCoord virtual_end = device->virtual_core_from_logical_core(core_range.end_coord, core_type);
 
         uint32_t num_receivers = core_range.size();
-        dst_noc_multicast_info.push_back(std::make_pair(CoreRange(virtual_start, virtual_end), num_receivers));
+        dst_noc_multicast_info.push_back(multicast_transfer_info{CoreRange(virtual_start, virtual_end), num_receivers});
     }
     return dst_noc_multicast_info;
 }

--- a/tt_metal/impl/program/program_device_map.hpp
+++ b/tt_metal/impl/program/program_device_map.hpp
@@ -16,7 +16,12 @@ namespace tt::tt_metal {
 
 using transfer_info_cores = std::variant<CoreCoord, CoreRange>;
 
-std::vector<std::pair<transfer_info_cores, uint32_t>> extract_dst_noc_multicast_info(
+struct multicast_transfer_info {
+    transfer_info_cores cores;
+    uint32_t num_dests;
+};
+
+std::vector<multicast_transfer_info> extract_dst_noc_multicast_info(
     IDevice* device, const std::vector<CoreRange>& ranges, const CoreType core_type);
 struct transfer_info {
     std::uint32_t dst_base_addr;


### PR DESCRIPTION


### Problem description
The purpose of the uint32_t in the pair isn't clear.

### What's changed
Use a struct instead of a pair so both members can have names.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes