### PR TITLE
Vsuresh tt/#21149/group norm pcc last group error

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -14,6 +14,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc, check_with_pcc
 from models.utility_functions import skip_for_wormhole_b0
 
 
+@skip_for_blackhole("Fails on Blackhole. Issue #20913")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x",
@@ -47,6 +48,108 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
         pytest.skip()
 
     grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x)
+
+    # torch input tensor
+    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_weight = torch.rand((C,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.group_norm(
+        torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
+    )
+    torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    # input tensor
+    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    input_tensor_row_major = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    input_tensor_tilized = ttnn.tilize_with_zero_padding(input_tensor_row_major, use_multicore=True)
+
+    # input mask
+    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y)
+    input_mask_tensor = ttnn.from_torch(
+        input_mask_tensor,
+        dtype=ttnn.DataType.BFLOAT8_B,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # gamma/beta
+    gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.y)
+    beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.y)
+
+    gamma_t = ttnn.from_torch(
+        gamma,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    beta_t = ttnn.from_torch(
+        beta,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # groupnorm
+    output_tensor = ttnn.group_norm(
+        input_tensor_tilized,
+        num_groups=num_groups,
+        input_mask=input_mask_tensor,
+        weight=gamma_t,
+        bias=beta_t,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_layout=ttnn.TILE_LAYOUT,
+        core_grid=grid_size,
+        inplace=False,
+        num_out_blocks=num_out_blocks,
+    )
+
+    # output tensor
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output_tensor, output_tensor, 0.9996)
+
+
+def generate_sdxl_dram_test_inputs():
+    inputs = []
+
+    # 1024x1024 resoultion
+    # inputs.append(((2, 1920, 64, 64), 4, 4))  #  pcc 0.95
+    inputs.append(((2, 320, 128, 128), 2, 4))
+    inputs.append(((2, 640, 128, 128), 4, 4))
+    inputs.append(((2, 960, 128, 128), 2, 4))
+
+    # VAE tests
+    inputs.append(((1, 256, 1024, 1024), 4, 64))
+    inputs.append(((1, 256, 1024, 1024), 8, 64))
+    inputs.append(((1, 256, 515, 512), 8, 16))
+    inputs.append(((1, 512, 128, 128), 4, 4))
+    inputs.append(((1, 512, 256, 256), 8, 4))
+    inputs.append(((1, 512, 512, 512), 8, 16))
+
+    return inputs
+
+
+@skip_for_blackhole("Fails on Blackhole. Issue #20913")
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
+@pytest.mark.parametrize("input_shape, core_grid_y, num_out_blocks", generate_sdxl_dram_test_inputs())
+def test_sdxl_base_group_norm(device, input_shape, core_grid_y, num_out_blocks, use_program_cache):
+    torch.manual_seed(0)
+    if device.core_grid.y == 7:
+        pytest.skip()
+
+    num_groups = 32
+    N, C, H, W = input_shape
+    grid_size = ttnn.CoreGrid(y=core_grid_y, x=8)
 
     # torch input tensor
     torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -21,8 +21,24 @@ from models.utility_functions import skip_for_wormhole_b0
         (8, 768, 1, 512, 32, 2, 8, 8),  # base case
         (9, 768, 1, 512, 32, 2, 8, 8),  # test batch size 9 (uneven batch sizes)
         (1, 768, 1, 512, 32, 2, 8, 8),  # test group channel count is less than tile size
-        (1, 640, 128, 128, 32, 2, 4, 8),  # Stable Diffusion XL Variant 1
-        (1, 960, 128, 128, 32, 2, 2, 8),  # Stable Diffusion XL Variant 2
+        (1, 480, 1, 64, 8, 1, 1, 1),  # test last group ends less than max tile span
+        (1, 2560, 1, 512, 32, 2, 8, 8),  # test mcast num_out_blocks 2
+        (1, 2560, 1, 1024, 32, 4, 8, 8),  # test mcast num_out_blocks 4
+        (1, 768, 1, 512, 32, 2, 8, 8),  # test group channel count is less than tile size
+        (2, 768, 1, 512, 32, 2, 8, 8),  # test batch size 2 (still multicast)
+        (8, 768, 1, 512, 32, 2, 8, 8),  # test batch size 8 (no multicast)
+        (8, 768, 1, 512, 32, 3, 8, 8),  # test batch size 8 (no multicast), but uneven num_out_blocks divisor
+        (9, 768, 1, 512, 32, 2, 8, 8),  # test batch size 9 (uneven batch sizes)
+        (
+            1,
+            128,
+            1,
+            512,
+            32,
+            2,
+            4,
+            8,
+        ),  # test all groups on core fit in less than one tile, so need to reduce col core count
     ],
 )
 def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x):
@@ -31,107 +47,6 @@ def test_group_norm_DRAM(device, N, C, H, W, num_groups, num_out_blocks, cores_y
         pytest.skip()
 
     grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x)
-
-    # torch input tensor
-    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
-    torch_weight = torch.rand((C,), dtype=torch.bfloat16)
-    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
-    torch_output_tensor = torch.nn.functional.group_norm(
-        torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
-    )
-    torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
-
-    # input tensor
-    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
-    input_tensor_row_major = ttnn.from_torch(
-        input_tensor,
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    input_tensor_tilized = ttnn.tilize_with_zero_padding(input_tensor_row_major, use_multicore=True)
-
-    # input mask
-    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, grid_size.y)
-    input_mask_tensor = ttnn.from_torch(
-        input_mask_tensor,
-        dtype=ttnn.DataType.BFLOAT8_B,
-        layout=ttnn.TILE_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    # gamma/beta
-    gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, grid_size.y)
-    beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, grid_size.y)
-
-    gamma_t = ttnn.from_torch(
-        gamma,
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    beta_t = ttnn.from_torch(
-        beta,
-        dtype=ttnn.DataType.BFLOAT16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        device=device,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-
-    # groupnorm
-    output_tensor = ttnn.group_norm(
-        input_tensor_tilized,
-        num_groups=num_groups,
-        input_mask=input_mask_tensor,
-        weight=gamma_t,
-        bias=beta_t,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        output_layout=ttnn.TILE_LAYOUT,
-        core_grid=grid_size,
-        inplace=False,
-        num_out_blocks=num_out_blocks,
-    )
-
-    # output tensor
-    output_tensor = ttnn.from_device(output_tensor)
-    output_tensor = ttnn.to_torch(output_tensor)
-
-    assert_with_pcc(torch_output_tensor, output_tensor, 0.9996)
-
-
-def generate_sdxl_dram_test_inputs():
-    inputs = []
-
-    # 1024x1024 resoultion
-    # inputs.append(((2, 1920, 64, 64), 4, 4))  #  pcc 0.95
-    inputs.append(((2, 320, 128, 128), 2, 4))
-    inputs.append(((2, 640, 128, 128), 4, 4))
-    inputs.append(((2, 960, 128, 128), 2, 4))
-
-    # VAE tests
-    inputs.append(((1, 256, 1024, 1024), 4, 64))
-    inputs.append(((1, 256, 1024, 1024), 8, 64))
-    inputs.append(((1, 256, 515, 512), 8, 16))
-    inputs.append(((1, 512, 128, 128), 4, 4))
-    inputs.append(((1, 512, 256, 256), 8, 4))
-    inputs.append(((1, 512, 512, 512), 8, 16))
-
-    return inputs
-
-
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 0}], indirect=True)
-@pytest.mark.parametrize("input_shape, core_grid_y, num_out_blocks", generate_sdxl_dram_test_inputs())
-def test_sdxl_base_group_norm(device, input_shape, core_grid_y, num_out_blocks, use_program_cache):
-    torch.manual_seed(0)
-    if device.core_grid.y == 7:
-        pytest.skip()
-
-    num_groups = 32
-    N, C, H, W = input_shape
-    grid_size = ttnn.CoreGrid(y=core_grid_y, x=8)
 
     # torch input tensor
     torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -194,7 +194,9 @@ void kernel_main() {
 
                 for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                     for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                        if (index_g_offset + nt < row_tile_max_index) {
+                        // Checks, only relavent to the last group, that we are not indexing out of bounds
+                        // for the cases where our last group does not span the length of our max tile span for a group
+                        if ((index_g_offset + nt) < row_tile_max_index) {
                             noc_async_write_tile(
                                 out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
                                     index_b_offset + index_g_offset,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -103,7 +103,6 @@ void kernel_main() {
     }
 
     index_b_offset = 0;
-    DPRINT << "num_cols_tile_gamma_beta" << num_cols_tile_gamma_beta << ENDL();
     constexpr uint32_t row_tile_max_index = num_cols_tile_gamma_beta;
 
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -103,10 +103,14 @@ void kernel_main() {
     }
 
     index_b_offset = 0;
+    DPRINT << "num_cols_tile_gamma_beta" << num_cols_tile_gamma_beta << ENDL();
+    constexpr uint32_t row_tile_max_index = num_cols_tile_gamma_beta;
+
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
         uint32_t input_mask_tile_id = input_mask_tile_start_id;
         index_g_offset = 0;
         row_offset = num_cols_per_group;
+
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
             cb_reserve_back(cb_input_mask, block_w);
             uint32_t l1_write_addr_input_mask = get_write_ptr(cb_input_mask);
@@ -188,13 +192,16 @@ void kernel_main() {
                 }
                 cb_wait_front(cb_out, out_block_hw_normal);
                 uint32_t l1_read_addr = get_read_ptr(cb_out);
+
                 for (uint32_t mt = 0; mt < out_block_h_actual; mt++) {
                     for (uint32_t nt = 0; nt < block_w_curr; nt++) {
-                        noc_async_write_tile(
-                            out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt + index_b_offset +
-                                index_g_offset,
-                            dst_a,
-                            l1_read_addr);
+                        if (index_g_offset + nt < row_tile_max_index) {
+                            noc_async_write_tile(
+                                out_start_id + out_block_start_id_offset + (mt * num_channels_tiles) + nt +
+                                    index_b_offset + index_g_offset,
+                                dst_a,
+                                l1_read_addr);
+                        }
                         l1_read_addr += single_tile_size_bytes;
                     }
                     // l1_read_addr += (single_tile_size_bytes * (block_w-block_w_curr));


### PR DESCRIPTION
### Ticket
Link to Github Issue
https://github.com/tenstorrent/tt-metal/issues/21149#issuecomment-2858715098
### Problem description
Provide context for the problem.
There was a low pcc for certain groupnorm shapes

### What's changed
Describe the approach used to solve the problem.

For the last group, if it does not span into the max tile span for a group. Then it overwrites with it mask value to for a tile that will not be corrected like others in future loops

Summarize the changes made and its impact.
Added check to only write tile to DRAM if within channel tile span, otherwise continue

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes