### PR TITLE
#0: Replicate `tt_attention_mask` in mesh device

### DIFF
--- a/tests/ttnn/integration_tests/bert_tiny/test_bert_tiny_wh.py
+++ b/tests/ttnn/integration_tests/bert_tiny/test_bert_tiny_wh.py
@@ -59,7 +59,7 @@ def test_bert_attention_inference(
         device=mesh_device,
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        mesh_mapper=inputs_mesh_mapper,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     tt_output = bert_attention(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
https://github.com/tenstorrent/tt-metal/commit/d76ad46685bf5ea89761f0c4b79b2d3185668ba3 broke `FD WH N300 ttnn nightly wormhole_b0`.

The underlying issue seems to be that `tt_attention_mask` is not correctly uploaded to `MeshDevice`:
* We are attempting to shard `torch.zeros(1, 128)` with `ttnn.ShardTensorToMesh(mesh_device, dim=0)`
* This results in 1 shard.
* Code before https://github.com/tenstorrent/tt-metal/commit/d76ad46685bf5ea89761f0c4b79b2d3185668ba3 would incorrectly treat this "sharding" schema as replication, because there is 1 buffer. We fell back on the single-buffer storage `HostStorage` incorrectly.
* New code correctly distributes the tensor unevenly - sharding `torch.zeros(1, 128)` over first dim produces a single shard that gets uploaded to just one device. This should be correct behavior.

Note: in `test_bert_for_question_answering`, attention mask was replicated correctly all along, and the test was passing:
```
    ttnn_attention_mask = ttnn.from_torch(
        torch_attention_mask,
        dtype=ttnn.bfloat16,
        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
        device=mesh_device,
    )
```


### What's changed
Replicate `tt_attention_mask` in `test_bert_attention_inference`

### Checklist
- [X] [Single card perf tests](https://github.com/tenstorrent/tt-metal/actions/runs/14889056742). Failing stable diffusion the same as on main and is unrelated.
- [X] New/Existing tests provide coverage for changes

Tested locally (on T3K)