### PR TITLE
#20050: Update all sdxl weights to bf16, boost fidelities, add knobs to easily convert between bf16/bfp8

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo.py
@@ -134,7 +134,13 @@ def run_demo_inference(
     )
 
     # 2. Load tt_unet
-    tt_unet = TtUNet2DConditionModel(ttnn_device, pipeline.unet.state_dict(), "unet")
+    tt_unet = TtUNet2DConditionModel(
+        ttnn_device,
+        pipeline.unet.state_dict(),
+        "unet",
+        conv_weights_dtype=ttnn.bfloat16,
+        transformer_weights_dtype=ttnn.bfloat16,
+    )
 
     cpu_device = "cpu"
 

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+
 import gc
 from loguru import logger
 import torch

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattndownblock2d.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -15,10 +16,12 @@ from models.utility_functions import torch_random
     "input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, down_block_id, pcc",
     [
         ((1, 320, 64, 64), (1, 1280), (1, 77, 2048), 640, 10, 640, 1, 0.994),
-        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.975),
+        ((1, 640, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280, 2, 0.985),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 def test_crossattndown(
     device,
     input_shape,
@@ -31,6 +34,8 @@ def test_crossattndown(
     pcc,
     use_program_cache,
     reset_seeds,
+    transformer_weights_dtype,
+    conv_weights_dtype,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
@@ -41,7 +46,15 @@ def test_crossattndown(
 
     torch_crosattn = unet.down_blocks[down_block_id]
     tt_crosattn = TtCrossAttnDownBlock2D(
-        device, state_dict, f"down_blocks.{down_block_id}", query_dim, num_attn_heads, out_dim, down_block_id == 1
+        device,
+        state_dict,
+        f"down_blocks.{down_block_id}",
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        down_block_id == 1,
+        transformer_weights_dtype=transformer_weights_dtype,
+        conv_weights_dtype=conv_weights_dtype,
     )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
@@ -87,4 +100,5 @@ def test_crossattndown(
     del unet, tt_crosattn
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_crossattnmidblock2d.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -17,9 +18,21 @@ from models.utility_functions import torch_random
         ((1, 1280, 32, 32), (1, 1280), (1, 77, 2048), 1280, 20, 1280),
     ],
 )
+@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_crossattnmid(
-    device, input_shape, temb_shape, encoder_shape, query_dim, num_attn_heads, out_dim, use_program_cache, reset_seeds
+    device,
+    input_shape,
+    temb_shape,
+    encoder_shape,
+    query_dim,
+    num_attn_heads,
+    out_dim,
+    use_program_cache,
+    reset_seeds,
+    transformer_weights_dtype,
+    conv_weights_dtype,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
@@ -29,7 +42,16 @@ def test_crossattnmid(
     state_dict = unet.state_dict()
 
     torch_crosattn = unet.mid_block
-    tt_crosattn = TtUNetMidBlock2DCrossAttn(device, state_dict, f"mid_block", query_dim, num_attn_heads, out_dim)
+    tt_crosattn = TtUNetMidBlock2DCrossAttn(
+        device,
+        state_dict,
+        f"mid_block",
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        transformer_weights_dtype=transformer_weights_dtype,
+        conv_weights_dtype=conv_weights_dtype,
+    )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
     torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
@@ -74,4 +96,5 @@ def test_crossattnmid(
     del unet, tt_crosattn
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.973)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.976)
+    logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+
 import gc
 from loguru import logger
 import torch

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_downsample2d.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -16,14 +17,24 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 
 
 @pytest.mark.parametrize(
-    "input_shape, down_block_id, pcc", [((1, 320, 128, 128), 0, 0.998), ((1, 640, 64, 64), 1, 0.996)]
+    "input_shape, down_block_id, pcc", [((1, 320, 128, 128), 0, 0.999), ((1, 640, 64, 64), 1, 0.998)]
 )
 @pytest.mark.parametrize("stride", [(2, 2)])
 @pytest.mark.parametrize("padding", [(1, 1)])
 @pytest.mark.parametrize("dilation", [(1, 1)])
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_downsample2d(
-    device, input_shape, down_block_id, stride, padding, dilation, pcc, use_program_cache, reset_seeds
+    device,
+    input_shape,
+    down_block_id,
+    stride,
+    padding,
+    dilation,
+    pcc,
+    use_program_cache,
+    reset_seeds,
+    conv_weights_dtype,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
@@ -35,7 +46,14 @@ def test_downsample2d(
     torch_downsample = unet.down_blocks[down_block_id].downsamplers[0]
     groups = 1
     tt_downsample = TtDownsample2D(
-        device, state_dict, f"down_blocks.{down_block_id}.downsamplers.0", stride, padding, dilation, groups
+        device,
+        state_dict,
+        f"down_blocks.{down_block_id}.downsamplers.0",
+        stride,
+        padding,
+        dilation,
+        groups,
+        conv_weights_dtype=conv_weights_dtype,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
@@ -53,3 +71,5 @@ def test_downsample2d(
     gc.collect()
 
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+
 import gc
 from loguru import logger
 import torch
@@ -21,7 +22,9 @@ from models.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
-def test_feedforward(device, input_shape, block_id, transformer_block_id, use_program_cache, reset_seeds, transformer_weights_dtype):
+def test_feedforward(
+    device, input_shape, block_id, transformer_block_id, use_program_cache, reset_seeds, transformer_weights_dtype
+):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_feedforward.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -19,7 +20,8 @@ from models.utility_functions import torch_random
         ((4096, 640), 1, 1),
     ],
 )
-def test_feedforward(device, input_shape, block_id, transformer_block_id, use_program_cache, reset_seeds):
+@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
+def test_feedforward(device, input_shape, block_id, transformer_block_id, use_program_cache, reset_seeds, transformer_weights_dtype):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
@@ -30,7 +32,10 @@ def test_feedforward(device, input_shape, block_id, transformer_block_id, use_pr
     torch_ff = unet.down_blocks[block_id].attentions[0].transformer_blocks[transformer_block_id].ff
 
     tt_ff = TtFeedForward(
-        device, state_dict, f"down_blocks.{block_id}.attentions.0.transformer_blocks.{transformer_block_id}.ff"
+        device,
+        state_dict,
+        f"down_blocks.{block_id}.attentions.0.transformer_blocks.{transformer_block_id}.ff",
+        weights_dtype=transformer_weights_dtype,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
@@ -49,4 +54,5 @@ def test_feedforward(device, input_shape, block_id, transformer_block_id, use_pr
     del unet
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+
 import gc
 from loguru import logger
 import torch

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_geglu.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -19,7 +20,8 @@ from functools import reduce
         ((4096, 640), "down_blocks.1.attentions.0.transformer_blocks.0.ff.net.0"),
     ],
 )
-def test_geglu(device, input_shape, module_path, use_program_cache, reset_seeds):
+@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
+def test_geglu(device, input_shape, module_path, use_program_cache, reset_seeds, transformer_weights_dtype):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
@@ -36,7 +38,7 @@ def test_geglu(device, input_shape, module_path, use_program_cache, reset_seeds)
 
     assert torch_geglu is not None, f"{module_path} is not a valid UNet module"
 
-    tt_geglu = TtGEGLU(device, state_dict, module_path)
+    tt_geglu = TtGEGLU(device, state_dict, module_path, weights_dtype=transformer_weights_dtype)
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_output_tensor = torch_geglu(torch_input_tensor)
@@ -54,4 +56,5 @@ def test_geglu(device, input_shape, module_path, use_program_cache, reset_seeds)
     del unet
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_resnetblock2d.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -19,16 +20,17 @@ from models.utility_functions import torch_random
         ((1, 640, 64, 64), (1, 1280), 1, 1, False, 1, "down_blocks", 0.995),
         ((1, 640, 32, 32), (1, 1280), 2, 0, True, 1, "down_blocks", 0.997),
         ((1, 1280, 32, 32), (1, 1280), 2, 1, False, 1, "down_blocks", 0.992),
-        ((1, 960, 128, 128), (1, 1280), 2, 0, True, 6, "up_blocks", 0.979),
+        ((1, 960, 128, 128), (1, 1280), 2, 0, True, 6, "up_blocks", 0.980),
         ((1, 640, 128, 128), (1, 1280), 2, 1, True, 2, "up_blocks", 0.997),
-        ((1, 2560, 32, 32), (1, 1280), 0, 0, True, 1, "up_blocks", 0.988),
-        ((1, 1920, 32, 32), (1, 1280), 0, 2, True, 1, "up_blocks", 0.991),
-        ((1, 1920, 64, 64), (1, 1280), 1, 0, True, 1, "up_blocks", 0.985),
-        ((1, 1280, 64, 64), (1, 1280), 1, 1, True, 1, "up_blocks", 0.993),
+        ((1, 2560, 32, 32), (1, 1280), 0, 0, True, 1, "up_blocks", 0.986),
+        ((1, 1920, 32, 32), (1, 1280), 0, 2, True, 1, "up_blocks", 0.990),
+        ((1, 1920, 64, 64), (1, 1280), 1, 0, True, 1, "up_blocks", 0.983),
+        ((1, 1280, 64, 64), (1, 1280), 1, 1, True, 1, "up_blocks", 0.992),
         ((1, 960, 64, 64), (1, 1280), 1, 2, True, 1, "up_blocks", 0.996),
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 def test_resnetblock2d(
     device,
     temb_shape,
@@ -41,6 +43,7 @@ def test_resnetblock2d(
     pcc,
     use_program_cache,
     reset_seeds,
+    conv_weights_dtype,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
@@ -56,7 +59,12 @@ def test_resnetblock2d(
     else:
         assert "Incorrect block name"
     tt_resnet = TtResnetBlock2D(
-        device, state_dict, f"{block}.{down_block_id}.resnets.{resnet_id}", conv_shortcut, split_in
+        device,
+        state_dict,
+        f"{block}.{down_block_id}.resnets.{resnet_id}",
+        conv_shortcut,
+        split_in,
+        conv_weights_dtype=conv_weights_dtype,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
@@ -89,4 +97,5 @@ def test_resnetblock2d(
     del unet
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_timesteps.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_timesteps.py
@@ -9,6 +9,7 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_timesteps import TtTimes
 from diffusers import UNet2DConditionModel
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
+from loguru import logger
 
 
 @pytest.mark.parametrize(
@@ -43,4 +44,5 @@ def test_timesteps(device, input_shape, module_path, num_channels, use_program_c
     del unet
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
+    logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_transformermodel.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -15,9 +16,10 @@ from models.utility_functions import torch_random
     "input_shape, encoder_shape, down_block_id, query_dim, num_attn_heads, out_dim, pcc",
     [
         ((1, 640, 64, 64), (1, 77, 2048), 1, 640, 10, 640, 0.999),
-        ((1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.995),
+        ((1, 1280, 32, 32), (1, 77, 2048), 2, 1280, 20, 1280, 0.996),
     ],
 )
+@pytest.mark.parametrize("transformer_weights_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 def test_transformermodel(
     device,
@@ -30,6 +32,7 @@ def test_transformermodel(
     pcc,
     use_program_cache,
     reset_seeds,
+    transformer_weights_dtype,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
@@ -40,7 +43,13 @@ def test_transformermodel(
 
     torch_transformerblock = unet.down_blocks[down_block_id].attentions[0]
     tt_transformerblock = TtTransformer2DModel(
-        device, state_dict, f"down_blocks.{down_block_id}.attentions.0", query_dim, num_attn_heads, out_dim
+        device,
+        state_dict,
+        f"down_blocks.{down_block_id}.attentions.0",
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        weights_dtype=transformer_weights_dtype,
     )
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_encoder_tensor = torch_random(encoder_shape, -0.1, 0.1, dtype=torch.float32)
@@ -74,4 +83,5 @@ def test_transformermodel(
     del unet
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
@@ -37,7 +37,6 @@ def test_crossattnup(
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
-
     )
     # unet = pipe.unet
     unet.eval()

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -23,6 +24,7 @@ from models.utility_functions import torch_random
     ],
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 3 * 16384}], indirect=True)
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 def test_crossattnup(
     device,
     input_shape,
@@ -31,16 +33,18 @@ def test_crossattnup(
     block_id,
     use_program_cache,
     reset_seeds,
+    conv_weights_dtype,
 ):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
+
     )
     # unet = pipe.unet
     unet.eval()
     state_dict = unet.state_dict()
 
     torch_crosattn = unet.up_blocks[block_id]
-    tt_crosattn = TtUpBlock2D(device, state_dict, f"up_blocks.{block_id}")
+    tt_crosattn = TtUpBlock2D(device, state_dict, f"up_blocks.{block_id}", conv_weights_dtype=conv_weights_dtype)
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
     torch_temb_tensor = torch_random(temb_shape, -0.1, 0.1, dtype=torch.float32)
 
@@ -79,4 +83,5 @@ def test_crossattnup(
     del unet
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.96)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, 0.96)
+    logger.info(f"PCC is: {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
@@ -22,7 +22,9 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 @pytest.mark.parametrize("dilation", [(1, 1)])
 @pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_upsample2d(device, input_shape, pcc, conv_weights_dtype, up_block_id, stride, padding, dilation, use_program_cache, reset_seeds):
+def test_upsample2d(
+    device, input_shape, pcc, conv_weights_dtype, up_block_id, stride, padding, dilation, use_program_cache, reset_seeds
+):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upsample2d.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import gc
+from loguru import logger
 import torch
 import pytest
 import ttnn
@@ -15,12 +16,13 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 )
 
 
-@pytest.mark.parametrize("input_shape, up_block_id", [((1, 1280, 32, 32), 0), ((1, 640, 64, 64), 1)])
+@pytest.mark.parametrize("input_shape, up_block_id, pcc", [((1, 1280, 32, 32), 0, 0.995), ((1, 640, 64, 64), 1, 0.998)])
 @pytest.mark.parametrize("stride", [(1, 1)])
 @pytest.mark.parametrize("padding", [(1, 1)])
 @pytest.mark.parametrize("dilation", [(1, 1)])
+@pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_upsample2d(device, input_shape, up_block_id, stride, padding, dilation, use_program_cache, reset_seeds):
+def test_upsample2d(device, input_shape, pcc, conv_weights_dtype, up_block_id, stride, padding, dilation, use_program_cache, reset_seeds):
     unet = UNet2DConditionModel.from_pretrained(
         "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float32, use_safetensors=True, subfolder="unet"
     )
@@ -31,7 +33,14 @@ def test_upsample2d(device, input_shape, up_block_id, stride, padding, dilation,
     torch_upsample = unet.up_blocks[up_block_id].upsamplers[0]
     groups = 1
     tt_upsample = TtUpsample2D(
-        device, state_dict, f"up_blocks.{up_block_id}.upsamplers.0", stride, padding, dilation, groups
+        device,
+        state_dict,
+        f"up_blocks.{up_block_id}.upsamplers.0",
+        stride,
+        padding,
+        dilation,
+        groups,
+        conv_weights_dtype=conv_weights_dtype,
     )
 
     torch_input_tensor = torch_random(input_shape, -0.1, 0.1, dtype=torch.float32)
@@ -48,4 +57,5 @@ def test_upsample2d(device, input_shape, up_block_id, stride, padding, dilation,
     del unet
     gc.collect()
 
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.996)
+    _, pcc_message = assert_with_pcc(torch_output_tensor, output_tensor, pcc)
+    logger.info(f"PCC is {pcc_message}")

--- a/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/sdxl_utility.py
@@ -60,7 +60,7 @@ def prepare_linear_params(device, weights, bias, dtype):
 def prepare_conv_params(device, weights, bias, dtype, act_dtype=ttnn.bfloat16, act_block_h_override=0):
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
-        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_fidelity=ttnn.MathFidelity.HiFi4,
         fp32_dest_acc_en=False,
         packer_l1_acc=False,
     )
@@ -101,7 +101,7 @@ def prepare_split_conv_params(
 ):
     compute_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
-        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_fidelity=ttnn.MathFidelity.HiFi4,
         fp32_dest_acc_en=False,
         packer_l1_acc=False,
     )

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_crossattnmidblock2d.py
@@ -3,12 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch.nn as nn
+import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_transformermodel import TtTransformer2DModel
 from models.experimental.stable_diffusion_xl_base.tt.tt_resnetblock2d import TtResnetBlock2D
 
 
 class TtUNetMidBlock2DCrossAttn(nn.Module):
-    def __init__(self, device, state_dict, module_path, query_dim, num_attn_heads, out_dim):
+    def __init__(
+        self,
+        device,
+        state_dict,
+        module_path,
+        query_dim,
+        num_attn_heads,
+        out_dim,
+        transformer_weights_dtype=ttnn.bfloat16,
+        conv_weights_dtype=ttnn.bfloat16,
+    ):
         super().__init__()
 
         num_layers_attn = 1
@@ -19,12 +30,20 @@ class TtUNetMidBlock2DCrossAttn(nn.Module):
         for i in range(num_layers_attn):
             self.attentions.append(
                 TtTransformer2DModel(
-                    device, state_dict, f"{module_path}.attentions.{i}", query_dim, num_attn_heads, out_dim
+                    device,
+                    state_dict,
+                    f"{module_path}.attentions.{i}",
+                    query_dim,
+                    num_attn_heads,
+                    out_dim,
+                    weights_dtype=transformer_weights_dtype,
                 )
             )
 
         for i in range(num_layers_resn):
-            self.resnets.append(TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}"))
+            self.resnets.append(
+                TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}", conv_weights_dtype=conv_weights_dtype)
+            )
 
     def forward(self, input_tensor, input_shape, temb=None, encoder_hidden_states=None, attention_mask=None):
         B, C, H, W = input_shape

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_downblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_downblock2d.py
@@ -9,17 +9,26 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_downsample2d import TtDo
 
 
 class TtDownBlock2D(nn.Module):
-    def __init__(self, device, state_dict, module_path):
+    def __init__(self, device, state_dict, module_path, conv_weights_dtype=ttnn.bfloat16):
         super().__init__()
 
         num_layers = 2
         self.resnets = []
 
         for i in range(num_layers):
-            self.resnets.append(TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}"))
+            self.resnets.append(
+                TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}", conv_weights_dtype=conv_weights_dtype)
+            )
 
         self.downsamplers = TtDownsample2D(
-            device, state_dict, f"{module_path}.downsamplers.0", (2, 2), (1, 1), (1, 1), 1
+            device,
+            state_dict,
+            f"{module_path}.downsamplers.0",
+            (2, 2),
+            (1, 1),
+            (1, 1),
+            1,
+            conv_weights_dtype=conv_weights_dtype,
         )
 
     def forward(self, hidden_states, input_shape, temb):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
@@ -9,7 +9,9 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare
 
 
 class TtDownsample2D(nn.Module):
-    def __init__(self, device, state_dict, module_path, stride, padding, dilation, groups):
+    def __init__(
+        self, device, state_dict, module_path, stride, padding, dilation, groups, conv_weights_dtype=ttnn.bfloat16
+    ):
         super().__init__()
 
         self.device = device
@@ -22,7 +24,7 @@ class TtDownsample2D(nn.Module):
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
         self.compute_config, self.conv_config, self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
-            device, weights, bias, ttnn.bfloat8_b
+            device, weights, bias, conv_weights_dtype
         )
         self.conv_config.deallocate_activation = False
 

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_embedding.py
@@ -9,7 +9,7 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare
 
 
 class TtTimestepEmbedding(nn.Module):
-    def __init__(self, device, state_dict, module_path):
+    def __init__(self, device, state_dict, module_path, linear_weights_dtype=ttnn.bfloat16):
         super().__init__()
 
         self.device = device
@@ -19,8 +19,8 @@ class TtTimestepEmbedding(nn.Module):
         weights_2 = state_dict[f"{module_path}.linear_2.weight"].unsqueeze(0).unsqueeze(0)
         bias_2 = state_dict[f"{module_path}.linear_2.bias"]
 
-        self.tt_weights_1, self.tt_bias_1 = prepare_linear_params(device, weights_1, bias_1, ttnn.bfloat8_b)
-        self.tt_weights_2, self.tt_bias_2 = prepare_linear_params(device, weights_2, bias_2, ttnn.bfloat8_b)
+        self.tt_weights_1, self.tt_bias_1 = prepare_linear_params(device, weights_1, bias_1, linear_weights_dtype)
+        self.tt_weights_2, self.tt_bias_2 = prepare_linear_params(device, weights_2, bias_2, linear_weights_dtype)
 
     def forward(self, sample):
         sample = ttnn.linear(sample, self.tt_weights_1, bias=self.tt_bias_1, activation="silu")

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_feedforward.py
@@ -15,16 +15,17 @@ class TtFeedForward(nn.Module):
         device,
         state_dict,
         module_path,
+        weights_dtype=ttnn.bfloat16,
     ):
         super().__init__()
 
         self.device = device
-        self.tt_geglu = TtGEGLU(device, state_dict, f"{module_path}.net.0")
+        self.tt_geglu = TtGEGLU(device, state_dict, f"{module_path}.net.0", weights_dtype=weights_dtype)
 
         weights = state_dict[f"{module_path}.net.2.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.net.2.bias"]
 
-        self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, ttnn.bfloat8_b)
+        self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, weights_dtype)
 
     def forward(self, hidden_states):
         hidden_states = self.tt_geglu(hidden_states)

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_geglu.py
@@ -9,14 +9,14 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import prepare
 
 
 class TtGEGLU(nn.Module):
-    def __init__(self, device, state_dict, module_path):
+    def __init__(self, device, state_dict, module_path, weights_dtype=ttnn.bfloat16):
         super().__init__()
 
         self.device = device
         weights = state_dict[f"{module_path}.proj.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.proj.bias"]
 
-        self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, ttnn.bfloat8_b)
+        self.tt_weights, self.tt_bias = prepare_linear_params(device, weights, bias, weights_dtype)
 
     def forward(self, hidden_states):
         hidden_states = ttnn.linear(

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_timesteps.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_timesteps.py
@@ -22,9 +22,10 @@ class TtTimesteps:
         exponent = -log(self.max_period) * torch.arange(start=0, end=self.half_dim, dtype=torch.float32)
         exponent = exponent / (self.half_dim - downscale_freq_shift)
 
+        # Setting emb to bfloat16 increases image quality
         self.emb = ttnn.from_torch(
             torch.exp(exponent),
-            dtype=ttnn.DataType.BFLOAT8_B,
+            dtype=ttnn.DataType.BFLOAT16,
             layout=ttnn.TILE_LAYOUT,
             device=device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_transformermodel.py
@@ -15,7 +15,9 @@ from models.experimental.stable_diffusion_xl_base.tt.sdxl_utility import (
 
 
 class TtTransformer2DModel(nn.Module):
-    def __init__(self, device, state_dict, module_path, query_dim, num_attn_heads, out_dim):
+    def __init__(
+        self, device, state_dict, module_path, query_dim, num_attn_heads, out_dim, weights_dtype=ttnn.bfloat16
+    ):
         super().__init__()
 
         self.device = device
@@ -32,7 +34,13 @@ class TtTransformer2DModel(nn.Module):
         for i in range(self.num_layers):
             self.transformer_blocks.append(
                 TtBasicTransformerBlock(
-                    device, state_dict, f"{module_path}.transformer_blocks.{i}", query_dim, num_attn_heads, out_dim
+                    device,
+                    state_dict,
+                    f"{module_path}.transformer_blocks.{i}",
+                    query_dim,
+                    num_attn_heads,
+                    out_dim,
+                    weights_dtype=weights_dtype,
                 )
             )
 
@@ -43,11 +51,11 @@ class TtTransformer2DModel(nn.Module):
 
         weights = state_dict[f"{module_path}.proj_in.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.proj_in.bias"]
-        self.tt_weights_in, self.tt_bias_in = prepare_linear_params(device, weights, bias, ttnn.bfloat8_b)
+        self.tt_weights_in, self.tt_bias_in = prepare_linear_params(device, weights, bias, weights_dtype)
 
         weights = state_dict[f"{module_path}.proj_out.weight"].unsqueeze(0).unsqueeze(0)
         bias = state_dict[f"{module_path}.proj_out.bias"]
-        self.tt_weights_out, self.tt_bias_out = prepare_linear_params(device, weights, bias, ttnn.bfloat8_b)
+        self.tt_weights_out, self.tt_bias_out = prepare_linear_params(device, weights, bias, weights_dtype)
 
     def forward(self, input_tensor, input_shape, attention_mask=None, encoder_hidden_states=None):
         B, C, H, W = input_shape

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_upblock2d.py
@@ -8,7 +8,7 @@ from models.experimental.stable_diffusion_xl_base.tt.tt_resnetblock2d import TtR
 
 
 class TtUpBlock2D(nn.Module):
-    def __init__(self, device, state_dict, module_path):
+    def __init__(self, device, state_dict, module_path, conv_weights_dtype=ttnn.bfloat16):
         super().__init__()
 
         num_layers = 3
@@ -16,7 +16,14 @@ class TtUpBlock2D(nn.Module):
 
         for i in range(num_layers):
             self.resnets.append(
-                TtResnetBlock2D(device, state_dict, f"{module_path}.resnets.{i}", True, 6 if i == 0 else 2)
+                TtResnetBlock2D(
+                    device,
+                    state_dict,
+                    f"{module_path}.resnets.{i}",
+                    True,
+                    6 if i == 0 else 2,
+                    conv_weights_dtype=conv_weights_dtype,
+                )
             )
 
     def forward(self, hidden_states, res_hidden_states_tuple, input_shape, temb):

--- a/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_upsample2d.py
@@ -20,6 +20,7 @@ class TtUpsample2D(nn.Module):
         padding,
         dilation,
         groups,
+        conv_weights_dtype=ttnn.bfloat16,
     ):
         super().__init__()
 
@@ -35,7 +36,7 @@ class TtUpsample2D(nn.Module):
         bias = state_dict[f"{module_path}.conv.bias"].unsqueeze(0).unsqueeze(0).unsqueeze(0)
 
         self.compute_config, self.conv_config, self.tt_weights, self.tt_bias, self.conv_params = prepare_conv_params(
-            device, weights, bias, ttnn.bfloat8_b
+            device, weights, bias, conv_weights_dtype
         )
 
     def interpolate(self, hidden_states):


### PR DESCRIPTION
### Ticket
#20050 
### Problem description
Experiments have shown that by using bf16 weights + HiFi4 on convolutions (and bf16 timestep embeddigns) yield images that look much closer to CPU than we have at the moment.
For example, this is what we have on CPU:
<img width="738" alt="image" src="https://github.com/user-attachments/assets/9a05d539-62a9-47fb-a7cd-50f4ae74cc11" />
This is what we have now with all weights bfp8:
![image](https://github.com/user-attachments/assets/32d2834a-fc79-4073-8d4a-d06e7bd2287b)
This is what we have with just convolution weights bf16 + HiFi4 (and temb):
![image](https://github.com/user-attachments/assets/67a9cc2a-0341-4408-b953-6949246d56d8)
This is what we have with all weights bf16 (convs and matmuls)
![image](https://github.com/user-attachments/assets/96bc21ad-f7de-489b-8581-2ee34b0f503e)

It does seem based on these results that we can get away with using just conv bfp16 weights, and others bfp8, but since we don't have any broad accuracy results so far, to be on the safe side, I'm moving everything to bf16 at the moment.
Also added knobs to easily switch between bfloat16 and bfp8 on different modules for easier experimentation.
Unit tests are now testing bfloat16 as well, and almost all have PCC increased by a little bit. (Some have a little degradation)
Perf on Unet has gone from ~0.9s to ~1.2s, attributed to conv2d getting worse with bfloat16 weights. Others do not have a significant impact.
![image](https://github.com/user-attachments/assets/be6ac70f-2e72-4435-ac94-1ca7775cfe25)

### What's changed
Moved all weights to bfp16 in sdxl.
### Checklist
- [ x ] [All post commit]passing run here https://github.com/tenstorrent/tt-metal/actions/runs/14880049850
- [ x ] [Frequent model tests] https://github.com/tenstorrent/tt-metal/actions/runs/14880041863 - vae and bert tiny failures, not related to this PR
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes