### PR TITLE
tt_stl/strong_type constexpr and unique tags

### DIFF
--- a/tests/tt_metal/tt_metal/stl/test_strong_type.cpp
+++ b/tests/tt_metal/tt_metal/stl/test_strong_type.cpp
@@ -34,6 +34,19 @@ TEST(StrongTypeTest, Basic) {
     EXPECT_EQ(my_int_id1, my_int_id2);
 }
 
+TEST(StrongTypeTest, GuarenteedUnique) {
+    StrongType<int> one{1};
+    StrongType<int> otherone{1};
+
+    static_assert(not std::same_as<decltype(one), decltype(otherone)>);
+    static_assert(not std::is_convertible_v<decltype(one), decltype(otherone)>);
+
+    auto runtime_same = std::is_same_v<decltype(one), decltype(otherone)>;
+    EXPECT_FALSE(runtime_same);
+
+    EXPECT_EQ(*one, *otherone);
+}
+
 TEST(StrongTypeTest, UseInContainers) {
     std::unordered_set<MyIntId> unordered;
     std::set<MyIntId> ordered;


### PR DESCRIPTION
### Ticket
Closes #21664.

### Problem description
tt_stl strong_type didn't have constexpr, a default initializer, and a guarenteed uniqueness default.

### What's changed
Added more constexpr, added a default Tag guarenteeing uniqueness, and added a conditional default initializer (the lack of which was causing a build error at some point during a different refactor).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes