### PR TITLE
#21779: Retest and remove skip_for_blackhole for tests

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -16,7 +16,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
     run_single_pytorch_test,
 )
-from models.utility_functions import skip_for_blackhole
+
 
 mem_configs = [
     ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
@@ -24,7 +24,6 @@ mem_configs = [
 ]
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dim",
     (3, 2, 1, 0, -1, -2, -3, -4),

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_round.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_round.py
@@ -7,7 +7,7 @@ import torch
 import random
 from functools import partial
 import ttnn
-from models.utility_functions import skip_for_grayskull, skip_for_blackhole
+
 
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
@@ -42,7 +42,6 @@ mem_configs = [
     "dst_mem_config",
     mem_configs,
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
 class TestRound:
     def test_run_round(
         self,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_stats.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_stats.py
@@ -9,7 +9,7 @@ from functools import partial
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from models.utility_functions import is_wormhole_b0, skip_for_blackhole
+from models.utility_functions import is_wormhole_b0, is_blackhole
 import ttnn
 import numpy as np
 
@@ -21,7 +21,7 @@ fns = [
     "normalize_global",
 ]  # "std_global","var_global"]
 
-WH = is_wormhole_b0() * -0.01
+WH = (is_wormhole_b0() or is_blackhole()) * -0.01
 WH2 = 10 * WH
 shapes = [
     [
@@ -57,7 +57,6 @@ shapes = [
 ]
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "input_shapes_and_pcc",
     shapes,

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_sum.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_sum.py
@@ -9,10 +9,8 @@ from functools import partial
 
 from tests.tt_eager.python_api_testing.sweep_tests import comparison_funcs, generation_funcs
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import run_single_pytorch_test
-from models.utility_functions import skip_for_blackhole
 
 
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "input_shapes",
     [

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_unary_floor_div.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_unary_floor_div.py
@@ -12,7 +12,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
     run_single_pytorch_test,
 )
-from models.utility_functions import skip_for_grayskull, skip_for_blackhole
+
 
 mem_configs = [
     ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
@@ -20,7 +20,6 @@ mem_configs = [
 ]
 
 
-@skip_for_blackhole("Unsupported on non WH arch, see #12349")
 @pytest.mark.parametrize(
     "input_shapes",
     [
@@ -37,7 +36,6 @@ mem_configs = [
     "dst_mem_config",
     mem_configs,
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
 class TestUnary_Floor_Div:
     def test_run_unary_floor_div(
         self,

--- a/tests/ttnn/unit_tests/operations/test_moreh_sum.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_sum.py
@@ -10,7 +10,6 @@ from loguru import logger
 import ttnn
 from models.utility_functions import (
     comp_allclose_and_pcc,
-    skip_for_blackhole,
 )
 from tests.ttnn.unit_tests.operations.test_utils import (
     get_compute_kernel_options,


### PR DESCRIPTION
### Ticket
Link to Github Issue #21779 #12349

### Problem description
Some tests (that are not skipped for WH) are skipped for blackhole 

### What's changed
Retest and remove skip_for_blackhole for tests part of BH post-commit pipeline
Also removed skips for grayskull as they are no longer necessary

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14911424862
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes https://github.com/tenstorrent/tt-metal/actions/runs/14884998922
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes