### PR TITLE
sfpi v6.11.0, rename riscv target triple, remove GraySkull

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -139,10 +139,10 @@ function(get_alias INPUT_STRING OUTPUT_VAR)
 endfunction()
 
 # Define the compiler command
-set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-unknown-elf-g++)
+set(GPP_CMD ${PROJECT_SOURCE_DIR}/runtime/sfpi/compiler/bin/riscv32-tt-elf-g++)
 
 # May switch to this someday
-# set(GPP_CMD /opt/tenstorrent/sfpi/compiler/bin/riscv32-unknown-elf-g++)
+# set(GPP_CMD /opt/tenstorrent/sfpi/compiler/bin/riscv32-tt-elf-g++)
 
 set(GPP_DEFINES -DTENSIX_FIRMWARE)
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -143,7 +143,7 @@ void JitBuildEnv::init(
 
     bool sfpi_found = false;
     for (unsigned i = 0; i < 2; ++i) {
-        auto gxx = sfpi_roots[i] + "/compiler/bin/riscv32-unknown-elf-g++";
+        auto gxx = sfpi_roots[i] + "/compiler/bin/riscv32-tt-elf-g++";
         if (std::filesystem::exists(gxx)) {
             this->gpp_ += gxx + " ";
             this->gpp_include_dir_ = sfpi_roots[i] + "/include";

--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,7 +1,7 @@
 # set SFPI release version information
-sfpi_version=v6.10.2
+sfpi_version=v6.11.0
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
-sfpi_x86_64_Linux_tgz_md5=8937def463673c2726218ea7b9a504ea
-sfpi_x86_64_Linux_deb_md5=0f091cd70dfb641c87f052e2394a981a
-sfpi_aarch64_Linux_tgz_md5=816721dbbf602f6b320d56c9ece94651
-sfpi_aarch64_Linux_deb_md5=d2960200de58eb01e814374000866997
+sfpi_x86_64_Linux_tgz_md5=806f11a6b55cecfe0190671b0cb47776
+sfpi_x86_64_Linux_deb_md5=825fc8c7a82b62e70f836e5d5272122c
+sfpi_aarch64_Linux_tgz_md5=29025a436350e940a4c6088eef1ba500
+sfpi_aarch64_Linux_deb_md5=62034570bc71cc53c210143919baf259


### PR DESCRIPTION
### Ticket
NA

### Problem description
The target triple for the Riscv compiler is `riscv32-unknown-elf`, which can lead to inadvertent confusion with other riscv32 toolchains the user might have on their system.

GraySkull has been removed from TT metal, let's remove it.

### What's changed
Use `tt` as the manufacturer component of the triple -- `riscv32-tt-elf`.  In configuration the manufacturer is nearly always ignored -- it's only used in naming and identifying the binaries.

Adjust the jit compiler and cmake to accommodate the change.

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes