### PR TITLE
#21069: [skip ci] Run ttnn stress tests on blackhole nightly pipeline

### DIFF
--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -54,3 +54,21 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  ttnn-stress-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { runner-label: P100 },
+          { runner-label: P150 },
+        ]
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group.runner-label }}
+      timeout: 45
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   ttnn:
     name: ttnn stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on: ["in-service", "${{ inputs.runner-label }}", "pipeline-ttnn-stress"]
+    runs-on: ["in-service", "cloud-virtual-machine", "${{ inputs.runner-label }}"]
 
     container:
       image: ${{ inputs.docker-image }}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21069

### Problem description
Stress test pipeline created and needs to run on blackhole p100 and p150.

### What's changed
Run `ttnn-stress-tests-impl.yaml` as part of blackhole nightly.

### Checklist
- [x] BH nightly: https://github.com/tenstorrent/tt-metal/actions/runs/14908087659 (no failures in stress tests, ttnn failures are unrelated to change)