### PR TITLE
Add multi-tensor weights support for ring Matmul 

### DIFF
--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -47,6 +47,7 @@ def run_prefetcher_mm(
     dtypes,
     is_functional_test=False,
     enable_performance_mode=False,
+    batch_weights=False,
 ):
     logger.info(f"Running test_run_prefetcher with num_tensors={num_tensors}, num_layers={num_layers}")
     assert len(input_shapes) == len(dtypes)
@@ -279,8 +280,13 @@ def run_prefetcher_mm(
 
     in0_tensors = []
     in0_t_tensors = []
+    prev_shape = in0_shapes[0]
+    prev_in0 = torch.randn(prev_shape)
     for shape, shard_shape in zip(in0_shapes, shard_shapes):
         in0 = torch.randn(shape)
+        if batch_weights and prev_shape == shape:
+            in0 = prev_in0
+            prev_shape = shape
         in0_tensors.append(in0)
 
         _, _, M, _ = shape
@@ -345,20 +351,36 @@ def run_prefetcher_mm(
         outputs_dram = []
         for l in range(num_layers):
             outputs_l1 = []
-            for t in range(num_tensors):
+            t = 0
+            while t < num_tensors:
                 idx = l * num_tensors + t
-
-                output_t = ttnn.matmul(
-                    in0_t_tensors[t],
-                    tt_tensors_all[idx],
-                    program_config=program_configs[t],
-                    memory_config=output_mem_configs[t],
-                    compute_kernel_config=compute_kernel_config,
-                    global_cb=global_circular_buffer,
-                    sub_device_id=worker_sub_device_id,
-                )
-                outputs_l1.append(output_t)
-
+                if batch_weights and t < num_tensors - 1 and in0_t_tensors[t].shape == in0_t_tensors[t + 1].shape:
+                    logger.info(f"running matmul_batched_weights for layer {l}, tensor {t} and tensor {t+1}")
+                    [output_t1, output_t2] = ttnn.matmul_batched_weights(
+                        in0_t_tensors[t],
+                        [tt_tensors_all[idx], tt_tensors_all[idx + 1]],
+                        program_config=program_configs[t],
+                        memory_config=output_mem_configs[t],
+                        compute_kernel_config=compute_kernel_config,
+                        global_cb=global_circular_buffer,
+                        sub_device_id=worker_sub_device_id,
+                    )
+                    outputs_l1.append(output_t1)
+                    outputs_l1.append(output_t2)
+                    t += 2
+                else:
+                    logger.info(f"running normal matmul for layer {l}, tensor {t}")
+                    output_t = ttnn.matmul(
+                        in0_t_tensors[t],
+                        tt_tensors_all[idx],
+                        program_config=program_configs[t],
+                        memory_config=output_mem_configs[t],
+                        compute_kernel_config=compute_kernel_config,
+                        global_cb=global_circular_buffer,
+                        sub_device_id=worker_sub_device_id,
+                    )
+                    outputs_l1.append(output_t)
+                    t += 1
             # Send outputs to DRAM to so that we don't run out of L1 memory when testing for large number of layers
             for t in range(num_tensors):
                 outputs_dram.append(ttnn.to_memory_config(outputs_l1[t], ttnn.DRAM_MEMORY_CONFIG))
@@ -404,6 +426,8 @@ def run_prefetcher_mm(
 
             passing, output = comp_pcc(pt_out, tt_out, pcc_threshold)
             logger.info(output)
+            # logger.info(pt_out)
+            # logger.info(tt_out)
             all_passing = passing and all_passing
 
     device.clear_loaded_sub_device_manager()

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -426,8 +426,6 @@ def run_prefetcher_mm(
 
             passing, output = comp_pcc(pt_out, tt_out, pcc_threshold)
             logger.info(output)
-            # logger.info(pt_out)
-            # logger.info(tt_out)
             all_passing = passing and all_passing
 
     device.clear_loaded_sub_device_manager()

--- a/tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
+++ b/tests/ttnn/unit_tests/operations/test_prefetcher_TG.py
@@ -89,6 +89,64 @@ def test_run_prefetcher(
     )
 
 
+@pytest.mark.parametrize(
+    "num_reader_cores, num_tensors, input_shapes, dtypes, num_layers, batch_weights",
+    [
+        (2, 2, [(128, 128), (128, 128)], [ttnn.bfloat4_b] * 2, 2, True),
+        (2, 2, [(256, 1024), (256, 1024)], [ttnn.bfloat4_b] * 2, 5, True),
+        (
+            12,
+            5,
+            [(2304, 1536), (1536, 2304), (2304, 3840), (2304, 3840), (3840, 2304)],
+            [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
+            5,
+            True,
+        ),  # qkv + do + ff1 + ff3 + ff2
+        # Takes really long to set up
+        (
+            12,
+            5,
+            [(2048, 1280), (1280, 2048), (2048, 3584), (2048, 3584), (3584, 2048)],
+            [ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat4_b, ttnn.bfloat4_b, ttnn.bfloat8_b],
+            80,
+            True,
+        ),  # qkv + do + ff1 + ff3 + ff2
+    ],
+)
+@pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 23887872}],
+    indirect=True,
+)
+def test_run_prefetcher_batched_weights(
+    mesh_device,
+    num_tensors,
+    input_shapes,
+    num_layers,
+    batch_weights,
+    num_reader_cores,
+    dtypes,
+    use_program_cache,
+    function_level_defaults,
+):
+    device = mesh_device
+    # Only run these tests on unharvested TG
+    device_grid = (device.compute_with_storage_grid_size().x, device.compute_with_storage_grid_size().y)
+    if device_grid != (7, 10):
+        pytest.skip("Skipping test_run_prefetcher because it only works with a 7x10 grid")
+
+    run_prefetcher_mm(
+        mesh_device,
+        num_tensors,
+        input_shapes,
+        num_layers,
+        num_reader_cores,
+        dtypes,
+        batch_weights=batch_weights,
+    )
+
+
 @pytest.mark.parametrize("mesh_device", [pytest.param((2, 2), id="2x2_grid")], indirect=True)
 @pytest.mark.parametrize(
     "device_params",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul/device/multi_core/all_gather_matmul_op_multi_core.cpp
@@ -270,9 +270,9 @@ operation::ProgramWithCallbacks experimental::all_gather_matmul_multi_core_with_
                 matmul_program_with_callbacks = operations::matmul::matmul_multi_core_reuse_mcast_1d_optimized_helper(
                     program,
                     all_gather_output_tensor,
-                    weight_tensor,
+                    {weight_tensor},
                     bias,
-                    matmul_output_tensor,
+                    {matmul_output_tensor},
                     bcast_batch,
                     compute_kernel_config,
                     config,

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_ring_all_gather.cpp
@@ -48,41 +48,46 @@ void kernel_main() {
     constexpr uint32_t shard_size_bytes = shard_size_in_tiles * in0_single_tile_size_bytes;
 
     // Reserving/pushing the local shard is done in compute
-    cb_reserve_back(cb_id_in2, batch * (ring_size - 1) * shard_size_in_tiles);
+    cb_reserve_back(cb_id_in2, (ring_size - 1) * shard_size_in_tiles);
 
     uint32_t local_shard_read_addr = get_read_ptr(cb_id_in0);
     uint32_t l1_write_addr_in0 = get_write_ptr(cb_id_in2);
 
     uint32_t hop_core_offset = static_cast<uint32_t>(is_hop_core);
 
-    for (uint32_t b = 0; b < batch; ++b) {
-        for (uint32_t shard_cnt = hop_core_offset; shard_cnt < ring_size; shard_cnt++) {
-            uint32_t curr_ring_idx = (ring_idx + shard_cnt) % ring_size;
-            bool skip_send = unpadded_in0_shard_widths_in_tiles[curr_ring_idx] == 0 && !is_hop_core;
+    for (uint32_t shard_cnt = hop_core_offset; shard_cnt < ring_size; shard_cnt++) {
+        uint32_t curr_ring_idx = (ring_idx + shard_cnt) % ring_size;
+        bool skip_send = unpadded_in0_shard_widths_in_tiles[curr_ring_idx] == 0 && !is_hop_core;
 
-            uint32_t curr_shard_write_addr = l1_write_addr_in0 + shard_size_bytes * (shard_cnt - hop_core_offset);
-            uint64_t remote_curr_shard_write_addr =
-                get_noc_addr(next_core_noc_x, next_core_noc_y, curr_shard_write_addr, noc);
-            uint32_t curr_shard_read_addr =
-                shard_cnt == 0 ? local_shard_read_addr : l1_write_addr_in0 + shard_size_bytes * (shard_cnt - 1);
+        uint32_t curr_shard_write_addr = l1_write_addr_in0 + shard_size_bytes * (shard_cnt - hop_core_offset);
+        uint64_t remote_curr_shard_write_addr =
+            get_noc_addr(next_core_noc_x, next_core_noc_y, curr_shard_write_addr, noc);
+        uint32_t curr_shard_read_addr =
+            shard_cnt == 0 ? local_shard_read_addr : l1_write_addr_in0 + shard_size_bytes * (shard_cnt - 1);
 
-            // Wait for signal from previous core that data has been added to this core's in0
-            noc_semaphore_wait_min(l1_signal_sem_addr, shard_cnt);
+        // Wait for signal from previous core that data has been added to this core's in0
+        noc_semaphore_wait_min(l1_signal_sem_addr, shard_cnt);
 
-            // Send data to next core
-            if (shard_cnt < ring_size - 1 || is_hop_core) {  // Skip sending the last shard
-                if (!skip_send) {
-                    noc_async_write(curr_shard_read_addr, remote_curr_shard_write_addr, shard_size_bytes, noc);
-                }
-
-                // Signal the next core that data is ready
-                noc_semaphore_inc(remote_signal_semaphore_addr, 1, noc);
+        // Send data to next core
+        if (shard_cnt < ring_size - 1 || is_hop_core) {  // Skip sending the last shard
+            if (!skip_send) {
+                noc_async_write(curr_shard_read_addr, remote_curr_shard_write_addr, shard_size_bytes, noc);
             }
 
-            // Do stuff for matmul fusion here
-            if (shard_cnt > 0) {
-                cb_push_back(cb_id_in2, shard_size_in_tiles);
-            }
+            // Signal the next core that data is ready
+            noc_semaphore_inc(remote_signal_semaphore_addr, 1, noc);
+        }
+
+        // Do stuff for matmul fusion here
+        if (shard_cnt > 0) {
+            cb_push_back(cb_id_in2, shard_size_in_tiles);
+        }
+    }
+
+    if (!is_hop_core) {
+        for (uint32_t b = 0; b < batch - 1; ++b) {  // for rest batches, not need to gather in0 anymore
+            cb_reserve_back(cb_id_in2, (ring_size - 1) * shard_size_in_tiles);
+            cb_push_back(cb_id_in2, (ring_size - 1) * shard_size_in_tiles);
         }
     }
     noc_async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1423,6 +1423,31 @@ Tensor matmul(
         .at(0);
 }
 
+std::vector<Tensor> matmul_batched_weights(
+    const Tensor& input_tensor_a,
+    const std::vector<Tensor>& input_tensors_b,
+    const std::optional<const Tensor>& bias,
+    const struct Matmul& parameters,
+    const QueueId queue_id,
+    const std::optional<Tensor>& optional_output_tensor) {
+    std::vector<std::optional<const Tensor>> optional_input_tensors = {};
+    if (bias.has_value()) {
+        optional_input_tensors.push_back(bias.value());
+    } else {
+        optional_input_tensors.push_back(std::nullopt);
+    }
+
+    std::vector<Tensor> input_tensors = input_tensors_b;
+    input_tensors.insert(input_tensors.begin(), input_tensor_a);
+
+    return operation::run(
+        create_matmul_struct(input_tensor_a, input_tensors_b[0], parameters, {optional_output_tensor}),
+        input_tensors,
+        optional_input_tensors,
+        {optional_output_tensor},
+        queue_id);
+}
+
 void check_tensor_in_grid(const Tensor& tensor, const CoreCoord& grid_size) {
     // Validate tensor is within grid if sharded and not in DRAM
     if (tensor.memory_config().is_sharded() && tensor.memory_config().buffer_type() != BufferType::DRAM) {
@@ -1441,7 +1466,6 @@ void Matmul::validate(
     const std::vector<Tensor>& input_tensors,
     const std::vector<std::optional<const Tensor>>& optional_input_tensors,
     const std::vector<std::optional<Tensor>>& optional_output_tensors) const {
-    TT_FATAL(input_tensors.size() == 2, "Error");
     const auto& input_tensor_a = input_tensors.at(0);
     const auto& input_tensor_b = input_tensors.at(1);
     const auto& a_shape = input_tensor_a.get_logical_shape();
@@ -1556,6 +1580,29 @@ void Matmul::validate(
     }
     MatmulProgramConfig chosen_program_config =
         get_program_config(input_tensor_a, input_tensor_b, bias_single_tile_size, this);
+
+    if (std::holds_alternative<MatmulMultiCoreReuseMultiCast1DProgramConfig>(chosen_program_config) &&
+        this->global_cb.has_value() && input_tensor_b.is_sharded() && input_tensor_b.buffer()->is_dram()) {
+        for (uint32_t i = 1; i < input_tensors.size(); ++i) {
+            TT_FATAL(
+                input_tensor_b.get_logical_shape() == input_tensors[i].get_logical_shape(),
+                "for multi-tensor matmul, all weight tensors must have the same logical_shape");
+            TT_FATAL(
+                input_tensor_b.get_padded_shape() == input_tensors[i].get_padded_shape(),
+                "for multi-tensor matmul, all weight tensors must have the same padded_shape");
+            TT_FATAL(
+                input_tensor_b.get_tensor_spec() == input_tensors[i].get_tensor_spec(),
+                "for multi-tensor matmul, all weight tensors must have the same tensor_spec");
+            TT_FATAL(
+                input_tensor_b.get_layout() == input_tensors[i].get_layout(),
+                "for multi-tensor matmul, all weight tensors must have the same layout");
+            TT_FATAL(
+                input_tensor_b.get_dtype() == input_tensors[i].get_dtype(),
+                "for multi-tensor matmul, all weight tensors must have the same _dtype");
+        }
+    } else {
+        TT_FATAL(input_tensors.size() == 2, "Error");
+    }
 
     if (optional_bias.has_value()) {
         const auto& bias = optional_bias.value();
@@ -2161,9 +2208,12 @@ std::vector<ttnn::TensorSpec> Matmul::compute_output_specs(
                             ShardOrientation::ROW_MAJOR};
                         mem_config = mem_config.with_shard_spec(shard_spec);
                     }
-                    return {TensorSpec(
+                    // support for multi-tensor output
+                    const ttnn::TensorSpec tensor_spec(
                         output_shape,
-                        TensorLayout(output_dtype.value(), PageConfig(output_layout, output_tile), mem_config))};
+                        TensorLayout(output_dtype.value(), PageConfig(output_layout, output_tile), mem_config));
+                    std::vector<ttnn::TensorSpec> output_tensor_specs(input_tensors.size() - 1, tensor_spec);
+                    return output_tensor_specs;
                 } else if constexpr (std::is_same_v<
                                          ProgramConfigType,
                                          MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig>) {
@@ -2378,11 +2428,12 @@ operation::CacheableMeshWorkload<std::vector<Tensor>> Matmul::create_mesh_worklo
                 return create_homogenous_mesh_workload(mcast_mm_program, tensor_coords);
 
             } else if constexpr (std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                const std::vector<Tensor> input_tensors_b(input_tensors.begin() + 1, input_tensors.end());
                 auto mcast_mm_program = matmul_multi_core_reuse_mcast_1d_optimized(
                     input_tensor_a,
-                    input_tensor_b,
+                    input_tensors_b,
                     bias,
-                    output_tensor,
+                    output_tensors,
                     broadcast_batch,
                     program_config.compute_with_storage_grid_size,
                     this->compute_kernel_config.value(),

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1586,19 +1586,29 @@ void Matmul::validate(
         for (uint32_t i = 1; i < input_tensors.size(); ++i) {
             TT_FATAL(
                 input_tensor_b.get_logical_shape() == input_tensors[i].get_logical_shape(),
-                "for multi-tensor matmul, all weight tensors must have the same logical_shape");
+                "for multi-tensor matmul, all weight tensors must have the same logical_shape, {} is not equal to {}",
+                input_tensor_b.get_logical_shape(),
+                input_tensors[i].get_logical_shape());
             TT_FATAL(
                 input_tensor_b.get_padded_shape() == input_tensors[i].get_padded_shape(),
-                "for multi-tensor matmul, all weight tensors must have the same padded_shape");
+                "for multi-tensor matmul, all weight tensors must have the same padded_shape {} is not equal to {}",
+                input_tensor_b.get_padded_shape(),
+                input_tensors[i].get_padded_shape());
             TT_FATAL(
                 input_tensor_b.get_tensor_spec() == input_tensors[i].get_tensor_spec(),
-                "for multi-tensor matmul, all weight tensors must have the same tensor_spec");
+                "for multi-tensor matmul, all weight tensors must have the same tensor_spec {} is not equal to {}",
+                input_tensor_b.get_tensor_spec(),
+                input_tensors[i].get_tensor_spec());
             TT_FATAL(
                 input_tensor_b.get_layout() == input_tensors[i].get_layout(),
-                "for multi-tensor matmul, all weight tensors must have the same layout");
+                "for multi-tensor matmul, all weight tensors must have the same layout {} is not equal to {}",
+                input_tensor_b.get_layout(),
+                input_tensors[i].get_layout());
             TT_FATAL(
                 input_tensor_b.get_dtype() == input_tensors[i].get_dtype(),
-                "for multi-tensor matmul, all weight tensors must have the same _dtype");
+                "for multi-tensor matmul, all weight tensors must have the same _dtype {} is not equal to {}",
+                input_tensor_b.get_dtype(),
+                input_tensors[i].get_dtype());
         }
     } else {
         TT_FATAL(input_tensors.size() == 2, "Error");

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -52,9 +52,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast(
 
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(
     const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
+    const std::vector<Tensor>& input_tensor_b,
     const std::optional<const Tensor>& bias,
-    Tensor& output_tensor,
+    const std::vector<Tensor>& output_tensor,
     bool bcast_batch,
     CoreCoord compute_with_storage_grid_size,
     DeviceComputeKernelConfig compute_kernel_config,
@@ -230,9 +230,9 @@ Matmul create_matmul_struct(
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor_a,
-    const Tensor& input_tensor_b,
+    const std::vector<Tensor>& input_tensor_b,
     const std::optional<const Tensor>& bias,
-    Tensor& output_tensor,
+    const std::vector<Tensor>& output_tensor,
     bool bcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const MatmulProgramConfig& program_config,
@@ -255,6 +255,14 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_2d_o
 Tensor matmul(
     const Tensor& input_tensor_a,
     const Tensor& input_tensor_b,
+    const std::optional<const Tensor>& bias = std::nullopt,
+    const struct Matmul& parameters = Matmul{},
+    const QueueId queue_id = DefaultQueueId,
+    const std::optional<Tensor>& optional_output_tensor = std::nullopt);
+
+std::vector<Tensor> matmul_batched_weights(
+    const Tensor& input_tensor_a,
+    const std::vector<Tensor>& input_tensors_b,
     const std::optional<const Tensor>& bias = std::nullopt,
     const struct Matmul& parameters = Matmul{},
     const QueueId queue_id = DefaultQueueId,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.hpp
@@ -52,9 +52,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast(
 
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(
     const Tensor& input_tensor_a,
-    const std::vector<Tensor>& input_tensor_b,
+    const std::vector<Tensor>& input_tensors_b,
     const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensor,
+    const std::vector<Tensor>& output_tensors,
     bool bcast_batch,
     CoreCoord compute_with_storage_grid_size,
     DeviceComputeKernelConfig compute_kernel_config,
@@ -230,9 +230,9 @@ Matmul create_matmul_struct(
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt::tt_metal::Program& program,
     const Tensor& input_tensor_a,
-    const std::vector<Tensor>& input_tensor_b,
+    const std::vector<Tensor>& input_tensors_b,
     const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensor,
+    const std::vector<Tensor>& output_tensors,
     bool bcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const MatmulProgramConfig& program_config,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1942,6 +1942,11 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
         for (uint32_t i = 0; i < out_buffers.size(); ++i) {
             const auto& out_buffer = out_buffers[i];
             output_cb_index += i * 2;  // 5, 7, 9...
+            TT_FATAL(
+                output_cb_index <= tt::CBIndex::c_31,
+                "Output circular buffer index {} exceeds maximum value {}",
+                output_cb_index,
+                tt::CBIndex::c_31);
             // output
             std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
                 {output_cb_index, output_data_format},
@@ -1960,6 +1965,16 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
             const auto& out_buffer = out_buffers[i];
             output_cb_index += i * 2;   // 5, 7, 9...
             interm0_cb_index += i * 2;  // 6, 8, 10...
+            TT_FATAL(
+                output_cb_index <= tt::CBIndex::c_31,
+                "Output circular buffer index {} exceeds maximum value {}",
+                output_cb_index,
+                tt::CBIndex::c_31);
+            TT_FATAL(
+                interm0_cb_index <= tt::CBIndex::c_31,
+                "Interm circular buffer index {} exceeds maximum value {}",
+                interm0_cb_index,
+                tt::CBIndex::c_31);
             // share buffer
             std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
                 {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
@@ -2579,9 +2594,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
 
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(
     const Tensor& a,
-    const std::vector<Tensor>& b,
+    const std::vector<Tensor>& b_tensors,
     const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensor,
+    const std::vector<Tensor>& output_tensors,
     bool broadcast_batch,
     CoreCoord compute_with_storage_grid_size,
     DeviceComputeKernelConfig compute_kernel_config,
@@ -2607,9 +2622,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
     return matmul_multi_core_reuse_mcast_1d_optimized_(
         program,
         a,
-        b,
+        b_tensors,
         bias,
-        output_tensor,
+        output_tensors,
         broadcast_batch,
         compute_with_storage_grid_size,
         compute_kernel_config,
@@ -2635,9 +2650,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt::tt_metal::Program& program,
     const Tensor& a,
-    const std::vector<Tensor>& b,
+    const std::vector<Tensor>& b_tensors,
     const std::optional<const Tensor>& bias,
-    const std::vector<Tensor>& output_tensor,
+    const std::vector<Tensor>& output_tensors,
     bool broadcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const MatmulProgramConfig& program_config,
@@ -2651,9 +2666,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
     return matmul_multi_core_reuse_mcast_1d_optimized_(
         program,
         a,
-        b,
+        b_tensors,
         bias,
-        output_tensor,
+        output_tensors,
         broadcast_batch,
         config.compute_with_storage_grid_size,
         compute_kernel_config,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_mcast_1d_program_factory.cpp
@@ -1713,7 +1713,7 @@ enum class CORE_TYPE : uint32_t { IDLE_CORE = 0, WORKER_CORE = 1, HOP_CORE = 2 }
 tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
     tt_metal::Program& program,
     const tt::tt_metal::Tensor& a,
-    const tt::tt_metal::Tensor& b,
+    const std::vector<tt::tt_metal::Tensor>& b_tensors,
     tt_metal::IDevice* device,
     MathFidelity math_fidelity,
     bool fp32_dest_acc_en,
@@ -1735,7 +1735,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
     const CoreRangeSet& hop_cores,
     tt_metal::Buffer* in0_buffer,
     tt_metal::Buffer* in1_buffer,
-    tt_metal::Buffer* out_buffer,
+    std::vector<tt_metal::Buffer*> out_buffers,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& output_tile,
@@ -1746,6 +1746,9 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
     const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     uint32_t num_global_cb_receivers,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const auto b = b_tensors[0];
+    const auto num_output_cb = out_buffers.size();
+    const auto batch = b_tensors.size();
     const bool in1_is_dram_interleaved = in1_buffer->is_dram() && !b.is_sharded();
     const bool in1_is_dram_sharded =
         in1_buffer->is_dram() && b.is_sharded() && !global_cb.has_value();  // read from DRAM directly
@@ -1862,11 +1865,122 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
     uint32_t in1_per_core_w = out_subblock_w * in1_num_subblocks;
     uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
 
+    /* Create circular buffers */
+    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    tt_metal::CircularBufferConfig src0_cb_config =
+        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
+            .set_page_size(src0_cb_index, in0_single_tile_size)
+            .set_tile_dims(src0_cb_index, in0_tile)
+            .set_globally_allocated_address(*in0_buffer);
+    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
+
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
+    tt::tt_metal::CBHandle cb_src1;
+    if (use_global_cb) {
+        uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
+        uint32_t remote_cb_index = tt::CBIndex::c_31;
+        tt_metal::CircularBufferConfig remote_cb_config =
+            tt_metal::CircularBufferConfig((global_cb->size() / in1_block_size_bytes) * in1_block_size_bytes);
+        remote_cb_config.remote_index(remote_cb_index)
+            .set_page_size(in1_block_size_bytes)
+            .set_data_format(in1_data_format);
+        remote_cb_config.index(src1_cb_index).set_page_size(in1_single_tile_size).set_data_format(in1_data_format);
+        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, all_cores, remote_cb_config, *global_cb);
+    } else {
+        tt_metal::CircularBufferConfig src1_cb_config =
+            tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
+                .set_page_size(src1_cb_index, in1_single_tile_size)
+                .set_tile_dims(src1_cb_index, in1_tile);
+        if (!in1_is_dram_interleaved && !in1_is_dram_sharded) {
+            src1_cb_config = src1_cb_config.set_globally_allocated_address(*in1_buffer);
+        }
+        cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
+    }
+
+    uint32_t src2_cb_index = tt::CBIndex::c_2;
+    tt_metal::CircularBufferConfig src2_cb_config =
+        tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
+            .set_page_size(src2_cb_index, in2_single_tile_size)
+            .set_tile_dims(src2_cb_index, in0_tile);
+    auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
+
+    uint32_t sync_cb_index = tt::CBIndex::c_3;
+    uint32_t sync_cb_size_bytes = 16;
+    tt_metal::CircularBufferConfig sync_cb_config =
+        tt_metal::CircularBufferConfig(sync_cb_size_bytes, {{sync_cb_index, DataFormat::UInt16}})
+            .set_page_size(sync_cb_index, sync_cb_size_bytes);
+    auto cb_sync = tt_metal::CreateCircularBuffer(program, all_cores, sync_cb_config);
+
+    uint32_t sync_cb2_index = tt::CBIndex::c_4;
+    uint32_t sync_cb2_size_bytes = 16;
+    tt_metal::CircularBufferConfig sync_cb2_config =
+        tt_metal::CircularBufferConfig(sync_cb2_size_bytes, {{sync_cb2_index, DataFormat::UInt16}})
+            .set_page_size(sync_cb2_index, sync_cb2_size_bytes);
+    auto cb2_sync = tt_metal::CreateCircularBuffer(program, all_cores, sync_cb2_config);
+
+    uint32_t output_cb_index = tt::CBIndex::c_5;  // output operands start at index 16
+    uint32_t interm0_cb_index = tt::CBIndex::c_6;
+    tt_metal::CircularBufferConfig interm0_cb_config =
+        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
+    tt_metal::CircularBufferConfig output_cb_config =
+        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
+    std::vector<tt::tt_metal::CBHandle> cb_outputs;
+    std::vector<tt::tt_metal::CBHandle> output_cb_indices;
+    std::vector<tt::tt_metal::CBHandle> interm_cb_indices;
+
+    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
+        // interm0
+        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
+            {interm0_cb_index, interm0_data_format},
+        };
+        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
+                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                .set_tile_dims(interm0_cb_index, output_tile);
+
+        auto cb_interm0 = tt_metal::CreateCircularBuffer(program, all_cores, interm0_cb_config);
+
+        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
+            const auto& out_buffer = out_buffers[i];
+            output_cb_index += i * 2;  // 5, 7, 9...
+            // output
+            std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+                {output_cb_index, output_data_format},
+            };
+            output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                                   .set_page_size(output_cb_index, output_single_tile_size)
+                                   .set_tile_dims(output_cb_index, output_tile)
+                                   .set_globally_allocated_address(*out_buffer);
+            auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+            cb_outputs.push_back(cb_output);
+            output_cb_indices.push_back(output_cb_index);
+            interm_cb_indices.push_back(interm0_cb_index);
+        }
+    } else {
+        for (uint32_t i = 0; i < out_buffers.size(); ++i) {
+            const auto& out_buffer = out_buffers[i];
+            output_cb_index += i * 2;   // 5, 7, 9...
+            interm0_cb_index += i * 2;  // 6, 8, 10...
+            // share buffer
+            std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
+                {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
+            output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
+                                   .set_page_size(output_cb_index, output_single_tile_size)
+                                   .set_page_size(interm0_cb_index, interm0_single_tile_size)
+                                   .set_tile_dims(output_cb_index, output_tile)
+                                   .set_tile_dims(interm0_cb_index, output_tile)
+                                   .set_globally_allocated_address(*out_buffer);
+            auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+            cb_outputs.push_back(cb_output);
+            output_cb_indices.push_back(output_cb_index);
+            interm_cb_indices.push_back(interm0_cb_index);
+        }
+    }
+
     /* Compile time args */
     std::vector<uint32_t> in0_sender_compile_time_args = {
         (std::uint32_t)in0_shard_width_in_tiles,
         (std::uint32_t)per_core_M,  // in0_shard_height_in_tiles
-        (std::uint32_t)B,           // batch
+        (std::uint32_t)batch,       // batch
         (std::uint32_t)ring_size,   // ring_size
         (std::uint32_t)in0_signal_semaphore_id,
     };
@@ -1878,7 +1992,7 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
         (std::uint32_t)per_core_N,                 // in1_block_width_in_tiles
         (std::uint32_t)in1_tensor_width_in_tiles,  // in1_tensor_width_in_tiles
         (std::uint32_t)num_blocks,                 // num_blocks
-        (std::uint32_t)B,                          // batch
+        (std::uint32_t)batch,                      // batch
         (std::uint32_t)in1_block_page_size,
         (std::uint32_t)in1_block_page_size_last,
         (std::uint32_t)in1_block_width_num_pages,
@@ -1902,13 +2016,19 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
         out_subblock_h,          // out_subblock_h
         out_subblock_w,          // out_subblock_w
         out_subblock_num_tiles,  // out_subblock_num_tiles
-        B,                       // batch
+        batch,                   // batch
         out_block_tiles,         // out_block_num_tiles
 
         untilize_out,             // untilize_out
         in1_is_dram_interleaved,  // in1_is_dram_interleaved
         in1_is_dram_sharded,      // in1_is_dram_sharded
     };
+    for (uint32_t i = 0; i < num_output_cb; ++i) {
+        compute_kernel_args.push_back(output_cb_indices[i]);
+    }
+    for (uint32_t i = 0; i < num_output_cb; ++i) {
+        compute_kernel_args.push_back(interm_cb_indices[i]);
+    }
 
     /* Kernel defines */
     std::map<string, string> mm_in1_kernel_defines;
@@ -1977,97 +2097,6 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
             .math_approx_mode = math_approx_mode,
             .compile_args = compute_kernel_args,
             .defines = mm_kernel_defines});
-
-    /* Create circular buffers */
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    tt_metal::CircularBufferConfig src0_cb_config =
-        tt_metal::CircularBufferConfig(in0_CB_size, {{src0_cb_index, in0_data_format}})
-            .set_page_size(src0_cb_index, in0_single_tile_size)
-            .set_tile_dims(src0_cb_index, in0_tile)
-            .set_globally_allocated_address(*in0_buffer);
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, src0_cb_config);
-
-    uint32_t src1_cb_index = tt::CBIndex::c_1;
-    tt::tt_metal::CBHandle cb_src1;
-    if (use_global_cb) {
-        uint32_t in1_block_size_bytes = in1_single_tile_size * in1_block_num_tiles;
-        uint32_t remote_cb_index = tt::CBIndex::c_31;
-        tt_metal::CircularBufferConfig remote_cb_config =
-            tt_metal::CircularBufferConfig((global_cb->size() / in1_block_size_bytes) * in1_block_size_bytes);
-        remote_cb_config.remote_index(remote_cb_index)
-            .set_page_size(in1_block_size_bytes)
-            .set_data_format(in1_data_format);
-        remote_cb_config.index(src1_cb_index).set_page_size(in1_single_tile_size).set_data_format(in1_data_format);
-        cb_src1 = tt_metal::experimental::CreateCircularBuffer(program, all_cores, remote_cb_config, *global_cb);
-    } else {
-        tt_metal::CircularBufferConfig src1_cb_config =
-            tt_metal::CircularBufferConfig(in1_CB_size, {{src1_cb_index, in1_data_format}})
-                .set_page_size(src1_cb_index, in1_single_tile_size)
-                .set_tile_dims(src1_cb_index, in1_tile);
-        if (!in1_is_dram_interleaved && !in1_is_dram_sharded) {
-            src1_cb_config = src1_cb_config.set_globally_allocated_address(*in1_buffer);
-        }
-        cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, src1_cb_config);
-    }
-
-    uint32_t src2_cb_index = tt::CBIndex::c_2;
-    tt_metal::CircularBufferConfig src2_cb_config =
-        tt_metal::CircularBufferConfig(in2_CB_size, {{src2_cb_index, in0_data_format}})
-            .set_page_size(src2_cb_index, in2_single_tile_size)
-            .set_tile_dims(src2_cb_index, in0_tile);
-    auto cb_src2 = tt_metal::CreateCircularBuffer(program, all_cores, src2_cb_config);
-
-    uint32_t sync_cb_index = tt::CBIndex::c_3;
-    uint32_t sync_cb_size_bytes = 16;
-    tt_metal::CircularBufferConfig sync_cb_config =
-        tt_metal::CircularBufferConfig(sync_cb_size_bytes, {{sync_cb_index, DataFormat::UInt16}})
-            .set_page_size(sync_cb_index, sync_cb_size_bytes);
-    auto cb_sync = tt_metal::CreateCircularBuffer(program, all_cores, sync_cb_config);
-
-    uint32_t sync_cb2_index = tt::CBIndex::c_4;
-    uint32_t sync_cb2_size_bytes = 16;
-    tt_metal::CircularBufferConfig sync_cb2_config =
-        tt_metal::CircularBufferConfig(sync_cb2_size_bytes, {{sync_cb2_index, DataFormat::UInt16}})
-            .set_page_size(sync_cb2_index, sync_cb2_size_bytes);
-    auto cb2_sync = tt_metal::CreateCircularBuffer(program, all_cores, sync_cb2_config);
-
-    uint32_t output_cb_index = tt::CBIndex::c_5;  // output operands start at index 16
-    uint32_t interm0_cb_index = tt::CBIndex::c_6;
-    tt_metal::CircularBufferConfig interm0_cb_config =
-        tt_metal::CircularBufferConfig(0, {{interm0_cb_index, interm0_data_format}});
-    tt_metal::CircularBufferConfig output_cb_config =
-        tt_metal::CircularBufferConfig(0, {{output_cb_index, output_data_format}});
-
-    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
-        // output
-        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
-            {output_cb_index, output_data_format},
-        };
-        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-                               .set_page_size(output_cb_index, output_single_tile_size)
-                               .set_tile_dims(output_cb_index, output_tile)
-                               .set_globally_allocated_address(*out_buffer);
-        // interm0
-        std::map<uint8_t, tt::DataFormat> interm0_cb_data_format_spec{
-            {interm0_cb_index, interm0_data_format},
-        };
-        interm0_cb_config = tt_metal::CircularBufferConfig(interm0_CB_size, interm0_cb_data_format_spec)
-                                .set_page_size(interm0_cb_index, interm0_single_tile_size)
-                                .set_tile_dims(interm0_cb_index, output_tile);
-
-        auto cb_interm0 = tt_metal::CreateCircularBuffer(program, all_cores, interm0_cb_config);
-    } else {
-        // share buffer
-        std::map<uint8_t, tt::DataFormat> output_cb_data_format_spec{
-            {output_cb_index, output_data_format}, {interm0_cb_index, interm0_data_format}};
-        output_cb_config = tt_metal::CircularBufferConfig(out_CB_size, output_cb_data_format_spec)
-                               .set_page_size(output_cb_index, output_single_tile_size)
-                               .set_page_size(interm0_cb_index, interm0_single_tile_size)
-                               .set_tile_dims(output_cb_index, output_tile)
-                               .set_tile_dims(interm0_cb_index, output_tile)
-                               .set_globally_allocated_address(*out_buffer);
-    }
-    auto cb_output = tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
 
     // for all the cores in the rect grid, we send one rt arg to determine if they are worker core
     auto all_cores_vec = corerange_to_cores(all_cores, std::nullopt, row_major);
@@ -2239,16 +2268,18 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
     }
 
     auto override_runtime_arguments_callback =
-        [mm_kernel_in0_id, mm_kernel_in1_sender_writer_id, cb_src0, cb_src1, cb_output, num_cores, all_cores_vec](
+        [mm_kernel_in0_id, mm_kernel_in1_sender_writer_id, cb_src0, cb_src1, cb_outputs, num_cores, all_cores_vec](
             const void* operation,
             tt::tt_metal::Program& program,
             const std::vector<tt::tt_metal::Tensor>& input_tensors,
             const std::vector<std::optional<const tt::tt_metal::Tensor>>& optional_input_tensors,
             const std::vector<tt::tt_metal::Tensor>& output_tensors) {
-            TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
-            TT_ASSERT(output_tensors.size() == 1);
-
             auto& global_cb = static_cast<const ttnn::operations::matmul::Matmul*>(operation)->global_cb;
+
+            if (!global_cb.has_value()) {
+                TT_ASSERT(input_tensors.size() + optional_input_tensors.size() == 3);
+                TT_ASSERT(output_tensors.size() == 1);
+            }
 
             auto src_buffer_a = input_tensors[0].buffer();
             auto src_buffer_b = input_tensors[1].buffer();
@@ -2268,7 +2299,11 @@ tt::tt_metal::operation::ProgramWithCallbacks create_program_gather_in0(
                 }
             }
             if (out_sharded) {
-                UpdateDynamicCircularBufferAddress(program, cb_output, *dst_buffer);
+                for (uint32_t i = 0; i < cb_outputs.size(); ++i) {
+                    const auto& cb_output = cb_outputs[i];
+                    const auto& out_buffer = output_tensors[i].buffer();
+                    UpdateDynamicCircularBufferAddress(program, cb_output, *out_buffer);
+                }
             }
 
             if (not src1_sharded) {
@@ -2297,9 +2332,9 @@ namespace matmul {
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_(
     tt::tt_metal::Program& program,
     const Tensor& a,
-    const Tensor& b,
+    const std::vector<Tensor>& b_tensors,
     const std::optional<const Tensor>& bias,
-    Tensor& output,
+    const std::vector<Tensor>& output_tensors,
     bool bcast_batch,
     CoreCoord compute_with_storage_grid_size,
     DeviceComputeKernelConfig compute_kernel_config,
@@ -2320,6 +2355,11 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
     const std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer>& global_cb,
     uint32_t num_global_cb_receivers,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    const auto b = b_tensors[0];
+    const auto output = output_tensors[0];
+
+    TT_FATAL(output_tensors.size() == b_tensors.size(), "number of outputs must match number of inputs b");
+
     const auto &ashape = a.get_padded_shape(), bshape = b.get_padded_shape();
     auto in0_tile = a.get_tensor_spec().tile();
     auto in1_tile = b.get_tensor_spec().tile();
@@ -2415,10 +2455,14 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
     ////////////////////////////////////////////////////////////////////////////
 
     if (gather_in0) {
+        std::vector<tt_metal::Buffer*> out_buffers;
+        for (const auto& output_tensor : output_tensors) {
+            out_buffers.push_back(output_tensor.buffer());
+        }
         return reuse_mcast_1d_optimized_helpers::create_program_gather_in0(
             program,
             a,
-            b,
+            b_tensors,
             device,
             math_fidelity,
             fp32_dest_acc_en,
@@ -2440,7 +2484,7 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
             hop_cores,
             in0_buffer,
             in1_buffer,
-            out_buffer,
+            out_buffers,
             in0_tile,
             in1_tile,
             output_tile,
@@ -2535,9 +2579,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
 
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized(
     const Tensor& a,
-    const Tensor& b,
+    const std::vector<Tensor>& b,
     const std::optional<const Tensor>& bias,
-    Tensor& output_tensor,
+    const std::vector<Tensor>& output_tensor,
     bool broadcast_batch,
     CoreCoord compute_with_storage_grid_size,
     DeviceComputeKernelConfig compute_kernel_config,
@@ -2591,9 +2635,9 @@ tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_o
 tt::tt_metal::operation::ProgramWithCallbacks matmul_multi_core_reuse_mcast_1d_optimized_helper(
     tt::tt_metal::Program& program,
     const Tensor& a,
-    const Tensor& b,
+    const std::vector<Tensor>& b,
     const std::optional<const Tensor>& bias,
-    Tensor& output_tensor,
+    const std::vector<Tensor>& output_tensor,
     bool broadcast_batch,
     DeviceComputeKernelConfig compute_kernel_config,
     const MatmulProgramConfig& program_config,

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -258,6 +258,55 @@ Tensor LinearOperation::invoke(
         optional_output_tensor);
 }
 
+std::vector<Tensor> MatmulBatchedWeightsOperation::invoke(
+    const Tensor& input_tensor_a,
+    const std::vector<Tensor>& input_tensors_b,
+    const bool transpose_a,
+    const bool transpose_b,
+    const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const DataType> dtype,
+    const std::optional<const MatmulProgramConfig>& program_config,
+    const std::optional<const std::string>& activation,
+    const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+    const std::optional<const CoreGrid> core_grid,
+    const std::optional<const tt::tt_metal::Tile>& output_tile,
+    std::optional<Tensor> optional_output_tensor,
+    const std::optional<const GlobalCircularBuffer>& global_cb,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    TT_FATAL(transpose_a == false, "cannot transpose A in batched matmul");
+    TT_FATAL(transpose_b == false, "cannot transpose B in batched matmul");
+    TT_FATAL(memory_config.has_value(), "memory_config must be provided");
+    TT_FATAL(program_config.has_value(), "program_config must be provided");
+    TT_FATAL(!activation.has_value(), "activation must not be provided");
+    TT_FATAL(!core_grid.has_value(), "core_grid must not be provided");
+    TT_FATAL(!output_tile.has_value(), "output_tile must not be provided");
+    TT_FATAL(!optional_output_tensor.has_value(), "optional_output_tensor must not be provided");
+    TT_FATAL(global_cb.has_value(), "global_cb must be provided");
+    TT_FATAL(sub_device_id.has_value(), "sub_device_id must be provided");
+
+    return matmul_batched_weights(
+        input_tensor_a,
+        input_tensors_b,
+        /*bias=*/std::nullopt,
+        Matmul{
+            program_config,
+            /*bcast_batch=*/std::nullopt,
+            memory_config.has_value() ? memory_config.value() : ttnn::DRAM_MEMORY_CONFIG,
+            dtype,
+            compute_kernel_config,
+            /*untilize_out=*/false,
+            /*user_core_coord*/ std::nullopt,
+            get_fused_activation(activation),
+            /*user_run_batched=*/false,
+            transpose_a,
+            transpose_b,
+            output_tile,
+            global_cb,
+            sub_device_id},
+        DefaultQueueId,
+        optional_output_tensor);
+}
+
 }  // namespace matmul
 }  // namespace operations
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.cpp
@@ -270,7 +270,7 @@ std::vector<Tensor> MatmulBatchedWeightsOperation::invoke(
     const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
     const std::optional<const CoreGrid> core_grid,
     const std::optional<const tt::tt_metal::Tile>& output_tile,
-    std::optional<Tensor> optional_output_tensor,
+    const std::optional<Tensor>& optional_output_tensor,
     const std::optional<const GlobalCircularBuffer>& global_cb,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
     TT_FATAL(transpose_a == false, "cannot transpose A in batched matmul");

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -67,7 +67,7 @@ struct MatmulBatchedWeightsOperation {
         const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
         const std::optional<const CoreGrid> core_grid = std::nullopt,
         const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
-        std::optional<Tensor> optional_output_tensor = std::nullopt,
+        const std::optional<Tensor>& optional_output_tensor = std::nullopt,
         const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
         const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
 };

--- a/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul.hpp
@@ -54,6 +54,24 @@ struct MatmulOperation {
         const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
 };
 
+struct MatmulBatchedWeightsOperation {
+    static std::vector<Tensor> invoke(
+        const Tensor& input_tensor_a,
+        const std::vector<Tensor>& input_tensors_b,
+        const bool transpose_a = false,
+        const bool transpose_b = false,
+        const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<const DataType> dtype = std::nullopt,
+        const std::optional<const MatmulProgramConfig>& program_config = std::nullopt,
+        const std::optional<const std::string>& activation = std::nullopt,
+        const std::optional<const DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+        const std::optional<const CoreGrid> core_grid = std::nullopt,
+        const std::optional<const tt::tt_metal::Tile>& output_tile = std::nullopt,
+        std::optional<Tensor> optional_output_tensor = std::nullopt,
+        const std::optional<const GlobalCircularBuffer>& global_cb = std::nullopt,
+        const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id = std::nullopt);
+};
+
 struct LinearOperation {
     static Tensor invoke(
         const Tensor& input_tensor_a,
@@ -77,4 +95,6 @@ struct LinearOperation {
 }  // namespace operations
 constexpr auto matmul = ttnn::register_operation<"ttnn::matmul", operations::matmul::MatmulOperation>();
 constexpr auto linear = ttnn::register_operation<"ttnn::linear", operations::matmul::LinearOperation>();
+constexpr auto matmul_batched_weights =
+    ttnn::register_operation<"ttnn::matmul_batched_weights", operations::matmul::MatmulBatchedWeightsOperation>();
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_pybind.cpp
@@ -468,6 +468,81 @@ void py_module(py::module& module) {
             py::arg("global_cb") = std::nullopt,
             py::arg("sub_device_id") = std::nullopt,
         });
+
+    bind_registered_operation(
+        module,
+        ::ttnn::matmul_batched_weights,
+        R"doc(
+        performs matrix multiplication for a single input tensor a with multiple tensors b, return a vector of output tensors.
+
+        Args:
+            input_tensor_a (ttnn.Tensor): the first tensor to be multiplied. Needs to be on the device.
+            input_tensors_b (ttnn.Tensor): the second tensor vector to be multiplied. Needs to be on the device.
+
+        Keyword Args:
+            bias (ttnn.Tensor, optional): the bias tensor to be added. If specified, needs to be on the device. Defaults to `None`.
+            transpose_a (bool, optional): Whether to transpose input_tensor_a. Defaults to `False`.
+            transpose_b (bool, optional): Whether to transpose input_tensor_b. Defaults to `False`.
+            memory_config (ttnn.MemoryConfig, optional): the memory configuration of the output tensor. Defaults to `None`, which will result in using `ttnn.DRAM_MEMORY_CONFIG`.
+            dtype (ttnn.DataType, optional): the data type of the output tensor. Defaults to `None`.
+            program_config (MatmulProgramConfig, optional): the program configuration for the matmul operation. Defaults to `None`.
+            activation (str, optional): the activation function to be applied. Defaults to `None`.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
+            core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
+            output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of linear is to be written. Defaults to `None`.
+
+        Returns:
+            ttnn.Tensor: the output tensor.
+        )doc",
+        ttnn::pybind_overload_t{
+            [](decltype(::ttnn::matmul_batched_weights)& self,
+               const ttnn::Tensor& input_tensor_a,
+               const std::vector<ttnn::Tensor>& input_tensors_b,
+               const bool transpose_a,
+               const bool transpose_b,
+               const std::optional<const ttnn::MemoryConfig>& memory_config,
+               const std::optional<const DataType> dtype,
+               const std::optional<const MatmulProgramConfig>& program_config,
+               const std::optional<const std::string>& activation,
+               const std::optional<const DeviceComputeKernelConfig> compute_kernel_config,
+               const std::optional<const ttnn::CoreGrid> core_grid,
+               const std::optional<const tt::tt_metal::Tile>& output_tile,
+               std::optional<Tensor>& optional_output_tensor,
+               const std::optional<const GlobalCircularBuffer>& global_cb,
+               const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) -> std::vector<ttnn::Tensor> {
+                return self(
+                    input_tensor_a,
+                    input_tensors_b,
+                    transpose_a,
+                    transpose_b,
+                    memory_config,
+                    dtype,
+                    program_config,
+                    activation,
+                    compute_kernel_config,
+                    core_grid,
+                    output_tile,
+                    optional_output_tensor,
+                    global_cb,
+                    sub_device_id);
+            },
+            py::arg("input_tensor_a"),
+            py::arg("input_tensors_b"),
+            py::kw_only(),
+            py::arg("transpose_a") = false,
+            py::arg("transpose_b") = false,
+            py::arg("memory_config") = std::nullopt,
+            py::arg("dtype") = std::nullopt,
+            py::arg("program_config") = std::nullopt,
+            py::arg("activation") = std::nullopt,
+            py::arg("compute_kernel_config") = std::nullopt,
+            py::arg("core_grid") = std::nullopt,
+            py::arg("output_tile") = std::nullopt,
+            py::arg("optional_output_tensor") = std::nullopt,
+            py::arg("global_cb") = std::nullopt,
+            py::arg("sub_device_id") = std::nullopt,
+        });
 }
 
 }  // namespace matmul


### PR DESCRIPTION
We need to pass in multiple weight tensors to ring matmul, and return multiple output tensors, as a preparation for the fusion between reduce-scatter and matmul in llama attention. 
Final version would be a large kernel containing:
matmul ff1
Reduce-scatter
matmul ff2
Reduce-scatter

### Checklist
- [x] [All post commit]  https://github.com/tenstorrent/tt-metal/actions/runs/14931488525
- [x] TG frequent https://github.com/tenstorrent/tt-metal/actions/runs/14931506074
- [x] TG unit https://github.com/tenstorrent/tt-metal/actions/runs/14931532928