### PR TITLE
#21882: Enforce error when program cache is disabled but cache misses are also forbidden

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -76,7 +76,7 @@ def test_pad_rm_with_program_cache(device, n, c, h, w, padding, torch_padding, v
             device=device,
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
-    assert device.num_program_cache_entries() == 1
+        device.set_program_cache_misses_allowed(False)
 
 
 def run_pad_rm_sharded(device, n, c, h, w, padding, torch_padding, value, shard_orient):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21882

### Problem description
The existing program cache logic did not enforce a constraint when the program cache was disabled (`program_cache.is_enabled() == false`) but cache misses were also disallowed (`program_cache.cache_misses_allowed() == false`). This created a silent policy violation, allowing operations to proceed despite an invalid configuration.


### What's changed
A strict validation check was added to enforce consistency between the cache enabled state and cache miss policy. Specifically, an early `TT_THROW` is now triggered when:

* The program cache is disabled
* Cache misses are not allowed

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes:
  - https://github.com/tenstorrent/tt-metal/actions/runs/14921595761
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes