### PR TITLE
Remove limit for number of upstream and downstream kernels

### DIFF
--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -582,6 +582,16 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
 
                 // Pull nodes from the template, updating their index and device id
                 for (DispatchKernelNode node : *nodes_for_one_mmio) {
+                    TT_ASSERT(
+                        node.device_id < template_id_to_device_id.size(),
+                        "Device id {} out of bounds (max = {})",
+                        node.device_id,
+                        template_id_to_device_id.size());
+                    TT_ASSERT(
+                        node.servicing_device_id < template_id_to_device_id.size(),
+                        "Servicing device id {} out of bounds (max = {})",
+                        node.servicing_device_id,
+                        template_id_to_device_id.size());
                     node.device_id = template_id_to_device_id[node.device_id];
                     node.servicing_device_id = template_id_to_device_id[node.servicing_device_id];
                     increment_node_ids(node, index_offset);
@@ -684,13 +694,25 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
 
     // Connect the graph with upstream/downstream kernels
     for (const auto& node : nodes) {
-        for (int idx = 0; idx < k_dispatch_max_upstream_kernels; idx++) {
+        TT_ASSERT(node.upstream_ids.size() <= k_dispatch_max_upstream_kernels);
+        TT_ASSERT(node.downstream_ids.size() <= k_dispatch_max_downstream_kernels);
+        for (int idx = 0; idx < node.upstream_ids.size(); idx++) {
             if (node.upstream_ids[idx] >= 0) {
+                TT_ASSERT(
+                    node.upstream_ids[idx] < node_id_to_kernel.size(),
+                    "Upstream kernel id {} out of bounds (max = {})",
+                    node.upstream_ids[idx],
+                    node_id_to_kernel.size());
                 node_id_to_kernel.at(node.id)->AddUpstreamKernel(node_id_to_kernel.at(node.upstream_ids[idx]));
             }
         }
-        for (int idx = 0; idx < k_dispatch_max_downstream_kernels; idx++) {
+        for (int idx = 0; idx < node.downstream_ids.size(); idx++) {
             if (node.downstream_ids[idx] >= 0) {
+                TT_ASSERT(
+                    node.downstream_ids[idx] < node_id_to_kernel.size(),
+                    "Downstream kernel id {} out of bounds (max = {})",
+                    node.downstream_ids[idx],
+                    node_id_to_kernel.size());
                 node_id_to_kernel.at(node.id)->AddDownstreamKernel(node_id_to_kernel.at(node.downstream_ids[idx]));
             }
         }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -694,8 +694,6 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
 
     // Connect the graph with upstream/downstream kernels
     for (const auto& node : nodes) {
-        TT_ASSERT(node.upstream_ids.size() <= k_dispatch_max_upstream_kernels);
-        TT_ASSERT(node.downstream_ids.size() <= k_dispatch_max_downstream_kernels);
         for (int idx = 0; idx < node.upstream_ids.size(); idx++) {
             if (node.upstream_ids[idx] >= 0) {
                 TT_ASSERT(

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -23,8 +23,8 @@ enum DispatchWorkerType : uint32_t;
 namespace tt::tt_metal {
 
 // Max number of upstream/downstream dispatch kernels that can be connected to a single dispatch kernel.
-constexpr uint32_t k_dispatch_max_upstream_kernels = 4;
-constexpr uint32_t k_dispatch_max_downstream_kernels = 4;
+constexpr uint32_t k_dispatch_max_upstream_kernels = 8;
+constexpr uint32_t k_dispatch_max_downstream_kernels = 8;
 
 // NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
 // is required when setting up Command Queue objects on host.
@@ -36,9 +36,9 @@ struct DispatchKernelNode {
     chip_id_t servicing_device_id;   // Remote device that this kernel services, used for kernels on MMIO
     uint8_t cq_id;                   // CQ this kernel implements
     DispatchWorkerType kernel_type;  // Type of dispatch kernel this is
-    int upstream_ids[k_dispatch_max_upstream_kernels];      // Upstream dispatch kernels
-    int downstream_ids[k_dispatch_max_downstream_kernels];  // Downstream dispatch kernels
-    noc_selection_t noc_selection;                          // NOC selection
+    std::vector<int> upstream_ids;   // Upstream dispatch kernels. Max size is k_dispatch_max_upstream_kernels
+    std::vector<int> downstream_ids;  // Downstream dispatch kernels. Max size is k_dispatch_max_downstream_kernels
+    noc_selection_t noc_selection;    // NOC selection
 };
 
 // Create FD kernels for all given device ids. Creates all objects, but need to call create_and_compile_cq_program() use

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -22,10 +22,6 @@ enum DispatchWorkerType : uint32_t;
 
 namespace tt::tt_metal {
 
-// Max number of upstream/downstream dispatch kernels that can be connected to a single dispatch kernel.
-constexpr uint32_t k_dispatch_max_upstream_kernels = 8;
-constexpr uint32_t k_dispatch_max_downstream_kernels = 8;
-
 // NOC ID used by dispatch kernels to communicate with downstream cores. This parameter
 // is required when setting up Command Queue objects on host.
 constexpr NOC k_dispatch_downstream_noc = NOC::NOC_0;
@@ -36,8 +32,8 @@ struct DispatchKernelNode {
     chip_id_t servicing_device_id;   // Remote device that this kernel services, used for kernels on MMIO
     uint8_t cq_id;                   // CQ this kernel implements
     DispatchWorkerType kernel_type;  // Type of dispatch kernel this is
-    std::vector<int> upstream_ids;   // Upstream dispatch kernels. Max size is k_dispatch_max_upstream_kernels
-    std::vector<int> downstream_ids;  // Downstream dispatch kernels. Max size is k_dispatch_max_downstream_kernels
+    std::vector<int> upstream_ids;   // Upstream dispatch kernels
+    std::vector<int> downstream_ids;  // Downstream dispatch kernels
     noc_selection_t noc_selection;    // NOC selection
 };
 


### PR DESCRIPTION
### Ticket
#18726

### Problem description
- Up to 8 upstream kernels are present when using the TT Fabric Mux (4 prefetch H, 4 dispatch D)
- Need to specify {y,x,x,x,x,x,x,x} in all topologies to properly initialize the struct which is ugly and hard to read

### What's changed
- Use a vector
- Benefit of using vector is we don't need to keep specifying `x` many times to initialize to "unset". We can just set
   however many up/downstream kernels we need.
- `x` is still considered unset
- Add checks for any out of bounds accesses


### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14871628466
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14871062531
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14871785697