### PR TITLE
#21359: Add uint16 support for mul

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
@@ -19,13 +19,15 @@ inline void mul_uint16(const uint dst_offset) {
         TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_7, 0);
         // operand B - uint16
         TT_SFPLOAD(p_sfpu::LREG1, LO16, ADDR_MOD_7, dst_offset * dst_tile_size);
+
+        // The following cast+mul+cast method provides accurate results if the product of the inputs < 2**24
+        // since float32 can exactly represent integer up to 2**24. To preserve accuracy beyond 2**24,
+        // we could split the 16-bit input into two 8-bit chunks, cast to fp32, multiply and then cast back.
         // uint16 -> fp32
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
-
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_NOP;
-
         // fp32 -> uint16
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
         TTI_SFPSTORE(p_sfpu::LREG0, LO16, ADDR_MOD_7, 0);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void mul_uint16(const uint dst_offset) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+        // operand A - uint16
+        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_7, 0);
+        // operand B - uint16
+        TT_SFPLOAD(p_sfpu::LREG1, LO16, ADDR_MOD_7, dst_offset * dst_tile_size);
+        // uint16 -> fp32
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_NOP;
+
+        // fp32 -> uint16
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
+        TTI_SFPSTORE(p_sfpu::LREG0, LO16, ADDR_MOD_7, 0);
+
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_uint16.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_uint16.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_mul_uint16.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_uint16_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_uint16(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::mul_uint16<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -74,6 +74,7 @@ enum SfpuType {
     add1,
     sub_int32,
     sub_uint16,
+    mul_uint16,
     topk_local_sort,
     topk_merge,
     topk_rebuild,

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_addrmod.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_typecast.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void mul_uint16(const uint dst_offset) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+        // operand A - uint16
+        TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_3, 0);
+        // operand B - uint16
+        TT_SFPLOAD(p_sfpu::LREG1, LO16, ADDR_MOD_3, dst_offset * dst_tile_size);
+        // uint16 -> fp32
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_NOP;
+
+        // fp32 -> uint16
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
+        TTI_SFPSTORE(p_sfpu::LREG0, LO16, ADDR_MOD_3, 0);
+
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_mul_uint16.h
@@ -6,7 +6,6 @@
 
 #include "ckernel_addrmod.h"
 #include "sfpi.h"
-#include "ckernel_sfpu_typecast.h"
 
 namespace ckernel {
 namespace sfpu {
@@ -20,13 +19,15 @@ inline void mul_uint16(const uint dst_offset) {
         TTI_SFPLOAD(p_sfpu::LREG0, LO16, ADDR_MOD_3, 0);
         // operand B - uint16
         TT_SFPLOAD(p_sfpu::LREG1, LO16, ADDR_MOD_3, dst_offset * dst_tile_size);
+
+        // The following cast+mul+cast method provides accurate results if the product of the inputs < 2**24
+        // since float32 can exactly represent integer up to 2**24. To preserve accuracy beyond 2**24,
+        // we could split the 16-bit input into two 8-bit chunks, cast to fp32, multiply and then cast back.
         // uint16 -> fp32
         TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
         TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
-
         TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
         TTI_NOP;
-
         // fp32 -> uint16
         TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
         TTI_SFPSTORE(p_sfpu::LREG0, LO16, ADDR_MOD_3, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_uint16.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_mul_uint16.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_mul_uint16.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_uint16_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::unused, APPROXIMATE>();
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_mul_uint16(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        ckernel::sfpu::mul_uint16<APPROXIMATE>, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -75,6 +75,7 @@ enum SfpuType {
     add1,
     sub_int32,
     sub_uint16,
+    mul_uint16,
     topk_local_sort,
     topk_merge,
     topk_rebuild,

--- a/tt_metal/include/compute_kernel_api/mul_uint16_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/mul_uint16_sfpu.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_mul_uint16.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise mul operation with the two uint16 inputs: y = mul(x0,x1)
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ * A maximum of 4 tiles from each operand can be loaded into DST at once, for a total of 8 tiles,
+ * when using 16 bit formats. This gets reduced to 2 tiles from each operand for 32 bit formats.
+ *
+ * Return value: None
+ *
+ * | Argument              | Description                                                                 | Type     | Valid Range                                           | Required |
+ * |-----------------------|-----------------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0                 | The index of the tile in DST register buffer to use as first operand        | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1                 | The index of the tile in DST register buffer to use as second operand       | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+// clang-format on
+ALWI void mul_uint16_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_mul_uint16<APPROX>(idst0, idst1)));
+}
+
+/**
+ * Please refer to documentation for mul_uint16_tile_init.
+ */
+ALWI void mul_uint16_tile_init() { MATH((llk_math_eltwise_binary_sfpu_mul_uint16_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1782,7 +1782,7 @@ void py_module(py::module& module) {
         R"doc(Multiplies :attr:`input_tensor_a` by :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \mathrm{{input\_tensor\_a}}_i * \mathrm{{input\_tensor\_b}}_i)doc",
         R"doc(: :code:`'None'` | :code:`'relu'`. )doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc");
+        R"doc(BFLOAT16, BFLOAT8_B, UINT16 (range: 0 - 65535))doc");
 
     detail::bind_binary_inplace_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -212,8 +212,13 @@ std::map<std::string, std::string> get_defines_fp32(
             }
             break;
         case BinaryOpType::MUL:
-            new_defines.insert({"BINOP_INIT", fmt::format("mul_binary_tile_init();")});
-            op_name = "mul_binary_tile";
+            if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"MUL_UINT16_INIT", fmt::format("mul_uint16_tile_init();")});
+                op_name = "mul_uint16_tile";
+            } else {
+                new_defines.insert({"BINOP_INIT", fmt::format("mul_binary_tile_init();")});
+                op_name = "mul_binary_tile";
+            }
             break;
         case BinaryOpType::RSUB:
             new_defines.insert({"BINOP_INIT", fmt::format("rsub_binary_tile_init();")});

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -23,8 +23,10 @@ namespace utils {
             return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
                 || (a == DataType::UINT32 && b == DataType::UINT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::SUB:
-            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16));
+            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32)
+                || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::MUL:
+            return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::DIV:
         case BinaryOpType::RSUB:
         case BinaryOpType::LOGADDEXP:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -17,6 +17,7 @@
 #include "compute_kernel_api/add_uint16_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
 #include "compute_kernel_api/sub_uint16_sfpu.h"
+#include "compute_kernel_api/mul_uint16_sfpu.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"
 #include "compute_kernel_api/lcm.h"
@@ -131,6 +132,9 @@ void MAIN {
 #endif
 #ifdef SUB_UINT16_INIT
             SUB_UINT16_INIT
+#endif
+#ifdef MUL_UINT16_INIT
+            MUL_UINT16_INIT
 #endif
 #ifdef BITWISE_INIT
             BITWISE_INIT

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -18,7 +18,7 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
                 (a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT32 && b == UINT32) ||
                 (a == UINT16 && b == UINT16));
         case SUB: return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32) || (a == UINT16 && b == UINT16));
-        case MUL:
+        case MUL: return ((a == FLOAT32 && b == FLOAT32) || (a == UINT16 && b == UINT16));
         case DIV:
         case RSUB:
         case LOGADDEXP:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -322,7 +322,12 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             } else {
                 return {"sub_binary_tile_init();", "sub_binary_tile"};
             }
-        case MUL: return {"mul_binary_tile_init();", "mul_binary_tile"};
+        case MUL:
+            if (dtype == DataType::UINT16) {
+                return {"mul_uint16_tile_init();", "mul_uint16_tile"};
+            } else {
+                return {"mul_binary_tile_init();", "mul_binary_tile"};
+            }
         case DIV: return {"div_binary_tile_init();", "div_binary_tile"};
         case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
         case RSUB: return {"rsub_binary_tile_init();", "rsub_binary_tile"};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -15,6 +15,7 @@
 #include "compute_kernel_api/add_uint16_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
 #include "compute_kernel_api/sub_uint16_sfpu.h"
+#include "compute_kernel_api/mul_uint16_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -15,6 +15,7 @@
 #include "compute_kernel_api/add_uint16_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
 #include "compute_kernel_api/sub_uint16_sfpu.h"
+#include "compute_kernel_api/mul_uint16_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
 #include "compute_kernel_api/gcd.h"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -15,6 +15,7 @@
 #include "compute_kernel_api/add_uint16_sfpu.h"
 #include "compute_kernel_api/sub_int32_sfpu.h"
 #include "compute_kernel_api/sub_uint16_sfpu.h"
+#include "compute_kernel_api/mul_uint16_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 
 #include "eltwise_utils_common.hpp"


### PR DESCRIPTION
### Ticket
#21359 

### Problem description
Provide uint16 support for ttnn.mul with LLK implementation

### What's changed
- Added WH_B0 and BH LLK implementations for ttnn.mul to support uint16 datatype.
- Added support in binary and binary_ng infra.

### BH Results
<img width="1556" alt="Screenshot 2025-05-13 at 09 17 00" src="https://github.com/user-attachments/assets/37f38d79-cf7b-4351-8ccd-64ffa282cd18" />

### Checklist
- [x] BH Testing
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15065375791)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15051960845)
- [x] New/Existing tests provide coverage for changes