### PR TITLE
#21564: replace TT_ASSERT in fused, reduce, and matmul

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -901,8 +901,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0(
             const std::vector<tt::tt_metal::Tensor>& input_tensors,
             const std::vector<std::optional<const tt::tt_metal::Tensor>>& optional_input_tensors,
             const std::vector<tt::tt_metal::Tensor>& output_tensors) {
-            TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-            TT_ASSERT(output_tensors.size() == 1);
+            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+            TT_FATAL(output_tensors.size() == 1);
 
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
@@ -1644,8 +1644,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in1(
             const std::vector<tt::tt_metal::Tensor>& input_tensors,
             const std::vector<std::optional<const tt::tt_metal::Tensor>>& optional_input_tensors,
             const std::vector<tt::tt_metal::Tensor>& output_tensors) {
-            TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-            TT_ASSERT(output_tensors.size() == 1);
+            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+            TT_FATAL(output_tensors.size() == 1);
 
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();
@@ -2177,8 +2177,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
             const std::vector<tt::tt_metal::Tensor>& input_tensors,
             const std::vector<std::optional<const tt::tt_metal::Tensor>>& optional_input_tensors,
             const std::vector<tt::tt_metal::Tensor>& output_tensors) {
-            TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-            TT_ASSERT(output_tensors.size() == 1);
+            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+            TT_FATAL(output_tensors.size() == 1);
 
             auto& global_cb = static_cast<const ttnn::operations::matmul::Matmul*>(operation)->global_cb;
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_2d_program_factory.cpp
@@ -1248,8 +1248,8 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_mcast_in0_in1(
             const std::vector<tt::tt_metal::Tensor>& input_tensors,
             const std::vector<std::optional<const tt::tt_metal::Tensor>>& optional_input_tensors,
             const std::vector<tt::tt_metal::Tensor>& output_tensors) {
-            TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-            TT_ASSERT(output_tensors.size() == 1);
+            TT_FATAL(input_tensors.size() + optional_input_tensors.size() == 3);
+            TT_FATAL(output_tensors.size() == 1);
 
             auto src_buffer_a = input_tensors.at(0).buffer();
             auto src_buffer_b = input_tensors.at(1).buffer();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_dram_sharded_program_factory.cpp
@@ -295,7 +295,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
     uint32_t num_blocks_per_shard = num_blocks / all_storage_cores_vec.size();
     log_debug("num_blocks_per_shard: {}", num_blocks_per_shard);
     if (per_core_M > 1) {
-        TT_ASSERT(
+        TT_FATAL(
             num_blocks_per_shard == 1,
             "currently not support per_core_M larger than 1, while split one shard into multiple blocks");
     }
@@ -842,7 +842,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_dram_sharded(
         writer_kernel_ids.push_back(mm_kernel_in1_sender_writer_id);
     }
 
-    TT_ASSERT(
+    TT_FATAL(
         total_tensor_width_written_back <= expected_max_total_width,
         "more datums written back to sharded tensor, L1 corruption, expected: {}, actual: {}",
         expected_max_total_width,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/multi_core/groupnorm_op_multi_core.cpp
@@ -135,10 +135,10 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     bool inplace) {
     using namespace CMAKE_UNIQUE_NAMESPACE;
     if (gamma.has_value()) {
-        TT_ASSERT(gamma.value().get_layout() == Layout::ROW_MAJOR);
+        TT_FATAL(gamma.value().get_layout() == Layout::ROW_MAJOR);
     }
     if (beta.has_value()) {
-        TT_ASSERT(beta.value().get_layout() == Layout::ROW_MAJOR);
+        TT_FATAL(beta.value().get_layout() == Layout::ROW_MAJOR);
     }
 
     bool is_height_sharding = a.get_padded_shape()[3] == a.shard_spec().value().shape[1];
@@ -158,7 +158,7 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
                                : tt::DataFormat::Float16_b;
     uint32_t datum_size_bytes = 2;  // bfloat16
 
-    TT_ASSERT(out_data_format == in_data_format && "input and output must be the same data format");
+    TT_FATAL(out_data_format == in_data_format && "input and output must be the same data format");
 
     // tile sizes
     uint32_t in_single_tile_size = tt::tt_metal::detail::TileSize(in_data_format);
@@ -201,34 +201,34 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     uint32_t num_batches_per_core = num_batches > num_shards_r ? num_batches / num_shards_r : 1;
     uint32_t num_groups_per_core = num_groups > num_shards_c ? num_groups / num_shards_c : 1;
 
-    TT_ASSERT(per_core_N % num_datum_row_per_group == 0);
-    TT_ASSERT(per_core_M % TILE_HEIGHT == 0);
+    TT_FATAL(per_core_N % num_datum_row_per_group == 0);
+    TT_FATAL(per_core_M % TILE_HEIGHT == 0);
     if (per_core_N != W) {
         if (shard_orientation == ShardOrientation::COL_MAJOR) {
-            TT_ASSERT(per_core_N * num_cores_r == W);
-            TT_ASSERT(per_core_M * num_cores_c == H);
+            TT_FATAL(per_core_N * num_cores_r == W);
+            TT_FATAL(per_core_M * num_cores_c == H);
         } else {
-            TT_ASSERT(per_core_N * num_cores_c == W);
-            TT_ASSERT(per_core_M * num_cores_r == H);
+            TT_FATAL(per_core_N * num_cores_c == W);
+            TT_FATAL(per_core_M * num_cores_r == H);
         }
     }
 
-    TT_ASSERT(per_core_M % TILE_HEIGHT == 0 && "per_core_M must be divisble by TILE_HEIGHT");
+    TT_FATAL(per_core_M % TILE_HEIGHT == 0 && "per_core_M must be divisble by TILE_HEIGHT");
 
-    TT_ASSERT(W % num_groups == 0 && "Tensor W must be divisble by num_groups");
-    TT_ASSERT(H % per_core_M == 0 && "H dim must be divisible by per_core_M");
-    TT_ASSERT(W % per_core_N == 0 && "W dim must be divisible by per_core_N");
+    TT_FATAL(W % num_groups == 0 && "Tensor W must be divisble by num_groups");
+    TT_FATAL(H % per_core_M == 0 && "H dim must be divisible by per_core_M");
+    TT_FATAL(W % per_core_N == 0 && "W dim must be divisible by per_core_N");
     if (num_batches >= num_shards_r) {
-        TT_ASSERT(
+        TT_FATAL(
             num_batches % num_shards_r == 0 && "num_batches must be divisible by number of cores in a full column");
     } else {
-        TT_ASSERT(
+        TT_FATAL(
             num_shards_r % num_batches == 0 && "number of cores in a full column must be divisible by num_batches");
     }
     if (num_groups >= num_shards_c) {
-        TT_ASSERT(num_groups % num_shards_c == 0 && "num_groups must be divisible by number of cores in a full row");
+        TT_FATAL(num_groups % num_shards_c == 0 && "num_groups must be divisible by number of cores in a full row");
     } else {
-        TT_ASSERT(num_shards_c % num_groups == 0 && "number of cores in a full row must be divisible by num_groups");
+        TT_FATAL(num_shards_c % num_groups == 0 && "number of cores in a full row must be divisible by num_groups");
     }
 
     // subblock
@@ -261,38 +261,38 @@ operation::ProgramWithCallbacks groupnorm_multi_core_sharded(
     log_debug(tt::LogOp, "num_subblocks_w: {}", num_subblocks_w);
     log_debug(tt::LogOp, "reader_repack_output: {}", reader_repack_output);
 
-    TT_ASSERT(per_core_M % num_batches_per_core == 0 && "shard height must be div by per_core_batch");
-    TT_ASSERT(W % num_groups == 0 && "tensor width must be divisible by num_groups!");
+    TT_FATAL(per_core_M % num_batches_per_core == 0 && "shard height must be div by per_core_batch");
+    TT_FATAL(W % num_groups == 0 && "tensor width must be divisible by num_groups!");
     if (shard_orientation == ShardOrientation::ROW_MAJOR and num_groups_per_core == 1) {
-        TT_ASSERT(
+        TT_FATAL(
             num_cores_c % num_groups == 0 &&
             "for RM shard, when each group is split across cores, num_cores_c must be divisible by num_groups!");
     } else if (shard_orientation == ShardOrientation::COL_MAJOR and num_groups_per_core == 1) {
-        TT_ASSERT(
+        TT_FATAL(
             num_cores_r % num_groups == 0 &&
             "for CM shard, when each group is split across cores, num_cores_r must be divisible by num_groups!");
     }
 
     if (per_core_N != W) {  // block sharded
         if (shard_orientation == ShardOrientation::ROW_MAJOR and num_batches_per_core == 1) {
-            TT_ASSERT(
+            TT_FATAL(
                 num_cores_r % num_batches == 0 &&
                 "for RM shard, when each batch is split across cores, num_cores_r must be divisible by num_batches!");
         } else if (shard_orientation == ShardOrientation::COL_MAJOR and num_groups_per_core == 1) {
-            TT_ASSERT(
+            TT_FATAL(
                 num_cores_c % num_batches == 0 &&
                 "for CM shard, when each batch is split across cores, num_cores_c must be divisible by num_batches!");
         }
     } else {  // height sharded
         if (num_batches_per_core == 1) {
-            TT_ASSERT(
+            TT_FATAL(
                 (num_cores_c * num_cores_r) % num_batches == 0 &&
                 "for height shard, number of cores must be divisible by num_batches!");
         }
     }
 
     if (input_mask.has_value()) {
-        TT_ASSERT(
+        TT_FATAL(
             input_mask.value().get_padded_shape()[3] == block_wt * TILE_WIDTH &&
             "input mask must have the same width as block_wt");
     }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/multi_core/layernorm_op_multi_core.cpp
@@ -29,7 +29,7 @@ inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DR
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;
-    TT_ASSERT(sizeof float_num == sizeof uint32_data);
+    TT_FATAL(sizeof float_num == sizeof uint32_data);
 
     uint32_data = *reinterpret_cast<uint32_t*>(&float_num);
     // just move upper 16 to lower 16 (truncate)
@@ -238,33 +238,33 @@ operation::ProgramWithCallbacks layernorm_multi_core(
         }
     }
 
-    TT_ASSERT(
+    TT_FATAL(
         in0_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         in1_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         out0_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         im0_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         im3_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         in5_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         in6_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         im6_t % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(Wt % block_size == 0);
-    TT_ASSERT(num_gamma_tiles % block_size == 0);
-    TT_ASSERT(num_beta_tiles % block_size == 0);
+    TT_FATAL(Wt % block_size == 0);
+    TT_FATAL(num_gamma_tiles % block_size == 0);
+    TT_FATAL(num_beta_tiles % block_size == 0);
 
     uint32_t num_tile_rows = NC * Ht;
     auto grid_size = device->compute_with_storage_grid_size();
@@ -470,7 +470,7 @@ operation::ProgramWithCallbacks layernorm_multi_core(
         } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
+            TT_THROW("Core not in specified core ranges");
         }
 
         uint32_t tile_offset = curr_row * Wt;
@@ -1761,14 +1761,14 @@ operation::ProgramWithCallbacks layernorm_multi_core_sharded(
                     current_storage_core += 1;        // Move to next storage core
                     current_storage_core_offset = 0;  // Reset offset on new storage core
 
-                    TT_ASSERT(
+                    TT_FATAL(
                         current_storage_core <= num_storage_cores,
                         "current_storage_core {} is exceeding number of storage cores {}",
                         current_storage_core,
                         num_storage_cores);
                 }
             }
-            TT_ASSERT(
+            TT_FATAL(
                 worker_core_current_offset == block_wt,
                 "All worker core data should be written, but worker_core_current_offset {} != block_wt {}",
                 worker_core_current_offset,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -31,7 +31,7 @@ inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DR
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;
-    TT_ASSERT(sizeof float_num == sizeof uint32_data);
+    TT_FATAL(sizeof float_num == sizeof uint32_data);
 
     uint32_data = *reinterpret_cast<uint32_t*>(&float_num);
     // just move upper 16 to lower 16 (truncate)
@@ -201,28 +201,28 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
     const uint32_t intermed7_tiles = Wt;
     const uint32_t out0_tiles = Wt;
 
-    TT_ASSERT(
+    TT_FATAL(
         W <= TILE_WIDTH * in0_tiles &&
         "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
-    TT_ASSERT(
+    TT_FATAL(
         in0_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         in2_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         in3_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         out0_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         intermed5_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         intermed6_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         intermed7_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
 
@@ -437,7 +437,7 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
         } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
+            TT_THROW("Core not in specified core ranges");
         }
 
         uint32_t tile_offset = curr_row * Wt;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -28,7 +28,7 @@ inline bool is_dram(const Buffer* b) { return b->buffer_type() == BufferType::DR
 
 inline uint16_t bfloat16(float float_num) {
     uint32_t uint32_data;
-    TT_ASSERT(sizeof float_num == sizeof uint32_data);
+    TT_FATAL(sizeof float_num == sizeof uint32_data);
 
     uint32_data = *reinterpret_cast<uint32_t*>(&float_num);
     // just move upper 16 to lower 16 (truncate)
@@ -131,13 +131,13 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
         out0_tiles = 2;
     }
 
-    TT_ASSERT(
+    TT_FATAL(
         W <= TILE_WIDTH * in0_tiles &&
         "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
-    TT_ASSERT(
+    TT_FATAL(
         in0_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         intermed0_tiles % block_size == 0 &&
         "Size of buffer must be divisible by the size of block used by the reader and compute kernel.");
 
@@ -255,7 +255,7 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
         } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
+            TT_THROW("Core not in specified core ranges");
         }
 
         uint32_t in_tile_offset = curr_row * Wt;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/multi_core/softmax_op_multi_core.cpp
@@ -124,23 +124,23 @@ tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
 
     // cb_exps - keeps exps in tt::CBIndex in L1 to avoid recomputing
     uint32_t im0_t = block_size * tt::div_up(Wt, block_size);
-    TT_ASSERT(im0_t == Wt);
+    TT_FATAL(im0_t == Wt);
 
     // used for buffering scale-mask
     // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
     uint32_t im3_t = block_size * (tt::div_up(Wt, block_size) + 1);
-    TT_ASSERT(im3_t == Wt + block_size);
+    TT_FATAL(im3_t == Wt + block_size);
 
-    TT_ASSERT(Wt % block_size == 0);
-    TT_ASSERT((block_size != -1) && "Wt must be divisible by one of the numbers in the range from 8 to 1.");
-    TT_ASSERT(
+    TT_FATAL(Wt % block_size == 0);
+    TT_FATAL((block_size != -1) && "Wt must be divisible by one of the numbers in the range from 8 to 1.");
+    TT_FATAL(
         im0_t % block_size == 0 &&
         "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(
+    TT_FATAL(
         out0_t % block_size == 0 &&
         "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
-    TT_ASSERT(in4_t % block_size == 0);
-    TT_ASSERT(
+    TT_FATAL(in4_t % block_size == 0);
+    TT_FATAL(
         W <= TILE_WIDTH * im0_t &&
         "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
 
@@ -295,7 +295,7 @@ tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
         } else if (core_group_2.contains(core)) {
             num_tile_rows_per_core = num_tile_rows_per_core_group_2;
         } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
+            TT_THROW("Core not in specified core ranges");
         }
 
         uint32_t tile_offset = curr_row * Wt;
@@ -422,23 +422,23 @@ tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
 
             // cb_exps - keeps exps in tt::CBIndex in L1 to avoid recomputing
             uint32_t im0_t = block_size * tt::div_up(Wt, block_size);
-            TT_ASSERT(im0_t == Wt);
+            TT_FATAL(im0_t == Wt);
 
             // used for buffering scale-mask
             // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
             uint32_t im3_t = block_size * (tt::div_up(Wt, block_size) + 1);
-            TT_ASSERT(im3_t == Wt + block_size);
+            TT_FATAL(im3_t == Wt + block_size);
 
-            TT_ASSERT(Wt % block_size == 0);
-            TT_ASSERT((block_size != -1) && "Wt must be divisible by one of the numbers in the range from 8 to 1.");
-            TT_ASSERT(
+            TT_FATAL(Wt % block_size == 0);
+            TT_FATAL((block_size != -1) && "Wt must be divisible by one of the numbers in the range from 8 to 1.");
+            TT_FATAL(
                 im0_t % block_size == 0 &&
                 "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
-            TT_ASSERT(
+            TT_FATAL(
                 out0_t % block_size == 0 &&
                 "Size of cb must be divisible by the size of block used by the reader and compute kernel.");
-            TT_ASSERT(in4_t % block_size == 0);
-            TT_ASSERT(
+            TT_FATAL(in4_t % block_size == 0);
+            TT_FATAL(
                 W <= TILE_WIDTH * im0_t &&
                 "W exceeds the maximum supported size of tile buffer (kernel limitation right now).");
 
@@ -500,7 +500,7 @@ tt::tt_metal::operation::ProgramWithCallbacks scale_mask_softmax_multi_core(
                 } else if (core_group_2.contains(core)) {
                     num_tile_rows_per_core = num_tile_rows_per_core_group_2;
                 } else {
-                    TT_ASSERT(false, "Core not in specified core ranges");
+                    TT_THROW("Core not in specified core ranges");
                 }
 
                 uint32_t tile_offset = curr_row * Wt;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_h/reduce_op_multi_core_h.cpp
@@ -228,7 +228,7 @@ operation::ProgramWithCallbacks reduce_multi_core_h(
             } else if (core_group_2.contains(core)) {
                 num_cols_per_core = num_cols_per_core_group_2;
             } else {
-                TT_ASSERT(false, "Core not in specified core ranges");
+                TT_THROW("Core not in specified core ranges");
             }
             tt_metal::SetRuntimeArgs(
                 program,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/multi_core_w/reduce_op_multi_core_w.cpp
@@ -140,7 +140,7 @@ operation::ProgramWithCallbacks reduce_multi_core_w(
         } else if (core_group_2.contains(core)) {
             num_rows_per_core = num_rows_per_core_group_2;
         } else {
-            TT_ASSERT(false, "Core not in specified core ranges");
+            TT_THROW("Core not in specified core ranges");
         }
         uint32_t num_tensor_tiles_per_core = num_rows_per_core * Wt;
         tt_metal::SetRuntimeArgs(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -23,7 +23,7 @@ std::map<string, string> get_defines(tt::tt_metal::ReduceOpMath reduce_op, tt::t
         case tt::tt_metal::ReduceOpDim::W: reduce_dim_str = "ReduceDim::REDUCE_ROW"; break;
         case tt::tt_metal::ReduceOpDim::H: reduce_dim_str = "ReduceDim::REDUCE_COL"; break;
         case tt::tt_metal::ReduceOpDim::HW: reduce_dim_str = "ReduceDim::REDUCE_SCALAR"; break;
-        default: TT_ASSERT(false && "Invalid reduce_op!");
+        default: TT_THROW("Invalid reduce_op!");
     }
     defines["REDUCE_OP"] = (do_max ? "PoolType::MAX" : "PoolType::SUM");
     defines["REDUCE_DIM"] = reduce_dim_str;
@@ -206,7 +206,7 @@ Tensor reduce(
                 // Get the device
                 if (input_tensor.storage_type() != StorageType::DEVICE) {
                     device = ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice();
-                    TT_ASSERT(device != nullptr, "Requires setting default device if no inputs to op are on device");
+                    TT_FATAL(device != nullptr, "Requires setting default device if no inputs to op are on device");
                 } else {
                     device = input_tensor.device();
                 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/single_core_hw/reduce_op_single_core_hw.cpp
@@ -53,7 +53,7 @@ operation::ProgramWithCallbacks reduce_single_core_hw(
     tt_metal::IDevice* device = a.device();
 
     tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 2;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -68,7 +68,7 @@ ttnn::Shape compute_output_shape(const ttnn::Shape& input_shape, const int64_t& 
 
 inline Tensor create_output_tensor(
     const Tensor& input_tensor, const ttnn::Shape& output_shape, const MemoryConfig& mem_config) {
-    TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE);
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE);
     return create_device_tensor(
         output_shape, input_tensor.get_dtype(), Layout::TILE, input_tensor.device(), mem_config);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -17,7 +17,7 @@ namespace primary {
 
 tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
     const tt::tt_metal::Tensor& input, const tt::tt_metal::Tensor& output, int64_t dim) {
-    TT_ASSERT(dim == 0 || dim == 1);
+    TT_FATAL(dim == 0 || dim == 1);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Device Setup
@@ -168,10 +168,10 @@ tt::tt_metal::operation::ProgramWithCallbacks prod_nc_format(
         if (core_group_1.contains(core)) {
             SetRuntimeArgs(program, compute_kernel_1_id, core, {num_reduce_input_tile, num_tiles_per_core});
         } else if (core_group_2.contains(core)) {
-            TT_ASSERT(compute_kernel_2_id.has_value());
+            TT_FATAL(compute_kernel_2_id.has_value());
             SetRuntimeArgs(program, compute_kernel_2_id.value(), core, {num_reduce_input_tile, num_tiles_per_core});
         } else {
-            TT_ASSERT(false, "Core not in specified core ranges.");
+            TT_THROW("Core not in specified core ranges.");
         }
         tile_offset += num_tiles_per_core;
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue #21564 

### Problem description
- TT_ASSERTs are only for Debug builds, potentially masking problems in Release builds

### What's changed
- change them to TT_THROW/TT_FATAL

Note: This was done via sed. Updating the error messages will be done as part of a separate issue / PR

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes