### PR TITLE
#20050: SDXL VAE midblock

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+import ttnn
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_attention import TtAttention
+from diffusers import DiffusionPipeline
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+
+@pytest.mark.parametrize(
+    "input_shape, encoder_shape",
+    [
+        ((1, 512, 128, 128), None),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_vae_attention(device, input_shape, encoder_shape, use_program_cache, reset_seeds):
+    pipe = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    )
+    vae = pipe.vae
+    vae.eval()
+    state_dict = vae.state_dict()
+
+    torch_attention = vae.decoder.mid_block.attentions[0]
+    tt_attention = TtAttention(device, state_dict, "decoder.mid_block.attentions.0", 512, 1, 512, None, 512)
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_encoder_tensor = (
+        torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32) if encoder_shape is not None else None
+    )
+
+    torch_output_tensor = torch_attention(torch_input_tensor, torch_encoder_tensor)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    ttnn_encoder_tensor = (
+        ttnn.from_torch(
+            torch_encoder_tensor,
+            dtype=ttnn.bfloat16,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        if encoder_shape is not None
+        else None
+    )
+    ttnn_output_tensor = tt_attention.forward(ttnn_input_tensor, [B, C, H, W], ttnn_encoder_tensor)
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(B, H, W, C)
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.97)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -19,7 +19,7 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_vae_attention(device, input_shape, encoder_shape, use_program_cache, reset_seeds):
     pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True
     )
     vae = pipe.vae
     vae.eval()

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+import ttnn
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_midblock2d import TtUNetMidBlock2D
+from diffusers import DiffusionPipeline
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 512, 128, 128),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_vae_midblock(device, input_shape, use_program_cache, reset_seeds):
+    pipe = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    )
+    vae = pipe.vae
+    vae.eval()
+    state_dict = vae.state_dict()
+
+    torch_crosattn = vae.decoder.mid_block
+    tt_crosattn = TtUNetMidBlock2D(device, state_dict, "decoder.mid_block")
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output_tensor = torch_crosattn(torch_input_tensor, temb=None)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    ttnn_output_tensor, output_shape = tt_crosattn.forward(ttnn_input_tensor, [B, C, H, W])
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.997)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
@@ -19,7 +19,7 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_vae_midblock(device, input_shape, use_program_cache, reset_seeds):
     pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True
     )
     vae = pipe.vae
     vae.eval()

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+import ttnn
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_resnetblock2d import TtResnetBlock2D
+from diffusers import DiffusionPipeline
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+
+@pytest.mark.parametrize(
+    "input_shape, down_block_id, resnet_id, conv_shortcut, split_in, block, pcc",
+    [
+        ((1, 512, 128, 128), 0, 0, False, 1, "mid_block", 0.999),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_vae_resnetblock2d(
+    device, input_shape, down_block_id, resnet_id, conv_shortcut, split_in, block, pcc, use_program_cache
+):
+    pipe = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    )
+    vae = pipe.vae
+    vae.eval()
+    state_dict = vae.state_dict()
+
+    if block == "up_blocks":
+        torch_resnet = vae.decoder.up_blocks[down_block_id].resnets[resnet_id]
+        block = f"{block}.{down_block_id}"
+    else:
+        torch_resnet = vae.decoder.mid_block.resnets[resnet_id]
+    tt_resnet = TtResnetBlock2D(device, state_dict, f"decoder.{block}.resnets.{resnet_id}", conv_shortcut, split_in)
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_output_tensor = torch_resnet(torch_input_tensor, None)
+
+    input_mem_cfg = (
+        ttnn.L1_MEMORY_CONFIG if down_block_id != 0 and not block == "up_blocks" else ttnn.DRAM_MEMORY_CONFIG
+    )
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=input_mem_cfg
+    )
+    B, C, H, W = list(ttnn_input_tensor.shape)
+
+    ttnn_input_tensor = ttnn.permute(ttnn_input_tensor, (0, 2, 3, 1))
+    ttnn_input_tensor = ttnn.reshape(ttnn_input_tensor, (B, 1, H * W, C))
+
+    ttnn_output_tensor, output_shape = tt_resnet.forward(ttnn_input_tensor, None, [B, C, H, W])
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(input_shape[0], output_shape[1], output_shape[2], output_shape[0])
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
@@ -11,14 +11,14 @@ from models.utility_functions import torch_random
 
 
 @pytest.mark.parametrize(
-    "input_shape, down_block_id, resnet_id, conv_shortcut, split_in, block, pcc",
+    "input_shape, down_block_id, resnet_id, conv_shortcut, block, pcc",
     [
-        ((1, 512, 128, 128), 0, 0, False, 1, "mid_block", 0.999),
+        ((1, 512, 128, 128), 0, 0, False, "mid_block", 0.999),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_vae_resnetblock2d(
-    device, input_shape, down_block_id, resnet_id, conv_shortcut, split_in, block, pcc, use_program_cache
+    device, input_shape, down_block_id, resnet_id, conv_shortcut, block, pcc, use_program_cache, reset_seeds
 ):
     pipe = DiffusionPipeline.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
@@ -32,7 +32,7 @@ def test_vae_resnetblock2d(
         block = f"{block}.{down_block_id}"
     else:
         torch_resnet = vae.decoder.mid_block.resnets[resnet_id]
-    tt_resnet = TtResnetBlock2D(device, state_dict, f"decoder.{block}.resnets.{resnet_id}", conv_shortcut, split_in)
+    tt_resnet = TtResnetBlock2D(device, state_dict, f"decoder.{block}.resnets.{resnet_id}", conv_shortcut)
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_output_tensor = torch_resnet(torch_input_tensor, None)

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_attention.py
@@ -67,10 +67,10 @@ class TtAttention(nn.Module):
         out_weights = state_dict[f"{module_path}.to_out.0.weight"].unsqueeze(0).unsqueeze(0)
         out_bias = state_dict[f"{module_path}.to_out.0.bias"]
 
-        self.tt_q_weights, self.tt_q_bias = prepare_linear_params(device, q_weights, q_bias, ttnn.bfloat8_b)
-        self.tt_k_weights, self.tt_k_bias = prepare_linear_params(device, k_weights, k_bias, ttnn.bfloat8_b)
-        self.tt_v_weights, self.tt_v_bias = prepare_linear_params(device, v_weights, v_bias, ttnn.bfloat8_b)
-        self.tt_out_weights, self.tt_out_bias = prepare_linear_params(device, out_weights, out_bias, ttnn.bfloat8_b)
+        self.tt_q_weights, self.tt_q_bias = prepare_linear_params(device, q_weights, q_bias, ttnn.bfloat16)
+        self.tt_k_weights, self.tt_k_bias = prepare_linear_params(device, k_weights, k_bias, ttnn.bfloat16)
+        self.tt_v_weights, self.tt_v_bias = prepare_linear_params(device, v_weights, v_bias, ttnn.bfloat16)
+        self.tt_out_weights, self.tt_out_bias = prepare_linear_params(device, out_weights, out_bias, ttnn.bfloat16)
 
     def forward(self, input_tensor, input_shape, encoder_hidden_states=None):
         B, C, H, W = input_shape

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_attention.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import ttnn
+
+from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
+    prepare_gn_mask,
+    prepare_gn_beta_gamma,
+    prepare_linear_params,
+)
+
+
+class TtAttention(nn.Module):
+    def __init__(
+        self,
+        device,
+        state_dict,
+        module_path,
+        query_dim: int,
+        heads: int = 8,
+        out_dim: int = None,
+        kv_heads=None,
+        dim_head: int = 64,
+    ):
+        super().__init__()
+        self.device = device
+
+        self.norm_core_grid = ttnn.CoreGrid(y=4, x=8)
+        self.norm_groups = 32
+        self.norm_eps = 1e-6
+        self.num_out_blocks = 4
+
+        self.inner_dim = out_dim if out_dim is not None else dim_head * heads
+        self.inner_kv_dim = self.inner_dim if kv_heads is None else dim_head * kv_heads
+        self.query_dim = query_dim
+        self.out_dim = out_dim if out_dim is not None else query_dim
+        self.heads = out_dim // dim_head if out_dim is not None else heads
+
+        self.sdpa_program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+            q_chunk_size=32,
+            k_chunk_size=32,
+            exp_approx_mode=False,
+        )
+
+        self.compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=False,
+        )
+
+        norm_weights = state_dict[f"{module_path}.group_norm.weight"]
+        norm_bias = state_dict[f"{module_path}.group_norm.bias"]
+        self.gamma_t, self.beta_t = prepare_gn_beta_gamma(device, norm_weights, norm_bias, self.norm_core_grid.y)
+        self.input_mask = prepare_gn_mask(self.device, norm_weights.shape[0], self.norm_groups, self.norm_core_grid.y)
+
+        q_weights = state_dict[f"{module_path}.to_q.weight"].unsqueeze(0).unsqueeze(0)
+        q_bias = state_dict[f"{module_path}.to_q.bias"]
+        k_weights = state_dict[f"{module_path}.to_k.weight"].unsqueeze(0).unsqueeze(0)
+        k_bias = state_dict[f"{module_path}.to_k.bias"]
+        v_weights = state_dict[f"{module_path}.to_v.weight"].unsqueeze(0).unsqueeze(0)
+        v_bias = state_dict[f"{module_path}.to_v.bias"]
+
+        out_weights = state_dict[f"{module_path}.to_out.0.weight"].unsqueeze(0).unsqueeze(0)
+        out_bias = state_dict[f"{module_path}.to_out.0.bias"]
+
+        self.tt_q_weights, self.tt_q_bias = prepare_linear_params(device, q_weights, q_bias, ttnn.bfloat8_b)
+        self.tt_k_weights, self.tt_k_bias = prepare_linear_params(device, k_weights, k_bias, ttnn.bfloat8_b)
+        self.tt_v_weights, self.tt_v_bias = prepare_linear_params(device, v_weights, v_bias, ttnn.bfloat8_b)
+        self.tt_out_weights, self.tt_out_bias = prepare_linear_params(device, out_weights, out_bias, ttnn.bfloat8_b)
+
+    def forward(self, input_tensor, input_shape, encoder_hidden_states=None):
+        B, C, H, W = input_shape
+
+        hidden_states = ttnn.to_memory_config(input_tensor, ttnn.DRAM_MEMORY_CONFIG)
+        hidden_states = ttnn.group_norm(
+            hidden_states,
+            num_groups=self.norm_groups,
+            input_mask=self.input_mask,
+            weight=self.gamma_t,
+            bias=self.beta_t,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            core_grid=self.norm_core_grid,
+            epsilon=self.norm_eps,
+            inplace=False,
+            num_out_blocks=self.num_out_blocks,
+        )
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+
+        query = ttnn.linear(
+            hidden_states,
+            self.tt_q_weights,
+            bias=self.tt_q_bias,
+        )
+        key = ttnn.linear(
+            encoder_hidden_states,
+            self.tt_k_weights,
+            bias=self.tt_k_bias,
+        )
+        value = ttnn.linear(
+            encoder_hidden_states,
+            self.tt_v_weights,
+            bias=self.tt_v_bias,
+        )
+        inner_dim = list(key.shape)[-1]
+        head_dim = inner_dim // self.heads
+
+        query = ttnn.reshape(query, [B, -1, self.heads, head_dim])
+        query = ttnn.transpose(query, 1, 2)
+
+        key = ttnn.reshape(key, [B, -1, self.heads, head_dim])
+        key = ttnn.transpose(key, 1, 2)
+
+        value = ttnn.reshape(value, [B, -1, self.heads, head_dim])
+        value = ttnn.transpose(value, 1, 2)
+
+        hidden_states = ttnn.transformer.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            is_causal=False,
+            attn_mask=None,
+            program_config=self.sdpa_program_config,
+            compute_kernel_config=self.compute_kernel_config,
+        )
+        hidden_states = ttnn.transpose(hidden_states, 1, 2)
+        hidden_states = ttnn.reshape(hidden_states, [B, -1, self.heads * head_dim])
+
+        hidden_states = ttnn.linear(
+            hidden_states,
+            self.tt_out_weights,
+            bias=self.tt_out_bias,
+        )
+        hidden_states = ttnn.add(hidden_states, input_tensor)
+
+        return hidden_states

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_midblock2d.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_attention import TtAttention
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_resnetblock2d import TtResnetBlock2D
+
+
+class TtUNetMidBlock2D(nn.Module):
+    def __init__(self, device, state_dict, module_path):
+        super().__init__()
+
+        num_layers_attn = 1
+        num_layers_resn = num_layers_attn + 1
+        self.attentions = []
+        self.resnets = []
+
+        for i in range(num_layers_attn):
+            self.attentions.append(
+                TtAttention(device, state_dict, f"{module_path}.attentions.{i}", 512, 1, 512, None, 512)
+            )
+
+        for i in range(num_layers_resn):
+            self.resnets.append(TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}"))
+
+    def forward(self, input_tensor, input_shape, temb=None):
+        B, C, H, W = input_shape
+        hidden_states = input_tensor
+
+        hidden_states, [C, H, W] = self.resnets[0].forward(hidden_states, temb, [B, C, H, W])
+
+        tt_blocks = list(zip(self.resnets[1:], self.attentions))
+        for resnet, attn in tt_blocks:
+            hidden_states = attn.forward(hidden_states, [B, C, H, W])
+            hidden_states, [C, H, W] = resnet.forward(hidden_states, temb, [B, C, H, W])
+
+        return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_midblock2d.py
@@ -24,15 +24,15 @@ class TtUNetMidBlock2D(nn.Module):
         for i in range(num_layers_resn):
             self.resnets.append(TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}"))
 
-    def forward(self, input_tensor, input_shape, temb=None):
+    def forward(self, input_tensor, input_shape):
         B, C, H, W = input_shape
         hidden_states = input_tensor
 
-        hidden_states, [C, H, W] = self.resnets[0].forward(hidden_states, temb, [B, C, H, W])
+        hidden_states, [C, H, W] = self.resnets[0].forward(hidden_states, [B, C, H, W])
 
         tt_blocks = list(zip(self.resnets[1:], self.attentions))
         for resnet, attn in tt_blocks:
             hidden_states = attn.forward(hidden_states, [B, C, H, W])
-            hidden_states, [C, H, W] = resnet.forward(hidden_states, temb, [B, C, H, W])
+            hidden_states, [C, H, W] = resnet.forward(hidden_states, [B, C, H, W])
 
         return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -71,17 +71,17 @@ class TtResnetBlock2D(nn.Module):
             self.tt_conv1_weights,
             self.tt_conv1_bias,
             self.conv1_params,
-        ) = prepare_conv_params(device, conv_weights_1, conv_bias_1, ttnn.bfloat8_b, act_block_h_override=32)
+        ) = prepare_conv_params(device, conv_weights_1, conv_bias_1, ttnn.bfloat16, act_block_h_override=32)
         self.conv1_slice_config = get_DRAM_conv_config(module_path, 1)
 
         _, _, self.tt_conv2_weights, self.tt_conv2_bias, self.conv2_params = prepare_conv_params(
-            device, conv_weights_2, conv_bias_2, ttnn.bfloat8_b, act_block_h_override=32
+            device, conv_weights_2, conv_bias_2, ttnn.bfloat16, act_block_h_override=32
         )
         self.conv2_slice_config = get_DRAM_conv_config(module_path, 2)
 
         if conv_shortcut:
             _, _, self.tt_conv3_weights, self.tt_conv3_bias, self.conv3_params = prepare_conv_params(
-                device, conv_weights_3, conv_bias_3, ttnn.bfloat8_b, act_block_h_override=32
+                device, conv_weights_3, conv_bias_3, ttnn.bfloat16, act_block_h_override=32
             )
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -86,7 +86,7 @@ class TtResnetBlock2D(nn.Module):
         else:
             self.tt_conv3_weights = self.tt_conv3_bias = None
 
-    def forward(self, input_tensor, temb, input_shape):
+    def forward(self, input_tensor, input_shape):
         B, C, H, W = input_shape
         hidden_states = input_tensor
 

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_resnetblock2d.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import ttnn
+
+from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
+    prepare_gn_mask,
+    prepare_gn_beta_gamma,
+    prepare_conv_params,
+)
+from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import get_DRAM_GN_config, get_DRAM_conv_config
+
+
+class TtResnetBlock2D(nn.Module):
+    def __init__(self, device, state_dict, module_path, conv_shortcut=False):
+        super().__init__()
+
+        self.device = device
+
+        # fixed for ResnetBlock
+        self.stride = (1, 1)
+        self.padding = (1, 1)
+        self.dilation = (1, 1)
+        self.groups = 1
+
+        self.norm_groups = 32
+        self.norm_eps = 1e-5
+
+        # loading weights
+        norm_weights_1 = state_dict[f"{module_path}.norm1.weight"]
+        norm_bias_1 = state_dict[f"{module_path}.norm1.bias"]
+
+        conv_weights_1 = state_dict[f"{module_path}.conv1.weight"]
+        conv_bias_1 = state_dict[f"{module_path}.conv1.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
+
+        norm_weights_2 = state_dict[f"{module_path}.norm2.weight"]
+        norm_bias_2 = state_dict[f"{module_path}.norm2.bias"]
+
+        conv_weights_2 = state_dict[f"{module_path}.conv2.weight"]
+        conv_bias_2 = state_dict[f"{module_path}.conv2.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
+
+        if conv_shortcut:
+            conv_weights_3 = state_dict[f"{module_path}.conv_shortcut.weight"]
+            conv_bias_3 = state_dict[f"{module_path}.conv_shortcut.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
+
+        core_y, self.norm_blocks_1 = get_DRAM_GN_config(module_path, 1)
+        self.norm_core_grid_1 = ttnn.CoreGrid(y=core_y, x=8)
+
+        self.gamma_t_1, self.beta_t_1 = prepare_gn_beta_gamma(
+            device, norm_weights_1, norm_bias_1, self.norm_core_grid_1.y
+        )
+        self.input_mask_1 = prepare_gn_mask(
+            self.device, norm_weights_1.shape[0], self.norm_groups, self.norm_core_grid_1.y
+        )
+
+        core_y, self.norm_blocks_2 = get_DRAM_GN_config(module_path, 2)
+        self.norm_core_grid_2 = ttnn.CoreGrid(y=core_y, x=8)
+
+        self.gamma_t_2, self.beta_t_2 = prepare_gn_beta_gamma(
+            device, norm_weights_2, norm_bias_2, self.norm_core_grid_2.y
+        )
+        self.input_mask_2 = prepare_gn_mask(
+            self.device, norm_weights_2.shape[0], self.norm_groups, self.norm_core_grid_2.y
+        )
+
+        (
+            self.compute_config,
+            self.conv_config,
+            self.tt_conv1_weights,
+            self.tt_conv1_bias,
+            self.conv1_params,
+        ) = prepare_conv_params(device, conv_weights_1, conv_bias_1, ttnn.bfloat8_b, act_block_h_override=32)
+        self.conv1_slice_config = get_DRAM_conv_config(module_path, 1)
+
+        _, _, self.tt_conv2_weights, self.tt_conv2_bias, self.conv2_params = prepare_conv_params(
+            device, conv_weights_2, conv_bias_2, ttnn.bfloat8_b, act_block_h_override=32
+        )
+        self.conv2_slice_config = get_DRAM_conv_config(module_path, 2)
+
+        if conv_shortcut:
+            _, _, self.tt_conv3_weights, self.tt_conv3_bias, self.conv3_params = prepare_conv_params(
+                device, conv_weights_3, conv_bias_3, ttnn.bfloat8_b, act_block_h_override=32
+            )
+        else:
+            self.tt_conv3_weights = self.tt_conv3_bias = None
+
+    def forward(self, input_tensor, temb, input_shape):
+        B, C, H, W = input_shape
+        hidden_states = input_tensor
+
+        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+        hidden_states = ttnn.group_norm(
+            hidden_states,
+            num_groups=self.norm_groups,
+            input_mask=self.input_mask_1,
+            weight=self.gamma_t_1,
+            bias=self.beta_t_1,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            core_grid=self.norm_core_grid_1,
+            epsilon=self.norm_eps,
+            inplace=False,
+            num_out_blocks=self.norm_blocks_1,
+        )
+
+        hidden_states = ttnn.silu(hidden_states)
+
+        self.conv_config.shard_layout = (
+            hidden_states.memory_config().memory_layout if hidden_states.is_sharded() else None
+        )
+        self.conv_config.act_block_h_override = 32 if hidden_states.is_sharded() else 0
+
+        [hidden_states, [H, W], [d_w, d_b]] = ttnn.conv2d(
+            input_tensor=hidden_states,
+            weight_tensor=self.tt_conv1_weights,
+            in_channels=self.conv1_params["input_channels"],
+            out_channels=self.conv1_params["output_channels"],
+            device=self.device,
+            bias_tensor=self.tt_conv1_bias,
+            kernel_size=self.conv1_params["kernel_size"],
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            batch_size=B,
+            input_height=H,
+            input_width=W,
+            conv_config=self.conv_config,
+            compute_config=self.compute_config,
+            groups=self.groups,
+            memory_config=None,
+            slice_config=self.conv1_slice_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+        )
+        C = self.conv1_params["output_channels"]
+
+        self.tt_conv1_weights = d_w
+        self.tt_conv1_bias = d_b
+
+        hidden_states = ttnn.to_memory_config(hidden_states, ttnn.DRAM_MEMORY_CONFIG)
+        hidden_states = ttnn.group_norm(
+            hidden_states,
+            num_groups=self.norm_groups,
+            input_mask=self.input_mask_2,
+            weight=self.gamma_t_2,
+            bias=self.beta_t_2,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            core_grid=self.norm_core_grid_2,
+            epsilon=self.norm_eps,
+            inplace=False,
+            num_out_blocks=self.norm_blocks_2,
+        )
+
+        hidden_states = ttnn.silu(hidden_states)
+
+        self.conv_config.shard_layout = None
+        [hidden_states, [H, W], [d_w, d_b]] = ttnn.conv2d(
+            input_tensor=hidden_states,
+            weight_tensor=self.tt_conv2_weights,
+            in_channels=self.conv2_params["input_channels"],
+            out_channels=self.conv2_params["output_channels"],
+            device=self.device,
+            bias_tensor=self.tt_conv2_bias,
+            kernel_size=self.conv2_params["kernel_size"],
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            batch_size=B,
+            input_height=H,
+            input_width=W,
+            conv_config=self.conv_config,
+            compute_config=self.compute_config,
+            groups=self.groups,
+            memory_config=None,
+            slice_config=self.conv2_slice_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+        )
+        C = self.conv2_params["output_channels"]
+        self.tt_conv2_weights = d_w
+        self.tt_conv2_bias = d_b
+
+        if self.tt_conv3_weights is not None:
+            if input_tensor.shape[3] >= 1920:
+                input_tensor = ttnn.to_layout(input_tensor, ttnn.ROW_MAJOR_LAYOUT)
+                input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
+            self.conv_config.shard_layout = None
+            self.conv_config.act_block_h_override = 0
+            [input_tensor, [H, W], [d_w, d_b]] = ttnn.conv2d(
+                input_tensor=input_tensor,
+                weight_tensor=self.tt_conv3_weights,
+                in_channels=self.conv3_params["input_channels"],
+                out_channels=self.conv3_params["output_channels"],
+                device=self.device,
+                bias_tensor=self.tt_conv3_bias,
+                kernel_size=self.conv3_params["kernel_size"],
+                stride=self.stride,
+                padding=(0, 0),
+                dilation=self.dilation,
+                batch_size=input_shape[0],
+                input_height=input_shape[2],
+                input_width=input_shape[3],
+                conv_config=self.conv_config,
+                compute_config=self.compute_config,
+                groups=self.groups,
+                memory_config=None,
+                return_output_dim=True,
+                return_weights_and_bias=True,
+            )
+            C = self.conv3_params["output_channels"]
+            self.tt_conv3_weights = d_w
+            self.tt_conv3_bias = d_b
+            if input_tensor.is_sharded():
+                input_tensor = ttnn.sharded_to_interleaved(input_tensor, ttnn.L1_MEMORY_CONFIG)
+
+        hidden_states = ttnn.add(input_tensor, hidden_states)
+
+        self.conv_config.preprocess_weights_on_device = False
+        self.conv_config.always_preprocess_weights = False
+        return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -9,6 +9,8 @@ def get_DRAM_GN_config(module_path, idx):
     if "mid_block" in module_path:
         core_y = 4
         num_out_blocks = 4
+    else:
+        assert "Only mid_block is implemented for VAE"
 
     return core_y, num_out_blocks
 
@@ -17,6 +19,8 @@ def get_DRAM_conv_config(module_path, idx):
     if "mid_block" in module_path:
         slice_type = None
         num_slices = 1
+    else:
+        assert "Only mid_block is implemented for VAE"
 
     slice_config = (
         ttnn.Conv2dSliceConfig(

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+
+
+def get_DRAM_GN_config(module_path, idx):
+    if "mid_block" in module_path:
+        core_y = 4
+        num_out_blocks = 4
+
+    return core_y, num_out_blocks
+
+
+def get_DRAM_conv_config(module_path, idx):
+    if "mid_block" in module_path:
+        slice_type = None
+        num_slices = 1
+
+    slice_config = (
+        ttnn.Conv2dSliceConfig(
+            slice_type=slice_type,
+            num_slices=num_slices,
+        )
+        if num_slices > 1 and slice_type is not None
+        else None
+    )
+    return slice_config

--- a/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_attention.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_attention.py
@@ -1,0 +1,1 @@
+../../../../../models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_midblock2d.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_midblock2d.py
@@ -1,0 +1,1 @@
+../../../../../models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_resnetblock2d.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_resnetblock2d.py
@@ -1,0 +1,1 @@
+../../../../../models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-metal/issues/20050)

### What's changed
Functional implementation with tests for `TtAttention` and `TtResnetBlock2D` used in VAE mid block. `TtUNetMidBlock2D` implemented.

### Checklist
CI in progress
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14831946128) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14831957418) CI passes