### PR TITLE
Output path to elf files when using watcher.

### DIFF
--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -143,7 +143,10 @@ class Kernel : public JitBuildSettings {
 
     bool is_idle_eth() const;
 
-   protected:
+    // May only be called after kernel_full_name_ is set.
+    void register_kernel_elf_paths_with_watcher(IDevice* device);
+
+protected:
     int watcher_kernel_id_;
     KernelSource kernel_src_;
     std::string kernel_full_name_;  // Name + hash
@@ -169,7 +172,9 @@ class Kernel : public JitBuildSettings {
 
     virtual std::string config_hash() const = 0;
 
-   private:
+    virtual std::vector<std::string> file_paths(IDevice* device) const = 0;
+
+private:
     void register_kernel_with_watcher();
 };
 
@@ -204,6 +209,7 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
+    std::vector<std::string> file_paths(IDevice* device) const override;
 };
 
 class EthernetKernel : public Kernel {
@@ -237,6 +243,7 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
+    std::vector<std::string> file_paths(IDevice* device) const override;
 };
 
 class ComputeKernel : public Kernel {
@@ -271,6 +278,7 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
+    std::vector<std::string> file_paths(IDevice* device) const override;
 };
 
 std::ostream& operator<<(std::ostream& os, const DataMovementProcessor& processor);

--- a/tt_metal/api/tt-metalium/kernel.hpp
+++ b/tt_metal/api/tt-metalium/kernel.hpp
@@ -144,7 +144,7 @@ class Kernel : public JitBuildSettings {
     bool is_idle_eth() const;
 
     // May only be called after kernel_full_name_ is set.
-    void register_kernel_elf_paths_with_watcher(IDevice* device);
+    void register_kernel_elf_paths_with_watcher(IDevice& device);
 
 protected:
     int watcher_kernel_id_;
@@ -172,7 +172,7 @@ protected:
 
     virtual std::string config_hash() const = 0;
 
-    virtual std::vector<std::string> file_paths(IDevice* device) const = 0;
+    virtual std::vector<std::string> file_paths(IDevice& device) const = 0;
 
 private:
     void register_kernel_with_watcher();
@@ -209,7 +209,7 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
-    std::vector<std::string> file_paths(IDevice* device) const override;
+    std::vector<std::string> file_paths(IDevice& device) const override;
 };
 
 class EthernetKernel : public Kernel {
@@ -243,7 +243,7 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
-    std::vector<std::string> file_paths(IDevice* device) const override;
+    std::vector<std::string> file_paths(IDevice& device) const override;
 };
 
 class ComputeKernel : public Kernel {
@@ -278,7 +278,7 @@ private:
     uint8_t expected_num_binaries() const override;
 
     std::string config_hash() const override;
-    std::vector<std::string> file_paths(IDevice* device) const override;
+    std::vector<std::string> file_paths(IDevice& device) const override;
 };
 
 std::ostream& operator<<(std::ostream& os, const DataMovementProcessor& processor);

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -66,6 +66,8 @@ static std::chrono::time_point start_time = std::chrono::system_clock::now();
 static std::vector<string> kernel_names;
 static FILE* kernel_file = nullptr;
 static string kernel_file_name = "kernel_names.txt";
+static FILE* kernel_elf_file = nullptr;
+static string kernel_elf_file_name = "kernel_elf_paths.txt";
 
 // Flag to signal whether the watcher server has been killed due to a thrown exception.
 static std::atomic<bool> watcher_killed_due_to_error = false;
@@ -147,6 +149,20 @@ void create_kernel_file() {
     fflush(f);
 
     watcher::kernel_file = f;
+}
+
+void create_kernel_elf_file() {
+    FILE* f;
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    std::filesystem::path output_dir(rtoptions.get_root_dir() + watcher::logfile_path);
+    std::filesystem::create_directories(output_dir);
+    string fname = output_dir.string() + watcher::kernel_elf_file_name;
+    if ((f = fopen(fname.c_str(), "w")) == nullptr) {
+        TT_THROW("Watcher failed to create kernel ELF file\n");
+    }
+    watcher::kernel_elf_file = f;
+    fprintf(f, "0: blank\n");
+    fflush(f);
 }
 
 // noinline so that this fn exists to be called from dgb
@@ -495,6 +511,19 @@ int watcher_register_kernel(const string& name) {
     fflush(watcher::kernel_file);
 
     return k_id;
+}
+
+void watcher_register_kernel_elf_paths(int id, std::vector<std::string> paths) {
+    const std::lock_guard<std::mutex> lock(watcher::watch_mutex);
+    if (!watcher::kernel_elf_file) {
+        watcher::create_kernel_elf_file();
+    }
+    std::string combined_paths = paths[0];
+    for (int i = 1; i < paths.size(); i++) {
+        combined_paths += ":" + paths[i];
+    }
+    fprintf(watcher::kernel_elf_file, "%d: %s\n", id, combined_paths.c_str());
+    fflush(watcher::kernel_elf_file);
 }
 
 bool watcher_server_killed_due_to_error() { return watcher::watcher_killed_due_to_error; }

--- a/tt_metal/impl/debug/watcher_server.hpp
+++ b/tt_metal/impl/debug/watcher_server.hpp
@@ -20,6 +20,7 @@ void watcher_sanitize_host_noc_read(const metal_SocDescriptor& soc_d, CoreCoord 
 void watcher_sanitize_host_noc_write(const metal_SocDescriptor& soc_d, CoreCoord core, uint64_t addr, uint32_t len);
 
 int watcher_register_kernel(const std::string& name);
+void watcher_register_kernel_elf_paths(int id, std::vector<std::string> paths);
 
 // Helper functions for manually dumping watcher contents.
 void watcher_dump();

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -83,6 +83,11 @@ void Kernel::register_kernel_with_watcher() {
     }
 }
 
+void Kernel::register_kernel_elf_paths_with_watcher(IDevice* device) {
+    TT_ASSERT(this->kernel_full_name_.size() > 0, "Kernel full name not set!");
+    watcher_register_kernel_elf_paths(this->watcher_kernel_id_, this->file_paths(device));
+}
+
 std::string Kernel::name() const { return this->kernel_src_.name(); }
 
 const std::set<CoreCoord> &Kernel::logical_cores() const { return this->logical_cores_; }
@@ -462,6 +467,16 @@ void DataMovementKernel::read_binaries(IDevice* device) {
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
+std::vector<std::string> DataMovementKernel::file_paths(IDevice* device) const {
+    uint32_t tensix_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
+    int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
+    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+        device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
+    return {build_state.get_target_out_path(this->kernel_full_name_)};
+}
+
 bool EthernetKernel::binaries_exist_on_disk(const IDevice* device) const {
     const uint32_t erisc_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
@@ -510,6 +525,16 @@ void EthernetKernel::read_binaries(IDevice* device) {
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
+std::vector<std::string> EthernetKernel::file_paths(IDevice* device) const {
+    uint32_t erisc_core_type =
+        MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
+    int erisc_id = magic_enum::enum_integer(this->config_.processor);
+    const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+        device->build_id(), erisc_core_type, dm_class_idx, erisc_id);
+    return {build_state.get_target_out_path(this->kernel_full_name_)};
+}
+
 bool ComputeKernel::binaries_exist_on_disk(const IDevice* device) const {
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
@@ -544,6 +569,21 @@ void ComputeKernel::read_binaries(IDevice* device) {
     }
     this->set_binaries(
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
+}
+
+std::vector<std::string> ComputeKernel::file_paths(IDevice* device) const {
+    std::vector<std::string> file_paths;
+    auto& hal = MetalContext::instance().hal();
+    uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
+    uint32_t compute_class_idx = magic_enum::enum_integer(HalProcessorClassType::COMPUTE);
+    uint32_t processor_types_count =
+        hal.get_processor_types_count(this->get_kernel_programmable_core_type(), compute_class_idx);
+    for (int trisc_id = 0; trisc_id < processor_types_count; trisc_id++) {
+        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+            device->build_id(), tensix_core_type, compute_class_idx, trisc_id);
+        file_paths.push_back(build_state.get_target_out_path(this->kernel_full_name_));
+    }
+    return file_paths;
 }
 
 RISCV DataMovementKernel::processor() const {

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -83,7 +83,7 @@ void Kernel::register_kernel_with_watcher() {
     }
 }
 
-void Kernel::register_kernel_elf_paths_with_watcher(IDevice* device) {
+void Kernel::register_kernel_elf_paths_with_watcher(IDevice& device) {
     TT_ASSERT(this->kernel_full_name_.size() > 0, "Kernel full name not set!");
     watcher_register_kernel_elf_paths(this->watcher_kernel_id_, this->file_paths(device));
 }
@@ -467,13 +467,13 @@ void DataMovementKernel::read_binaries(IDevice* device) {
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
-std::vector<std::string> DataMovementKernel::file_paths(IDevice* device) const {
+std::vector<std::string> DataMovementKernel::file_paths(IDevice& device) const {
     uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type<DataMovementProcessor>::type>(this->config_.processor);
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
+        device.build_id(), tensix_core_type, dm_class_idx, riscv_id);
     return {build_state.get_target_out_path(this->kernel_full_name_)};
 }
 
@@ -525,13 +525,13 @@ void EthernetKernel::read_binaries(IDevice* device) {
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
-std::vector<std::string> EthernetKernel::file_paths(IDevice* device) const {
+std::vector<std::string> EthernetKernel::file_paths(IDevice& device) const {
     uint32_t erisc_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = magic_enum::enum_integer(HalProcessorClassType::DM);
     int erisc_id = magic_enum::enum_integer(this->config_.processor);
     const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-        device->build_id(), erisc_core_type, dm_class_idx, erisc_id);
+        device.build_id(), erisc_core_type, dm_class_idx, erisc_id);
     return {build_state.get_target_out_path(this->kernel_full_name_)};
 }
 
@@ -571,7 +571,7 @@ void ComputeKernel::read_binaries(IDevice* device) {
         BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key, std::move(binaries));
 }
 
-std::vector<std::string> ComputeKernel::file_paths(IDevice* device) const {
+std::vector<std::string> ComputeKernel::file_paths(IDevice& device) const {
     std::vector<std::string> file_paths;
     auto& hal = MetalContext::instance().hal();
     uint32_t tensix_core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
@@ -580,7 +580,7 @@ std::vector<std::string> ComputeKernel::file_paths(IDevice* device) const {
         hal.get_processor_types_count(this->get_kernel_programmable_core_type(), compute_class_idx);
     for (int trisc_id = 0; trisc_id < processor_types_count; trisc_id++) {
         const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, compute_class_idx, trisc_id);
+            device.build_id(), tensix_core_type, compute_class_idx, trisc_id);
         file_paths.push_back(build_state.get_target_out_path(this->kernel_full_name_));
     }
     return file_paths;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1387,7 +1387,7 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);
 
-                    kernel->register_kernel_elf_paths_with_watcher(device);
+                    kernel->register_kernel_elf_paths_with_watcher(*device);
 
                     if (enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
                         if (not detail::HashLookup::inst().exists(kernel_hash)) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1387,6 +1387,8 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
                     kernel->set_full_name(kernel_path_suffix);
                     build_options.set_name(kernel_path_suffix);
 
+                    kernel->register_kernel_elf_paths_with_watcher(device);
+
                     if (enable_persistent_kernel_cache && kernel->binaries_exist_on_disk(device)) {
                         if (not detail::HashLookup::inst().exists(kernel_hash)) {
                             detail::HashLookup::inst().add(kernel_hash);


### PR DESCRIPTION
### Problem description
It can be difficult to discover the correct paths to elf files that are used in any specific kernel invocation.

### What's changed
Register the path to the elf files used based on the kernel ID, and write that out to kernel_elf_paths.txt. That simplifies using debug tools like exalens to get backtraces, especially in conjunction with the TT_METAL_WATCHER_TEXT_START environment variable.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes