### PR TITLE
Use 3.3 weights for model perf test for TG Llama3

### DIFF
--- a/tests/scripts/tg/run_tg_demo_tests.sh
+++ b/tests/scripts/tg/run_tg_demo_tests.sh
@@ -7,7 +7,7 @@ run_tg_llama3_tests() {
 
   echo "LOG_METAL: Running run_tg_llama3_tests"
 
-  # Llama3.1-70B
+  # Llama3.3-70B
   llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
 
   # Run all Llama3 tests for 1B, 3B, 8B, 11B and 70B weights

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -30,8 +30,8 @@ run_tg_cnn_tests() {
 
 run_tg_llama_70b_model_perf_tests() {
 
-  # Llama3.1-70B
-  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
+  # Llama3.3-70B
+  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
 
   echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
 


### PR DESCRIPTION
### Ticket

#21733 

### Problem description

Why old weights - FUCK THE OLD WEIGHTS!

### What's changed

Use 3.3 for model perf

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes