### PR TITLE
#0: [skip ci] Custom test dispatch: only set WH_ARCH_YAML if running on wormhole

### DIFF
--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -101,7 +101,7 @@ jobs:
             -e ARCH_NAME=${{ inputs.arch }}
             -e LD_LIBRARY_PATH=${{ github.workspace }}/build/lib
             -e GTEST_OUTPUT=xml:generated/test_reports/
-            -e WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml
+            ${{ (inputs.arch == 'wormhole_b0' && '-e WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml') || '' }}
           run_args: |
             pip3 install pytest-repeat
             ${{ inputs.command }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Setting `WH_ARCH_YAML` when running blackhole on custom test dispatch can cause tests to crash with fatal python errors:
https://github.com/tenstorrent/tt-metal/actions/runs/14886765336/job/41810076622#step:8:214

Passes when not set: 
https://github.com/tenstorrent/tt-metal/actions/runs/14886986122/job/41810158996

### What's changed
Only set `WH_ARCH_YAML` env var in docker container when arch is `wormhole_b0`

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes