### PR TITLE
Fix hang for untilize with unpadding with int32

### DIFF
--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -436,7 +436,7 @@ def test_to_layout_wh2(shape, input_layout, output_layout, device):
 
 
 @pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64]])
-def test_untilize_with_unpad1_int32(shape, device):
+def test_untilize_with_unpad_int32(shape, device):
     torch.manual_seed(2005)
     end_shape = [x - 1 for x in shape]
     input_a = torch.randint(1, 64, shape, dtype=torch.int32)

--- a/tests/ttnn/unit_tests/test_to_layout.py
+++ b/tests/ttnn/unit_tests/test_to_layout.py
@@ -433,3 +433,14 @@ def test_to_layout_wh2(shape, input_layout, output_layout, device):
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(input_a, output_tensor)
+
+
+@pytest.mark.parametrize("shape", [[32, 128], [2, 4, 96, 256], [1, 160, 64]])
+def test_untilize_with_unpad1_int32(shape, device):
+    torch.manual_seed(2005)
+    end_shape = [x - 1 for x in shape]
+    input_a = torch.randint(1, 64, shape, dtype=torch.int32)
+    input_tensor = ttnn.from_torch(input_a, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.int32)
+    output_tensor = ttnn.untilize_with_unpadding(input_tensor, end_shape)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(input_a, output_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -143,8 +143,9 @@ operation::ProgramWithCallbacks untilize_with_unpadding_single_core(
         (std::uint32_t)out_is_dram,
         (std::uint32_t)stick_size_is_power_of_two,
         (std::uint32_t)log2_stick_size,
-        (std::uint32_t)(
-            (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32))};
+        (std::uint32_t)((
+            input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
+            input_cb_data_format == tt::DataFormat::Int32))};
 
     // Tilized reader
     tt::tt_metal::KernelHandle unary_reader_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_program_factory.cpp
@@ -759,8 +759,9 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_interleaved(
             {out_is_dram,
              stick_size_is_power_of_two,
              log2_stick_size,
-             (std::uint32_t)(
-                 input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32)}));
+             (std::uint32_t)(input_cb_data_format == tt::DataFormat::Float32 or
+                             input_cb_data_format == tt::DataFormat::UInt32 or
+                             input_cb_data_format == tt::DataFormat::Int32)}));
 
     /** compute
      */
@@ -998,7 +999,8 @@ operation::ProgramWithCallbacks untilize_with_unpadding_multi_core_sharded(
         std::vector<uint32_t> writer_ct_args = {
             (uint32_t)out_is_dram,
             (uint32_t)(input_cb_data_format == tt::DataFormat::Float32 or
-                       input_cb_data_format == tt::DataFormat::UInt32)};
+                       input_cb_data_format == tt::DataFormat::UInt32 or
+                       input_cb_data_format == tt::DataFormat::Int32)};
         unary_writer_kernel_id = CreateKernel(
             program,
             "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp",


### PR DESCRIPTION
### Ticket
Link to Github Issue https://github.com/tenstorrent/tt-metal/issues/16860

### Problem description
Untilize with unpadding hangs with int32

### What's changed
Add int32 to data formats in untilize with unpadding program factory

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14917108921
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes