### PR TITLE
Allow WorkerToFabricEdmSenderImpl to be allocated in global variables

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -47,7 +47,7 @@ struct WorkerToFabricEdmSenderImpl {
     static constexpr uint32_t open_connection_value = 1;
     static constexpr uint32_t close_connection_request_value = 2;
 
-    WorkerToFabricEdmSenderImpl() : from_remote_buffer_slot_rdptr_ptr(nullptr) {}
+    WorkerToFabricEdmSenderImpl() = default;
 
     template <ProgrammableCoreType my_core_type>
     static WorkerToFabricEdmSenderImpl build_from_args(std::size_t& arg_idx) {
@@ -92,6 +92,56 @@ struct WorkerToFabricEdmSenderImpl {
             write_at_cmd_buf);
     }
 
+    void init(
+        bool connected_to_persistent_fabric,
+        uint8_t direction,
+        uint8_t edm_worker_x,
+        uint8_t edm_worker_y,
+        std::size_t edm_buffer_base_addr,
+        uint8_t num_buffers_per_channel,
+        size_t edm_l1_sem_id,  // may also be an address
+        std::size_t edm_connection_handshake_l1_id,
+        std::size_t edm_worker_location_info_addr,  // The EDM's location for `EDMChannelWorkerLocationInfo`
+        uint16_t buffer_size_bytes,
+        size_t edm_buffer_index_id,
+        volatile uint32_t* const from_remote_buffer_slot_rdptr_ptr,
+        volatile uint32_t* const worker_teardown_addr,
+        uint32_t local_buffer_index_addr,
+        uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        this->direction = direction;
+        this->edm_buffer_addr = edm_buffer_base_addr;
+        this->edm_buffer_slot_wrptr_addr = connected_to_persistent_fabric
+                                               ? edm_l1_sem_id
+                                               : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_l1_sem_id);
+        this->edm_connection_handshake_l1_addr =
+            connected_to_persistent_fabric
+                ? edm_connection_handshake_l1_id
+                : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_connection_handshake_l1_id);
+        this->edm_worker_location_info_addr = edm_worker_location_info_addr;
+        this->edm_buffer_index_addr = connected_to_persistent_fabric
+                                          ? edm_buffer_index_id
+                                          : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_buffer_index_id);
+        this->from_remote_buffer_slot_rdptr_ptr = from_remote_buffer_slot_rdptr_ptr;
+        this->worker_teardown_addr = worker_teardown_addr;
+        this->edm_buffer_base_addr = edm_buffer_base_addr;
+        this->buffer_slot_wrptr_ptr = reinterpret_cast<tt_l1_ptr size_t*>(local_buffer_index_addr);
+        this->buffer_size_bytes = buffer_size_bytes;
+        this->num_buffers_per_channel = num_buffers_per_channel;
+        this->last_buffer_index = num_buffers_per_channel - 1;
+        this->edm_noc_x = edm_worker_x;
+        this->edm_noc_y = edm_worker_y;
+        this->data_noc_cmd_buf = data_noc_cmd_buf;
+        this->sync_noc_cmd_buf = sync_noc_cmd_buf;
+        ASSERT(buffer_size_bytes > 0);
+        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
+            ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
+            for (size_t i = 0; i < EDM_NUM_BUFFER_SLOTS; ++i) {
+                edm_buffer_slot_addrs[i] = edm_buffer_base_addr + (i * buffer_size_bytes);
+            }
+        }
+    }
+
     WorkerToFabricEdmSenderImpl(
         bool connected_to_persistent_fabric,
         uint8_t direction,
@@ -108,38 +158,24 @@ struct WorkerToFabricEdmSenderImpl {
         volatile uint32_t* const worker_teardown_addr,
         uint32_t local_buffer_index_addr,
         uint8_t data_noc_cmd_buf = write_reg_cmd_buf,
-        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) :
-        edm_buffer_addr(edm_buffer_base_addr),
-        edm_buffer_slot_wrptr_addr(
-            connected_to_persistent_fabric ? edm_l1_sem_id
-                                           : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_l1_sem_id)),
-        edm_connection_handshake_l1_addr(
-            connected_to_persistent_fabric
-                ? edm_connection_handshake_l1_id
-                : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_connection_handshake_l1_id)),
-        edm_worker_location_info_addr(edm_worker_location_info_addr),
-        edm_buffer_index_addr(
-            connected_to_persistent_fabric ? edm_buffer_index_id
-                                           : get_semaphore<ProgrammableCoreType::ACTIVE_ETH>(edm_buffer_index_id)),
-        from_remote_buffer_slot_rdptr_ptr(from_remote_buffer_slot_rdptr_ptr),
-        worker_teardown_addr(worker_teardown_addr),
-        edm_buffer_base_addr(edm_buffer_base_addr),
-        buffer_slot_wrptr_ptr(reinterpret_cast<tt_l1_ptr size_t*>(local_buffer_index_addr)),
-        buffer_size_bytes(buffer_size_bytes),
-        num_buffers_per_channel(num_buffers_per_channel),
-        last_buffer_index(num_buffers_per_channel - 1),
-        edm_noc_x(edm_worker_x),
-        edm_noc_y(edm_worker_y),
-        data_noc_cmd_buf(data_noc_cmd_buf),
-        sync_noc_cmd_buf(sync_noc_cmd_buf),
-        direction(direction) {
-        ASSERT(buffer_size_bytes > 0);
-        if constexpr (USER_DEFINED_NUM_BUFFER_SLOTS) {
-            ASSERT(num_buffers_per_channel == EDM_NUM_BUFFER_SLOTS);
-            for (size_t i = 0; i < EDM_NUM_BUFFER_SLOTS; ++i) {
-                edm_buffer_slot_addrs[i] = edm_buffer_base_addr + (i * buffer_size_bytes);
-            }
-        }
+        uint8_t sync_noc_cmd_buf = write_at_cmd_buf) {
+        this->init(
+            connected_to_persistent_fabric,
+            direction,
+            edm_worker_x,
+            edm_worker_y,
+            edm_buffer_base_addr,
+            num_buffers_per_channel,
+            edm_l1_sem_id,
+            edm_connection_handshake_l1_id,
+            edm_worker_location_info_addr,
+            buffer_size_bytes,
+            edm_buffer_index_id,
+            from_remote_buffer_slot_rdptr_ptr,
+            worker_teardown_addr,
+            local_buffer_index_addr,
+            data_noc_cmd_buf,
+            sync_noc_cmd_buf);
     }
 
     template <uint8_t EDM_TO_DOWNSTREAM_NOC = noc_index, uint8_t EDM_TO_DOWNSTREAM_NOC_VC = NOC_UNICAST_WRITE_VC>


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- Cannot put `WorkerToFabricEdmSenderImpl` in the global variables / static section because it has a non-trivial constructor
- Some kernels are limited in stack space


Right now this doesn't work

```cpp

...
// Globals and static variables section
tt::tt_fabric::WorkerToFabricEdmSender edm_sender;

void kernel_main() {
  edm_sender.init(...);
}
```


### What's changed
- Make the default constructor default
- Add an init function to initialize the variables. This will allow use cases in kernels that have a limited amount of stack size because this object uses ~90B and not everything will get inlined. The dispatcher kernels only have a few bytes left on the stack..

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15030171333
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/15012308787
TG
https://github.com/tenstorrent/tt-metal/actions/runs/15012306987
BH
https://github.com/tenstorrent/tt-metal/actions/runs/15032336383