### PR TITLE
feat: use exp_init/recip_init instead of hardcoded constants

### DIFF
--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -42,15 +42,7 @@ inline void calculate_elu(uint slope) {
 
 template <bool APPROXIMATION_MODE>
 void elu_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    exp_init<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -42,7 +42,7 @@ inline void calculate_elu(uint slope) {
 
 template <bool APPROXIMATION_MODE>
 void elu_init() {
-    exp_init<APPROXIMATION_MODE>();
+    exp_init<APPROXIMATION_MODE, false>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -30,15 +30,7 @@ inline void calculate_exp2() {
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    exp_init<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -30,7 +30,7 @@ inline void calculate_exp2() {
 
 template <bool APPROXIMATION_MODE>
 inline void exp2_init() {
-    exp_init<APPROXIMATION_MODE>();
+    exp_init<APPROXIMATION_MODE, false>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -27,7 +27,7 @@ inline void calculate_expm1() {
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    exp_init<APPROXIMATION_MODE>();
+    exp_init<APPROXIMATION_MODE, false>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_expm1.h
@@ -27,15 +27,7 @@ inline void calculate_expm1() {
 
 template <bool APPROXIMATION_MODE>
 void expm1_init() {
-    if constexpr (APPROXIMATION_MODE) {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = s2vFloat16b(p_exp::C23_73);
-        vConstFloatPrgm2 = s2vFloat16b(p_exp::ADJ_EXP);
-    } else {
-        vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-        vConstFloatPrgm1 = 2.0f;
-        vConstFloatPrgm2 = 0.863281f;
-    }
+    exp_init<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_rsqrt.h
@@ -39,8 +39,7 @@ inline void calculate_rsqrt() {
 
 template <bool APPROXIMATION_MODE>
 inline void rsqrt_init() {
-    vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-    vConstFloatPrgm1 = 2.0f;
+    recip_init<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -245,8 +245,7 @@ inline void calculate_acos() {
 
 template <bool APPROXIMATION_MODE>
 void atan_init() {
-    vConstFloatPrgm0 = 1.442695f;  // ln2_recip
-    vConstFloatPrgm1 = 2.0f;
+    recip_init<APPROXIMATION_MODE>();
 }
 
 }  // namespace sfpu


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21622

### Problem description
Hardcoded constants shouldn't be used here; they should be set by the LLK init functions.

### What's changed
This is a combined effort of tt-llk uplift and https://github.com/tenstorrent/tt-metal/pull/21623 from @jasondavies.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14926703372) CI passes