### PR TITLE
Fix literal operator errors in clang

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
@@ -13,9 +13,9 @@
 #include "tt_metal/impl/allocator/algorithms/free_list_opt.hpp"
 
 // UDL to convert integer literals to SI units
-constexpr size_t operator"" _KiB(unsigned long long x) { return x * 1024; }
-constexpr size_t operator"" _MiB(unsigned long long x) { return x * 1024 * 1024; }
-constexpr size_t operator"" _GiB(unsigned long long x) { return x * 1024 * 1024 * 1024; }
+constexpr size_t operator""_KiB(unsigned long long x) { return x * 1024; }
+constexpr size_t operator""_MiB(unsigned long long x) { return x * 1024 * 1024; }
+constexpr size_t operator""_GiB(unsigned long long x) { return x * 1024 * 1024 * 1024; }
 
 TEST(FreeListOptTest, Allocation) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);


### PR DESCRIPTION
### Ticket
#21598

### Problem description
Clang 20 doesn't like spaces between `""` and literal operator names.

### What's changed
Took out the problematic spaces.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14823569157?pr=21599)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes