### PR TITLE
#19201: add nops to sdpa decode for BH to avoid hang

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -338,6 +338,11 @@ void MAIN {
             }
         }
         /* END OF FLASH ATTENTION LOOP */
+#ifdef ARCH_BLACKHOLE
+        for (uint32_t i = 0; i < 10; i++) {
+            asm volatile("nop");  // #19201 BH hang workaround
+        }
+#endif
 
         // do reduction across intermediates from other cores if this is the reduction core
         if (do_reduce) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #19201

### Problem description
- there is a hang in sdpa decode for llama on BH 

### What's changed
- adding in nops at the specific location makes this specific hang go away
- to help to unblock other testing, add in a temporary fix until the root cause is identified

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes