### PR TITLE
Optimised ttnn.{gcd,lcm} for Wormhole/Blackhole.

### DIFF
--- a/tests/sweep_framework/sweeps/composite/binary/gcd/gcd.py
+++ b/tests/sweep_framework/sweeps/composite/binary/gcd/gcd.py
@@ -29,8 +29,8 @@ parameters = {
         "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 4)
         + gen_shapes([1, 32, 32], [12, 256, 256], [1, 32, 32], 4)
         + gen_shapes([32, 32], [256, 256], [32, 32], 4),
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_b_dtype": [ttnn.bfloat16],
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
@@ -68,8 +68,8 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    torch_input_tensor_a = torch.randint(-100, 100, input_shape, dtype=torch.int32)
-    torch_input_tensor_b = torch.randint(-80, 180, input_shape, dtype=torch.int32)
+    torch_input_tensor_a = torch.randint(-2147483647, 2147483648, input_shape, dtype=torch.int32)
+    torch_input_tensor_b = torch.randint(-2147483647, 2147483648, input_shape, dtype=torch.int32)
 
     golden_function = ttnn.get_golden_function(ttnn.gcd)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/sweep_framework/sweeps/composite/binary/lcm/lcm.py
+++ b/tests/sweep_framework/sweeps/composite/binary/lcm/lcm.py
@@ -29,8 +29,8 @@ parameters = {
         "input_shape": gen_shapes([1, 1, 32, 32], [6, 12, 256, 256], [1, 1, 32, 32], 4)
         + gen_shapes([1, 32, 32], [12, 256, 256], [1, 32, 32], 4)
         + gen_shapes([32, 32], [256, 256], [32, 32], 4),
-        "input_a_dtype": [ttnn.bfloat16],
-        "input_b_dtype": [ttnn.bfloat16],
+        "input_a_dtype": [ttnn.int32],
+        "input_b_dtype": [ttnn.int32],
         "input_a_layout": [ttnn.TILE_LAYOUT],
         "input_b_layout": [ttnn.TILE_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
@@ -68,8 +68,8 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    torch_input_tensor_a = torch.randint(-100, 100, input_shape, dtype=torch.int32)
-    torch_input_tensor_b = torch.randint(-80, 180, input_shape, dtype=torch.int32)
+    torch_input_tensor_a = torch.randint(-32767, 32768, input_shape, dtype=torch.int32)
+    torch_input_tensor_b = torch.randint(-32767, 32768, input_shape, dtype=torch.int32)
 
     golden_function = ttnn.get_golden_function(ttnn.lcm)
     torch_output_tensor = golden_function(torch_input_tensor_a, torch_input_tensor_b)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -915,8 +915,10 @@ def test_nei_ttnn(input_shapes, scalar, device):
 )
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_gcd_ttnn(input_shapes, device):
-    in_data1, input_tensor1 = data_gen_with_range_int(input_shapes, -1024, 1024, device)
-    in_data2, input_tensor2 = data_gen_with_range_int(input_shapes, -1000, 1000, device)
+    in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
+    in_data2 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.gcd(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.gcd)
     golden_tensor = golden_function(in_data1, in_data2)
@@ -936,10 +938,10 @@ def test_binary_gcd_ttnn(input_shapes, device):
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_lcm_ttnn(input_shapes, device):
     torch.manual_seed(213919)
-    in_data1 = torch.randint(-100, 100, input_shapes, dtype=torch.int32)
-    in_data2 = torch.randint(-80, 180, input_shapes, dtype=torch.int32)
-    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    in_data1 = torch.randint(-32767, 32768, input_shapes, dtype=torch.int32)
+    in_data2 = torch.randint(-32767, 32768, input_shapes, dtype=torch.int32)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.lcm(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.lcm)
     golden_tensor = golden_function(in_data1, in_data2)
@@ -958,12 +960,12 @@ def test_binary_lcm_ttnn(input_shapes, device):
     ),
 )
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
-def test_binary_gcd_fp32(input_shapes, device):
+def test_binary_gcd_int32(input_shapes, device):
     torch.manual_seed(213919)
-    in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
-    in_data2 = torch.randint(-1024, 1024, input_shapes, dtype=torch.int32)
-    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
+    in_data2 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
     output_tensor = ttnn.gcd(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.gcd)
@@ -985,11 +987,11 @@ def test_binary_gcd_fp32(input_shapes, device):
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_lcm_pos(input_shapes, device):
     torch.manual_seed(213919)
-    in_data1 = torch.randint(1, 1000, input_shapes, dtype=torch.int32)
-    in_data2 = torch.randint(1, 1024, input_shapes, dtype=torch.int32)
+    in_data1 = torch.randint(1, 32768, input_shapes, dtype=torch.int32)
+    in_data2 = torch.randint(1, 32768, input_shapes, dtype=torch.int32)
 
-    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.lcm(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.lcm)
     golden_tensor = golden_function(in_data1, in_data2)
@@ -1008,14 +1010,13 @@ def test_binary_lcm_pos(input_shapes, device):
     ),
 )
 @skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
-# when both inputs are 0, torch=0, tt=nan
 def test_binary_lcm_neg(input_shapes, device):
     torch.manual_seed(213919)
-    in_data1 = torch.randint(-1000, -1, input_shapes, dtype=torch.int32)
-    in_data2 = torch.randint(-1024, -1, input_shapes, dtype=torch.int32)
+    in_data1 = torch.randint(-32767, 0, input_shapes, dtype=torch.int32)
+    in_data2 = torch.randint(-32767, 0, input_shapes, dtype=torch.int32)
 
-    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor1 = ttnn.from_torch(in_data1, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor2 = ttnn.from_torch(in_data2, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.lcm(input_tensor1, input_tensor2)
     golden_function = ttnn.get_golden_function(ttnn.lcm)
     golden_tensor = golden_function(in_data1, in_data2)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <int max_input_bits = 31>
+inline void calculate_sfpu_gcd_body() {
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // c = a
+    TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG2, 0); // c |= b
+
+    TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG3, 0); // d = c
+    TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // d = -d
+    TTI_SFPAND(0, p_sfpu::LREG2, p_sfpu::LREG3, 0); // d &= c (isolate LSB)
+    TTI_SFPLZ(0, p_sfpu::LREG3, p_sfpu::LREG3, 0); // d = clz(d)
+
+    // Ensure that b is odd: if LSB is zero, then swap with a.
+    TTI_SFPSHFT2(p_sfpu::LREG1, p_sfpu::LREG3, p_sfpu::LREG2, SFPSHFT2_MOD1_SHFT_LREG); // c = b << d
+    TTI_SFPSETCC(0, p_sfpu::LREG2, 0, 6); // if c == 0 then b is even
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 0); // swap(a, b)
+    TTI_SFPENCC(0, 0, 0, 0);
+    TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG0, 0); // a = abs(a)
+    TTI_SFPABS(0, p_sfpu::LREG1, p_sfpu::LREG1, 0); // b = abs(b)
+
+    TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // a = -a
+    TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // d = -d
+
+    int iterations = max_input_bits - 1;
+
+    #pragma GCC unroll 7
+    while (iterations / 4 > 0) {
+        TTI_REPLAY(0, 7 * 4, 0, 0);
+        iterations -= 4;
+    }
+
+    // Replay 2 more iterations, making a total of 30 iterations.
+    // The worst case for 31-bit inputs is 31 iterations, but we can skip the final iteration as it only affects a.
+    // In addition, we can skip the final operation of the 30th iteration as it only affects a.
+    TTI_REPLAY(0, 7 * iterations - 1, 0, 0);
+
+    TTI_SFPENCC(0, 0, 0, 0);
+}
+
+template <int ITERATIONS = 8>
+inline void calculate_sfpu_gcd(const uint dst_offset)
+{
+    // Binary GCD algorithm.
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+
+        calculate_sfpu_gcd_body<31>();
+
+        TTI_SFPSTORE(p_sfpu::LREG1, 4, 3, 0);
+        dst_reg++;
+    }
+}
+
+inline void calculate_sfpu_gcd_init() {
+    TTI_REPLAY(0, 7 * 4, 0, 1);
+    #pragma GCC unroll 4
+    for (int i = 0; i < 4; ++i) {
+        // We store {-a, a} in {LREG0, LREG2}, which is convenient for isolating the LSB of a.
+        TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // LREG2 = +a
+        TTI_SFPAND(0, p_sfpu::LREG2, p_sfpu::LREG0, 0); // LREG0 &= a (isolate LSB and overwrite -a)
+        TTI_SFPLZ(0, p_sfpu::LREG0, p_sfpu::LREG0, SFPLZ_MOD1_CC_NE0); // LREG0 = clz(LREG0), disable lanes where a == 0
+        TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE); // LREG0 += d
+        TTI_SFPSHFT2(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG0, SFPSHFT2_MOD1_SHFT_LREG); // LREG0 = a >> -LREG0, making a definitely odd (now both a and b are odd)
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, SFPSWAP_MOD1_VEC_MIN_MAX); // ensure b < a
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // a = b - a (now a is even)
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_gcd.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+// inputs are lreg0, lreg1. output is lreg4
+inline void calculate_sfpu_mul_u16_to_u32_body() {
+    // mask
+    TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0xff);
+    // copy
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+    TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
+    // shift
+    TTI_SFPSHFT((-8) & 0xfff, 0, p_sfpu::LREG2, 1);
+    TTI_SFPSHFT((-8) & 0xfff, 0, p_sfpu::LREG3, 1);
+    // mask lowest 8 bits
+    TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);
+    TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
+    // cast to fp32
+    TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+    TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
+    TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
+    // multiply in fp32
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG4, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+    TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+    TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
+    // cast back
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG4, p_sfpu::LREG4, 6);
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG7, p_sfpu::LREG7, 6);
+    // shift back
+    TTI_SFPSHFT(8, 0, p_sfpu::LREG5, 1);
+    TTI_SFPSHFT(8, 0, p_sfpu::LREG6, 1);
+    TTI_SFPSHFT(16, 0, p_sfpu::LREG7, 1);
+    TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG4, SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG4, SFPIADD_MOD1_CC_NONE);
+}
+
+template <int ITERATIONS = 8>
+inline void calculate_sfpu_lcm(const uint dst_offset)
+{
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+
+        // Binary GCD algorithm; assumes abs(a) < 2^15 and abs(b) < 2^15, hence gcd(a, b) < 2^15
+        calculate_sfpu_gcd_body<15>();
+
+        // Two iterations of Newton's method to find reciprocal of gcd(a, b)
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);
+        TTI_SFPSETSGN(1, p_sfpu::LREG2, p_sfpu::LREG1, 1);
+        TTI_SFPSETEXP(126, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+        TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG13, p_sfpu::LREG12, p_sfpu::LREG0, 0);
+        TTI_SFPEXEXP(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
+
+        // 1st iteration
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, 0);
+        TTI_SFPNOP;
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPNOP;
+        // 2nd iteration
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, 0);
+        TTI_SFPNOP;
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPIADD((-126) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_IMM);
+
+        // Re-bias
+        TTI_SFPEXEXP(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
+        TTI_SFPSETEXP(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+
+	// Load a and multiply by 1/gcd(a, b)
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0);
+        TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size);
+        TTI_SFPABS(0, p_sfpu::LREG1, p_sfpu::LREG1, 0);
+
+	// Convert a/gcd(a, b) to int32
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
+
+	// Finally, compute lcm(a, b) = a/gcd(a, b) * b
+        calculate_sfpu_mul_u16_to_u32_body();
+
+        TTI_SFPSTORE(p_sfpu::LREG4, 4, 3, 0);
+        dst_reg++;
+    }
+}
+
+inline void calculate_sfpu_lcm_init()
+{
+    calculate_sfpu_gcd_init();
+
+    // constants for reciprocal calculation
+    sfpi::vConstFloatPrgm0 = 48.0f / 17.0f;
+    sfpi::vConstFloatPrgm1 = 32.0f / 17.0f;
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -7,7 +7,6 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_gcd.h"
-#include "ckernel_sfpu_recip.h"
 #include "sfpi.h"
 
 using namespace sfpi;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_gcd.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gcd_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gcd, APPROXIMATE>(
+        sfpu::calculate_sfpu_gcd_init);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gcd(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_lcm.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lcm_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lcm, APPROXIMATE>(
+        sfpu::calculate_sfpu_lcm_init);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lcm(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu_types.h
@@ -102,4 +102,6 @@ enum SfpuType {
     cpy_values,
     unary_max,
     unary_min,
+    gcd,
+    lcm,
 };

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_gcd.h
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <int max_input_bits = 31>
+inline void calculate_sfpu_gcd_body() {
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // c = a
+    TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG2, 0); // c |= b
+
+    TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG3, 0); // d = c
+    TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // d = -d
+    TTI_SFPAND(0, p_sfpu::LREG2, p_sfpu::LREG3, 0); // d &= c (isolate LSB)
+    TTI_SFPLZ(0, p_sfpu::LREG3, p_sfpu::LREG3, 0); // d = clz(d)
+
+    // Ensure that b is odd: if LSB is zero, then swap with a.
+    TTI_SFPSHFT2(p_sfpu::LREG1, p_sfpu::LREG3, p_sfpu::LREG2, SFPSHFT2_MOD1_SHFT_LREG); // c = b << d
+    TTI_SFPSETCC(0, p_sfpu::LREG2, 0, 6); // if c == 0 then b is even
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, 0); // swap(a, b)
+    TTI_SFPENCC(0, 0, 0, 0);
+    TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG0, 0); // a = abs(a)
+    TTI_SFPABS(0, p_sfpu::LREG1, p_sfpu::LREG1, 0); // b = abs(b)
+
+    TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // a = -a
+    TTI_SFPIADD(0, p_sfpu::LCONST_0, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // d = -d
+
+    int iterations = max_input_bits - 1;
+
+    #pragma GCC unroll 7
+    while (iterations / 4 > 0) {
+        TTI_REPLAY(0, 7 * 4, 0, 0);
+        iterations -= 4;
+    }
+
+    // Replay 2 more iterations, making a total of 30 iterations.
+    // The worst case for 31-bit inputs is 31 iterations, but we can skip the final iteration as it only affects a.
+    // In addition, we can skip the final operation of the 30th iteration as it only affects a.
+    TTI_REPLAY(0, 7 * iterations - 1, 0, 0);
+
+    TTI_SFPENCC(0, 0, 0, 0);
+}
+
+template <int ITERATIONS = 8>
+inline void calculate_sfpu_gcd(const uint dst_offset)
+{
+    // Binary GCD algorithm.
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+
+        calculate_sfpu_gcd_body<31>();
+
+        TTI_SFPSTORE(p_sfpu::LREG1, 4, 3, 0);
+        dst_reg++;
+    }
+}
+
+inline void calculate_sfpu_gcd_init() {
+    TTI_REPLAY(0, 7 * 4, 0, 1);
+    #pragma GCC unroll 4
+    for (int i = 0; i < 4; ++i) {
+        // We store {-a, a} in {LREG0, LREG2}, which is convenient for isolating the LSB of a.
+        TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG2, 0); // LREG2 = +a
+        TTI_SFPAND(0, p_sfpu::LREG2, p_sfpu::LREG0, 0); // LREG0 &= a (isolate LSB and overwrite -a)
+        TTI_SFPLZ(0, p_sfpu::LREG0, p_sfpu::LREG0, SFPLZ_MOD1_CC_NE0); // LREG0 = clz(LREG0), disable lanes where a == 0
+        TTI_SFPIADD(0, p_sfpu::LREG3, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE); // LREG0 += d
+        TTI_SFPSHFT2(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG0, SFPSHFT2_MOD1_SHFT_LREG); // LREG0 = a >> -LREG0, making a definitely odd (now both a and b are odd)
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, SFPSWAP_MOD1_VEC_MIN_MAX); // ensure b < a
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST); // a = b - a (now a is even)
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_gcd.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+// inputs are lreg0, lreg1. output is lreg4
+inline void calculate_sfpu_mul_u16_to_u32_body() {
+    // mask
+    TTI_SFPLOADI(p_sfpu::LREG7, SFPLOADI_MOD0_USHORT, 0xff);
+    // copy
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG2, 0);
+    TTI_SFPMOV(0, p_sfpu::LREG1, p_sfpu::LREG3, 0);
+    // shift
+    TTI_SFPSHFT((-8) & 0xfff, 0, p_sfpu::LREG2, 1);
+    TTI_SFPSHFT((-8) & 0xfff, 0, p_sfpu::LREG3, 1);
+    // mask lowest 8 bits
+    TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);
+    TTI_SFPAND(0, p_sfpu::LREG7, p_sfpu::LREG1, 0);
+    // cast to fp32
+    TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+    TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG1, 0);
+    TTI_SFPCAST(p_sfpu::LREG2, p_sfpu::LREG2, 0);
+    TTI_SFPCAST(p_sfpu::LREG3, p_sfpu::LREG3, 0);
+    // multiply in fp32
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG4, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG5, 0);
+    TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG1, p_sfpu::LCONST_0, p_sfpu::LREG6, 0);
+    TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG7, 0);
+    // cast back
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG4, p_sfpu::LREG4, 6);
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG5, p_sfpu::LREG5, 6);
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG6, p_sfpu::LREG6, 6);
+    TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG7, p_sfpu::LREG7, 6);
+    // shift back
+    TTI_SFPSHFT(8, 0, p_sfpu::LREG5, 1);
+    TTI_SFPSHFT(8, 0, p_sfpu::LREG6, 1);
+    TTI_SFPSHFT(16, 0, p_sfpu::LREG7, 1);
+    TTI_SFPIADD(0, p_sfpu::LREG5, p_sfpu::LREG4, SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(0, p_sfpu::LREG6, p_sfpu::LREG4, SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(0, p_sfpu::LREG7, p_sfpu::LREG4, SFPIADD_MOD1_CC_NONE);
+}
+
+template <int ITERATIONS = 8>
+inline void calculate_sfpu_lcm(const uint dst_offset)
+{
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr uint dst_tile_size = 64;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0); // a
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size); // b
+
+        // Binary GCD algorithm; assumes abs(a) < 2^15 and abs(b) < 2^15, hence gcd(a, b) < 2^15
+        calculate_sfpu_gcd_body<15>();
+
+        // Two iterations of Newton's method to find reciprocal of gcd(a, b)
+        TTI_SFPCAST(p_sfpu::LREG1, p_sfpu::LREG2, 0);
+        TTI_SFPSETSGN(1, p_sfpu::LREG2, p_sfpu::LREG1, 1);
+        TTI_SFPSETEXP(126, p_sfpu::LREG1, p_sfpu::LREG1, 1);
+        TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG13, p_sfpu::LREG12, p_sfpu::LREG0, 0);
+        TTI_SFPEXEXP(0, p_sfpu::LREG2, p_sfpu::LREG3, 0);
+
+        // 1st iteration
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, 0);
+        TTI_SFPNOP;
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPNOP;
+        // 2nd iteration
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, 0);
+        TTI_SFPNOP;
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPIADD((-126) & 0xfff, p_sfpu::LREG3, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_IMM);
+
+        // Re-bias
+        TTI_SFPEXEXP(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        TTI_SFPIADD(0, p_sfpu::LREG4, p_sfpu::LREG3, SFPIADD_MOD1_CC_NONE | SFPIADD_MOD1_ARG_2SCOMP_LREG_DST);
+        TTI_SFPSETEXP(0, p_sfpu::LREG0, p_sfpu::LREG3, 0);
+
+	// Load a and multiply by 1/gcd(a, b)
+        TTI_SFPLOAD(p_sfpu::LREG0, 4, 3, 0);
+        TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPCAST(p_sfpu::LREG0, p_sfpu::LREG0, 0);
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG3, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TT_SFPLOAD(p_sfpu::LREG1, 4, 3, dst_offset * dst_tile_size);
+        TTI_SFPABS(0, p_sfpu::LREG1, p_sfpu::LREG1, 0);
+
+	// Convert a/gcd(a, b) to int32
+        TTI_SFP_STOCH_RND(0, 0, 0, p_sfpu::LREG0, p_sfpu::LREG0, 6);
+
+	// Finally, compute lcm(a, b) = a/gcd(a, b) * b
+        calculate_sfpu_mul_u16_to_u32_body();
+
+        TTI_SFPSTORE(p_sfpu::LREG4, 4, 3, 0);
+        dst_reg++;
+    }
+}
+
+inline void calculate_sfpu_lcm_init()
+{
+    calculate_sfpu_gcd_init();
+
+    // constants for reciprocal calculation
+    sfpi::vConstFloatPrgm0 = 48.0f / 17.0f;
+    sfpi::vConstFloatPrgm1 = 32.0f / 17.0f;
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lcm.h
@@ -7,7 +7,6 @@
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_sfpu_gcd.h"
-#include "ckernel_sfpu_recip.h"
 #include "sfpi.h"
 
 using namespace sfpi;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_gcd.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_gcd.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gcd_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::gcd, APPROXIMATE>(
+        sfpu::calculate_sfpu_gcd_init);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_gcd(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        sfpu::calculate_sfpu_gcd, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_lcm.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_eltwise_binary_sfpu_init.h"
+#include "llk_math_eltwise_binary_sfpu_params.h"
+#include "ckernel_sfpu_lcm.h"
+
+namespace ckernel {
+
+// New LLK SFPU APIs
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lcm_init() {
+    llk_math_eltwise_binary_sfpu_init<SfpuType::lcm, APPROXIMATE>(
+        sfpu::calculate_sfpu_lcm_init);
+}
+
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_binary_sfpu_lcm(
+    uint dst_index0, uint32_t dst_index1, int vector_mode = VectorMode::RC) {
+    llk_math_eltwise_binary_sfpu_params<APPROXIMATE>(
+        sfpu::calculate_sfpu_lcm, dst_index0, dst_index1, vector_mode);
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu_types.h
@@ -103,4 +103,6 @@ enum SfpuType {
     alt_complex_rotate90,
     round,
     cpy_values,
+    gcd,
+    lcm,
 };

--- a/tt_metal/include/compute_kernel_api/gcd.h
+++ b/tt_metal/include/compute_kernel_api/gcd.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_gcd.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise GCD operation on two inputs: y = gcd(x0, x1).
+ * Both inputs must be int32.
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+ // clang-format on
+ALWI void gcd_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_gcd<APPROX>(idst0, idst1)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void gcd_tile_init() { MATH((llk_math_eltwise_binary_sfpu_gcd_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/tt_metal/include/compute_kernel_api/lcm.h
+++ b/tt_metal/include/compute_kernel_api/lcm.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "compute_kernel_api/common_globals.h"
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_binary_sfpu_lcm.h"
+#define MAIN math_main()
+#define MATH(x) x
+#else
+#define MATH(x)
+#endif
+
+namespace ckernel {
+
+// clang-format off
+/**
+ * Performs an elementwise LCM operation on two inputs: y = lcm(x0, x1).
+ * Both inputs must be int32 with values constrained to |value| ≤ 2^15-1 (32,767).
+ * Output overwrites first operand in DST.
+ *
+ * The DST register buffer must be in acquired state via *acquire_dst* call. This call is blocking and is only available
+ * on the compute engine.
+ *
+ * Return value: None
+ *
+ * | Argument       | Description                                                           | Type     | Valid Range                                           | Required |
+ * |----------------|-----------------------------------------------------------------------|----------|-------------------------------------------------------|----------|
+ * | idst0          | The index of the tile in DST register buffer to use as first operand  | uint32_t | Must be less than the size of the DST register buffer | True     |
+ * | idst1          | The index of the tile in DST register buffer to use as second operand | uint32_t | Must be less than the size of the DST register buffer | True     |
+ */
+ // clang-format on
+ALWI void lcm_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_lcm<APPROX>(idst0, idst1)));
+}
+
+/**
+ * Please refer to documentation for any_init.
+ */
+ALWI void lcm_tile_init() { MATH((llk_math_eltwise_binary_sfpu_lcm_init<APPROX>())); }
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -88,7 +88,7 @@ constexpr bool is_associative(BinaryOpType op) {
     return op == BinaryOpType::ADD || op == BinaryOpType::MUL || op == BinaryOpType::EQ || op == BinaryOpType::NE ||
            op == BinaryOpType::LOGICAL_AND || op == BinaryOpType::LOGICAL_OR || op == BinaryOpType::LOGADDEXP ||
            op == BinaryOpType::LOGADDEXP2 || op == BinaryOpType::LOGICAL_XOR || op == BinaryOpType::MAXIMUM ||
-           op == BinaryOpType::MINIMUM;
+           op == BinaryOpType::MINIMUM || op == BinaryOpType::GCD || op == BinaryOpType::LCM;
 }
 
 // Tensor - Scalar
@@ -588,5 +588,7 @@ template struct BinaryOperationSfpu<BinaryOpType::LEFT_SHIFT>;
 template struct BinaryOperationSfpu<BinaryOpType::RIGHT_SHIFT>;
 template struct BinaryOperationSfpu<BinaryOpType::MAXIMUM>;
 template struct BinaryOperationSfpu<BinaryOpType::MINIMUM>;
+template struct BinaryOperationSfpu<BinaryOpType::GCD>;
+template struct BinaryOperationSfpu<BinaryOpType::LCM>;
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_composite.hpp
@@ -268,16 +268,20 @@ struct ExecuteBinaryRemainder {
 
 struct ExecuteLCM {
     static Tensor invoke(
+        QueueId queue_id,
         const Tensor& input_tensor_a,
         const Tensor& input_tensor_b,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
 struct ExecuteGCD {
     static Tensor invoke(
-        const Tensor& input_tensor_a,
-        const Tensor& input_tensor_b,
-        const std::optional<MemoryConfig>& memory_config = std::nullopt);
+        QueueId queue_id,
+        const Tensor& input_tensor_a_arg,
+        const Tensor& input_tensor_b_arg,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt);
 };
 
 struct ExecuteMaximum {

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_types.hpp
@@ -37,6 +37,8 @@ enum class BinaryOpType {
     DEQUANT,
     MAXIMUM,
     MINIMUM,
+    GCD,
+    LCM,
 };
 
 }  // namespace ttnn::operations::binary

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -263,6 +263,14 @@ std::map<std::string, std::string> get_defines_fp32(
                 op_name = "binary_min_tile";
             }
             break;
+        case BinaryOpType::GCD:
+            new_defines.insert({"BINOP_INIT", fmt::format("gcd_tile_init();")});
+            op_name = "gcd_tile";
+            break;
+        case BinaryOpType::LCM:
+            new_defines.insert({"BINOP_INIT", fmt::format("lcm_tile_init();")});
+            op_name = "lcm_tile";
+            break;
         case BinaryOpType::LOGADDEXP:
             // PRE_IN0_0 ===> Applies prescaling for first input
             // PRE_IN1_0 ====> Applies prescaling for second input

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -41,6 +41,8 @@ namespace utils {
         case BinaryOpType::LTE:
         case BinaryOpType::EQ:
         case BinaryOpType::NE: return ((a == DataType::FLOAT32 && b == DataType::FLOAT32) || (a == DataType::INT32 && b == DataType::INT32));
+        case BinaryOpType::GCD:
+        case BinaryOpType::LCM:
         case BinaryOpType::LEFT_SHIFT:
         case BinaryOpType::RIGHT_SHIFT:
         case BinaryOpType::BITWISE_XOR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/kernels/compute/eltwise_binary_sfpu_kernel.cpp
@@ -18,6 +18,8 @@
 #include "compute_kernel_api/sub_int32_sfpu.h"
 #include "compute_kernel_api/sub_uint16_sfpu.h"
 #include "compute_kernel_api/binary_max_min.h"
+#include "compute_kernel_api/gcd.h"
+#include "compute_kernel_api/lcm.h"
 
 #define PRE_SCALE defined SFPU_OP_INIT_PRE_IN0_0 || defined SFPU_OP_INIT_PRE_IN1_0
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -35,6 +35,8 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LTE:
         case EQ:
         case NE: return ((a == FLOAT32 && b == FLOAT32) || (a == INT32 && b == INT32));
+        case LCM:
+        case GCD:
         case LEFT_SHIFT:
         case RIGHT_SHIFT:
         case BITWISE_XOR:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -283,6 +283,20 @@ OpConfig::OpConfig(BinaryOpType binary_op_type, std::in_place_type_t<EnumT>) : b
                 TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
             }
             break;
+        case BinaryOpType::GCD:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::GCD;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
+        case BinaryOpType::LCM:
+            if (is_sfpu_op()) {
+                binary_op = SfpuBinaryOp::LCM;
+            } else {
+                TT_THROW("Unsupported binary op for FPU {}", binary_op_type);
+            }
+            break;
         default: TT_THROW("Unsupported binary op {}", binary_op_type);
     }
 }
@@ -312,6 +326,8 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
         case DIV: return {"div_binary_tile_init();", "div_binary_tile"};
         case POWER: return {"power_binary_tile_init();", "power_binary_tile"};
         case RSUB: return {"rsub_binary_tile_init();", "rsub_binary_tile"};
+        case GCD: return {"gcd_tile_init();", "gcd_tile"};
+        case LCM: return {"lcm_tile_init();", "lcm_tile"};
         case LEFT_SHIFT: return {"binary_shift_tile_init();", "binary_left_shift_tile"};
         case RIGHT_SHIFT: return {"binary_shift_tile_init();", "binary_right_shift_tile"};
         case BITWISE_AND: return {"binary_bitwise_tile_init();", "and_binary_tile"};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.hpp
@@ -52,6 +52,8 @@ struct OpConfig {
         DIV,
         POWER,
         RSUB,
+        GCD,
+        LCM,
         LEFT_SHIFT,
         RIGHT_SHIFT,
         BITWISE_AND,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu.cpp
@@ -17,6 +17,8 @@
 #include "compute_kernel_api/sub_uint16_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
+#include "compute_kernel_api/gcd.h"
+#include "compute_kernel_api/lcm.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast.cpp
@@ -17,6 +17,8 @@
 #include "compute_kernel_api/sub_uint16_sfpu.h"
 #include "compute_kernel_api/quantization.h"
 #include "compute_kernel_api/binary_max_min.h"
+#include "compute_kernel_api/gcd.h"
+#include "compute_kernel_api/lcm.h"
 
 #include "eltwise_utils_common.hpp"
 #include "eltwise_utils_sfpu.hpp"


### PR DESCRIPTION
### Ticket

#17771 (original ticket) and #21847 (Blackhole failures)

### Problem description

This was originally merged to main but didn't have support for Blackhole.  This is a reattempt with LLKs copied for Blackhole.

The original ttnn.gcd implementation didn't support int32 at all. It did work for floating point tensors, but only with a limited range (±1024.0). The use of ttnn::remainder made it quite inefficient.

### What's changed

- Implemented binary GCD for int32 on SFPU, dropping the old inefficient floating point version.
- Reimplemented LCM for int32 for max(abs(a), abs(b)) ≤ 32767 on SFPU (relies on GCD).

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes