### PR TITLE
ttnn stress test pipeline workflow

### DIFF
--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -1,0 +1,61 @@
+name: "[internal] ttnn stress tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        required: true
+        type: string
+      runner-label:
+        required: true
+        type: string
+      timeout:
+        required: false
+        type: number
+        default: 45
+      docker-image:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+
+jobs:
+  ttnn:
+    strategy:
+      # Do not fail-fast because we need to ensure all tests go to completion
+      # so we try not to get hanging machines
+
+    name: ttnn stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
+    runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-ttnn-stress"]
+
+    container:
+      image: ${{ inputs.docker-image }}
+      env:
+        ARCH_NAME: ${{ inputs.arch }}
+        LOGURU_LEVEL: INFO
+        PYTHONPATH: /work
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: ⬇️  Setup Job
+        uses: tenstorrent/tt-metal/.github/actions/setup-job@main
+        timeout-minutes: 10
+        with:
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: Run Stress Tests
+        timeout-minutes: ${{ inputs.timeout }}
+        run: pytest tests/ttnn/stress_tests/
+
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/ttnn-stress-tests.yaml
+++ b/.github/workflows/ttnn-stress-tests.yaml
@@ -1,0 +1,41 @@
+name: "ttnn stress tests"
+
+on:
+  workflow_dispatch:
+    inputs:
+      arch:
+        required: true
+        type: choice
+        options:
+          - wormhole_b0
+          - blackhole
+      runner-label:
+        required: true
+        type: choice
+        options:
+          - N150
+          - N300
+          - BH
+      timeout:
+        required: false
+        type: number
+        default: 120
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      build-wheel: true
+      version: 22.04
+  test:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
+    with:
+      arch: ${{ inputs.arch || 'wormhole_b0' }}
+      runner-label: ${{ inputs.runner-label || 'N150' }}
+      timeout: ${{ (github.event_name == 'schedule' && 120) || fromJSON(inputs.timeout) }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/ttnn-stress-tests.yaml
+++ b/.github/workflows/ttnn-stress-tests.yaml
@@ -15,7 +15,8 @@ on:
         options:
           - N150
           - N300
-          - BH
+          - P100
+          - P150
       timeout:
         required: false
         type: number


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21069

### Problem description
A simple hardware stress test that could be initiated from CI was required

### What's changed
- Added gitlab workflow yaml to execute ttnn stress tests

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes