### PR TITLE
[WIP] First version of binary element-wise kernels to operate on ROW_MAJOR tensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,6 @@ endif()
 # Project setup
 ############################################
 
-set(Python3_EXECUTABLE "/root/miniforge3/envs/tt-metal/bin/python")
-set(Python_EXECUTABLE "/root/miniforge3/envs/tt-metal/bin/python")
-
 # For single-config generators, default to RelWithDebInfo if unspecified
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT isMultiConfig)
@@ -142,8 +139,6 @@ if(WITH_PYTHON_BINDINGS)
             Development
     )
     message(STATUS "Python3 include dirs: ${Python3_INCLUDE_DIRS}")
-    message(STATUS "Python3 version: ${Python3_VERSION}")
-    message(STATUS "Python3 libraries: ${Python3_LIBRARIES}")
 endif()
 
 find_library(NUMA_LIBRARY NAMES numa)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ endif()
 # Project setup
 ############################################
 
+set(Python3_EXECUTABLE "/root/miniforge3/envs/tt-metal/bin/python")
+set(Python_EXECUTABLE "/root/miniforge3/envs/tt-metal/bin/python")
+
 # For single-config generators, default to RelWithDebInfo if unspecified
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT isMultiConfig)
@@ -132,7 +135,6 @@ else()
 endif()
 
 if(WITH_PYTHON_BINDINGS)
-    set(Python3_FIND_STRATEGY LOCATION)
     find_package(
         Python3
         COMPONENTS
@@ -140,6 +142,8 @@ if(WITH_PYTHON_BINDINGS)
             Development
     )
     message(STATUS "Python3 include dirs: ${Python3_INCLUDE_DIRS}")
+    message(STATUS "Python3 version: ${Python3_VERSION}")
+    message(STATUS "Python3 libraries: ${Python3_LIBRARIES}")
 endif()
 
 find_library(NUMA_LIBRARY NAMES numa)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ else()
 endif()
 
 if(WITH_PYTHON_BINDINGS)
+    set(Python3_FIND_STRATEGY LOCATION)
     find_package(
         Python3
         COMPONENTS

--- a/cmake/packaging.cmake
+++ b/cmake/packaging.cmake
@@ -44,7 +44,7 @@ set(CPACK_DEBIAN_METALIUM-DEV_PACKAGE_DEPENDS "libboost-dev (>= 1.78) | libboost
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     ${PROJECT_BINARY_DIR}/tt-metalium-config-version.cmake
-    VERSION ${PROJECT_VERSION}
+    VERSION "0.58.0-dev"
     COMPATIBILITY SameMajorVersion
 )
 configure_package_config_file(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -222,17 +222,8 @@ inline auto invoke_binary_ng(
 
     // RM is never BFLOAT8 or BFLOAT4 so we can assume it goes in here.
     if (not typecast_a and not typecast_b) {
-        const auto input_a_rm = detail::is_layout(lhs, Layout::ROW_MAJOR);
-        const auto input_b_rm = detail::is_layout(rhs, Layout::ROW_MAJOR);
-        const auto input_a = detail::to_layout(lhs, Layout::TILE);
-        const auto input_b = detail::to_layout(rhs, Layout::TILE);
-
-        if (input_a_rm and input_b_rm) {
-            // we don't support to_layout with optional output tensor
-            TT_FATAL(
-                !output_preallocated,
-                "Optional output tensor with Row Major input is not supported right now for Elementwise operations");
-        }
+        const auto input_a = lhs;
+        const auto input_b = rhs;
 
         auto result = ttnn::prim::binary_ng(
             queue_id,
@@ -245,13 +236,6 @@ inline auto invoke_binary_ng(
             lhs_activations,
             rhs_activations,
             post_activations);
-
-        // if both inputs are in row major, convert the output to row major
-        // since there's no consensus here, avoiding the conversion if we have an excuse to is likely the best option
-        // since it leads to better perf
-        if (input_a_rm and input_b_rm) {
-            return detail::to_layout(result, Layout::ROW_MAJOR);
-        }
 
         return result;
     } else {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -268,7 +268,7 @@ BinaryDeviceOperation::spec_return_value_t BinaryDeviceOperation::compute_output
             return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), memory_config));
         }
     }
-    return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::TILE), operation_attributes.memory_config));
+    return TensorSpec(output_shape, TensorLayout(operation_attributes.dtype, PageConfig(Layout::ROW_MAJOR), operation_attributes.memory_config));
 }
 
 BinaryDeviceOperation::tensor_return_value_t BinaryDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -117,8 +117,6 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
 
     BinaryDeviceOperation::validate_on_program_cache_hit(attributes, tensor_args);
 
-    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "Input to eltwise binary must be tilized");
-
     bool tensor_b_sharded = false;
 
     if (input_tensor_b.has_value()) {
@@ -128,7 +126,6 @@ void BinaryDeviceOperation::validate_on_program_cache_miss(
                 input_tensor_a.device() == input_tensor_b->device(),
                 "Operands to eltwise binary need to be on the same device!");
         }
-        TT_FATAL(input_tensor_b->get_layout() == Layout::TILE, "Inputs to eltwise binary must be tilized");
     }
 
     if (input_tensor_a.memory_config().is_sharded()) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -168,7 +168,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
         (block_or_width_sharded and not out_sharded)
             ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
               "writer_unary_sharded_blocks_interleaved_start_id.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_row_major.cpp",
+            : "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp",
         all_device_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/element_wise_multi_core_program_factory.cpp
@@ -159,7 +159,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
 
     KernelHandle binary_reader_kernel_id = tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_binary_interleaved_start_id.cpp",
+        "ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp",
         all_device_cores,
         tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
 
@@ -168,7 +168,7 @@ BinaryDeviceOperation::ElementWiseMultiCore::cached_program_t BinaryDeviceOperat
         (block_or_width_sharded and not out_sharded)
             ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
               "writer_unary_sharded_blocks_interleaved_start_id.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_row_major.cpp",
         all_device_cores,
         tt_metal::WriterDataMovementConfig(writer_compile_time_args, writer_defines));
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
@@ -86,7 +86,7 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
         }
     }
 
-    uint32_t num_tiles = a.volume() / TILE_HW;
+    uint32_t num_tiles = 32; // a.volume() / TILE_HW;
 
     uint32_t num_cores, num_tiles_per_core_group_1, num_tiles_per_core_group_2, num_cores_total;
     if (zero_start_grid) {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/eltwise_multi_core_program_factory_common.hpp
@@ -43,6 +43,8 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
 
     CoreRangeSet all_cores, core_group_1, core_group_2;
 
+    uint32_t row_size = a.get_padded_shape()[-1];
+
     std::optional<ShardSpec> shard_spec = std::nullopt;
     std::optional<TensorMemoryLayout> sharded_layout = std::nullopt;
     bool src0_sharded = a.memory_config().is_sharded();
@@ -162,12 +164,12 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
     std::vector<std::vector<uint32_t>> eltwise_binary_args;
     std::vector<std::vector<uint32_t>> unary_writer_args;
     if constexpr (initialize_args) {
-        binary_reader_args = {cores.size(), std::vector<uint32_t>(7)};
+        binary_reader_args = {cores.size(), std::vector<uint32_t>(8)};
         eltwise_binary_args = {cores.size(), std::vector<uint32_t>(2)};
         if (block_or_width_sharded and not out_sharded) {
             unary_writer_args = {cores.size(), std::vector<uint32_t>(7)};
         } else {
-            unary_writer_args = {cores.size(), std::vector<uint32_t>(3)};
+            unary_writer_args = {cores.size(), std::vector<uint32_t>(4)};
         }
     }
 
@@ -236,7 +238,8 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
                 block_height,
                 block_width,
                 num_shards_per_width,
-                num_shards_per_width};
+		row_size,
+	    };
             eltwise_binary_args[i] = {block_cnt_per_core, block_size_per_core};
         } else {
             auto& reader_args = cached_reader_args.at(core.x).at(core.y);
@@ -247,6 +250,7 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
             reader_args[4] = block_height;
             reader_args[5] = block_width;
             reader_args[6] = num_shards_per_width;
+	    reader_args[7] = row_size;
             auto& eltwise_args = cached_eltwise_args.at(core.x).at(core.y);
             eltwise_args[0] = block_cnt_per_core;
             eltwise_args[1] = block_size_per_core;
@@ -296,12 +300,13 @@ inline __attribute__((always_inline)) void set_eltwise_binary_runtime_args(
             }
         } else {
             if constexpr (initialize_args) {
-                unary_writer_args[i] = {dst_buffer->address(), num_tiles_per_core, num_tiles_read};
+                unary_writer_args[i] = {dst_buffer->address(), num_tiles_per_core, num_tiles_read, row_size};
             } else {
                 auto& writer_args = cached_writer_args.at(core.x).at(core.y);
                 writer_args[0] = dst_buffer->address();
                 writer_args[1] = num_tiles_per_core;
                 writer_args[2] = num_tiles_read;
+		writer_args[3] = row_size;
             }
         }
         num_tiles_read += num_tiles_per_core;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_kernel.cpp
@@ -10,10 +10,16 @@
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 
+constexpr uint32_t TILE_SIZE = 1024;
+
 namespace NAMESPACE {
 void MAIN {
     uint32_t per_core_block_cnt = get_arg_val<uint32_t>(0);
     uint32_t per_core_block_size = get_arg_val<uint32_t>(1);
+    uint32_t row_size = get_arg_val<uint32_t>(2);
+
+    const uint32_t num_tiles_per_row = (row_size + TILE_SIZE - 1) / TILE_SIZE;
+    per_core_block_cnt *= num_tiles_per_row;
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
     constexpr auto cb_in1 = tt::CBIndex::c_1;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
         .bank_base_address = b_addr, .page_size = datum_size_bytes * row_size};
 
     // Calculate the range of rows this core should process
-    const uint32_t end_row_id = start_tile_id + n_rows;
+    const uint32_t end_row_id = start_row_id + n_rows;
     const uint32_t num_tiles_per_row = (row_size + TILE_SIZE - 1) / TILE_SIZE;
 
     // Now we loop over the assigned rows and read them into the circular

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include <cstdint>
+
+constexpr uint32_t TILE_SIZE = 1024;
+
+void kernel_main() {
+    // Read parameters from the kernel arguments
+    uint32_t a_addr = get_arg_val<uint32_t>(0);
+    uint32_t b_addr = get_arg_val<uint32_t>(1);
+    uint32_t n_rows = get_arg_val<uint32_t>(2);
+    uint32_t start_row_id = get_arg_val<uint32_t>(3);
+    uint32_t row_size = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t datum_size_bytes = 2;
+
+    // The circular buffers to read the tiles into
+    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_in1 = get_compile_time_arg_val(1);
+
+    const uint32_t tile_size_bytes = get_tile_size(cb_in0);
+
+    const InterleavedAddrGen<true> a = {
+        .bank_base_address = a_addr, .page_size = datum_size_bytes * row_size};
+
+    const InterleavedAddrGen<true> b = {
+        .bank_base_address = b_addr, .page_size = datum_size_bytes * row_size};
+
+    // Calculate the range of rows this core should process
+    const uint32_t end_row_id = start_tile_id + n_rows;
+    const uint32_t num_tiles_per_row = (row_size + TILE_SIZE - 1) / TILE_SIZE;
+
+    // Now we loop over the assigned rows and read them into the circular
+    // buffers
+    for (uint32_t i = start_row_id; i < end_row_id; i++) {
+        uint32_t offset = 0;
+        for (uint32_t j = 0; j < num_tiles_per_row; ++j) {
+            uint64_t a_noc_addr = get_noc_addr(i, a, offset);
+            uint64_t b_noc_addr = get_noc_addr(i, b, offset);
+
+            cb_reserve_back(cb_in0, 1);
+            uint32_t cb_in0_addr = get_write_ptr(cb_in0);
+            cb_reserve_back(cb_in1, 1);
+            uint32_t cb_in1_addr = get_write_ptr(cb_in1);
+
+            uint32_t bytes_to_read = min(TILE_SIZE * datum_size_bytes, row_size * datum_size_bytes - offset);
+	        noc_async_read(a_noc_addr, cb_in0_addr, bytes_to_read);
+	        noc_async_read(b_noc_addr, cb_in1_addr, bytes_to_read);
+
+            noc_async_read_barrier();
+
+            cb_push_back(cb_in0, 1);
+            cb_push_back(cb_in1, 1);
+
+            offset += bytes_to_read;
+	    }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
@@ -19,8 +19,8 @@ void kernel_main() {
     constexpr uint32_t datum_size_bytes = 2;
 
     // The circular buffers to read the tiles into
-    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_in1 = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_in1 = tt::CBIndex::c_1;
 
     const uint32_t tile_size_bytes = get_tile_size(cb_in0);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
@@ -14,7 +14,7 @@ void kernel_main() {
     uint32_t b_addr = get_arg_val<uint32_t>(1);
     uint32_t n_rows = get_arg_val<uint32_t>(2);
     uint32_t start_row_id = get_arg_val<uint32_t>(3);
-    uint32_t row_size = get_arg_val<uint32_t>(4);
+    uint32_t row_size = 32 * 32;
 
     constexpr uint32_t datum_size_bytes = 2;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/reader_row_major.cpp
@@ -14,7 +14,7 @@ void kernel_main() {
     uint32_t b_addr = get_arg_val<uint32_t>(1);
     uint32_t n_rows = get_arg_val<uint32_t>(2);
     uint32_t start_row_id = get_arg_val<uint32_t>(3);
-    uint32_t row_size = 32 * 32;
+    uint32_t row_size = get_arg_val<uint32_t>(7);
 
     constexpr uint32_t datum_size_bytes = 2;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
@@ -10,25 +10,20 @@ constexpr uint32_t TILE_SIZE = 1024;
 
 void kernel_main() {
     // Read parameters from the kernel arguments
-    uint32_t a_addr = get_arg_val<uint32_t>(0);
-    uint32_t b_addr = get_arg_val<uint32_t>(1);
-    uint32_t n_rows = get_arg_val<uint32_t>(2);
-    uint32_t start_row_id = get_arg_val<uint32_t>(3);
-    uint32_t row_size = get_arg_val<uint32_t>(4);
+    uint32_t c_addr = get_arg_val<uint32_t>(0);
+    uint32_t n_rows = get_arg_val<uint32_t>(1);
+    uint32_t start_row_id = get_arg_val<uint32_t>(2);
+    uint32_t row_size = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t datum_size_bytes = 2;
 
-    // The circular buffers to read the tiles into
-    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_in1 = get_compile_time_arg_val(1);
+    // The circular buffer to write the results into
+    constexpr uint32_t cb_out0 = tt::CBIndex::c_3;
 
-    const uint32_t tile_size_bytes = get_tile_size(cb_in0);
+    const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 
-    const InterleavedAddrGen<true> a = {
-        .bank_base_address = a_addr, .page_size = datum_size_bytes * row_size};
-
-    const InterleavedAddrGen<true> b = {
-        .bank_base_address = b_addr, .page_size = datum_size_bytes * row_size};
+    const InterleavedAddrGen<true> c = {
+        .bank_base_address = c_addr, .page_size = datum_size_bytes * row_size};
 
     // Calculate the range of rows this core should process
     const uint32_t end_row_id = start_tile_id + n_rows;
@@ -39,22 +34,16 @@ void kernel_main() {
     for (uint32_t i = start_row_id; i < end_row_id; i++) {
         uint32_t offset = 0;
         for (uint32_t j = 0; j < num_tiles_per_row; ++j) {
-            uint64_t a_noc_addr = get_noc_addr(i, a, offset);
-            uint64_t b_noc_addr = get_noc_addr(i, b, offset);
+            uint64_t c_noc_addr = get_noc_addr(i, c, offset);
 
-            cb_wait_front(cb_in0, 1);
-            uint32_t cb_in0_addr = get_write_ptr(cb_in0);
-            cb_wait_front(cb_in1, 1);
-            uint32_t cb_in1_addr = get_write_ptr(cb_in1);
+            cb_wait_front(cb_out0, 1);
+            uint32_t cb_out0_addr = get_write_ptr(cb_out0);
 
             uint32_t bytes_to_write = min(TILE_SIZE * datum_size_bytes, row_size * datum_size_bytes - offset);
-	        noc_async_write(cb_in0_addr, a_noc_addr, bytes_to_write);
-	        noc_async_write(cb_in1_addr, b_noc_addr, bytes_to_write);
-
+            noc_async_write(cb_out0_addr, c_noc_addr, bytes_to_write);
             noc_async_write_barrier();
 
-            cb_pop_front(cb_in0, 1);
-            cb_pop_front(cb_in1, 1);
+            cb_pop_front(cb_out0, 1);
 
             offset += bytes_to_write;
 	    }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
@@ -13,7 +13,7 @@ void kernel_main() {
     uint32_t c_addr = get_arg_val<uint32_t>(0);
     uint32_t n_rows = get_arg_val<uint32_t>(1);
     uint32_t start_row_id = get_arg_val<uint32_t>(2);
-    uint32_t row_size = 32 * 32;
+    uint32_t row_size = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t datum_size_bytes = 2;
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
@@ -13,12 +13,12 @@ void kernel_main() {
     uint32_t c_addr = get_arg_val<uint32_t>(0);
     uint32_t n_rows = get_arg_val<uint32_t>(1);
     uint32_t start_row_id = get_arg_val<uint32_t>(2);
-    uint32_t row_size = get_arg_val<uint32_t>(3);
+    uint32_t row_size = 32 * 32;
 
     constexpr uint32_t datum_size_bytes = 2;
 
     // The circular buffer to write the results into
-    constexpr uint32_t cb_out0 = tt::CBIndex::c_3;
+    constexpr uint32_t cb_out0 = tt::CBIndex::c_2;
 
     const uint32_t tile_size_bytes = get_tile_size(cb_out0);
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
         .bank_base_address = c_addr, .page_size = datum_size_bytes * row_size};
 
     // Calculate the range of rows this core should process
-    const uint32_t end_row_id = start_tile_id + n_rows;
+    const uint32_t end_row_id = start_row_id + n_rows;
     const uint32_t num_tiles_per_row = (row_size + TILE_SIZE - 1) / TILE_SIZE;
 
     // Now we loop over the assigned rows and read them into the circular

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/dataflow/writer_row_major.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+#include <cstdint>
+
+constexpr uint32_t TILE_SIZE = 1024;
+
+void kernel_main() {
+    // Read parameters from the kernel arguments
+    uint32_t a_addr = get_arg_val<uint32_t>(0);
+    uint32_t b_addr = get_arg_val<uint32_t>(1);
+    uint32_t n_rows = get_arg_val<uint32_t>(2);
+    uint32_t start_row_id = get_arg_val<uint32_t>(3);
+    uint32_t row_size = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t datum_size_bytes = 2;
+
+    // The circular buffers to read the tiles into
+    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_in1 = get_compile_time_arg_val(1);
+
+    const uint32_t tile_size_bytes = get_tile_size(cb_in0);
+
+    const InterleavedAddrGen<true> a = {
+        .bank_base_address = a_addr, .page_size = datum_size_bytes * row_size};
+
+    const InterleavedAddrGen<true> b = {
+        .bank_base_address = b_addr, .page_size = datum_size_bytes * row_size};
+
+    // Calculate the range of rows this core should process
+    const uint32_t end_row_id = start_tile_id + n_rows;
+    const uint32_t num_tiles_per_row = (row_size + TILE_SIZE - 1) / TILE_SIZE;
+
+    // Now we loop over the assigned rows and read them into the circular
+    // buffers
+    for (uint32_t i = start_row_id; i < end_row_id; i++) {
+        uint32_t offset = 0;
+        for (uint32_t j = 0; j < num_tiles_per_row; ++j) {
+            uint64_t a_noc_addr = get_noc_addr(i, a, offset);
+            uint64_t b_noc_addr = get_noc_addr(i, b, offset);
+
+            cb_wait_front(cb_in0, 1);
+            uint32_t cb_in0_addr = get_write_ptr(cb_in0);
+            cb_wait_front(cb_in1, 1);
+            uint32_t cb_in1_addr = get_write_ptr(cb_in1);
+
+            uint32_t bytes_to_write = min(TILE_SIZE * datum_size_bytes, row_size * datum_size_bytes - offset);
+	        noc_async_write(cb_in0_addr, a_noc_addr, bytes_to_write);
+	        noc_async_write(cb_in1_addr, b_noc_addr, bytes_to_write);
+
+            noc_async_write_barrier();
+
+            cb_pop_front(cb_in0, 1);
+            cb_pop_front(cb_in1, 1);
+
+            offset += bytes_to_write;
+	    }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -181,8 +181,6 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
             "If both output dtype and output tensor provided dtype should match");
     }
 
-    TT_FATAL(input_tensor_a.get_layout() == Layout::TILE, "First operand to eltwise binary must be tilized");
-
     bool tensor_a_sharded = input_tensor_a.memory_config().is_sharded();
     if (not tensor_a_sharded) {
         TT_FATAL(
@@ -204,7 +202,6 @@ void BinaryNgDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             input_tensor_a.device() == input_tensor_b->device(),
             "Operands to eltwise binary need to be on the same device!");
-        TT_FATAL(input_tensor_b->get_layout() == Layout::TILE, "Second operand to eltwise binary must be tilized");
 
         if (not tensor_b_sharded) {
             TT_FATAL(


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/17967)

### Problem description
Currently the row major version of eltwise is performed by converting to tiled, performing the eltwise and then converting back to row major.

### What's changed
Perform the eltwise operation on the original row major tensor to avoid costly conversions to and from tiled tensors.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes