### PR TITLE
Add support for non-6U systems for system health check

### DIFF
--- a/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
+++ b/tests/tt_metal/tt_fabric/system_health/test_system_health.cpp
@@ -22,12 +22,18 @@ TEST(Cluster, ReportSystemHealth) {
     // It is a report of system health
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
 
-    const auto& unique_chip_ids = tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids();
+    auto unique_chip_ids = tt::tt_metal::MetalContext::instance().get_cluster().get_unique_chip_ids();
     std::stringstream ss;
     ss << "Found " << unique_chip_ids.size() << " chips in cluster:" << std::endl;
     std::vector<std::uint32_t> read_vec;
     auto retrain_count_addr = tt::tt_metal::MetalContext::instance().hal().get_dev_addr(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::RETRAIN_COUNT);
+    if (unique_chip_ids.empty()) {
+        // Temporary patch to workaround unique chip ids not being set for non-6U systems
+        for (const auto& chip_id : cluster.user_exposed_chip_ids()) {
+            unique_chip_ids[chip_id] = chip_id;
+        }
+    }
 
     std::vector<std::string> unexpected_system_states;
     for (const auto& [chip_id, unique_chip_id] : unique_chip_ids) {
@@ -61,7 +67,7 @@ TEST(Cluster, ReportSystemHealth) {
 
     // Print a summary of unexpected system states
     for (const auto& err_str : unexpected_system_states) {
-        log_error(tt::LogTest, "{}", err_str);
+        log_warning(tt::LogTest, "{}", err_str);
     }
 }
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/20712)

### Problem description
Currently, UMD unique ids does not include chips on non-6U systems

### What's changed
Added support for health check on t3ks as well, by grabbing the non-unique chip ids.
Downgraded error to warning for down links.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes