### PR TITLE
#0: [skip ci] Run ttnn and L2 tests on blackhole nightly instead of 1x a week

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -8,10 +8,6 @@ on:
           required: true
           type: string
           default: 'BH'
-      run-ttnn-tests:
-          description: "Run ttnn unit and L2 test suite"
-          default: false
-          type: boolean
   workflow_call:
     inputs:
       runner-label:
@@ -21,9 +17,8 @@ on:
           default: 'BH'
   schedule:
     - cron: "0 */12 * * *"  # Every day at 0:00 and 12:00 UTC
-    - cron: "0 8 * * 6"     # Runs at 8am UTC every Saturday
 
-run-name: ${{ (github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)) && '(Blackhole) Blackhole nightly tests (with ttnn+L2)' || '(Blackhole) Blackhole nightly tests' }}  # Dynamically change name based on day
+run-name: '(Blackhole) Blackhole nightly tests'
 
 jobs:
   build-artifact:
@@ -42,7 +37,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   ttnn-unit-tests:
     needs: build-artifact
-    if: github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)  # Only run ttnn on the weekends or if workflow manually triggered with ttnn enabled
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml
     with:
@@ -53,7 +47,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
   ttnn-l2-tests:
     needs: build-artifact
-    if: github.event.schedule == '0 8 * * 6' || (github.event_name == 'workflow_dispatch' && inputs.run-ttnn-tests)  # Only run L2 on the weekends or if workflow manually triggered with ttnn enabled
     secrets: inherit
     uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
     with:

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -18,8 +18,6 @@ on:
   schedule:
     - cron: "0 */12 * * *"  # Every day at 0:00 and 12:00 UTC
 
-run-name: '(Blackhole) Blackhole nightly tests'
-
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml


### PR DESCRIPTION
### Ticket
None

### Problem description
We want to eventually run ttnn tests in blackhole post commit, but tests are still red.
Now that we have increase BH runner capacity, we should try to run ttnn in nightly more frequently.

### What's changed
Remove 1x a week restriction on running ttnn tests (will now run 2x a night) to improve signal on how ttnn tests on BH are doing.

### Checklist
- [ ] New/Existing tests provide coverage for changes