### PR TITLE
AllGatherConcat 4 links + ring support

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -22,6 +22,7 @@ from tests.ttnn.unit_tests.operations.ccl.fusion_subtests.concat_fuse_test impor
 )
 
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
+from conftest import is_6u
 
 
 def run_allgather_only_with_trace(
@@ -584,6 +585,121 @@ def test_concat_fuse(
         input_shard_shape,
         input_shard_grid,
         all_gather_topology=ttnn.Topology.Linear,
+        warmup_iters=warmup_iters,
+        num_iters=num_iters,
+        output_shard_shape=output_shard_shape,
+        output_shard_grid=output_shard_grid,
+        tensor_mem_layout=tensor_mem_layout,
+        trace_mode=trace_mode,
+        profiler=profiler,
+    )
+
+
+@pytest.mark.skipif(not is_6u())
+@pytest.mark.parametrize(
+    "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
+    [
+        # Before Concat Heads
+        (
+            4,
+            [1, 32, 32, 128],
+            1,
+            ttnn.ROW_MAJOR_LAYOUT,
+            (32, 128),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 2), ttnn.CoreCoord(2, 2)),
+                }
+            ),
+            (32, 64),
+            ttnn.CoreRangeSet(
+                [
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 6), ttnn.CoreCoord(6, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 7), ttnn.CoreCoord(6, 7)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 9), ttnn.CoreCoord(6, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 0), ttnn.CoreCoord(6, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 1), ttnn.CoreCoord(6, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 2), ttnn.CoreCoord(6, 2)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 4), ttnn.CoreCoord(6, 4)),
+                    ttnn.CoreRange(ttnn.CoreCoord(6, 5), ttnn.CoreCoord(6, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 5), ttnn.CoreCoord(5, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 6), ttnn.CoreCoord(5, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 7), ttnn.CoreCoord(5, 7)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 9), ttnn.CoreCoord(5, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(5, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 1), ttnn.CoreCoord(5, 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 2), ttnn.CoreCoord(5, 2)),
+                    ttnn.CoreRange(ttnn.CoreCoord(5, 4), ttnn.CoreCoord(5, 4)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 4), ttnn.CoreCoord(1, 4)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 5), ttnn.CoreCoord(1, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 9), ttnn.CoreCoord(1, 9)),
+                    ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 0)),
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 4), ttnn.CoreCoord(2, 4)),
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 5), ttnn.CoreCoord(2, 5)),
+                    ttnn.CoreRange(ttnn.CoreCoord(2, 9), ttnn.CoreCoord(2, 9)),
+                ]
+            ),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("num_links", [4])
+@pytest.mark.parametrize(
+    "input_dtype",
+    [
+        ttnn.bfloat16,
+        # ttnn.bfloat8_b,
+    ],
+)
+@pytest.mark.parametrize("num_iters, warmup_iters", [[75, 5]])
+@pytest.mark.parametrize("trace_mode", [True])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "trace_region_size": 23887872,
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_concat_fuse_6u(
+    mesh_device,
+    num_devices,
+    output_shape,
+    dim,
+    num_links,
+    input_dtype,
+    layout,
+    num_iters,
+    warmup_iters,
+    use_program_cache,
+    function_level_defaults,
+    input_shard_shape,
+    input_shard_grid,
+    output_shard_shape,
+    output_shard_grid,
+    tensor_mem_layout,
+    trace_mode,
+):
+    profiler = BenchmarkProfiler()
+    run_concat_fuse_impl(
+        mesh_device,
+        num_devices,
+        output_shape,
+        dim,
+        num_links,
+        input_dtype,
+        layout,
+        use_program_cache,
+        function_level_defaults,
+        input_shard_shape,
+        input_shard_grid,
+        all_gather_topology=ttnn.Topology.Ring,
         warmup_iters=warmup_iters,
         num_iters=num_iters,
         output_shard_shape=output_shard_shape,

--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -595,7 +595,7 @@ def test_concat_fuse(
     )
 
 
-@pytest.mark.skipif(not is_6u())
+@pytest.mark.skipif(not is_6u(), reason="skip when not 6u")
 @pytest.mark.parametrize(
     "num_devices, output_shape, dim, layout, input_shard_shape, input_shard_grid, output_shard_shape, output_shard_grid, tensor_mem_layout",
     [

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_op.cpp
@@ -100,9 +100,13 @@ tt::tt_metal::operation::ProgramWithCallbacks AllGatherConcat::create_program_at
             device_index = i;
             if (i != 0) {
                 backward_device = devices.at(i - 1);
+            } else if (this->topology == ttnn::ccl::Topology::Ring) {
+                backward_device = devices.at(this->ring_size - 1);
             }
             if (i != this->ring_size - 1) {
                 forward_device = devices.at(i + 1);
+            } else if (this->topology == ttnn::ccl::Topology::Ring) {
+                forward_device = devices.at(0);
             }
         }
     }
@@ -163,9 +167,6 @@ Tensor all_gather_concat(
     const std::optional<uint32_t> num_links,
     const ttnn::ccl::Topology topology,
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id) {
-    TT_FATAL(
-        topology == ttnn::ccl::Topology::Linear,
-        "This all_gather API with cluster_axis is currently supported only for the Linear topology");
     const auto mesh_view = mesh_device.get_view();
     uint32_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/all_gather_concat_program.cpp
@@ -36,7 +36,8 @@ namespace ttnn {
 using namespace ccl;
 
 struct llama_config {
-    CoreRange sem_drain_core = CoreRange({1, 0}, {1, 0});
+    CoreRange sem_drain_core_3 = CoreRange({1, 0}, {1, 0});
+    CoreRange sem_drain_core_4 = CoreRange({3, 0}, {3, 0});
     CoreRange nlp_only_core_range_1 = CoreRange({1, 1}, {3, 1});  // cores that are used for NLP op only
     CoreRange nlp_only_core_range_2 = CoreRange({1, 2}, {2, 2});
     uint32_t num_cores_input_tensor = 8;
@@ -93,15 +94,18 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
     std::vector<Tensor> output_tensors = {output_tensor};
     std::vector<Tensor> temp_tensors = {temp_tensor};
     const auto& op_config = ttnn::ccl::CCLOpConfig(input_tensors, temp_tensors, topology);
-    LineTopology line_topology(ring_size, ring_index);
-    const size_t num_targets_forward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::FORWARD);
-    const size_t num_targets_backward = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::BACKWARD);
+    auto [num_targets_forward, num_targets_backward, dynamic_alternate] =
+        ccl::get_forward_backward_configuration(ring_size, ring_index, topology);
 
     // To overlap NLP local data with all gather, we divide the batches for each device into:
     //      - local batch (starts with start_local)
     //      - remote batches
     //          - batch 1 (from batch_start_1 to batch end_1)
     //          - batch 2 (from batch_start_2 to batch end_2) if applicable
+    LineTopology line_topology(ring_size, ring_index);
+    const size_t num_targets_right = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::FORWARD);
+    const size_t num_targets_left = line_topology.get_distance_to_end_of_line(ttnn::ccl::LineDirection::BACKWARD);
+
     uint32_t batch_size = 1;
     uint32_t batch_start_1 = 8;
     uint32_t batch_end_1 = 32;
@@ -109,21 +113,21 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
     uint32_t batch_end_2 = 0;
     uint32_t start_local = 0;
 
-    if (num_targets_forward == 2 && num_targets_backward == 1) {
+    if (num_targets_right == 2 && num_targets_left == 1) {
         batch_size = 2;
         batch_start_1 = 0;
         batch_end_1 = 8;
         batch_start_2 = 16;
         batch_end_2 = 32;
         start_local = 8;
-    } else if (num_targets_forward == 1 && num_targets_backward == 2) {
+    } else if (num_targets_right == 1 && num_targets_left == 2) {
         batch_size = 2;
         batch_start_1 = 0;
         batch_end_1 = 16;
         batch_start_2 = 24;
         batch_end_2 = 32;
         start_local = 16;
-    } else if (num_targets_forward == 0 && num_targets_backward == 3) {
+    } else if (num_targets_right == 0 && num_targets_left == 3) {
         batch_size = 1;
         batch_start_1 = 0;
         batch_end_1 = 24;
@@ -133,7 +137,12 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
     // Get worker cores, assuming 1 worker per link
     uint32_t num_workers_per_link = 1;
 
-    auto sender_worker_core_range = CoreRangeSet(CoreRange({1, 0}, {num_links, 0}));
+    CoreRangeSet sender_worker_core_range;
+    if (num_links == 4) {
+        sender_worker_core_range = CoreRangeSet(CoreRange({3, 0}, {3, num_links - 1}));
+    } else {
+        sender_worker_core_range = CoreRangeSet(CoreRange({1, 0}, {num_links, 0}));
+    }
     auto sender_worker_cores = corerange_to_cores(sender_worker_core_range, num_links, true);
     // Tensor Info
     const uint32_t logical_dim_2 = input_tensor.get_logical_shape()[2];
@@ -235,7 +244,11 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
     }
     const auto& q_cores_updated = CoreRangeSet(q_cores_vector);
     std::vector<CoreRange> sem_cores_vector;
-    sem_cores_vector.push_back(llama_configuration.sem_drain_core);
+    if (num_links == 4) {
+        sem_cores_vector.push_back(llama_configuration.sem_drain_core_4);
+    } else {
+        sem_cores_vector.push_back(llama_configuration.sem_drain_core_3);
+    }
     range_count = 0;
     for (auto cr : ring_core_ranges) {
         sem_cores_vector.push_back(cr);
@@ -335,7 +348,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
             .compile_args = all_gather_reader_ct_args});
 
     // Writer
-    uint32_t out_ready_sem_wait_value = ring_size * num_links;
+    uint32_t out_ready_sem_wait_value = (dynamic_alternate ? (ring_size + 1) : ring_size) * num_links;
     std::vector<uint32_t> all_gather_writer_ct_args = {
         ring_index,                       // my_chip_id
         reserved_packet_header_CB_index,  // reserved_packet_header_cb_id
@@ -345,6 +358,7 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
         op_config.get_page_size(),        // tensor0_page_size
         num_targets_forward,              // num_targets_forward_direction
         num_targets_backward,             // num_targets_backward_direction
+        dynamic_alternate,                // alternate
         llama_configuration.num_semaphore_ranges,
         out_ready_sem_wait_value};
 
@@ -432,7 +446,6 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
         if (link == 0) {
             // drain sync core is the first worker core
             drain_sync_core = mesh_device->worker_core_from_logical_core(core);
-            TT_ASSERT(drain_sync_core.x == 19 && drain_sync_core.y == 18, "This op should run on a TG machine");
         }
 
         // Set reader runtime args
@@ -465,6 +478,8 @@ tt::tt_metal::operation::ProgramWithCallbacks all_gather_concat_llama_sharded(
             output_tensor_cores_x.size(),         // num_cores
             wait_output_semaphore,                // wait_output_semaphore
             reset_global_semaphore,               // reset_global_semaphore
+            drain_sync_core.x,
+            drain_sync_core.y,
             concat_semaphore_id,
             concat_semaphore_id2,
         };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_concat_heads_fused/device/kernels/llama_all_gather_concat_writer.cpp
@@ -25,8 +25,12 @@ constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(4);
 constexpr uint32_t tensor0_page_size = get_compile_time_arg_val(5);
 constexpr uint32_t num_targets_forward_direction = get_compile_time_arg_val(6);
 constexpr uint32_t num_targets_backward_direction = get_compile_time_arg_val(7);
-constexpr uint32_t num_sem_ranges = get_compile_time_arg_val(8);
-constexpr uint32_t out_ready_sem_wait_value = get_compile_time_arg_val(9);
+constexpr bool dynamic_alternate = get_compile_time_arg_val(8);
+constexpr uint32_t num_sem_ranges = get_compile_time_arg_val(9);
+constexpr uint32_t out_ready_sem_wait_value = get_compile_time_arg_val(10);
+constexpr uint32_t num_max_targets = std::max(num_targets_forward_direction, num_targets_backward_direction);
+constexpr uint32_t num_sync_targets_forward = dynamic_alternate ? num_max_targets : num_targets_forward_direction;
+constexpr uint32_t num_sync_targets_backward = dynamic_alternate ? num_max_targets : num_targets_backward_direction;
 
 /*
  * CCL Send will present various operating modes. Although there is only a single send kernel, it may (compile time)
@@ -47,8 +51,8 @@ void kernel_main() {
     uint32_t num_cores = get_arg_val<uint32_t>(arg_idx++);
     bool wait_output_semaphore = get_arg_val<uint32_t>(arg_idx++);
     bool reset_global_semaphore = get_arg_val<uint32_t>(arg_idx++);
-    constexpr uint8_t out_ready_sem_noc0_x = 19;       // get_arg_val<uint32_t>(arg_idx++);
-    constexpr uint8_t out_ready_sem_noc0_y = 18;       // get_arg_val<uint32_t>(arg_idx++);
+    uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
 
     const uint32_t concat_semaphore_send_addr = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
     const uint32_t concat_semaphore_send_addr2 = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
@@ -68,6 +72,7 @@ void kernel_main() {
     arg_idx += num_sem_ranges;
 
     size_t arg_for_fab = arg_idx;
+    constexpr bool connect_to_fabric_when_creating = true;
     auto fabric_connection =
         FabricConnectionManager::build_from_args<FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
             arg_idx);
@@ -80,6 +85,8 @@ void kernel_main() {
     auto packet_header_buffer_addr_backward = get_write_ptr(reserved_packet_header_cb_id);
     cb_push_back(reserved_packet_header_cb_id, 1);
     cb_reserve_back(reserved_packet_header_cb_id, 1);
+    auto packet_header_buffer_seminc = get_write_ptr(reserved_packet_header_cb_id);
+    cb_push_back(reserved_packet_header_cb_id, 1);
 
     // pre-populate packet headers
     volatile PACKET_HEADER_TYPE* pkt_hdr_forward =
@@ -115,6 +122,12 @@ void kernel_main() {
             fabric_connection,
             l1_read_addr,
             num_tiles_to_read_this_core * tensor0_page_size);
+        if constexpr (dynamic_alternate) {
+            std::swap(
+                pkt_hdr_forward->routing_fields.value,
+                pkt_hdr_backward->routing_fields.value);  // alternate the packet header distance for better balancing
+        }
+        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
 
         tiles_read += num_tiles_to_read_this_core;
         shard_tile_id += num_tiles_to_read_this_core;
@@ -122,41 +135,31 @@ void kernel_main() {
             shard_tile_id = 0;
             core_id++;
         }
-
-        noc_async_writes_flushed();
-        cb_pop_front(cb0_id, num_tiles_to_read_this_core);
     }
 
     // 2. mcast output ready semaphore
+    auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem_bank_addr, 0);
+    pkt_hdr->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+        out_ready_sem_noc_addr_in_pkt,
+        static_cast<uint16_t>(1),  // increment 1
+        32});
     // Write the mcast packet (forward)
     if (fabric_connection.has_forward_connection()) {
-        auto* pkt_hdr_fwd = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_addr_forward);
-        pkt_hdr_fwd->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-            out_ready_sem_noc_addr_in_pkt,
-            static_cast<uint16_t>(1),  // increment 1
-            32});
-
         fabric_connection.get_forward_connection().wait_for_empty_write_slot();
-        pkt_hdr_fwd->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_forward_direction)});
-        fabric_connection.get_forward_connection().send_payload_flush_non_blocking_from_address(
-            reinterpret_cast<uint32_t>(pkt_hdr_fwd), sizeof(PACKET_HEADER_TYPE));
+        pkt_hdr->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_forward)});
+        fabric_connection.get_forward_connection().send_payload_flush_blocking_from_address(
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // Write the mcast packet (backward)
     if (fabric_connection.has_backward_connection()) {
-        auto* pkt_hdr_bwd = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_addr_backward);
-        pkt_hdr_bwd->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-            out_ready_sem_noc_addr_in_pkt,
-            static_cast<uint16_t>(1),  // increment 1
-            32});
-
-        pkt_hdr_bwd->to_chip_multicast(
-            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_targets_backward_direction)});
+        pkt_hdr->to_chip_multicast(
+            tt::tt_fabric::MulticastRoutingCommandHeader{1, static_cast<uint8_t>(num_sync_targets_backward)});
         fabric_connection.get_backward_connection().wait_for_empty_write_slot();
         fabric_connection.get_backward_connection().send_payload_non_blocking_from_address(
-            reinterpret_cast<uint32_t>(pkt_hdr_bwd), sizeof(PACKET_HEADER_TYPE));
+            packet_header_buffer_seminc, sizeof(PACKET_HEADER_TYPE));
     }
     // increment locally
     uint64_t out_ready_sem_noc_addr =


### PR DESCRIPTION
### Ticket
Llama project

### Problem description
The current AllGatherConcat op only supports Linear topology and 3 links

### What's changed
This PR adds the support for AllGatherConcat for 4 links and Ring topology. 
When tested with the model on a 6U, it increases the tokens/s/usr by 0.8

### Checklist
- [x] TG unit tests https://github.com/tenstorrent/tt-metal/actions/runs/14885854672
- [x] TG frequent tests https://github.com/tenstorrent/tt-metal/actions/runs/14885820844
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15402661688
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes