### PR TITLE
Ensure matching hooks on Buffer allocation/deallocation

### DIFF
--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -329,6 +329,7 @@ private:
     Allocator* allocator_;
 
     AllocationStatus allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
+    bool hooked_allocation_ = false;
     DeviceAddr address_ = 0;
 
     // Private helper function to commonize code path for buffer creation with either ShardSpecBuffer or

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -139,7 +139,7 @@ public:
         }
     }
 
-    bool hook_allocate(Buffer* buffer);
+    bool hook_allocate(const Buffer* buffer);
 
     bool hook_deallocate(Buffer* buffer);
 
@@ -155,7 +155,7 @@ public:
 
 private:
     GraphTracker() = default;
-    ~GraphTracker();
+    ~GraphTracker() = default;
     GraphTracker(const GraphTracker&) = delete;
     GraphTracker(GraphTracker&&) = delete;
 
@@ -164,6 +164,6 @@ private:
     std::shared_ptr<IGraphHooks> hook;
 
     std::mutex hooked_buffers_mutex;
-    std::unordered_set<Buffer*> hooked_buffers;
+    std::unordered_set<const Buffer*> hooked_buffers;
 };
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -139,7 +139,7 @@ public:
         }
     }
 
-    bool hook_allocate(const Buffer* buffer);
+    bool hook_allocate(Buffer* buffer);
 
     bool hook_deallocate(Buffer* buffer);
 
@@ -164,6 +164,6 @@ private:
     std::shared_ptr<IGraphHooks> hook;
 
     std::mutex hooked_buffers_mutex;
-    std::unordered_set<const Buffer*> hooked_buffers;
+    std::unordered_set<Buffer*> hooked_buffers;
 };
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/graph_tracking.hpp
+++ b/tt_metal/api/tt-metalium/graph_tracking.hpp
@@ -10,9 +10,11 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 #include <tt-metalium/buffer.hpp>
@@ -153,12 +155,15 @@ public:
 
 private:
     GraphTracker() = default;
-    ~GraphTracker() = default;
+    ~GraphTracker();
     GraphTracker(const GraphTracker&) = delete;
     GraphTracker(GraphTracker&&) = delete;
 
     std::vector<std::shared_ptr<IGraphProcessor>> processors;
 
     std::shared_ptr<IGraphHooks> hook;
+
+    std::mutex hooked_buffers_mutex;
+    std::unordered_set<const Buffer*> hooked_buffers;
 };
 }  // namespace tt::tt_metal

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -134,17 +134,17 @@ void GraphTracker::clear() {
 
 void GraphTracker::clear_hook() {
     std::lock_guard<std::mutex> lock(hooked_buffers_mutex);
-    size_t num_hooked_buffers = hooked_buffers.size();
-    for (auto hooked_buffer : hooked_buffers) {
+    auto hooked_buffers_copy = hooked_buffers;
+    for (auto hooked_buffer : hooked_buffers_copy) {
         DeallocateBuffer(*hooked_buffer);
         tt::log_warning(
             "Forcefully deallocating buffer {}, which was allocated by the hook", hooked_buffer->unique_id());
     }
+
     hooked_buffers.clear();
-
-    TT_FATAL(num_hooked_buffers > 0, "Clearing hook with {} allocated buffers", num_hooked_buffers);
-
     hook = nullptr;
+
+    TT_FATAL(hooked_buffers_copy.size() > 0, "Clearing hook with {} allocated buffers", hooked_buffers_copy.size());
 }
 
 GraphTracker::~GraphTracker() { clear(); }

--- a/tt_metal/graph/graph_tracking.cpp
+++ b/tt_metal/graph/graph_tracking.cpp
@@ -91,14 +91,29 @@ bool GraphTracker::hook_allocate(const Buffer* buffer) {
         return false;
     }
 
-    return hook->hook_allocate(buffer);
+    bool hooked = hook->hook_allocate(buffer);
+    if (hooked) {
+        std::lock_guard<std::mutex> lock(hooked_buffers_mutex);
+        bool inserted = hooked_buffers.insert(buffer).second;
+        TT_FATAL(!inserted, "Can't hook allocation of a buffer which is already allocated");
+    }
+    return hooked;
 }
 
 bool GraphTracker::hook_deallocate(Buffer* buffer) {
     if (hook == nullptr) {
         return false;
     }
-    return hook->hook_deallocate(buffer);
+
+    bool hooked = hook->hook_deallocate(buffer);
+    if (hooked) {
+        std::lock_guard<std::mutex> lock(hooked_buffers_mutex);
+        auto buffer_it = hooked_buffers.find(buffer);
+        TT_FATAL(
+            buffer_it != hooked_buffers.end(), "Can't hook deallocation of a buffer which allocation wasn't hooked");
+        hooked_buffers.erase(buffer_it);
+    }
+    return hooked;
 }
 
 bool GraphTracker::hook_program(tt::tt_metal::Program* program) {
@@ -114,9 +129,16 @@ const std::shared_ptr<IGraphHooks>& GraphTracker::get_hook() const { return hook
 
 void GraphTracker::clear() {
     processors.clear();
-    hook = nullptr;
+    clear_hook();
 }
 
-void GraphTracker::clear_hook() { hook = nullptr; }
+void GraphTracker::clear_hook() {
+    hook = nullptr;
+
+    std::lock_guard<std::mutex> lock(hooked_buffers_mutex);
+    TT_FATAL(hooked_buffers.empty(), "Clearing hook with {} allocated buffers", hooked_buffers.size());
+}
+
+GraphTracker::~GraphTracker() { clear(); }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1267,6 +1267,9 @@ bool Device::close() {
 
     tt_metal::detail::DumpDeviceProfileResults(this, ProfilerDumpState::LAST_CLOSE_DEVICE);
 
+    this->disable_and_clear_program_cache();
+    this->set_program_cache_misses_allowed(true);
+
     sub_device_manager_tracker_.reset(nullptr);
 
     std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> not_done_dispatch_cores;
@@ -1329,8 +1332,6 @@ bool Device::close() {
     this->compute_cores_.clear();
     this->storage_only_cores_.clear();
     this->ethernet_cores_.clear();
-    this->disable_and_clear_program_cache();
-    this->set_program_cache_misses_allowed(true);
     this->command_queue_programs_.clear();
     this->command_queues_.clear();
     this->sysmem_manager_.reset();


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21315

### Problem description
Currently there is an issue with inconsistent hooks on Buffer allocation/deallocation, which happens specifically when a Buffer was cached by an OP (stored in override runtime args callbacks) and preserved by ProgramCache.
This PR ensures that program cache is cleared at the appropriate time of device closing to ensure correct handling and adds diagnostic to easily find such issues in the future.

We shouldn't be storing the Buffers inside of override runtime arguments to begin with, because it's basically a memory leak with program cache enabled, but this will be addressed separately for each of the OPs individually.

### What's changed
Moved clearing program cache up in the Device::close()
Stored a set of hooked buffers in GraphTracker with validation that we hook deallocation for exactly the same buffers where we hooked the allocation
Stored in buffer whether its allocation was hooked and avoiding deallocation for them even if the hook was removed

### Checklist
- [x] [All post commit CI passes](https://github.com/tenstorrent/tt-metal/actions/runs/14897246210)
- [x] New/Existing tests provide coverage for changes