### PR TITLE
Separate out ringbuffer size from scratch db size

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2066,6 +2066,7 @@ void configure_for_single_chip(
         0,
         0,
         0,
+        scratch_db_size_g,
     };
 
     constexpr NOC my_noc_index = NOC::NOC_0;

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -35,6 +35,8 @@ uint32_t DispatchMemMap::scratch_db_base() const { return scratch_db_base_; }
 
 uint32_t DispatchMemMap::scratch_db_size() const { return settings.prefetch_scratch_db_size_; }
 
+uint32_t DispatchMemMap::ringbuffer_size() const { return settings.prefetch_ringbuffer_size_; }
+
 uint32_t DispatchMemMap::dispatch_buffer_block_size_pages() const { return dispatch_buffer_block_size_pages_; }
 
 uint32_t DispatchMemMap::dispatch_buffer_base() const { return dispatch_buffer_base_; }
@@ -168,6 +170,13 @@ void DispatchMemMap::reset(const CoreType& core_type, const uint32_t num_hw_cqs)
     const uint32_t dispatch_cb_end = dispatch_buffer_base_ + settings.dispatch_size_;
 
     TT_ASSERT(scratch_db_base_ + settings.prefetch_scratch_db_size_ < l1_size);
+    TT_FATAL(
+        scratch_db_base_ + settings.prefetch_ringbuffer_size_ <= l1_size,
+        "Ringbuffer (start: {}, end: {}) extends past L1 end (size: {})",
+        scratch_db_base_,
+        scratch_db_base_ + settings.prefetch_scratch_db_size_,
+        l1_size);
+
     TT_ASSERT(dispatch_cb_end < l1_size);
 }
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -48,6 +48,8 @@ public:
 
     uint32_t scratch_db_size() const;
 
+    uint32_t ringbuffer_size() const;
+
     uint32_t dispatch_buffer_block_size_pages() const;
 
     uint32_t dispatch_buffer_base() const;

--- a/tt_metal/impl/dispatch/dispatch_settings.hpp
+++ b/tt_metal/impl/dispatch/dispatch_settings.hpp
@@ -62,6 +62,9 @@ public:
     // Trivial setter for prefetch_scratch_db_size
     DispatchSettings& prefetch_scratch_db_size(uint32_t val);
 
+    // Trivial setter for prefetch_ringbuffer_size
+    DispatchSettings& prefetch_ringbuffer_size(uint32_t val);
+
     // Setter for prefetch_q_entries and update prefetch_q_size
     DispatchSettings& prefetch_q_entries(uint32_t val);
 
@@ -158,6 +161,7 @@ public:
     uint32_t prefetch_max_cmd_size_;
     uint32_t prefetch_cmddat_q_size_;
     uint32_t prefetch_scratch_db_size_;
+    uint32_t prefetch_ringbuffer_size_;
     uint32_t prefetch_d_buffer_size_;
     uint32_t prefetch_d_pages_;  // prefetch_d_buffer_size_ / PREFETCH_D_BUFFER_LOG_PAGE_SIZE
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -64,6 +64,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.scratch_db_size = my_dispatch_constants.scratch_db_size();
         static_config_.downstream_sync_sem_id =
             tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+        static_config_.ringbuffer_size = my_dispatch_constants.ringbuffer_size();
 
         // prefetch_d only
         static_config_.cmddat_q_pages = my_dispatch_constants.prefetch_d_buffer_pages();
@@ -116,6 +117,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.scratch_db_base = my_dispatch_constants.scratch_db_base();
         static_config_.scratch_db_size = my_dispatch_constants.scratch_db_size();
         static_config_.downstream_sync_sem_id = 0;  // Unused for prefetch_h
+        static_config_.ringbuffer_size = my_dispatch_constants.ringbuffer_size();
 
         static_config_.cmddat_q_pages = my_dispatch_constants.prefetch_d_buffer_pages();
         static_config_.my_upstream_cb_sem_id =
@@ -166,6 +168,7 @@ void PrefetchKernel::GenerateStaticConfigs() {
         static_config_.scratch_db_size = my_dispatch_constants.scratch_db_size();
         static_config_.downstream_sync_sem_id =
             tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+        static_config_.ringbuffer_size = my_dispatch_constants.ringbuffer_size();
 
         static_config_.cmddat_q_pages = my_dispatch_constants.prefetch_d_buffer_pages();
         static_config_.my_upstream_cb_sem_id =
@@ -389,10 +392,11 @@ void PrefetchKernel::CreateKernel() {
         dependent_config_.fabric_router_noc_xy.value_or(0),
         dependent_config_.outbound_eth_chan.value_or(0),
         static_config_.client_interface_addr.value_or(0),
+        static_config_.ringbuffer_size.value(),
         static_config_.is_d_variant.value(),
         static_config_.is_h_variant.value(),
     };
-    TT_ASSERT(compile_args.size() == 35);
+    TT_ASSERT(compile_args.size() == 36);
     auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
     auto upstream_virtual_core =
         device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -31,6 +31,7 @@ struct prefetch_static_config_t {
     std::optional<uint32_t> scratch_db_base;
     std::optional<uint32_t> scratch_db_size;
     std::optional<uint32_t> downstream_sync_sem_id;
+    std::optional<uint32_t> ringbuffer_size;
 
     // Used for prefetch_d
     std::optional<uint32_t> cmddat_q_pages;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -79,12 +79,15 @@ constexpr uint32_t fabric_router_noc_xy = get_compile_time_arg_val(30);
 constexpr uint32_t outbound_eth_chan = get_compile_time_arg_val(31);
 constexpr uint32_t client_interface_addr = get_compile_time_arg_val(32);
 
-constexpr uint32_t is_d_variant = get_compile_time_arg_val(33);
-constexpr uint32_t is_h_variant = get_compile_time_arg_val(34);
+constexpr uint32_t ringbuffer_size = get_compile_time_arg_val(33);
+
+constexpr uint32_t is_d_variant = get_compile_time_arg_val(34);
+constexpr uint32_t is_h_variant = get_compile_time_arg_val(35);
 
 constexpr uint32_t prefetch_q_end = prefetch_q_base + prefetch_q_size;
 constexpr uint32_t cmddat_q_end = cmddat_q_base + cmddat_q_size;
 constexpr uint32_t scratch_db_end = scratch_db_base + scratch_db_size;
+constexpr uint32_t ringbuffer_end = scratch_db_base + ringbuffer_size;
 
 // hd and h: fetch_q, cmddat_q, scratch_db
 static_assert(
@@ -1191,7 +1194,7 @@ uint32_t process_paged_to_ringbuffer_cmd(uint32_t cmd_ptr, uint32_t& downstream_
     }
 
     ASSERT(length % DRAM_ALIGNMENT == 0);
-    ASSERT(length + ringbuffer_wp <= scratch_db_end);
+    ASSERT(length + ringbuffer_wp <= ringbuffer_end);
 
     const bool is_dram = true;
     InterleavedPow2AddrGen<is_dram> addr_gen{.bank_base_address = base_addr, .log_base_2_of_page_size = log2_page_size};

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -76,6 +76,7 @@ DispatchSettings DispatchSettings::worker_defaults(const tt::Cluster& cluster, c
         .prefetch_max_cmd_size(128_KB)
         .prefetch_cmddat_q_size(256_KB)
         .prefetch_scratch_db_size(128_KB)
+        .prefetch_ringbuffer_size(1024_KB)
         .prefetch_d_buffer_size(256_KB)
 
         .dispatch_size(512_KB)
@@ -96,6 +97,7 @@ DispatchSettings DispatchSettings::eth_defaults(const tt::Cluster& /*cluster*/, 
         .prefetch_max_cmd_size(32_KB)
         .prefetch_cmddat_q_size(64_KB)
         .prefetch_scratch_db_size(19_KB)
+        .prefetch_ringbuffer_size(90_KB)
         .prefetch_d_buffer_size(128_KB)
 
         .dispatch_size(128_KB)
@@ -239,6 +241,12 @@ DispatchSettings& DispatchSettings::prefetch_cmddat_q_size(uint32_t val) {
 // Trivial setter for prefetch_scratch_db_size
 DispatchSettings& DispatchSettings::prefetch_scratch_db_size(uint32_t val) {
     this->prefetch_scratch_db_size_ = val;
+    return *this;
+}
+
+// Trivial setter for prefetch_ringbuffer_size
+DispatchSettings& DispatchSettings::prefetch_ringbuffer_size(uint32_t val) {
+    this->prefetch_ringbuffer_size_ = val;
     return *this;
 }
 


### PR DESCRIPTION
### Problem description
The ringbuffer size may be bigger than the scratch db size, since the scratch db size is limited for pipelining reasons and to avoid attempting to overfill the dispatch buffer size, while the ringbuffer is used as a cache and should be able to take up all of L1.

### What's changed
Add new methods to DispatchSettings and DispatchMemMap to get the ringbuffer size, and pass that size to the prefetcher so it can validate writes to the ringbuffer.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes