### PR TITLE
#21735: Re-enable lower level eth ubenchmark tests on BH

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -172,8 +172,13 @@ jobs:
     needs:
       - get-image-tags
       - build-images
+    strategy:
+      matrix:
+        bh-card:
+          - P100
+          - P150
     runs-on:
-      - BH
+      - ${{ matrix.bh-card }}
       - in-service
       - cloud-virtual-machine
     steps:

--- a/tests/scripts/single_card/run_bh_upstream_profiler_tests.sh
+++ b/tests/scripts/single_card/run_bh_upstream_profiler_tests.sh
@@ -6,6 +6,5 @@ pytest --collect-only tests/ttnn/unit_tests
 
 echo "[upstream-profiler-tests] Running BH ethernet profiler tests"
 eth_api_iterations=5
-# Ugh some other std::unordered_map bad ref error, Almeet will take a look
-# ARCH_NAME=blackhole pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py::test_erisc_latency_uni_dir --num-iterations $eth_api_iterations
-# ARCH_NAME=blackhole pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py::test_erisc_bw_uni_dir --num-iterations $eth_api_iterations
+ARCH_NAME=blackhole pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_latency.py::test_erisc_latency_uni_dir --num-iterations $eth_api_iterations
+ARCH_NAME=blackhole pytest tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_bandwidth.py::test_erisc_bw_uni_dir --num-iterations $eth_api_iterations


### PR DESCRIPTION
### Ticket

#21735 

### Problem description

Disabled bc broke

### What's changed

Re-enable! But we gotta fix first

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes