### PR TITLE
[skip ci] #21651: vLLM nightly tests placeholder

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -1,0 +1,63 @@
+name: "[internal] vLLM nightly tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+
+jobs:
+  vllm-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          {
+            name: "Llama3 vLLM T3K test",
+            arch: wormhole_b0,
+            runner-label: config-t3000,
+            owner_id: U08E1JCDVNX # Pavle Petrovic
+          },
+          {
+            name: "Llama3 vLLM TG test",
+            arch: wormhole_b0,
+            runner-label: config-tg,
+            owner_id: U08E1JCDVNX # Pavle Petrovic
+          },
+        ]
+    runs-on:
+      - arch-${{ matrix.test-group.arch }}
+      - ${{ matrix.test-group.runner-label }}
+      - in-service
+      - bare-metal
+      - pipeline-functional
+    container:
+      image: ${{ inputs.docker-image }}
+      env:
+        LOGURU_LEVEL: INFO
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: 👋 Hello World
+        run: echo "Hello from vLLM nightly tests!"
+
+      - uses: ./.github/actions/slack-report
+        if: ${{ failure() }}
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          owner: ${{ matrix.test-group.owner_id }}
+
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/vllm-nightly-tests.yaml
+++ b/.github/workflows/vllm-nightly-tests.yaml
@@ -1,0 +1,22 @@
+name: "vLLM nightly tests"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # This cron schedule runs the workflow every day at 12am UTC
+
+jobs:
+  build-artifact:
+    uses: ./.github/workflows/build-artifact.yaml
+    secrets: inherit
+    with:
+      version: 22.04
+      build-wheel: true
+  vllm-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/vllm-nightly-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}


### PR DESCRIPTION
### Ticket
[Link to Github Issue 21651](https://github.com/tenstorrent/tt-metal/issues/21651)

### Problem description
vLLM is an important component in the delivery of language models.
We need a way to keep it aligned with tt-metal.

### What's changed
Add vLLM nightly test placeholder, so that we can trigger it from a workflow.
Full test will follow

### Checklist
CI skipped