### PR TITLE
Add parameter for DP in TTT

### DIFF
--- a/models/tt_transformers/demo/conftest.py
+++ b/models/tt_transformers/demo/conftest.py
@@ -15,6 +15,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--max_generated_tokens", action="store", type=int, help="Maximum number of tokens to generate for each user"
     )
+    parser.addoption("--data_parallel", action="store", type=int, help="Number of data parallel workers")
     parser.addoption(
         "--paged_attention", action="store", type=bool, help="Whether to use paged attention or default attention"
     )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -436,6 +436,7 @@ def test_demo_text(
     max_seq_len = request.config.getoption("--max_seq_len") or max_seq_len
     batch_size = request.config.getoption("--batch_size") or batch_size
     max_generated_tokens = request.config.getoption("--max_generated_tokens") or max_generated_tokens
+    data_parallel = request.config.getoption("--data_parallel") or data_parallel
     paged_attention = request.config.getoption("--paged_attention") or paged_attention
     page_params = request.config.getoption("--page_params") or page_params
     sampling_params = request.config.getoption("--sampling_params") or sampling_params


### PR DESCRIPTION
Makes data_parallel parametrizable in TT-Transformers, for ease of use.