### PR TITLE
#21500: Supply offset in `MeshDeviceView::get_line_coordinates`

### DIFF
--- a/tests/tt_metal/distributed/CMakeLists.txt
+++ b/tests/tt_metal/distributed/CMakeLists.txt
@@ -4,6 +4,7 @@ set(UNIT_TESTS_DISTRIBUTED_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_coord.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_device_reshape.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_device_view.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_workload.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_sub_device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test_mesh_allocator.cpp

--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/base.h>
+#include <gmock/gmock.h>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/shape2d.hpp>
+#include <tt-metalium/mesh_device_view.hpp>
+
+namespace tt::tt_metal::distributed {
+namespace {
+
+using ::testing::IsEmpty;
+using ::testing::SizeIs;
+
+TEST(MeshDeviceViewTest, GetRingCoordinatesRingShapeEmpty) {
+    EXPECT_ANY_THROW(
+        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(1, 0), /*mesh_shape*/ Shape2D(2, 4)));
+    EXPECT_ANY_THROW(
+        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(0, 1), /*mesh_shape*/ Shape2D(2, 4)));
+}
+
+TEST(MeshDeviceViewTest, GetRingCoordinatesRingShapeTooBig) {
+    EXPECT_ANY_THROW(
+        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(2, 4), /*mesh_shape*/ Shape2D(2, 2)));
+    EXPECT_ANY_THROW(
+        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(4, 2), /*mesh_shape*/ Shape2D(2, 2)));
+}
+
+TEST(MeshDeviceViewTest, GetRingCoordinates) {
+    auto ring_coords = MeshDeviceView::get_ring_coordinates(Shape2D(2, 2), Shape2D(2, 2));
+    ASSERT_THAT(ring_coords, SizeIs(4));
+    EXPECT_EQ(ring_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(ring_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(ring_coords[2], MeshCoordinate(1, 1));
+    EXPECT_EQ(ring_coords[3], MeshCoordinate(1, 0));
+}
+
+TEST(MeshDeviceViewTest, GetRingCoordinatesDonut) {
+    auto ring_coords = MeshDeviceView::get_ring_coordinates(Shape2D(3, 3), Shape2D(4, 4));
+    ASSERT_THAT(ring_coords, SizeIs(8));
+    EXPECT_EQ(ring_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(ring_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(ring_coords[2], MeshCoordinate(0, 2));
+    EXPECT_EQ(ring_coords[3], MeshCoordinate(1, 2));
+    EXPECT_EQ(ring_coords[4], MeshCoordinate(2, 2));
+    EXPECT_EQ(ring_coords[5], MeshCoordinate(2, 1));
+    EXPECT_EQ(ring_coords[6], MeshCoordinate(2, 0));
+    EXPECT_EQ(ring_coords[7], MeshCoordinate(1, 0));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinatesLineTooBig) {
+    EXPECT_ANY_THROW((void)MeshDeviceView::get_line_coordinates(
+        /*length*/ 10, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0)));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinatesWithShorterLine) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 3, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
+    ASSERT_THAT(line_coords, SizeIs(3));
+    EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(line_coords[2], MeshCoordinate(1, 1));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates2x2) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 4, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
+    ASSERT_THAT(line_coords, SizeIs(4));
+    EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(line_coords[2], MeshCoordinate(1, 1));
+    EXPECT_EQ(line_coords[3], MeshCoordinate(1, 0));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates2x2WithOffset) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 2, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(1, 0));
+    ASSERT_THAT(line_coords, SizeIs(2));
+    EXPECT_EQ(line_coords[0], MeshCoordinate(1, 0));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(1, 1));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates3x3) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 9, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(0, 0));
+    ASSERT_THAT(line_coords, SizeIs(9));
+    EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
+    EXPECT_EQ(line_coords[2], MeshCoordinate(0, 2));
+    EXPECT_EQ(line_coords[3], MeshCoordinate(1, 2));
+    EXPECT_EQ(line_coords[4], MeshCoordinate(1, 1));
+    EXPECT_EQ(line_coords[5], MeshCoordinate(1, 0));
+    EXPECT_EQ(line_coords[6], MeshCoordinate(2, 0));
+    EXPECT_EQ(line_coords[7], MeshCoordinate(2, 1));
+    EXPECT_EQ(line_coords[8], MeshCoordinate(2, 2));
+}
+
+TEST(MeshDeviceViewTest, GetLineCoordinates3x3WithOffset) {
+    auto line_coords =
+        MeshDeviceView::get_line_coordinates(/*length*/ 5, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(1, 1));
+    ASSERT_THAT(line_coords, SizeIs(5));
+    EXPECT_EQ(line_coords[0], MeshCoordinate(1, 1));
+    EXPECT_EQ(line_coords[1], MeshCoordinate(1, 2));
+    EXPECT_EQ(line_coords[2], MeshCoordinate(2, 2));
+    EXPECT_EQ(line_coords[3], MeshCoordinate(2, 1));
+    EXPECT_EQ(line_coords[4], MeshCoordinate(2, 0));
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -96,7 +96,8 @@ public:
     //
     // Important: these utilities currently only support 2D meshes.
     // TODO: #17477 - Remove the methods that assume 2D mesh.
-    [[nodiscard]] static std::vector<MeshCoordinate> get_line_coordinates(size_t length, const Shape2D& mesh_shape);
+    [[nodiscard]] static std::vector<MeshCoordinate> get_line_coordinates(
+        size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset);
     [[nodiscard]] static std::vector<MeshCoordinate> get_ring_coordinates(
         const Shape2D& ring_shape, const Shape2D& mesh_shape);
     [[nodiscard]] std::vector<IDevice*> get_ring_devices() const;

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -142,13 +142,13 @@ chip_id_t MeshDeviceView::find_device_id(const MeshCoordinate& coord) const {
 
 bool MeshDeviceView::is_mesh_2d() const { return shape_2d_.has_value(); }
 
-std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(size_t length, const Shape2D& mesh_shape) {
-    // Iterate in a zigzag pattern from top-left to bottom-right.
+std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(
+    size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset) {
+    // Iterate in a zigzag pattern from top-left to bottom-right, starting at the offset.
     std::vector<MeshCoordinate> line_coords;
     line_coords.reserve(length);
     const auto [num_rows, num_cols] = mesh_shape;
-    int row_index = 0;
-    int col_index = 0;
+    auto [row_index, col_index] = mesh_offset;
     bool left_to_right = true;
 
     for (size_t i = 0; i < length && row_index < num_rows && col_index < num_cols; ++i) {
@@ -207,7 +207,8 @@ std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& 
 
 std::vector<IDevice*> MeshDeviceView::get_line_devices() const {
     TT_FATAL(shape_2d_.has_value(), "MeshDeviceView is not 2D!");
-    auto boundary_coords = get_line_coordinates(devices_.shape().mesh_size(), *shape_2d_);
+    auto boundary_coords =
+        get_line_coordinates(devices_.shape().mesh_size(), *shape_2d_, /*mesh_offset=*/Shape2D(0, 0));
     return get_devices_from_coordinates(*this, boundary_coords);
 }
 

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -170,14 +170,17 @@ std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(
 
 std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& ring_shape, const Shape2D& mesh_shape) {
     const auto [ring_rows, ring_cols] = ring_shape;
+    TT_FATAL(ring_rows > 0 && ring_cols > 0, "Ring shape must not be empty along either dimension. Got {}", ring_shape);
+    TT_FATAL(
+        ring_rows <= mesh_shape.height() && ring_cols <= mesh_shape.width(),
+        "Subgrid {} is out of mesh bounds {}",
+        ring_shape,
+        mesh_shape);
+
     const auto end_row = ring_rows - 1;
     const auto end_col = ring_cols - 1;
 
-    // Validate the specified subgrid
     std::vector<MeshCoordinate> boundary_coords;
-    if (ring_rows > mesh_shape.height() || ring_cols > mesh_shape.width()) {
-        TT_THROW("Subgrid is out of mesh bounds.");
-    }
 
     // Traverse the top row from left to right
     for (size_t col = 0; col <= end_col; ++col) {

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -102,10 +102,12 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(
             "The specifed offset {} is out of bounds for the system mesh shape {}",
             system_offset,
             system_shape);
-        Shape2D shape_2d(system_shape[0] - system_offset[0], system_shape[1] - system_offset[1]);
+        Shape2D system_mesh_2d(system_shape[0], system_shape[1]);
+        Shape2D system_offset_2d(system_offset[0], system_offset[1]);
 
         auto line_length = shape.mesh_size();
-        for (const auto& logical_coordinate : MeshDeviceView::get_line_coordinates(line_length, shape_2d)) {
+        for (const auto& logical_coordinate :
+             MeshDeviceView::get_line_coordinates(line_length, system_mesh_2d, system_offset_2d)) {
             auto physical_device_id = get_physical_device_id(logical_coordinate);
             physical_device_ids.push_back(physical_device_id);
 

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -95,13 +95,14 @@ std::vector<chip_id_t> SystemMesh::Impl::get_mapped_physical_device_ids(
     }();
 
     if (is_line_topology(shape)) {
-        TT_FATAL(
-            std::all_of(system_offset.coords().begin(), system_offset.coords().end(), [](int dim) { return dim == 0; }),
-            "Offsets are unsupported for a line mesh");
-
         // TODO: consider if we can do this in 3D.
         TT_FATAL(system_shape.dims() == 2, "Line topology is only supported for 2D meshes");
-        Shape2D shape_2d(system_shape[0], system_shape[1]);
+        TT_FATAL(
+            system_shape[0] > system_offset[0] && system_shape[1] > system_offset[1],
+            "The specifed offset {} is out of bounds for the system mesh shape {}",
+            system_offset,
+            system_shape);
+        Shape2D shape_2d(system_shape[0] - system_offset[0], system_shape[1] - system_offset[1]);
 
         auto line_length = shape.mesh_size();
         for (const auto& logical_coordinate : MeshDeviceView::get_line_coordinates(line_length, shape_2d)) {


### PR DESCRIPTION
### Ticket
#21500

### Problem description
Opening a "root" mesh device at an offset fails:
```
mesh_device = ttnn.open_mesh_device(
        mesh_shape=ttnn.MeshShape(1, 4),
        offset=ttnn.MeshCoordinate(1, 0),
)
```

Note the use cases specified in #21500 still fail (cannot have 2 "root" mesh devices), pending work at `DevicePool`.

### What's changed
Allow specifying the offset. Add tests.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14799706380)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14799710619)
- [X] New/Existing tests provide coverage for changes