### PR TITLE
#15061: Rationalize from_torch

### DIFF
--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -302,6 +302,7 @@ def from_torch(
         tensor = ttnn.to_torch(tensor)
 
     tensor_creation_args = [tensor, dtype]
+    # TODO: Try calling the ttnn sharding path directly and the tilize directly removing the need to reformat after tilizing bfb
     if mesh_mapper:
         shards = mesh_mapper.map(tensor)
         tensor_creation_args[0] = shards

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -302,7 +302,9 @@ def from_torch(
         tensor = ttnn.to_torch(tensor)
 
     tensor_creation_args = [tensor, dtype]
-    # TODO: Try calling the ttnn sharding path directly and the tilize directly removing the need to reformat after tilizing bfb
+    # TODO: (jjiang) - Try calling the ttnn sharding path directly and the tilize directly removing the need to reshape at the end after tilizing bfb, would likely avoid a lot of bugs
+    # TODO: (jjiang) - Could also extend the pytensor.cpp apis to support bfpb types and provide richer initialization options, removing the need for tilize, to_layout, and to_device
+    # much of the groundwork for that has already been done and it would likely just be a few fairly trivial function calls
     if mesh_mapper:
         shards = mesh_mapper.map(tensor)
         tensor_creation_args[0] = shards

--- a/ttnn/ttnn/operations/core.py
+++ b/ttnn/ttnn/operations/core.py
@@ -274,7 +274,6 @@ def from_torch(
         Tensor([[1.375, -1.30469, -0.714844],
             [-0.761719, 0.53125, -0.652344]], dtype=bfloat16)
     """
-
     if memory_config is not None:
         if device is None:
             raise RuntimeError("ttnn.from_torch: device must be specified when memory_config is specified")
@@ -302,17 +301,14 @@ def from_torch(
         tensor = tensor.reshape(tensor.padded_shape)
         tensor = ttnn.to_torch(tensor)
 
+    tensor_creation_args = [tensor, dtype]
     if mesh_mapper:
         shards = mesh_mapper.map(tensor)
-        if tile is not None:
-            tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config(), tile)
-        else:
-            tensor = ttnn.Tensor(shards, dtype, mesh_mapper.config())
-    else:
-        if tile is not None:
-            tensor = ttnn.Tensor(tensor, dtype, {}, tile)
-        else:
-            tensor = ttnn.Tensor(tensor, dtype)
+        tensor_creation_args[0] = shards
+        tensor_creation_args.append(mesh_mapper.config())
+    if tile is not None:
+        tensor_creation_args.append(tile)
+    tensor = ttnn.Tensor(*tensor_creation_args)
 
     if layout is not None and not (dtype == ttnn.bfloat8_b or dtype == ttnn.bfloat4_b):
         if pad_value is not None:


### PR DESCRIPTION
### Ticket
Link to Github Issue: https://github.com/tenstorrent/tt-metal/issues/15061

### Problem description
From_torch currently has a fairly difficult to understand group of if checks. It would be nice to simplify this for maintainability purposes.

### What's changed
Refactor the if checks for tilization and sharding.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes