### PR TITLE
No throwing in noexcept context

### DIFF
--- a/tt_metal/api/tt-metalium/hlk_desc.hpp
+++ b/tt_metal/api/tt-metalium/hlk_desc.hpp
@@ -170,9 +170,7 @@ struct std::hash<tt::tt_hlk_desc> {
             hash_hlk_args(hash_value, hlk_args, hlk_args_size);
         } else if (hlk_args == nullptr and hlk_args_size == 0) {
         } else {
-            TT_THROW(
-                "Mismatching values, either hlk_args == nullptr and hlk_args_size == 0 or hlk_args != nullptr and "
-                "hlk_args_size > 0!");
+            tt::log_fatal("Invalid hlk_args, hlk_args == {}, hlk_args_size == {}", hlk_args, hlk_args_size);
         }
 
         return hash_value;

--- a/tt_metal/api/tt-metalium/hlk_desc.hpp
+++ b/tt_metal/api/tt-metalium/hlk_desc.hpp
@@ -153,7 +153,7 @@ inline void hash_hlk_args(size_t& seed, void* hlk_args, size_t hlk_args_size) {
 
 template <>
 struct std::hash<tt::tt_hlk_desc> {
-    std::size_t operator()(tt::tt_hlk_desc const& obj) const noexcept {
+    std::size_t operator()(tt::tt_hlk_desc const& obj) const {
         std::size_t hash_value = 0;
         for (int i = 0; i < NUM_CIRCULAR_BUFFERS; i++) {
             tt::utils::hash_combine(hash_value, hash<tt::DataFormat>{}(obj.get_buf_dataformat(i)));
@@ -170,7 +170,7 @@ struct std::hash<tt::tt_hlk_desc> {
             hash_hlk_args(hash_value, hlk_args, hlk_args_size);
         } else if (hlk_args == nullptr and hlk_args_size == 0) {
         } else {
-            tt::log_fatal("Invalid hlk_args, hlk_args == {}, hlk_args_size == {}", hlk_args, hlk_args_size);
+            TT_THROW("Invalid hlk_args, hlk_args == {}, hlk_args_size == {}", hlk_args, hlk_args_size);
         }
 
         return hash_value;

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -557,7 +557,7 @@ DebugPrintServerContext::~DebugPrintServerContext() {
     // Wait for the thread to end, with a timeout
     auto future = std::async(std::launch::async, &std::thread::join, print_server_thread_);
     if (future.wait_for(std::chrono::seconds(2)) == std::future_status::timeout) {
-        TT_THROW("Timed out waiting on debug print thread to terminate.");
+        tt::log_fatal("Timed out waiting on debug print thread to terminate.");
     }
     delete print_server_thread_;
     print_server_thread_ = nullptr;


### PR DESCRIPTION
### Problem description
The overcomplicated nature of the `TT_THROW` macro makes it so that the compiler cannot detect when we are throwing in noexcept settings. Throwing in a destructor is undefined behavior.

### What's changed
Change from `TT_THROW` to `log_fatal`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14807565922) CI passes
- [x] New/Existing tests provide coverage for changes