### PR TITLE
Update blackhole_simulation descriptor and add condition for blackhole arch

### DIFF
--- a/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
+++ b/tt_metal/core_descriptors/blackhole_simulation_1x2_arch.yaml
@@ -5,7 +5,7 @@
 #   num of HW command queues:
 #     core descriptor config
 
-blackhole:
+unharvested:
   col:
     1:
       compute_with_storage_grid_range: # Logical only start and end [x, y]

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -216,7 +216,7 @@ void Cluster::generate_cluster_descriptor() {
     }
     this->cluster_type_ = Cluster::get_cluster_type_from_cluster_desc(this->rtoptions_, this->cluster_desc_);
 
-    if (this->arch_ == tt::ARCH::BLACKHOLE) {
+    if (this->target_type_ != TargetDevice::Simulator && this->arch_ == tt::ARCH::BLACKHOLE) {
         TT_FATAL(
             this->cluster_desc_->get_noc_translation_table_en().at(0),
             "Running Metal on Blackhole requires FW >= 80.18.0.0");


### PR DESCRIPTION
### Problem description
When running the Blackhole simulator on a compute device, tt-metal tests fail due to a firmware version check that is not applicable in the simulator context.
Additionally, a runtime exception is thrown because a required key is missing in the simulator descriptor file:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  TT_ASSERT @ /localdev/dzivanovic/tt-metal/tt_metal/llrt/core_descriptor.cpp:155: compute_with_storage_start.IsSequence() and compute_with_storage_end.IsSequence()
```


### What's changed
Skipped firmware version check when running metal on the Blackhole simulator, since it's not needed. This enables simulator execution on compute devices.
Minor fix in the simulation descriptor.
### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14928221337) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14972285709) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes