### PR TITLE
Limit single-core pad to 64 byte writes to pass on BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/test_pad.py
@@ -440,7 +440,6 @@ def test_pad_conv2d_sweep(device, dtype, use_multicore, shape, padded_shape):
     assert_with_pcc(in_torch, out_torch, 0.9999)
 
 
-@skip_for_blackhole("Fails on Blackhole. Issue #20698")
 @pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("shape", [[1, 1, 18, 13]])
 @pytest.mark.parametrize("padshape", [[1, 1, TILE_HEIGHT, TILE_WIDTH]])

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
     const uint32_t padded_X_nbytes = get_arg_val<uint32_t>(11);
     const uint32_t padded_X_diff_nbytes = get_arg_val<uint32_t>(12);
     const uint32_t pad_value_const_buffer_addr = get_arg_val<uint32_t>(13);
-    const uint32_t pad_value_const_buffer_nbytes = 64;  // assumed to be 64 bytes, necessary for BH. TODO: generalize?
+    const uint32_t pad_value_const_buffer_nbytes = 64;  // assumed to be 64 bytes, fails on BH when > 64. TODO: generalize? (Issue #21978)
     const uint32_t pad_value_packed = get_arg_val<uint32_t>(15);
     const uint32_t start_src_stick_id = get_arg_val<uint32_t>(16);
     const uint32_t start_src_stick_wi = get_arg_val<uint32_t>(18);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp
@@ -41,8 +41,7 @@ void kernel_main() {
     const uint32_t padded_X_nbytes = get_arg_val<uint32_t>(11);
     const uint32_t padded_X_diff_nbytes = get_arg_val<uint32_t>(12);
     const uint32_t pad_value_const_buffer_addr = get_arg_val<uint32_t>(13);
-    const uint32_t pad_value_const_buffer_nbytes =
-        get_arg_val<uint32_t>(14);  // assumed to be 64 bytes. TODO: generalize?
+    const uint32_t pad_value_const_buffer_nbytes = 64;  // assumed to be 64 bytes, necessary for BH. TODO: generalize?
     const uint32_t pad_value_packed = get_arg_val<uint32_t>(15);
     const uint32_t start_src_stick_id = get_arg_val<uint32_t>(16);
     const uint32_t start_src_stick_wi = get_arg_val<uint32_t>(18);


### PR DESCRIPTION
### Ticket
[#20698](https://github.com/tenstorrent/tt-metal/issues/20698)

### Problem description
Failing pad unit test on BH

### What's changed
Fixed by limiting write size to 64, unclear as to why larger writes don't work. Temporary fix to generalize later.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14922784599) CI passes