### PR TITLE
#21303: Convert event order assert to fatal

### DIFF
--- a/tt_metal/impl/event/dispatch.cpp
+++ b/tt_metal/impl/event/dispatch.cpp
@@ -185,7 +185,7 @@ void read_events_from_completion_queue(
         channel);
     uint32_t event_completed = dispatch_cmd_and_event[sizeof(CQDispatchCmd) / sizeof(uint32_t)];
 
-    TT_ASSERT(
+    TT_FATAL(
         event_completed == event_descriptor.event_id,
         "Event Order Issue: expected to read back completion signal for event {} but got {}!",
         event_descriptor.event_id,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21303

### Problem description
Verification for ordered event ids is only done in debug mode. This leads to ND issues only being seen in debug builds.
This is a fairly lightweight check so its worth keeping in release mode for sanity. 

### What's changed
Change 

```
 TT_ASSERT(
        event_completed == event_descriptor.event_id,
        "Event Order Issue: expected to read back completion signal for event {} but got {}!",
        event_descriptor.event_id,
        event_completed);
```

to 

```
 TT_FATAL(
        event_completed == event_descriptor.event_id,
        "Event Order Issue: expected to read back completion signal for event {} but got {}!",
        event_descriptor.event_id,
        event_completed);
```
### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes