### PR TITLE
EXTERNAL PR: TTNN Support for flip [adding new ttnn op]

### DIFF
--- a/tests/ttnn/unit_tests/test_flip.py
+++ b/tests/ttnn/unit_tests/test_flip.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "input_tensor, dim",
+    [
+        (torch.arange(12).reshape([4, 3]), [0]),
+        (torch.arange(12).reshape([4, 3]), [0]),
+        (torch.arange(6).reshape([2, 3]), [0]),
+        (torch.arange(6).reshape([2, 3]), [0]),
+        (torch.arange(16).reshape([4, 4]), [0]),
+        (torch.arange(16).reshape([4, 4]), [0]),
+        (torch.arange(25).reshape([5, 5]), [0]),
+        (torch.arange(25).reshape([5, 5]), [0]),
+        ([[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]], [0, 2]),
+        ([[[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]], [0, 2, 3]),
+        (torch.arange(24).reshape([2, 4, 3]), [0, 1]),
+        (torch.arange(24).reshape([2, 4, 3]), [1, 0]),
+        (torch.arange(30).reshape([3, 5, 2]), [0, 1]),
+        (torch.arange(30).reshape([3, 5, 2]), [0, 1]),
+        (torch.arange(48).reshape([2, 3, 4, 2]), [0, 1]),
+        (torch.arange(48).reshape([2, 3, 4, 2]), [1, 2]),
+        (torch.arange(48).reshape([2, 3, 4, 2]), [2]),
+        (torch.arange(48).reshape([2, 3, 4, 2]), [0, 2]),
+        (torch.arange(48).reshape([2, 3, 4, 2]), [2, 0]),
+        (torch.arange(100).reshape([10, 10]), [0]),
+        (torch.arange(120).reshape([5, 4, 6]), [0, 1]),
+        (torch.arange(120).reshape([5, 4, 6]), [1]),
+        (torch.arange(120).reshape([5, 4, 6]), [0]),
+        (torch.arange(120).reshape([5, 4, 6]), [0, 1]),
+        (torch.arange(8).reshape([2, 2, 2]), [0, 1]),
+        (torch.arange(8).reshape([2, 2, 2]), [1]),
+        (torch.arange(8).reshape([2, 2, 2]), [0]),
+        (torch.arange(8).reshape([2, 2, 2]), [0, 1]),
+        (
+            [
+                [
+                    [[[[[1, 2], [3, 4]], [[5, 6], [7, 8]]], [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]],
+                    [[[[[17, 18], [19, 20]], [[21, 22], [23, 24]]], [[[25, 26], [27, 28]], [[29, 30], [31, 32]]]]],
+                ]
+            ],
+            [0, 4],
+        ),
+    ],
+)
+def test_ttnn_flip(device, input_tensor, dim):
+    tensor = torch.tensor(input_tensor, dtype=torch.bfloat16)
+    ttnn_tensor = ttnn.from_torch(tensor)
+
+    ttnn_tensor = ttnn.to_layout(ttnn_tensor, ttnn.ROW_MAJOR_LAYOUT)
+
+    ttnn_tensor = ttnn.to_device(ttnn_tensor, device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    torch_flipped = torch.flip(tensor, dim)
+    ttnn_flipped = ttnn.flip(ttnn_tensor, dim)
+
+    ttnn_flipped_torch = ttnn.to_torch(ttnn_flipped)
+
+    assert_with_pcc(torch_flipped, ttnn_flipped_torch)
+    assert (
+        torch_flipped.shape == ttnn_flipped_torch.shape
+    ), f"Shape mismatch: {torch_flipped.shape} vs {ttnn_flipped_torch.shape}"

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -736,6 +736,7 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/moreh/moreh_clip_grad_norm/moreh_clip_grad_norm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/chunk/chunk.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/expand/expand.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/flip/flip.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/dropout/device/dropout_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/dropout/dropout.cpp
@@ -855,6 +856,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/copy/copy_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/chunk/chunk_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/expand/expand_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/flip/flip_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/fill_pad/fill_pad_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/fill_rm/fill_rm_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/data_movement/fold/fold_${PY_BINDING}.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/data_movement_pybind.hpp
@@ -19,6 +19,7 @@
 #include "ttnn/operations/data_movement/expand/expand_pybind.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad_pybind.hpp"
 #include "ttnn/operations/data_movement/fill_rm/fill_rm_pybind.hpp"
+#include "ttnn/operations/data_movement/flip/flip_pybind.hpp"
 #include "ttnn/operations/data_movement/fold/fold_pybind.hpp"
 #include "ttnn/operations/data_movement/indexed_fill/indexed_fill_pybind.hpp"
 #include "ttnn/operations/data_movement/move/move_pybind.hpp"
@@ -74,6 +75,7 @@ void py_module(py::module& module) {
     detail::py_bind_move(module);
     py_bind_chunk(module);
     py_bind_expand(module);
+    py_bind_flip(module);
     py_bind_interleaved_to_sharded(module);
     py_bind_interleaved_to_sharded_partial(module);
     py_bind_repeat(module);

--- a/ttnn/cpp/ttnn/operations/data_movement/flip/flip.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/flip/flip.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "flip.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include "cpp/ttnn/operations/data_movement/concat/concat.hpp"
+#include "cpp/ttnn/operations/data_movement/chunk/chunk.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::data_movement {
+
+ttnn::Tensor FlipOperation::invoke(const ttnn::Tensor& input_tensor, const std::vector<int>& dims) {
+    auto size = input_tensor.get_logical_shape();
+    int num_dims = size.rank();
+
+    std::vector<int> flip_dims;
+    for (int dim : dims) {
+        int flip_dim = (dim < 0) ? (dim + num_dims) : dim;
+        TT_FATAL(
+            flip_dim >= 0 && flip_dim < num_dims,
+            "Invalid dimension for flip operation, the dimensions should be in the range of [{}, {}]",
+            -num_dims,
+            num_dims - 1);
+        flip_dims.push_back(flip_dim);
+    }
+
+    ttnn::Tensor output_tensor = input_tensor;
+    for (int flip_dim : flip_dims) {
+        int num_chunks = size[flip_dim];
+
+        std::vector<ttnn::Tensor> chunks = ttnn::chunk(output_tensor, num_chunks, flip_dim);
+
+        std::vector<ttnn::Tensor> reversed_chunks;
+        reversed_chunks.reserve(num_chunks);
+        for (int i = num_chunks - 1; i >= 0; --i) {
+            reversed_chunks.push_back(chunks[i]);
+        }
+
+        output_tensor = ttnn::concat(reversed_chunks, flip_dim);
+    }
+
+    return output_tensor;
+}
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/flip/flip.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/flip/flip.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ttnn/decorators.hpp"
+#include <vector>
+
+namespace ttnn {
+namespace operations::data_movement {
+
+struct FlipOperation {
+    static ttnn::Tensor invoke(const ttnn::Tensor& input_tensor, const std::vector<int>& dims);
+};
+
+}  // namespace operations::data_movement
+
+constexpr auto flip = ttnn::register_operation<"ttnn::flip", ttnn::operations::data_movement::FlipOperation>();
+
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/flip/flip_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/flip/flip_pybind.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "flip_pybind.hpp"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ttnn-pybind/decorators.hpp"
+#include "ttnn/operations/data_movement/flip/flip.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::data_movement {
+
+namespace detail {
+
+template <typename data_movement_operation_t>
+void bind_flip(pybind11::module& module, const data_movement_operation_t& operation, const char* doc) {
+    bind_registered_operation(
+        module,
+        operation,
+        doc,
+        ttnn::pybind_overload_t{
+            [](const data_movement_operation_t& self, const ttnn::Tensor& input_tensor, const std::vector<int>& dims)
+                -> ttnn::Tensor { return self(input_tensor, dims); },
+            py::arg("input_tensor"),
+            py::arg("dims")});
+}
+
+}  // namespace detail
+
+void py_bind_flip(pybind11::module& module) {
+    detail::bind_flip(
+        module,
+        ttnn::flip,
+        R"doc(flip(input_tensor: ttnn.Tensor, dims: List[int]) -> ttnn.Tensor
+
+
+       Flips a tensor along multiple specified dimensions.
+
+
+       Args:
+           * :attr:`input_tensor`: The tensor to flip.
+           * :attr:`dims`: List of dimensions along which to flip.
+
+
+       )doc");
+}
+
+}  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/flip/flip_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/flip/flip_pybind.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::data_movement {
+
+void py_bind_flip(pybind11::module& module);
+
+}  // namespace ttnn::operations::data_movement


### PR DESCRIPTION
### Ticket
Link to Github Issue : N/A

### Problem description
ttnn doesn't have support for flip.

### What's changed
Enabled support for flip op in ttnn as a composite op and added pytest

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes