### PR TITLE
sfpi v6.10.2

### DIFF
--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,7 +1,7 @@
 # set SFPI release version information
-sfpi_version=v6.10.1
+sfpi_version=v6.10.2
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
-sfpi_x86_64_Linux_tgz_md5=bb4c943c13992ab54b75fc65ed267c93
-sfpi_x86_64_Linux_deb_md5=441f7021bb77e438b5002391319cd57b
-sfpi_aarch64_Linux_tgz_md5=d186965594713c8ad685c8270855b829
-sfpi_aarch64_Linux_deb_md5=d186965594713c8ad685c8270855b829
+sfpi_x86_64_Linux_tgz_md5=8937def463673c2726218ea7b9a504ea
+sfpi_x86_64_Linux_deb_md5=0f091cd70dfb641c87f052e2394a981a
+sfpi_aarch64_Linux_tgz_md5=816721dbbf602f6b320d56c9ece94651
+sfpi_aarch64_Linux_deb_md5=d2960200de58eb01e814374000866997


### PR DESCRIPTION
### Ticket
NA

### Problem description
Static linking gcc's dependencies is bad

### What's changed
Build gcc:
* without system-zlib (using it's own copy)
* without zesty
* Adjust Debian package dependencies to not need zlib nor zstd

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes