### PR TITLE
Avoid pessimizing moves that prevent copy elision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,6 @@ add_compile_options(
     -Werror
     # The following list is not indicative of what we _desire_ only the status quo to build.
     -Wno-deprecated-declarations
-    -Wno-pessimizing-move
     -Wno-range-loop-construct
     -Wno-unused-but-set-variable
     -Wno-unused-function

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -78,7 +78,7 @@ tt::tt_metal::Program initialize_program_data_movement(
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
     tt::tt_metal::detail::CompileProgram(device, program);
-    return std::move(program);
+    return program;
 }
 
 tt::tt_metal::Program initialize_program_data_movement_rta(
@@ -108,7 +108,7 @@ tt::tt_metal::Program initialize_program_data_movement_rta(
             .defines = dm_defines});
 
     tt::tt_metal::detail::CompileProgram(device, program);
-    return std::move(program);
+    return program;
 }
 
 tt::tt_metal::KernelHandle initialize_program_compute(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -1104,7 +1104,7 @@ tt_metal::Program create_program_single_core(
             .compile_args = compute_kernel_args,
             .defines = mm_kernel_defines});
 
-    return std::move(program);
+    return program;
 }
 
 tt_metal::Program create_program(
@@ -1385,7 +1385,7 @@ tt_metal::Program create_program(
             tt_metal::SetRuntimeArgs(program, mm_in1_reader_writer_kernel_id, core, mm_in1_reader_writer_args);
         }
     }
-    return std::move(program);
+    return program;
 }
 
 std::vector<float> generate_fp32_random(uint32_t num_elems, int32_t rand_max_val = 100) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -898,7 +898,7 @@ tt_metal::Program create_program_mcast_in0_in1(
             }
         }
     }
-    return std::move(program);
+    return program;
 }
 
 std::vector<bfloat16> select_columns(std::vector<bfloat16> data, int M, int K, int N) {

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -171,7 +171,7 @@ Program create_program(IDevice* device, const ProgramAttributes& program_attribu
             .math_approx_mode = program_attributes.math_approx_mode,
             .compile_args = compute_kernel_args});
 
-    return std::move(program);
+    return program;
 }
 
 void assert_kernel_binary_path_exists(

--- a/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_fabric_edm_common.hpp
@@ -2421,7 +2421,7 @@ static std::vector<std::vector<IDevice*>> generate_line_fabrics_under_test(
     std::vector<std::vector<IDevice*>> fabrics_under_test;
     if (use_default_device_selection) {
         fabrics_under_test.push_back(
-            std::move(generate_default_line_fabric_under_test(use_galaxy, use_tg, line_size, topology, view)));
+            generate_default_line_fabric_under_test(use_galaxy, use_tg, line_size, topology, view));
     } else {
         fabrics_under_test.reserve(params.num_fabric_rows + params.num_fabric_cols);
         TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -75,12 +75,9 @@ Tensor create_tensor_from_owned_buffer(
     tt::tt_metal::HostBuffer buf, DataType& output_dtype, ttnn::Shape& output_shape) {
     if constexpr (std::is_same<T, float>::value) {
         if (output_dtype == DataType::BFLOAT8_B || output_dtype == DataType::BFLOAT4_B) {
-            auto tensor = Tensor(
-                              std::move(tt::tt_metal::HostStorage{std::move(buf)}),
-                              output_shape,
-                              DataType::FLOAT32,
-                              Layout::ROW_MAJOR)
-                              .to_layout(Layout::TILE);
+            auto tensor =
+                Tensor(tt::tt_metal::HostStorage{std::move(buf)}, output_shape, DataType::FLOAT32, Layout::ROW_MAJOR)
+                    .to_layout(Layout::TILE);
             auto output_float_data = tt::tt_metal::host_buffer::get_as<float>(tensor);
             auto output_packed_data =
                 output_dtype == DataType::BFLOAT8_B
@@ -88,18 +85,14 @@ Tensor create_tensor_from_owned_buffer(
                     : pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
             auto output_uint32_buffer = tt::tt_metal::host_buffer::create<uint32_t>(std::move(output_packed_data));
             return Tensor(
-                std::move(tt::tt_metal::HostStorage{std::move(output_uint32_buffer)}),
-                output_shape,
-                output_dtype,
-                Layout::TILE);
+                tt::tt_metal::HostStorage{std::move(output_uint32_buffer)}, output_shape, output_dtype, Layout::TILE);
         }
     } else {
         TT_FATAL(
             (output_dtype != DataType::BFLOAT8_B) || (output_dtype != DataType::BFLOAT4_B),
             "Unsupported output datatype");
     }
-    auto rm_tensor =
-        Tensor(std::move(tt::tt_metal::HostStorage{std::move(buf)}), output_shape, output_dtype, Layout::ROW_MAJOR);
+    auto rm_tensor = Tensor(tt::tt_metal::HostStorage{std::move(buf)}, output_shape, output_dtype, Layout::ROW_MAJOR);
     return rm_tensor.to_layout(Layout::TILE);
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward.cpp
@@ -100,7 +100,7 @@ std::vector<OptionalTensor> WhereBackwardOperation::invoke(
     } else {
         result.emplace_back(std::nullopt);
     }
-    return std::move(result);
+    return result;
 }
 
 // lerp(input, end, weight) = self: grad * (1 - weight), end: grad * weight

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm_backward/moreh_group_norm_backward.cpp
@@ -62,7 +62,7 @@ std::vector<std::optional<Tensor>> MorehGroupNormBackward::invoke(
         outputs.push_back(std::nullopt);
         outputs.push_back(std::nullopt);
     }
-    return std::move(outputs);
+    return outputs;
 }
 
 }  // namespace ttnn::operations::moreh::moreh_group_norm_backward

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -136,7 +136,7 @@ Tensor pad_bfloat8_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return Tensor(std::move(HostStorage{std::move(output_uint32_buffer)}), output_spec);
+    return Tensor(HostStorage{std::move(output_uint32_buffer)}, output_spec);
 }
 
 Tensor unpad_bfloat8_b(
@@ -167,7 +167,7 @@ Tensor unpad_bfloat8_b(
         pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = host_buffer::create<uint32_t>(std::move(output_packed_data));
     return Tensor(
-        std::move(HostStorage{std::move(output_uint32_buffer)}),
+        HostStorage{std::move(output_uint32_buffer)},
         TensorSpec(
             float_tensor.get_logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -216,7 +216,7 @@ Tensor pad_bfloat4_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return Tensor(std::move(HostStorage{std::move(output_uint32_buffer)}), output_spec);
+    return Tensor(HostStorage{std::move(output_uint32_buffer)}, output_spec);
 }
 
 Tensor unpad_bfloat4_b(
@@ -247,7 +247,7 @@ Tensor unpad_bfloat4_b(
         pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = host_buffer::create<uint32_t>(std::move(output_packed_data));
     return Tensor(
-        std::move(HostStorage{std::move(output_uint32_buffer)}),
+        HostStorage{std::move(output_uint32_buffer)},
         TensorSpec(
             float_tensor.get_logical_shape(),
             TensorLayout::fromPaddedShape(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
move()'ing temporaries and return values prevents copy elision.  We have nothing to gain by pessimizing moves.

### What's changed
Don't do that.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14806758563)