### PR TITLE
Write runtime args in topology kernels

### DIFF
--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -853,6 +853,8 @@ std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
 
     // Compile the program and return it so Device can register it
     detail::CompileProgram(device, *cq_program, /*force_slow_dispatch=*/true);
+    // Write runtime args to device
+    detail::WriteRuntimeArgsToDevice(device, *cq_program, /*force_slow_dispatch=*/true);
     // Erase from map. Note: program in map is no longer valid
     // It is returned from this function and the caller will take ownership of it
     command_queue_pgms.erase(device->id());


### PR DESCRIPTION
### Ticket
#18726

### Problem description
Unexpected how kernels created in FD topology were not writing runtime args. Some high level APIs (e.g., setup fabric connection) uses runtime args.

### What's changed
Add the missing call to write runtime args to the kernels

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14869629531
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14869631938
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14869634642