### PR TITLE
Add binary ng testing for relational ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -635,7 +635,7 @@ def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
 
     in_data = in_data[-num_elements:].reshape(input_shapes)
 
-    if use_legacy == False and ((in_data - scalar) < -2147483647).any():
+    if is_wormhole_b0() and use_legacy == False and ((in_data - scalar) < -2147483647).any():
         pytest.xfail("Overflow occurs as in case of binary_ng, sub_tile is called")
 
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -622,7 +622,8 @@ def test_unary_zero_comp_edge_case(input_shapes, ttnn_function, device):
 )
 @pytest.mark.parametrize("scalar", [-100, -54, -1, 0, 1, 13, 29])
 @pytest.mark.parametrize("ttnn_op", [ttnn.ne, ttnn.eq])
-def test_unary_comp_ops(input_shapes, scalar, ttnn_op, device):
+@pytest.mark.parametrize("use_legacy", [True, False])
+def test_unary_comp_ops(input_shapes, scalar, ttnn_op, use_legacy, device):
     torch.manual_seed(213919)
 
     # Generate a uniform range of values across the valid int32 range
@@ -634,9 +635,12 @@ def test_unary_comp_ops(input_shapes, scalar, ttnn_op, device):
 
     in_data = in_data[-num_elements:].reshape(input_shapes)
 
+    if use_legacy == False and ((in_data - scalar) < -2147483647).any():
+        pytest.xfail("Overflow occurs as in case of binary_ng, sub_tile is called")
+
     input_tensor = ttnn.from_torch(in_data, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn_op(input_tensor, scalar)
+    output_tensor = ttnn_op(input_tensor, scalar, use_legacy=use_legacy)
     golden_function = ttnn.get_golden_function(ttnn_op)
     golden_tensor = golden_function(in_data, scalar)
 


### PR DESCRIPTION
### Ticket
#21620 

### Problem description
- Relational ops test failing in binary_ng infra for certain inputs.
- WH can store only upto +/- 2147483647 for int32 datatype, but in general, the range for int32 is (-2,147,483,648 to 2,147,483,647)

### What's changed
Add xfail for unsupported cases, issue explained in https://github.com/tenstorrent/tt-metal/issues/21620#issuecomment-2853423602

148 passed, 20 xfailed

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/14964688599
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/14972370039
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes