### PR TITLE
#21556: Disable tests in test_multiprod_queue.cpp

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multiprod_queue.cpp
@@ -39,7 +39,8 @@ using ::tt::tt_metal::is_device_tensor;
 
 using MultiProducerCommandQueueTest = ttnn::MultiCommandQueueSingleDeviceFixture;
 
-TEST_F(MultiProducerCommandQueueTest, Stress) {
+// #21556: Disabled until we have clarity about user space multi-threading support
+TEST_F(MultiProducerCommandQueueTest, DISABLED_Stress) {
     // Spawn 2 application level threads intefacing with the same device through the async engine.
     // This leads to shared access of the work_executor and host side worker queue.
     // Test thread safety.
@@ -86,7 +87,8 @@ TEST_F(MultiProducerCommandQueueTest, Stress) {
     t1.join();
 }
 
-TEST_F(MultiProducerCommandQueueTest, EventSync) {
+// #21556: Disabled until we have clarity about user space multi-threading support
+TEST_F(MultiProducerCommandQueueTest, DISABLED_EventSync) {
     // Verify that the event_synchronize API stalls the calling thread until
     // the device records the event being polled.
     // Thread 0 = writer thread. Thread 1 = reader thread.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21556)

### Problem description
- User space multit-threading is currently not supported in TTNN, since runtime data-structures exposed by `MeshDevice` are not inherently thread-safe.
- TTNN used `push_work` all over the stack to access shared resources in the past, which made data-structure accesses inherently thread-safe

### What's changed
Disable tests for user-space multi-threading until we have clarity regarding whether this feature is a customer requirement.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes