### PR TITLE
Create padded output tensors in nlp create/concat heads

### DIFF
--- a/models/tt_transformers/tt/multimodal/llama_cross_attention.py
+++ b/models/tt_transformers/tt/multimodal/llama_cross_attention.py
@@ -269,6 +269,8 @@ class TtLlamaCrossAttention(LightweightModule):
         output = ttnn.slice(output, (0, 0, 0, 0), (1, self.n_local_heads, batch, self.head_dim))
         output = ttnn.to_layout(output, layout=ttnn.TILE_LAYOUT)
         output = ttnn.experimental.nlp_concat_heads(output)
+        # NOTE: The rest of the model expects output to be padded to tile height
+        output = ttnn.reshape(output, output.padded_shape, output.padded_shape)
 
         output = ttnn.matmul(
             output,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_concat_heads/device/nlp_concat_heads_device_operation.cpp
@@ -38,7 +38,7 @@ void NLPConcatHeadsDeviceOperation::validate(const std::vector<Tensor>& input_te
 std::vector<ttnn::TensorSpec> NLPConcatHeadsDeviceOperation::compute_output_specs(
     const std::vector<Tensor>& input_tensors) const {
     const auto& input_tensor = input_tensors.at(0);
-    const auto input_shape = input_tensor.get_padded_shape();
+    const auto input_shape = input_tensor.get_logical_shape();
 
     auto num_heads = input_shape[1];
     auto sequence_length = input_shape[2];

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -117,13 +117,13 @@ NlpCreateHeadsDeviceOperation::spec_return_value_t NlpCreateHeadsDeviceOperation
     }
 
     const auto& input_tensor = tensor_args.input_tensor_q;
-    const auto input_shape = input_tensor.get_padded_shape();
+    const auto input_shape = input_tensor.get_logical_shape();
 
     auto sequence_length = input_shape[2];
     auto head_dim = operation_attributes.head_dim;
-    if (sequence_length % TILE_HEIGHT != 0) {
-        sequence_length = (sequence_length / TILE_HEIGHT + 1) * TILE_HEIGHT;
-    }
+    // if (sequence_length % TILE_HEIGHT != 0) {
+    //     sequence_length = (sequence_length / TILE_HEIGHT + 1) * TILE_HEIGHT;
+    // }
     if (head_dim % TILE_WIDTH != 0) {
         head_dim = (head_dim / TILE_WIDTH + 1) * TILE_WIDTH;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads/device/nlp_create_qkv_heads_device_operation.cpp
@@ -121,9 +121,7 @@ NlpCreateHeadsDeviceOperation::spec_return_value_t NlpCreateHeadsDeviceOperation
 
     auto sequence_length = input_shape[2];
     auto head_dim = operation_attributes.head_dim;
-    // if (sequence_length % TILE_HEIGHT != 0) {
-    //     sequence_length = (sequence_length / TILE_HEIGHT + 1) * TILE_HEIGHT;
-    // }
+
     if (head_dim % TILE_WIDTH != 0) {
         head_dim = (head_dim / TILE_WIDTH + 1) * TILE_WIDTH;
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21773

### Problem description
nlp concat and create heads created an output tensor with logical shape equal to the padded shape of the input.

### What's changed
This PR creates output specs with the logical input shape to preserve padding information.

### Checklist
- [ ] [T3K unit frequent and demo](https://github.com/tenstorrent/tt-metal/actions/runs/15167992747)