### PR TITLE
#21532: Split devices in BH post commit models tests by P100 and P150

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -131,9 +131,16 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/models-post-commit.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { runner-label: P100 },
+          { runner-label: P150 },
+        ]
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.test-group.runner-label }}
       timeout: 20
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21532

### Problem description
@esmalTT added shallow Unet model that runs on p100a but is skipped on p150
For full coverage we need to make sure to run models tests on both p100 and p150 separately.

### What's changed
Add matrix by card type p100, p150

### Checklist
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14798589477