### PR TITLE
#20050: SDXL VAE upblocks

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_attention.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_attention import TtAttention
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -32,10 +33,10 @@ def test_attention(
     use_program_cache,
     reset_seeds,
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -78,5 +79,8 @@ def test_attention(
     )
     ttnn_output_tensor = tt_attention.forward(ttnn_input_tensor, None, ttnn_encoder_tensor)
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
+
+    del unet, tt_attention
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_crossattndownblock2d import TtCrossAttnDownBlock2D
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -31,10 +32,10 @@ def test_crossattndown(
     use_program_cache,
     reset_seeds,
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -82,5 +83,8 @@ def test_crossattndown(
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del unet, tt_crosattn
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_crossattnmidblock2d import TtUNetMidBlock2DCrossAttn
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -20,10 +21,10 @@ from models.utility_functions import torch_random
 def test_crossattnmid(
     device, input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, use_program_cache, reset_seeds
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -69,5 +70,8 @@ def test_crossattnmid(
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del unet, tt_crosattn
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.973)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnupblock.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_crossattnupblock2d import TtCrossAttnUpBlock2D
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -52,10 +53,10 @@ def test_crossattnup(
     use_program_cache,
     reset_seeds,
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -104,5 +105,8 @@ def test_crossattnup(
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del unet, tt_crosattn
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downblock2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_downblock2d import TtDownBlock2D
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -18,10 +19,10 @@ from models.utility_functions import torch_random
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_downblock2d(device, temb_shape, input_shape, use_program_cache, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -50,5 +51,8 @@ def test_downblock2d(device, temb_shape, input_shape, use_program_cache, reset_s
 
     output_tensor = output_tensor.reshape(input_shape[0], output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del unet, tt_downblock
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.994)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_downsample2d import TtDownsample2D
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
@@ -24,10 +25,10 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 def test_downsample2d(
     device, input_shape, down_block_id, stride, padding, dilation, pcc, use_program_cache, reset_seeds
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -47,5 +48,8 @@ def test_downsample2d(
     output_tensor = from_channel_last_ttnn(
         ttnn_output_tensor, [input_shape[0], output_shape[1], output_shape[2], output_shape[0]]
     )
+
+    del unet, tt_downsample
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_feedforward import TtFeedForward
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -19,10 +20,10 @@ from models.utility_functions import torch_random
     ],
 )
 def test_feedforward(device, input_shape, block_id, transformer_block_id, use_program_cache, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -44,5 +45,8 @@ def test_feedforward(device, input_shape, block_id, transformer_block_id, use_pr
     )
     ttnn_output_tensor = tt_ff.forward(ttnn_input_tensor)
     output_tensor = ttnn.to_torch(ttnn_output_tensor).squeeze()
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_geglu import TtGEGLU
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 from functools import reduce
@@ -19,10 +20,10 @@ from functools import reduce
     ],
 )
 def test_geglu(device, input_shape, module_path, use_program_cache, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -49,5 +50,8 @@ def test_geglu(device, input_shape, module_path, use_program_cache, reset_seeds)
     )
     ttnn_output_tensor = tt_geglu.forward(ttnn_input_tensor)
     output_tensor = ttnn.to_torch(ttnn_output_tensor).squeeze()
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_timesteps.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_timesteps.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_timesteps import TtTimesteps
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -14,10 +15,10 @@ from models.utility_functions import torch_random
     "input_shape, module_path, num_channels", [((1,), "time_proj", 320), ((6,), "add_time_proj", 256)]
 )
 def test_timesteps(device, input_shape, module_path, num_channels, use_program_cache, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -38,5 +39,8 @@ def test_timesteps(device, input_shape, module_path, num_channels, use_program_c
     )
     ttnn_output_tensor = tt_timesteps.forward(ttnn_input_tensor)
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformerblock.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformerblock import TtBasicTransformerBlock
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -32,10 +33,10 @@ def test_transformerblock(
     use_program_cache,
     reset_seeds,
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -69,5 +70,8 @@ def test_transformerblock(
     )
     ttnn_output_tensor = tt_transformerblock.forward(ttnn_input_tensor, None, ttnn_encoder_tensor)
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.998)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformermodel import TtTransformer2DModel
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -30,10 +31,10 @@ def test_transformermodel(
     use_program_cache,
     reset_seeds,
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -69,5 +70,8 @@ def test_transformermodel(
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, H, W, C)
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_unet.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -80,10 +81,10 @@ def test_unet(
     use_program_cache,
     reset_seeds,
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -117,9 +118,9 @@ def test_unet(
         device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
     )
 
-    import tracy
+    # import tracy
 
-    tracy.signpost("Compilation pass")
+    # tracy.signpost("Compilation pass")
     _, _ = tt_unet.forward(
         ttnn_input_tensor,
         [B, C, H, W],
@@ -138,7 +139,7 @@ def test_unet(
         device, torch_input_tensor, torch_timestep_tensor, torch_temb_tensor, torch_encoder_tensor, torch_time_ids
     )
 
-    tracy.signpost("Second pass")
+    # tracy.signpost("Second pass")
     ttnn_output_tensor, output_shape = tt_unet.forward(
         ttnn_input_tensor,
         [B, C, H, W],
@@ -150,5 +151,8 @@ def test_unet(
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.985)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_upblock2d import TtUpBlock2D
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -31,10 +32,10 @@ def test_crossattnup(
     use_program_cache,
     reset_seeds,
 ):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -74,5 +75,8 @@ def test_crossattnup(
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.96)

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_upsample2d import TtUpsample2D
-from diffusers import DiffusionPipeline
+from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
@@ -20,10 +21,10 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 @pytest.mark.parametrize("dilation", [(1, 1)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_upsample2d(device, input_shape, up_block_id, stride, padding, dilation, use_program_cache, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    unet = UNet2DConditionModel.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
-    unet = pipe.unet
+    # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
@@ -43,5 +44,8 @@ def test_upsample2d(device, input_shape, up_block_id, stride, padding, dilation,
     output_tensor = from_channel_last_ttnn(
         ttnn_output_tensor, [input_shape[0], output_shape[1], output_shape[2], output_shape[0]]
     )
+
+    del unet
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.996)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_attention import TtAttention
-from diffusers import DiffusionPipeline
+from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -18,10 +19,10 @@ from models.utility_functions import torch_random
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_vae_attention(device, input_shape, encoder_shape, use_program_cache, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True
+    vae = AutoencoderKL.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"
     )
-    vae = pipe.vae
+    # vae = pipe.vae
     vae.eval()
     state_dict = vae.state_dict()
 
@@ -61,5 +62,8 @@ def test_vae_attention(device, input_shape, encoder_shape, use_program_cache, re
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, H, W, C)
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del vae, tt_attention
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.97)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_midblock2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_midblock2d import TtUNetMidBlock2D
-from diffusers import DiffusionPipeline
+from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -18,10 +19,10 @@ from models.utility_functions import torch_random
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_vae_midblock(device, input_shape, use_program_cache, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True
+    vae = AutoencoderKL.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"
     )
-    vae = pipe.vae
+    # vae = pipe.vae
     vae.eval()
     state_dict = vae.state_dict()
 
@@ -47,5 +48,8 @@ def test_vae_midblock(device, input_shape, use_program_cache, reset_seeds):
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del vae
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+import ttnn
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upblock2d import TtUpDecoderBlock2D
+from diffusers import DiffusionPipeline
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+
+
+@pytest.mark.parametrize(
+    "input_shape, block_id, pcc",
+    [
+        ((1, 512, 128, 128), 0, 0.997),
+        ((1, 512, 256, 256), 1, 0.985),
+        ((1, 512, 512, 512), 2, 0.995),
+        ((1, 256, 1024, 1024), 3, 0.982),
+    ],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
+def test_vae_upblock(device, input_shape, block_id, pcc, reset_seeds):
+    pipe = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True
+    )
+    vae = pipe.vae
+    vae.eval()
+    state_dict = vae.state_dict()
+
+    torch_crosattn = vae.decoder.up_blocks[block_id]
+    tt_crosattn = TtUpDecoderBlock2D(
+        device, state_dict, f"decoder.up_blocks.{block_id}", has_upsample=block_id < 3, conv_shortcut=block_id > 1
+    )
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+
+    torch_output_tensor = torch_crosattn(torch_input_tensor, temb=None)
+
+    B, C, H, W = input_shape
+    torch_input_tensor = torch.permute(torch_input_tensor, (0, 2, 3, 1))
+    torch_input_tensor = torch_input_tensor.reshape(B, 1, H * W, C)
+
+    ttnn_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn_output_tensor, output_shape = tt_crosattn.forward(ttnn_input_tensor, [B, C, H, W])
+    output_tensor = ttnn.to_torch(ttnn_output_tensor)
+    output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
+    output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    assert_with_pcc(torch_output_tensor, output_tensor, pcc)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upblock2d import TtUpDecoderBlock2D
-from diffusers import DiffusionPipeline
+from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 
@@ -21,10 +22,10 @@ from models.utility_functions import torch_random
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
 def test_vae_upblock(device, input_shape, block_id, pcc, reset_seeds):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True
+    vae = AutoencoderKL.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"
     )
-    vae = pipe.vae
+    # vae = pipe.vae
     vae.eval()
     state_dict = vae.state_dict()
 
@@ -52,5 +53,8 @@ def test_vae_upblock(device, input_shape, block_id, pcc, reset_seeds):
     output_tensor = ttnn.to_torch(ttnn_output_tensor)
     output_tensor = output_tensor.reshape(B, output_shape[1], output_shape[2], output_shape[0])
     output_tensor = torch.permute(output_tensor, (0, 3, 1, 2))
+
+    del vae
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import gc
 import torch
 import pytest
 import ttnn
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upsample2d import TtUpsample2D
-from diffusers import DiffusionPipeline
+from diffusers import AutoencoderKL
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
 from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
@@ -22,10 +23,10 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 @pytest.mark.parametrize("dilation", [(1, 1)])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
 def test_vae_upsample2d(device, input_shape, up_block_id, stride, padding, dilation, use_program_cache):
-    pipe = DiffusionPipeline.from_pretrained(
-        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    vae = AutoencoderKL.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="vae"
     )
-    vae = pipe.vae
+    # vae = pipe.vae
     vae.eval()
     state_dict = vae.state_dict()
 
@@ -45,5 +46,8 @@ def test_vae_upsample2d(device, input_shape, up_block_id, stride, padding, dilat
     output_tensor = from_channel_last_ttnn(
         ttnn_output_tensor, [input_shape[0], output_shape[1], output_shape[2], output_shape[0]]
     )
+
+    del vae
+    gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+import ttnn
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upsample2d import TtUpsample2D
+from diffusers import DiffusionPipeline
+from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import torch_random
+from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
+    to_channel_last_ttnn,
+    from_channel_last_ttnn,
+)
+
+
+@pytest.mark.parametrize(
+    "input_shape, up_block_id", [((1, 512, 128, 128), 0), ((1, 512, 256, 256), 1), ((1, 256, 512, 512), 2)]
+)
+@pytest.mark.parametrize("stride", [(1, 1)])
+@pytest.mark.parametrize("padding", [(1, 1)])
+@pytest.mark.parametrize("dilation", [(1, 1)])
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 4 * 16384}], indirect=True)
+def test_vae_upsample2d(device, input_shape, up_block_id, stride, padding, dilation, use_program_cache):
+    pipe = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, variant="fp16"
+    )
+    vae = pipe.vae
+    vae.eval()
+    state_dict = vae.state_dict()
+
+    torch_upsample = vae.decoder.up_blocks[up_block_id].upsamplers[0]
+    groups = 1
+    tt_upsample = TtUpsample2D(
+        device, state_dict, f"decoder.up_blocks.{up_block_id}.upsamplers.0", stride, padding, dilation, groups
+    )
+
+    torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
+    torch_output_tensor = torch_upsample(torch_input_tensor)
+
+    ttnn_input_tensor = to_channel_last_ttnn(
+        torch_input_tensor, ttnn.bfloat16, device, ttnn.DRAM_MEMORY_CONFIG, ttnn.ROW_MAJOR_LAYOUT
+    )
+    ttnn_output_tensor, output_shape = tt_upsample.forward(ttnn_input_tensor)
+    output_tensor = from_channel_last_ttnn(
+        ttnn_output_tensor, [input_shape[0], output_shape[1], output_shape[2], output_shape[0]]
+    )
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upblock2d.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import ttnn
+import torch.nn as nn
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_resnetblock2d import TtResnetBlock2D
+from models.experimental.stable_diffusion_xl_base.vae.tt.tt_upsample2d import TtUpsample2D
+
+
+class TtUpDecoderBlock2D(nn.Module):
+    def __init__(self, device, state_dict, module_path, has_upsample=False, conv_shortcut=False):
+        super().__init__()
+
+        num_layers = 3
+        self.attentions = []
+        self.resnets = []
+
+        for i in range(num_layers):
+            self.resnets.append(
+                TtResnetBlock2D(
+                    device, state_dict, f"{module_path}.resnets.{i}", conv_shortcut=conv_shortcut and (i == 0)
+                )
+            )
+
+        self.upsamplers = (
+            TtUpsample2D(device, state_dict, f"{module_path}.upsamplers.0", (1, 1), (1, 1), (1, 1), 1)
+            if has_upsample
+            else None
+        )
+
+    def forward(self, input_tensor, input_shape):
+        B, C, H, W = input_shape
+        hidden_states = input_tensor
+
+        for resnet in self.resnets:
+            hidden_states, [C, H, W] = resnet.forward(hidden_states, [B, C, H, W])
+
+        ttnn.deallocate(input_tensor)
+        if self.upsamplers is not None:
+            hidden_states = ttnn.to_layout(hidden_states, ttnn.ROW_MAJOR_LAYOUT)
+            hidden_states = ttnn.reshape(hidden_states, (B, H, W, C))
+            hidden_states = ttnn.move(hidden_states)
+            hidden_states, [C, H, W] = self.upsamplers.forward(hidden_states)
+
+        return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_upsample2d.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch.nn as nn
+import ttnn
+
+from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
+    prepare_conv_params,
+)
+from models.experimental.stable_diffusion_xl_base.vae.tt.vae_utility import get_DRAM_conv_config
+
+
+class TtUpsample2D(nn.Module):
+    def __init__(
+        self,
+        device,
+        state_dict,
+        module_path,
+        stride,
+        padding,
+        dilation,
+        groups,
+    ):
+        super().__init__()
+
+        self.device = device
+
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+        self.scale_factor = 2  # fixed number for now
+
+        weights = state_dict[f"{module_path}.conv.weight"]
+        bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
+
+        self.compute_config, self.conv_config, self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
+            device, weights, bias, ttnn.bfloat16
+        )
+        self.conv_slice_config = get_DRAM_conv_config(module_path, 1)
+
+    def interpolate(self, hidden_states):
+        hidden_states = ttnn.upsample(hidden_states, (self.scale_factor, self.scale_factor))
+        B, H, W, C = list(hidden_states.shape)
+        return hidden_states, [B, C, H, W]
+
+    def forward(self, input_tensor):
+        hidden_state_l1, input_shape = self.interpolate(input_tensor)
+        B, C, H, W = input_shape
+        if input_tensor.memory_config() != ttnn.DRAM_MEMORY_CONFIG:
+            ttnn.deallocate(input_tensor)
+
+            hidden_states = ttnn.to_memory_config(hidden_state_l1, ttnn.DRAM_MEMORY_CONFIG)
+            ttnn.deallocate(hidden_state_l1)
+        else:
+            hidden_states = hidden_state_l1
+        [hidden_states, [H, W], [d_w, d_b]] = ttnn.conv2d(
+            input_tensor=hidden_states,
+            weight_tensor=self.tt_weights,
+            in_channels=self.conv_params["input_channels"],
+            out_channels=self.conv_params["output_channels"],
+            device=self.device,
+            bias_tensor=self.tt_bias,
+            kernel_size=self.conv_params["kernel_size"],
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            batch_size=B,
+            input_height=H,
+            input_width=W,
+            conv_config=self.conv_config,
+            compute_config=self.compute_config,
+            groups=self.groups,
+            memory_config=None,
+            slice_config=self.conv_slice_config,
+            return_output_dim=True,
+            return_weights_and_bias=True,
+        )
+        C = self.conv_params["output_channels"]
+        self.tt_weights = d_w
+        self.tt_bias = d_b
+
+        self.conv_config.preprocess_weights_on_device = False
+        self.conv_config.always_preprocess_weights = False
+
+        return hidden_states, [C, H, W]

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -10,7 +10,24 @@ def get_DRAM_GN_config(module_path, idx):
         core_y = 4
         num_out_blocks = 4
     else:
-        assert "Only mid_block is implemented for VAE"
+        parts = module_path.split(".")
+        block_id = int(parts[parts.index("up_blocks") + 1])
+
+        if block_id == 0:
+            core_y = 4
+            num_out_blocks = 4
+        elif block_id == 1:
+            core_y = 8
+            num_out_blocks = 4
+        elif block_id == 2:
+            core_y = 8
+            num_out_blocks = 16
+        else:
+            if idx == 1:
+                core_y = 8
+            else:
+                core_y = 4
+            num_out_blocks = 64
 
     return core_y, num_out_blocks
 
@@ -20,8 +37,32 @@ def get_DRAM_conv_config(module_path, idx):
         slice_type = None
         num_slices = 1
     else:
-        assert "Only mid_block is implemented for VAE"
+        parts = module_path.split(".")
+        block_id = int(parts[parts.index("up_blocks") + 1])
 
+        slice_type = ttnn.Conv2dSliceWidth
+
+        if "upsamplers" in module_path:
+            if block_id == 0:
+                num_slices = 2
+            elif block_id == 1:
+                num_slices = 8
+            elif block_id == 2:
+                num_slices = 16
+            else:
+                num_slices = 32
+        else:
+            if block_id == 0:
+                num_slices = 1
+            elif block_id == 1:
+                num_slices = 2
+            elif block_id == 2:
+                if idx == 1:
+                    num_slices = 8
+                else:
+                    num_slices = 4
+            else:
+                num_slices = 32
     slice_config = (
         ttnn.Conv2dSliceConfig(
             slice_type=slice_type,

--- a/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_upblock2d.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_upblock2d.py
@@ -1,0 +1,1 @@
+../../../../../models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py

--- a/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_upsample2d.py
+++ b/tests/nightly/single_card/stable_diffusion_xl_base/vae/test_module_tt_upsample2d.py
@@ -1,0 +1,1 @@
+../../../../../models/experimental/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upsample2d.py


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-metal/issues/20050)

### What's changed
Functional implementation with unit tests for `TtUpsample2D` and `TtUpDecoderBlock2D`.
Additionally, to reduce memory consumption we load only UNet/VAE weights not the whole pipeline and call the garbage collector explicitly.

### Checklist
CI in progress
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14858308277) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/14855585066) CI passes
