### PR TITLE
Update tsu computation for perf test (first layer compile vs trace)

### DIFF
--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -474,6 +474,10 @@ def print_dict(input_dict, dict_name):
     print("}")
 
 
+def is_collective_op(op_code):
+    return "AllGather" in op_code or "ReduceScatter" in op_code or "AllReduce" in op_code
+
+
 @pytest.mark.models_device_performance_bare_metal
 # To update:
 # Run FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device
@@ -541,6 +545,15 @@ def test_llama_TG_perf_device(
     kernel_duration_dict_trace = build_duration_dict(mid_layers_raw_dict_trace, "DEVICE KERNEL DURATION [ns]")
     dispatch_duration_dict = build_duration_dict(mid_layers_raw_dict_trace, "OP TO OP LATENCY [ns]")
 
+    # first layer
+    kernel_duration_dict_compilation_first_layer = build_duration_dict(
+        first_layer_raw_dict_compilation, "DEVICE KERNEL DURATION [ns]"
+    )
+    kernel_duration_dict_trace_first_layer = build_duration_dict(
+        first_layer_raw_dict_trace, "DEVICE KERNEL DURATION [ns]"
+    )
+    dispatch_duration_dict_first_layer = build_duration_dict(first_layer_raw_dict_trace, "OP TO OP LATENCY [ns]")
+
     # Build dicts of op_code_with_id to list of durations - one list per op instance
     kernel_duration_per_instance_dict_compilation = build_duration_per_instance_dict(
         kernel_duration_dict_compilation, num_layers - 1
@@ -549,6 +562,17 @@ def test_llama_TG_perf_device(
         kernel_duration_dict_trace, num_layers - 1
     )
     dispatch_duration_per_instance_dict = build_duration_per_instance_dict(dispatch_duration_dict, num_layers - 1)
+
+    # first layer
+    kernel_duration_per_instance_dict_compilation_first_layer = build_duration_per_instance_dict(
+        kernel_duration_dict_compilation_first_layer, 1
+    )
+    kernel_duration_per_instance_dict_trace_first_layer = build_duration_per_instance_dict(
+        kernel_duration_dict_trace_first_layer, 1
+    )
+    dispatch_duration_per_instance_dict_first_layer = build_duration_per_instance_dict(
+        dispatch_duration_dict_first_layer, 1
+    )
 
     # Average over all iterations of each op instance
     kernel_duration_per_instance_averaged_dict_compilation = average_per_instance_dict(
@@ -559,12 +583,14 @@ def test_llama_TG_perf_device(
     )
     dispatch_duration_per_instance_averaged_dict = average_per_instance_dict(dispatch_duration_per_instance_dict)
 
+    # Min over all iterations of each op instance
     kernel_duration_per_instance_min_dict_compilation = min_per_instance_dict(
         kernel_duration_per_instance_dict_compilation
     )
     kernel_duration_per_instance_min_dict_trace = min_per_instance_dict(kernel_duration_per_instance_dict_trace)
     dispatch_duration_per_instance_min_dict = min_per_instance_dict(dispatch_duration_per_instance_dict)
 
+    # Max over all iterations of each op instance
     kernel_duration_per_instance_max_dict_compilation = max_per_instance_dict(
         kernel_duration_per_instance_dict_compilation
     )
@@ -707,27 +733,35 @@ def test_llama_TG_perf_device(
 
     # Calculate e2e performance
     e2e_estimate_80l = 0
-    for entry in first_layer_raw_dict_compilation:
-        kernel_duration = entry["DEVICE KERNEL DURATION [ns]"]
-        e2e_estimate_80l += kernel_duration
-    for entry in first_layer_raw_dict_trace:
-        dispatch_duration = entry["OP TO OP LATENCY [ns]"]
-        e2e_estimate_80l += dispatch_duration
-    for op_code_with_id in kernel_duration_per_instance_averaged_dict_compilation.keys():
-        if "AllGather" in op_code_with_id or "ReduceScatter" in op_code_with_id or "AllReduce" in op_code_with_id:
-            avg_kernel_duration = kernel_duration_per_instance_averaged_dict_trace[op_code_with_id]
+    for op_id in kernel_duration_per_instance_dict_trace_first_layer.keys():  # first layer
+        op_to_op_latency = dispatch_duration_per_instance_dict_first_layer[op_id][0]
+        if is_collective_op(op_id):
+            kernel_duration = kernel_duration_per_instance_dict_trace_first_layer[op_id][0]
         else:
-            avg_kernel_duration = kernel_duration_per_instance_averaged_dict_compilation[op_code_with_id]
-        avg_dispatch_duration = dispatch_duration_per_instance_averaged_dict[op_code_with_id]
+            kernel_duration = kernel_duration_per_instance_dict_compilation_first_layer[op_id][0]
+
+        if op_to_op_latency < 0:
+            op_to_op_latency = 0
+
+        print(f"op_id: {op_id}, kernel_duration: {kernel_duration}, op_to_op_latency: {op_to_op_latency}")
+
+        e2e_estimate_80l += kernel_duration + op_to_op_latency
+    for op_id in kernel_duration_per_instance_averaged_dict_trace.keys():  # 79 layers based on average of layers 2-9
+        if is_collective_op(op_id):
+            avg_kernel_duration = kernel_duration_per_instance_averaged_dict_trace[op_id]
+        else:
+            avg_kernel_duration = kernel_duration_per_instance_averaged_dict_compilation[op_id]
+        avg_dispatch_duration = dispatch_duration_per_instance_averaged_dict[op_id]
         e2e_estimate_80l += (avg_kernel_duration + avg_dispatch_duration) * 79  # weighting avg for 79 layers
 
-    print(f"e2e estimate: {e2e_estimate_80l}")
+    # Estimated T/s/u is 1000000 / (80L-duration + ~2100 lmhead+sampling+embeddings + ~300 python-overhead
+    tsu_estimate = 1000000 / (e2e_estimate_80l / 1000 + 2100 + 300)
+
+    print(f"80L e2e time estimate: {e2e_estimate_80l}")
+    print(f"80L T/s/u estimate: {tsu_estimate}")
 
     benchmark_data.add_measurement(profiler, 0, step_name, "e2e_estimate_80l", e2e_estimate_80l)
-    # Estimated T/s/u is 1000000 / (80L-duration + ~2100 lmhead+sampling+embeddings + ~300 python-overhead
-    benchmark_data.add_measurement(
-        profiler, 0, step_name, "tsu_estimate", 1000000 / (e2e_estimate_80l / 1000 + 2100 + 300)
-    )
+    benchmark_data.add_measurement(profiler, 0, step_name, "tsu_estimate", tsu_estimate)
 
     benchmark_data.save_partial_run_json(
         profiler,


### PR DESCRIPTION
### Ticket
None

### Problem description
estimated e2e tsu in device test was inaccurate

### What's changed
Changed first layer times to
- use compiled/traced time based on non-ccl / ccl ops
- exclude first ops op-to-op time since it's a bit negative number due to prefetcher

Did not run CI since no model changes but only e2e tsu calculation change. Tested locally.