### PR TITLE
Topk: extend to sub_core_grid and use max available cores in column

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -6,7 +6,6 @@ import pytest
 import torch
 import ttnn
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_grayskull
 
 
 def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids=None):
@@ -20,10 +19,6 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
     ttnn_topk_values, ttnn_topk_indices = ttnn.topk(
         ttnn_input, k, dim=dim, largest=largest, sorted=sorted, sub_core_grids=sub_core_grids
     )
-
-    print(f"topk done")
-    print(f"unit test: ttnn_topk_values: {ttnn_topk_values}")
-    print(f"unit test: ttnn_topk_indices: {ttnn_topk_indices}")
 
     desired_shape = [N, C, H, W]
     desired_shape[dim] = k
@@ -49,13 +44,9 @@ def run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_g
 
     assert ttnn_torch_cosine > 0.99, "Cosine similarity between topk values and gather from indices is less than 0.99"
 
-    print(f"unit test: pyt_topk_values: {pyt_topk_values}")
-    print(f"unit test: ttnn_torch_values: {ttnn_torch_values}")
-
     assert_with_pcc(pyt_topk_values, ttnn_torch_values, pcc_values)
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "dtype",
     (
@@ -114,7 +105,6 @@ def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids
     run_topk_test(N, C, H, W, k, dtype, dim, sorted, largest, device, sub_core_grids)
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "dtype",
     (ttnn.bfloat8_b,),

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -133,12 +133,11 @@ def test_topk(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids
     [
         ttnn.CoreRangeSet(
             [
-                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+                ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 7)),
             ]
         ),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 def test_topk_sub_core_grids(N, C, H, W, dim, k, dtype, sorted, largest, device, sub_core_grids):
     if dim == 0 or dim == 1:
         # As of now, when we try to get top-k for dim = 0 or 1, we get following error from transpose_op.cpp's validate():

--- a/tests/ttnn/unit_tests/operations/test_plus_one.py
+++ b/tests/ttnn/unit_tests/operations/test_plus_one.py
@@ -12,11 +12,18 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
 @pytest.mark.parametrize("w", [1, 4, 8, 32])
-def test_plus_one(device, w):
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ttnn.int32,
+        ttnn.uint32,
+    ],
+)
+def test_plus_one(device, w, dtype):
     torch_input_tensor = torch.randint(32000, (w,))
     torch_output_tensor = torch_input_tensor + 1
 
-    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.int32, device=device)
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, device=device)
     ttnn.plus_one(input_tensor)
     output_tensor = ttnn.to_torch(input_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -221,6 +221,9 @@ std::vector<CoreCoord> grid_to_cores_with_noop(
 std::vector<CoreCoord> corerange_to_cores(
     const CoreRangeSet& crs, std::optional<uint32_t> max_cores = std::nullopt, bool row_wise = false);
 
+CoreRangeSet select_from_corerange(
+    const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise = false);
+
 bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b);
 
 template <>

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -626,6 +626,15 @@ std::vector<CoreCoord> corerange_to_cores(const CoreRangeSet& crs, std::optional
     return all_cores;
 }
 
+CoreRangeSet select_from_corerange(const CoreRangeSet& crs, uint32_t start_index, uint32_t end_index, bool row_wise) {
+    auto all_cores = corerange_to_cores(crs, end_index + 1, row_wise);
+    std::vector<CoreRange> selected_cores;
+    for (uint32_t i = start_index; i <= end_index; i++) {
+        selected_cores.push_back(CoreRange(all_cores[i], all_cores[i]));
+    }
+    return CoreRangeSet(selected_cores);
+}
+
 bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b) { return !(a == b); }
 
 auto fmt::formatter<CoreRangeSet>::format(const CoreRangeSet& core_range_set, format_context& ctx) const

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     constexpr uint32_t K = get_compile_time_arg_val(5);
     constexpr uint32_t Kt = get_compile_time_arg_val(6);
 
-    uint32_t start_ht = get_arg_val<uint32_t>(0);
+    uint32_t start_ht = get_arg_val<uint32_t>(0);  // TODO: remove this, unused
     uint32_t start_wt = get_arg_val<uint32_t>(1);
 
     constexpr uint32_t values_cb_index = tt::CBIndex::c_16;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp
@@ -13,8 +13,7 @@ void kernel_main() {
     constexpr uint32_t K = get_compile_time_arg_val(5);
     constexpr uint32_t Kt = get_compile_time_arg_val(6);
 
-    uint32_t start_ht = get_arg_val<uint32_t>(0);  // TODO: remove this, unused
-    uint32_t start_wt = get_arg_val<uint32_t>(1);
+    uint32_t start_wt = get_arg_val<uint32_t>(0);
 
     constexpr uint32_t values_cb_index = tt::CBIndex::c_16;
     constexpr uint32_t output_ind_cb_index = tt::CBIndex::c_17;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -10,7 +10,12 @@ using namespace tt::tt_metal;
 namespace topk_utils {
 
 static inline bool verify_multi_core_cost(
-    const std::vector<Tensor>& input_tensors, uint16_t width, uint16_t min_dim, uint16_t max_dim, uint32_t k) {
+    const std::vector<Tensor>& input_tensors,
+    uint16_t width,
+    uint16_t min_dim,
+    uint16_t max_dim,
+    uint32_t k,
+    CoreRangeSet core_range_set) {
     auto device = input_tensors.at(0).device();
     tt::DataFormat value_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).get_dtype());
@@ -19,10 +24,9 @@ static inline bool verify_multi_core_cost(
     uint32_t value_tile_size = tile_size(value_cb_data_format);
     uint32_t index_tile_size = tile_size(index_cb_data_format);
 
-    const auto max_cores =
-        device->compute_with_storage_grid_size().y - 1;  // reserve one core for the gather - switch to grid.x as it
-                                                         // allows for more cores and allow spillover to next row
-    for (uint16_t split_size = max_dim; split_size >= min_dim; split_size /= 2) {
+    const auto core_range = core_range_set.ranges().at(0);
+    const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
+    for (uint16_t split_size = min_dim; split_size <= max_dim; split_size *= 2) {
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);
         uint32_t memory_cost_gather =
@@ -90,7 +94,12 @@ void TopK::validate_with_output_tensors(
 
     if (input_shape[dim] >= topk_utils::multi_core_min_width) {  // multicore implementation
         can_run = topk_utils::verify_multi_core_cost(
-            input_tensors, input_shape[this->dim], 64, input_shape[this->dim] / 2, this->k);
+            input_tensors, input_shape[this->dim], 64, input_shape[this->dim] / 2, this->k, this->sub_core_grids);
+
+        TT_FATAL(
+            this->sub_core_grids.ranges().size() == 1,
+            "Only one core range is supported right now, got {}",
+            this->sub_core_grids.ranges().size());
 
         if (!can_run) {  // can we default to new topk implementation on single core
             can_run = topk_utils::verify_single_core_cost(input_tensors, this->k);
@@ -154,16 +163,30 @@ operation::ProgramWithCallbacks TopK::create_program(
     // tensor size, so it can handle larger input tensor sizes.
     // TODO: implement new topk implementation for multicore
     multicore_supported &= topk_utils::verify_multi_core_cost(
-        input_tensors, input_shape[this->dim], 64, input_shape[this->dim] / 2, this->k);
+        input_tensors, input_shape[this->dim], 64, input_shape[this->dim] / 2, this->k, this->sub_core_grids);
 
     multicore_supported &= (this->k <= 64);  // old implementation cannot handle k>64
 
     if (!multicore_supported) {
         return detail::topk_single_core_interleaved(
-            input_tensor, this->k, this->dim, this->largest, this->sorted, output_tensors.at(0), output_tensors.at(1));
+            input_tensor,
+            this->k,
+            this->dim,
+            this->largest,
+            this->sorted,
+            this->sub_core_grids,
+            output_tensors.at(0),
+            output_tensors.at(1));
     } else {
         return detail::topk_multicore_interleaved(
-            input_tensor, this->k, this->dim, this->largest, this->sorted, output_tensors.at(0), output_tensors.at(1));
+            input_tensor,
+            this->k,
+            this->dim,
+            this->largest,
+            this->sorted,
+            this->sub_core_grids,
+            output_tensors.at(0),
+            output_tensors.at(1));
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -26,7 +26,8 @@ static inline bool verify_multi_core_cost(
 
     const auto core_range = core_range_set.ranges().at(0);
     const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
-    for (uint16_t split_size = max_dim; split_size >= min_dim; split_size /= 2) {
+    uint16_t start_split_size = width / max_cores;
+    for (uint16_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);
         uint32_t memory_cost_gather =
@@ -38,7 +39,7 @@ static inline bool verify_multi_core_cost(
                                                   // as a matching set of indices, is processed by a core
         if (num_cores <= max_cores &&
             (memory_cost_gather + (memory_cost_local * num_cores)) < (device->l1_size_per_core() * num_cores) &&
-            num_cores > 1) {
+            num_cores > 1 && split_size >= min_dim) {
             return true;
         }
     }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -17,7 +17,7 @@ static inline bool verify_multi_core_cost(
     uint16_t min_dim,
     uint16_t max_dim,
     uint32_t k,
-    CoreRangeSet core_range_set) {
+    const CoreRangeSet& core_range_set) {
     auto device = input_tensors.at(0).device();
     tt::DataFormat value_cb_data_format =
         tt::tt_metal::datatype_to_dataformat_converter(input_tensors.at(0).get_dtype());

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.cpp
@@ -9,6 +9,8 @@ using namespace tt::tt_metal;
 
 namespace topk_utils {
 
+static inline uint32_t largest_power_of_two(std::uint32_t x) { return x == 0 ? 0 : (1 << (31 - __builtin_clz(x))); }
+
 static inline bool verify_multi_core_cost(
     const std::vector<Tensor>& input_tensors,
     uint16_t width,
@@ -26,7 +28,7 @@ static inline bool verify_multi_core_cost(
 
     const auto core_range = core_range_set.ranges().at(0);
     const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
-    uint16_t start_split_size = width / max_cores;
+    uint16_t start_split_size = width / largest_power_of_two(max_cores);
     for (uint16_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_op.hpp
@@ -17,6 +17,7 @@ struct TopK {
     const bool largest;
     const bool sorted;
     const tt::tt_metal::MemoryConfig output_mem_config;
+    const CoreRangeSet sub_core_grids;
 
     void validate_with_output_tensors(
         const std::vector<Tensor>& input_tensors, const std::vector<std::optional<Tensor>>& output_tensors) const;

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -20,14 +20,16 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     const int8_t dim,
     const bool largest,
     const bool sorted,
+    const CoreRangeSet& sub_core_grids,
     Tensor& value_tensor,
     Tensor& index_tensor) {
     using namespace tt::constants;
     tt::tt_metal::Program program{};
-    CoreRange core({0, 0}, {0, 0});
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
     tt::DataFormat output_val_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(value_tensor.get_dtype());
     tt::DataFormat output_ind_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(index_tensor.get_dtype());
+
+    auto core = corerange_to_cores(sub_core_grids, 1, true).at(0);
 
     uint32_t input_tile_size = tile_size(input_cb_data_format);
     uint32_t value_tile_size = tile_size(output_val_cb_data_format);
@@ -184,7 +186,7 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
         core,
         tt::tt_metal::ComputeConfig{.compile_args = compute_args});
 
-    auto override_runtime_args_callback = [unary_reader_kernel_id, binary_writer_kernel_id](
+    auto override_runtime_args_callback = [unary_reader_kernel_id, binary_writer_kernel_id, core](
                                               const void* operation,
                                               const Program& program,
                                               const std::vector<Tensor>& input_tensors,
@@ -194,8 +196,6 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
 
         auto values_buffer = output_tensors.at(0).buffer();
         auto index_buffer = output_tensors.at(1).buffer();
-
-        CoreCoord core = {0, 0};
 
         {
             auto& reader_runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
@@ -223,14 +223,13 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
     uint16_t width,
     uint16_t min_dim,
     uint16_t max_dim,
-    CoreCoord grid,
+    CoreRange core_range,
     uint32_t k,
     const uint32_t l1_size,
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
-    const auto max_cores = grid.y - 1;  // reserve one core for the gather - switch to grid.x as it allows for more
-                                        // cores and allow spillover to next row
-    for (uint16_t split_size = max_dim; split_size >= min_dim; split_size /= 2) {
+    const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
+    for (uint16_t split_size = min_dim; split_size <= max_dim; split_size *= 2) {
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);
         uint32_t memory_cost_gather =
@@ -263,6 +262,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     const int8_t dim,
     const bool largest,
     const bool sorted,
+    const CoreRangeSet& sub_core_grids,
     Tensor& value_tensor,
     Tensor& index_tensor) {
     using namespace tt::constants;
@@ -271,6 +271,9 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.get_dtype());
     tt::DataFormat value_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(value_tensor.get_dtype());
     tt::DataFormat index_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(index_tensor.get_dtype());
+
+    auto first_core_range = sub_core_grids.ranges().at(0);
+    auto first_core_range_set = ttnn::CoreRangeSet(first_core_range);
 
     uint32_t input_tile_size = tile_size(input_cb_data_format);
     uint32_t value_tile_size = tile_size(value_cb_data_format);
@@ -294,17 +297,19 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         input_shape[dim],
         64,
         input_shape[dim] / 2,
-        device->compute_with_storage_grid_size(),
+        first_core_range,
         k,
         device->l1_size_per_core(),
         value_tile_size,
         index_tile_size);
 
-    CoreRange core({0, 0}, {0, num_cores - 1u});
+    auto all_cores_range_set = select_from_corerange(first_core_range_set, 0, num_cores - 1u, false);
 
-    CoreRange local_cores({0, 0}, {0, num_cores - 2u});
+    auto local_cores_range_set = select_from_corerange(first_core_range_set, 0, num_cores - 2u, false);
+    auto local_cores = corerange_to_cores(local_cores_range_set, num_cores - 1u, false);
 
-    CoreRange final_cores({0, num_cores - 1u}, {0, num_cores - 1u});
+    auto final_cores_range_set = select_from_corerange(first_core_range_set, num_cores - 1u, num_cores - 1u, false);
+    auto final_core = corerange_to_cores(final_cores_range_set, 1u, false).at(0);
 
     uint32_t Wt_local = local_topk_input_size / TILE_WIDTH;
     uint32_t Wt_final = final_topk_input_size / TILE_WIDTH;
@@ -321,7 +326,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::CircularBufferConfig input_cb_config =
         tt::tt_metal::CircularBufferConfig(cb_in_units * value_tile_size, {{input_cb_index, input_cb_data_format}})
             .set_page_size(input_cb_index, input_tile_size);
-    auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, core, input_cb_config);
+    auto cb_input_tensor = tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, input_cb_config);
 
     // Two tiles are loaded in for topk_local_sort at a time, and we double buffer to avoid stalls, so allocate four
     // tiles of space This CB carries the indices that are created in the reader kernel
@@ -329,7 +334,8 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::CircularBufferConfig index_input_intermed0_config =
         tt::tt_metal::CircularBufferConfig(cb_in_units * index_tile_size, {{index_cb_index, index_cb_data_format}})
             .set_page_size(index_cb_index, index_tile_size);
-    auto cb_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, index_input_intermed0_config);
+    auto cb_index_tensor =
+        tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, index_input_intermed0_config);
 
     // Single buffered circular buffer that holds the transposed input tiles
     uint32_t input_transposed_cb_index = tt::CBIndex::c_24;
@@ -337,7 +343,8 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         tt::tt_metal::CircularBufferConfig(
             Wt_local * value_tile_size, {{input_transposed_cb_index, input_cb_data_format}})
             .set_page_size(input_transposed_cb_index, input_tile_size);
-    auto cb_input_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, input_transposed_cb_config);
+    auto cb_input_transposed_tiles =
+        tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, input_transposed_cb_config);
 
     // Single buffered circular buffer that holds the transposed index tiles
     uint32_t index_transposed_cb_index = tt::CBIndex::c_25;
@@ -345,14 +352,16 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
         tt::tt_metal::CircularBufferConfig(
             Wt_local * index_tile_size, {{index_transposed_cb_index, index_cb_data_format}})
             .set_page_size(index_transposed_cb_index, index_tile_size);
-    auto cb_index_transposed_tiles = tt::tt_metal::CreateCircularBuffer(program, core, index_transposed_cb_config);
+    auto cb_index_transposed_tiles =
+        tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, index_transposed_cb_config);
 
     uint32_t gathered_values_cb_index = tt::CBIndex::c_26;
     tt::tt_metal::CircularBufferConfig gathered_values_cb_config =
         tt::tt_metal::CircularBufferConfig(
             Wt_final * value_tile_size, {{gathered_values_cb_index, value_cb_data_format}})
             .set_page_size(gathered_values_cb_index, value_tile_size);
-    auto cb_gathered_topk_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, gathered_values_cb_config);
+    auto cb_gathered_topk_values_tensor =
+        tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, gathered_values_cb_config);
 
     uint32_t gathered_indices_cb_index = tt::CBIndex::c_27;
     tt::tt_metal::CircularBufferConfig gathered_indices_cb_config =
@@ -360,37 +369,39 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
             Wt_final * index_tile_size, {{gathered_indices_cb_index, index_cb_data_format}})
             .set_page_size(gathered_indices_cb_index, index_tile_size);
     auto cb_gathered_topk_indices_tensor =
-        tt::tt_metal::CreateCircularBuffer(program, core, gathered_indices_cb_config);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, gathered_indices_cb_config);
 
     uint32_t final_values_cb_index = tt::CBIndex::c_28;
     tt::tt_metal::CircularBufferConfig final_values_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt_final * value_tile_size, {{final_values_cb_index, value_cb_data_format}})
             .set_page_size(final_values_cb_index, value_tile_size);
-    auto cb_final_topk_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, final_values_cb_config);
+    auto cb_final_topk_values_tensor =
+        tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, final_values_cb_config);
 
     uint32_t final_indices_cb_index = tt::CBIndex::c_29;
     tt::tt_metal::CircularBufferConfig final_indices_cb_config =
         tt::tt_metal::CircularBufferConfig(Wt_final * index_tile_size, {{final_indices_cb_index, index_cb_data_format}})
             .set_page_size(final_indices_cb_index, index_tile_size);
-    auto cb_final_topk_index_tensor = tt::tt_metal::CreateCircularBuffer(program, core, final_indices_cb_config);
+    auto cb_final_topk_index_tensor =
+        tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, final_indices_cb_config);
 
     // Output topk values
     uint32_t values_cb_index = tt::CBIndex::c_16;
     tt::tt_metal::CircularBufferConfig values_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * value_tile_size, {{values_cb_index, value_cb_data_format}})
             .set_page_size(values_cb_index, value_tile_size);
-    auto cb_values_tensor = tt::tt_metal::CreateCircularBuffer(program, core, values_cb_config);
+    auto cb_values_tensor = tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, values_cb_config);
 
     // Output topk indices
     uint32_t output_ind_cb_index = tt::CBIndex::c_17;
     tt::tt_metal::CircularBufferConfig output_ind_cb_config =
         tt::tt_metal::CircularBufferConfig(num_cb_unit * index_tile_size, {{output_ind_cb_index, index_cb_data_format}})
             .set_page_size(output_ind_cb_index, index_tile_size);
-    auto cb_output_ind_tensor = tt::tt_metal::CreateCircularBuffer(program, core, output_ind_cb_config);
+    auto cb_output_ind_tensor = tt::tt_metal::CreateCircularBuffer(program, all_cores_range_set, output_ind_cb_config);
 
     // Create semaphores
-    auto sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, core, INVALID);
-    auto receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, core, INVALID);
+    auto sender_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores_range_set, INVALID);
+    auto receiver_semaphore_id = tt::tt_metal::CreateSemaphore(program, all_cores_range_set, INVALID);
     std::vector<uint32_t> reader_local_compile_time_args = {
         input_cb_index,
         index_cb_index,
@@ -402,11 +413,11 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_create_index_local_topk.cpp",
-        local_cores,
+        local_cores_range_set,
         tt::tt_metal::ReaderDataMovementConfig(reader_local_compile_time_args));
 
-    CoreCoord local_cores_physical_start = device->worker_core_from_logical_core({0, 0});
-    CoreCoord local_cores_physical_end = device->worker_core_from_logical_core({0, num_cores - 2u});
+    CoreCoord local_cores_physical_start = device->worker_core_from_logical_core(local_cores.at(0));
+    CoreCoord local_cores_physical_end = device->worker_core_from_logical_core(local_cores.at(num_cores - 2u));
     std::vector<uint32_t> reader_compile_time_args = {
         (std::uint32_t)receiver_semaphore_id,
         (std::uint32_t)sender_semaphore_id,
@@ -422,10 +433,10 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::KernelHandle unary_reader_final_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_final_topk.cpp",
-        final_cores,
+        final_cores_range_set,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args));
 
-    CoreCoord final_cores_physical = device->worker_core_from_logical_core({0, num_cores - 1u});
+    CoreCoord final_cores_physical = device->worker_core_from_logical_core(final_core);
     std::vector<uint32_t> writer_compile_time_args = {
         (std::uint32_t)receiver_semaphore_id,
         (std::uint32_t)sender_semaphore_id,
@@ -438,7 +449,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::KernelHandle binary_writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_local_topk.cpp",
-        local_cores,
+        local_cores_range_set,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args));
 
     std::vector<uint32_t> writer_compile_time_args_final = {
@@ -446,7 +457,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::KernelHandle binary_writer_final_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_final_topk.cpp",
-        final_cores,
+        final_cores_range_set,
         tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args_final));
 
     std::vector<uint32_t> compute_args = {
@@ -468,7 +479,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::KernelHandle topk_compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_local.cpp",
-        local_cores,
+        local_cores_range_set,
         tt::tt_metal::ComputeConfig{.compile_args = compute_args});
 
     std::vector<uint32_t> compute_args_final = {
@@ -491,75 +502,71 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::tt_metal::KernelHandle topk_final_compute_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_final.cpp",
-        final_cores,
+        final_cores_range_set,
         tt::tt_metal::ComputeConfig{.compile_args = compute_args_final});
 
-    for (uint32_t core_h = 0; core_h < 1; core_h++) {
-        bool ascending = !largest;
-        for (uint32_t core_w = 0; core_w < num_cores - 1; core_w++) {
-            CoreCoord core = {core_h, core_w};
-            SetRuntimeArgs(
-                program,
-                unary_reader_kernel_id,
-                core,
-                {
-                    input_buffer->address(),
-                    0,  // no height parallelism for now
-                    core_w * Wt_local,
-                });
-
-            SetRuntimeArgs(
-                program,
-                binary_writer_kernel_id,
-                core,
-                {
-                    core_h,
-                    core_w,
-                });
-
-            SetRuntimeArgs(
-                program,
-                topk_compute_kernel_id,
-                core,
-                {
-                    ascending,
-                });
-
-            ascending = !ascending;
-        }
-        CoreCoord core = {core_h, num_cores - 1u};
+    int core_h = 0;
+    int core_w = 0;
+    bool ascending = !largest;
+    for (auto core : local_cores) {
         SetRuntimeArgs(
             program,
-            binary_writer_final_kernel_id,
+            unary_reader_kernel_id,
             core,
             {
-                values_buffer->address(),
-                index_buffer->address(),
+                input_buffer->address(),
+                0,  // no height parallelism for now
+                core_w * Wt_local,
             });
+
+        SetRuntimeArgs(
+            program,
+            binary_writer_kernel_id,
+            core,
+            {
+                core_h,  // TODO: remove this, unused
+                core_w,
+            });
+
+        SetRuntimeArgs(
+            program,
+            topk_compute_kernel_id,
+            core,
+            {
+                ascending,
+            });
+        core_w++;
+        ascending = !ascending;
     }
+    SetRuntimeArgs(
+        program,
+        binary_writer_final_kernel_id,
+        final_core,
+        {
+            values_buffer->address(),
+            index_buffer->address(),
+        });
 
-    auto override_runtime_args_callback = [unary_reader_kernel_id, binary_writer_final_kernel_id, num_cores](
-                                              const void* operation,
-                                              const Program& program,
-                                              const std::vector<Tensor>& input_tensors,
-                                              const std::vector<std::optional<const Tensor>>&,
-                                              const std::vector<Tensor>& output_tensors) {
-        auto input_buffer = input_tensors.at(0).buffer();
-        auto values_buffer = output_tensors.at(0).buffer();
-        auto index_buffer = output_tensors.at(1).buffer();
+    auto override_runtime_args_callback =
+        [unary_reader_kernel_id, binary_writer_final_kernel_id, local_cores, final_core](
+            const void* operation,
+            const Program& program,
+            const std::vector<Tensor>& input_tensors,
+            const std::vector<std::optional<const Tensor>>&,
+            const std::vector<Tensor>& output_tensors) {
+            auto input_buffer = input_tensors.at(0).buffer();
+            auto values_buffer = output_tensors.at(0).buffer();
+            auto index_buffer = output_tensors.at(1).buffer();
 
-        for (uint32_t core_h = 0; core_h < 1; core_h++) {
-            for (uint32_t core_w = 0; core_w < num_cores - 1; core_w++) {
-                CoreCoord core = {core_h, core_w};
+            for (auto core : local_cores) {
                 auto& reader_runtime_args = GetRuntimeArgs(program, unary_reader_kernel_id, core);
                 reader_runtime_args[0] = input_buffer->address();
-
-                auto& writer_runtime_args = GetRuntimeArgs(program, binary_writer_final_kernel_id, core);
-                writer_runtime_args[0] = values_buffer->address();
-                writer_runtime_args[1] = index_buffer->address();
             }
-        }
-    };
+
+            auto& writer_runtime_args = GetRuntimeArgs(program, binary_writer_final_kernel_id, final_core);
+            writer_runtime_args[0] = values_buffer->address();
+            writer_runtime_args[1] = index_buffer->address();
+        };
 
     return {std::move(program), override_runtime_args_callback};
 }

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -229,7 +229,8 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
     const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
-    for (uint16_t split_size = max_dim; split_size >= min_dim; split_size /= 2) {
+    uint16_t start_split_size = width / max_cores;
+    for (uint16_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);
         uint32_t memory_cost_gather =
@@ -240,7 +241,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
             (value_tile_size + index_tile_size);  // we divide the width into split_size chunks and each chunk, as well
                                                   // as a matching set of indices, is processed by a core
         if (num_cores <= max_cores && (memory_cost_gather + memory_cost_local * num_cores) < (l1_size * num_cores) &&
-            num_cores > 1) {
+            num_cores > 1 && split_size >= min_dim) {
             return {
                 num_cores + 1,
                 split_size,

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -229,7 +229,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
     const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
-    for (uint16_t split_size = min_dim; split_size <= max_dim; split_size *= 2) {
+    for (uint16_t split_size = max_dim; split_size >= min_dim; split_size /= 2) {
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);
         uint32_t memory_cost_gather =

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -524,7 +524,6 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
             binary_writer_kernel_id,
             core,
             {
-                core_h,  // TODO: remove this, unused
                 core_w,
             });
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -276,7 +276,7 @@ operation::ProgramWithCallbacks topk_multicore_interleaved(
     tt::DataFormat index_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(index_tensor.get_dtype());
 
     auto first_core_range = sub_core_grids.ranges().at(0);
-    auto first_core_range_set = ttnn::CoreRangeSet(first_core_range);
+    auto first_core_range_set = CoreRangeSet(first_core_range);
 
     uint32_t input_tile_size = tile_size(input_cb_data_format);
     uint32_t value_tile_size = tile_size(value_cb_data_format);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.cpp
@@ -210,6 +210,8 @@ operation::ProgramWithCallbacks topk_single_core_interleaved(
     return {std::move(program), override_runtime_args_callback};
 }
 
+static inline uint32_t largest_power_of_two(std::uint32_t x) { return x == 0 ? 0 : (1 << (31 - __builtin_clz(x))); }
+
 /**
  * Split the work along the width such that the width is divisible by min_dim and the number of cores used is less than
  * or equal to max_cores. Each core must have a minimum of two tiles - min_dim = 64 as that's the minimum size for the
@@ -229,7 +231,7 @@ static inline std::tuple<uint16_t, uint16_t, uint16_t, uint16_t> cores_utilized(
     const uint32_t value_tile_size,
     const uint32_t index_tile_size) {
     const auto max_cores = core_range.end_coord.y - core_range.start_coord.y - 1;
-    uint16_t start_split_size = width / max_cores;
+    uint16_t start_split_size = width / largest_power_of_two(max_cores);
     for (uint16_t split_size = start_split_size; split_size <= max_dim; split_size *= 2) {
         uint16_t rem = width % split_size;
         uint16_t num_cores = width / split_size + (rem > 0);

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_program_factory.hpp
@@ -12,6 +12,7 @@ tt::tt_metal::operation::ProgramWithCallbacks topk_single_core_interleaved(
     const int8_t dim,
     const bool largest,
     const bool sorted,
+    const CoreRangeSet& sub_core_grids,
     Tensor& value_tensor,
     Tensor& index_tensor);
 
@@ -21,6 +22,7 @@ tt::tt_metal::operation::ProgramWithCallbacks topk_multicore_interleaved(
     const int8_t dim,
     const bool largest,
     const bool sorted,
+    const CoreRangeSet& sub_core_grids,
     Tensor& value_tensor,
     Tensor& index_tensor);
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.hpp
@@ -21,6 +21,7 @@ struct ExecuteTopK {
         const bool largest,
         const bool sorted,
         const std::optional<MemoryConfig>& memory_config,
+        const std::optional<CoreRangeSet>& sub_core_grids,
         std::optional<std::tuple<Tensor, Tensor>> optional_output_tensors = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk_pybind.hpp
@@ -62,8 +62,18 @@ void bind_reduction_topk_operation(py::module& module) {
                const bool sorted,
                std::optional<std::tuple<ttnn::Tensor, ttnn::Tensor>> optional_output_tensors,
                const std::optional<ttnn::MemoryConfig>& memory_config,
+               const std::optional<ttnn::CoreRangeSet>& sub_core_grids,
                QueueId queue_id) {
-                return self(queue_id, input_tensor, k, dim, largest, sorted, memory_config, optional_output_tensors);
+                return self(
+                    queue_id,
+                    input_tensor,
+                    k,
+                    dim,
+                    largest,
+                    sorted,
+                    memory_config,
+                    sub_core_grids,
+                    optional_output_tensors);
             },
             py::arg("input_tensor").noconvert(),
             py::arg("k") = 32,
@@ -73,6 +83,7 @@ void bind_reduction_topk_operation(py::module& module) {
             py::kw_only(),
             py::arg("out") = std::nullopt,
             py::arg("memory_config") = std::nullopt,
+            py::arg("sub_core_grids") = std::nullopt,
             py::arg("queue_id") = DefaultQueueId});
 }
 


### PR DESCRIPTION
### Ticket
None
### Problem description
Topk does not have support for sub_core_grids to run in the TG llama setting with multiple sub devices. It's also using the minimal num cores that fit all inputs.

### What's changed
- Extended topk to support sub_core_grids argument for TG llama case
- Topk is now using the maximum number of cores available in the column from the passed in sub_core_grid/compute grid
- Checks that only one grid is passed into sub_core_grid core range set

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/14970704404
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14837647475
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14837667374
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/14905726703
- [x] New/Existing tests provide coverage for changes