### PR TITLE
[skip ci] Update README.md with DeepWiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![tt-metal CI](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml/badge.svg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tenstorrent/tt-metal)
 
 <div align="center">
 


### PR DESCRIPTION
### Ticket
None

### What's changed
Adding a link to tt-metal deepwiki 
https://deepwiki.com/tenstorrent/tt-metal