### PR TITLE
Add ttnn pybinds for event sync

### DIFF
--- a/ttnn/cpp/ttnn-pybind/events.cpp
+++ b/ttnn/cpp/ttnn-pybind/events.cpp
@@ -97,13 +97,24 @@ void py_module(py::module& module) {
 
     module.def(
         "event_synchronize",
-        py::overload_cast<const std::shared_ptr<tt::tt_metal::Event>&>(&event_synchronize),
+        py::overload_cast<const std::shared_ptr<Event>&>(&event_synchronize),
         py::arg("event"),
         R"doc(
             Synchronizes an event, blocking until the event is completed.
 
             Args:
                 event (event): The event to synchronize.
+        )doc");
+
+    module.def(
+        "event_synchronize",
+        py::overload_cast<const MeshEvent&>(&event_synchronize),
+        py::arg("mesh_event"),
+        R"doc(
+            Synchronizes a mesh event, blocking until the event is completed.
+
+            Args:
+                mesh_event (MeshEvent): The mesh event to synchronize.
         )doc");
 }
 

--- a/ttnn/cpp/ttnn-pybind/events.cpp
+++ b/ttnn/cpp/ttnn-pybind/events.cpp
@@ -94,6 +94,17 @@ void py_module(py::module& module) {
                 cq_id (int): The Command Queue on which the barrier is being issued.
                 mesh_event (MeshEvent): The Command Queue will stall until this event is completed.
             )doc");
+
+    module.def(
+        "event_synchronize",
+        py::overload_cast<const std::shared_ptr<tt::tt_metal::Event>&>(&event_synchronize),
+        py::arg("event"),
+        R"doc(
+            Synchronizes an event, blocking until the event is completed.
+
+            Args:
+                event (event): The event to synchronize.
+        )doc");
 }
 
 }  // namespace ttnn::events

--- a/ttnn/cpp/ttnn-pybind/events.cpp
+++ b/ttnn/cpp/ttnn-pybind/events.cpp
@@ -97,17 +97,6 @@ void py_module(py::module& module) {
 
     module.def(
         "event_synchronize",
-        py::overload_cast<const std::shared_ptr<Event>&>(&event_synchronize),
-        py::arg("event"),
-        R"doc(
-            Synchronizes an event, blocking until the event is completed.
-
-            Args:
-                event (event): The event to synchronize.
-        )doc");
-
-    module.def(
-        "event_synchronize",
         py::overload_cast<const MeshEvent&>(&event_synchronize),
         py::arg("mesh_event"),
         R"doc(

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -16,7 +16,6 @@ namespace ttnn::events {
 
 using ::tt::tt_metal::EnqueueRecordEvent;
 using ::tt::tt_metal::EnqueueWaitForEvent;
-using ::tt::tt_metal::EventSynchronize;
 using ::tt::tt_metal::distributed::EnqueueRecordEventToHost;
 using ::tt::tt_metal::distributed::EnqueueWaitForEvent;
 using ::tt::tt_metal::distributed::EventSynchronize;
@@ -60,8 +59,6 @@ MeshEvent record_mesh_event(
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event) {
     EnqueueWaitForEvent(event.device()->mesh_command_queue(*cq_id), event);
 }
-
-void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event) { EventSynchronize(event); }
 
 void event_synchronize(const MeshEvent& event) { EventSynchronize(event); }
 

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -16,6 +16,7 @@ namespace ttnn::events {
 
 using ::tt::tt_metal::EnqueueRecordEvent;
 using ::tt::tt_metal::EnqueueWaitForEvent;
+using ::tt::tt_metal::EventSynchronize;
 using ::tt::tt_metal::distributed::EnqueueRecordEventToHost;
 using ::tt::tt_metal::distributed::EnqueueWaitForEvent;
 
@@ -58,5 +59,7 @@ MeshEvent record_mesh_event(
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event) {
     EnqueueWaitForEvent(event.device()->mesh_command_queue(*cq_id), event);
 }
+
+void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event) { EventSynchronize(event); }
 
 }  // namespace ttnn::events

--- a/ttnn/cpp/ttnn/events.cpp
+++ b/ttnn/cpp/ttnn/events.cpp
@@ -19,6 +19,7 @@ using ::tt::tt_metal::EnqueueWaitForEvent;
 using ::tt::tt_metal::EventSynchronize;
 using ::tt::tt_metal::distributed::EnqueueRecordEventToHost;
 using ::tt::tt_metal::distributed::EnqueueWaitForEvent;
+using ::tt::tt_metal::distributed::EventSynchronize;
 
 std::shared_ptr<tt::tt_metal::Event> record_event(
     tt::tt_metal::IDevice* device, QueueId cq_id, const std::vector<tt::tt_metal::SubDeviceId>& sub_device_ids) {
@@ -61,5 +62,7 @@ void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event) {
 }
 
 void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event) { EventSynchronize(event); }
+
+void event_synchronize(const MeshEvent& event) { EventSynchronize(event); }
 
 }  // namespace ttnn::events

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -39,5 +39,7 @@ MeshEvent record_mesh_event(
     const std::optional<ttnn::MeshCoordinateRange>& device_range = std::nullopt);
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event);
 
+void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event);
+
 }  // namespace events
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -40,6 +40,7 @@ MeshEvent record_mesh_event(
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event);
 
 void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event);
+void event_synchronize(const MeshEvent& event);
 
 }  // namespace events
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/events.hpp
+++ b/ttnn/cpp/ttnn/events.hpp
@@ -39,7 +39,6 @@ MeshEvent record_mesh_event(
     const std::optional<ttnn::MeshCoordinateRange>& device_range = std::nullopt);
 void wait_for_mesh_event(QueueId cq_id, const MeshEvent& event);
 
-void event_synchronize(const std::shared_ptr<tt::tt_metal::Event>& event);
 void event_synchronize(const MeshEvent& event);
 
 }  // namespace events

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -115,6 +115,7 @@ from ttnn._ttnn.events import (
     MeshEvent,
     record_event,
     wait_for_event,
+    event_synchronize,
 )
 
 from ttnn._ttnn.operations.trace import (


### PR DESCRIPTION
### Problem description
For llama70B demo, we need to overlap host postprocessing with execution of trace and this requires synchronization of host with the tensor readback events. Unfortunately, event_synchronize is not exposed at the ttnn level.

### What's changed
Add pybinds for ttnn.event_synchronize for
1. MeshEvent

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14913598197) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
