### PR TITLE
Modified profiler to use DMA when interacting with control buffer and profiler buffer on WH PCIe chips

### DIFF
--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -117,6 +117,24 @@ void ReadFromBuffer(std::shared_ptr<Buffer> buffer, std::vector<DType>& host_buf
     ReadFromBuffer(*buffer, host_buffer, shard_order);
 }
 
+// DMA reads and writes are only supported for MMIO devices
+void ReadFromBufferUsingDMA(Buffer& buffer, uint8_t* host_buffer, bool shard_order = false);
+
+template <typename DType>
+void ReadFromBufferUsingDMA(Buffer& buffer, std::vector<DType>& host_buffer, bool shard_order = false) {
+    ReadFromBufferUsingDMA(buffer, reinterpret_cast<uint8_t*>(host_buffer.data()), shard_order);
+}
+
+void WriteToBufferUsingDMA(Buffer& buffer, tt::stl::Span<const uint8_t> host_buffer);
+
+template <typename DType>
+void WriteToBufferUsingDMA(Buffer& buffer, const std::vector<DType>& host_buffer) {
+    WriteToBufferUsingDMA(
+        buffer,
+        tt::stl::Span<const uint8_t>(
+            reinterpret_cast<const uint8_t*>(host_buffer.data()), host_buffer.size() * sizeof(DType)));
+}
+
 void ReadShard(Buffer& buffer, uint8_t* host_buffer, const uint32_t& core_id);
 /**
  * Copies data from a buffer into a host buffer

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -122,6 +122,8 @@ void ReadFromBufferUsingDMA(Buffer& buffer, uint8_t* host_buffer, bool shard_ord
 
 template <typename DType>
 void ReadFromBufferUsingDMA(Buffer& buffer, std::vector<DType>& host_buffer, bool shard_order = false) {
+    TT_FATAL(buffer.size() % sizeof(DType) == 0, "Buffer size is not divisible by dtype size");
+    host_buffer.resize(buffer.size() / sizeof(DType));
     ReadFromBufferUsingDMA(buffer, reinterpret_cast<uint8_t*>(host_buffer.data()), shard_order);
 }
 

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -160,8 +160,7 @@ void write_control_buffer_to_core(
                 mesh_cq.enqueue_write_shard_to_core(
                     address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);
             } else {
-                tt::llrt::write_hex_vec_to_core(
-                    device->id(), core, control_buffer, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector));
+                write_control_buffer_to_core_slow_dispatch(device, core, core_type, control_buffer);
             }
         } else {
             dynamic_cast<HWCommandQueue&>(device->command_queue())
@@ -173,8 +172,7 @@ void write_control_buffer_to_core(
                     true);
         }
     } else {
-        tt::llrt::write_hex_vec_to_core(
-            device->id(), core, control_buffer, reinterpret_cast<uint64_t>(profiler_msg->control_vector));
+        write_control_buffer_to_core_slow_dispatch(device, core, core_type, control_buffer);
     }
 }
 HalProgrammableCoreType get_core_type(chip_id_t device_id, const CoreCoord& core) {

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -68,6 +68,27 @@ void issue_fd_read_from_profiler_buffer(
     }
 }
 
+std::vector<uint32_t> read_control_buffer_from_core_slow_dispatch(
+    IDevice* device, const CoreCoord& core, const HalProgrammableCoreType core_type) {
+    std::vector<uint32_t> control_buffer;
+    profiler_msg_t* profiler_msg =
+        MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
+    if (MetalContext::instance().hal().get_arch() == tt::ARCH::WORMHOLE_B0 && device->is_mmio_capable()) {
+        control_buffer = tt::llrt::dma_read_hex_vec_from_core(
+            device->id(),
+            core,
+            reinterpret_cast<DeviceAddr>(profiler_msg->control_vector),
+            kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
+    } else {
+        control_buffer = tt::llrt::read_hex_vec_from_core(
+            device->id(),
+            core,
+            reinterpret_cast<DeviceAddr>(profiler_msg->control_vector),
+            kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
+    }
+    return control_buffer;
+}
+
 std::vector<uint32_t> read_control_buffer_from_core(
     IDevice* device, const CoreCoord& core, const HalProgrammableCoreType core_type, const ProfilerDumpState state) {
     std::vector<uint32_t> control_buffer;
@@ -85,11 +106,7 @@ std::vector<uint32_t> read_control_buffer_from_core(
                 mesh_cq.enqueue_read_shard_from_core(
                     address, control_buffer.data(), kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE, true);
             } else {
-                control_buffer = tt::llrt::read_hex_vec_from_core(
-                    device->id(),
-                    core,
-                    reinterpret_cast<DeviceAddr>(profiler_msg->control_vector),
-                    kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
+                control_buffer = read_control_buffer_from_core_slow_dispatch(device, core, core_type);
             }
         } else {
             control_buffer.resize(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE);
@@ -102,14 +119,26 @@ std::vector<uint32_t> read_control_buffer_from_core(
                     true);
         }
     } else {
-        control_buffer = tt::llrt::read_hex_vec_from_core(
-            device->id(),
-            core,
-            reinterpret_cast<uint64_t>(profiler_msg->control_vector),
-            kernel_profiler::PROFILER_L1_CONTROL_BUFFER_SIZE);
+        control_buffer = read_control_buffer_from_core_slow_dispatch(device, core, core_type);
     }
 
     return control_buffer;
+}
+
+void write_control_buffer_to_core_slow_dispatch(
+    IDevice* device,
+    const CoreCoord& core,
+    const HalProgrammableCoreType core_type,
+    const std::vector<uint32_t>& control_buffer) {
+    profiler_msg_t* profiler_msg =
+        MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
+    if (MetalContext::instance().hal().get_arch() == tt::ARCH::WORMHOLE_B0 && device->is_mmio_capable()) {
+        tt::llrt::dma_write_hex_vec_to_core(
+            device->id(), core, control_buffer, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector));
+    } else {
+        tt::llrt::write_hex_vec_to_core(
+            device->id(), core, control_buffer, reinterpret_cast<DeviceAddr>(profiler_msg->control_vector));
+    }
 }
 
 void write_control_buffer_to_core(

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -268,6 +268,8 @@ public:
     void setSyncInfo(const std::tuple<double, double, double>& sync_info);
 };
 
+bool supports_dma_operations(const IDevice* device);
+
 void issue_fd_write_to_profiler_buffer(distributed::AnyBuffer& buffer, IDevice* device, std::vector<uint32_t>& data);
 
 void write_control_buffer_to_core(

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -91,6 +91,12 @@ std::vector<uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord &co
     return read_hex_vec;
 }
 
+std::vector<uint32_t> dma_read_hex_vec_from_core(chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size) {
+    std::vector<uint32_t> data;
+    tt::tt_metal::MetalContext::instance().get_cluster().dma_read_core(data, size, tt_cxy_pair(chip, core), addr);
+    return data;
+}
+
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, const CoreCoord &ethernet_core) {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
         chip_id, ethernet_core);

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -89,6 +89,16 @@ void write_hex_vec_to_core(
 
 std::vector<std::uint32_t> read_hex_vec_from_core(chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);
 
+// DMA reads and writes only supported on MMIO devices
+template <typename DType>
+void dma_write_hex_vec_to_core(
+    chip_id_t chip, const CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) {
+    tt::tt_metal::MetalContext::instance().get_cluster().dma_write_core(
+        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
+}
+
+std::vector<uint32_t> dma_read_hex_vec_from_core(chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);
+
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord& ethernet_core);
 
 void write_launch_msg_to_core(

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -97,6 +97,13 @@ void dma_write_hex_vec_to_core(
         hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
 }
 
+template <typename DType>
+void dma_write_hex_vec_to_core(
+    chip_id_t chip, const CoreCoord& core, tt::stl::Span<const DType> hex_vec, uint64_t addr) {
+    tt::tt_metal::MetalContext::instance().get_cluster().dma_write_core(
+        hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(chip, core), addr);
+}
+
 std::vector<uint32_t> dma_read_hex_vec_from_core(chip_id_t chip, const CoreCoord& core, uint64_t addr, uint32_t size);
 
 CoreCoord logical_core_from_ethernet_core(chip_id_t chip_id, CoreCoord& ethernet_core);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -668,6 +668,28 @@ void Cluster::read_core(
     read_core(data.data(), size_in_bytes, core, addr, small_access);
 }
 
+void Cluster::dma_write_core(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+    const chip_id_t chip_id = core.chip;
+    TT_FATAL(this->cluster_desc_->is_chip_mmio_capable(chip_id), "DMA write to non-MMIO device is not supported");
+    const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
+    tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
+    this->driver_->dma_write_to_device(mem_ptr, size_in_bytes, chip_id, core_coord, addr);
+}
+
+void Cluster::dma_read_core(void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+    const chip_id_t chip_id = core.chip;
+    TT_FATAL(this->cluster_desc_->is_chip_mmio_capable(chip_id), "DMA read from non-MMIO device is not supported");
+    const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
+    tt::umd::CoreCoord core_coord = soc_desc.get_coord_at(core, CoordSystem::TRANSLATED);
+    this->driver_->dma_read_from_device(mem_ptr, size_in_bytes, chip_id, core_coord, addr);
+}
+
+void Cluster::dma_read_core(
+    std::vector<uint32_t>& data, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const {
+    data.resize(size_in_bytes / sizeof(uint32_t));
+    dma_read_core(data.data(), size_in_bytes, core, addr);
+}
+
 void Cluster::write_reg(const std::uint32_t *mem_ptr, tt_cxy_pair target, uint64_t addr) const {
     const unsigned int size_in_bytes = sizeof(uint32_t);
     int chip_id = target.chip;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -157,6 +157,16 @@ public:
         uint64_t addr,
         bool small_access = false) const;
 
+    void dma_read_dram_vec(
+        std::vector<uint32_t>& vec,
+        uint32_t size_in_bytes,
+        chip_id_t device_id,
+        int dram_view,
+        uint64_t addr,
+        bool small_access = false) const;
+    void dma_write_dram_vec(
+        std::vector<uint32_t>& vec, chip_id_t device_id, int dram_view, uint64_t addr, bool small_access = false) const;
+
     // Accepts physical noc coordinates
     void write_core(
         const void* mem_ptr, uint32_t sz_in_bytes, tt_cxy_pair core, uint64_t addr, bool small_access = false) const;
@@ -383,6 +393,18 @@ private:
 
     // Set tunnels from mmio
     void set_tunnels_from_mmio_device();
+
+    void read_dram_vec(
+        std::vector<uint32_t>& vec,
+        uint32_t size_in_bytes,
+        chip_id_t device_id,
+        int dram_view,
+        uint64_t addr,
+        bool small_access,
+        bool use_dma) const;
+    void write_dram_vec(
+        std::vector<uint32_t>& vec, chip_id_t device_id, int dram_view, uint64_t addr, bool small_access, bool use_dma)
+        const;
 
     ARCH arch_;
     TargetDevice target_type_;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -169,6 +169,11 @@ public:
         uint64_t addr,
         bool small_access = false) const;
 
+    // DMA reads and writes only supported on MMIO devices
+    void dma_write_core(const void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+    void dma_read_core(void* mem_ptr, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+    void dma_read_core(std::vector<uint32_t>& data, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const;
+
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair& target) const {
         tt::umd::CoreCoord target_coord = get_soc_desc(target.chip).get_coord_at(target, CoordSystem::TRANSLATED);
         auto tlb_configuration = driver_->get_tlb_configuration(target.chip, target_coord);

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
#21008
This PR modifies the profiler to use DMA reads and writes when interacting with the control buffer and profiler buffer on WH PCIe chips.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes