### PR TITLE
#21654: [skip ci] Remove generate-system-logs action from workflows

### DIFF
--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -97,9 +97,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - name: Generate system logs on failure
-        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
-        if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -105,9 +105,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - name: Generate system logs on failure
-        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
-        if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -79,9 +79,6 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - name: Generate system logs on failure
-        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
-        if: ${{ failure() }}
       - name: Generate gtest annotations on failure
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -82,6 +82,3 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - name: Generate system logs on failure
-        uses: tenstorrent/tt-metal/.github/actions/generate-system-logs@main
-        if: ${{ failure() }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21654

### Problem description
Action still fails after https://github.com/tenstorrent/tt-metal/pull/21092
https://github.com/tenstorrent/tt-metal/actions/runs/14842927849/job/41670745526#step:8:22
lspci/lshw not installed in docker container
```
sudo: lspci: command not found
sudo: lshw: command not found
```

### What's changed
I don't think anyone is looking at the logs since the action stopped working, remove it.
Note: will remove the action itself later. If we remove the action right now it will instantly break any running APC jobs without giving developers time to rebase.

### Checklist
- [ ] New/Existing tests provide coverage for changes