### PR TITLE
Make FDMeshCommandQueue::in_use_ thread safe to suppress Tsan warnings

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -134,7 +134,7 @@ private:
     inline static std::mutex reader_thread_pool_mutex_;
     // Used to Maintain state: Mark/Check if this data structure is being used for dispatch.
     // This is temporary - will not be needed when we MeshCommandQueue is the only dispatch interface.
-    bool in_use_ = false;
+    std::atomic<bool> in_use_ = false;
 
 protected:
     void write_shard_to_device(


### PR DESCRIPTION
### Ticket
No Ticket.

### Problem description
TSan warning seen due to `FDMeshCommandQueue::in_use_` being a non-atomic boolean written to by multiple threads.
This isn't actually a functional issue, since all threads write the value `1` to this variable, but it does raise warning in TSan builds.

### What's changed
Make `FDMeshCommandQueue::in_use_`  an atomic boolean.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes