### PR TITLE
Afuller/check assert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ project(
 message(STATUS "Metalium version: ${PROJECT_VERSION}")
 message(STATUS "Building Unified Library for all architectures, thanks to blozano-tt")
 
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+# FIXME: Why are we setting these ourselves?
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DDEBUG")
 # Defining build types is the pervue of the top-level project
 if(PROJECT_IS_TOP_LEVEL)
     include(sanitizers)
@@ -82,12 +87,6 @@ endif()
 
 include(compilers)
 CHECK_COMPILERS()
-
-message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DDEBUG")
-set(CMAKE_CXX_FLAGS_CI "-O3 -DDEBUG")
 
 # We're not currently using C++20 modules, so don't bother scanning for them
 set(CMAKE_CXX_SCAN_FOR_MODULES FALSE)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
ASan and TSan were missing TT_ASSERT because TT_ASSERT was guarded by -DDEBUG which was being set later than when we initialized the flags for ASan and TSan.

We are referencing CMAKE_<lang>_FLAGS_RELWITHDEBINFO here: https://github.com/tenstorrent/tt-metal/blob/main/cmake/sanitizers.cmake#L24
We invoke that code on line 35: https://github.com/tenstorrent/tt-metal/blob/main/CMakeLists.txt#L35
But we're not actually overriding it with the -DDEBUG which is expected to exist for TT_ASSERT until line 89: https://github.com/tenstorrent/tt-metal/blob/main/CMakeLists.txt#L89
This means we're using the original value and not the updated value.  Thus we missed out on -DDEBUG.

### What's changed
Ensure that custom RelWithDebInfo flags are set before we reference them for setting ASan and TSan flags.


Confirmed functional: https://github.com/tenstorrent/tt-metal/actions/runs/14801193838/job/41560984194?pr=21576#step:6:59