### PR TITLE
#21087: use dram bank count for BH in dram matmul test

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -6,7 +6,6 @@ import pytest
 from loguru import logger
 from models.utility_functions import (
     is_wormhole_b0,
-    is_grayskull,
     is_blackhole,
     skip_for_wormhole_b0,
     skip_for_blackhole,
@@ -44,7 +43,8 @@ def find_max_subblock(out_block_h, out_block_w):
     return best_h, best_w, max_product
 
 
-def pad_to_dram_banks(num, lcm=32 * 12):
+def pad_to_dram_banks(num, num_banks):
+    lcm = 32 * num_banks
     remainder = num % lcm
     if remainder == 0:
         return num
@@ -71,15 +71,11 @@ def run_test_matmul_in1_dram_sharded(
     function_level_defaults,
     use_program_cache,
 ):
-    if is_grayskull() and (N == 4096 or K == 32768):
-        pytest.skip("Skipping too large tensor test on Grayskull")
-
-    if is_grayskull() or is_blackhole():
-        N_padded = N
-        num_banks = 8
+    if is_blackhole():
+        num_banks = device.dram_grid_size().x  # need to match harvesting of dram
     else:
-        N_padded = pad_to_dram_banks(N)
         num_banks = 12
+    N_padded = pad_to_dram_banks(N, num_banks)
 
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
@@ -151,18 +147,12 @@ def run_test_matmul_in1_dram_sharded(
         fused_activation=None,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=fidelity,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=fidelity,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=True,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=fidelity,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
 
     if has_bias:
         output_t = ttnn.linear(
@@ -196,7 +186,6 @@ def run_test_matmul_in1_dram_sharded(
     assert passing
 
 
-@skip_for_blackhole("Failing on harvested BH, see #21087")
 @pytest.mark.parametrize(
     "fidelity",
     [
@@ -299,15 +288,11 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
     function_level_defaults,
     use_program_cache,
 ):
-    if is_grayskull() and (N == 4096 or K == 32768):
-        pytest.skip("Skipping too large tensor test on Grayskull")
-
-    if is_grayskull() or is_blackhole():
-        N_padded = N
-        num_banks = 8
+    if is_blackhole():
+        num_banks = device.dram_grid_size().x  # need to match harvesting of dram
     else:
-        N_padded = pad_to_dram_banks(N)
         num_banks = 12
+    N_padded = pad_to_dram_banks(N, num_banks)
 
     in0_shape = [1, 1, M, K]
     in1_shape = [1, 1, K, N]
@@ -355,18 +340,12 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
         fused_activation=None,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=fidelity,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=fidelity,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=True,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=fidelity,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
 
     # 1st mm
     output_t = ttnn.matmul(
@@ -402,7 +381,6 @@ def run_test_matmul_in1_dram_sharded_mm_chain(
     assert True
 
 
-@skip_for_blackhole("Failing on harvested BH, see #21421")
 @pytest.mark.parametrize(
     "fidelity",
     [
@@ -497,12 +475,11 @@ def test_matmul_2d_in1_dram_sharded(
     fuse_batch,
     function_level_defaults,
 ):
-    if is_grayskull() or is_blackhole():
-        N_padded = N
-        num_banks = 8
+    if is_blackhole():
+        num_banks = device.dram_grid_size().x  # need to match harvesting of dram
     else:
-        N_padded = pad_to_dram_banks(N)
         num_banks = 12
+    N_padded = pad_to_dram_banks(N, num_banks)
 
     if fuse_batch:
         in0_shape = [1, 1, M, K]
@@ -590,18 +567,12 @@ def test_matmul_2d_in1_dram_sharded(
         fuse_batch=fuse_batch,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=fidelity,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=fidelity,
-            math_approx_mode=True,
-            fp32_dest_acc_en=fp32_acc_mode,
-            packer_l1_acc=packer_l1_acc,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=fidelity,
+        math_approx_mode=True,
+        fp32_dest_acc_en=fp32_acc_mode,
+        packer_l1_acc=packer_l1_acc,
+    )
     if has_bias:
         output_t = ttnn.linear(
             in0_t,


### PR DESCRIPTION
### Ticket
Link to Github Issue #21087 and #21421

### Problem description
- the dram optimized matmul requires the physical number of dram banks to be used and it wasn't for harvested BH parts

### What's changed
- update the bank count to be based on the BH device
- remove the relevant skips
- also removed GS related test code

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14801264082
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14804239057
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes