### PR TITLE
[skip ci] Use the Docker proxy when we're running in CIv2

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -145,7 +145,7 @@ jobs:
       build_artifact_name: ${{ steps.set_build_artifact_name.outputs.build_artifact_name }}
       wheel_artifact_name: ${{ steps.set_wheel_artifact_name.outputs.wheel_artifact_name }}
     container:
-      image: ${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!'}}
+      image: harbor.ci.tenstorrent.net/${{ needs.build-docker-image.outputs.ci-build-tag || 'docker-image-unresolved!' }}
       env:
         CCACHE_REMOTE_ONLY: "true"
         CCACHE_TEMPDIR: /tmp/ccache


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Docker fetches can be surprisingly slow from ghcr.
Ephemeral runners fetch each time.
That's a bad combo.

### What's changed
When running in CIv2, go through the Docker proxy to reduce how much we pull from ghcr.