### PR TITLE
#21637: Disable check-docs-links

### DIFF
--- a/.github/workflows/all-static-checks.yaml
+++ b/.github/workflows/all-static-checks.yaml
@@ -78,7 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: find-changed-files
     # We get rate-limited if we run too often; only run when it's useful
-    if: ${{ github.ref_name == 'main' || needs.find-changed-files.outputs.docs-changed == 'true' }}
+    # Issue 21637: Disable check-docs-links for now to unblock developers
+    if: false  # ${{ github.ref_name == 'main' || needs.find-changed-files.outputs.docs-changed == 'true' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21637

### Problem description
check-docs-link failing with "Network error: Too Many Requests" which is blocking developers from submitting PRs.

### What's changed
Disable the check

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes