### PR TITLE
#18485: add skips for tests not working on BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -123,6 +123,7 @@ def generate_sdxl_dram_test_inputs():
     return inputs
 
 
+@skip_for_blackhole("Fails on Blackhole. Issue #20913")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 @pytest.mark.parametrize("input_shape, core_grid_y, num_out_blocks", generate_sdxl_dram_test_inputs())
 def test_sdxl_base_group_norm(device, input_shape, core_grid_y, num_out_blocks, use_program_cache):

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -11,9 +11,10 @@ from loguru import logger
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
 
 
+@skip_for_blackhole("Fails on Blackhole. Issue #20913")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -7,9 +7,11 @@ import torch
 import ttnn
 
 from loguru import logger
+from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import check_with_pcc
 
 
+@skip_for_blackhole("Fails on Blackhole. Issue #21862")
 @pytest.mark.parametrize(
     argnames="tensor_shape, dim, keepdim, use_multicore",
     argvalues=[

--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -7,7 +7,7 @@ from math import prod
 import pytest
 import torch
 
-from models.utility_functions import skip_for_wormhole_b0
+from models.utility_functions import skip_for_wormhole_b0, skip_for_blackhole
 from tests.ttnn.unit_tests.operations.test_utils import (
     TILE_HEIGHT,
     TILE_WIDTH,
@@ -416,6 +416,7 @@ def test_pad_for_tensor_in_tile_layout(device, h, w, padding, value):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
+@skip_for_blackhole("Fails on Blackhole. Issue #20698")
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bfloat16", "float32"])
 @pytest.mark.parametrize("use_multicore", [True, False], ids=["multicore", "singlecore"])
 @pytest.mark.parametrize(
@@ -439,6 +440,7 @@ def test_pad_conv2d_sweep(device, dtype, use_multicore, shape, padded_shape):
     assert_with_pcc(in_torch, out_torch, 0.9999)
 
 
+@skip_for_blackhole("Fails on Blackhole. Issue #20698")
 @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("shape", [[1, 1, 18, 13]])
 @pytest.mark.parametrize("padshape", [[1, 1, TILE_HEIGHT, TILE_WIDTH]])

--- a/tests/ttnn/unit_tests/operations/test_prefetcher.py
+++ b/tests/ttnn/unit_tests/operations/test_prefetcher.py
@@ -7,11 +7,11 @@ import torch
 import ttnn
 from loguru import logger
 
-from models.utility_functions import is_grayskull, is_wormhole_b0, is_blackhole
+from models.utility_functions import is_wormhole_b0, is_blackhole, skip_for_blackhole
 from tests.ttnn.unit_tests.operations.prefetcher_common import run_prefetcher_mm
 
 
-@pytest.mark.skipif(is_grayskull(), reason="GS not supported")
+@skip_for_blackhole("Hangs on Blackhole. Issue #21304")
 @pytest.mark.parametrize(
     "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers",
     [
@@ -59,7 +59,6 @@ def test_run_prefetcher_post_commit(
 
 
 # Test DRAM Prefetcher x Matmul on T3K
-@pytest.mark.skipif(is_grayskull(), reason="GS not supported")
 @pytest.mark.parametrize(
     "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers",
     [


### PR DESCRIPTION
### Ticket
Link to Github Issue #18485

### Problem description
- some tests are failing on BH

### What's changed
- skip tests to allow subsequent tests to run in pipelines

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14915108158/job/41899438242 except profiler regressions which has nothing to do with this change
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14914993597
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes