### PR TITLE
Remove FPU util from performance model tests

### DIFF
--- a/tests/ttnn/tracy/test_perf_op_report.py
+++ b/tests/ttnn/tracy/test_perf_op_report.py
@@ -72,6 +72,5 @@ class TestSingleOp:
             "PM BANDWIDTH [ns]": 7,
             "PM REQ I BW": "[292.5714416503906; 292.5714416503906]",
             "PM REQ O BW": "[292.5714416503906]",
-            "PM FPU UTIL (%)": 0.1,
         }
         verify_columns(received_columns, expected_columns, verify_equal)

--- a/tt_metal/tools/profiler/process_ops_logs.py
+++ b/tt_metal/tools/profiler/process_ops_logs.py
@@ -864,7 +864,7 @@ def generate_reports(ops, deviceOps, traceOps, signposts, logFolder, outputFolde
                                 * float(rowDict["PM COMPUTE [ns]"])
                                 / float(rowDict["DEVICE KERNEL DURATION [ns]"])
                             )
-                            rowDict["PM FPU UTIL (%)"] = round(fpu_util, 1)
+                            rowDict["PM FPU UTIL (%)"] = round(fpu_util, 3)
                         except ZeroDivisionError:
                             rowDict["PM FPU UTIL (%)"] = 0.0
 


### PR DESCRIPTION
### Ticket
#21542 

### Problem description
FPU % utilization is not a purely performance model number and depends on kernel duration measurements. It therefore fluctuates and cannot be tested again an exact number.
 
### What's changed
Remove the test on FPU % as it is not really a perf model value

### Checklist
- [x] [All post commit profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14799633891)
- [x] [T3K Profiler](https://github.com/tenstorrent/tt-metal/actions/runs/14799625017)