### PR TITLE
#0: [skip ci] Don't assume cwd is infra/ for infra tests

### DIFF
--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -13,14 +13,15 @@ def test_dummy():
 
 def test_create_pipeline_json_with_passing_post_commit(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = "tests/_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow.json"
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow_jobs.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow.json"
+    )
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/all_post_commit_passing_10662355710/"
-    ).resolve()
+    workflow_outputs_dir = (test_dir / "_data/data_collection/cicd/all_post_commit_passing_10662355710/").resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
 
@@ -47,15 +48,16 @@ def get_non_success_jobs_(pipeline):
 
 def test_create_pipeline_json_to_detect_job_timeout_error_v1(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow.json"
     )
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow_jobs.json"
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/"
+    workflow_outputs_dir = (
+        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -85,15 +87,16 @@ def test_create_pipeline_json_to_detect_job_timeout_error_v1(workflow_run_gh_env
 
 def test_create_pipeline_json_to_detect_runner_comm_error_v1_among_other_failures(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow.json"
     )
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow_jobs.json"
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/"
+    workflow_outputs_dir = (
+        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -124,15 +127,16 @@ def test_create_pipeline_json_to_detect_runner_comm_error_v1_among_other_failure
 
 def test_create_pipeline_json_for_run_github_timed_out_job(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow.json"
     )
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow_jobs.json"
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/"
+    workflow_outputs_dir = (
+        test_dir / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -156,15 +160,16 @@ def test_create_pipeline_json_for_run_github_timed_out_job(workflow_run_gh_envir
 
 def test_create_pipeline_json_for_timeout_bad_testcase(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow.json"
     )
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow_jobs.json"
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/"
+    workflow_outputs_dir = (
+        test_dir / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -187,15 +192,16 @@ def test_create_pipeline_json_for_timeout_bad_testcase(workflow_run_gh_environme
 
 def test_create_pipeline_json_for_gtest_testcases(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow.json"
     )
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow_jobs.json"
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/"
+    workflow_outputs_dir = (
+        test_dir / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -241,7 +247,8 @@ def test_create_pipeline_json_for_gtest_testcases(workflow_run_gh_environment):
 
 def test_empty_gtest_xml(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    workflow_outputs_dir = pathlib.Path("tests/_data/data_collection/cicd/all_post_commit_job_37712709106/").resolve()
+    test_dir = pathlib.Path(__file__).parent.parent
+    workflow_outputs_dir = (test_dir / "_data/data_collection/cicd/all_post_commit_job_37712709106/").resolve()
     assert (
         workflows.get_tests_from_test_report_path(workflow_outputs_dir / "distributed_unit_tests_wormhole_b0.xml") == []
     )
@@ -249,15 +256,16 @@ def test_empty_gtest_xml(workflow_run_gh_environment):
 
 def test_create_pipeline_json_for_testcases_with_annotations(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow.json"
     )
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow_jobs.json"
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/"
+    workflow_outputs_dir = (
+        test_dir / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -295,16 +303,15 @@ def test_create_pipeline_json_for_testcases_with_annotations(workflow_run_gh_env
 
 def test_create_pipeline_json_for_ctest_case(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    github_pipeline_json_filename = (
-        "tests/_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow.json"
+    test_dir = pathlib.Path(__file__).parent.parent
+    github_pipeline_json_filename = str(
+        test_dir / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow.json"
     )
-    github_jobs_json_filename = (
-        "tests/_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow_jobs.json"
+    github_jobs_json_filename = str(
+        test_dir / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = pathlib.Path(
-        "tests/_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/"
-    ).resolve()
+    workflow_outputs_dir = (test_dir / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/").resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
 

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -6,6 +6,8 @@ from infra.data_collection.cicd import create_cicd_json_for_data_analysis
 from infra.data_collection.models import InfraErrorV1, TestErrorV1
 from infra.data_collection.pydantic_models import JobStatus
 
+INFRA_TESTS_DIR = pathlib.Path(__file__).parent.parent
+
 
 def test_dummy():
     pass
@@ -13,15 +15,16 @@ def test_dummy():
 
 def test_create_pipeline_json_with_passing_post_commit(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow_jobs.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_passing_10662355710/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = (test_dir / "_data/data_collection/cicd/all_post_commit_passing_10662355710/").resolve()
+    workflow_outputs_dir = (
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_passing_10662355710/"
+    ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
 
@@ -48,16 +51,15 @@ def get_non_success_jobs_(pipeline):
 
 def test_create_pipeline_json_to_detect_job_timeout_error_v1(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow_jobs.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/workflow_jobs.json"
     )
 
     workflow_outputs_dir = (
-        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_runner_died_12626_10996802864/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -87,16 +89,15 @@ def test_create_pipeline_json_to_detect_job_timeout_error_v1(workflow_run_gh_env
 
 def test_create_pipeline_json_to_detect_runner_comm_error_v1_among_other_failures(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow_jobs.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/workflow_jobs.json"
     )
 
     workflow_outputs_dir = (
-        test_dir / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_runner_died_12626_11110261767/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -127,16 +128,15 @@ def test_create_pipeline_json_to_detect_runner_comm_error_v1_among_other_failure
 
 def test_create_pipeline_json_for_run_github_timed_out_job(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow_jobs.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/workflow_jobs.json"
     )
 
     workflow_outputs_dir = (
-        test_dir / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_github_timeout_11034942442/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -160,16 +160,16 @@ def test_create_pipeline_json_for_run_github_timed_out_job(workflow_run_gh_envir
 
 def test_create_pipeline_json_for_timeout_bad_testcase(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow_jobs.json"
+        INFRA_TESTS_DIR
+        / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/workflow_jobs.json"
     )
 
     workflow_outputs_dir = (
-        test_dir / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_timeout_bad_testcase_13077087562/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -192,16 +192,15 @@ def test_create_pipeline_json_for_timeout_bad_testcase(workflow_run_gh_environme
 
 def test_create_pipeline_json_for_gtest_testcases(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow_jobs.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/workflow_jobs.json"
     )
 
     workflow_outputs_dir = (
-        test_dir / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_gtest_testcases_13315815702/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -247,8 +246,7 @@ def test_create_pipeline_json_for_gtest_testcases(workflow_run_gh_environment):
 
 def test_empty_gtest_xml(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
-    workflow_outputs_dir = (test_dir / "_data/data_collection/cicd/all_post_commit_job_37712709106/").resolve()
+    workflow_outputs_dir = (INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_job_37712709106/").resolve()
     assert (
         workflows.get_tests_from_test_report_path(workflow_outputs_dir / "distributed_unit_tests_wormhole_b0.xml") == []
     )
@@ -256,16 +254,15 @@ def test_empty_gtest_xml(workflow_run_gh_environment):
 
 def test_create_pipeline_json_for_testcases_with_annotations(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow_jobs.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/workflow_jobs.json"
     )
 
     workflow_outputs_dir = (
-        test_dir / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_test_annotations_13443325356/"
     ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
@@ -303,15 +300,16 @@ def test_create_pipeline_json_for_testcases_with_annotations(workflow_run_gh_env
 
 def test_create_pipeline_json_for_ctest_case(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
-    test_dir = pathlib.Path(__file__).parent.parent
     github_pipeline_json_filename = str(
-        test_dir / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow.json"
     )
     github_jobs_json_filename = str(
-        test_dir / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow_jobs.json"
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/workflow_jobs.json"
     )
 
-    workflow_outputs_dir = (test_dir / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/").resolve()
+    workflow_outputs_dir = (
+        INFRA_TESTS_DIR / "_data/data_collection/cicd/tt_train_post_commit_ctest_13858791332/"
+    ).resolve()
     assert workflow_outputs_dir.is_dir()
     assert workflow_outputs_dir.exists()
 


### PR DESCRIPTION
### Ticket
None

### Problem description
I can't run `pytest infra/tests` from `tt-metal/`
I have to first `cd infra` and then run `pytest tests`

### What's changed
Make the infra pytests not reliant on current working directory == `infra/`
Instead construct the path to the data files from the location of `test_cicd.py`.

### Checklist
- [x] New/Existing tests provide coverage for changes