### PR TITLE
Enable shift op parens warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,6 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-mismatched-tags>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-missing-braces>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-reorder-ctor>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wno-shift-op-parentheses>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-lambda-capture>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-local-typedef>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -68,7 +68,7 @@ void* align(void* ptr, std::size_t max_alignment) {
     // ex. if the current ptr here is 16, but we specified an alignment of 8,
     // then this is both 8 and 16 byte aligned, so we offset again by our
     // specified alignment to make the max alignment what was specified
-    aligned = aligned & (max_alignment << 1 - 1) ? aligned : aligned + max_alignment;
+    aligned = aligned & (max_alignment << (1 - 1)) ? aligned : aligned + max_alignment;
 
     return reinterpret_cast<void*>(aligned);
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_pull_from_pcie.cpp
@@ -68,7 +68,7 @@ void* align(void* ptr, std::size_t max_alignment) {
     // ex. if the current ptr here is 16, but we specified an alignment of 8,
     // then this is both 8 and 16 byte aligned, so we offset again by our
     // specified alignment to make the max alignment what was specified
-    aligned = aligned & (max_alignment << (1 - 1)) ? aligned : aligned + max_alignment;
+    aligned = aligned & ((max_alignment << 1) - 1) ? aligned : aligned + max_alignment;
 
     return reinterpret_cast<void*>(aligned);
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We're ignoring a warning that can help us avoid bugs.

### What's changed
* Enabled shift-op-parens warning
* Edited the code to maintain current behaviour.  Which looks like it's revealing a bug.  I don't think the current behaviour is what is desired.