### PR TITLE
#0: Add serialization for tt-distributed

### DIFF
--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -15,6 +15,10 @@ namespace tt::tt_metal::distributed {
 
 MeshWorkload CreateMeshWorkload() { return MeshWorkload(); }
 
+// TODO: add lightmetalcapture with the below to all functions, maybe check to see if it's been activated in
+// tt_metal.cpp? (should have been)
+// TODO:    LIGHT_METAL_TRACE_FUNCTION_ENTRY();
+// TODO:    LIGHT_METAL_TRACE_FUNCTION_CALL(Capture${FunctionName}, arg1, arg2, etc..);
 void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRange& device_range) {
     mesh_workload.add_program(device_range, std::move(program));
 }

--- a/tt_metal/impl/flatbuffer/buffer_types.fbs
+++ b/tt_metal/impl/flatbuffer/buffer_types.fbs
@@ -51,6 +51,61 @@ table ShardSpecBuffer {
   tensor2d_shape_in_pages_w: uint32;
 }
 
+struct ShardedBufferConfig {
+    // Note: Only 2D sharding and replication is supported by the APIs exposed through this struct.
+    // This interface will likely change over time depending on the status of native ND sharding.
+    // Global buffer size. Each device will get a fraction of this size.
+    global_size: uint64 = 0;
+
+    global_shape_h: uint32;
+    global_shape_w: uint32;
+
+    shard_shape_h: uint32;
+    shard_shape_w: uint32;
+
+    // Orientation of the shards in a mesh.
+    shard_orientation: ShardOrientation = RowMajor;
+
+//TODO:
+//uint32_t ShardedBufferConfig::compute_datum_size_bytes() const {
+//    return global_size / (global_buffer_shape.height() * global_buffer_shape.width());
+//}
+
+//std::pair<bool, bool> ShardedBufferConfig::replicated_dims() const {
+//    return {shard_shape.height() == 0, shard_shape.width() == 0};
+//}
+
+//Shape2D ShardedBufferConfig::physical_shard_shape() const {
+//    const auto [shard_height, shard_width] = shard_shape;
+//    const auto [global_height, global_width] = global_buffer_shape;
+//    return Shape2D(shard_height == 0 ? global_height : shard_height, shard_width == 0 ? global_width : shard_width);
+//}
+};
+
+//TODO: delete  DeviceAddr page_size = 0 field?
+table DeviceLocalBufferConfig {
+    page_size: uint64 = 0;
+
+    buffer_type: BufferType = DRAM;
+
+    buffer_layout: TensorMemoryLayout = Interleaved;
+
+    // Must be set for sharded buffer layouts.
+    shard_parameters: ShardSpecBuffer;
+
+    // The direction in which memory for this buffer is allocated.
+    bottom_up: BoolOptional;
+};
+
+struct ReplicatedBufferConfig {
+    size: uint64 = 0;
+};
+
+union MeshBufferConfig {
+  ShardedBufferConfig,
+  ReplicatedBufferConfig
+}
+
 struct CBConfigPageSize {
   index: uint32;  // The index in the array
   size: uint32;   // The page-size value for this index

--- a/tt_metal/impl/flatbuffer/buffer_types.fbs
+++ b/tt_metal/impl/flatbuffer/buffer_types.fbs
@@ -51,7 +51,7 @@ table ShardSpecBuffer {
   tensor2d_shape_in_pages_w: uint32;
 }
 
-struct ShardedBufferConfig {
+table ShardedBufferConfig {
     // Note: Only 2D sharding and replication is supported by the APIs exposed through this struct.
     // This interface will likely change over time depending on the status of native ND sharding.
     // Global buffer size. Each device will get a fraction of this size.
@@ -80,7 +80,7 @@ struct ShardedBufferConfig {
 //    const auto [global_height, global_width] = global_buffer_shape;
 //    return Shape2D(shard_height == 0 ? global_height : shard_height, shard_width == 0 ? global_width : shard_width);
 //}
-};
+}
 
 //TODO: delete  DeviceAddr page_size = 0 field?
 table DeviceLocalBufferConfig {
@@ -95,11 +95,11 @@ table DeviceLocalBufferConfig {
 
     // The direction in which memory for this buffer is allocated.
     bottom_up: BoolOptional;
-};
+}
 
 struct ReplicatedBufferConfig {
     size: uint64 = 0;
-};
+}
 
 union MeshBufferConfig {
   ShardedBufferConfig,

--- a/tt_metal/impl/flatbuffer/buffer_types.fbs
+++ b/tt_metal/impl/flatbuffer/buffer_types.fbs
@@ -66,7 +66,7 @@ table ShardedBufferConfig {
     // Orientation of the shards in a mesh.
     shard_orientation: ShardOrientation = RowMajor;
 
-//TODO:
+//TODO: (jjiang) - these probably need to be implemented in lightmetal_capture as helpers along with all the other buffer stuff
 //uint32_t ShardedBufferConfig::compute_datum_size_bytes() const {
 //    return global_size / (global_buffer_shape.height() * global_buffer_shape.width());
 //}
@@ -82,6 +82,8 @@ table ShardedBufferConfig {
 //}
 }
 
+//jjiang:
+//TODO: createmeshbuffer in lightmetal_capture.cpp
 //TODO: delete  DeviceAddr page_size = 0 field?
 table DeviceLocalBufferConfig {
     page_size: uint64 = 0;
@@ -96,11 +98,11 @@ table DeviceLocalBufferConfig {
     // The direction in which memory for this buffer is allocated.
     bottom_up: BoolOptional;
 }
-
+//TODO: (jjiang) - createmeshbuffer in lightmetal_capture.cpp
 struct ReplicatedBufferConfig {
     size: uint64 = 0;
 }
-
+//TODO: (jjiang) - createmeshbuffer in lightmetal_capture.cpp
 union MeshBufferConfig {
   ShardedBufferConfig,
   ReplicatedBufferConfig

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -81,19 +81,19 @@ table MeshBufferCreateCommand {
   mesh_buffer_config: MeshBufferConfig;
   device_local_config: DeviceLocalBufferConfig;
   mesh_device_id: int; // Reference to IDevice of type MeshDevice *mesh_device;
-  address: uint64 //std::optional<DeviceAddr>
+  address: uint64; //std::optional<DeviceAddr>
 }
 
 table MeshWorkloadCreateCommand {
 }
 
-AddProgramToMeshWorkloadCommand {
+table AddProgramToMeshWorkloadCommand {
   mesh_workload_global_id: uint32; // Reference to MeshWorkload
   program_global_id: uint32; // Reference to Program TODO: requires std::move(program) in orig, reference to a reference
   device_range : MeshCoordinateRange;
 }
 
-EnqueueMeshWorkloadCommand {
+table EnqueueMeshWorkloadCommand {
   cq_global_id: uint32; // reference to MeshCommandQueue
   mesh_workload_global_id: uint32; // Reference to MeshWorkload
   blocking: bool;
@@ -135,30 +135,30 @@ table SynchronizeCommand {
 
 table EnqueueReadMeshBufferCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  dst: [Any];
+  dst: [uint32];  // Data to be written. Support only some types for now.
   mesh_global_id: uint32; // Reference to MeshBuffer used as src
   blocking: bool = true;
 }
 
 table EnqueueWriteMeshBufferCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  mesh_global_id: uint32 // Reference to MeshBuffer used as dest
-  src: [Any];
+  mesh_global_id: uint32; // Reference to MeshBuffer used as dest
+  src: [uint32];  // Data to be written. Support only some types for now.
   blocking: bool = false;
 }
 
-void ReadShardCommand {
+table ReadShardCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  dst: [Any];
-  mesh_global_id: uint32 // Reference to MeshBuffer used as src
+  dst: [uint32];  // Data to be written. Support only some types for now.
+  mesh_global_id: uint32; // Reference to MeshBuffer used as src
   coord: MeshCoordinate;
   blocking: bool = true;
 }
 
 table WriteShardCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  mesh_global_id: uint32 // Reference to MeshBuffer used as dest
-  src: [Any];
+  mesh_global_id: uint32; // Reference to MeshBuffer used as dest
+  src: [uint32];  // Data to be written. Support only some types for now.
   coord: MeshCoordinate;
   blocking: bool = false;
 }

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -5,9 +5,21 @@ include "flatbuffer/base_types.fbs";
 
 namespace tt.tt_metal.flatbuffer;
 
+//TODO: in impl, add this to the meshtrace list, it will return a meshtraceid
+table BeginTraceCaptureCommand {
+  mesh_device_id: int;  // Reference to IDevice
+  cq_global_id: uint32; // Reference to MeshCommandQueue of IDevice
+}
+
+table EndTraceCaptureCommand {
+  mesh_device_id: int;  // Reference to IDevice
+  cq_global_id: uint32; // Reference to MeshCommandQueue of IDevice
+  trace_id: uint32;
+}
+
 table ReplayTraceCommand {
-  // TODO (kmabee) - add device.
-  cq_id: int;
+  mesh_device_id: int;  // Reference to IDevice
+  cq_id: int; // Can be regular cq or mesh cq TODO
   tid: int;
   blocking: bool;
 }
@@ -25,7 +37,7 @@ table LoadTraceCommand {
 }
 
 table ReleaseTraceCommand {
-  // TODO (kmabee) - add device.
+  mesh_device_id: int;  // Reference to IDevice
   tid: int; // Pointer to trace data.
 }
 
@@ -63,27 +75,26 @@ table EnqueueReadBufferCommand {
   blocking: bool;
 }
 
-
 //NEW:
 //TODO: check all of these to see which are actually mcq and which can just be cq
 table MeshBufferCreateCommand {
   mesh_buffer_config: MeshBufferConfig;
   device_local_config: DeviceLocalBufferConfig;
   mesh_device_id: int; // Reference to IDevice of type MeshDevice *mesh_device;
-  address: uint64
+  address: uint64 //std::optional<DeviceAddr>
 }
 
 table MeshWorkloadCreateCommand {
-  global_id: uint32;  //Reference to MeshWorkload
 }
 
 AddProgramToMeshWorkloadCommand {
   mesh_workload_global_id: uint32; // Reference to MeshWorkload
-  progprogram_global_id: uint32; // Reference to Program
+  program_global_id: uint32; // Reference to Program TODO: requires std::move(program) in orig, reference to a reference
   device_range : MeshCoordinateRange;
 }
 
 EnqueueMeshWorkloadCommand {
+  cq_global_id: uint32; // reference to MeshCommandQueue
   mesh_workload_global_id: uint32; // Reference to MeshWorkload
   blocking: bool;
 }
@@ -96,19 +107,19 @@ table MeshEvent {
 }
 
 table EnqueueRecordEventCommand {
-  cq_global_id: uint32;       // reference to CommandQueue of type MeshCommandQueue
+  cq_global_id: uint32;       // reference to MeshCommandQueue
   sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id
   device_range: MeshCoordinateRange;
 }
 
 table EnqueueRecordEventToHostCommand {
-  cq_global_id: uint32;       // reference to CommandQueue of type MeshCommandQueue
+  cq_global_id: uint32;       // reference to MeshCommandQueue
   sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id
   device_range: MeshCoordinateRange;
 }
 
 table EnqueueWaitForEventCommand {
-  cq_global_id: uint32;       // reference to CommandQueue of type MeshCommandQueue
+  cq_global_id: uint32;       // reference to MeshCommandQueue
   event: MeshEvent;
 }
 
@@ -116,59 +127,36 @@ table EventSynchronizeCommand {
   event: MeshEvent;
 }
 
-//TODO: in impl, add this to the meshtrace list, it will return a meshtraceid
-table BeginTraceCapture {
-  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-}
-
-table EndTraceCapture {
-  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  trace_id: uint32;
-}
-
-table ReplayTrace {
-  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  trace_id: uint32;
-  blocking: bool;
-}
-
-table ReleaseTrace {
-  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
-  trace_id: uint32;
-}
-
-table Synchronize {
-  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
+table SynchronizeCommand {
+  mesh_device_id: int;  // Reference to IDevice
+  cq_global_id: uint32; // reference to CommandQueue
   sub_device_ids: [ubyte];
 }
 
-table EnqueueReadMeshBuffer {
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+table EnqueueReadMeshBufferCommand {
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
   dst: [Any];
   mesh_global_id: uint32; // Reference to MeshBuffer used as src
   blocking: bool = true;
 }
 
-table EnqueueWriteMeshBuffer {
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+table EnqueueWriteMeshBufferCommand {
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
   mesh_global_id: uint32 // Reference to MeshBuffer used as dest
   src: [Any];
   blocking: bool = false;
 }
 
-void ReadShard(
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+void ReadShardCommand {
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
   dst: [Any];
   mesh_global_id: uint32 // Reference to MeshBuffer used as src
   coord: MeshCoordinate;
   blocking: bool = true;
+}
 
-table WriteShard {
-  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+table WriteShardCommand {
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
   mesh_global_id: uint32 // Reference to MeshBuffer used as dest
   src: [Any];
   coord: MeshCoordinate;
@@ -177,7 +165,7 @@ table WriteShard {
 //ENDNEW
 
 table FinishCommand {
-  cq_global_id: uint32;       // reference to CommandQueue
+  cq_global_id: uint32;       // reference to CommandQueue or MeshCommandQueue
   sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id
 }
 
@@ -234,15 +222,30 @@ table LightMetalCompareCommand {
 }
 
 union CommandType {
+  BeginTraceCaptureCommand,
+  EndTraceCaptureCommand,
   ReplayTraceCommand,
   EnqueueTraceCommand,
   LoadTraceCommand,
   ReleaseTraceCommand,
+  EnqueueRecordEventCommand,
+  EnqueueRecordEventToHostCommand,
+  EnqueueWaitForEventCommand,
+  EventSynchronizeCommand,
+  SynchronizeCommand,
   BufferCreateCommand,
   BufferDeallocateCommand,
   BufferDeleteCommand,
   EnqueueWriteBufferCommand,
   EnqueueReadBufferCommand,
+  MeshBufferCreateCommand,
+  MeshWorkloadCreateCommand,
+  AddProgramToMeshWorkloadCommand,
+  EnqueueMeshWorkloadCommand,
+  EnqueueReadMeshBufferCommand,
+  EnqueueWriteMeshBufferCommand,
+  ReadShardCommand,
+  WriteShardCommand
   FinishCommand,
   ProgramConstructorCommand,
   EnqueueProgramCommand,

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -5,21 +5,26 @@ include "flatbuffer/base_types.fbs";
 
 namespace tt.tt_metal.flatbuffer;
 
-//TODO: in impl, add this to the meshtrace list, it will return a meshtraceid
+//TODO: (jjiang) - in tt-metal/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp,
+//TODO: add this to the global_id list and make it return a traceId object in lightmetal_capture.cpp
+//TODO: add the capture in lightmetal_capture.cpp
 table BeginTraceCaptureCommand {
-  mesh_device_id: int;  // Reference to IDevice
-  cq_global_id: uint32; // Reference to MeshCommandQueue of IDevice
+  mesh_device_id: int;  // Reference to IDevice of type MeshDevice
+  mesh_cq_global_id: uint32; // Reference to MeshCommandQueue of IDevice
 }
 
+//TODO: (jjiang) - in tt-metal/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp,
+//TODO: remove the traceid from the global_id list and make it take a traceId object in lightmetal_cpature.cpp and act accordingly
+//TODO: add the capture in lightmetal_capture.cpp
 table EndTraceCaptureCommand {
-  mesh_device_id: int;  // Reference to IDevice
-  cq_global_id: uint32; // Reference to MeshCommandQueue of IDevice
+  mesh_device_id: int;  // Reference to IDevice of type MeshDevice
+  mesh_cq_global_id: uint32; // Reference to MeshCommandQueue of IDevice
   trace_id: uint32;
 }
 
 table ReplayTraceCommand {
-  mesh_device_id: int;  // Reference to IDevice
-  cq_id: int; // Can be regular cq or mesh cq TODO
+  device_id: int;  // Reference to IDevice
+  cq_id: int; // Can be regular cq or mesh cq
   tid: int;
   blocking: bool;
 }
@@ -75,8 +80,9 @@ table EnqueueReadBufferCommand {
   blocking: bool;
 }
 
-//NEW:
-//TODO: check all of these to see which are actually mcq and which can just be cq
+//TODO START NEW (jjiang): Interim constructs, potentially will be changed as they're implemented
+//basically none of these have been added to capture.cpp or replay_impl.cpp yet, but the
+//translation tables necessary for tracking have been added to
 table MeshBufferCreateCommand {
   mesh_buffer_config: MeshBufferConfig;
   device_local_config: DeviceLocalBufferConfig;
@@ -94,11 +100,13 @@ table AddProgramToMeshWorkloadCommand {
 }
 
 table EnqueueMeshWorkloadCommand {
-  cq_global_id: uint32; // reference to MeshCommandQueue
+  mesh_cq_id: uint32; // reference to MeshCommandQueue
   mesh_workload_global_id: uint32; // Reference to MeshWorkload
   blocking: bool;
 }
 
+//TODO: (jjiang) - this is just a data structure, offsets need to be calculated and it probably needs to be
+//hand serialized like the existing data structures; should be similar though
 table MeshEvent {
   id: uint32 = 0;
   mesh_device_id: int; // Reference to IDevice of type MeshDevice *mesh_device;
@@ -107,13 +115,13 @@ table MeshEvent {
 }
 
 table EnqueueRecordEventCommand {
-  cq_global_id: uint32;       // reference to MeshCommandQueue
+  mesh_cq_id: uint32;       // reference to MeshCommandQueue
   sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id
   device_range: MeshCoordinateRange;
 }
 
 table EnqueueRecordEventToHostCommand {
-  cq_global_id: uint32;       // reference to MeshCommandQueue
+  mesh_cq_id: uint32;       // reference to MeshCommandQueue
   sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id
   device_range: MeshCoordinateRange;
 }
@@ -136,13 +144,13 @@ table SynchronizeCommand {
 table EnqueueReadMeshBufferCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
   dst: [uint32];  // Data to be written. Support only some types for now.
-  mesh_global_id: uint32; // Reference to MeshBuffer used as src
+  mesh_buffer_global_id: uint32; // Reference to MeshBuffer used as src
   blocking: bool = true;
 }
 
 table EnqueueWriteMeshBufferCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  mesh_global_id: uint32; // Reference to MeshBuffer used as dest
+  mesh_buffer_global_id: uint32; // Reference to MeshBuffer used as dest
   src: [uint32];  // Data to be written. Support only some types for now.
   blocking: bool = false;
 }
@@ -150,19 +158,19 @@ table EnqueueWriteMeshBufferCommand {
 table ReadShardCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
   dst: [uint32];  // Data to be written. Support only some types for now.
-  mesh_global_id: uint32; // Reference to MeshBuffer used as src
+  mesh_buffer_global_id: uint32; // Reference to MeshBuffer used as src
   coord: MeshCoordinate;
   blocking: bool = true;
 }
 
 table WriteShardCommand {
   cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
-  mesh_global_id: uint32; // Reference to MeshBuffer used as dest
+  mesh_buffer_global_id: uint32; // Reference to MeshBuffer used as dest
   src: [uint32];  // Data to be written. Support only some types for now.
   coord: MeshCoordinate;
   blocking: bool = false;
 }
-//ENDNEW
+//TODO END (jjiang)
 
 table FinishCommand {
   cq_global_id: uint32;       // reference to CommandQueue or MeshCommandQueue

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -63,6 +63,119 @@ table EnqueueReadBufferCommand {
   blocking: bool;
 }
 
+
+//NEW:
+//TODO: check all of these to see which are actually mcq and which can just be cq
+table MeshBufferCreateCommand {
+  mesh_buffer_config: MeshBufferConfig;
+  device_local_config: DeviceLocalBufferConfig;
+  mesh_device_id: int; // Reference to IDevice of type MeshDevice *mesh_device;
+  address: uint64
+}
+
+table MeshWorkloadCreateCommand {
+  global_id: uint32;  //Reference to MeshWorkload
+}
+
+AddProgramToMeshWorkloadCommand {
+  mesh_workload_global_id: uint32; // Reference to MeshWorkload
+  progprogram_global_id: uint32; // Reference to Program
+  device_range : MeshCoordinateRange;
+}
+
+EnqueueMeshWorkloadCommand {
+  mesh_workload_global_id: uint32; // Reference to MeshWorkload
+  blocking: bool;
+}
+
+table MeshEvent {
+  id: uint32 = 0;
+  mesh_device_id: int; // Reference to IDevice of type MeshDevice *mesh_device;
+  mesh_cq_id: uint32 = 0;
+  device_range: MeshCoordinateRange;
+}
+
+table EnqueueRecordEventCommand {
+  cq_global_id: uint32;       // reference to CommandQueue of type MeshCommandQueue
+  sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id
+  device_range: MeshCoordinateRange;
+}
+
+table EnqueueRecordEventToHostCommand {
+  cq_global_id: uint32;       // reference to CommandQueue of type MeshCommandQueue
+  sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id
+  device_range: MeshCoordinateRange;
+}
+
+table EnqueueWaitForEventCommand {
+  cq_global_id: uint32;       // reference to CommandQueue of type MeshCommandQueue
+  event: MeshEvent;
+}
+
+table EventSynchronizeCommand {
+  event: MeshEvent;
+}
+
+//TODO: in impl, add this to the meshtrace list, it will return a meshtraceid
+table BeginTraceCapture {
+  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
+}
+
+table EndTraceCapture {
+  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
+  trace_id: uint32;
+}
+
+table ReplayTrace {
+  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
+  trace_id: uint32;
+  blocking: bool;
+}
+
+table ReleaseTrace {
+  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
+  trace_id: uint32;
+}
+
+table Synchronize {
+  mesh_device_id: int;  // Reference to IDevice of type MeshDevice *mesh_device;
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue
+  sub_device_ids: [ubyte];
+}
+
+table EnqueueReadMeshBuffer {
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+  dst: [Any];
+  mesh_global_id: uint32; // Reference to MeshBuffer used as src
+  blocking: bool = true;
+}
+
+table EnqueueWriteMeshBuffer {
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+  mesh_global_id: uint32 // Reference to MeshBuffer used as dest
+  src: [Any];
+  blocking: bool = false;
+}
+
+void ReadShard(
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+  dst: [Any];
+  mesh_global_id: uint32 // Reference to MeshBuffer used as src
+  coord: MeshCoordinate;
+  blocking: bool = true;
+
+table WriteShard {
+  cq_global_id: uint32; // reference to CommandQueue of type MeshCommandQueue TODO: legit mcq
+  mesh_global_id: uint32 // Reference to MeshBuffer used as dest
+  src: [Any];
+  coord: MeshCoordinate;
+  blocking: bool = false;
+}
+//ENDNEW
+
 table FinishCommand {
   cq_global_id: uint32;       // reference to CommandQueue
   sub_device_ids: [ubyte];    // array of uint8 values representing SubDeviceId::Id

--- a/tt_metal/impl/flatbuffer/command.fbs
+++ b/tt_metal/impl/flatbuffer/command.fbs
@@ -245,7 +245,7 @@ union CommandType {
   EnqueueReadMeshBufferCommand,
   EnqueueWriteMeshBufferCommand,
   ReadShardCommand,
-  WriteShardCommand
+  WriteShardCommand,
   FinishCommand,
   ProgramConstructorCommand,
   EnqueueProgramCommand,

--- a/tt_metal/impl/flatbuffer/program_types.fbs
+++ b/tt_metal/impl/flatbuffer/program_types.fbs
@@ -2,12 +2,14 @@ include "flatbuffer/base_types.fbs";
 
 namespace tt.tt_metal.flatbuffer;
 
+//TODO: (jjiang) - data structure that probably needs to be hand serialized
 table MeshCoordinate {
   x: int;
   y: int;
   z: int = -127; //Set default to -127 so if no coordinate passed, coords including z will error out
 }
 
+//TODO: (jjiang) - data structure that probably needs to be hand serialized
 table MeshCoordinateRange {
   start: MeshCoordinate;
   end: MeshCoordinate;

--- a/tt_metal/impl/flatbuffer/program_types.fbs
+++ b/tt_metal/impl/flatbuffer/program_types.fbs
@@ -2,6 +2,17 @@ include "flatbuffer/base_types.fbs";
 
 namespace tt.tt_metal.flatbuffer;
 
+table MeshCoordinate {
+  x: int;
+  y: int;
+  z: int = -127; //Set default to -127 so if no coordinate passed, coords including z will error out
+}
+
+table MeshCoordinateRange {
+  start: MeshCoordinate;
+  end: MeshCoordinate;
+}
+
 table CoreCoord {
   x: int;
   y: int;

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -63,6 +63,8 @@ void CaptureCommand(tt::tt_metal::flatbuffer::CommandType cmd_type, ::flatbuffer
 }
 }  // namespace
 
+// TODO: (jjiang) Add new captures for mesh
+
 void CaptureReplayTrace(IDevice* /*device*/, uint8_t cq_id, uint32_t trace_id, bool blocking) {
     auto& ctx = LightMetalCaptureContext::get();
     log_debug(tt::LogMetalTrace, "{}: cq_id: {} trace_id: {} blocking: {}", __FUNCTION__, cq_id, trace_id, blocking);
@@ -90,6 +92,8 @@ void CaptureReleaseTrace(IDevice* /*device*/, uint32_t trace_id) {
     auto cmd = tt::tt_metal::flatbuffer::CreateReleaseTraceCommand(ctx.get_builder(), trace_id);
     CaptureCommand(tt::tt_metal::flatbuffer::CommandType::ReleaseTraceCommand, cmd.Union());
 }
+
+// TODO: (jjiang) Add new mesh apis
 
 void CaptureBufferCreate(
     const std::shared_ptr<Buffer>& buffer,

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "flatbuffers/flatbuffers.h"
+#include "host_api.hpp"
 #include "lightmetal/lightmetal_capture.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt_stl/span.hpp>
@@ -69,6 +70,11 @@ struct TraceScope {
 namespace tt::tt_metal {
 
 // Per Command type capture helper functions
+// TODO
+void CaptureBeginTraceCapture(IDevice* device, uint8_t cq_id);
+// TODO
+void CaptureEndTraceCapture(IDevice* device, uint8_t cq_id, uint32_t tid);
+
 void CaptureReplayTrace(IDevice* device, uint8_t cq_id, uint32_t tid, bool blocking);
 
 void CaptureEnqueueTrace(CommandQueue& cq, uint32_t tid, bool blocking);
@@ -91,6 +97,37 @@ void CaptureBufferCreate(
 
 void CaptureBufferDeallocate(const Buffer& buffer);
 void CaptureBufferDelete(const Buffer& buffer);
+
+// TODO START
+void CaptureMeshWorkloadCreate();
+
+void CaptureAddProgramToMeshWorkload(
+    MeshWorkload& mesh_workload, Program&& program, const MeshCoordinateRange& device_range);
+
+void CaptureEnqueueMeshWorkload(
+    CommandQueue& cq,
+    MeshWorkload& mesh_workload,
+    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
+    const std::variant<DataMovementConfig, ComputeConfig, EthernetConfig>& config);
+
+void CaptureEnqueueRecordEvent();
+
+void CaptureEnqueueRecordEventToHost();
+
+void CaptureEnqueueWaitForEvent();
+
+void CaptureEventSynchronize();
+
+void CaptureSynchronize();
+
+void CaptureEnqueueReadMeshBuffer();
+
+void CaptureEnqueueWriteMeshBuffer();
+
+void CaptureEnqueueReadShard();
+
+void CaptureEnqueueWriteShard();
+// END TODO
 
 void CaptureEnqueueWriteBuffer(
     CommandQueue& cq,

--- a/tt_metal/impl/lightmetal/lightmetal_capture.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.cpp
@@ -186,9 +186,13 @@ uint32_t LightMetalCaptureContext::get_global_id(const CBHandle handle) {
     }
 }
 
+// TODO: add new mesh objects
+
 ////////////////////////////////////////////
 // Non-Class Helper Functions             //
 ////////////////////////////////////////////
+
+// TODO: (jjiang) - may need to specially to_flatbuffer the mesh_event, mesh_coord, mesh_coordrange as well
 
 // Serialize tt-metal traceDescriptor and trace_id to flatbuffer format.
 TraceDescriptorByTraceIdOffset to_flatbuffer(

--- a/tt_metal/impl/lightmetal/lightmetal_capture.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.hpp
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 #include <memory>
 #include <flatbuffers/flatbuffers.h>
 #include <lightmetal_binary.hpp>
+#include <tt-metalium/mesh_workload.hpp>
 
 // Forward decl for command_generated.h
 namespace tt::tt_metal::flatbuffer {
@@ -82,9 +84,9 @@ private:
     // TODO (kmabee) - consider adding map for CommandQueue object.
 
     // TODO: fix this
-
+    std::unordered_map<uint64_t, uint32_t> mesh_trace_id_to_global_id_map_;
     std::unordered_map<uint64_t, uint32_t> mesh_buffer_id_to_global_id_map_;
-    std::unordered_map<MeshWorkload, uint32_t> mesh_workload_to_global_id_map_;
+    std::unordered_map<distributed::MeshWorkload, uint32_t> mesh_workload_to_global_id_map_;
 
     LightMetalCaptureContext(const LightMetalCaptureContext&) = delete;
     LightMetalCaptureContext& operator=(const LightMetalCaptureContext&) = delete;

--- a/tt_metal/impl/lightmetal/lightmetal_capture.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.hpp
@@ -81,6 +81,11 @@ private:
     std::unordered_map<CBHandle, uint32_t> cb_handle_to_global_id_map_;
     // TODO (kmabee) - consider adding map for CommandQueue object.
 
+    // TODO: fix this
+
+    std::unordered_map<uint64_t, uint32_t> mesh_buffer_id_to_global_id_map_;
+    std::unordered_map<MeshWorkload, uint32_t> mesh_workload_to_global_id_map_;
+
     LightMetalCaptureContext(const LightMetalCaptureContext&) = delete;
     LightMetalCaptureContext& operator=(const LightMetalCaptureContext&) = delete;
 };

--- a/tt_metal/impl/lightmetal/lightmetal_capture.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_capture.hpp
@@ -10,6 +10,8 @@
 #include <flatbuffers/flatbuffers.h>
 #include <lightmetal_binary.hpp>
 #include <tt-metalium/mesh_workload.hpp>
+#include "mesh_buffer.hpp"
+#include "mesh_trace_id.hpp"
 
 // Forward decl for command_generated.h
 namespace tt::tt_metal::flatbuffer {
@@ -65,6 +67,19 @@ public:
     uint32_t add_to_map(const CBHandle handle);
     void remove_from_map(const CBHandle handle);
     uint32_t get_global_id(const CBHandle handle);
+    // TODO: to be implemented, require translations between these objects and the backing schema
+    bool is_in_map(const distributed::MeshTraceId id);
+    uint32_t add_to_map(const distributed::MeshTraceId id);
+    void remove_from_map(const distributed::MeshTraceId id);
+    uint32_t get_global_id(const distributed::MeshTraceId id);
+    bool is_in_map(const distributed::MeshBuffer obj);
+    uint32_t add_to_map(const distributed::MeshBuffer obj);
+    void remove_from_map(const distributed::MeshBuffer obj);
+    uint32_t get_global_id(const distributed::MeshBuffer obj);
+    bool is_in_map(const distributed::MeshWorkload id);
+    uint32_t add_to_map(const distributed::MeshWorkload id);
+    void remove_from_map(const distributed::MeshWorkload id);
+    uint32_t get_global_id(const distributed::MeshWorkload id);
 
 private:
     LightMetalCaptureContext();  // Private constructor
@@ -83,9 +98,12 @@ private:
     std::unordered_map<CBHandle, uint32_t> cb_handle_to_global_id_map_;
     // TODO (kmabee) - consider adding map for CommandQueue object.
 
-    // TODO: fix this
+    // TODO: (jjiang) - for tracing programs, calling begintrace will populate this and traceids will be tracked through
+    // it
     std::unordered_map<uint64_t, uint32_t> mesh_trace_id_to_global_id_map_;
+    // TODO: (jjiang) - for meshbuffers, calling createmeshbuffer (TBD) will populate this
     std::unordered_map<uint64_t, uint32_t> mesh_buffer_id_to_global_id_map_;
+    // TODO: (jjiang) - for mesh workload, calling createmeshworkload will populate this
     std::unordered_map<distributed::MeshWorkload, uint32_t> mesh_workload_to_global_id_map_;
 
     LightMetalCaptureContext(const LightMetalCaptureContext&) = delete;

--- a/tt_metal/impl/lightmetal/lightmetal_replay.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay.cpp
@@ -13,6 +13,8 @@ namespace tt::tt_metal {
 LightMetalReplay::LightMetalReplay(LightMetalBinary&& binary, IDevice* device) :
     pimpl_(std::make_unique<detail::LightMetalReplayImpl>(std::move(binary), device)) {}
 
+// TODO: enforce meshdevice checks
+
 LightMetalReplay::~LightMetalReplay() = default;
 
 LightMetalReplay::LightMetalReplay(LightMetalReplay&&) noexcept = default;

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -5,6 +5,7 @@
 #include "lightmetal_replay_impl.hpp"
 
 #include <iostream>
+#include "distributed.hpp"
 #include "light_metal_binary_generated.h"
 #include "command_generated.h"
 #include <trace_buffer.hpp>
@@ -19,6 +20,8 @@
 #include "flatbuffer/base_types_from_flatbuffer.hpp"
 #include "flatbuffer/program_types_from_flatbuffer.hpp"
 #include "flatbuffer/buffer_types_from_flatbuffer.hpp"
+#include "mesh_device.hpp"
+#include "mesh_trace_id.hpp"
 
 namespace tt::tt_metal {
 
@@ -289,10 +292,12 @@ void LightMetalReplayImpl::clear_object_maps() {
 // execute a command by dispatching to appropriate handler based on type.
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* command) {
     switch (command->cmd_type()) {
+        // TODO: (jjiang) - finish
         case ::tt::tt_metal::flatbuffer::CommandType::BeginTraceCaptureCommand: {
             execute(command->cmd_as_LightMetalCompareCommand());
             break;
         }
+        // TODO: (jjiang) - finish
         case ::tt::tt_metal::flatbuffer::CommandType::EndTraceCaptureCommand: {
             execute(command->cmd_as_EndTraceCaptureCommand());
             break;
@@ -301,6 +306,7 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
             execute(command->cmd_as_EnqueueTraceCommand());
             break;
         }
+        // TODO: (jjiang) - check compatability
         case ::tt::tt_metal::flatbuffer::CommandType::ReplayTraceCommand: {
             execute(command->cmd_as_ReplayTraceCommand());
             break;
@@ -309,48 +315,79 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
             execute(command->cmd_as_LoadTraceCommand());
             break;
         }
+        // TODO: (jjiang) - check compatability
         case ::tt::tt_metal::flatbuffer::CommandType::ReleaseTraceCommand: {
             execute(command->cmd_as_ReleaseTraceCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::EnqueueRecordEventCommand: {
             execute(command->cmd_as_EnqueueRecordEventCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::EnqueueRecordEventToHostCommand: {
             execute(command->cmd_as_EnqueueRecordEventToHostCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::EnqueueWaitForEventCommand: {
             execute(command->cmd_as_EnqueueWaitForEventCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::EventSynchronizeCommand: {
             execute(command->cmd_as_EventSynchronizeCommand());
             break;
         }
+        // TODO: (jjiang) - maybe implement?
         case ::tt::tt_metal::flatbuffer::CommandType::SynchronizeCommand: {
             execute(command->cmd_as_SynchronizeCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::EnqueueMeshWorkloadCommand: {
             execute(command->cmd_as_EnqueueMeshWorkloadCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::EnqueueReadMeshBufferCommand: {
             execute(command->cmd_as_EnqueueReadMeshBufferCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::EnqueueWriteMeshBufferCommand: {
             execute(command->cmd_as_EnqueueWriteMeshBufferCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::ReadShardCommand: {
             execute(command->cmd_as_ReadShardCommand());
             break;
         }
+        // TODO: (jjiang) - implement
         case ::tt::tt_metal::flatbuffer::CommandType::WriteShardCommand: {
             execute(command->cmd_as_WriteShardCommand());
+            break;
+        }
+        // TODO: (jjiang) - implement
+        case ::tt::tt_metal::flatbuffer::CommandType::MeshWorkloadCreateCommand: {
+            execute(command->cmd_as_MeshBufferCreateCommand());
+            break;
+        }
+        // TODO: (jjiang) - implement
+        case ::tt::tt_metal::flatbuffer::CommandType::AddProgramToMeshWorkloadCommand: {
+            execute(command->cmd_as_AddProgramToMeshWorkloadCommand());
+            break;
+        }
+        // TODO: (jjiang) - implement
+        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueMeshWorkloadCommand: {
+            execute(command->cmd_as_EnqueueMeshWorkloadCommand());
+            break;
+        }
+        // TODO: (jjiang) - implement
+        case ::tt::tt_metal::flatbuffer::CommandType::MeshBufferCreateCommand: {
+            execute(command->cmd_as_EnqueueReadBufferCommand());
             break;
         }
         case ::tt::tt_metal::flatbuffer::CommandType::BufferCreateCommand: {
@@ -416,6 +453,20 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
 }
 
 // Per API command handlers.
+void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::BeginTraceCaptureCommand* cmd) {
+    log_debug(
+        tt::LogMetalTrace,
+        "LightMetalReplay(BeginTraceCapture) cq_id: {}",
+        dynamic_cast<distributed::MeshDevice*>(device_)->mesh_command_queue(cmd->cq_global_id()));
+    distributed::MeshTraceId trace_id = tt::tt_metal::distributed::BeginTraceCapture(device_, cmd->cq_global_id());
+    this->mesh_trace_ids_.push_back(trace_id);
+};
+
+void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::EndTraceCaptureCommand* cmd) {
+    log_debug(tt::LogMetalTrace, "LightMetalReplay(EndTraceCapture) cq_id: {}", cmd->cq_global_id());
+    tt::tt_metal::distributed::EndTraceCapture(
+        device_, cmd->cq_global_id(), get_mesh_trace_by_id(cmd->trace_id()));  // use getter from map
+}
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::EnqueueTraceCommand* cmd) {
     log_debug(
         tt::LogMetalTrace,

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -289,6 +289,14 @@ void LightMetalReplayImpl::clear_object_maps() {
 // execute a command by dispatching to appropriate handler based on type.
 void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* command) {
     switch (command->cmd_type()) {
+        case ::tt::tt_metal::flatbuffer::CommandType::BeginTraceCaptureCommand: {
+            execute(command->cmd_as_LightMetalCompareCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EndTraceCaptureCommand: {
+            execute(command->cmd_as_EndTraceCaptureCommand());
+            break;
+        }
         case ::tt::tt_metal::flatbuffer::CommandType::EnqueueTraceCommand: {
             execute(command->cmd_as_EnqueueTraceCommand());
             break;
@@ -303,6 +311,46 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::Command* comm
         }
         case ::tt::tt_metal::flatbuffer::CommandType::ReleaseTraceCommand: {
             execute(command->cmd_as_ReleaseTraceCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueRecordEventCommand: {
+            execute(command->cmd_as_EnqueueRecordEventCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueRecordEventToHostCommand: {
+            execute(command->cmd_as_EnqueueRecordEventToHostCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueWaitForEventCommand: {
+            execute(command->cmd_as_EnqueueWaitForEventCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EventSynchronizeCommand: {
+            execute(command->cmd_as_EventSynchronizeCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::SynchronizeCommand: {
+            execute(command->cmd_as_SynchronizeCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueMeshWorkloadCommand: {
+            execute(command->cmd_as_EnqueueMeshWorkloadCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueReadMeshBufferCommand: {
+            execute(command->cmd_as_EnqueueReadMeshBufferCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::EnqueueWriteMeshBufferCommand: {
+            execute(command->cmd_as_EnqueueWriteMeshBufferCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::ReadShardCommand: {
+            execute(command->cmd_as_ReadShardCommand());
+            break;
+        }
+        case ::tt::tt_metal::flatbuffer::CommandType::WriteShardCommand: {
+            execute(command->cmd_as_WriteShardCommand());
             break;
         }
         case ::tt::tt_metal::flatbuffer::CommandType::BufferCreateCommand: {

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -114,7 +114,7 @@ public:
     void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsCommand* command);
     void execute(const tt::tt_metal::flatbuffer::CreateCircularBufferCommand* command);
     void execute(const tt::tt_metal::flatbuffer::LightMetalCompareCommand* command);
-    void execute(const tt::tt_metal::flatbuffer::* command);
+
     // Object maps public accessors
     void add_buffer_to_map(uint32_t global_id, const std::shared_ptr<::tt::tt_metal::Buffer>& buffer);
     std::shared_ptr<::tt::tt_metal::Buffer> get_buffer_from_map(uint32_t global_id) const;
@@ -166,8 +166,6 @@ private:
     tt::tt_metal::IDevice* device_ = nullptr;
 
     // Object maps for storing objects by global_id
-
-    std::vector<distributed::MeshTraceId> trace_id;
     std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>> mesh_buffer_map_;
     std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshWorkload>> mesh_workload_map_;
     std::unordered_map<uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>> buffer_map_;

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -22,15 +22,30 @@ class TraceDescriptor;
 // Forward decl for command_generated.h / light_metal_binary_generated.h
 namespace tt::tt_metal::flatbuffer {
 struct Command;
+struct BeginTraceCaptureCommand;
+struct EndTraceCaptureCommand;
 struct ReplayTraceCommand;
 struct EnqueueTraceCommand;
 struct LoadTraceCommand;
 struct ReleaseTraceCommand;
+struct EnqueueRecordEventCommand;
+struct EnqueueRecordEventToHostCommand;
+struct EnqueueWaitForEventCommand;
+struct EventSynchronizeCommand;
+struct SynchronizeCommand;
 struct BufferCreateCommand;
 struct BufferDeallocateCommand;
 struct BufferDeleteCommand;
 struct EnqueueWriteBufferCommand;
 struct EnqueueReadBufferCommand;
+struct MeshBufferCreateCommand;
+struct MeshWorkloadCreateCommand;
+struct AddProgramToMeshWorkloadCommand;
+struct EnqueueMeshWorkloadCommand;
+struct EnqueueReadMeshBufferCommand;
+struct EnqueueWriteMeshBufferCommand;
+struct ReadShardCommand;
+struct WriteShardCommand;
 struct FinishCommand;
 struct ProgramConstructorCommand;
 struct EnqueueProgramCommand;
@@ -41,6 +56,8 @@ struct SetRuntimeArgsCommand;
 struct CreateCircularBufferCommand;
 struct LightMetalCompareCommand;
 struct RuntimeArg;
+
+struct MeshEvent;
 
 struct TraceDescriptor;
 struct TraceDescriptorByTraceId;
@@ -64,25 +81,40 @@ public:
 
     // Executor functions for all traced host API calls (commands)
     void execute(const tt::tt_metal::flatbuffer::Command* command);
-    void execute(const tt::tt_metal::flatbuffer::EnqueueTraceCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::BeginTraceCaptureCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EndTraceCaptureCommand* command);
     void execute(const tt::tt_metal::flatbuffer::ReplayTraceCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EnqueueTraceCommand* command);
     void execute(const tt::tt_metal::flatbuffer::LoadTraceCommand* command);
     void execute(const tt::tt_metal::flatbuffer::ReleaseTraceCommand* command);
-    void execute(const tt::tt_metal::flatbuffer::BufferCreateCommand* cmd);
+    void execute(const tt::tt_metal::flatbuffer::EnqueueRecordEventCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EnqueueRecordEventToHostCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EnqueueWaitForEventCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EventSynchronizeCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::SynchronizeCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::BufferCreateCommand* command);
     void execute(const tt::tt_metal::flatbuffer::BufferDeallocateCommand* command);
     void execute(const tt::tt_metal::flatbuffer::BufferDeleteCommand* command);
     void execute(const tt::tt_metal::flatbuffer::EnqueueWriteBufferCommand* command);
     void execute(const tt::tt_metal::flatbuffer::EnqueueReadBufferCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::MeshBufferCreateCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::MeshWorkloadCreateCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::AddProgramToMeshWorkloadCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EnqueueMeshWorkloadCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EnqueueReadMeshBufferCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::EnqueueWriteMeshBufferCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::ReadShardCommand* command);
+    void execute(const tt::tt_metal::flatbuffer::WriteShardCommand* command);
     void execute(const tt::tt_metal::flatbuffer::FinishCommand* command);
     void execute(const tt::tt_metal::flatbuffer::ProgramConstructorCommand* command);
     void execute(const tt::tt_metal::flatbuffer::EnqueueProgramCommand* command);
     void execute(const tt::tt_metal::flatbuffer::CreateKernelCommand* command);
     void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsUint32Command* command);
-    void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsUint32VecPerCoreCommand* cmd);
+    void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsUint32VecPerCoreCommand* command);
     void execute(const tt::tt_metal::flatbuffer::SetRuntimeArgsCommand* command);
     void execute(const tt::tt_metal::flatbuffer::CreateCircularBufferCommand* command);
     void execute(const tt::tt_metal::flatbuffer::LightMetalCompareCommand* command);
-
+    void execute(const tt::tt_metal::flatbuffer::* command);
     // Object maps public accessors
     void add_buffer_to_map(uint32_t global_id, const std::shared_ptr<::tt::tt_metal::Buffer>& buffer);
     std::shared_ptr<::tt::tt_metal::Buffer> get_buffer_from_map(uint32_t global_id) const;

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -12,6 +12,8 @@
 
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 
 namespace tt::tt_metal {
 class TraceDescriptor;
@@ -102,6 +104,11 @@ public:
     ::tt::tt_metal::CBHandle get_cb_handle_from_map(uint32_t global_id) const;
     void remove_cb_handle_from_map(uint32_t global_id);
 
+    void add_mesh_workload_to_map(
+        uint32_t global_id, const std::shared_ptr<::tt::tt_metal::MeshWorkload>& meshworkload);
+    std::shared_ptr<::tt::tt_metal::MeshWorkload> get_mesh_workload_from_map(uint32_t global_id) const;
+    void remove_mesh_workload_from_map(uint32_t global_id);
+
     // Return the TraceDescriptor for a given trace_id from flatbuffer.
     std::optional<TraceDescriptor> get_trace_by_id(uint32_t target_trace_id);
 
@@ -127,6 +134,10 @@ private:
     tt::tt_metal::IDevice* device_ = nullptr;
 
     // Object maps for storing objects by global_id
+
+    std::vector<distributed::MeshTraceId> trace_id;
+    std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>> mesh_buffer_map_;
+    std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshWorkload>> mesh_workload_map_;
     std::unordered_map<uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>> buffer_map_;
     std::unordered_map<uint32_t, std::shared_ptr<::tt::tt_metal::Program>> program_map_;
     std::unordered_map<uint32_t, tt::tt_metal::KernelHandle> kernel_handle_map_;

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -166,9 +166,11 @@ private:
     tt::tt_metal::IDevice* device_ = nullptr;
 
     // Object maps for storing objects by global_id
+    // TODO: (jjiang) - Access these with the translation tables from capture, use them in impl
     std::unordered_map<uint32_t, tt::tt_metal::distributed::MeshTraceId> mesh_trace_ids_;
     std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>> mesh_buffer_map_;
     std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshWorkload>> mesh_workload_map_;
+
     std::unordered_map<uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>> buffer_map_;
     std::unordered_map<uint32_t, std::shared_ptr<::tt::tt_metal::Program>> program_map_;
     std::unordered_map<uint32_t, tt::tt_metal::KernelHandle> kernel_handle_map_;

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -137,9 +137,8 @@ public:
     ::tt::tt_metal::CBHandle get_cb_handle_from_map(uint32_t global_id) const;
     void remove_cb_handle_from_map(uint32_t global_id);
 
-    void add_mesh_workload_to_map(
-        uint32_t global_id, const std::shared_ptr<::tt::tt_metal::MeshWorkload>& meshworkload);
-    std::shared_ptr<::tt::tt_metal::MeshWorkload> get_mesh_workload_from_map(uint32_t global_id) const;
+    void add_mesh_workload_to_map(uint32_t global_id, const std::shared_ptr<distributed::MeshWorkload>& meshworkload);
+    std::shared_ptr<distributed::MeshWorkload> get_mesh_workload_from_map(uint32_t global_id) const;
     void remove_mesh_workload_from_map(uint32_t global_id);
 
     // Return the TraceDescriptor for a given trace_id from flatbuffer.

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <flatbuffers/flatbuffers.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <optional>
@@ -166,6 +167,7 @@ private:
     tt::tt_metal::IDevice* device_ = nullptr;
 
     // Object maps for storing objects by global_id
+    std::unordered_map<uint32_t, tt::tt_metal::distributed::MeshTraceId> mesh_trace_ids_;
     std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>> mesh_buffer_map_;
     std::unordered_map<uint32_t, std::shared_ptr<tt::tt_metal::distributed::MeshWorkload>> mesh_workload_map_;
     std::unordered_map<uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>> buffer_map_;


### PR DESCRIPTION
### Problem description
Most classes in host-api.cpp currently come with lightmetalcapture serialization. The distributed.cpp classes don't include this functionality yet though. 

### What's changed
Add flatbuffer schema for the distributed objects and expand the lightmetal serialization to include tt-metal apis. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes