### PR TITLE
#21390: [skip ci] Run blackhole demo tests on p100a cards

### DIFF
--- a/.github/workflows/blackhole-demo-tests-impl.yaml
+++ b/.github/workflows/blackhole-demo-tests-impl.yaml
@@ -15,7 +15,7 @@ on:
       runner-label:
         required: false
         type: string
-        default: "BH-baremetal"
+        default: "BH"
 
 jobs:
   single-card-demo-tests:
@@ -56,8 +56,7 @@ jobs:
         with:
           name: ${{ inputs.wheel-artifact-name }}
       - name: Enable Performance mode
-        # Only touch the perf governor if we're running on a baremetal machine
-        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH-baremetal' }}
+        if: ${{ contains(matrix.test-group.name, 'performance') }}
         run: |
           sudo cpupower frequency-set -g performance
       - name: Run demo regression tests
@@ -81,7 +80,7 @@ jobs:
           path: generated/test_reports/
           prefix: "test_reports_"
       - name: Disable Performance mode
-        if: ${{ contains(matrix.test-group.name, 'performance') && inputs.runner-label == 'BH-baremetal' }}
+        if: ${{ contains(matrix.test-group.name, 'performance') }}
         run: |
           sudo cpupower frequency-set -g ondemand
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main

--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: BH-baremetal
+      runner-label: BH
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -152,7 +152,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml
     with:
-      runner-label: BH-baremetal
+      runner-label: BH
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -33,10 +33,6 @@ on:
         description: 'Enable watcher in BH Post commit'
         default: false
         type: boolean
-      run-demo-tests:
-        description: 'Run blackhole demo tests'
-        default: true
-        type: boolean
   schedule:
     - cron: "0 */4 * * *"
   # Pause this since not enough runners to support every commit to main
@@ -146,8 +142,6 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
   blackhole-demo-tests:
-    # Issue 20998: Due to capacity constraints, only run blackhole demo tests on workflow_dispatch events
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-demo-tests == true }}
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/blackhole-demo-tests-impl.yaml


### PR DESCRIPTION
### Ticket
Resolves https://github.com/tenstorrent/tt-metal/issues/21390 and resolves https://github.com/tenstorrent/tt-metal/issues/21014

### Problem description
Blackhole demo tests were running on p100 scrappy cards only due to hang on p100a, which was fixed with https://github.com/tenstorrent/tt-metal/issues/21210 

### What's changed
Change `BH-baremetal` label (p100 scrappy label) back to `BH` label (p100a) in workflows
Always run demo tests as part of blackhole post-commit

### Checklist
- [x] Blackhole demo tests: https://github.com/tenstorrent/tt-metal/actions/runs/15004202696 (failure is on perf metric target)