### PR TITLE
Terminate Fabric Last

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -97,6 +97,8 @@ private:
     void wait_for_fabric_router_sync() const;
     tt_metal::IDevice* get_device(chip_id_t id) const;
 
+    void teardown_fd(const std::unordered_set<chip_id_t>& devices_to_close);
+
     static DevicePool* _inst;
 };
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1261,15 +1261,6 @@ bool Device::close() {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
 
-    for (const auto& hw_command_queue : command_queues_) {
-        if (hw_command_queue->sysmem_manager().get_bypass_mode()) {
-            hw_command_queue->record_end();
-        }
-        hw_command_queue->terminate();
-    }
-
-    dispatch_firmware_active_ = false;
-
     tt_metal::detail::DumpDeviceProfileResults(this, ProfilerDumpState::LAST_CLOSE_DEVICE);
 
     this->disable_and_clear_program_cache();
@@ -1285,6 +1276,9 @@ bool Device::close() {
     std::unordered_set<CoreCoord> wait_for_cores = not_done_dispatch_cores[mmio_device_id];
 
     llrt::internal_::wait_until_cores_done(mmio_device_id, RUN_MSG_GO, wait_for_cores);
+
+    // Dispatch firmware must be inactive because all relevant cores are done
+    dispatch_firmware_active_ = false;
 
     DprintServerDetach(this->id());
     watcher_detach(this->id());

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1261,6 +1261,8 @@ bool Device::close() {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
 
+    dispatch_firmware_active_ = false;
+
     tt_metal::detail::DumpDeviceProfileResults(this, ProfilerDumpState::LAST_CLOSE_DEVICE);
 
     this->disable_and_clear_program_cache();
@@ -1276,9 +1278,6 @@ bool Device::close() {
     std::unordered_set<CoreCoord> wait_for_cores = not_done_dispatch_cores[mmio_device_id];
 
     llrt::internal_::wait_until_cores_done(mmio_device_id, RUN_MSG_GO, wait_for_cores);
-
-    // Dispatch firmware must be inactive because all relevant cores are done
-    dispatch_firmware_active_ = false;
 
     DprintServerDetach(this->id());
     watcher_detach(this->id());

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -35,8 +35,8 @@
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/dispatch/system_memory_manager.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
-#include "tt_metal/api/tt-metalium/system_memory_manager.hpp"
 #include <umd/device/tt_core_coordinates.h>
 
 using namespace tt::tt_metal;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -808,13 +808,14 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
         }
     }
 
-    detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
-
     tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
         dev->close();
     }
+
+    // All devices closed and CQs are null (dispatch_firmware_active_ = false). Profiler will use slow dispatch path.
+    detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
 }
 
 DevicePool::~DevicePool() {


### PR DESCRIPTION
### Ticket
#18726

### Problem description
- Fabric being terminated before it's clients is wrong

### What's changed
- Hoist FD termination to Device Pool. Terminate it for the relevant devices before we terminate Fabric

### Checklist
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14918898604
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14918900917