### PR TITLE
Deallocate SubDeviceManagerTracker after clearing program cache.

### DIFF
--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1267,8 +1267,6 @@ bool Device::close() {
 
     tt_metal::detail::DumpDeviceProfileResults(this, ProfilerDumpState::LAST_CLOSE_DEVICE);
 
-    sub_device_manager_tracker_.reset(nullptr);
-
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> not_done_dispatch_cores;
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> cores_to_skip;
     this->get_associated_dispatch_virtual_cores(not_done_dispatch_cores, cores_to_skip);
@@ -1334,6 +1332,7 @@ bool Device::close() {
     this->command_queue_programs_.clear();
     this->command_queues_.clear();
     this->sysmem_manager_.reset();
+    this->sub_device_manager_tracker_.reset(nullptr);
     this->initialized_ = false;
 
     return true;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21315

### Problem description
A callback in program cache can keep a reference to a Buffer object which needs to access Allocator, but the Allocator is owned by SubDeviceManagerTracker and is deallocated before clearing the program cache.  This results in a use-after-free.

### What's changed
Deallocating SubDeviceManagerTracker after clearing program cache avoids use-after-free.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes