### PR TITLE
Add MeshGraph, Cluster support for multi host

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -1661,7 +1661,7 @@ TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
     auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
-    auto current_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(current_device_id);
+    auto current_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(current_device_id);
     auto sender_logical_coord = CoreCoord(0, 0);
     auto recv_logical_coord = CoreCoord(0, 1);
     auto sender_virtual_coord = md0->worker_core_from_logical_core(sender_logical_coord);
@@ -1701,8 +1701,8 @@ TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
         recv_config,
         send_socket,
         recv_socket,
-        current_mesh_chip_id.second,
-        current_mesh_chip_id.second,
+        current_fabric_node_id.chip_id,
+        current_fabric_node_id.chip_id,
         sender_virtual_coord,
         recv_virtual_coord,
         socket_fifo_size);
@@ -1713,7 +1713,7 @@ TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
     auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
     auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
-    auto current_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(current_device_id);
+    auto current_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(current_device_id);
     std::size_t socket_fifo_size = 1024;
     const auto& worker_grid = md0->compute_with_storage_grid_size();
     std::vector<CoreCoord> sender_logical_coords;
@@ -1780,8 +1780,8 @@ TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
             recv_config,
             send_socket,
             recv_socket,
-            current_mesh_chip_id.second,
-            current_mesh_chip_id.second,
+            current_fabric_node_id.chip_id,
+            current_fabric_node_id.chip_id,
             sender_virtual_coord,
             recv_virtual_coord,
             socket_fifo_size);
@@ -1897,15 +1897,15 @@ TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceTest) {
         const auto& sender_config = sender_configs_per_dev_coord[sender_device_coord][sender_idx];
         const auto& recv_config = recv_configs_per_dev_coord[recv_device_coord][recv_idx];
 
-        auto sender_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(sender_device_id);
-        auto receiver_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(receiver_device_id);
+        auto sender_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(sender_device_id);
+        auto receiver_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(receiver_device_id);
         verify_socket_configs(
             sender_config,
             recv_config,
             send_socket_l1,
             recv_socket_l1,
-            receiver_mesh_chip_id.second,
-            sender_mesh_chip_id.second,
+            receiver_fabric_node_id.chip_id,
+            sender_fabric_node_id.chip_id,
             sender_virtual_coord,
             recv_virtual_coord,
             socket_fifo_size);

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -102,7 +102,7 @@ class CustomMeshGraphFabric2DDynamicFixture : public BaseFabricFixture {
 public:
     void SetUp(
         const std::string& mesh_graph_desc_file,
-        const std::vector<std::vector<chip_id_t>>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+        const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
         tt::tt_metal::MetalContext::instance().get_cluster().set_custom_control_plane_mesh_graph(
             mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
         this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC);

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -17,8 +17,8 @@ namespace fabric_router_tests {
 // Find a device with enough neighbours in the specified direction
 bool find_device_with_neighbor_in_multi_direction(
     BaseFabricFixture* fixture,
-    std::pair<mesh_id_t, chip_id_t>& src_mesh_chip_id,
-    std::unordered_map<RoutingDirection, std::vector<std::pair<mesh_id_t, chip_id_t>>>& dst_mesh_chip_ids_by_dir,
+    FabricNodeId& src_fabric_node_id,
+    std::unordered_map<RoutingDirection, std::vector<FabricNodeId>>& dst_fabric_node_ids_by_dir,
     chip_id_t& src_physical_device_id,
     std::unordered_map<RoutingDirection, std::vector<chip_id_t>>& dst_physical_device_ids_by_dir,
     const std::unordered_map<RoutingDirection, uint32_t>& mcast_hops,
@@ -29,34 +29,28 @@ bool find_device_with_neighbor_in_multi_direction(
     // Find a device with enough neighbours in the specified direction
     bool connection_found = false;
     for (auto* device : devices) {
-        src_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+        src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
         if (incoming_direction.has_value()) {
-            if (!control_plane
-                     ->get_intra_chip_neighbors(
-                         src_mesh_chip_id.first, src_mesh_chip_id.second, incoming_direction.value())
-                     .size()) {
+            if (!control_plane->get_intra_chip_neighbors(src_fabric_node_id, incoming_direction.value()).size()) {
                 // This potential source will not have the requested incoming direction, skip
                 continue;
             }
         }
-        std::unordered_map<RoutingDirection, std::vector<std::pair<mesh_id_t, chip_id_t>>>
-            temp_end_mesh_chip_ids_by_dir;
+        std::unordered_map<RoutingDirection, std::vector<FabricNodeId>> temp_end_fabric_node_ids_by_dir;
         std::unordered_map<RoutingDirection, std::vector<chip_id_t>> temp_physical_end_device_ids_by_dir;
         connection_found = true;
         for (auto [routing_direction, num_hops] : mcast_hops) {
             bool direction_found = true;
-            auto& temp_end_mesh_chip_ids = temp_end_mesh_chip_ids_by_dir[routing_direction];
+            auto& temp_end_fabric_node_ids = temp_end_fabric_node_ids_by_dir[routing_direction];
             auto& temp_physical_end_device_ids = temp_physical_end_device_ids_by_dir[routing_direction];
-            uint32_t curr_mesh_id = src_mesh_chip_id.first;
-            uint32_t curr_chip_id = src_mesh_chip_id.second;
+            auto curr_fabric_node_id = src_fabric_node_id;
             for (uint32_t i = 0; i < num_hops; i++) {
-                auto neighbors = control_plane->get_intra_chip_neighbors(curr_mesh_id, curr_chip_id, routing_direction);
+                auto neighbors = control_plane->get_intra_chip_neighbors(curr_fabric_node_id, routing_direction);
                 if (neighbors.size() > 0) {
-                    temp_end_mesh_chip_ids.emplace_back(curr_mesh_id, neighbors[0]);
+                    temp_end_fabric_node_ids.emplace_back(curr_fabric_node_id.mesh_id, neighbors[0]);
                     temp_physical_end_device_ids.push_back(
-                        control_plane->get_physical_chip_id_from_mesh_chip_id(temp_end_mesh_chip_ids.back()));
-                    curr_mesh_id = temp_end_mesh_chip_ids.back().first;
-                    curr_chip_id = temp_end_mesh_chip_ids.back().second;
+                        control_plane->get_physical_chip_id_from_fabric_node_id(temp_end_fabric_node_ids.back()));
+                    curr_fabric_node_id = temp_end_fabric_node_ids.back();
                 } else {
                     direction_found = false;
                     break;
@@ -69,7 +63,7 @@ bool find_device_with_neighbor_in_multi_direction(
         }
         if (connection_found) {
             src_physical_device_id = device->id();
-            dst_mesh_chip_ids_by_dir = std::move(temp_end_mesh_chip_ids_by_dir);
+            dst_fabric_node_ids_by_dir = std::move(temp_end_fabric_node_ids_by_dir);
             dst_physical_device_ids_by_dir = std::move(temp_physical_end_device_ids_by_dir);
             break;
         }
@@ -79,41 +73,38 @@ bool find_device_with_neighbor_in_multi_direction(
 
 bool find_device_with_neighbor_in_direction(
     BaseFabricFixture* fixture,
-    std::pair<mesh_id_t, chip_id_t>& src_mesh_chip_id,
-    std::pair<mesh_id_t, chip_id_t>& dst_mesh_chip_id,
+    FabricNodeId& src_fabric_node_id,
+    FabricNodeId& dst_fabric_node_id,
     chip_id_t& src_physical_device_id,
     chip_id_t& dst_physical_device_id,
     RoutingDirection direction) {
     auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto devices = fixture->get_devices();
     for (auto* device : devices) {
-        src_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+        src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
 
         // Get neighbours within a mesh in the given direction
-        auto neighbors =
-            control_plane->get_intra_chip_neighbors(src_mesh_chip_id.first, src_mesh_chip_id.second, direction);
+        auto neighbors = control_plane->get_intra_chip_neighbors(src_fabric_node_id, direction);
         if (neighbors.size() > 0) {
             src_physical_device_id = device->id();
-            dst_mesh_chip_id = {src_mesh_chip_id.first, neighbors[0]};
-            dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
+            dst_fabric_node_id = FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]);
+            dst_physical_device_id = control_plane->get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
             return true;
         }
     }
     return false;
 }
 
-std::vector<std::vector<chip_id_t>> get_physical_chip_mapping_from_eth_coords_mapping(
+std::map<FabricNodeId, chip_id_t> get_physical_chip_mapping_from_eth_coords_mapping(
     const std::vector<std::vector<eth_coord_t>>& mesh_graph_eth_coords) {
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
-    std::vector<std::vector<chip_id_t>> physical_chip_ids_mapping;
-    physical_chip_ids_mapping.reserve(mesh_graph_eth_coords.size());
-    for (const auto& mesh : mesh_graph_eth_coords) {
-        std::vector<chip_id_t> physical_chip_ids;
-        physical_chip_ids.reserve(mesh.size());
-        for (const auto& eth_coord : mesh) {
-            physical_chip_ids.push_back(cluster.get_physical_chip_id_from_eth_coord(eth_coord));
+    std::map<FabricNodeId, chip_id_t> physical_chip_ids_mapping;
+    for (std::uint32_t mesh_id = 0; mesh_id < mesh_graph_eth_coords.size(); mesh_id++) {
+        for (std::uint32_t chip_id = 0; chip_id < mesh_graph_eth_coords[mesh_id].size(); chip_id++) {
+            const auto& eth_coord = mesh_graph_eth_coords[mesh_id][chip_id];
+            physical_chip_ids_mapping.insert(
+                {FabricNodeId(mesh_id, chip_id), cluster.get_physical_chip_id_from_eth_coord(eth_coord)});
         }
-        physical_chip_ids_mapping.push_back(physical_chip_ids);
     }
     return physical_chip_ids_mapping;
 }

--- a/tests/tt_metal/tt_fabric/common/utils.hpp
+++ b/tests/tt_metal/tt_fabric/common/utils.hpp
@@ -17,8 +17,8 @@ namespace fabric_router_tests {
 
 bool find_device_with_neighbor_in_multi_direction(
     BaseFabricFixture* fixture,
-    std::pair<mesh_id_t, chip_id_t>& src_mesh_chip_id,
-    std::unordered_map<RoutingDirection, std::vector<std::pair<mesh_id_t, chip_id_t>>>& dst_mesh_chip_ids_by_dir,
+    FabricNodeId& src_fabric_node_id,
+    std::unordered_map<RoutingDirection, std::vector<FabricNodeId>>& dst_fabric_node_ids_by_dir,
     chip_id_t& src_physical_device_id,
     std::unordered_map<RoutingDirection, std::vector<chip_id_t>>& dst_physical_device_ids_by_dir,
     const std::unordered_map<RoutingDirection, uint32_t>& mcast_hops,
@@ -26,13 +26,13 @@ bool find_device_with_neighbor_in_multi_direction(
 
 bool find_device_with_neighbor_in_direction(
     BaseFabricFixture* fixture,
-    std::pair<mesh_id_t, chip_id_t>& src_mesh_chip_id,
-    std::pair<mesh_id_t, chip_id_t>& dst_mesh_chip_id,
+    FabricNodeId& src_fabric_node_id,
+    FabricNodeId& dst_fabric_node_id,
     chip_id_t& src_physical_device_id,
     chip_id_t& dst_physical_device_id,
     RoutingDirection direction);
 
-std::vector<std::vector<chip_id_t>> get_physical_chip_mapping_from_eth_coords_mapping(
+std::map<FabricNodeId, chip_id_t> get_physical_chip_mapping_from_eth_coords_mapping(
     const std::vector<std::vector<eth_coord_t>>& mesh_graph_eth_coords);
 
 }  // namespace fabric_router_tests

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x1_mesh_graph_descriptor.yaml
@@ -20,42 +20,42 @@ Mesh: [
   id: 0,
   board:  1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 1,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 2,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 3,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 4,
   board:  1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 5,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 6,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 7,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_1x2_mesh_graph_descriptor.yaml
@@ -20,22 +20,22 @@ Mesh: [
   id: 0,
   board:  1x2,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 1,
   board: 1x2,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 2,
   board: 1x2,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 3,
   board: 1x2,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_1x2_1x1_mesh_graph_descriptor.yaml
@@ -26,22 +26,22 @@ Mesh: [
   id: 0,
   board:  2x2,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 1,
   board: 1x2,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 2,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 3,
   board: 1x1,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
+++ b/tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.yaml
@@ -20,12 +20,12 @@ Mesh: [
   id: 0,
   board: 2x2,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 1,
   board: 2x2,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -121,7 +121,7 @@ std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
     std::unordered_map<tt_fabric::RoutingDirection, chip_id_t> chip_0_neigbors;
     std::optional<tt_fabric::RoutingDirection> chip_1_direction = std::nullopt;
     for (const auto& direction : routing_directions) {
-        auto neighbors = control_plane->get_intra_chip_neighbors(mesh_id, 0, direction);
+        auto neighbors = control_plane->get_intra_chip_neighbors(FabricNodeId(mesh_id, 0), direction);
         if (neighbors.empty()) {
             continue;
         }
@@ -203,7 +203,8 @@ std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
             if (logical_chip_id > physical_chip_ids.size()) {
                 throw std::runtime_error("Failed to setup neighbor map, logical chip id exceeding bounds");
             }
-            chip_id_t phys_chip_id = control_plane->get_physical_chip_id_from_mesh_chip_id({mesh_id, logical_chip_id});
+            chip_id_t phys_chip_id =
+                control_plane->get_physical_chip_id_from_fabric_node_id(FabricNodeId(mesh_id, logical_chip_id));
             physical_chip_matrix[i][j] = phys_chip_id;
             logical_chip_id += row_offset;
         }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -53,9 +53,9 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(tg_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
-    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 3);
+    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(0, 0), 3);
     for (auto chan : valid_chans) {
-        auto path = control_plane->get_fabric_route(0, 0, 4, 31, chan);
+        auto path = control_plane->get_fabric_route(FabricNodeId(0, 0), FabricNodeId(4, 31), chan);
         EXPECT_EQ(path.size() > 0, true);
     }
 }
@@ -81,14 +81,14 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
     auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
-    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 0);
+    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(0, 0), 0);
     for (auto chan : valid_chans) {
-        auto path = control_plane->get_fabric_route(0, 0, 0, 7, chan);
+        auto path = control_plane->get_fabric_route(FabricNodeId(0, 0), FabricNodeId(0, 7), chan);
         EXPECT_EQ(path.size() > 0, true);
     }
-    valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 1);
+    valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(FabricNodeId(0, 0), 1);
     for (auto chan : valid_chans) {
-        auto path = control_plane->get_fabric_route(0, 0, 0, 7, chan);
+        auto path = control_plane->get_fabric_route(FabricNodeId(0, 0), FabricNodeId(0, 7), chan);
         EXPECT_EQ(path.size() > 0, true);
     }
 }
@@ -129,10 +129,12 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
             auto dst_mesh_shape = control_plane->get_physical_mesh_shape(dst_mesh);
             auto dst_mesh_size = dst_mesh_shape[0] * dst_mesh_shape[1];
             auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(
-                src_mesh, std::rand() % src_mesh_size, std::rand() % num_routing_planes);
+                FabricNodeId(src_mesh, std::rand() % src_mesh_size), std::rand() % num_routing_planes);
             for (auto chan : valid_chans) {
                 auto path = control_plane->get_fabric_route(
-                    src_mesh, std::rand() % src_mesh_size, dst_mesh, std::rand() % dst_mesh_size, chan);
+                    FabricNodeId(src_mesh, std::rand() % src_mesh_size),
+                    FabricNodeId(dst_mesh, std::rand() % dst_mesh_size),
+                    chan);
                 EXPECT_EQ(path.size() > 0, true);
             }
         }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -108,8 +108,9 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto control_plane = std::make_unique<ControlPlane>(
+    auto global_control_plane = std::make_unique<GlobalControlPlane>(
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+    auto control_plane = global_control_plane->get_local_node_control_plane();
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
 }
 
@@ -117,8 +118,9 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kFabricRoutes) {
     auto [mesh_graph_desc_path, mesh_graph_eth_coords] = GetParam();
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) / mesh_graph_desc_path;
-    auto control_plane = std::make_unique<ControlPlane>(
+    auto global_control_plane = std::make_unique<GlobalControlPlane>(
         t3k_mesh_graph_desc_path.string(), get_physical_chip_mapping_from_eth_coords_mapping(mesh_graph_eth_coords));
+    auto control_plane = global_control_plane->get_local_node_control_plane();
     control_plane->configure_routing_tables_for_fabric_ethernet_channels();
     // TODO: Query this
     constexpr uint32_t num_routing_planes = 2;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_multi_hop_sanity.cpp
@@ -308,8 +308,12 @@ int main(int argc, char** argv) {
             throw std::runtime_error("Test cannot run on specified device.");
         }
 
-        auto [dev_l_mesh_id, dev_l_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_l);
-        auto [dev_r_mesh_id, dev_r_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_r);
+        auto dev_l_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(test_device_id_l);
+        auto dev_r_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(test_device_id_r);
+        auto dev_l_mesh_id = dev_l_fabric_node_id.mesh_id;
+        auto dev_l_chip_id = dev_l_fabric_node_id.chip_id;
+        auto dev_r_mesh_id = dev_r_fabric_node_id.mesh_id;
+        auto dev_r_chip_id = dev_r_fabric_node_id.chip_id;
 
         log_info(
             LogTest,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_mux_bandwidth.cpp
@@ -337,7 +337,7 @@ int main(int argc, char** argv) {
     auto mesh_id = control_plane->get_user_physical_mesh_ids()[0];
     chip_id_t logical_chip_id = 0;
     auto physical_chip_id =
-        control_plane->get_physical_chip_id_from_mesh_chip_id(std::make_pair(mesh_id, logical_chip_id));
+        control_plane->get_physical_chip_id_from_fabric_node_id(tt::tt_fabric::FabricNodeId(mesh_id, logical_chip_id));
 
     std::map<chip_id_t, tt::tt_metal::IDevice*> devices = tt::tt_metal::detail::CreateDevices({physical_chip_id});
     tt::tt_metal::IDevice* device = devices.at(physical_chip_id);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -305,8 +305,12 @@ int main(int argc, char** argv) {
             throw std::runtime_error("Test cannot run on specified device.");
         }
 
-        auto [dev_l_mesh_id, dev_l_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_l);
-        auto [dev_r_mesh_id, dev_r_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(test_device_id_r);
+        auto dev_l_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(test_device_id_l);
+        auto dev_r_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(test_device_id_r);
+        auto dev_l_mesh_id = dev_l_fabric_node_id.mesh_id;
+        auto dev_l_chip_id = dev_l_fabric_node_id.chip_id;
+        auto dev_r_mesh_id = dev_r_fabric_node_id.mesh_id;
+        auto dev_r_chip_id = dev_r_fabric_node_id.chip_id;
 
         log_info(
             LogTest,
@@ -353,7 +357,7 @@ int main(int argc, char** argv) {
                                             .get_cluster()
                                             .get_soc_desc(test_device_id_l)
                                             .logical_eth_core_to_chan_map.at(router_logical_core);
-                        routing_plane = control_plane->get_routing_plane_id(dev_l_mesh_id, dev_l_chip_id, eth_chan);
+                        routing_plane = control_plane->get_routing_plane_id(dev_l_fabric_node_id, eth_chan);
                         router_core_found = true;
                     }
                     auto connected_logical_cores = device.second->get_ethernet_sockets(neighbor);

--- a/tt_metal/distributed/coordinate_translation.cpp
+++ b/tt_metal/distributed/coordinate_translation.cpp
@@ -41,8 +41,8 @@ const MeshContainer<PhysicalMeshCoordinate>& get_system_mesh_coordinate_translat
         physical_coordinates.reserve(mesh_shape.mesh_size());
         for (int logical_chip_id = 0; logical_chip_id < mesh_shape.mesh_size(); ++logical_chip_id) {
             // Query the control plane to get the physical chip id from logical chip id
-            const auto physical_chip_id =
-                control_plane->get_physical_chip_id_from_mesh_chip_id({mesh_id, logical_chip_id});
+            const auto physical_chip_id = control_plane->get_physical_chip_id_from_fabric_node_id(
+                tt::tt_fabric::FabricNodeId(mesh_id, logical_chip_id));
             TT_FATAL(
                 unique_chip_ids.insert(physical_chip_id).second,
                 "Found duplicate physical chip id: {}, mesh id: {}",

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -70,9 +70,9 @@ uint32_t get_sender_receiver_chip_fabric_encoding(
         // 2D/Mesh Fabric requires looking up "logical" encodings from the control plane
         auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
         if (is_sender) {
-            return control_plane->get_mesh_chip_id_from_physical_chip_id(recv_physical_device_id).second;
+            return control_plane->get_fabric_node_id_from_physical_chip_id(recv_physical_device_id).chip_id;
         } else {
-            return control_plane->get_mesh_chip_id_from_physical_chip_id(sender_physical_device_id).second;
+            return control_plane->get_fabric_node_id_from_physical_chip_id(sender_physical_device_id).chip_id;
         }
     }
 }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -121,7 +121,7 @@ bool is_chip_on_corner_of_mesh(
 ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
     this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file);
     // Printing, only enabled with log_debug
-    this->routing_table_generator_->print_connectivity();
+    this->routing_table_generator_->mesh_graph->print_connectivity();
     // Printing, only enabled with log_debug
     this->routing_table_generator_->print_routing_tables();
 
@@ -133,10 +133,10 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
 
 ControlPlane::ControlPlane(
     const std::string& mesh_graph_desc_file,
-    const std::vector<std::vector<chip_id_t>>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file);
     // Printing, only enabled with log_debug
-    this->routing_table_generator_->print_connectivity();
+    this->routing_table_generator_->mesh_graph->print_connectivity();
     // Printing, only enabled with log_debug
     this->routing_table_generator_->print_routing_tables();
 
@@ -145,21 +145,23 @@ ControlPlane::ControlPlane(
 }
 
 void ControlPlane::load_physical_chip_mapping(
-    const std::vector<std::vector<chip_id_t>>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     this->logical_mesh_chip_id_to_physical_chip_id_mapping_ = logical_mesh_chip_id_to_physical_chip_id_mapping;
     this->validate_mesh_connections();
 }
 
 void ControlPlane::validate_mesh_connections(mesh_id_t mesh_id) const {
-    std::uint32_t mesh_ns_size = routing_table_generator_->get_mesh_ns_size(mesh_id);
-    std::uint32_t mesh_ew_size = routing_table_generator_->get_mesh_ew_size(mesh_id);
-    std::uint32_t num_ports_per_side = routing_table_generator_->get_chip_spec().num_eth_ports_per_direction;
-    for (int i = 0; i < mesh_ns_size; i++) {
-        for (int j = 0; j < mesh_ew_size - 1; j++) {
+    std::uint32_t mesh_ns_size = routing_table_generator_->mesh_graph->get_mesh_ns_size(mesh_id);
+    std::uint32_t mesh_ew_size = routing_table_generator_->mesh_graph->get_mesh_ew_size(mesh_id);
+    std::uint32_t num_ports_per_side =
+        routing_table_generator_->mesh_graph->get_chip_spec().num_eth_ports_per_direction;
+    for (std::uint32_t i = 0; i < mesh_ns_size; i++) {
+        for (std::uint32_t j = 0; j < mesh_ew_size - 1; j++) {
             chip_id_t logical_chip_id = i * mesh_ew_size + j;
-            chip_id_t physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_chip_id];
-            chip_id_t physical_chip_id_next =
-                logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_chip_id + 1];
+            FabricNodeId fabric_node_id{mesh_id, logical_chip_id};
+            FabricNodeId fabric_node_id_next{mesh_id, logical_chip_id + 1};
+            chip_id_t physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
+            chip_id_t physical_chip_id_next = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id_next);
 
             const auto& eth_links = get_ethernet_cores_grouped_by_connected_chips(physical_chip_id);
             auto eth_links_to_next = eth_links.find(physical_chip_id_next);
@@ -169,15 +171,16 @@ void ControlPlane::validate_mesh_connections(mesh_id_t mesh_id) const {
                 physical_chip_id,
                 physical_chip_id_next);
             TT_FATAL(
-                eth_links_to_next->second.size() == num_ports_per_side,
+                eth_links_to_next->second.size() >= num_ports_per_side,
                 "Chip {} to chip {} has {} links but expecting {}",
                 physical_chip_id,
                 physical_chip_id_next,
                 eth_links.at(physical_chip_id_next).size(),
                 num_ports_per_side);
             if (i != mesh_ns_size - 1) {
+                FabricNodeId fabric_node_id_next_row{mesh_id, logical_chip_id + mesh_ew_size};
                 chip_id_t physical_chip_id_next_row =
-                    logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_chip_id + mesh_ew_size];
+                    logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id_next_row);
                 auto eth_links_to_next_row = eth_links.find(physical_chip_id_next_row);
                 TT_FATAL(
                     eth_links_to_next_row != eth_links.end(),
@@ -185,7 +188,7 @@ void ControlPlane::validate_mesh_connections(mesh_id_t mesh_id) const {
                     physical_chip_id,
                     physical_chip_id_next_row);
                 TT_FATAL(
-                    eth_links_to_next_row->second.size() == num_ports_per_side,
+                    eth_links_to_next_row->second.size() >= num_ports_per_side,
                     "Chip {} to chip {} has {} links but expecting {}",
                     physical_chip_id,
                     physical_chip_id_next_row,
@@ -197,8 +200,8 @@ void ControlPlane::validate_mesh_connections(mesh_id_t mesh_id) const {
 }
 
 void ControlPlane::validate_mesh_connections() const {
-    for (uint32_t i = 0; i < this->logical_mesh_chip_id_to_physical_chip_id_mapping_.size(); i++) {
-        this->validate_mesh_connections(i);
+    for (const auto& mesh_id : this->routing_table_generator_->mesh_graph->get_mesh_ids()) {
+        this->validate_mesh_connections(mesh_id);
     }
 }
 
@@ -206,7 +209,8 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
     std::uint32_t mesh_ns_size,
     std::uint32_t mesh_ew_size,
     chip_id_t nw_chip_physical_chip_id) const {
-    std::uint32_t num_ports_per_side = routing_table_generator_->get_chip_spec().num_eth_ports_per_direction;
+    std::uint32_t num_ports_per_side =
+        routing_table_generator_->mesh_graph->get_chip_spec().num_eth_ports_per_direction;
 
     const auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
     std::set<chip_id_t> corner_chips;
@@ -256,7 +260,7 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
                     continue;
                 }
             }
-            if (eth_ports.size() == num_ports_per_side) {
+            if (eth_ports.size() >= num_ports_per_side) {
                 if (visited_physical_chips.find(connected_chip_id) == visited_physical_chips.end()) {
                     q.push(connected_chip_id);
                     visited_physical_chips.insert(connected_chip_id);
@@ -325,7 +329,7 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
                     continue;
                 }
                 if (visited_physical_chips.find(connected_chip_id) == visited_physical_chips.end() and
-                    eth_ports.size() == num_ports_per_side) {
+                    eth_ports.size() >= num_ports_per_side) {
                     physical_chip_ids[i * mesh_ew_size + j] = connected_chip_id;
                     visited_physical_chips.insert(connected_chip_id);
                     found_chip = true;
@@ -347,12 +351,12 @@ std::vector<chip_id_t> ControlPlane::get_mesh_physical_chip_ids(
     return physical_chip_ids;
 }
 
-std::vector<std::vector<chip_id_t>> ControlPlane::get_physical_chip_mapping_from_mesh_graph_desc_file(
+std::map<FabricNodeId, chip_id_t> ControlPlane::get_physical_chip_mapping_from_mesh_graph_desc_file(
     const std::string& mesh_graph_desc_file) {
     chip_id_t nw_chip_physical_id;
     std::uint32_t mesh_ns_size, mesh_ew_size;
     std::string mesh_graph_desc_filename = std::filesystem::path(mesh_graph_desc_file).filename().string();
-    std::vector<std::vector<chip_id_t>> logical_mesh_chip_id_to_physical_chip_id_mapping;
+    std::map<FabricNodeId, chip_id_t> logical_mesh_chip_id_to_physical_chip_id_mapping;
     if (mesh_graph_desc_filename == "tg_mesh_graph_descriptor.yaml") {
         // Add the N150 MMIO devices
         auto eth_coords_per_chip =
@@ -363,44 +367,53 @@ std::vector<std::vector<chip_id_t>> ControlPlane::get_physical_chip_mapping_from
                 eth_coord_y_for_gateway_chips[eth_coord.y] = chip_id;
             }
         }
-        logical_mesh_chip_id_to_physical_chip_id_mapping.reserve(5);
-        logical_mesh_chip_id_to_physical_chip_id_mapping.push_back({eth_coord_y_for_gateway_chips[3]});
-        logical_mesh_chip_id_to_physical_chip_id_mapping.push_back({eth_coord_y_for_gateway_chips[2]});
-        logical_mesh_chip_id_to_physical_chip_id_mapping.push_back({eth_coord_y_for_gateway_chips[1]});
-        logical_mesh_chip_id_to_physical_chip_id_mapping.push_back({eth_coord_y_for_gateway_chips[0]});
+        logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(0, 0), eth_coord_y_for_gateway_chips[3]});
+        logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(1, 0), eth_coord_y_for_gateway_chips[2]});
+        logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(2, 0), eth_coord_y_for_gateway_chips[1]});
+        logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(3, 0), eth_coord_y_for_gateway_chips[0]});
 
         nw_chip_physical_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_physical_chip_id_from_eth_coord({0, 3, 7, 0, 1});
-        mesh_ns_size = routing_table_generator_->get_mesh_ns_size(/*mesh_id=*/4);
-        mesh_ew_size = routing_table_generator_->get_mesh_ew_size(/*mesh_id=*/4);
+        mesh_ns_size = routing_table_generator_->mesh_graph->get_mesh_ns_size(/*mesh_id=*/4);
+        mesh_ew_size = routing_table_generator_->mesh_graph->get_mesh_ew_size(/*mesh_id=*/4);
         // Main board
-        logical_mesh_chip_id_to_physical_chip_id_mapping.push_back(
-            this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id));
+        const auto& physical_chip_ids =
+            this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id);
+        for (std::uint32_t i = 0; i < physical_chip_ids.size(); i++) {
+            logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(4, i), physical_chip_ids[i]});
+        }
     } else if (
         mesh_graph_desc_filename == "quanta_galaxy_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "quanta_galaxy_torus_2d_graph_descriptor.yaml" ||
+        mesh_graph_desc_filename == "dual_galaxy_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p100_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p150_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p150_x2_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "p150_x4_mesh_graph_descriptor.yaml") {
         // TODO: update to pick out chip automatically
         nw_chip_physical_id = 0;
-        mesh_ns_size = routing_table_generator_->get_mesh_ns_size(/*mesh_id=*/0);
-        mesh_ew_size = routing_table_generator_->get_mesh_ew_size(/*mesh_id=*/0);
+        mesh_ns_size = routing_table_generator_->mesh_graph->get_mesh_ns_size(/*mesh_id=*/0);
+        mesh_ew_size = routing_table_generator_->mesh_graph->get_mesh_ew_size(/*mesh_id=*/0);
         // Main board
-        logical_mesh_chip_id_to_physical_chip_id_mapping.push_back(
-            this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id));
+        const auto& physical_chip_ids =
+            this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id);
+        for (std::uint32_t i = 0; i < physical_chip_ids.size(); i++) {
+            logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(0, i), physical_chip_ids[i]});
+        }
     } else if (
         mesh_graph_desc_filename == "t3k_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n150_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n300_mesh_graph_descriptor.yaml") {
         nw_chip_physical_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_physical_chip_id_from_eth_coord({0, 0, 0, 0, 0});
-        mesh_ns_size = routing_table_generator_->get_mesh_ns_size(/*mesh_id=*/0);
-        mesh_ew_size = routing_table_generator_->get_mesh_ew_size(/*mesh_id=*/0);
+        mesh_ns_size = routing_table_generator_->mesh_graph->get_mesh_ns_size(/*mesh_id=*/0);
+        mesh_ew_size = routing_table_generator_->mesh_graph->get_mesh_ew_size(/*mesh_id=*/0);
         // Main board
-        logical_mesh_chip_id_to_physical_chip_id_mapping.push_back(
-            this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id));
+        const auto& physical_chip_ids =
+            this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id);
+        for (std::uint32_t i = 0; i < physical_chip_ids.size(); i++) {
+            logical_mesh_chip_id_to_physical_chip_id_mapping.insert({FabricNodeId(0, i), physical_chip_ids[i]});
+        }
     } else {
         TT_THROW("Unsupported mesh graph descriptor file {}", mesh_graph_desc_file);
     }
@@ -413,19 +426,15 @@ routing_plane_id_t ControlPlane::get_routing_plane_id(
     return std::distance(eth_chans_in_direction.begin(), it);
 }
 
-routing_plane_id_t ControlPlane::get_routing_plane_id(
-    mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t eth_chan_id) const {
+routing_plane_id_t ControlPlane::get_routing_plane_id(FabricNodeId fabric_node_id, chan_id_t eth_chan_id) const {
     TT_FATAL(
-        mesh_id < this->router_port_directions_to_physical_eth_chan_map_.size(), "Mesh ID {} out of bounds", mesh_id);
-
-    TT_FATAL(
-        chip_id < this->router_port_directions_to_physical_eth_chan_map_[mesh_id].size(),
-        "Chip ID {} out of bounds for Mesh ID {}",
-        chip_id,
-        mesh_id);
+        this->router_port_directions_to_physical_eth_chan_map_.contains(fabric_node_id),
+        "Mesh {} Chip {} out of bounds",
+        fabric_node_id.mesh_id,
+        fabric_node_id.chip_id);
 
     std::optional<std::vector<chan_id_t>> eth_chans_in_direction;
-    const auto& chip_eth_chans_map = this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id];
+    const auto& chip_eth_chans_map = this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id);
     for (const auto& [_, eth_chans] : chip_eth_chans_map) {
         if (std::find(eth_chans.begin(), eth_chans.end(), eth_chan_id) != eth_chans.end()) {
             eth_chans_in_direction = eth_chans;
@@ -436,8 +445,8 @@ routing_plane_id_t ControlPlane::get_routing_plane_id(
         eth_chans_in_direction.has_value(),
         "Could not find Eth chan ID {} for Chip ID {}, Mesh ID {}",
         eth_chan_id,
-        chip_id,
-        mesh_id);
+        fabric_node_id.chip_id,
+        fabric_node_id.mesh_id);
 
     return get_routing_plane_id(eth_chan_id, eth_chans_in_direction.value());
 }
@@ -471,22 +480,22 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     // Convert it to be unique per ethernet channel
 
     const auto& router_intra_mesh_routing_table = this->routing_table_generator_->get_intra_mesh_table();
-    this->intra_mesh_routing_tables_.resize(router_intra_mesh_routing_table.size());
-    for (mesh_id_t mesh_id = 0; mesh_id < router_intra_mesh_routing_table.size(); mesh_id++) {
-        this->intra_mesh_routing_tables_[mesh_id].resize(router_intra_mesh_routing_table[mesh_id].size());
-        for (chip_id_t src_chip_id = 0; src_chip_id < router_intra_mesh_routing_table[mesh_id].size(); src_chip_id++) {
+    for (std::uint32_t mesh_id = 0; mesh_id < router_intra_mesh_routing_table.size(); mesh_id++) {
+        for (std::uint32_t src_chip_id = 0; src_chip_id < router_intra_mesh_routing_table[mesh_id].size();
+             src_chip_id++) {
+            FabricNodeId src_fabric_node_id{mesh_id, src_chip_id};
             const auto& physical_chip_id =
-                this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][src_chip_id];
+                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
             std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
                                                    .get_cluster()
                                                    .get_soc_desc(physical_chip_id)
                                                    .get_cores(CoreType::ETH)
                                                    .size();
-            this->intra_mesh_routing_tables_[mesh_id][src_chip_id].resize(
+            this->intra_mesh_routing_tables_[src_fabric_node_id].resize(
                 num_ports_per_chip);  // contains more entries than needed, this size is for all eth channels on chip
             for (int i = 0; i < num_ports_per_chip; i++) {
                 // Size the routing table to the number of chips in the mesh
-                this->intra_mesh_routing_tables_[mesh_id][src_chip_id][i].resize(
+                this->intra_mesh_routing_tables_[src_fabric_node_id][i].resize(
                     router_intra_mesh_routing_table[mesh_id][src_chip_id].size());
             }
             for (chip_id_t dst_chip_id = 0; dst_chip_id < router_intra_mesh_routing_table[mesh_id][src_chip_id].size();
@@ -497,26 +506,26 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
                 // W[0] and so on For all live ethernet channels on this chip, set the routing table entry to the
                 // destination chip as the ethernet channel on the same plane
                 for (const auto& [direction, eth_chans_on_side] :
-                     this->router_port_directions_to_physical_eth_chan_map_[mesh_id][src_chip_id]) {
+                     this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id)) {
                     for (const auto& src_chan_id : eth_chans_on_side) {
                         if (src_chip_id == dst_chip_id) {
                             TT_ASSERT(
                                 (target_direction == RoutingDirection::C),
                                 "Expecting same direction for intra mesh routing");
                             // This entry represents chip to itself, should not be used by FW
-                            this->intra_mesh_routing_tables_[mesh_id][src_chip_id][src_chan_id][dst_chip_id] =
+                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id] =
                                 src_chan_id;
                         } else if (target_direction == direction) {
                             // This entry represents an outgoing eth channel
-                            this->intra_mesh_routing_tables_[mesh_id][src_chip_id][src_chan_id][dst_chip_id] =
+                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id] =
                                 src_chan_id;
                         } else {
                             const auto& eth_chans_in_target_direction =
-                                this->router_port_directions_to_physical_eth_chan_map_[mesh_id][src_chip_id]
-                                                                                      [target_direction];
+                                this->router_port_directions_to_physical_eth_chan_map_.at(
+                                    src_fabric_node_id)[target_direction];
                             const auto src_routing_plane_id =
                                 this->get_routing_plane_id(src_chan_id, eth_chans_on_side);
-                            this->intra_mesh_routing_tables_[mesh_id][src_chip_id][src_chan_id][dst_chip_id] =
+                            this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id] =
                                 this->get_downstream_eth_chan_id(src_routing_plane_id, eth_chans_in_target_direction);
                         }
                     }
@@ -526,23 +535,22 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     }
 
     const auto& router_inter_mesh_routing_table = this->routing_table_generator_->get_inter_mesh_table();
-    this->inter_mesh_routing_tables_.resize(router_inter_mesh_routing_table.size());
-    for (mesh_id_t src_mesh_id = 0; src_mesh_id < router_inter_mesh_routing_table.size(); src_mesh_id++) {
-        this->inter_mesh_routing_tables_[src_mesh_id].resize(router_inter_mesh_routing_table[src_mesh_id].size());
-        for (chip_id_t src_chip_id = 0; src_chip_id < router_inter_mesh_routing_table[src_mesh_id].size();
+    for (std::uint32_t src_mesh_id = 0; src_mesh_id < router_inter_mesh_routing_table.size(); src_mesh_id++) {
+        for (std::uint32_t src_chip_id = 0; src_chip_id < router_inter_mesh_routing_table[src_mesh_id].size();
              src_chip_id++) {
+            FabricNodeId src_fabric_node_id{src_mesh_id, src_chip_id};
             const auto& physical_chip_id =
-                this->logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
+                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
             std::uint32_t num_ports_per_chip = tt::tt_metal::MetalContext::instance()
                                                    .get_cluster()
                                                    .get_soc_desc(physical_chip_id)
                                                    .get_cores(CoreType::ETH)
                                                    .size();
-            this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id].resize(
+            this->inter_mesh_routing_tables_[src_fabric_node_id].resize(
                 num_ports_per_chip);  // contains more entries than needed
             for (int i = 0; i < num_ports_per_chip; i++) {
                 // Size the routing table to the number of meshes
-                this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][i].resize(
+                this->inter_mesh_routing_tables_[src_fabric_node_id][i].resize(
                     router_inter_mesh_routing_table[src_mesh_id][src_chip_id].size());
             }
             for (chip_id_t dst_mesh_id = 0;
@@ -555,26 +563,26 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
                 // W[0] and so on For all live ethernet channels on this chip, set the routing table entry to the
                 // destination mesh as the ethernet channel on the same plane
                 for (const auto& [direction, eth_chans_on_side] :
-                     this->router_port_directions_to_physical_eth_chan_map_[src_mesh_id][src_chip_id]) {
+                     this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id)) {
                     for (const auto& src_chan_id : eth_chans_on_side) {
                         if (src_mesh_id == dst_mesh_id) {
                             TT_ASSERT(
                                 (target_direction == RoutingDirection::C),
                                 "ControlPlane: Expecting same direction for inter mesh routing");
                             // This entry represents mesh to itself, should not be used by FW
-                            this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id] =
+                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id] =
                                 src_chan_id;
                         } else if (target_direction == direction) {
                             // This entry represents an outgoing eth channel
-                            this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id] =
+                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id] =
                                 src_chan_id;
                         } else {
                             const auto& eth_chans_in_target_direction =
-                                this->router_port_directions_to_physical_eth_chan_map_[src_mesh_id][src_chip_id]
-                                                                                      [target_direction];
+                                this->router_port_directions_to_physical_eth_chan_map_.at(
+                                    src_fabric_node_id)[target_direction];
                             const auto src_routing_plane_id =
                                 this->get_routing_plane_id(src_chan_id, eth_chans_on_side);
-                            this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id] =
+                            this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id] =
                                 this->get_downstream_eth_chan_id(src_routing_plane_id, eth_chans_in_target_direction);
                         }
                     }
@@ -588,18 +596,15 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
 
 // order ethernet channels using virtual coordinates
 void ControlPlane::order_ethernet_channels() {
-    for (mesh_id_t mesh_id = 0; mesh_id < this->router_port_directions_to_physical_eth_chan_map_.size(); mesh_id++) {
-        for (chip_id_t chip_id = 0; chip_id < this->router_port_directions_to_physical_eth_chan_map_[mesh_id].size();
-             chip_id++) {
-            for (auto& [_, eth_chans] : this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
-                auto phys_chip_id = this->get_physical_chip_id_from_mesh_chip_id({mesh_id, chip_id});
-                const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(phys_chip_id);
-                std::sort(eth_chans.begin(), eth_chans.end(), [&soc_desc](const auto& a, const auto& b) {
-                    auto virt_coords_a = soc_desc.get_eth_core_for_channel(a, CoordSystem::VIRTUAL);
-                    auto virt_coords_b = soc_desc.get_eth_core_for_channel(b, CoordSystem::VIRTUAL);
-                    return virt_coords_a.x < virt_coords_b.x;
-                });
-            }
+    for (auto& [fabric_node_id, eth_chans_by_dir] : this->router_port_directions_to_physical_eth_chan_map_) {
+        for (auto& [_, eth_chans] : eth_chans_by_dir) {
+            auto phys_chip_id = this->get_physical_chip_id_from_fabric_node_id(fabric_node_id);
+            const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(phys_chip_id);
+            std::sort(eth_chans.begin(), eth_chans.end(), [&soc_desc](const auto& a, const auto& b) {
+                auto virt_coords_a = soc_desc.get_eth_core_for_channel(a, CoordSystem::VIRTUAL);
+                auto virt_coords_b = soc_desc.get_eth_core_for_channel(b, CoordSystem::VIRTUAL);
+                return virt_coords_a.x < virt_coords_b.x;
+            });
         }
     }
 }
@@ -609,15 +614,17 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
     this->inter_mesh_routing_tables_.clear();
     this->router_port_directions_to_physical_eth_chan_map_.clear();
 
-    const auto& intra_mesh_connectivity = this->routing_table_generator_->get_intra_mesh_connectivity();
-    const auto& inter_mesh_connectivity = this->routing_table_generator_->get_inter_mesh_connectivity();
+    const auto& intra_mesh_connectivity = this->routing_table_generator_->mesh_graph->get_intra_mesh_connectivity();
+    const auto& inter_mesh_connectivity = this->routing_table_generator_->mesh_graph->get_inter_mesh_connectivity();
 
     auto add_ethernet_channel_to_router_mapping = [&](mesh_id_t mesh_id,
                                                       chip_id_t chip_id,
                                                       const CoreCoord& eth_core,
                                                       RoutingDirection direction) {
-        auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
-        auto fabric_router_channels_on_chip = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_chip_id);
+        FabricNodeId fabric_node_id{mesh_id, chip_id};
+        auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
+        auto fabric_router_channels_on_chip =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_ethernet_channels(physical_chip_id);
         // TODO: get_fabric_ethernet_channels accounts for down links, but we should manage down links in control plane
         auto chan_id = tt::tt_metal::MetalContext::instance()
                            .get_cluster()
@@ -625,7 +632,7 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
                            .logical_eth_core_to_chan_map.at(eth_core);
         // TODO: add logic here to disable unsed routers, e.g. Mesh on Torus system
         if (fabric_router_channels_on_chip.contains(chan_id)) {
-            this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id][direction].push_back(chan_id);
+            this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)[direction].push_back(chan_id);
         } else {
             log_debug(
                 tt::LogFabric, "Control Plane: Disabling router on M{}D{} eth channel {}", mesh_id, chip_id, chan_id);
@@ -633,20 +640,25 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
     };
 
     // Initialize the bookkeeping for mapping from mesh/chip/direction to physical ethernet channels
-    this->router_port_directions_to_physical_eth_chan_map_.resize(intra_mesh_connectivity.size());
-    for (mesh_id_t mesh_id = 0; mesh_id < intra_mesh_connectivity.size(); mesh_id++) {
-        this->router_port_directions_to_physical_eth_chan_map_[mesh_id].resize(intra_mesh_connectivity[mesh_id].size());
-        for (chip_id_t chip_id = 0; chip_id < intra_mesh_connectivity[mesh_id].size(); chip_id++) {
-            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
+    for (const auto& [fabric_node_id, _] : this->logical_mesh_chip_id_to_physical_chip_id_mapping_) {
+        if (!this->router_port_directions_to_physical_eth_chan_map_.contains(fabric_node_id)) {
+            this->router_port_directions_to_physical_eth_chan_map_[fabric_node_id] = {};
+        }
+    }
+
+    for (std::uint32_t mesh_id = 0; mesh_id < intra_mesh_connectivity.size(); mesh_id++) {
+        for (std::uint32_t chip_id = 0; chip_id < intra_mesh_connectivity[mesh_id].size(); chip_id++) {
+            auto physical_chip_id =
+                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(FabricNodeId(mesh_id, chip_id));
             const auto& connected_chips_and_eth_cores =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
                     physical_chip_id);
             for (const auto& [logical_connected_chip_id, edge] : intra_mesh_connectivity[mesh_id][chip_id]) {
-                const auto& physical_connected_chip_id =
-                    this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_connected_chip_id];
+                const auto& physical_connected_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(
+                    FabricNodeId(mesh_id, logical_connected_chip_id));
                 const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
                 TT_FATAL(
-                    connected_eth_cores.size() == edge.connected_chip_ids.size(),
+                    connected_eth_cores.size() >= edge.connected_chip_ids.size(),
                     "Expected {} eth links from physical chip {} to physical chip {}",
                     edge.connected_chip_ids.size(),
                     physical_chip_id,
@@ -660,9 +672,10 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
             }
         }
     }
-    for (mesh_id_t mesh_id = 0; mesh_id < inter_mesh_connectivity.size(); mesh_id++) {
-        for (chip_id_t chip_id = 0; chip_id < inter_mesh_connectivity[mesh_id].size(); chip_id++) {
-            auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
+    for (std::uint32_t mesh_id = 0; mesh_id < inter_mesh_connectivity.size(); mesh_id++) {
+        for (std::uint32_t chip_id = 0; chip_id < inter_mesh_connectivity[mesh_id].size(); chip_id++) {
+            auto physical_chip_id =
+                this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(FabricNodeId(mesh_id, chip_id));
             const auto& connected_chips_and_eth_cores =
                 tt::tt_metal::MetalContext::instance().get_cluster().get_ethernet_cores_grouped_by_connected_chips(
                     physical_chip_id);
@@ -677,9 +690,8 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
                         continue;
                     }
                     visited_chip_ids.insert(logical_connected_chip_id);
-                    const auto& physical_connected_chip_id =
-                        this->logical_mesh_chip_id_to_physical_chip_id_mapping_[connected_mesh_id]
-                                                                               [logical_connected_chip_id];
+                    const auto& physical_connected_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(
+                        FabricNodeId(connected_mesh_id, logical_connected_chip_id));
                     const auto& connected_eth_cores = connected_chips_and_eth_cores.at(physical_connected_chip_id);
                     for (const auto& eth_core : connected_eth_cores) {
                         add_ethernet_channel_to_router_mapping(mesh_id, chip_id, eth_core, edge.port_direction);
@@ -695,13 +707,13 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
 }
 
 void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chip_id) const {
-    // TODO: remove this
-    const auto& chip_intra_mesh_routing_tables = this->intra_mesh_routing_tables_[mesh_id][chip_id];
-    const auto& chip_inter_mesh_routing_tables = this->inter_mesh_routing_tables_[mesh_id][chip_id];
-    const auto& physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
+    FabricNodeId fabric_node_id{mesh_id, chip_id};
+    const auto& chip_intra_mesh_routing_tables = this->intra_mesh_routing_tables_.at(fabric_node_id);
+    const auto& chip_inter_mesh_routing_tables = this->inter_mesh_routing_tables_.at(fabric_node_id);
+    auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
     // Loop over ethernet channels to only write to cores with ethernet links
     // Looping over chip_intra/inter_mesh_routing_tables will write to all cores, even if they don't have ethernet links
-    const auto& chip_eth_chans_map = this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id];
+    const auto& chip_eth_chans_map = this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id);
     for (const auto& [direction, eth_chans] : chip_eth_chans_map) {
         for (const auto& eth_chan : eth_chans) {
             // eth_chans are the active ethernet channels on this chip
@@ -755,8 +767,8 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
 
             fabric_router_config.my_mesh_id = mesh_id;
             fabric_router_config.my_device_id = chip_id;
-            fabric_router_config.north_dim = this->routing_table_generator_->get_mesh_ns_size(mesh_id);
-            fabric_router_config.east_dim = this->routing_table_generator_->get_mesh_ew_size(mesh_id);
+            fabric_router_config.north_dim = this->routing_table_generator_->mesh_graph->get_mesh_ns_size(mesh_id);
+            fabric_router_config.east_dim = this->routing_table_generator_->mesh_graph->get_mesh_ew_size(mesh_id);
 
             // Write data to physical eth core
             CoreCoord virtual_eth_core =
@@ -786,29 +798,26 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
     tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(physical_chip_id);
 }
 
-std::pair<mesh_id_t, chip_id_t> ControlPlane::get_mesh_chip_id_from_physical_chip_id(chip_id_t physical_chip_id) const {
-    for (mesh_id_t mesh_id = 0; mesh_id < logical_mesh_chip_id_to_physical_chip_id_mapping_.size(); ++mesh_id) {
-        for (chip_id_t logical_mesh_chip_id = 0;
-             logical_mesh_chip_id < logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id].size();
-             ++logical_mesh_chip_id) {
-            if (logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][logical_mesh_chip_id] == physical_chip_id) {
-                return {mesh_id, logical_mesh_chip_id};
-            }
+FabricNodeId ControlPlane::get_fabric_node_id_from_physical_chip_id(chip_id_t physical_chip_id) const {
+    for (const auto& [fabric_node_id, mapped_physical_chip_id] :
+         this->logical_mesh_chip_id_to_physical_chip_id_mapping_) {
+        if (mapped_physical_chip_id == physical_chip_id) {
+            return fabric_node_id;
         }
     }
     TT_FATAL(false, "Physical chip id not found in logical mesh chip id mapping");
-    return {};
+    return FabricNodeId(0, 0);
 }
 
-chip_id_t ControlPlane::get_physical_chip_id_from_mesh_chip_id(
-    const std::pair<mesh_id_t, chip_id_t>& mesh_chip_id) const {
-    return logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_chip_id.first][mesh_chip_id.second];
+chip_id_t ControlPlane::get_physical_chip_id_from_fabric_node_id(const FabricNodeId& fabric_node_id) const {
+    TT_ASSERT(logical_mesh_chip_id_to_physical_chip_id_mapping_.contains(fabric_node_id));
+    return logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
 }
 
-std::tuple<mesh_id_t, chip_id_t, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_ids(
-    mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t chan_id) const {
+std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_ids(
+    FabricNodeId fabric_node_id, chan_id_t chan_id) const {
     // TODO: simplify this and maybe have this functionality in ControlPlane
-    auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id];
+    auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
     tt::umd::CoreCoord eth_core = tt::tt_metal::MetalContext::instance()
                                       .get_cluster()
                                       .get_soc_desc(physical_chip_id)
@@ -817,20 +826,19 @@ std::tuple<mesh_id_t, chip_id_t, chan_id_t> ControlPlane::get_connected_mesh_chi
         tt::tt_metal::MetalContext::instance().get_cluster().get_connected_ethernet_core(
             std::make_tuple(physical_chip_id, CoreCoord{eth_core.x, eth_core.y}));
 
-    auto [connected_mesh_id, connected_chip_id] =
-        this->get_mesh_chip_id_from_physical_chip_id(connected_physical_chip_id);
+    auto connected_fabric_node_id = this->get_fabric_node_id_from_physical_chip_id(connected_physical_chip_id);
     auto connected_chan_id = tt::tt_metal::MetalContext::instance()
                                  .get_cluster()
                                  .get_soc_desc(connected_physical_chip_id)
                                  .logical_eth_core_to_chan_map.at(connected_eth_core);
-    return std::make_tuple(connected_mesh_id, connected_chip_id, connected_chan_id);
+    return std::make_pair(connected_fabric_node_id, connected_chan_id);
 }
 
 std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(
-    mesh_id_t mesh_id, chip_id_t chip_id, routing_plane_id_t routing_plane_id) const {
+    FabricNodeId fabric_node_id, routing_plane_id_t routing_plane_id) const {
     std::vector<chan_id_t> valid_eth_chans;
     for (const auto& [direction, eth_chans] :
-         this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
+         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
         for (const auto& eth_chan : eth_chans) {
             if (this->get_routing_plane_id(eth_chan, eth_chans) == routing_plane_id) {
                 valid_eth_chans.push_back(eth_chan);
@@ -853,10 +861,10 @@ eth_chan_directions ControlPlane::routing_direction_to_eth_direction(RoutingDire
 }
 
 std::set<std::pair<chan_id_t, eth_chan_directions>> ControlPlane::get_active_fabric_eth_channels(
-    mesh_id_t mesh_id, chip_id_t chip_id) const {
+    FabricNodeId fabric_node_id) const {
     std::set<std::pair<chan_id_t, eth_chan_directions>> active_fabric_eth_channels;
     for (const auto& [direction, eth_chans] :
-         this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
+         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
         for (const auto& eth_chan : eth_chans) {
             active_fabric_eth_channels.insert({eth_chan, this->routing_direction_to_eth_direction(direction)});
         }
@@ -864,9 +872,9 @@ std::set<std::pair<chan_id_t, eth_chan_directions>> ControlPlane::get_active_fab
     return active_fabric_eth_channels;
 }
 
-eth_chan_directions ControlPlane::get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, int chan) const {
+eth_chan_directions ControlPlane::get_eth_chan_direction(FabricNodeId fabric_node_id, int chan) const {
     for (const auto& [direction, eth_chans] :
-         this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
+         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
         for (const auto& eth_chan : eth_chans) {
             if (chan == eth_chan) {
                 return this->routing_direction_to_eth_direction(direction);
@@ -877,27 +885,27 @@ eth_chan_directions ControlPlane::get_eth_chan_direction(mesh_id_t mesh_id, chip
 }
 
 std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
-    mesh_id_t src_mesh_id,
-    chip_id_t src_chip_id,
-    mesh_id_t dst_mesh_id,
-    chip_id_t dst_chip_id,
-    chan_id_t src_chan_id) const {
+    FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id, chan_id_t src_chan_id) const {
     std::vector<std::pair<chip_id_t, chan_id_t>> route;
     int i = 0;
     // Find any eth chan on the plane id
-    while (src_mesh_id != dst_mesh_id or src_chip_id != dst_chip_id) {
+    while (src_fabric_node_id != dst_fabric_node_id) {
         i++;
+        auto src_mesh_id = src_fabric_node_id.mesh_id;
+        auto src_chip_id = src_fabric_node_id.chip_id;
+        auto dst_mesh_id = dst_fabric_node_id.mesh_id;
+        auto dst_chip_id = dst_fabric_node_id.chip_id;
         if (i >= tt::tt_fabric::MAX_MESH_SIZE * tt::tt_fabric::MAX_NUM_MESHES) {
             return {};
         }
-        auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
+        auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
         chan_id_t next_chan_id = 0;
         if (src_mesh_id != dst_mesh_id) {
             // Inter-mesh routing
-            next_chan_id = this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id];
+            next_chan_id = this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id];
         } else if (src_chip_id != dst_chip_id) {
             // Intra-mesh routing
-            next_chan_id = this->intra_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_chip_id];
+            next_chan_id = this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id];
         }
         if (next_chan_id == eth_chan_magic_values::INVALID_DIRECTION) {
             // The complete route b/w src and dst not found, probably some eth cores are reserved along the path
@@ -908,9 +916,10 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
             route.push_back({physical_chip_id, next_chan_id});
         }
 
-        std::tie(src_mesh_id, src_chip_id, src_chan_id) =
-            this->get_connected_mesh_chip_chan_ids(src_mesh_id, src_chip_id, next_chan_id);
-        auto connected_physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
+        std::tie(src_fabric_node_id, src_chan_id) =
+            this->get_connected_mesh_chip_chan_ids(src_fabric_node_id, next_chan_id);
+        auto connected_physical_chip_id =
+            this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(src_fabric_node_id);
         route.push_back({connected_physical_chip_id, src_chan_id});
     }
 
@@ -918,18 +927,22 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
 }
 
 std::optional<RoutingDirection> ControlPlane::get_forwarding_direction(
-    mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id) const {
+    FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id) const {
     const auto& router_direction_eth_channels =
-        this->router_port_directions_to_physical_eth_chan_map_[src_mesh_id][src_chip_id];
+        this->router_port_directions_to_physical_eth_chan_map_.at(src_fabric_node_id);
+    auto src_mesh_id = src_fabric_node_id.mesh_id;
+    auto src_chip_id = src_fabric_node_id.chip_id;
+    auto dst_mesh_id = dst_fabric_node_id.mesh_id;
+    auto dst_chip_id = dst_fabric_node_id.chip_id;
     for (const auto& [direction, eth_chans] : router_direction_eth_channels) {
         for (const auto& src_chan_id : eth_chans) {
             chan_id_t next_chan_id = 0;
             if (src_mesh_id != dst_mesh_id) {
                 // Inter-mesh routing
-                next_chan_id = this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id];
+                next_chan_id = this->inter_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_mesh_id];
             } else if (src_chip_id != dst_chip_id) {
                 // Intra-mesh routing
-                next_chan_id = this->intra_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_chip_id];
+                next_chan_id = this->intra_mesh_routing_tables_.at(src_fabric_node_id)[src_chan_id][dst_chip_id];
             }
             if (src_chan_id != next_chan_id) {
                 continue;
@@ -944,28 +957,23 @@ std::optional<RoutingDirection> ControlPlane::get_forwarding_direction(
 }
 
 std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
-    mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id) const {
-    const auto& forwarding_direction = get_forwarding_direction(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
+    FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id) const {
+    const auto& forwarding_direction = get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
     if (!forwarding_direction.has_value()) {
         return {};
     }
 
-    return this->get_forwarding_eth_chans_to_chip(
-        src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id, *forwarding_direction);
+    return this->get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id, *forwarding_direction);
 }
 
 std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
-    mesh_id_t src_mesh_id,
-    chip_id_t src_chip_id,
-    mesh_id_t dst_mesh_id,
-    chip_id_t dst_chip_id,
-    RoutingDirection forwarding_direction) const {
+    FabricNodeId src_fabric_node_id, FabricNodeId dst_fabric_node_id, RoutingDirection forwarding_direction) const {
     std::vector<chan_id_t> forwarding_channels;
     const auto& active_channels =
-        this->get_active_fabric_eth_channels_in_direction(src_mesh_id, src_chip_id, forwarding_direction);
+        this->get_active_fabric_eth_channels_in_direction(src_fabric_node_id, forwarding_direction);
     for (const auto& src_chan_id : active_channels) {
         // check for end-to-end route before accepting this channel
-        if (get_fabric_route(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id, src_chan_id).empty()) {
+        if (this->get_fabric_route(src_fabric_node_id, dst_fabric_node_id, src_chan_id).empty()) {
             continue;
         }
         forwarding_channels.push_back(src_chan_id);
@@ -975,9 +983,10 @@ std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
 }
 
 stl::Span<const chip_id_t> ControlPlane::get_intra_chip_neighbors(
-    mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const {
+    FabricNodeId src_fabric_node_id, RoutingDirection routing_direction) const {
     for (const auto& [_, routing_edge] :
-         this->routing_table_generator_->get_intra_mesh_connectivity()[src_mesh_id][src_chip_id]) {
+         this->routing_table_generator_->mesh_graph
+             ->get_intra_mesh_connectivity()[src_fabric_node_id.mesh_id][src_fabric_node_id.chip_id]) {
         if (routing_edge.port_direction == routing_direction) {
             return routing_edge.connected_chip_ids;
         }
@@ -986,14 +995,16 @@ stl::Span<const chip_id_t> ControlPlane::get_intra_chip_neighbors(
 }
 
 std::unordered_map<mesh_id_t, std::vector<chip_id_t>> ControlPlane::get_chip_neighbors(
-    mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const {
+    FabricNodeId src_fabric_node_id, RoutingDirection routing_direction) const {
     std::unordered_map<mesh_id_t, std::vector<chip_id_t>> neighbors;
-    auto intra_neighbors = this->get_intra_chip_neighbors(src_mesh_id, src_chip_id, routing_direction);
+    auto intra_neighbors = this->get_intra_chip_neighbors(src_fabric_node_id, routing_direction);
+    auto src_mesh_id = src_fabric_node_id.mesh_id;
+    auto src_chip_id = src_fabric_node_id.chip_id;
     if (!intra_neighbors.empty()) {
         neighbors[src_mesh_id].insert(neighbors[src_mesh_id].end(), intra_neighbors.begin(), intra_neighbors.end());
     }
     for (const auto& [mesh_id, routing_edge] :
-         this->routing_table_generator_->get_inter_mesh_connectivity()[src_mesh_id][src_chip_id]) {
+         this->routing_table_generator_->mesh_graph->get_inter_mesh_connectivity()[src_mesh_id][src_chip_id]) {
         if (routing_edge.port_direction == routing_direction) {
             neighbors[mesh_id] = routing_edge.connected_chip_ids;
         }
@@ -1001,21 +1012,21 @@ std::unordered_map<mesh_id_t, std::vector<chip_id_t>> ControlPlane::get_chip_nei
     return neighbors;
 }
 
-size_t ControlPlane::get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t chip_id) const {
+size_t ControlPlane::get_num_active_fabric_routers(FabricNodeId fabric_node_id) const {
     // Return the number of active fabric routers on the chip
     // Not always all the available FABRIC_ROUTER cores given by Cluster, since some may be disabled
     size_t num_routers = 0;
     for (const auto& [direction, eth_chans] :
-         this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
+         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
         num_routers += eth_chans.size();
     }
     return num_routers;
 }
 
 std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction(
-    mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const {
+    FabricNodeId fabric_node_id, RoutingDirection routing_direction) const {
     for (const auto& [direction, eth_chans] :
-         this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
+         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
         if (routing_direction == direction) {
             return eth_chans;
         }
@@ -1027,59 +1038,48 @@ void ControlPlane::write_routing_tables_to_all_chips() const {
     // Configure the routing tables on the chips
     TT_ASSERT(
         this->intra_mesh_routing_tables_.size() == this->inter_mesh_routing_tables_.size(),
-        "Intra mesh routing tables num_meshes mismatch with inter mesh routing tables");
-    for (mesh_id_t mesh_id = 0; mesh_id < this->intra_mesh_routing_tables_.size(); mesh_id++) {
+        "Intra mesh routing tables size mismatch with inter mesh routing tables");
+    for (const auto& [fabric_node_id, _] : this->intra_mesh_routing_tables_) {
         TT_ASSERT(
-            this->intra_mesh_routing_tables_[mesh_id].size() == this->inter_mesh_routing_tables_[mesh_id].size(),
-            "Intra mesh routing tables num_devices in mesh {} mismatch with inter mesh routing tables",
-            mesh_id);
-        for (chip_id_t chip_id = 0; chip_id < this->intra_mesh_routing_tables_[mesh_id].size(); chip_id++) {
-            this->write_routing_tables_to_chip(mesh_id, chip_id);
-        }
+            this->inter_mesh_routing_tables_.contains(fabric_node_id),
+            "Intra mesh routing tables keys mismatch with inter mesh routing tables");
+        this->write_routing_tables_to_chip(fabric_node_id.mesh_id, fabric_node_id.chip_id);
     }
 }
 
+// TODO: remove this after TG is deprecated
 std::vector<mesh_id_t> ControlPlane::get_user_physical_mesh_ids() const {
     std::vector<mesh_id_t> physical_mesh_ids;
     const auto user_chips = tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids();
-    for (int mesh_id = 0; mesh_id < this->logical_mesh_chip_id_to_physical_chip_id_mapping_.size(); mesh_id++) {
-        bool add_mesh = true;
-        for (int chip_id = 0; chip_id < this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id].size();
-             chip_id++) {
-            if (user_chips.find(this->logical_mesh_chip_id_to_physical_chip_id_mapping_[mesh_id][chip_id]) ==
-                user_chips.end()) {
-                add_mesh = false;
-                break;
-            }
-        }
-        if (add_mesh) {
-            physical_mesh_ids.push_back(mesh_id);
+    for (const auto& [fabric_node_id, physical_chip_id] : this->logical_mesh_chip_id_to_physical_chip_id_mapping_) {
+        if (user_chips.find(physical_chip_id) != user_chips.end() and
+            std::find(physical_mesh_ids.begin(), physical_mesh_ids.end(), fabric_node_id.mesh_id) ==
+                physical_mesh_ids.end()) {
+            physical_mesh_ids.push_back(fabric_node_id.mesh_id);
         }
     }
-
     return physical_mesh_ids;
 }
 
-tt::tt_metal::distributed::MeshShape ControlPlane::get_physical_mesh_shape(mesh_id_t mesh_id) const {
-    uint32_t x = this->routing_table_generator_->get_mesh_ns_size(mesh_id);
-    uint32_t y = this->routing_table_generator_->get_mesh_ew_size(mesh_id);
-    return tt::tt_metal::distributed::MeshShape(x, y);
+MeshShape ControlPlane::get_physical_mesh_shape(mesh_id_t mesh_id) const {
+    uint32_t x = this->routing_table_generator_->mesh_graph->get_mesh_ns_size(mesh_id);
+    uint32_t y = this->routing_table_generator_->mesh_graph->get_mesh_ew_size(mesh_id);
+    return MeshShape(x, y);
 };
 
 void ControlPlane::print_routing_tables() const {
+    this->print_ethernet_channels();
+
     std::stringstream ss;
     ss << "Control Plane: IntraMesh Routing Tables" << std::endl;
-    for (int mesh_id = 0; mesh_id < this->intra_mesh_routing_tables_.size(); mesh_id++) {
-        ss << "M" << mesh_id << ":" << std::endl;
-        for (int chip_id = 0; chip_id < this->intra_mesh_routing_tables_[mesh_id].size(); chip_id++) {
-            const auto& chip_routing_table = this->intra_mesh_routing_tables_[mesh_id][chip_id];
-            for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
-                ss << "   D" << chip_id << " Eth Chan " << eth_chan << ": ";
-                for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
-                    ss << (std::uint16_t)dst_chan_id << " ";
-                }
-                ss << std::endl;
+    for (const auto& [fabric_node_id, chip_routing_table] : this->intra_mesh_routing_tables_) {
+        ss << fabric_node_id << ":" << std::endl;
+        for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
+            ss << "   Eth Chan " << eth_chan << ": ";
+            for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
+                ss << (std::uint16_t)dst_chan_id << " ";
             }
+            ss << std::endl;
         }
     }
 
@@ -1087,17 +1087,14 @@ void ControlPlane::print_routing_tables() const {
     ss.str(std::string());
     ss << "Control Plane: InterMesh Routing Tables" << std::endl;
 
-    for (int mesh_id = 0; mesh_id < this->inter_mesh_routing_tables_.size(); mesh_id++) {
-        ss << "M" << mesh_id << ":" << std::endl;
-        for (int chip_id = 0; chip_id < this->inter_mesh_routing_tables_[mesh_id].size(); chip_id++) {
-            const auto& chip_routing_table = this->inter_mesh_routing_tables_[mesh_id][chip_id];
-            for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
-                ss << "   D" << chip_id << " Eth Chan " << eth_chan << ": ";
-                for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
-                    ss << (std::uint16_t)dst_chan_id << " ";
-                }
-                ss << std::endl;
+    for (const auto& [fabric_node_id, chip_routing_table] : this->inter_mesh_routing_tables_) {
+        ss << fabric_node_id << ":" << std::endl;
+        for (int eth_chan = 0; eth_chan < chip_routing_table.size(); eth_chan++) {
+            ss << "   Eth Chan " << eth_chan << ": ";
+            for (const auto& dst_chan_id : chip_routing_table[eth_chan]) {
+                ss << (std::uint16_t)dst_chan_id << " ";
             }
+            ss << std::endl;
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());
@@ -1106,18 +1103,14 @@ void ControlPlane::print_routing_tables() const {
 void ControlPlane::print_ethernet_channels() const {
     std::stringstream ss;
     ss << "Control Plane: Physical eth channels in each direction" << std::endl;
-    for (uint32_t mesh_id = 0; mesh_id < this->router_port_directions_to_physical_eth_chan_map_.size(); mesh_id++) {
-        for (uint32_t chip_id = 0; chip_id < this->router_port_directions_to_physical_eth_chan_map_[mesh_id].size();
-             chip_id++) {
-            ss << "M" << mesh_id << "D" << chip_id << ": " << std::endl;
-            for (const auto& [direction, eth_chans] :
-                 this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
-                ss << "   " << magic_enum::enum_name(direction) << ":";
-                for (const auto& eth_chan : eth_chans) {
-                    ss << " " << (std::uint16_t)eth_chan;
-                }
-                ss << std::endl;
+    for (const auto& [fabric_node_id, fabric_eth_channels] : this->router_port_directions_to_physical_eth_chan_map_) {
+        ss << fabric_node_id << ": " << std::endl;
+        for (const auto& [direction, eth_chans] : fabric_eth_channels) {
+            ss << "   " << magic_enum::enum_name(direction) << ":";
+            for (const auto& eth_chan : eth_chans) {
+                ss << " " << (std::uint16_t)eth_chan;
             }
+            ss << std::endl;
         }
     }
     log_debug(tt::LogFabric, "{}", ss.str());
@@ -1149,5 +1142,37 @@ FabricContext& ControlPlane::get_fabric_context() const {
 void ControlPlane::clear_fabric_context() { this->fabric_context_.reset(nullptr); }
 
 ControlPlane::~ControlPlane() = default;
+
+GlobalControlPlane::GlobalControlPlane(const std::string& mesh_graph_desc_file) {
+    mesh_graph_desc_file_ = mesh_graph_desc_file;
+    // Initialize host mappings
+    this->initialize_host_mapping();
+    control_plane_ = std::make_unique<ControlPlane>(mesh_graph_desc_file);
+}
+
+GlobalControlPlane::GlobalControlPlane(
+    const std::string& mesh_graph_desc_file,
+    const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    this->initialize_host_mapping();
+    control_plane_ =
+        std::make_unique<ControlPlane>(mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
+}
+
+void GlobalControlPlane::initialize_host_mapping() {
+    this->routing_table_generator_ = std::make_unique<RoutingTableGenerator>(mesh_graph_desc_file_);
+    // Grab available hosts in the system and map to physical chip ids
+    // ping for all hosts in cluster, grab mapping of all physical chip ids/physical hosts
+    const auto& mesh_ids = this->routing_table_generator_->mesh_graph->get_mesh_ids();
+
+    for (const auto& mesh_id : mesh_ids) {
+        MeshShape mesh_shape = this->routing_table_generator_->mesh_graph->get_mesh_shape(mesh_id);
+        const auto& host_ranks = this->routing_table_generator_->mesh_graph->get_host_ranks(mesh_id);
+        for (const auto& [coord, rank] : host_ranks) {
+            this->host_rank_to_sub_mesh_shape_[rank].push_back(coord);
+        }
+    }
+}
+
+GlobalControlPlane::~GlobalControlPlane() = default;
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1153,6 +1153,7 @@ GlobalControlPlane::GlobalControlPlane(const std::string& mesh_graph_desc_file) 
 GlobalControlPlane::GlobalControlPlane(
     const std::string& mesh_graph_desc_file,
     const std::map<FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    mesh_graph_desc_file_ = mesh_graph_desc_file;
     this->initialize_host_mapping();
     control_plane_ =
         std::make_unique<ControlPlane>(mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -32,7 +32,7 @@ std::unordered_map<mesh_id_t, bool> FabricContext::check_for_wrap_around_mesh() 
         const uint32_t corner_chip_id = 0;
         uint32_t corner_chip_connections = 0;
         for (const auto& direction : FabricContext::routing_directions) {
-            if (!control_plane->get_intra_chip_neighbors(mesh_id, corner_chip_id, direction).empty()) {
+            if (!control_plane->get_intra_chip_neighbors(FabricNodeId(mesh_id, corner_chip_id), direction).empty()) {
                 corner_chip_connections++;
             }
         }

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -61,15 +61,15 @@ FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::Cluster
 std::vector<uint32_t> get_forwarding_link_indices_in_direction(
     chip_id_t src_chip_id, chip_id_t dst_chip_id, RoutingDirection direction) {
     const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    const auto [src_mesh_id, src_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(src_chip_id);
-    const auto [dst_mesh_id, dst_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dst_chip_id);
+    const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
+    const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
 
     // the subset of routers that support forwarding b/w those chips
-    const std::vector<chan_id_t>& forwarding_channels = control_plane->get_forwarding_eth_chans_to_chip(
-        src_mesh_id, src_logical_chip_id, dst_mesh_id, dst_logical_chip_id, direction);
+    const std::vector<chan_id_t>& forwarding_channels =
+        control_plane->get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id, direction);
 
     const std::vector<chan_id_t>& fabric_channels =
-        control_plane->get_active_fabric_eth_channels_in_direction(src_mesh_id, src_logical_chip_id, direction);
+        control_plane->get_active_fabric_eth_channels_in_direction(src_fabric_node_id, direction);
 
     std::vector<uint32_t> link_indices;
     for (uint32_t i = 0; i < fabric_channels.size(); i++) {
@@ -84,12 +84,11 @@ std::vector<uint32_t> get_forwarding_link_indices_in_direction(
 
 std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id) {
     const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    const auto [src_mesh_id, src_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(src_chip_id);
-    const auto [dst_mesh_id, dst_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dst_chip_id);
+    const auto src_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(src_chip_id);
+    const auto dst_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(dst_chip_id);
 
     // find the forwarding direction b/w src and dest chip
-    const auto& forwarding_direction =
-        control_plane->get_forwarding_direction(src_mesh_id, src_logical_chip_id, dst_mesh_id, dst_logical_chip_id);
+    const auto& forwarding_direction = control_plane->get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
     if (!forwarding_direction.has_value()) {
         return {};
     }

--- a/tt_metal/fabric/mesh_graph.cpp
+++ b/tt_metal/fabric/mesh_graph.cpp
@@ -189,18 +189,20 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         .num_eth_ports_per_direction = num_eth_ports_per_direction,
         .num_z_ports = chip["ethernet_ports"]["Z"].IsDefined() ? chip["ethernet_ports"]["Z"].as<std::uint32_t>() : 0};
 
-    std::unordered_map<std::string, std::vector<std::unordered_map<chip_id_t, RouterEdge>>> board_to_mesh_connectivity;
-    std::unordered_map<std::string, std::array<std::uint32_t, 2>> board_to_topology;
+    std::unordered_map<std::string, std::array<std::uint32_t, 2>> board_name_to_topology;
+    std::unordered_map<std::string, FabricType> board_name_to_fabric_type;
     for (const auto& board : yaml["Board"]) {
         std::string board_name = board["name"].as<std::string>();
         TT_FATAL(
-            board_to_mesh_connectivity.find(board_name) == board_to_mesh_connectivity.end(),
+            board_name_to_topology.find(board_name) == board_name_to_topology.end(),
             "MeshGraph: Duplicate board name: {}",
             board_name);
         auto fabric_type =
             magic_enum::enum_cast<FabricType>(board["type"].as<std::string>(), magic_enum::case_insensitive);
         TT_FATAL(
             fabric_type.has_value(), "MeshGraph: Invalid yaml fabric board type: {}", board["type"].as<std::string>());
+
+        board_name_to_fabric_type[board_name] = fabric_type.value();
         TT_FATAL(board["topology"].IsDefined(), "MeshGraph: Expecting yaml board to define topology");
         // Topology
         // e.g. [4, 8]:
@@ -208,20 +210,11 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
         //    chip 0 is NW corner, chip 1 is E of chip 0
         std::uint32_t row_size = board["topology"][1].as<std::uint32_t>();
         std::uint32_t col_size = board["topology"][0].as<std::uint32_t>();
-        std::uint32_t num_chips_in_board = row_size * col_size;
-        board_to_topology[board_name] = {col_size, row_size};
-
-        // Fill in connectivity for Board
-        board_to_mesh_connectivity[board_name].resize(num_chips_in_board);
-        for (std::uint32_t i = 0; i < num_chips_in_board; i++) {
-            board_to_mesh_connectivity[board_name][i] =
-                this->get_valid_connections(i, row_size, num_chips_in_board, fabric_type.value());
-        }
+        board_name_to_topology[board_name] = {col_size, row_size};
     }
     // Loop over Meshes, populate intra mesh
     std::vector<std::unordered_map<port_id_t, chip_id_t, hash_pair>> mesh_edge_ports_to_chip_id;
     for (const auto& mesh : yaml["Mesh"]) {
-        // TODO: handle host mapping and topology
         std::string mesh_board = mesh["board"].as<std::string>();
         mesh_id_t mesh_id = mesh["id"].as<std::uint32_t>();
         if (this->intra_mesh_connectivity_.size() <= mesh_id) {
@@ -229,24 +222,71 @@ void MeshGraph::initialize_from_yaml(const std::string& mesh_graph_desc_file_pat
             this->intra_mesh_connectivity_.resize(mesh_id + 1);
             this->inter_mesh_connectivity_.resize(mesh_id + 1);
             this->mesh_shapes_.resize(mesh_id + 1);
+            this->mesh_host_ranks_.resize(mesh_id + 1, MeshContainer<std::uint32_t>({}, {}));
+            this->host_rank_coord_ranges_.resize(mesh_id + 1);
             mesh_edge_ports_to_chip_id.resize(mesh_id + 1);
+            this->mesh_ids_.push_back(mesh_id);
         }
         TT_FATAL(
-            board_to_mesh_connectivity.find(mesh_board) != board_to_mesh_connectivity.end(),
+            board_name_to_topology.find(mesh_board) != board_name_to_topology.end(),
             "MeshGraph: Board not found: {}",
             mesh["board"].as<std::string>());
 
-        TT_FATAL(
-            (mesh["topology"][0].as<std::uint32_t>() == 1) and (mesh["topology"][1].as<std::uint32_t>() == 1),
-            "Add support for non 1x1 mesh");
-        // Find board in board_to_mesh_connectivity and populate, need to add support for topology
-        this->intra_mesh_connectivity_[mesh_id] = board_to_mesh_connectivity[mesh["board"].as<std::string>()];
-        this->inter_mesh_connectivity_[mesh_id].resize(this->intra_mesh_connectivity_[mesh_id].size());
+        std::uint32_t mesh_board_ew_size = mesh["topology"][1].as<std::uint32_t>();
+        std::uint32_t mesh_board_ns_size = mesh["topology"][0].as<std::uint32_t>();
+        std::uint32_t mesh_ew_size = mesh_board_ew_size * board_name_to_topology[mesh_board][1];
+        std::uint32_t mesh_ns_size = mesh_board_ns_size * board_name_to_topology[mesh_board][0];
 
-        std::uint32_t mesh_ew_size = mesh["topology"][1].as<std::uint32_t>() * board_to_topology[mesh_board][1];
-        std::uint32_t mesh_ns_size = mesh["topology"][0].as<std::uint32_t>() * board_to_topology[mesh_board][0];
         std::uint32_t mesh_size = mesh_ew_size * mesh_ns_size;
         this->mesh_shapes_[mesh_id] = {mesh_ns_size, mesh_ew_size};
+
+        // Fill in host ranks for Mesh
+        TT_FATAL(
+            mesh["host_ranks"].IsSequence() and mesh["host_ranks"].size() == mesh_board_ns_size,
+            "MeshGraph: Expecting host_ranks to define a 2D array that matches topology");
+
+        std::vector<std::uint32_t> mesh_host_ranks_values;
+        mesh_host_ranks_values.reserve(mesh_board_ns_size * mesh_board_ew_size);
+
+        // Track the start and end coordinates of each host rank
+        std::unordered_map<std::uint32_t, std::pair<MeshCoordinate, MeshCoordinate>> host_rank_submesh_start_end_coords;
+        for (std::uint32_t i = 0; i < mesh_board_ns_size; i++) {
+            TT_FATAL(
+                mesh["host_ranks"][i].IsSequence() and mesh["host_ranks"][i].size() == mesh_board_ew_size,
+                "MeshGraph: Expecting host_ranks to define a 2D array that matches topology");
+            for (std::uint32_t j = 0; j < mesh_board_ew_size; j++) {
+                std::uint32_t host_rank = mesh["host_ranks"][i][j].as<std::uint32_t>();
+                if (host_rank_submesh_start_end_coords.find(host_rank) == host_rank_submesh_start_end_coords.end()) {
+                    host_rank_submesh_start_end_coords.insert(
+                        {host_rank, std::make_pair(MeshCoordinate(i, j), MeshCoordinate(i, j))});
+                } else {
+                    host_rank_submesh_start_end_coords.at(host_rank).second = MeshCoordinate(i, j);
+                }
+                mesh_host_ranks_values.push_back(host_rank);
+            }
+        }
+        // Fill in all host rank coordinate ranges
+        this->host_rank_coord_ranges_[mesh_id].resize(mesh_host_ranks_values.size(), MeshCoordinateRange({}));
+        for (const auto& [host_rank, coords] : host_rank_submesh_start_end_coords) {
+            this->host_rank_coord_ranges_[mesh_id][host_rank] = MeshCoordinateRange(
+                MeshCoordinate(
+                    coords.first[0] * board_name_to_topology[mesh_board][0],
+                    coords.first[1] * board_name_to_topology[mesh_board][1]),
+                MeshCoordinate(
+                    (coords.second[0] + 1) * board_name_to_topology[mesh_board][0] - 1,
+                    (coords.second[1] + 1) * board_name_to_topology[mesh_board][1] - 1));
+        }
+        this->mesh_host_ranks_[mesh_id] =
+            MeshContainer<std::uint32_t>(MeshShape(mesh_board_ns_size, mesh_board_ew_size), mesh_host_ranks_values);
+
+        // Fill in connectivity for Mesh
+        this->intra_mesh_connectivity_[mesh_id].resize(mesh_size);
+        for (std::uint32_t i = 0; i < mesh_size; i++) {
+            this->intra_mesh_connectivity_[mesh_id][i] =
+                this->get_valid_connections(i, mesh_ew_size, mesh_size, board_name_to_fabric_type[mesh_board]);
+        }
+
+        this->inter_mesh_connectivity_[mesh_id].resize(this->intra_mesh_connectivity_[mesh_id].size());
 
         // Print Mesh
         std::stringstream ss;

--- a/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/dual_galaxy_mesh_graph_descriptor.yaml
@@ -1,17 +1,17 @@
 ChipSpec: {
   arch: wormhole_b0,
   ethernet_ports: {
-    N: 4,
-    E: 4,
-    S: 4,
-    W: 4,
+    N: 1,
+    E: 1,
+    S: 1,
+    W: 1,
   }
 }
 
 
 Board: [
   { name: Galaxy,
-    type: TORUS_2D,
+    type: Mesh,
     topology: [8, 4]}
  ]
 
@@ -19,8 +19,8 @@ Mesh: [
 {
   id: 0,
   board: Galaxy,
-  topology: [1, 1],
-  host_ranks: [[0]]}
+  topology: [1, 2],
+  host_ranks: [[0, 1]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n150_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
   id: 0,
   board: N150,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/n300_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
   id: 0,
   board: N300,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p100_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
   id: 0,
   board: P100,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
   id: 0,
   board: P150,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x2_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
   id: 0,
   board: P150,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/p150_x4_mesh_graph_descriptor.yaml
@@ -19,7 +19,7 @@ Mesh: [
   id: 0,
   board: P150,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   id: 0,
   board: Galaxy,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml
@@ -20,7 +20,7 @@ Mesh: [
   id: 0,
   board: T3K,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]}
 ]
 
 Graph: [

--- a/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml
@@ -23,27 +23,27 @@ Mesh: [
   id: 0,
   board: N150Gateway,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 1,
   board: N150Gateway,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 2,
   board: N150Gateway,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 3,
   board: N150Gateway,
   topology: [1, 1],
-  host_mapping: [[]]},
+  host_ranks: [[0]]},
 {
   id: 4,
   board: Galaxy,
   topology: [1, 1],
-  host_mapping: [[]]}
+  host_ranks: [[0]]},
 ]
 
 Graph: [

--- a/tt_metal/fabric/routing_table_generator.cpp
+++ b/tt_metal/fabric/routing_table_generator.cpp
@@ -16,11 +16,32 @@
 #include "logger.hpp"
 
 namespace tt::tt_fabric {
+
+FabricNodeId::FabricNodeId(std::uint32_t mesh_id, std::uint32_t chip_id) {
+    this->mesh_id = mesh_id;
+    this->chip_id = chip_id;
+}
+
+bool operator==(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id == rhs.mesh_id && lhs.chip_id == rhs.chip_id;
+}
+bool operator!=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs == rhs); }
+bool operator<(const FabricNodeId& lhs, const FabricNodeId& rhs) {
+    return lhs.mesh_id < rhs.mesh_id || (lhs.mesh_id == rhs.mesh_id && lhs.chip_id < rhs.chip_id);
+}
+bool operator>(const FabricNodeId& lhs, const FabricNodeId& rhs) { return rhs < lhs; }
+bool operator<=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(rhs > lhs); }
+bool operator>=(const FabricNodeId& lhs, const FabricNodeId& rhs) { return !(lhs < rhs); }
+std::ostream& operator<<(std::ostream& os, const FabricNodeId& fabric_node_id) {
+    os << "M" << fabric_node_id.mesh_id << "D" << fabric_node_id.chip_id;
+    return os;
+}
+
 RoutingTableGenerator::RoutingTableGenerator(const std::string& mesh_graph_desc_yaml_file) {
-    this->mesh_graph_ = std::make_unique<MeshGraph>(mesh_graph_desc_yaml_file);
+    this->mesh_graph = std::make_unique<MeshGraph>(mesh_graph_desc_yaml_file);
     // Use IntraMeshConnectivity to size all variables
-    const auto& intra_mesh_connectivity = this->mesh_graph_->get_intra_mesh_connectivity();
-    const auto& inter_mesh_connectivity = this->mesh_graph_->get_inter_mesh_connectivity();
+    const auto& intra_mesh_connectivity = this->mesh_graph->get_intra_mesh_connectivity();
+    const auto& inter_mesh_connectivity = this->mesh_graph->get_inter_mesh_connectivity();
     this->intra_mesh_table_.resize(intra_mesh_connectivity.size());
     this->inter_mesh_table_.resize(intra_mesh_connectivity.size());
     for (mesh_id_t mesh_id = 0; mesh_id < intra_mesh_connectivity.size(); mesh_id++) {
@@ -46,7 +67,7 @@ void RoutingTableGenerator::generate_intramesh_routing_table(const IntraMeshConn
     for (mesh_id_t mesh_id = 0; mesh_id < this->intra_mesh_table_.size(); mesh_id++) {
         for (chip_id_t src_chip_id = 0; src_chip_id < this->intra_mesh_table_[mesh_id].size(); src_chip_id++) {
             for (chip_id_t dst_chip_id = 0; dst_chip_id < this->intra_mesh_table_[mesh_id].size(); dst_chip_id++) {
-                int row_size = this->mesh_graph_->get_mesh_ew_size(mesh_id);
+                int row_size = this->mesh_graph->get_mesh_ew_size(mesh_id);
                 uint32_t src_x = src_chip_id / row_size;
                 uint32_t src_y = src_chip_id % row_size;
                 uint32_t dst_x = dst_chip_id / row_size;
@@ -158,8 +179,8 @@ void RoutingTableGenerator::generate_intermesh_routing_table(
     const InterMeshConnectivity& inter_mesh_connectivity, const IntraMeshConnectivity& /*intra_mesh_connectivity*/) {
     for (mesh_id_t src_mesh_id = 0; src_mesh_id < this->inter_mesh_table_.size(); src_mesh_id++) {
         auto paths = get_paths_to_all_meshes(src_mesh_id, inter_mesh_connectivity);
-        std::uint32_t ew_size = this->mesh_graph_->get_mesh_ew_size(src_mesh_id);
-        std::uint32_t ns_size = this->mesh_graph_->get_mesh_ns_size(src_mesh_id);
+        std::uint32_t ew_size = this->mesh_graph->get_mesh_ew_size(src_mesh_id);
+        std::uint32_t ns_size = this->mesh_graph->get_mesh_ns_size(src_mesh_id);
         for (chip_id_t src_chip_id = 0; src_chip_id < this->inter_mesh_table_[src_mesh_id].size(); src_chip_id++) {
             for (mesh_id_t dst_mesh_id = 0; dst_mesh_id < this->inter_mesh_table_.size(); dst_mesh_id++) {
                 if (dst_mesh_id == src_mesh_id) {

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -35,12 +35,16 @@ void FabricRouterVC::GenerateDependentConfigs() {
         // Upstream can be PREFETCH_H or DISPATCH_D
         // Downstream can be PREFETCH_D or DISPATCH_H
         // 4 Combinations
-        const auto& [src_mesh_id, src_chip_id] =
-            control_plane->get_mesh_chip_id_from_physical_chip_id(us_kernel->GetDeviceId());
-        const auto& [dst_mesh_id, dst_chip_id] =
-            control_plane->get_mesh_chip_id_from_physical_chip_id(ds_kernel->GetDeviceId());
+        const auto& src_fabric_node_id =
+            control_plane->get_fabric_node_id_from_physical_chip_id(us_kernel->GetDeviceId());
+        const auto& dst_fabric_node_id =
+            control_plane->get_fabric_node_id_from_physical_chip_id(ds_kernel->GetDeviceId());
+        auto src_mesh_id = src_fabric_node_id.mesh_id;
+        auto src_chip_id = src_fabric_node_id.chip_id;
+        auto dst_mesh_id = dst_fabric_node_id.mesh_id;
+        auto dst_chip_id = dst_fabric_node_id.chip_id;
         const auto& router_chans =
-            control_plane->get_forwarding_eth_chans_to_chip(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
+            control_plane->get_forwarding_eth_chans_to_chip(src_fabric_node_id, dst_fabric_node_id);
         TT_ASSERT(
             !router_chans.empty(),
             "No routers for (mesh {}, chip {}) to (mesh {}, chip{})",
@@ -53,7 +57,7 @@ void FabricRouterVC::GenerateDependentConfigs() {
                 us_kernel->GetDeviceId(), *router_chans.begin());
 
         const auto& router_chans_rev =
-            control_plane->get_forwarding_eth_chans_to_chip(dst_mesh_id, dst_chip_id, src_mesh_id, src_chip_id);
+            control_plane->get_forwarding_eth_chans_to_chip(dst_fabric_node_id, src_fabric_node_id);
         TT_ASSERT(
             !router_chans_rev.empty(),
             "No routers for return path (mesh {}, chip {}) to (mesh {}, chip{})",

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1029,15 +1029,14 @@ void build_tt_fabric_program(
     std::unordered_map<tt::tt_fabric::chan_id_t, tt::tt_fabric::FabricEriscDatamoverBuilder>& edm_builders) {
     using namespace tt_fabric;
     const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    std::pair<mesh_id_t, chip_id_t> mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
+    auto fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
     const bool is_TG = (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG);
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
     const auto& fabric_context = control_plane->get_fabric_context();
     const auto& edm_config = fabric_context.get_fabric_router_config();
 
     if (is_TG && device->is_mmio_capable()) {
-        auto router_chans_and_direction =
-            control_plane->get_active_fabric_eth_channels(mesh_chip_id.first, mesh_chip_id.second);
+        auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(fabric_node_id);
         for (const auto& [eth_chan, eth_direction] : router_chans_and_direction) {
             // remote chip id is only used to dertmine the handshake master, no functional impact
             // for now treat the mmio chips as the handshake master
@@ -1067,13 +1066,12 @@ void build_tt_fabric_program(
     const bool is_2D_routing = topology == Topology::Mesh;
 
     for (const auto& direction : tt::tt_fabric::FabricContext::routing_directions) {
-        auto active_eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
-            mesh_chip_id.first, mesh_chip_id.second, direction);
+        auto active_eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(fabric_node_id, direction);
         if (active_eth_chans.empty()) {
             continue;
         }
-        auto neighbors = control_plane->get_chip_neighbors(mesh_chip_id.first, mesh_chip_id.second, direction);
-        auto intra_chip_neighbors = neighbors.find(mesh_chip_id.first);
+        auto neighbors = control_plane->get_chip_neighbors(fabric_node_id, direction);
+        auto intra_chip_neighbors = neighbors.find(fabric_node_id.mesh_id);
         if (intra_chip_neighbors != neighbors.end()) {
             // only count the number of unique intra chip neighbors
             // we assume that all neighbors in a direction are the same
@@ -1098,9 +1096,8 @@ void build_tt_fabric_program(
             }
         }
 
-        std::pair<mesh_id_t, chip_id_t> neighbor_mesh_chip_id = {
-            neighbors.begin()->first, neighbors.begin()->second[0]};
-        chip_neighbors[direction] = control_plane->get_physical_chip_id_from_mesh_chip_id(neighbor_mesh_chip_id);
+        FabricNodeId neighbor_fabric_node_id = FabricNodeId(neighbors.begin()->first, neighbors.begin()->second[0]);
+        chip_neighbors[direction] = control_plane->get_physical_chip_id_from_fabric_node_id(neighbor_fabric_node_id);
 
         active_fabric_eth_channels.insert({direction, active_eth_chans});
     }
@@ -1110,15 +1107,17 @@ void build_tt_fabric_program(
         return;
     }
 
-    const bool wrap_around_mesh = fabric_context.is_wrap_around_mesh(mesh_chip_id.first);
+    const bool wrap_around_mesh = fabric_context.is_wrap_around_mesh(fabric_node_id.mesh_id);
 
     for (const auto& [direction, remote_physical_chip_id] : chip_neighbors) {
-        auto [remote_mesh_id, remote_chip_id] =
-            control_plane->get_mesh_chip_id_from_physical_chip_id(remote_physical_chip_id);
-        bool is_dateline =
-            remote_mesh_id == mesh_chip_id.first &&
-            check_dateline(
-                *control_plane, topology, mesh_chip_id.first, mesh_chip_id.second, remote_chip_id, wrap_around_mesh);
+        auto remote_fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(remote_physical_chip_id);
+        bool is_dateline = remote_fabric_node_id.mesh_id == fabric_node_id.mesh_id && check_dateline(
+                                                                                          *control_plane,
+                                                                                          topology,
+                                                                                          fabric_node_id.mesh_id,
+                                                                                          fabric_node_id.chip_id,
+                                                                                          remote_fabric_node_id.chip_id,
+                                                                                          wrap_around_mesh);
 
         const auto& curr_edm_config = fabric_context.get_fabric_router_config(is_dateline);
 
@@ -1274,8 +1273,8 @@ void configure_fabric_cores(IDevice* device) {
     std::vector<uint32_t> router_zero_buf(1, 0);
     auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
     const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    const auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
-    const auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
+    const auto fabric_node_id = control_plane->get_fabric_node_id_from_physical_chip_id(device->id());
+    const auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(fabric_node_id);
     const auto addresses_to_clear = control_plane->get_fabric_context().get_fabric_router_addresses_to_clear();
     for (const auto& [router_chan, _] : router_chans_and_direction) {
         auto router_logical_core = soc_desc.get_eth_core_for_channel(router_chan, CoordSystem::LOGICAL);

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1086,22 +1086,22 @@ std::unordered_set<CoreCoord> Cluster::get_active_ethernet_cores(
 }
 
 tt::tt_fabric::ControlPlane* Cluster::get_control_plane() {
-    if (control_plane_.get() == nullptr) {
+    if (global_control_plane_.get() == nullptr) {
         this->initialize_control_plane();
     }
-    return control_plane_.get();
+    return global_control_plane_->get_local_node_control_plane();
 }
 
 void Cluster::set_custom_control_plane_mesh_graph(
     const std::string& mesh_graph_desc_file,
-    const std::vector<std::vector<chip_id_t>>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
+    const std::map<tt_fabric::FabricNodeId, chip_id_t>& logical_mesh_chip_id_to_physical_chip_id_mapping) {
     TT_FATAL(
         !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
         "Modifying control plane requires no devices to be active");
-    if (control_plane_.get() != nullptr) {
-        control_plane_.reset();
+    if (global_control_plane_.get() != nullptr) {
+        global_control_plane_.reset();
     }
-    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(
+    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(
         mesh_graph_desc_file, logical_mesh_chip_id_to_physical_chip_id_mapping);
     this->initialize_fabric_config(fabric_config_);
 }
@@ -1110,8 +1110,8 @@ void Cluster::set_default_control_plane_mesh_graph() {
     TT_FATAL(
         !DevicePool::is_initialized() || DevicePool::instance().get_all_active_devices().size() == 0,
         "Modifying control plane requires no devices to be active");
-    if (control_plane_.get() != nullptr) {
-        control_plane_.reset();
+    if (global_control_plane_.get() != nullptr) {
+        global_control_plane_.reset();
     }
     this->initialize_control_plane();
     this->initialize_fabric_config(fabric_config_);
@@ -1220,12 +1220,48 @@ std::tuple<chip_id_t, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple
     const auto &soc_desc = get_soc_desc(std::get<0>(eth_core));
     ethernet_channel_t eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
     TT_ASSERT(
-        (this->cluster_desc_->ethernet_core_has_active_ethernet_link(std::get<0>(eth_core), eth_chan)),
+        this->is_ethernet_link_up(std::get<0>(eth_core), std::get<1>(eth_core)),
         "Logical eth core {} is not an active eth core on chip {}.",
         std::get<1>(eth_core).str(),
         std::get<0>(eth_core));
+    const auto& ethernet_connections_within_cluster = this->get_ethernet_connections();
+    TT_ASSERT(
+        (ethernet_connections_within_cluster.find(std::get<0>(eth_core)) !=
+         ethernet_connections_within_cluster.end()) and
+            (ethernet_connections_within_cluster.at(std::get<0>(eth_core)).find(eth_chan) !=
+             ethernet_connections_within_cluster.at(std::get<0>(eth_core)).end()),
+        "Chip {} logical eth core {} connects to a remote mmio device",
+        std::get<0>(eth_core),
+        std::get<1>(eth_core).str());
     auto connected_eth_core =
         this->cluster_desc_->get_chip_and_channel_of_remote_ethernet_core(std::get<0>(eth_core), eth_chan);
+    return std::make_tuple(
+        std::get<0>(connected_eth_core),
+        soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL));
+}
+
+// TODO: unify uint64_t with ChipUID
+std::tuple<uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_mmio_device(
+    std::tuple<chip_id_t, CoreCoord> eth_core) const {
+    const auto& soc_desc = get_soc_desc(std::get<0>(eth_core));
+    ethernet_channel_t eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
+    TT_ASSERT(
+        this->is_ethernet_link_up(std::get<0>(eth_core), std::get<1>(eth_core)),
+        "Logical eth core {} is not an active eth core on chip {}.",
+        std::get<1>(eth_core).str(),
+        std::get<0>(eth_core));
+    const auto& ethernet_connections_to_remote_cluster = this->get_ethernet_connections_to_remote_mmio_devices();
+    const auto& local_chip_id = std::get<0>(eth_core);
+    const auto& local_eth_core = std::get<1>(eth_core);
+    TT_ASSERT(
+        (ethernet_connections_to_remote_cluster.find(local_chip_id) != ethernet_connections_to_remote_cluster.end()) and
+            (ethernet_connections_to_remote_cluster.at(local_chip_id).find(eth_chan) !=
+             ethernet_connections_to_remote_cluster.at(local_chip_id).end()),
+        "Chip {} logical eth core {} connects to a local mmio device",
+        local_chip_id,
+        local_eth_core.str());
+
+    const auto& connected_eth_core = ethernet_connections_to_remote_cluster.at(local_chip_id).at(eth_chan);
     return std::make_tuple(
         std::get<0>(connected_eth_core),
         soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL));
@@ -1407,7 +1443,7 @@ void Cluster::initialize_control_plane() {
     const std::filesystem::path mesh_graph_desc_path = std::filesystem::path(rtoptions_.get_root_dir()) /
                                                        "tt_metal/fabric/mesh_graph_descriptors" / mesh_graph_descriptor;
 
-    control_plane_ = std::make_unique<tt::tt_fabric::ControlPlane>(mesh_graph_desc_path.string());
+    global_control_plane_ = std::make_unique<tt::tt_fabric::GlobalControlPlane>(mesh_graph_desc_path.string());
 }
 
 }  // namespace tt


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/20945
### Problem description
Current Metal/UMD infra does not have support for multi support.

### What's changed
Add MeshGraph, Cluster support for multi host
- Refactor CP, MeshGraph use FabricMeshId for bookkeeping in CP
- allow more than expected links in CP
- UMD uplift to include changes for connections to other-host systems

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes