### PR TITLE
#19177: Remove Tensor ctors used for async runtime

### DIFF
--- a/ttnn/cpp/ttnn-pybind/operations/core.hpp
+++ b/ttnn/cpp/ttnn-pybind/operations/core.hpp
@@ -215,31 +215,11 @@ void py_module(py::module& module) {
 
     module.def(
         "allocate_tensor_on_device",
-        py::overload_cast<const ttnn::TensorSpec&, IDevice*>(&ttnn::operations::core::allocate_tensor_on_device),
-        py::arg("tensor_spec"),
-        py::arg("device"));
-
-    module.def(
-        "allocate_tensor_on_device",
         [](const ttnn::TensorSpec& spec, MeshDevice* device) {
             return tt::tt_metal::allocate_tensor_on_mesh(spec, device);
         },
         py::arg("tensor_spec"),
         py::arg("mesh_device"));
-
-    module.def(
-        "allocate_tensor_on_device",
-        py::overload_cast<
-            const ttnn::Shape&,
-            ttnn::DataType,
-            ttnn::Layout,
-            IDevice*,
-            const std::optional<ttnn::MemoryConfig>&>(&ttnn::operations::core::allocate_tensor_on_device),
-        py::arg("shape"),
-        py::arg("dtype"),
-        py::arg("layout"),
-        py::arg("device"),
-        py::arg("memory_config") = std::nullopt);
 
     module.def(
         "allocate_tensor_on_device",

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -33,9 +33,6 @@ Tensor aggregate_as_tensor(
 
 std::vector<int> get_t3k_physical_device_ids_ring();
 
-// Maps a tensor to the set of devices in the device-mesh that the shards will be distributed across.
-std::vector<tt::tt_metal::IDevice*> get_mapped_devices(const Tensor& tensor, MeshDevice& mesh_device);
-
 // Returns the distributed tensor config from a tensor.
 tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
 

--- a/ttnn/cpp/ttnn/operations/core/core.cpp
+++ b/ttnn/cpp/ttnn/operations/core/core.cpp
@@ -66,20 +66,6 @@ ttnn::Tensor allocate_tensor_on_device(
     const Shape& shape,
     DataType data_type,
     Layout layout,
-    IDevice* device,
-    const std::optional<MemoryConfig>& memory_config) {
-    return allocate_tensor_on_device(
-        TensorSpec(
-            shape,
-            tt::tt_metal::TensorLayout(
-                data_type, tt::tt_metal::PageConfig(layout), memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG))),
-        device);
-}
-
-ttnn::Tensor allocate_tensor_on_device(
-    const Shape& shape,
-    DataType data_type,
-    Layout layout,
     MeshDevice* mesh_device,
     const std::optional<MemoryConfig>& memory_config) {
     return allocate_tensor_on_mesh(
@@ -88,10 +74,6 @@ ttnn::Tensor allocate_tensor_on_device(
             tt::tt_metal::TensorLayout(
                 data_type, tt::tt_metal::PageConfig(layout), memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG))),
         mesh_device);
-}
-
-ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, IDevice* device) {
-    return tt::tt_metal::allocate_tensor_on_devices(spec, {device});
 }
 
 ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, MeshDevice* mesh_device) {

--- a/ttnn/cpp/ttnn/operations/core/core.hpp
+++ b/ttnn/cpp/ttnn/operations/core/core.hpp
@@ -40,17 +40,9 @@ ttnn::Tensor allocate_tensor_on_device(
     const Shape& shape,
     DataType data_type,
     Layout layout,
-    IDevice* device,
-    const std::optional<MemoryConfig>& memory_config);
-
-ttnn::Tensor allocate_tensor_on_device(
-    const Shape& shape,
-    DataType data_type,
-    Layout layout,
     MeshDevice* mesh_device,
     const std::optional<MemoryConfig>& memory_config);
 
-ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, IDevice* device);
 ttnn::Tensor allocate_tensor_on_device(const ttnn::TensorSpec& spec, MeshDevice* device);
 
 ttnn::Tensor from_device(const ttnn::Tensor& tensor, bool blocking = true, ttnn::QueueId cq_id = ttnn::DefaultQueueId);

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -291,23 +291,9 @@ struct EmptyLike {
         Layout layout_value = layout.value_or(tensor.get_layout());
         DataType dtype_value = dtype.value_or(tensor.get_dtype());
         MemoryConfig mem_cfg = memory_config.value_or(tensor.memory_config());
-        if (device.has_value()) {
-            return allocate_tensor_on_mesh(
-                TensorSpec(tensor.get_logical_shape(), TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg)),
-                &device->get());
-        } else {
-            auto tensor_device = tensor.device();
-            // TODO #20966: Remove single device support and branches + dynamic_cast
-            if (auto mesh_device = dynamic_cast<MeshDevice*>(tensor_device)) {
-                return allocate_tensor_on_mesh(
-                    TensorSpec(
-                        tensor.get_logical_shape(), TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg)),
-                    mesh_device);
-            }
-            return allocate_tensor_on_devices(
-                TensorSpec(tensor.get_logical_shape(), TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg)),
-                tensor.get_workers(/*blocking=*/true));
-        }
+        return allocate_tensor_on_mesh(
+            TensorSpec(tensor.get_logical_shape(), TensorLayout(dtype_value, PageConfig(layout_value), mem_cfg)),
+            device.has_value() ? &device->get() : tensor.mesh_device());
     }
 };
 

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -33,8 +33,6 @@ DeviceStorage::DeviceStorage(
     std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs_) :
     strategy(std::move(strategy_)), specs(std::move(specs_)), mesh_buffer(std::move(mesh_buffer_)) {}
 
-void DeviceStorage::insert_buffer(const std::shared_ptr<Buffer>& buffer_) { this->buffer = buffer_; }
-
 Buffer* DeviceStorage::get_buffer() const {
     if (this->mesh_buffer.get() != nullptr) {
         return this->mesh_buffer->get_reference_buffer();

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -43,7 +43,6 @@ struct DeviceStorage {
         std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs_);
 
     MemoryConfig memory_config() const;
-    void insert_buffer(const std::shared_ptr<Buffer>& buffer_);
     Buffer* get_buffer() const;
     std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer() const;
 
@@ -106,14 +105,6 @@ struct MultiDeviceHostStorage {
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
-
-    // Helper Functions - Getters and setters to get/modify storage attributes. These are needed to
-    // preinitialize empty tensor handles and use/populate them in the worker threads.
-    void insert_buffer_and_spec_for_device(int buffer_index, const HostBuffer& buffer, TensorSpec spec) {
-        std::lock_guard<std::mutex> lock(mtx);
-        buffers[buffer_index] = buffer;
-        specs[buffer_index] = std::move(spec);
-    }
 
     HostBuffer get_buffer(int buffer_index) const {
         std::lock_guard<std::mutex> lock(mtx);

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -20,10 +20,6 @@ struct HostStorage {
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
 
-    void insert_buffer(const HostBuffer& buffer_) { this->buffer = buffer_; }
-
-    HostBuffer get_buffer() const { return this->buffer; }
-
     bool is_allocated() const { return buffer.is_allocated(); }
 };
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -75,7 +75,6 @@ public:
         uint32_t num_buffers,
         TensorSpec spec,
         std::optional<DistributedTensorConfig> distributed_tensor_config = std::nullopt);
-    explicit Tensor(const std::vector<IDevice*>& workers, TensorSpec spec);
     explicit Tensor(distributed::MeshDevice* mesh_device, TensorSpec spec);
 
     Tensor(const Tensor& other);
@@ -355,8 +354,6 @@ void memcpy(
 void memcpy(Tensor& dst, const void* src, const std::optional<BufferRegion>& region = std::nullopt);
 
 void memcpy(Tensor& dst, const Tensor& src, const std::optional<BufferRegion>& region = std::nullopt);
-
-Tensor allocate_tensor_on_devices(const TensorSpec& spec, const std::vector<IDevice*>& devices);
 
 // Allocates a tensor on a mesh device through mesh buffer.
 Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshDevice* mesh_device);

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -69,30 +69,10 @@ public:
         const std::optional<Tile>& tile = std::nullopt);
     Tensor(Storage storage, TensorSpec tensor_spec);
 
-    // Constructors to initialize unpopulated tensor with workers and storage specified. Use this when creating tensor
-    // handles in async mode.
-    explicit Tensor(
-        uint32_t num_buffers,
-        TensorSpec spec,
-        std::optional<DistributedTensorConfig> distributed_tensor_config = std::nullopt);
-    explicit Tensor(distributed::MeshDevice* mesh_device, TensorSpec spec);
-
     Tensor(const Tensor& other);
-
     Tensor& operator=(const Tensor& other);
-
     Tensor(Tensor&& other) noexcept = default;
-
-    Tensor& operator=(Tensor&& other) {
-        // Don't self assign
-        this->tensor_id = std::move(other.tensor_id);
-        if (this->tensor_attributes != other.tensor_attributes) {
-            this->workers = std::move(other.workers);
-            this->tensor_attributes = std::move(other.tensor_attributes);
-        }
-        this->mesh_device_ = std::move(other.mesh_device_);
-        return *this;
-    }
+    Tensor& operator=(Tensor&& other) noexcept;
 
     ~Tensor();
 
@@ -299,8 +279,6 @@ public:
         return std::forward_as_tuple(
             this->tensor_attributes->get_storage(), this->tensor_attributes->get_tensor_spec());
     }
-
-    std::vector<uint32_t> host_page_ordering();
 
 private:
     void init(Storage storage, TensorSpec tensor_spec);

--- a/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl_wrapper.hpp
@@ -33,10 +33,6 @@ auto dispatch(DataType dtype, Func&& func, Args&&... args) {
             std::get<0>(std::forward_as_tuple(args...)).get_dtype(), AS_LAMBDA(func), std::forward<Args>(args)...); \
     }
 
-inline size_t packed_buffer_size_bytes_wrapper(DataType dtype, size_t volume_unpacked_data) {
-    return dispatch(dtype, AS_LAMBDA(packed_buffer_size_bytes), volume_unpacked_data);
-}
-
 WRAP_FUNCTION(to_host)
 WRAP_FUNCTION(to_host_mesh_tensor)
 WRAP_FUNCTION(extract_shard)

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -119,7 +119,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
                     std::vector<Tensor> shards(s.buffers.size());
                     for (std::size_t shard_idx = 0; shard_idx < s.buffers.size(); ++shard_idx) {
                         // Multi-Thread Host tilization of shards.
-                        mesh_device->enqueue_to_thread_pool([&]() {
+                        mesh_device->enqueue_to_thread_pool([shard_idx, &s, &shards, target_layout]() {
                             ZoneScopedN("HostTilize");
                             Tensor shard(s.buffers[shard_idx], s.specs[shard_idx]);
                             shards[shard_idx] = tensor_impl::to_layout_wrapper(shard, target_layout);

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -4,6 +4,8 @@
 
 #include "tensor_ops.hpp"
 
+#include "tt_stl/overloaded.hpp"
+#include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 #include <cstdint>
@@ -57,12 +59,20 @@ Tensor tensor_to_device(
 }
 
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id) {
-    if (input_tensor.storage_type() == StorageType::HOST) {
+    if (input_tensor.storage_type() != StorageType::DEVICE) {
         return input_tensor;
     }
 
     ZoneScoped;
     GraphTracker::instance().track_function_start("Tensor::cpu", input_tensor, blocking);
+
+    if (input_tensor.mesh_device_.has_value()) {
+        auto output = tensor_impl::to_host_mesh_tensor_wrapper(input_tensor, blocking, cq_id);
+        output = tt::tt_metal::set_tensor_id(output);
+        GraphTracker::instance().track_function_end(output);
+        return output;
+    }
+
     auto workers = input_tensor.get_workers(blocking);
     if (not workers.size()) {
         // Tensor is on host and does not have a worker group.
@@ -73,23 +83,11 @@ Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id) {
         return output;
     }
 
-    Tensor host_tensor(
-        workers.size(), input_tensor.get_tensor_spec(), std::get<DeviceStorage>(input_tensor.get_storage()).strategy);
-    for (int worker_index = 0; worker_index < workers.size(); worker_index++) {
-        auto* target_device = workers[worker_index];
-        auto shard = get_shard_for_device(input_tensor, target_device);
-        shard = tensor_impl::to_host_wrapper(shard, blocking, cq_id);
-        insert_buffer_and_shape_for_device(target_device, shard, host_tensor, worker_index);
-    }
-
+    TT_FATAL(workers.size() == 1, "Unexpected number of workers");
+    Tensor host_tensor = tensor_impl::to_host_wrapper(input_tensor, blocking, cq_id);
     host_tensor = tt::tt_metal::set_tensor_id(host_tensor);
     GraphTracker::instance().track_function_end(host_tensor);
     return host_tensor;
-}
-
-Tensor tensor_cpu(const Tensor& input_tensor, distributed::MeshDevice* mesh_device, bool blocking, QueueId cq_id) {
-    ZoneScoped;
-    return tensor_impl::to_host_mesh_tensor_wrapper(input_tensor, blocking, cq_id);
 }
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker) {
@@ -105,7 +103,7 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevic
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device) {
     ZoneScoped;
-    TT_ASSERT(
+    TT_FATAL(
         is_cpu_tensor(input_tensor) || is_multi_device_host_tensor(input_tensor),
         "to(layout) must be called on host tensors with MULTI_DEVICE_HOST_STORAGE when multiple "
         "workers "
@@ -114,42 +112,32 @@ Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distri
     GraphTracker::instance().track_function_start("Tensor::to_layout", input_tensor, target_layout, mesh_device);
     if (mesh_device) {
         // Mesh Device provided - have a handle to the thread-pool
-        uint32_t num_shards = ttnn::distributed::get_mapped_devices(input_tensor, *mesh_device).size();
+        Tensor tensor_modified_layout = std::visit(
+            tt::stl::overloaded{
+                [&](const HostStorage& s) { return tensor_impl::to_layout_wrapper(input_tensor, target_layout); },
+                [&](const MultiDeviceHostStorage& s) {
+                    std::vector<Tensor> shards(s.buffers.size());
+                    for (std::size_t shard_idx = 0; shard_idx < s.buffers.size(); ++shard_idx) {
+                        // Multi-Thread Host tilization of shards.
+                        mesh_device->enqueue_to_thread_pool([&]() {
+                            ZoneScopedN("HostTilize");
+                            Tensor shard(s.buffers[shard_idx], s.specs[shard_idx]);
+                            shards[shard_idx] = tensor_impl::to_layout_wrapper(shard, target_layout);
+                        });
+                    }
+                    mesh_device->wait_for_thread_pool();
+                    return ttnn::distributed::aggregate_as_tensor(shards, s.strategy);
+                },
+                [&](const DeviceStorage& s) -> Tensor { TT_THROW("Unexpected storage type"); },
+            },
+            input_tensor.get_storage());
 
-        std::optional<DistributedTensorConfig> distributed_config = std::nullopt;
-        if (auto* host_storage = std::get_if<MultiDeviceHostStorage>(&input_tensor.get_storage());
-            host_storage != nullptr) {
-            distributed_config = host_storage->strategy;
-        }
-
-        const auto& original_layout = input_tensor.get_tensor_spec().tensor_layout();
-        Tensor tensor_modified_layout(
-            num_shards,
-            TensorSpec(
-                input_tensor.get_logical_shape(),
-                TensorLayout(
-                    original_layout.get_data_type(),
-                    PageConfig(target_layout, original_layout.get_tile()),
-                    original_layout.get_memory_config())),
-            distributed_config);
-        for (std::size_t shard_idx = 0; shard_idx < num_shards; ++shard_idx) {
-            // Multi-Thread Host tilization of shards.
-            mesh_device->enqueue_to_thread_pool(
-                [&input_tensor, &tensor_modified_layout, target_layout, mesh_device, shard_idx]() {
-                    ZoneScopedN("HostTilize");
-                    auto shard = get_shard_for_device(input_tensor, mesh_device, shard_idx);
-                    shard = tensor_impl::to_layout_wrapper(shard, target_layout);
-                    insert_buffer_and_shape_for_device(mesh_device, shard, tensor_modified_layout, shard_idx);
-                });
-        }
         tensor_modified_layout = tt::tt_metal::set_tensor_id(tensor_modified_layout);
         GraphTracker::instance().track_function_end(tensor_modified_layout);
-        mesh_device->wait_for_thread_pool();
         return tensor_modified_layout;
     }
+
     // Running without worker threads (non-async)
-    TT_ASSERT(
-        input_tensor.storage_type() != StorageType::DEVICE, "Bring tensor to host before converting to target layout");
     auto output = tensor_impl::to_layout_wrapper(input_tensor, target_layout);
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.hpp
@@ -25,15 +25,11 @@ Tensor tensor_to_device(
 Tensor tensor_to_device(
     const Tensor& input_tensor, distributed::MeshDevice* mesh_device, const MemoryConfig& mem_config, QueueId cq_id);
 
-Tensor tensor_to_device(
-    const Tensor& input_tensor, const std::vector<IDevice*>& workers, const MemoryConfig& mem_config, QueueId cq_id);
-
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, IDevice* worker);
 
 Tensor tensor_to_layout(const Tensor& input_tensor, Layout target_layout, distributed::MeshDevice* mesh_device);
 
 Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id);
-Tensor tensor_cpu(const Tensor& input_tensor, distributed::MeshDevice* mesh_device, bool blocking, QueueId cq_id);
 
 void tensor_print(const Tensor& input_tensor);
 

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -56,12 +56,6 @@ void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& calla
 [[deprecated]] Tensor get_shard_for_device(
     const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index = std::nullopt);
 
-void insert_buffer_and_shape_for_device(
-    IDevice* target_device,
-    const Tensor& shard,
-    Tensor& tensor_to_modify,
-    std::optional<int> buffer_index = std::nullopt);
-
 template <class T>
 uint32_t get_batch_size(const T& shape) {
     uint32_t result = 1;


### PR DESCRIPTION
### Ticket
#19177

### Problem description
Tensors used to be created in "pending" state, where worker threads processed and asynchronously added device shards.

This is not needed any more.

### What's changed
Remove the ctors and a bunch of related APIs that are no longer needed.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14864464530)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/14865153337)
- [x] New/Existing tests provide coverage for changes