### PR TITLE
Replace sqrt_tile+recip_tile with rsqrt_tile.

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/layernorm.cpp
@@ -181,10 +181,8 @@ void MAIN {
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
         cb_reserve_back(cb_ex2pe, 1);  // 1
-        sqrt_tile_init();
-        sqrt_tile(dst0);
-        recip_tile_init();
-        recip_tile(dst0);
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
         pack_tile(dst0, cb_ex2pe);
         cb_push_back(cb_ex2pe, 1);
         REL();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/rmsnorm.cpp
@@ -138,10 +138,8 @@ void MAIN {
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
         cb_reserve_back(cb_ex2pe, 1);  // 1
-        sqrt_tile_init();
-        sqrt_tile(dst0);
-        recip_tile_init();
-        recip_tile(dst0);
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
         pack_tile(dst0, cb_ex2pe);
         cb_push_back(cb_ex2pe, 1);
         REL();

--- a/tt_metal/include/compute_kernel_api/layernorm.h
+++ b/tt_metal/include/compute_kernel_api/layernorm.h
@@ -4,5 +4,4 @@
 
 #pragma once
 
-#include "compute_kernel_api/eltwise_unary/sqrt.h"
-#include "compute_kernel_api/eltwise_unary/recip.h"
+#include "compute_kernel_api.h"

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_sharded_post.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/compute/rms_sharded_post.cpp
@@ -92,10 +92,8 @@ void MAIN {
             tile_regs_acquire();
             add_tiles(cb_var, cb_eps, 0, 0, dst0);
             tile_regs_wait();
-            sqrt_tile_init();
-            sqrt_tile(dst0);
-            recip_tile_init();
-            recip_tile(dst0);
+            rsqrt_tile_init();
+            rsqrt_tile(dst0);
             tile_regs_commit();
             tile_regs_wait();
             cb_reserve_back(cb_stats_reduced, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -522,13 +522,9 @@ void MAIN {
             add_tiles_init(cb_ex2_global, cb_eps);
             add_tiles(cb_ex2_global, cb_eps, 0, 0, dst0);
             tile_regs_wait();
-            // sqrt(Var + eps)
-            sqrt_tile_init();
-            sqrt_tile(dst0);
-            tile_regs_wait();
             // 1/[sqrt(Var + eps)]
-            recip_tile_init();
-            recip_tile(dst0);
+            rsqrt_tile_init();
+            rsqrt_tile(dst0);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_ex2pe);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -363,13 +363,9 @@ void MAIN {
             add_tiles_init(cb_ex_global, cb_eps);
             add_tiles(cb_ex_global, cb_eps, 0, 0, dst0);
             tile_regs_wait();
-            // sqrt(Var + eps)
-            sqrt_tile_init();
-            sqrt_tile(dst0);
-            tile_regs_wait();
             // 1/[sqrt(Var + eps)]
-            recip_tile_init();
-            recip_tile(dst0);
+            rsqrt_tile_init();
+            rsqrt_tile(dst0);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_ex2pe);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm.cpp
@@ -223,10 +223,8 @@ void MAIN {
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
         cb_reserve_back(cb_ex2pe, 1);  // 1
-        sqrt_tile_init();
-        sqrt_tile(dst0);
-        recip_tile_init();
-        recip_tile(dst0);
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
         pack_tile(dst0, cb_ex2pe);
         cb_push_back(cb_ex2pe, 1);
         REL();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -200,11 +200,8 @@ void MAIN {
         add_tiles_init(cb_ex2, cb_eps);
         add_tiles(cb_ex2, cb_eps, 0, 0, dst0);
 
-        sqrt_tile_init();
-        sqrt_tile(dst0);
-
-        recip_tile_init();
-        recip_tile(dst0);
+        rsqrt_tile_init();
+        rsqrt_tile(dst0);
 
         tile_regs_commit();
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded.cpp
@@ -314,13 +314,8 @@ void MAIN {
                 add_tiles_init(cb_ex2, cb_eps);
                 add_tiles(cb_ex2, cb_eps, i, 0, dst0);
                 tile_regs_wait();
-                // sqrt(Var + eps)
-                sqrt_tile_init();
-                sqrt_tile(dst0);
-                tile_regs_wait();
-                // 1/[sqrt(Var + eps)]
-                recip_tile_init();
-                recip_tile(dst0);
+                rsqrt_tile_init();
+                rsqrt_tile(dst0);
                 tile_regs_commit();
                 tile_regs_wait();
                 pack_tile(dst0, cb_ex2pe);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_post_allgather.cpp
@@ -183,10 +183,8 @@ void MAIN {
             tile_regs_acquire();
             add_tiles(cb_var, cb_eps, 0, 0, dst0);
             tile_regs_wait();
-            sqrt_tile_init();
-            sqrt_tile(dst0);
-            recip_tile_init();
-            recip_tile(dst0);
+            rsqrt_tile_init();
+            rsqrt_tile(dst0);
             tile_regs_commit();
             tile_regs_wait();
             pack_tile(dst0, cb_stats_reduced);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather.cpp
@@ -185,10 +185,8 @@ void MAIN {
         add_tiles_init(cb_var, cb_eps);
         ACQ();
         add_tiles(cb_var, cb_eps, 0, 0, 0);
-        sqrt_tile_init();
-        sqrt_tile(0);
-        recip_tile_init();
-        recip_tile(0);
+        rsqrt_tile_init();
+        rsqrt_tile(0);
         pack_tile(0, cb_recip_sqrt_var);
         REL();
         cb_push_back(cb_recip_sqrt_var, 1);


### PR DESCRIPTION
### Ticket

#21890

### Problem description

It's theoretically faster to compute reciprocal square root in one go.  This pushes responsibility for optimising rsqrt_tile to the LLK.

### What's changed

Replace all instances of `sqrt_tile_init, sqrt_tile, recip_tile_init, recip_tile` with `rsqrt_tile_init, rsqrt_tile`.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes