### PR TITLE
#0: Fix disabling program cache on MeshDevice

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -521,6 +521,9 @@ void MeshDevice::enable_program_cache() {
 
 void MeshDevice::disable_and_clear_program_cache() {
     log_info(tt::LogMetal, "Disabling and clearing program cache on MeshDevice {}", this->id());
+    if (program_cache_->is_enabled()) {
+        program_cache_->disable();
+    }
     program_cache_->clear();
 }
 


### PR DESCRIPTION
### Problem description
In the current implementation of `MeshDevice`, `disable_and_clear_program_cache` is going to clear program cache, but not to disable it.

### What's changed
Disable program cache if it is enabled in that function.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14931406144) - running