### PR TITLE
Honor FP32 acc value in ComputeConfig for blackhole as well

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_bmm.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from loguru import logger
 
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc, is_grayskull, skip_for_blackhole
+from models.utility_functions import comp_allclose_and_pcc, is_grayskull
 from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
     compute_kernel_options,
@@ -195,7 +195,6 @@ def run_moreh_bmm_backward(
         assert passing
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -213,7 +212,6 @@ def test_moreh_bmm_shape(shape, device):
     run_moreh_bmm(shape, True, False if is_grayskull() else True, device)
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize("optional_output", [False, True])
 def test_moreh_bmm_optional_output(optional_output, device):
     """
@@ -232,7 +230,6 @@ def test_moreh_bmm_compute_kernel_options(compute_kernel_options, device):
     run_moreh_bmm([10, 191, 447, 159], True, compute_kernel_options, device)
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_bmm_ttnn_dtype(ttnn_dtype, device):
     """
@@ -245,7 +242,6 @@ def test_moreh_bmm_ttnn_dtype(ttnn_dtype, device):
     run_moreh_bmm([10, 191, 447, 159], True, False if is_grayskull() else True, device, ttnn_dtype=ttnn_dtype)
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shape",
     [[10, 191, 447, 159]],
@@ -267,7 +263,6 @@ def test_moreh_bmm_callback(shape, device, use_program_cache):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shape",
     [
@@ -285,7 +280,6 @@ def test_moreh_bmm_backward_shape(shape, device):
     run_moreh_bmm_backward(shape, [True, True], False if is_grayskull() else True, device)
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "requires_grad",
     [
@@ -311,7 +305,6 @@ def test_moreh_bmm_backward_compute_kernel_options(compute_kernel_options, devic
     run_moreh_bmm_backward([7, 511, 313, 765], [True, True], compute_kernel_options, device)
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize("ttnn_dtype", [ttnn.bfloat8_b, ttnn.bfloat16])
 def test_moreh_bmm_backward_ttnn_dtype(ttnn_dtype, device):
     """
@@ -326,7 +319,6 @@ def test_moreh_bmm_backward_ttnn_dtype(ttnn_dtype, device):
     )
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "requires_grad",
     [

--- a/tests/ttnn/unit_tests/operations/test_moreh_linear.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_linear.py
@@ -5,7 +5,7 @@
 import pytest
 import torch
 import ttnn
-from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
+from models.utility_functions import comp_allclose_and_pcc
 from loguru import logger
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
@@ -392,7 +392,6 @@ def test_moreh_linear_backward_enable_cache(shapes, device, use_program_cache):
     assert num_program_cache_entries_list[0] == num_program_cache_entries_list[1]
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "shapes",
     (

--- a/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_matmul.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import ttnn
 import ttnn.operations
-from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
+from models.utility_functions import comp_allclose_and_pcc
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,
     compute_kernel_options,
@@ -320,7 +320,6 @@ def test_moreh_matmul_enable_cache(params, device, use_program_cache):
     assert device.num_program_cache_entries() == 2
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "params",
     (
@@ -417,7 +416,6 @@ def test_moreh_matmul_backward(params, requires_grad, dtype, device):
     moreh_matmul_backward(params, requires_grad, device, dtype=dtype)
 
 
-@skip_for_blackhole("Fails on BH. Issue #19639")
 @pytest.mark.parametrize(
     "params",
     (

--- a/tests/ttnn/unit_tests/operations/test_utils.py
+++ b/tests/ttnn/unit_tests/operations/test_utils.py
@@ -8,38 +8,24 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import is_wormhole_b0
 
 TILE_HEIGHT = 32
 TILE_WIDTH = 32
 
 
-compute_kernel_options = [False]
-compute_kernel_ids = ["fp32_dest_acc_en=False"]
-if is_wormhole_b0():
-    compute_kernel_options.append(True)
-    compute_kernel_ids.append("fp32_dest_acc_en=True")
+compute_kernel_options = [False, True]
+compute_kernel_ids = ["fp32_dest_acc_en=False", "fp32_dest_acc_en=True"]
 
 
-def get_compute_kernel_options(compute_kernel_options):
-    if compute_kernel_options is None:
+def get_compute_kernel_options(fp32_dest_acc_en):
+    if fp32_dest_acc_en is None:
         return None
-    if is_wormhole_b0():
-        fp32_dest_acc_en = compute_kernel_options
-        packer_l1_acc = False
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
-            math_approx_mode=False,
-            fp32_dest_acc_en=fp32_dest_acc_en,
-            packer_l1_acc=packer_l1_acc,
-        )
-    else:
-        # Grayskull doesn't support FP32, but passing a Grayskull config in the test is OK.
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.HiFi4,
-            math_approx_mode=True,
-        )
-    return compute_kernel_config
+    return ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+        packer_l1_acc=False,
+    )
 
 
 def to_torch(ttnn_tensor, *, shape=None):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/19639

### Problem description
Existing `test_utils` implementation reverts to Grayskull's config when device is not wormhole. This is not forward compatible. For example, tests run on blackhole should _also_ use wormhole compute config.

### What's changed
1. Since grayskull has reached end of life, we deprecate the fall through and standardize compute config that works for both wormhole and blackhole.
2. Remove conditional skips that were dependent on resolution of the issue tagged above.
3. Rename argument of the helper function to clarify that the fp32_acc is the value being set.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) Passing: https://github.com/tenstorrent/tt-metal/actions/runs/14800769909
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI passing: https://github.com/tenstorrent/tt-metal/actions/runs/14800775502
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes