### PR TITLE
Add sfpi-version as configure-significant

### DIFF
--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -22,6 +22,10 @@ while IFS= read -r FILE; do
         CMakeLists.txt|**/CMakeLists.txt|**/*.cmake)
             CMAKE_CHANGED=true
             ;;
+	tt_metal/sfpi-version.sh)
+	    # Read in by a cmake file
+            CMAKE_CHANGED=true
+            ;;
         .clang-tidy|**/.clang-tidy)
             CLANG_TIDY_CONFIG_CHANGED=true
             ;;

--- a/.github/workflows/build-docker-artifact.yaml
+++ b/.github/workflows/build-docker-artifact.yaml
@@ -79,11 +79,12 @@ jobs:
         run: |
           HASH=$(cat \
             .github/workflows/build-docker-artifact.yaml \
-            install_dependencies.sh \
             dockerfile/Dockerfile \
-            tt_metal/python_env/requirements-dev.txt \
             docs/requirements-docs.txt \
+            install_dependencies.sh \
             tests/sweep_framework/requirements-sweeps.txt \
+            tt_metal/python_env/requirements-dev.txt \
+            tt_metal/sfpi-version.sh \
             | sha1sum | cut -d' ' -f1)
           echo "ci-build-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_BUILD_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT
           echo "ci-test-tag=ghcr.io/${{ github.repository }}/tt-metalium/${{ env.CI_TEST_IMAGE_NAME }}:${HASH}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Ticket
NA

### Problem description
Subsequent to landing https://github.com/tenstorrent/tt-metal/pull/21528, updating sfpi failed because CI persisted in using the older toolchain for part of the testing.  Even though I had tested this exact scenario.

What's happening is that in PR21528 both `install_dependencies.sh` and a cmake file were changed, and that triggered docker rebuilding.  This time only sfpi-version.sh was changed, and so the docker image remained.

### What's changed
`tt_metal/sfpi-version.sh` needs
* Adding to the docker rebuild hash
* Treated as a logical cmake file (it is read into cmake during configure).

While there. I sorted the list of files to create the docker hash.

With this patch I was able to correctly test an sfpi update.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes