### PR TITLE
#21675: added i/o reshape to dram sliced conv

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -177,6 +177,10 @@ Result conv2d_DRAM(
     } else {
         input_tensor_on_device = input_tensor;
     }
+
+    const auto unflattened_input_shape = ttnn::Shape{batch_size, input_height, input_width, in_channels};
+    input_tensor_on_device = ttnn::reshape(input_tensor_on_device, unflattened_input_shape, unflattened_input_shape);
+
     DeviceComputeKernelConfig compute_config = compute_config_.value_or(get_conv_default_compute_kernel_config(device));
     const auto compute_grid_size = device->compute_with_storage_grid_size();
 
@@ -362,6 +366,11 @@ Result conv2d_DRAM(
         output_slice_dim_start += output_slice_size;
         slice_index++;
     }
+
+    const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.get_logical_shape());
+    const auto flattened_padded_output_shape = flatten_4d_shape(dram_output_tensor.get_padded_shape());
+
+    dram_output_tensor = ttnn::reshape(dram_output_tensor, flattened_output_shape, flattened_padded_output_shape);
 
     return {dram_output_tensor, output_height, output_width, weight_tensor_on_device, bias_tensor_on_device};
 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -572,7 +572,7 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_s
     }
 }
 
-static ttnn::Shape flatten_4d_shape(const ttnn::Shape& input_shape) {
+ttnn::Shape flatten_4d_shape(const ttnn::Shape& input_shape) {
     TT_FATAL(input_shape.size() == 4, "Expected 4D shape");
     const uint32_t nhw = input_shape[0] * input_shape[1] * input_shape[2];
     const uint32_t channels = input_shape[3];

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -149,7 +149,7 @@ Conv2dConfig determine_conv_config_for_auto_shard(
     const bool enable_bias,
     const DeviceComputeKernelConfig& compute_config);
 
-static ttnn::Shape flatten_4d_shape(const ttnn::Shape& input_shape);
+ttnn::Shape flatten_4d_shape(const ttnn::Shape& input_shape);
 
 template <typename T>
 std::tuple<ttnn::Tensor, sliding_window::ParallelConfig, sliding_window::ParallelConfig>

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -149,6 +149,8 @@ Conv2dConfig determine_conv_config_for_auto_shard(
     const bool enable_bias,
     const DeviceComputeKernelConfig& compute_config);
 
+static ttnn::Shape flatten_4d_shape(const ttnn::Shape& input_shape);
+
 template <typename T>
 std::tuple<ttnn::Tensor, sliding_window::ParallelConfig, sliding_window::ParallelConfig>
 shard_or_reshard_tensor_if_required(


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-metal/issues/21675)

### Problem description
Different input shapes supported by DRAM sliced and L1 conv2d op. Difference in shape of the output tensor produced by ops.

### What's changed
Added reshape of the input to unflattened shape and reshape of the output to flattened shape in DRAM sliced conv.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14840911253) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14840915714) CI with demo tests passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14840907488/job/41664067059) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/14853001876) CI passes