### PR TITLE
#21694: Clean up ephemeral runner suffix

### DIFF
--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -208,6 +208,15 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
     else:
         ubuntu_version = None
 
+    # Clean up ephemeral runner names
+    if host_name and host_name.startswith("tt-beta"):
+        parts = host_name.split("-")
+        # Remove non-constant ephemeral runner suffix from tt-beta runner names only if the second last part is "runner"
+        # We don't want to remove the suffix for non-ephemeral tt-beta runners (e.g. tt-beta-ubuntu-2204-xlarge)
+        # E.g. tt-beta-ubuntu-2204-n150-large-stable-nk6pd-runner-5g5f9 -> tt-beta-ubuntu-2204-n150-large-stable-nk6pd
+        if len(parts) >= 2 and parts[-2] == "runner":
+            host_name = "-".join(parts[:-1])
+
     os = ubuntu_version
 
     name = github_job["name"]

--- a/infra/data_collection/github/utils.py
+++ b/infra/data_collection/github/utils.py
@@ -211,6 +211,7 @@ def get_job_row_from_github_job(github_job, github_job_id_to_annotations, workfl
     # Clean up ephemeral runner names
     if host_name and host_name.startswith("tt-beta"):
         parts = host_name.split("-")
+        # Issue: https://github.com/tenstorrent/tt-metal/issues/21694
         # Remove non-constant ephemeral runner suffix from tt-beta runner names only if the second last part is "runner"
         # We don't want to remove the suffix for non-ephemeral tt-beta runners (e.g. tt-beta-ubuntu-2204-xlarge)
         # E.g. tt-beta-ubuntu-2204-n150-large-stable-nk6pd-runner-5g5f9 -> tt-beta-ubuntu-2204-n150-large-stable-nk6pd


### PR DESCRIPTION
### Ticket
#21694

### Problem description
After switch to CIv2, each ephemeral runner instance creates a new hostname entry per job, which makes the table very large.

### What's changed
If runner is ephemeral (e.g. starts with `tt-beta`), extract non-ephemeral portion of host name (drop anything after the `-runner` portion of the host name)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes