### PR TITLE
Make sure all eth link tests don't error out when run on single chip systems

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_common.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_all_ethernet_links_common.py
@@ -59,6 +59,7 @@ def process_profile_results(packet_size, num_packets, channel_count, benchmark_t
         link_stats_fname = PROFILER_LOGS_DIR / "eth_link_stats.csv"
         df = pd.read_csv(link_stats_fname)
 
+    results = []
     for device_id in devices_data["devices"]:
         for core, core_data in devices_data["devices"][device_id]["cores"].items():
             if core == "DEVICE":
@@ -225,6 +226,7 @@ def write_results_to_csv(file_name, test_latency):
         append_to_csv(file_name, add_newline=True)
         append_to_csv(file_name, header)
 
+    mean = 0
     for sender_info, data_to_write in results_per_sender_link.items():
         receiver_info, benchmark_type, num_packets, packet_size, measurements, link_stats = data_to_write
         assert len(measurements) == len(link_stats)


### PR DESCRIPTION
### Ticket
N/A 

### Problem description
This is run in upstream tests (https://github.com/tenstorrent/tt-metal/actions/runs/14870884109/job/41760372576) but failing because the test doesn't post process when it is skipped on single chip systems

### Checklist
- [ ] [microbench](https://github.com/tenstorrent/tt-metal/actions/runs/14893501187) CI passes