### PR TITLE
#0: Remove functionality related to tracking worker threads

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -59,9 +59,6 @@ public:
     bool close_device(chip_id_t device_id);
     void close_devices(const std::vector<tt_metal::IDevice*>& devices, bool skip_synchronize = false);
     bool is_device_active(chip_id_t id) const;
-    void register_worker_thread_for_device(tt_metal::IDevice* device, std::thread::id worker_thread_id);
-    void unregister_worker_thread_for_device(tt_metal::IDevice* device);
-    const std::unordered_set<std::thread::id>& get_worker_thread_ids() const;
     void init_profiler() const;
     void initialize_fabric_and_dispatch_fw() const;
 
@@ -78,14 +75,8 @@ private:
     bool initialize_fabric_and_dispatch_fw_ = false;
 
     std::mutex lock;
-    // TODO replace std::vector<std::unique_ptr<IDevice>> with stl::SlotMap<v1::DeviceKey, Device> when removing v0
     std::vector<std::unique_ptr<tt_metal::IDevice>> devices;
-    // Used to track worker thread handles (1 worker thread created per device)
-    // when we need to check if a call is made from an application thread or a
-    // worker thread
-    std::unordered_map<tt_metal::IDevice*, std::thread::id> device_to_worker_thread_id;
-    std::unordered_set<std::thread::id> worker_thread_ids;
-    std::thread::id device_pool_creation_thread_id;
+
     bool skip_remote_devices;
     // Issue #19729: use_max_eth_core_count_on_all_devices_ is a workaround
     // to allow TT-Mesh Workload dispatch to target active ethernet cores.
@@ -97,8 +88,10 @@ private:
     std::unordered_map<uint32_t, uint32_t> completion_queue_reader_to_cpu_core_map;
     void init_firmware_on_active_devices() const;
     void activate_device(chip_id_t id);
+
     // Initialize state on the host for this device
     void initialize_host(tt_metal::IDevice* dev) const;
+
     // Initialize state for activated devices
     void initialize_active_devices() const;
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -39,9 +39,6 @@ namespace detail {
 
 bool DispatchStateCheck(bool isFastDispatch);
 
-bool InWorkerThread();
-inline bool InMainThread() { return not InWorkerThread(); }
-
 // Call before CreateDevices to enable fabric, which uses all free ethernet cores
 void InitializeFabricConfig(FabricConfig fabric_config);
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -239,10 +239,6 @@ void DevicePool::initialize(
     _inst->l1_bank_remap.assign(l1_bank_remap.begin(), l1_bank_remap.end());
     _inst->init_profiler_ = init_profiler;
     _inst->initialize_fabric_and_dispatch_fw_ = initialize_fabric_and_dispatch_fw;
-    // Track the thread where the Device Pool was created. Certain functions
-    // modifying the state of this instance, for example those responsible for
-    // (un)registering worker threads, can only be called in the creation thread
-    _inst->device_pool_creation_thread_id = std::this_thread::get_id();
 
     // Never skip for TG Cluster
     bool skip = not tt::tt_metal::MetalContext::instance().get_cluster().is_galaxy_cluster();
@@ -437,7 +433,6 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
             devices_to_activate.insert(device_id);
         }
     } else {
-        std::vector<chip_id_t> all_device_ids = {};
         for (const auto& device_id : device_ids) {
             // Get list of all devices in the cluster connected to the passed in device_ids
             const auto& mmio_device_id =
@@ -582,39 +577,6 @@ void DevicePool::wait_for_fabric_router_sync() const {
     }
 }
 
-void DevicePool::register_worker_thread_for_device(IDevice* device, std::thread::id worker_thread_id) {
-    TT_FATAL(
-        std::this_thread::get_id() == this->device_pool_creation_thread_id,
-        "Worker threads can only be registered in the thread where the Device(s) were created");
-    auto worker_thread_handle = this->device_to_worker_thread_id.find(device);
-    if (worker_thread_handle != this->device_to_worker_thread_id.end()) {
-        TT_FATAL(
-            worker_thread_handle->second == worker_thread_id,
-            "Cannot register more than one worker thread per device.");
-        ;
-    } else {
-        TT_FATAL(
-            this->worker_thread_ids.find(worker_thread_id) == this->worker_thread_ids.end(),
-            "Cannot register a single worker thread on multiple devices");
-    }
-
-    this->device_to_worker_thread_id.insert({device, worker_thread_id});
-    this->worker_thread_ids.insert(worker_thread_id);
-}
-
-void DevicePool::unregister_worker_thread_for_device(IDevice* device) {
-    TT_FATAL(
-        std::this_thread::get_id() == this->device_pool_creation_thread_id,
-        "Worker threads can only be unregistered in the thread where the Device(s) were created");
-    auto worker_thread_handle = this->device_to_worker_thread_id.find(device);
-    if (worker_thread_handle != this->device_to_worker_thread_id.end()) {
-        this->worker_thread_ids.erase(worker_thread_handle->second);
-        this->device_to_worker_thread_id.erase(device);
-    }
-}
-
-const std::unordered_set<std::thread::id>& DevicePool::get_worker_thread_ids() const { return this->worker_thread_ids; }
-
 void DevicePool::init_firmware_on_active_devices() const {
     const auto& active_devices = this->get_all_active_devices();
     for (const auto& dev : active_devices) {
@@ -716,7 +678,6 @@ bool DevicePool::close_device(chip_id_t device_id) {
         auto device = get_device(mmio_controlled_device_id);
         if (device && device->is_initialized()) {
             pass &= device->close();
-            this->unregister_worker_thread_for_device(device);
         }
     }
     return pass;
@@ -829,9 +790,6 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
         dev->close();
-        // When a device is closed, its worker thread is joined. Stop tracking this
-        // worker thread.
-        this->unregister_worker_thread_for_device(dev);
     }
 }
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -429,21 +429,6 @@ void CloseDevices(const std::map<chip_id_t, IDevice*>& devices) {
     tt::DevicePool::instance().close_devices(devices_to_close);
 }
 
-bool InWorkerThread() {
-    // These are values are cached per thread. in_worker_thread is a 1:1 function of the thread_id.
-    // Therefore it does not need to be recomputed or looked up using the worker_thread_ids each time.
-    // This is a performance optimization, since looking up the thread id inside worker_thread_ids for
-    // each function call significantly degrades runtime perf.
-    thread_local static bool in_worker_thread = false;
-    thread_local static bool is_thread_status_checked = false;
-    if (not is_thread_status_checked) {
-        auto worker_thread_ids = tt::DevicePool::instance().get_worker_thread_ids();
-        in_worker_thread = worker_thread_ids.find(std::this_thread::get_id()) != worker_thread_ids.end();
-        is_thread_status_checked = true;
-    }
-    return in_worker_thread;
-}
-
 void print_page(
     uint32_t dev_page_id,
     CoreCoord core,

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -786,8 +786,6 @@ Tensor allocate_tensor_on_devices(const TensorSpec& tensor_spec, const std::vect
 
 Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device) {
     // Allocate a mesh buffer synchronously.
-    TT_FATAL(
-        tt::tt_metal::detail::InMainThread(), "Allocation of a tensor on mesh must be called from the main thread");
     auto mesh_buffer = tensor_impl::allocate_mesh_buffer_on_device(mesh_device, tensor_spec);
     std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs;
     specs.reserve(mesh_device->shape().mesh_size());

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -547,7 +547,6 @@ Tensor to_host<bfloat8_b>(const Tensor& tensor, bool blocking, ttnn::QueueId cq_
 
 template <typename T>
 Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id) {
-    TT_FATAL(tt::tt_metal::detail::InMainThread(), "to_host_mesh_tensor must be called from the main thread");
     TT_ASSERT(tensor.is_allocated(), "Buffer must be allocated on device!");
     const auto& storage = std::get<DeviceStorage>(tensor.get_storage());
     const auto& mesh_buffer = storage.mesh_buffer;
@@ -818,7 +817,6 @@ Tensor to_device_mesh_tensor(
         return tensor;  // Tensor already on device
     }
 
-    TT_FATAL(tt::tt_metal::detail::InMainThread(), "to_device_mesh_tensor must be called from the main thread");
     TT_FATAL(mesh_device != nullptr, "Need target device in order to move tensor to device!");
     TT_FATAL(tensor.is_allocated(), "Need data to exist in order to move it to device");
 
@@ -846,7 +844,6 @@ template <typename T>
 void copy_to_mesh_tensor(const Tensor& host_tensor, Tensor& mesh_tensor, ttnn::QueueId cq_id) {
     TT_FATAL(host_tensor.storage_type() != StorageType::DEVICE, "Host tensor is on device.");
     TT_FATAL(mesh_tensor.storage_type() == StorageType::DEVICE, "Mesh tensor is not on device.");
-    TT_FATAL(tt::tt_metal::detail::InMainThread(), "copy_to_mesh_tensor must be called from the main thread");
     TT_FATAL(mesh_tensor.is_allocated(), "Need data to exist in order to move it to device");
 
     TT_FATAL(host_tensor.get_logical_shape() == mesh_tensor.get_logical_shape(), "Host tensor has different shape");


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Async runtime was removed, so the methods tracking worker threads are now obsolete.

### What's changed
Delete dead code.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14800161447)
- [x] New/Existing tests provide coverage for changes