### PR TITLE
rotary_embedding_llama allow cos/sin to vary by head

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_llama.py
@@ -482,7 +482,6 @@ def apply_rotary_emb_qk_real(
 
 
 @skip_for_blackhole("Requires eth connected devices to run, only single chip BH available. See #12349")
-@skip_for_grayskull("Requires eth connected devices to run")
 @pytest.mark.parametrize(
     "batch, seq_len",
     (

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -100,9 +100,14 @@ void RotaryEmbeddingLlama::validate(const std::vector<Tensor>& input_tensors) co
 
         // Checks for cos and sin
         TT_FATAL(
-            cos.get_logical_shape()[0] == 1 && cos.get_logical_shape()[1] == 1 &&
-                cos.get_logical_shape()[-1] == head_dim,
+            cos.get_logical_shape()[0] == 1 && cos.get_logical_shape()[-1] == head_dim,
             "Cos dims must match input dims");
+        // Check num_heads in cos/sin
+        TT_FATAL(
+            cos.get_logical_shape()[1] == input_tensor.get_logical_shape()[1] || cos.get_logical_shape()[1] == 1,
+            "Num heads in cos/sin must match input tensor num heads or be 1. Expected {}, got {}",
+            input_tensor.get_logical_shape()[1],
+            cos.get_logical_shape()[1]);
         TT_FATAL(
             input_tensor.memory_config().memory_layout == sin.memory_config().memory_layout,
             "Input tensor and sin tensor must have same memory layout");

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_program_factory.cpp
@@ -44,6 +44,9 @@ operation::ProgramWithCallbacks rotary_embedding_llama_multi_core(
     const uint32_t seq_len_t = input.get_padded_shape()[2] / TILE_HEIGHT;
     const uint32_t head_dim_t = input.get_padded_shape()[3] / TILE_WIDTH;
 
+    // Flag for whether or not sin/cos vary per head. If false, they will be broadcasted across heads.
+    const bool freq_per_head = cos.get_padded_shape()[1] == n_heads;
+
     const uint32_t Wbytes = input.get_padded_shape()[-1] * sizeof(bfloat16);
 
     tt_metal::IDevice* device = input.device();
@@ -80,9 +83,10 @@ operation::ProgramWithCallbacks rotary_embedding_llama_multi_core(
 
     uint32_t input_cb_num_tiles = num_sin_cos_rows_per_core * num_input_tiles;
 
-    const bool use_reload_impl = num_rows_per_core > 8;
+    // Reload implementation is used if sequence length is larger than some heuristic threshold where
+    // the buffer size will be too large or if sin/cos are not broadcasted across heads.
+    const bool use_reload_impl = num_rows_per_core > 8 || freq_per_head;
     if (use_reload_impl) {
-        // Do reload implementation of kernel to reduce buffer sizes
         // Only size CBs to double buffer head_dim_t tiles for all inputs
         input_cb_num_tiles = num_input_tiles;
         num_cos_sin_tiles = num_input_tiles;
@@ -171,6 +175,7 @@ operation::ProgramWithCallbacks rotary_embedding_llama_multi_core(
         (std::uint32_t)n_heads,
         (std::uint32_t)seq_len_t,
         (std::uint32_t)head_dim_t,
+        (std::uint32_t)freq_per_head,
     };
     bool dst_is_dram = dst_buffer->buffer_type() == tt_metal::BufferType::DRAM;
     std::vector<uint32_t> writer_compile_time_args = {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama_pybind.cpp
@@ -25,6 +25,9 @@ void py_bind_rotary_embedding_llama(pybind11::module& module) {
 
             When token_idx is passed, this assumes input is transposed to [seq_len, 1, B, head_dim], and seq_len is 1.
 
+            `cos_cache` and `sin_cache` must be of shape [1, n_heads, seq_len, head_dim] or [1, 1, seq_len, head_dim].
+            If shape[1] is 1 then the sin/cos will be broadcasted across heads.
+
             Args:
                 * :attr:`input_tensor`: Input Tensor
                 * :attr:`cos_cache`: Cosine Cache Tensor


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21773

### Problem description
`rotary_embedding_llama` assumes that the cos/sin matrices are broadcasted over the head dimension. Some models require different embeddings per head, so this assumption must change.

### What's changed
The op now allows for cos/sin inputs where the num_heads dimension matches the input tensor. If that's the case, it correctly indexes into the num_heads dimension when reading cos/sin.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14888105061)
- [x] New/Existing tests provide coverage for changes