### PR TITLE
Added sd14 vae wrapper for vae decoding

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
@@ -4,9 +4,7 @@
 
 import pytest
 import torch
-from diffusers import (
-    AutoencoderKL,
-)
+from diffusers import AutoencoderKL
 
 import ttnn
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae import Vae

--- a/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from diffusers import (
+    AutoencoderKL,
+)
+
+import ttnn
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae import Vae
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 8 * 8192}], indirect=True)
+@pytest.mark.parametrize(
+    """input_channels, input_height, input_width, out_channels, output_height, output_width""",
+    [
+        (
+            4,  # input_channels
+            64,  # input_height
+            64,  # input_width
+            3,  # out_channels
+            512,  # output_height
+            512,  # output_width
+        ),
+    ],
+)
+def test_decoder(
+    device,
+    input_channels,
+    input_height,
+    input_width,
+    out_channels,
+    output_height,
+    output_width,
+):
+    torch.manual_seed(0)
+
+    vae = AutoencoderKL.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="vae")
+
+    # Run pytorch model
+    torch_input = torch.randn([1, input_channels, input_height, input_width])
+    torch_output = vae.decode(torch_input).sample
+
+    # Initialize ttnn model
+    ttnn_model = Vae(torch_vae=vae, device=device)
+
+    # Prepare ttnn input
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
+    )
+
+    # Run ttnn model twice to test program cache and weights reuse
+    ttnn_output = ttnn_model.decode(ttnn_input)
+    ttnn_input = ttnn.from_torch(
+        torch_input.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
+    )
+    ttnn_output = ttnn_model.decode(ttnn_input)
+
+    ttnn_output = ttnn.reshape(ttnn_output, [1, output_height, output_width, out_channels])
+    ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    # TODO: Improve PCC (issue #21131)
+    assert_with_pcc(torch_output, ttnn_output, 0.985)

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae.py
@@ -1,0 +1,59 @@
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_decoder import VaeDecoder, ConvBlock
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
+    MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
+    MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
+    UPBLOCK_RESNET_NORM_NUM_BLOCKS,
+    UPBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
+    UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS,
+)
+
+
+# This is a wrapper class for the VAE decoder that is the equivalent of the AutoencoderKL
+# class in the original Stable Diffusion codebase, but used exclusively for the VAE decoder.
+# It uses AutoencoderKL vae for its weights and biases, and the VaeDecoder class
+# for the actual decoding process.
+class Vae:
+    def __init__(self, torch_vae, device):
+        input_height = 64
+        input_width = 64
+        in_channels = 4
+        out_channels = 3
+        output_height = 512
+        output_width = 512
+
+        self.device = device
+
+        self.decoder = VaeDecoder(
+            torch_decoder=torch_vae.decoder,
+            device=device,
+            in_channels=in_channels,
+            input_height=input_height,
+            input_width=input_width,
+            out_channels=out_channels,
+            midblock_in_channels=512,
+            output_height=output_height,
+            output_width=output_width,
+            midblock_norm_blocks=MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
+            midblock_conv_channel_split_factors=MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
+            upblock_out_channels=[512, 512, 256, 128],
+            upblock_out_dimensions=[128, 256, 512, 512],
+            upblock_norm_blocks=UPBLOCK_RESNET_NORM_NUM_BLOCKS,
+            upblock_resnet_conv_channel_split_factors=UPBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
+            upblock_upsample_conv_channel_split_factors=UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS,
+        )
+
+        self.post_quant_conv = ConvBlock(
+            torch_vae.post_quant_conv,
+            device,
+            in_channels=in_channels,
+            out_channels=in_channels,
+            input_height=input_width,
+            input_width=input_width,
+            padding=0,
+            kernel_size=1,
+        )
+
+    def decode(self, x):
+        x = self.post_quant_conv(x)
+        x = self.decoder(x)
+        return x

--- a/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae.py
+++ b/models/demos/wormhole/stable_diffusion/tt/vae/ttnn_vae.py
@@ -1,11 +1,15 @@
-from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_decoder import VaeDecoder, ConvBlock
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_configs import (
-    MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
     MIDBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
-    UPBLOCK_RESNET_NORM_NUM_BLOCKS,
+    MIDBLOCK_RESNET_NORM_NUM_BLOCKS,
     UPBLOCK_RESNET_CONV_CHANNEL_SPLIT_FACTORS,
+    UPBLOCK_RESNET_NORM_NUM_BLOCKS,
     UPBLOCK_UPSAMPLE_CONV_CHANNEL_SPLIT_FACTORS,
 )
+from models.demos.wormhole.stable_diffusion.tt.vae.ttnn_vae_decoder import ConvBlock, VaeDecoder
 
 
 # This is a wrapper class for the VAE decoder that is the equivalent of the AutoencoderKL

--- a/tests/nightly/single_card/stable_diffusion/vae/test_vae.py
+++ b/tests/nightly/single_card/stable_diffusion/vae/test_vae.py
@@ -1,0 +1,1 @@
+../../../../../models/demos/wormhole/stable_diffusion/tests/vae/test_vae.py


### PR DESCRIPTION
### Ticket
[#21688](https://github.com/tenstorrent/tt-metal/issues/21688)

### Problem description
Previously Stable diffusion v1-4 VAE Decoder was missing a wrapper that run a conv
before running the decoder

### What's changed
Added SD v1-4 VAE wrapper

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14973453697)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14973461855)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14974143736)