### PR TITLE
Avoid recreating additional reference embedding model

### DIFF
--- a/models/tt_transformers/tests/test_model.py
+++ b/models/tt_transformers/tests/test_model.py
@@ -211,12 +211,13 @@ def test_model_inference(
         else:
             encoded_prompts = [model_args.encode_prompt(prompt, instruct=False) for prompt in prompts]
 
+    reference_model = None
     if run_ref_pt:
         reference_model = model_args.reference_transformer()
         reference_model.load_state_dict(reference_state_dict)
 
     # Embedding on host
-    embd = model_args.reference_embedding()
+    embd = model_args.reference_embedding(reference_model)
     embd.load_state_dict({"emb.weight": state_dict[f"{state_dict_prefix}tok_embeddings.weight"]})
 
     generation_start_pos = 0

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1917,9 +1917,10 @@ class ModelArgs:
         else:
             if reference_model is None:
                 model = self.reference_transformer(wrap=False)
+                layer = model.model.embed_tokens
             else:
-                model = reference_model
-            layer = model.model.embed_tokens
+                layer = reference_model.model.model.embed_tokens
+
             layer._load_state_dict = layer.load_state_dict
             layer.load_state_dict = lambda x: layer._load_state_dict(convert_meta_to_hf(x, self.head_dim))
             return layer


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21749

### Problem description
test_model.py creates reference embedding model every time, rather try to use the reference_model if available. This reduces memory footprint needed by the test. Also fix model_config.py to accommodate the changes by passing correct reference to embedding layer.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes