### PR TITLE
Make program/dispatch only rely on ProgramImpl

### DIFF
--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -41,10 +41,6 @@ CBHandle CreateCircularBuffer(
 }  // namespace experimental
 
 namespace program_dispatch {
-void assemble_device_commands(
-    ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device, SubDeviceId sub_device_id);
-template <typename T>
-void finalize_program_offsets(T& workload_type, IDevice* device);
 template <typename WorkloadType, typename DeviceType>
 uint32_t program_base_addr_on_core(
     WorkloadType& workload, DeviceType generic_device, HalProgrammableCoreType core_type);
@@ -145,7 +141,6 @@ public:
     const std::vector<Semaphore>& semaphores() const;
 
     KernelGroup* kernels_on_core(const CoreCoord& core, uint32_t programmable_core_type_index);
-    std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
     void add_buffer(std::shared_ptr<Buffer> buf);
     void release_buffers();
@@ -227,20 +222,11 @@ private:
 
     void add_semaphore(const CoreRangeSet& crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type);
 
-    void set_launch_msg_sem_offsets();
-    void populate_dispatch_data(IDevice* device);
-    const ProgramTransferInfo& get_program_transfer_info() const noexcept;
-    std::shared_ptr<Buffer> get_kernels_buffer(IDevice* device) const noexcept;
-    std::vector<uint32_t>& get_program_config_sizes() const noexcept;
     bool runs_on_noc_unicast_only_cores();
     bool runs_on_noc_multicast_only_cores();
     std::unordered_map<uint64_t, ProgramCommandSequence>& get_cached_program_command_sequences() noexcept;
     bool kernel_binary_always_stored_in_ringbuffer();
 
-    friend void program_dispatch::assemble_device_commands(
-        ProgramCommandSequence& program_command_sequence, Program& program, IDevice* device, SubDeviceId sub_device_id);
-    template <typename WorkloadType, typename DeviceType>
-    friend uint32_t program_dispatch::program_base_addr_on_core(WorkloadType&, DeviceType, HalProgrammableCoreType);
     friend HWCommandQueue;
     friend EnqueueProgramCommand;
     friend distributed::MeshWorkload;

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -244,7 +244,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     for (auto& [device_range, program] : mesh_workload.get_programs()) {
         auto& program_cmd_seq = mesh_workload.get_dispatch_cmds_for_program(program, command_hash);
         program_dispatch::update_program_dispatch_commands(
-            program,
+            program.impl(),
             program_cmd_seq,
             (*worker_launch_message_buffer_state_)[*sub_device_id].get_mcast_wptr(),
             (*worker_launch_message_buffer_state_)[*sub_device_id].get_unicast_wptr(),

--- a/tt_metal/impl/dispatch/data_collection.cpp
+++ b/tt_metal/impl/dispatch/data_collection.cpp
@@ -28,6 +28,7 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
+using tt::tt_metal::detail::ProgramImpl;
 namespace {
 
 // Class to track stats for DispatchData
@@ -131,9 +132,9 @@ public:
     };
     ~DataCollector() { inst = nullptr; };
 
-    void RecordData(Program& program, data_collector_t type, uint32_t transaction_size, RISCV riscv);
-    void RecordKernelGroups(Program& program, CoreType core_type, std::vector<KernelGroup>& kernel_groups);
-    void RecordProgramRun(Program& program);
+    void RecordData(uint64_t program_id, data_collector_t type, uint32_t transaction_size, RISCV riscv);
+    void RecordKernelGroups(ProgramImpl& program, CoreType core_type, std::vector<KernelGroup>& kernel_groups);
+    void RecordProgramRun(uint64_t program_id);
     void DumpData();
 
 private:
@@ -143,8 +144,7 @@ private:
     std::map<uint64_t, int> program_id_to_call_count;
 };
 
-void DataCollector::RecordData(Program& program, data_collector_t type, uint32_t transaction_size, RISCV riscv) {
-    uint64_t program_id = program.get_id();
+void DataCollector::RecordData(uint64_t program_id, data_collector_t type, uint32_t transaction_size, RISCV riscv) {
     if (program_id_to_dispatch_data.count(program_id) == 0) {
         // If no existing data for this program, initialize starting values.
         program_id_to_dispatch_data[program_id] = std::vector<DispatchData>();
@@ -158,7 +158,8 @@ void DataCollector::RecordData(Program& program, data_collector_t type, uint32_t
     program_id_to_dispatch_data[program_id].at(type).Update(transaction_size, riscv);
 }
 
-void DataCollector::RecordKernelGroups(Program& program, CoreType core_type, std::vector<KernelGroup>& kernel_groups) {
+void DataCollector::RecordKernelGroups(
+    ProgramImpl& program, CoreType core_type, std::vector<KernelGroup>& kernel_groups) {
     uint64_t program_id = program.get_id();
     // Make a copy of relevant info, since user may destroy program before we dump.
     for (KernelGroup& kernel_group : kernel_groups) {
@@ -172,8 +173,7 @@ void DataCollector::RecordKernelGroups(Program& program, CoreType core_type, std
     }
 }
 
-void DataCollector::RecordProgramRun(Program& program) {
-    uint64_t program_id = program.get_id();
+void DataCollector::RecordProgramRun(uint64_t program_id) {
     program_id_to_call_count[program_id]++;
 }
 
@@ -269,17 +269,17 @@ void InitDataCollector() {
 
 namespace tt {
 
-void RecordDispatchData(Program& program, data_collector_t type, uint32_t transaction_size, RISCV riscv) {
+void RecordDispatchData(uint64_t program_id, data_collector_t type, uint32_t transaction_size, RISCV riscv) {
     // Do nothing if we're not enabling data collection.
     if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
 
     InitDataCollector();
-    DataCollector::inst->RecordData(program, type, transaction_size, riscv);
+    DataCollector::inst->RecordData(program_id, type, transaction_size, riscv);
 }
 
-void RecordKernelGroups(Program& program, CoreType core_type, std::vector<KernelGroup>& kernel_groups) {
+void RecordKernelGroups(ProgramImpl& program, CoreType core_type, std::vector<KernelGroup>& kernel_groups) {
     // Do nothing if we're not enabling data collection.
     if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
         return;
@@ -289,14 +289,14 @@ void RecordKernelGroups(Program& program, CoreType core_type, std::vector<Kernel
     DataCollector::inst->RecordKernelGroups(program, core_type, kernel_groups);
 }
 
-void RecordProgramRun(Program& program) {
+void RecordProgramRun(uint64_t program_id) {
     // Do nothing if we're not enabling data collection.
     if (!tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_data_collection_enabled()) {
         return;
     }
 
     InitDataCollector();
-    DataCollector::inst->RecordProgramRun(program);
+    DataCollector::inst->RecordProgramRun(program_id);
 }
 
 }  // namespace tt

--- a/tt_metal/impl/dispatch/data_collection.hpp
+++ b/tt_metal/impl/dispatch/data_collection.hpp
@@ -9,6 +9,7 @@
 
 #include "command_queue_interface.hpp"
 #include "tt_backend_api_types.hpp"
+#include "program/program_impl.hpp"
 
 enum class CoreType;
 
@@ -36,14 +37,14 @@ enum data_collector_t {
  *      riscv - riscv core that this transaction is used for, only relevant for DISPATCH_DATA_BINARY transactions.
  */
 void RecordDispatchData(
-    tt_metal::Program& program, data_collector_t type, uint32_t transaction_size, RISCV riscv = RISCV::MAX);
+    uint64_t program_id, data_collector_t type, uint32_t transaction_size, RISCV riscv = RISCV::MAX);
 
 // Record the KernelGroups present in this program (per core type). Should only be called per program created, not
 // program enqueued.
 void RecordKernelGroups(
-    tt_metal::Program& program, CoreType core_type, std::vector<tt_metal::KernelGroup>& kernel_groups);
+    tt_metal::detail::ProgramImpl& program, CoreType core_type, std::vector<tt_metal::KernelGroup>& kernel_groups);
 
 // Update stats with an enqueue of given program.
-void RecordProgramRun(tt_metal::Program& program);
+void RecordProgramRun(uint64_t program_id);
 
 }  // end namespace tt

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -417,11 +417,11 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     if (program.get_program_binary_status(device_->id()) == ProgramBinaryStatus::NotSent) {
         // Write program binaries to device if it hasn't previously been cached
         program.allocate_kernel_bin_buf_on_device(device_);
-        if (program.get_program_transfer_info().binary_data.size()) {
-            const BufferRegion buffer_region(0, program.get_kernels_buffer(device_)->size());
+        if (program.impl().get_program_transfer_info().binary_data.size()) {
+            const BufferRegion buffer_region(0, program.impl().get_kernels_buffer(device_)->size());
             this->enqueue_write_buffer(
-                *program.get_kernels_buffer(device_),
-                program.get_program_transfer_info().binary_data.data(),
+                *program.impl().get_kernels_buffer(device_),
+                program.impl().get_program_transfer_info().binary_data.data(),
                 buffer_region,
                 false);
         }
@@ -436,12 +436,12 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
 #ifdef DEBUG
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_validate_kernel_binaries()) {
         TT_FATAL(!this->manager_.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
-        if (const auto buffer = program.get_kernels_buffer(device_)) {
+        if (const auto buffer = program.impl().get_kernels_buffer(device_)) {
             std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
             const BufferRegion region(0, buffer->size());
             this->enqueue_read_buffer(*buffer, read_data.data(), region, true);
             TT_FATAL(
-                program.get_program_transfer_info().binary_data == read_data,
+                program.impl().get_program_transfer_info().binary_data == read_data,
                 "Binary for program to be executed is corrupted. Another program likely corrupted this binary");
         }
     }
@@ -501,12 +501,12 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
 #ifdef DEBUG
     if (tt::tt_metal::MetalContext::instance().rtoptions().get_validate_kernel_binaries()) {
         TT_FATAL(!this->manager_.get_bypass_mode(), "Tracing cannot be used while validating program binaries");
-        if (const auto buffer = program.get_kernels_buffer(device_)) {
+        if (const auto buffer = program.impl().get_kernels_buffer(device_)) {
             std::vector<uint32_t> read_data(buffer->page_size() * buffer->num_pages() / sizeof(uint32_t));
             const BufferRegion region(0, buffer->size());
             this->enqueue_read_buffer(*buffer, read_data.data(), region, true);
             TT_FATAL(
-                program.get_program_transfer_info().binary_data == read_data,
+                program.impl().get_program_transfer_info().binary_data == read_data,
                 "Binary for program that executed is corrupted. This program likely corrupted its own binary.");
         }
     }
@@ -515,7 +515,7 @@ void HWCommandQueue::enqueue_program(Program& program, bool blocking) {
     log_trace(
         tt::LogMetal,
         "Created EnqueueProgramCommand (active_cores: {} bypass_mode: {} expected_workers_completed: {})",
-        program.get_program_transfer_info().num_active_cores,
+        program.impl().get_program_transfer_info().num_active_cores,
         this->manager_.get_bypass_mode(),
         expected_workers_completed);
 }

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -136,20 +136,20 @@ void EnqueueProgramCommand::process() {
     // Reserve space for this program in the kernel config ring buffer
     program_dispatch::reserve_space_in_kernel_config_buffer(
         this->config_buffer_mgr,
-        program.get_program_config_sizes(),
+        program.impl().get_program_config_sizes(),
         program.get_program_binary_status(device->id()),
         num_workers,
         this->expected_num_workers_completed,
         dispatch_metadata);
 
-    RecordProgramRun(program);
+    RecordProgramRun(program.get_id());
 
     // Access the program dispatch-command cache
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
     auto& cached_program_command_sequence = program.get_cached_program_command_sequences().at(command_hash);
     // Update the generated dispatch commands based on the state of the CQ and the ring buffer
     program_dispatch::update_program_dispatch_commands(
-        program,
+        program.impl(),
         cached_program_command_sequence,
         this->multicast_cores_launch_message_wptr,
         this->unicast_cores_launch_message_wptr,

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -21,6 +21,7 @@
 #include "dev_msgs.h"
 #include "dispatch/dispatch_settings.hpp"
 #include "kernel_types.hpp"
+#include "program_impl.hpp"
 #include "sub_device_types.hpp"
 
 enum class CoreType;
@@ -107,7 +108,7 @@ void reserve_space_in_kernel_config_buffer(
     ProgramDispatchMetadata& dispatch_md);
 
 void update_program_dispatch_commands(
-    Program& program,
+    detail::ProgramImpl& program,
     ProgramCommandSequence& cached_program_command_sequence,
     uint32_t multicast_cores_launch_message_wptr,
     uint32_t unicast_cores_launch_message_wptr,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -115,6 +115,8 @@ size_t get_ringbuffer_size(IDevice* device, HalProgrammableCoreType programmable
 
 namespace tt::tt_metal {
 
+using detail::ProgramImpl;
+
 namespace {
 std::atomic<bool> enable_persistent_kernel_cache = false;
 
@@ -423,10 +425,6 @@ std::vector<std::shared_ptr<KernelGroup>>& detail::ProgramImpl::get_kernel_group
     uint32_t programmable_core_type_index) {
     update_kernel_groups(programmable_core_type_index);
     return kernel_groups_[programmable_core_type_index];
-}
-
-std::vector<std::shared_ptr<KernelGroup>> &Program::get_kernel_groups(uint32_t programmable_core_type_index) {
-    return pimpl_->get_kernel_groups(programmable_core_type_index);
 }
 
 std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& detail::ProgramImpl::get_kernels(
@@ -1269,9 +1267,6 @@ void detail::ProgramImpl::allocate_kernel_bin_buf_on_device(IDevice* device) {
     }
 }
 
-void Program::set_launch_msg_sem_offsets() { pimpl_->set_launch_msg_sem_offsets(); }
-void Program::populate_dispatch_data(IDevice* device) { pimpl_->populate_dispatch_data(device); }
-
 void Program::generate_dispatch_commands(IDevice* device) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
@@ -1296,7 +1291,7 @@ void Program::generate_dispatch_commands(IDevice* device) {
         ProgramCommandSequence program_command_sequence;
         program_dispatch::insert_empty_program_dispatch_preamble_cmd(program_command_sequence);
         program_dispatch::insert_stall_cmds(program_command_sequence, sub_device_id, device);
-        program_dispatch::assemble_device_commands(program_command_sequence, *this, device, sub_device_id);
+        program_dispatch::assemble_device_commands(program_command_sequence, impl(), device, sub_device_id);
         // TODO: We currently do not have a mechanism of removing entries in the cache when a manager is removed
         // This means programs will contain stale entries in the cache until the program is deleted
         cached_program_command_sequences.insert({command_hash, std::move(program_command_sequence)});
@@ -1430,7 +1425,7 @@ void Program::set_runtime_id(uint64_t id) { pimpl_->set_runtime_id(id); }
 
 uint32_t Program::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
-    uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
+    uint32_t base_addr = program_dispatch::program_base_addr_on_core(impl(), device, programmable_core_type);
     return base_addr +
            get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
                .sem_offset;
@@ -1438,7 +1433,7 @@ uint32_t Program::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/,
 
 uint32_t Program::get_cb_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
-    uint32_t base_addr = program_dispatch::program_base_addr_on_core(*this, device, programmable_core_type);
+    uint32_t base_addr = program_dispatch::program_base_addr_on_core(impl(), device, programmable_core_type);
     return base_addr +
            get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
                .cb_offset;
@@ -1586,10 +1581,12 @@ void Program::set_program_binary_status(std::size_t device_id, ProgramBinaryStat
 
 const std::vector<SubDeviceId> &Program::determine_sub_device_ids(const IDevice* device) { return pimpl_->determine_sub_device_ids(device); }
 
-const ProgramTransferInfo &Program::get_program_transfer_info() const noexcept { return pimpl_->program_transfer_info; }
+const ProgramTransferInfo& detail::ProgramImpl::get_program_transfer_info() const noexcept {
+    return program_transfer_info;
+}
 
-std::shared_ptr<Buffer> Program::get_kernels_buffer(IDevice* device) const noexcept {
-    if (auto it = pimpl_->kernels_buffer_.find(device->id()); it != pimpl_->kernels_buffer_.end()) {
+std::shared_ptr<Buffer> ProgramImpl::get_kernels_buffer(IDevice* device) const noexcept {
+    if (auto it = kernels_buffer_.find(device->id()); it != kernels_buffer_.end()) {
         return it->second;
     }
     return nullptr;
@@ -1598,8 +1595,6 @@ std::shared_ptr<Buffer> Program::get_kernels_buffer(IDevice* device) const noexc
 void Program::set_kernels_bin_buffer(const std::shared_ptr<Buffer>& buffer) {
     pimpl_->kernels_buffer_.insert({buffer->device()->id(), buffer});
 }
-
-std::vector<uint32_t> &Program::get_program_config_sizes() const noexcept { return pimpl_->program_config_sizes_; }
 
 std::unordered_map<uint64_t, ProgramCommandSequence> &Program::get_cached_program_command_sequences() noexcept {
     return pimpl_->cached_program_command_sequences_;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include "program_command_sequence.hpp"
 
 #include "tt-metalium/buffer.hpp"
@@ -44,6 +46,16 @@ class JitBuildOptions;
 
 namespace experimental {
 class GlobalCircularBuffer;
+}
+
+namespace program_dispatch {
+
+void assemble_device_commands(
+    ProgramCommandSequence& program_command_sequence,
+    detail::ProgramImpl& program,
+    IDevice* device,
+    SubDeviceId sub_device_id);
+
 }
 
 namespace detail {
@@ -148,6 +160,8 @@ public:
         const KernelGroupsGetter& kernel_groups_getter,
         const SemaphoresGetter& semaphores_getter,
         tt::stl::Span<ProgramImpl*> programs);
+
+    std::vector<uint32_t>& get_program_config_sizes() noexcept { return program_config_sizes_; }
 
 private:
     CommandQueue* last_used_command_queue_for_testing = nullptr;
@@ -265,9 +279,20 @@ private:
     void set_program_offsets_and_sizes(uint32_t index, const ProgramOffsetsState& state);
     void set_program_attrs_across_core_types(IDevice* device);
 
+    const ProgramTransferInfo& get_program_transfer_info() const noexcept;
+    std::shared_ptr<Buffer> get_kernels_buffer(IDevice* device) const noexcept;
+
+    friend void program_dispatch::assemble_device_commands(
+        ProgramCommandSequence& program_command_sequence,
+        ProgramImpl& program,
+        IDevice* device,
+        SubDeviceId sub_device_id);
+
+    friend HWCommandQueue;
     friend EnqueueProgramCommand;
     friend Program;
     friend Internal_;
+    friend distributed::MeshWorkload;
 };
 
 }  // namespace detail

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -45,6 +45,7 @@
 #include "llrt.hpp"
 #include "logger.hpp"
 #include "tt-metalium/program.hpp"
+#include "program/program_impl.hpp"
 #include "semaphore.hpp"
 #include "tracy/Tracy.hpp"
 #include <umd/device/tt_xy_pair.h>
@@ -890,7 +891,7 @@ void WriteRuntimeArgsToDevice(IDevice* device, Program& program, bool force_slow
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         CoreType core_type = hal.get_core_type(index);
         uint32_t processor_classes = hal.get_processor_classes_count(index);
-        for (const auto& kg : program.get_kernel_groups(index)) {
+        for (const auto& kg : program.impl().get_kernel_groups(index)) {
             uint32_t kernel_config_base = kg->launch_msg.kernel_config.kernel_config_base[index];
             for (const CoreRange& core_range : kg->core_ranges.ranges()) {
                 for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {


### PR DESCRIPTION
### Problem description
Currently a lot of the methods exposed from Program aren't intended to be used by clients.

### What's changed
Add a method to grab the ProgramImpl from the program, and move program/dispatch to only rely on ProgramImpl and not Program. This will let us hide things (like KernelGroups) from the public API, as well as allow us to modify ProgramImpl lifetime to make it easier to store for Trace 2.0.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes