### PR TITLE
Prod - Support Non-4D Tensors, Remove 'all_dimensions' Argument 

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -27,13 +27,14 @@ mem_configs = [
 @skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize(
     "dim",
-    (3, 2, 1, 0, -1, -2, -3, -4),
+    (3, 2, 1, 0, -1, -2, -3, -4, None),
 )
-@pytest.mark.parametrize("all_dimensions", [False, True])
 @pytest.mark.parametrize("keepdim", [False, True])
 @pytest.mark.parametrize(
     "input_shapes",
     [
+        [[64, 64]],
+        [[32, 32, 2]],
         [[1, 1, 32, 32]],
         [[4, 3, 32, 32]],
         [[2, 2, 32, 32]],
@@ -51,15 +52,17 @@ mem_configs = [
 class TestProd:
     def test_run_prod_op(
         self,
-        all_dimensions,
         dim,
         keepdim,
         input_shapes,
         dst_mem_config,
         device,
     ):
-        if keepdim and all_dimensions:
-            pytest.skip("keepdim=True with all_dimensions=True is not a valid configuration")
+        if keepdim and (dim is None):
+            pytest.skip("Not a valid configuration to keepdim while reducing all dimensions")
+
+        if dim and (dim >= len(input_shapes[0]) or dim < -len(input_shapes[0])):
+            pytest.skip(f"Dimension {dim} is out of bounds for tensor of rank {len(input_shapes[0])}")
 
         datagen_func = [
             generation_funcs.gen_func_with_cast(partial(generation_funcs.gen_rand, low=1, high=1.5), torch.bfloat16)
@@ -67,7 +70,6 @@ class TestProd:
         test_args = generation_funcs.gen_default_dtype_layout_device(input_shapes)[0]
         test_args.update(
             {
-                "all_dimensions": all_dimensions,
                 "dim": dim,
                 "keepdim": keepdim,
             }

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -37,6 +37,8 @@ mem_configs = [
         [[1, 1, 32, 32]],
         [[4, 3, 32, 32]],
         [[2, 2, 32, 32]],
+        [[2, 8, 16, 5, 4]],
+        [[1, 8, 7, 5, 3, 2]],
         # [[6, 4, 32, 32]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )
         # [[1, 1, 320, 320]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )
         # [[1, 3, 320, 64]], #Fails for all_dimensions = True ( expected result is inf but the result generated in nan )

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -974,10 +974,9 @@ def xlogy(x, y, *args, **kwargs):
     return torch.xlogy(x, y)
 
 
-def prod(x, *args, all_dimensions, dim, **kwargs):
-    if all_dimensions:
+def prod(x, *args, dim, **kwargs):
+    if dim is None:
         return torch.prod(x)
-
     return torch.prod(x, dim, keepdim=kwargs["keepdim"])
 
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1254,7 +1254,6 @@ def arange(
 def prod(
     x,
     *args,
-    all_dimensions,
     dim,
     keepdim,
     device,
@@ -1264,12 +1263,11 @@ def prod(
     output_mem_config,
     **kwargs,
 ):
-    t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
-    t1 = ttnn.prod(t0, all_dimensions, dim, keepdim=keepdim, memory_config=output_mem_config)
+    t0 = ttnn.from_torch(x, device=device, layout=layout[0], memory_config=input_mem_config[0], dtype=dtype[0])
+    t1 = ttnn.prod(t0, dim, keepdim=keepdim, memory_config=output_mem_config)
     output_tensor = ttnn.from_device(t1)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.ROW_MAJOR_LAYOUT)
     output_tensor = ttnn.to_torch(output_tensor)
-
     return output_tensor
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/test_prod_all.py
@@ -54,7 +54,7 @@ def test_prod(shapes, device):
     torch_output = torch.prod(torch_input)
 
     cpu_layout = ttnn.ROW_MAJOR_LAYOUT
-    tt_output_cpu = ttnn.prod(tt_input, all_dimensions=True).cpu().to(cpu_layout).to_torch()
+    tt_output_cpu = ttnn.prod(tt_input).cpu().to(cpu_layout).to_torch()
     N = tt_output_cpu.shape
     torch.set_printoptions(threshold=10000, precision=5, sci_mode=False)
     logger.info("Input shape")

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_prod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_prod.py
@@ -43,17 +43,20 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
 )
 @pytest.mark.parametrize(
     "dim",
-    [-4, -3, -2, -1, 0, 1, 2, 3],
+    [-4, -3, -2, -1, 0, 1, 2, 3, None],
 )
-@pytest.mark.parametrize("all_dimensions", [True, False])
-def test_bw_prod(input_shapes, all_dimensions, dim, device):
+def test_bw_prod(input_shapes, dim, device):
+    all_dimensions = dim is None
     in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
     grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device, all_dimensions, dim)
-    if all_dimensions == False:
-        pyt_y = torch.prod(in_data, dim=dim, keepdim=True)
-    else:
+
+    if all_dimensions:
         pyt_y = torch.prod(in_data)
-    tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor, all_dimensions=all_dimensions, dim=dim)
+        tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor)
+    else:
+        pyt_y = torch.prod(in_data, dim=dim, keepdim=True)
+        tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor, dim=dim)
+
     in_data.retain_grad()
     pyt_y.backward(gradient=grad_data)
 
@@ -77,33 +80,6 @@ def test_bw_prod_default_both(input_shapes, device):
     grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device)
     pyt_y = torch.prod(in_data)
     tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor)
-    in_data.retain_grad()
-    pyt_y.backward(gradient=grad_data)
-
-    golden_tensor = [in_data.grad]
-
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
-
-    assert comp_pass
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    (
-        (torch.Size([1, 1, 32, 32])),
-        (torch.Size([1, 1, 320, 384])),
-        (torch.Size([32, 64, 64, 64])),
-    ),
-)
-@pytest.mark.parametrize("all_dimensions", [True, False])
-def test_bw_prod_default_dim(input_shapes, all_dimensions, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt_prod(input_shapes, device, all_dimensions)
-    if all_dimensions == False:
-        pyt_y = torch.prod(in_data, dim=0, keepdim=True)
-    else:
-        pyt_y = torch.prod(in_data)
-    tt_output_tensor_on_device = ttnn.prod_bw(grad_tensor, input_tensor, all_dimensions=all_dimensions)
     in_data.retain_grad()
     pyt_y.backward(gradient=grad_data)
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -1795,14 +1795,9 @@ std::vector<Tensor> ExecuteUnaryBackwardProd::invoke(
     auto output_memory_config = output_mem_config.value_or(
         input.memory_config());  // TODO: Remove after ternary forward ops migration is completed
 
-    Tensor prod_result;
     const bool all_dimensions = !dim.has_value();
-
-    if (all_dimensions) {
-        prod_result = ttnn::prod(input, /*dim=*/std::nullopt, /*keepdim=*/false, output_memory_config);
-    } else {
-        prod_result = ttnn::prod(input, *dim, /*keepdim=*/true, output_memory_config);
-    }
+    const bool keepdim = !all_dimensions;
+    Tensor prod_result = ttnn::prod(input, dim, keepdim, output_memory_config);
 
     if (prod_result.get_layout() == Layout::ROW_MAJOR && prod_result.storage_type() == StorageType::DEVICE) {
         prod_result = ttnn::operations::unary_backward::change_layout_to_tile(prod_result, output_memory_config);

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.hpp
@@ -547,8 +547,7 @@ struct ExecuteUnaryBackwardProd {
     static std::vector<Tensor> invoke(
         const Tensor& grad_tensor_arg,
         const Tensor& input_tensor_arg,
-        bool all_dimensions = true,
-        int64_t dim = 0,
+        const std::optional<int64_t> dim = std::nullopt,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 };
 

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward_pybind.hpp
@@ -1098,15 +1098,15 @@ template <typename unary_backward_operation_t>
 void bind_unary_backward_prod_bw(py::module& module, const unary_backward_operation_t& operation) {
     auto doc = fmt::format(
         R"doc(
-        Performs backward operations for prod on :attr:`input_tensor` with given :attr:`grad_tensor` along `all_dimensions` or a particular `dim`.
+        Performs backward operations for prod on :attr:`input_tensor` with given :attr:`grad_tensor` along a particular `dim`.
+        If no `dim` is provided, the prod is taken over all dimensions.
 
         Args:
             grad_tensor (ttnn.Tensor): the input gradient tensor.
             input_tensor (ttnn.Tensor): the input tensor.
 
         Keyword args:
-            all_dimensions (bool, optional): perform prod backward along all dimensions, ignores dim param. Defaults to `True`.
-            dim (int, optional): dimension to perform prod backward. Defaults to `0`.
+            dim (int, optional): dimension to perform prod backward. Defaults to `None`.
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
 
         Returns:
@@ -1131,9 +1131,9 @@ void bind_unary_backward_prod_bw(py::module& module, const unary_backward_operat
 
             >>> grad_tensor = ttnn.from_torch(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> input = ttnn.from_torch(torch.rand([1, 1, 32, 32], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device)
-            >>> all_dimensions = True
             >>> dim =0
-            >>> output = {1}(grad_tensor, input, all_dimensions, dim)
+            >>> output = {1}(grad_tensor, input, dim)
+            >>> all_dims_output = {1}(grad_tensor, input)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name());
@@ -1146,16 +1146,14 @@ void bind_unary_backward_prod_bw(py::module& module, const unary_backward_operat
             [](const unary_backward_operation_t& self,
                const ttnn::Tensor& grad_tensor,
                const ttnn::Tensor& input_tensor,
-               bool all_dimensions,
-               int64_t dim,
+               const std::optional<int64_t> dim,
                const std::optional<MemoryConfig>& memory_config) {
-                return self(grad_tensor, input_tensor, all_dimensions, dim, memory_config);
+                return self(grad_tensor, input_tensor, dim, memory_config);
             },
             py::arg("grad_tensor"),
             py::arg("input_tensor"),
             py::kw_only(),
-            py::arg("all_dimensions") = true,
-            py::arg("dim") = 0,
+            py::arg("dim") = std::nullopt,
             py::arg("memory_config") = std::nullopt});
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -94,10 +94,8 @@ Tensor prod_nc(
     const Tensor& output,
     ttnn::SmallVector<int64_t>& dims,
     const MemoryConfig& output_mem_config) {
-    // reduce for all dims
-    if (dims.empty()) {
-        dims = {0, 1, 2, 3};
-    }
+    // Should not be empty
+    TT_FATAL(!dims.empty(), "dims should not be empty");
 
     ttnn::SmallVector<int64_t> sorted_dims = dims;
     std::sort(sorted_dims.begin(), sorted_dims.end());

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_op.cpp
@@ -94,8 +94,7 @@ Tensor prod_nc(
     const Tensor& output,
     ttnn::SmallVector<int64_t>& dims,
     const MemoryConfig& output_mem_config) {
-    // Should not be empty
-    TT_FATAL(!dims.empty(), "dims should not be empty");
+    TT_FATAL(!dims.empty(), "prod_nc dims should not be empty");
 
     ttnn::SmallVector<int64_t> sorted_dims = dims;
     std::sort(sorted_dims.begin(), sorted_dims.end());

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -188,6 +188,10 @@ Tensor ProdOperation::invoke(
     ttnn::SmallVector<int64_t>& dims,
     const std::optional<MemoryConfig>& memory_config) {
     auto mem_cfg = memory_config.value_or(input.memory_config());
+
+    if (dims.empty()) {
+        return prod_all(input, mem_cfg);
+    }
     return tt::operations::primary::prod_nc(input, output, dims, mem_cfg);
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -80,62 +80,110 @@ Tensor ProdOperation::invoke(
     const int size = static_cast<int>(input_a.get_logical_shape().rank());
 
     const auto old_rank = input_a.get_logical_shape().rank();
+    const ttnn::Shape input_shape = input_a.get_logical_shape();
 
-    auto input_tensor_4d = (old_rank > 4)   ? data_movement::squeeze_from_ND_to_4D(input_a)
-                           : (old_rank < 4) ? ttnn::unsqueeze_to_4D(input_a)
-                                            : input_a;
     if (all_dimensions) {
         TT_FATAL(!keepdim, "Not possible to keepdim with all_dimensions enabled, as this returns a scalar");
         return prod_all(input_a, output_mem_config);
     }
+
+    TT_FATAL(size > 0, "Tensor has no dimensions");
     TT_FATAL(
-        size && dim >= -size && dim <= size - 1,
+        dim >= -size && dim <= size - 1,
         "Dimension for prod is out of range (expected to be in range of [{}, {}]",
         -size,
         size - 1);
 
-    // update the dim because we unsqueezed input to 4d
-    const int64_t old_dim = dim;
-    if (dim >= 0) {
-        dim = (4 - old_rank + dim);
+    // Bring dim into range [0, size - 1]
+    if (dim < 0) {
+        dim += size;
     }
 
-    Tensor temp = input_tensor_4d;
-    // Permute for dim 2,3
-    if (dim == 2 || dim == -2) {
-        ttnn::SmallVector<int64_t> permute_dims = {2, 0, 1, 3};
-        temp = ttnn::permute(input_tensor_4d, permute_dims, output_mem_config);
-    } else if (dim == 3 || dim == -1) {
-        ttnn::SmallVector<int64_t> permute_dims = {3, 0, 1, 2};
-        temp = ttnn::permute(input_tensor_4d, permute_dims, output_mem_config);
+    // For higher dimension Tensors, we need to squeeze to 4D to perform the reduction
+    if (old_rank > 4) {
+        // Prod only can do reduction on dim0 or dim1.
+        // After squeezing the ND tensor to 4D, the third last dimension will become the second (i.e, [1]) dimension
+        // We will permute the target reduction dim to this eventual position in a 4D tensor, and reduce it there
+        // Then unsqueeze back to ND, and move the reduction dim back to its original position
+
+        // First, permute the target reduction dim to the third last position
+        ttnn::SmallVector<int64_t> post_permute_dims(input_a.get_logical_shape().rank());
+        std::iota(post_permute_dims.begin(), post_permute_dims.end(), 0);
+
+        const int third_last_dim_idx = input_a.get_logical_shape().rank() - 3;
+        std::swap(post_permute_dims[third_last_dim_idx], post_permute_dims[dim]);
+
+        ttnn::Tensor permuted = ttnn::permute(input_a, post_permute_dims, output_mem_config);
+
+        // Now squeeze to 4D and do the 4D prod.
+        // Dim0 grows to include the rest of the dimensions, and our "third last" dim moves into dim1, which is our 4D
+        // reduction dim
+        auto input_tensor_4d = data_movement::squeeze_from_ND_to_4D(permuted);
+        Tensor result = prod_nc(input_tensor_4d, /*dim=*/1, output_mem_config);
+
+        // Unsqueeze dim0 to restore the original tensor rank
+        ttnn::Shape output_shape = ttnn::Shape(input_shape);
+        output_shape[dim] = output_shape[third_last_dim_idx];
+        output_shape[third_last_dim_idx] = 1;
+
+        result = ttnn::reshape(result, output_shape);
+
+        // Can now permute the reduced dim to the correct position
+        result = ttnn::permute(result, post_permute_dims, output_mem_config);
+
+        if (!keepdim) {
+            result = ttnn::squeeze(result, dim);
+        }
+        return result;
     }
-    Tensor result = prod_nc(temp, dim, output_mem_config);
-    // Permute and unpad result for dim 2,3. Don't need to process dim 0,1.
-    auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
-    if (dim == 0 || dim == 1 || dim == -4 || dim == -3) {
-        result = ttnn::squeeze_from_4D(result, old_rank);
-    } else if (dim == 2 || dim == -2) {
-        ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
-        Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
-        const auto& input_shape = input_tensor_4d.get_logical_shape();
-        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[3]};
-        result = ttnn::squeeze_from_4D(ttnn::slice(required, start_index, end_index, step, std::nullopt), old_rank);
-    } else {  // dim 3
-        // permute
-        ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
-        Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
-        // unpad
-        const auto& input_shape = input_tensor_4d.get_logical_shape();
-        ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
-        ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[2]};
-        Tensor new_unpad_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
-        // permute back
-        after_permute_dims = {0, 1, 3, 2};
-        Tensor res_host = ttnn::permute(new_unpad_tensor, after_permute_dims, output_mem_config);
-        result = ttnn::squeeze_from_4D(res_host, old_rank);
+    // 4D or lower dimension Tensors
+    else {
+        // For lower dimension Tensors, we need to unsqueeze to 4D
+        auto input_tensor_4d = ttnn::unsqueeze_to_4D(input_a);
+
+        // update the dim because we unsqueezed input to 4d
+        const int64_t old_dim = dim;
+        if (dim >= 0) {
+            dim = (4 - old_rank + dim);
+        }
+
+        Tensor temp = input_tensor_4d;
+        // Permute for dim 2,3
+        if (dim == 2 || dim == -2) {
+            ttnn::SmallVector<int64_t> permute_dims = {2, 0, 1, 3};
+            temp = ttnn::permute(input_tensor_4d, permute_dims, output_mem_config);
+        } else if (dim == 3 || dim == -1) {
+            ttnn::SmallVector<int64_t> permute_dims = {3, 0, 1, 2};
+            temp = ttnn::permute(input_tensor_4d, permute_dims, output_mem_config);
+        }
+        Tensor result = prod_nc(temp, dim, output_mem_config);
+        // Permute and unpad result for dim 2,3. Don't need to process dim 0,1.
+        auto step = ttnn::SmallVector<uint32_t>({1, 1, 1, 1});
+        if (dim == 0 || dim == 1 || dim == -4 || dim == -3) {
+            result = ttnn::squeeze_from_4D(result, old_rank);
+        } else if (dim == 2 || dim == -2) {
+            ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
+            Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
+            const auto& input_shape = input_tensor_4d.get_logical_shape();
+            ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+            ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[3]};
+            result = ttnn::squeeze_from_4D(ttnn::slice(required, start_index, end_index, step, std::nullopt), old_rank);
+        } else {  // dim 3
+            // permute
+            ttnn::SmallVector<int64_t> after_permute_dims = {1, 2, 0, 3};
+            Tensor required = ttnn::permute(result, after_permute_dims, output_mem_config);
+            // unpad
+            const auto& input_shape = input_tensor_4d.get_logical_shape();
+            ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
+            ttnn::SmallVector<uint32_t> end_index = {input_shape[0], input_shape[1], 1, input_shape[2]};
+            Tensor new_unpad_tensor = ttnn::slice(required, start_index, end_index, step, std::nullopt);
+            // permute back
+            after_permute_dims = {0, 1, 3, 2};
+            Tensor res_host = ttnn::permute(new_unpad_tensor, after_permute_dims, output_mem_config);
+            result = ttnn::squeeze_from_4D(res_host, old_rank);
+        }
+        return keepdim ? result : ttnn::squeeze(result, old_dim);
     }
-    return keepdim ? result : ttnn::squeeze(result, old_dim);
 }
 
 Tensor ProdOperation::invoke(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.hpp
@@ -16,8 +16,7 @@ namespace operations::reduction {
 struct ProdOperation {
     static Tensor invoke(
         const Tensor& input,
-        bool all_dimensions = false,
-        int64_t dim = 0,
+        const std::optional<int64_t> dim = std::nullopt,
         const bool keepdim = false,
         const std::optional<MemoryConfig>& memory_config = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_pybind.hpp
@@ -19,18 +19,18 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
     auto doc = fmt::format(
         R"doc(
 
-            Computes the prod function along specified ``dim`` or all dimensions on the ``input`` tensor.
+            Computes the product of all elements on specified ``dim`` of the ``input`` tensor.
 
-            .. math::
-                {0}(\\mathrm{{input\\_tensor}}_i)
+            If no ``dim`` is provided (or ``dim`` is set to `None`), it will compute the product of all elements in the ``input`` tensor.
+            If ``keepdim`` is `True`, the resulting tensor will have a similar shape as the ``input`` tensor, but with the specified ``dim`` reduced to 1. This is not supported when taking the product across all dimensions.
+            Otherwise, the target ``dim`` will be squeezed, resulting in an output tensor with one less dimension than the ``input`` tensor.
 
             Args:
                 input_tensor (ttnn.Tensor): the input tensor.
-                all_dimensions (bool, optional): prod along all dimensions. Defaults to `False`.
-                dim (int, optional): Dimension to perform prod. Defaults to `0`.
-                keepdim (bool, optional): keep original dimension size. Defaults to `False`.
 
             Keyword Args:
+                dim (int, optional): Dimension to perform prod. Defaults to `None`.
+                keepdim (bool, optional): keep original dimension size. Defaults to `False`.
                 memory_config (ttnn.MemoryConfig, optional): Memory configuration for the operation. Defaults to `None`.
 
             Returns:
@@ -39,7 +39,8 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
             Example::
 
                 >>> tensor = ttnn.from_torch(torch.tensor((1, 2), dtype=torch.bfloat16), device=device)
-                >>> output = {1}(tensor)
+                >>> output = {1}(tensor, dim=0)
+                >>> output_all_dims = {1}(tensor)
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name());
@@ -51,15 +52,13 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
         ttnn::pybind_overload_t{
             [](const unary_operation_t& self,
                const Tensor& input_tensor,
-               bool all_dimensions,
-               int dim,
+               const std::optional<int64_t> dim,
                const bool keepdim,
                const std::optional<MemoryConfig>& memory_config) {
-                return self(input_tensor, all_dimensions, dim, keepdim, memory_config);
+                return self(input_tensor, dim, keepdim, memory_config);
             },
             py::arg("input_tensor"),
-            py::arg("all_dimensions") = false,
-            py::arg("dim") = 0,
+            py::arg("dim") = std::nullopt,
             py::arg("keepdim") = false,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt},
@@ -75,7 +74,7 @@ void bind_reduction_prod_operation(py::module& module, const unary_operation_t& 
             py::arg("input_tensor"),
             py::arg("output_tensor"),
             py::kw_only(),
-            py::arg("dims") = ttnn::SmallVector<int64_t>(),
+            py::arg("dims"),
             py::arg("memory_config") = std::nullopt});
 }
 


### PR DESCRIPTION
### Ticket
Resolves #12939

### Problem description
Prod was made to support 4D tensors, and would either yield strange results or throw unclear errors when >4D tensors were supplied.

The prod interface also differed from the `torch.prod` interface. When no `dim` argument was supplied PyTorch would reduce along all dimensions, while TTNN would default to dim0. TTNN instead had an `all_dimensions` argument, which when enabled would override the selected `dim`.

### What's changed
Non-4D tensors are supported by reshaping and permuting the input tensor to turn it into an input the prod kernels can support (i.e., a 4D tensor being reduced on either N or C), then restoring the output tensor to the shape expected for the original input.

The `all_dimensions` argument has been removed, and running without a `dim` argument (or supplying `None`) will result in a full prod, matching `torch.prod`.

Tests have been updated for this change in arguments, and to include 2D, 3D, 5D, and 6D testcases. 

This is a follow up to [20716](https://github.com/tenstorrent/tt-metal/pull/20716), which added ND support to the full prod operation. 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14898563348)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes