### PR TITLE
#21649: [skip ci] Put user in sudoers so that people can do whatever they need in the container

### DIFF
--- a/dockerfile/upstream_test_images/Dockerfile
+++ b/dockerfile/upstream_test_images/Dockerfile
@@ -12,6 +12,8 @@ LABEL org.opencontainers.image.licenses=MIT
 
 ## add user
 RUN adduser --uid 1000 --shell /bin/bash user
+RUN usermod -aG sudo user
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER user
 
 RUN git clone https://github.com/tenstorrent/tt-metal --recurse-submodules /home/user/tt-metal

--- a/dockerfile/upstream_test_images/Dockerfile
+++ b/dockerfile/upstream_test_images/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.licenses=MIT
 ## add user
 RUN adduser --uid 1000 --shell /bin/bash user
 RUN usermod -aG sudo user
-RUN echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN echo 'user ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/user && chmod 0440 /etc/sudoers.d/user
 USER user
 
 RUN git clone https://github.com/tenstorrent/tt-metal --recurse-submodules /home/user/tt-metal


### PR DESCRIPTION
…

### Ticket

#21649

### Problem description

Upstream users needed to do additional root-level actions in the container.

### What's changed

Put `user` in the sudoers. This is not safe, but upstream users should be siloed enough that this shouldn't affect them as much.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes