### PR TITLE
Add check that all devices have same harvesting + add device init/teardown to smoke tests

### DIFF
--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -25,3 +25,27 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/test/tt_metal
 )
+
+add_library(unit_tests_device_smoke OBJECT)
+add_library(TT::Metalium::Test::Device::Smoke ALIAS unit_tests_device_smoke)
+TT_ENABLE_UNITY_BUILD(unit_tests_device_smoke)
+
+target_sources(unit_tests_device_smoke PRIVATE test_device_init_and_teardown.cpp)
+
+target_link_libraries(unit_tests_device_smoke PRIVATE test_metal_common_libs)
+
+target_include_directories(
+    unit_tests_device_smoke
+    PRIVATE
+        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
+set_target_properties(
+    unit_tests_device_smoke
+    PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY
+            ${PROJECT_BINARY_DIR}/test/tt_metal
+)

--- a/tests/tt_metal/tt_metal/device/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/device/CMakeLists.txt
@@ -1,51 +1,44 @@
-set(UNIT_TESTS_DEVICE_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_device_cluster_api.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_device_init_and_teardown.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_device_pool.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_device.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_galaxy_cluster_api.cpp
-)
-
-add_executable(unit_tests_device ${UNIT_TESTS_DEVICE_SRC})
-TT_ENABLE_UNITY_BUILD(unit_tests_device)
-
-target_link_libraries(unit_tests_device PUBLIC test_metal_common_libs)
-target_include_directories(
-    unit_tests_device
-    PRIVATE
-        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
-        ${PROJECT_SOURCE_DIR}/tests
-        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/common
-)
-set_target_properties(
-    unit_tests_device
-    PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY
-            ${PROJECT_BINARY_DIR}/test/tt_metal
-)
-
+# Smoke tests
 add_library(unit_tests_device_smoke OBJECT)
 add_library(TT::Metalium::Test::Device::Smoke ALIAS unit_tests_device_smoke)
 TT_ENABLE_UNITY_BUILD(unit_tests_device_smoke)
-
 target_sources(unit_tests_device_smoke PRIVATE test_device_init_and_teardown.cpp)
-
-target_link_libraries(unit_tests_device_smoke PRIVATE test_metal_common_libs)
-
 target_include_directories(
     unit_tests_device_smoke
     PRIVATE
-        "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
         ${PROJECT_SOURCE_DIR}/tests
         ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/common
 )
+target_link_libraries(unit_tests_device_smoke PRIVATE test_metal_common_libs)
+
+# Remaining tests
+add_executable(unit_tests_device)
+TT_ENABLE_UNITY_BUILD(unit_tests_device)
 set_target_properties(
-    unit_tests_device_smoke
+    unit_tests_device
     PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/test/tt_metal
+)
+target_sources(
+    unit_tests_device
+    PRIVATE
+        test_device_cluster_api.cpp
+        test_device_pool.cpp
+        test_device.cpp
+        test_galaxy_cluster_api.cpp
+)
+target_include_directories(
+    unit_tests_device
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/tests
+        ${PROJECT_SOURCE_DIR}/tests/tt_metal/tt_metal/common
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(
+    unit_tests_device
+    PRIVATE
+        test_metal_common_libs
+        TT::Metalium::Test::Device::Smoke
 )

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -334,6 +334,7 @@ private:
     void assign_mem_channels_to_devices(chip_id_t mmio_device_id, const std::set<chip_id_t>& controlled_device_ids);
     void open_driver(const bool& skip_driver_allocs = false);
     void start_driver(tt_device_params& device_params) const;
+    void validate_harvesting_masks() const;
 
     void get_metal_desc_from_tt_desc();
     void generate_virtual_to_umd_coord_mapping();

--- a/tt_metal/test/CMakeLists.txt
+++ b/tt_metal/test/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(
     tt-metalium-validation-smoke
     PRIVATE
         TT::SystemHealth::Smoke
+        TT::Metalium::Test::Device::Smoke
         TT::Metalium::Test::Dispatch::Smoke
         TT::Metalium::Test::STL::Smoke
 )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Upstream syseng testing was failing on BH due to a BH QB having mix of harvested/unharvested P150 cards. 

### What's changed
No immediate plans for this to be an expected config so add a check after init umd to ensure same num of harvested cores for different harvested core types.

Also added test device init/teardown as part of smoke

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14872675773) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14872682359) CI with demo tests passes 
- [x] [T3K unit](https://github.com/tenstorrent/tt-metal/actions/runs/14872690106)
- [x] [TG unit](https://github.com/tenstorrent/tt-metal/actions/runs/14872696000)