### PR TITLE
Remove extraneous SFPSWAP NOPs.

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -23,7 +23,6 @@ inline void calculate_binary_max_min(const uint dst_offset) {
 
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
 
         if constexpr (IS_MAX_OP) {
             TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
@@ -52,7 +51,6 @@ inline void calculate_binary_max_min_int32(const uint dst_offset) {
 
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
 
         if constexpr (IS_MAX_OP) {
             TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, INSTR_MOD_CAST);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -14,18 +14,22 @@ namespace sfpu {
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min(uint value) {
+
+    // Load value param to lreg2
+    TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
+
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        // Load value param to lreg1
-        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
-        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
 
         // Load input to lreg0
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
 
+        // Copy value param to lreg1
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
 
         if constexpr (IS_MAX_OP) {
             TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_max_min.h
@@ -23,7 +23,6 @@ inline void calculate_binary_max_min(const uint dst_offset) {
 
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
 
         if constexpr (IS_MAX_OP) {
             TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);
@@ -45,7 +44,6 @@ inline void calculate_binary_max_min_int32(const uint dst_offset) {
 
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
 
         if constexpr (IS_MAX_OP) {
             TTI_SFPSTORE(p_sfpu::LREG1, 12, ADDR_MOD_3, 0);

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_max_min.h
@@ -6,7 +6,6 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
-#include "noc_nonblocking_api.h"
 
 using namespace sfpi;
 
@@ -15,18 +14,22 @@ namespace sfpu {
 
 template <bool IS_MAX_OP = true, bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_unary_max_min(uint value) {
+
+    // Load value param to lreg2
+    TT_SFPLOADI(p_sfpu::LREG2, 10, value & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG2, 8, value >> 16);
+
 #pragma GCC unroll 0
     for (int d = 0; d < ITERATIONS; d++) {
-        // Load value param to lreg1
-        TT_SFPLOADI(p_sfpu::LREG1, 10, value & 0xFFFF);
-        TT_SFPLOADI(p_sfpu::LREG1, 8, value >> 16);
 
         // Load input to lreg0
         TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, 0);
 
+        // Copy value param to lreg1
+        TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG1, 0);
+
         // Swap and store maximum in lreg1, minimum in lreg0
         TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, 1);
-        TTI_SFPNOP;
 
         if constexpr (IS_MAX_OP) {
             TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_3, 0);


### PR DESCRIPTION
### Ticket

tenstorrent/tt-llk#102

### Problem description

SFPSWAP doesn't need to be followed by SFPNOP.  See tenstorrent/tt-llk#102 for details.

### What's changed

- Removed nnecessary SFPNOPs.
- `unary_max_min` optimised slightly by moving repeated immediate loads out of the loop.
- Removed unused include.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes