### PR TITLE
#19177: Unconditionally attach `DistributedTensorConfig` to `TensorAttributes`

### DIFF
--- a/tests/tt_eager/ops/test_eltwise_binary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_binary_op.cpp
@@ -38,7 +38,7 @@ Tensor host_function(const Tensor& input_tensor_a, const Tensor& input_tensor_b)
         output_buffer[index] = bfloat16(value);
     }
     return Tensor(
-        tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+        tt::tt_metal::HostBuffer(std::move(output_buffer)),
         input_tensor_a.get_logical_shape(),
         input_tensor_a.get_dtype(),
         input_tensor_a.get_layout());

--- a/tests/tt_eager/ops/test_eltwise_unary_op.cpp
+++ b/tests/tt_eager/ops/test_eltwise_unary_op.cpp
@@ -64,7 +64,7 @@ Tensor host_function(const Tensor& input_tensor) {
     }
 
     return Tensor(
-        tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+        tt::tt_metal::HostBuffer(std::move(output_buffer)),
         input_tensor.get_logical_shape(),
         input_tensor.get_dtype(),
         input_tensor.get_layout());

--- a/tests/tt_eager/tensors/test_copy_and_move.cpp
+++ b/tests/tt_eager/tensors/test_copy_and_move.cpp
@@ -39,8 +39,7 @@ using namespace tt;
 using namespace tt_metal;
 using namespace constants;
 
-bool test_tensor_copy_semantics(distributed::MeshDevice* device) {
-    bool pass = true;
+void test_tensor_copy_semantics(distributed::MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     // host tensor to host tensor copy constructor
@@ -48,7 +47,7 @@ bool test_tensor_copy_semantics(distributed::MeshDevice* device) {
     Tensor host_a_copy = host_a;
     auto host_a_data = host_buffer::get_as<bfloat16>(host_a);
     auto host_a_copy_data = host_buffer::get_as<bfloat16>(host_a_copy);
-    pass &= std::equal(host_a_data.begin(), host_a_data.end(), host_a_copy_data.begin());
+    TT_FATAL(std::equal(host_a_data.begin(), host_a_data.end(), host_a_copy_data.begin()), "Test Failed");
 
     // dev tensor to dev tensor copy constructor
     Tensor dev_a = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device);
@@ -57,7 +56,7 @@ bool test_tensor_copy_semantics(distributed::MeshDevice* device) {
     auto dev_a_copy_on_host = dev_a_copy.cpu();
     auto dev_a_data = host_buffer::get_as<bfloat16>(dev_a_on_host);
     auto dev_a_copy_data = host_buffer::get_as<bfloat16>(dev_a_copy_on_host);
-    pass &= std::equal(dev_a_data.begin(), dev_a_data.end(), dev_a_copy_data.begin());
+    TT_FATAL(std::equal(dev_a_data.begin(), dev_a_data.end(), dev_a_copy_data.begin()), "Test Failed");
 
     // host tensor updated with host tensor copy assignment
     Tensor host_c = ttnn::experimental::view(
@@ -67,111 +66,111 @@ bool test_tensor_copy_semantics(distributed::MeshDevice* device) {
     host_c_copy = host_c;
     auto host_c_data = host_buffer::get_as<bfloat16>(host_c);
     auto host_c_copy_data = host_buffer::get_as<bfloat16>(host_c_copy);
-    pass &= std::equal(host_c_data.begin(), host_c_data.end(), host_c_copy_data.begin());
+    TT_FATAL(std::equal(host_c_data.begin(), host_c_data.end(), host_c_copy_data.begin()), "Test Failed");
 
     // host tensor updated with dev tensor copy assignment
     Tensor host_d_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE);
     host_d_copy = dev_a;
-    pass &= (host_d_copy.storage_type() == StorageType::DEVICE);
+    TT_FATAL(host_d_copy.storage_type() == StorageType::DEVICE, "Test Failed");
     auto host_d_copy_on_host = host_d_copy.cpu();
     auto host_d_copy_data = host_buffer::get_as<bfloat16>(host_d_copy_on_host);
-    pass &= std::equal(dev_a_data.begin(), dev_a_data.end(), host_d_copy_data.begin());
+    TT_FATAL(std::equal(dev_a_data.begin(), dev_a_data.end(), host_d_copy_data.begin()), "Test Failed");
 
     // dev tensor updated with host tensor copy assignment
     Tensor host_e = ttnn::ones(single_tile_shape, DataType::BFLOAT16, Layout::TILE);
     Tensor dev_e_copy = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device);
     dev_e_copy = host_e;
-    pass &= (dev_e_copy.storage_type() == StorageType::HOST);
+    TT_FATAL(dev_e_copy.storage_type() == StorageType::HOST, "Test Failed");
     auto host_e_data = host_buffer::get_as<bfloat16>(host_e);
     auto dev_e_copy_data = host_buffer::get_as<bfloat16>(dev_e_copy);
-    pass &= std::equal(host_e_data.begin(), host_e_data.end(), dev_e_copy_data.begin());
+    TT_FATAL(std::equal(host_e_data.begin(), host_e_data.end(), dev_e_copy_data.begin()), "Test Failed");
 
     // dev tensor updated with dev tensor copy assignment
     Tensor dev_b = ttnn::ones(single_tile_shape, DataType::BFLOAT16, Layout::TILE, *device);
     Tensor dev_b_copy = ttnn::zeros(single_tile_shape, DataType::BFLOAT16, Layout::TILE, *device);
     dev_b_copy = dev_b;
-    pass &= (dev_b_copy.storage_type() == StorageType::DEVICE);
+    TT_FATAL(dev_b_copy.storage_type() == StorageType::DEVICE, "Test Failed");
     auto dev_b_on_host = dev_b.cpu();
     auto dev_b_copy_on_host = dev_b_copy.cpu();
     auto dev_b_data = host_buffer::get_as<bfloat16>(dev_b_on_host);
     auto dev_b_copy_data = host_buffer::get_as<bfloat16>(dev_b_copy_on_host);
-    pass &= std::equal(dev_b_data.begin(), dev_b_data.end(), dev_b_copy_data.begin());
-
-    return pass;
+    TT_FATAL(std::equal(dev_b_data.begin(), dev_b_data.end(), dev_b_copy_data.begin()), "Test Failed");
 }
 
-bool test_tensor_move_semantics(distributed::MeshDevice* device) {
-    bool pass = true;
+void test_tensor_move_semantics(distributed::MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     auto random_tensor = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
     auto bfloat_data = host_buffer::get_as<bfloat16>(random_tensor);
 
     // host tensor to host tensor move constructor
-    Tensor host_a =
-        Tensor(HostStorage{host_buffer::create(bfloat_data)}, single_tile_shape, DataType::BFLOAT16, Layout::TILE);
+    Tensor host_a = Tensor(
+        HostBuffer(std::vector<bfloat16>(bfloat_data.begin(), bfloat_data.end())),
+        single_tile_shape,
+        DataType::BFLOAT16,
+        Layout::TILE);
     Tensor host_a_copy = std::move(host_a);
     auto host_a_copy_data = host_buffer::get_as<bfloat16>(host_a_copy);
-    pass &= std::equal(host_a_copy_data.begin(), host_a_copy_data.end(), bfloat_data.begin());
+    TT_FATAL(std::equal(host_a_copy_data.begin(), host_a_copy_data.end(), bfloat_data.begin()), "Test Failed");
 
     // dev tensor to dev tensor move constructor
-    Tensor dev_a =
-        Tensor(HostStorage{host_buffer::create(bfloat_data)}, single_tile_shape, DataType::BFLOAT16, Layout::TILE)
-            .to_device(device);
+    Tensor dev_a = Tensor(
+                       HostBuffer(std::vector<bfloat16>(bfloat_data.begin(), bfloat_data.end())),
+                       single_tile_shape,
+                       DataType::BFLOAT16,
+                       Layout::TILE)
+                       .to_device(device);
     auto og_buffer_a = dev_a.buffer();
     Tensor dev_a_copy = std::move(dev_a);
-    pass &= dev_a_copy.buffer() == og_buffer_a;
+    TT_FATAL(dev_a_copy.buffer() == og_buffer_a, "Test Failed");
     auto dev_a_copy_on_host = dev_a_copy.cpu();
     auto dev_a_copy_data = host_buffer::get_as<bfloat16>(dev_a_copy_on_host);
-    pass &= std::equal(dev_a_copy_data.begin(), dev_a_copy_data.end(), bfloat_data.begin());
+    TT_FATAL(std::equal(dev_a_copy_data.begin(), dev_a_copy_data.end(), bfloat_data.begin()), "Test Failed");
 
     // host tensor updated with host tensor move assignment
     auto random_tensor_three = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
     auto bfloat_data_three = host_buffer::get_as<bfloat16>(random_tensor_three);
     Tensor host_c = Tensor(
-        HostStorage{host_buffer::create(bfloat_data_three)}, single_tile_shape, DataType::BFLOAT16, Layout::TILE);
-    Tensor host_c_copy = Tensor(dev_a_copy_on_host.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE);
+        HostBuffer(std::vector<bfloat16>(bfloat_data_three.begin(), bfloat_data_three.end())),
+        single_tile_shape,
+        DataType::BFLOAT16,
+        Layout::TILE);
+    Tensor host_c_copy = dev_a_copy_on_host;
     host_c_copy = std::move(host_c);
     auto host_c_copy_data = host_buffer::get_as<bfloat16>(host_c_copy);
-    pass &= std::equal(host_c_copy_data.begin(), host_c_copy_data.end(), bfloat_data_three.begin());
+    TT_FATAL(std::equal(host_c_copy_data.begin(), host_c_copy_data.end(), bfloat_data_three.begin()), "Test Failed");
 
     // host tensor updated with dev tensor move assignment
-    Tensor host_d_copy = Tensor(host_c_copy.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE);
+    Tensor host_d_copy = host_c_copy;
     host_d_copy = std::move(dev_a_copy);
-    pass &= (host_d_copy.storage_type() == StorageType::DEVICE);
+    TT_FATAL(host_d_copy.storage_type() == StorageType::DEVICE, "Test Failed");
     auto host_d_copy_on_host = host_d_copy.cpu();
     auto host_d_copy_data = host_buffer::get_as<bfloat16>(host_d_copy_on_host);
-    pass &= std::equal(host_d_copy_data.begin(), host_d_copy_data.end(), bfloat_data.begin());
+    TT_FATAL(std::equal(host_d_copy_data.begin(), host_d_copy_data.end(), bfloat_data.begin()), "Test Failed");
 
     // dev tensor updated with host tensor copy assignment
     auto random_tensor_four = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
     auto bfloat_data_four = host_buffer::get_as<bfloat16>(random_tensor_four);
-    Tensor host_e = Tensor(random_tensor_four.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE);
-    Tensor dev_e_copy =
-        Tensor(host_c_copy.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to_device(device);
+    Tensor host_e = random_tensor_four;
+    Tensor dev_e_copy = host_c_copy.to_device(device);
     dev_e_copy = std::move(host_e);
-    pass &= (dev_e_copy.storage_type() == StorageType::HOST);
+    TT_FATAL(dev_e_copy.storage_type() == StorageType::HOST, "Test Failed");
     auto dev_e_copy_data = host_buffer::get_as<bfloat16>(dev_e_copy);
-    pass &= std::equal(dev_e_copy_data.begin(), dev_e_copy_data.end(), bfloat_data_four.begin());
+    TT_FATAL(std::equal(dev_e_copy_data.begin(), dev_e_copy_data.end(), bfloat_data_four.begin()), "Test Failed");
 
     // dev tensor updated with dev tensor copy assignment
     auto random_tensor_five = ttnn::random::uniform(bfloat16(-1.0f), bfloat16(1.0f), single_tile_shape);
     auto bfloat_data_five = host_buffer::get_as<bfloat16>(random_tensor_five);
-    Tensor dev_b =
-        Tensor(random_tensor_four.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to_device(device);
-    Tensor dev_b_copy =
-        Tensor(dev_e_copy.get_storage(), single_tile_shape, DataType::BFLOAT16, Layout::TILE).to_device(device);
+    Tensor dev_b = random_tensor_four.to_device(device);
+    Tensor dev_b_copy = dev_e_copy.to_device(device);
     dev_b_copy = std::move(dev_b);
-    pass &= (dev_b_copy.storage_type() == StorageType::DEVICE);
+    TT_FATAL(dev_b_copy.storage_type() == StorageType::DEVICE, "Test Failed");
     auto dev_b_copy_on_host = dev_b_copy.cpu();
     auto dev_b_copy_data = host_buffer::get_as<bfloat16>(dev_b_copy_on_host);
-    pass &= std::equal(dev_b_copy_data.begin(), dev_b_copy_data.end(), bfloat_data_five.begin());
-
-    return pass;
+    TT_FATAL(std::equal(dev_b_copy_data.begin(), dev_b_copy_data.end(), bfloat_data_five.begin()), "Test Failed");
 }
 
-bool test_tensor_deallocate_semantics(distributed::MeshDevice* device) {
-    bool pass = true;
+void test_tensor_deallocate_semantics(distributed::MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     MemoryConfig dram_mem_config =
@@ -185,14 +184,14 @@ bool test_tensor_deallocate_semantics(distributed::MeshDevice* device) {
     dev_a.deallocate();
     Tensor dev_b = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     uint32_t address_b = dev_b.buffer()->address();
-    pass &= address_a == address_b;
+    TT_FATAL(address_a == address_b, "Test Failed");
 
     // dev tensor allocate, allocate, deallocate, reallocate same address DRAM
     Tensor dev_c = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     dev_b.deallocate();
     Tensor dev_d = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, dram_mem_config);
     uint32_t address_d = dev_d.buffer()->address();
-    pass &= address_b == address_d;
+    TT_FATAL(address_b == address_d, "Test Failed");
 
     // dev tensor allocate, deallocate, reallocate same address L1
     Tensor dev_e = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
@@ -200,20 +199,17 @@ bool test_tensor_deallocate_semantics(distributed::MeshDevice* device) {
     dev_e.deallocate();
     Tensor dev_f = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
     uint32_t address_f = dev_f.buffer()->address();
-    pass &= address_e == address_f;
+    TT_FATAL(address_e == address_f, "Test Failed");
 
     // dev tensor allocate, allocate, deallocate, reallocate same address DRAM
     Tensor dev_g = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
     dev_f.deallocate();
     Tensor dev_h = ttnn::random::random(single_tile_shape).to_layout(Layout::TILE).to_device(device, l1_mem_config);
     uint32_t address_h = dev_h.buffer()->address();
-    pass &= address_f == address_h;
-
-    return pass;
+    TT_FATAL(address_f == address_h, "Test Failed");
 }
 
-bool test_tensor_deallocate_and_close_device(distributed::MeshDevice* device) {
-    bool pass = true;
+void test_tensor_deallocate_and_close_device(distributed::MeshDevice* device) {
     ttnn::Shape single_tile_shape({1, 1, TILE_HEIGHT, TILE_WIDTH});
 
     MemoryConfig dram_mem_config =
@@ -226,8 +222,6 @@ bool test_tensor_deallocate_and_close_device(distributed::MeshDevice* device) {
     uint32_t address_a = dev_a.buffer()->address();
     device->close();
     dev_a.deallocate();
-
-    return pass;
 }
 
 int main(int argc, char** argv) {
@@ -240,13 +234,13 @@ int main(int argc, char** argv) {
         int device_id = 0;
         auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
 
-        pass &= test_tensor_copy_semantics(device.get());
+        test_tensor_copy_semantics(device.get());
 
-        pass &= test_tensor_move_semantics(device.get());
+        test_tensor_move_semantics(device.get());
 
-        pass &= test_tensor_deallocate_semantics(device.get());
+        test_tensor_deallocate_semantics(device.get());
 
-        pass &= test_tensor_deallocate_and_close_device(device.get());
+        test_tensor_deallocate_and_close_device(device.get());
 
     } catch (const std::exception& e) {
         pass = false;

--- a/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
+++ b/tests/tt_eager/tensors/test_raw_host_memory_pointer.cpp
@@ -67,7 +67,6 @@ struct NDArray {
 void test_raw_host_memory_pointer() {
     using tt::tt_metal::DataType;
     using tt::tt_metal::HostBuffer;
-    using tt::tt_metal::HostStorage;
     using tt::tt_metal::Layout;
     using tt::tt_metal::Tensor;
 
@@ -78,10 +77,7 @@ void test_raw_host_memory_pointer() {
 
     // Host tensor to print the output
     Tensor tensor_for_printing = Tensor(
-        HostStorage{tt::tt_metal::host_buffer::create<bfloat16>(std::vector<bfloat16>(shape.volume()))},
-        shape,
-        DataType::BFLOAT16,
-        Layout::TILE);
+        tt::tt_metal::HostBuffer(std::vector<bfloat16>(shape.volume())), shape, DataType::BFLOAT16, Layout::TILE);
 
     /* Borrow Data from Numpy Start */
     // Create some
@@ -90,7 +86,7 @@ void test_raw_host_memory_pointer() {
     HostBuffer a_cpu_buffer(
         tt::stl::Span<bfloat16>(static_cast<bfloat16*>(a_np_array_data), a_np_array.size()),
         tt::tt_metal::MemoryPin([]() {}, []() {}));
-    Tensor a_cpu = Tensor(HostStorage{std::move(a_cpu_buffer)}, shape, DataType::BFLOAT16, Layout::TILE);
+    Tensor a_cpu = Tensor(std::move(a_cpu_buffer), shape, DataType::BFLOAT16, Layout::TILE);
     /* Borrow Data from Numpy End */
 
     /* Sanity Check Start */
@@ -138,7 +134,7 @@ void test_raw_host_memory_pointer() {
         tt::tt_metal::MemoryPin([]() {}, []() {}));
 
     Tensor alternative_tensor_for_printing =
-        Tensor(HostStorage{std::move(alternative_tensor_for_printing_buffer)}, shape, DataType::BFLOAT16, Layout::TILE);
+        Tensor(std::move(alternative_tensor_for_printing_buffer), shape, DataType::BFLOAT16, Layout::TILE);
     alternative_tensor_for_printing.print();
 
     for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(alternative_tensor_for_printing)) {
@@ -153,7 +149,7 @@ void test_raw_host_memory_pointer() {
     HostBuffer d_data_buffer(
         tt::stl::Span<bfloat16>(static_cast<bfloat16*>(d_np_array_data), d_np_array.size()),
         tt::tt_metal::MemoryPin([]() {}, []() {}));
-    Tensor d_cpu = Tensor(HostStorage{std::move(d_data_buffer)}, shape, DataType::BFLOAT16, Layout::TILE);
+    Tensor d_cpu = Tensor(std::move(d_data_buffer), shape, DataType::BFLOAT16, Layout::TILE);
 
     bfloat16 d_value = 8.0f;
     for (auto& element : tt::tt_metal::host_buffer::get_as<bfloat16>(d_cpu)) {

--- a/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/multi_thread/test_ccl_multi_cq_multi_device.cpp
@@ -124,7 +124,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
 
                 auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
-                Tensor input_tensor = Tensor(input_storage, input_shape, DataType::BFLOAT16, Layout::TILE);
+                Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
 
                 // Enqueue write_buffer to the read/write command queue and record the event
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), input_tensor, {host_data});
@@ -168,7 +168,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0) {
                 }
                 auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer};
-                Tensor dummy_tensor = Tensor(dummy_storage, input_shape, DataType::BFLOAT16, Layout::TILE);
+                Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{});
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), dummy_tensor, {dummy_data});
                 dispatch_ops_to_device(device, dummy_tensor, ttnn::QueueId(op_cq_id));
                 promise->set_value();
@@ -274,7 +274,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
                 auto input_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto input_storage = tt::tt_metal::DeviceStorage{input_buffer};
-                Tensor input_tensor = Tensor(input_storage, input_shape, DataType::BFLOAT16, Layout::TILE);
+                Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
 
                 // Enqueue write_buffer to the operation`s command queue and record the event
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), input_tensor, {host_data});
@@ -326,7 +326,7 @@ TEST_F(T3000MultiCQFabricMeshDeviceFixture, AsyncExecutionWorksCQ0CQ1) {
                 }
                 auto dummy_buffer = tt::tt_metal::tensor_impl::allocate_buffer_on_device(device, tensor_spec);
                 auto dummy_storage = tt::tt_metal::DeviceStorage{dummy_buffer};
-                Tensor dummy_tensor = Tensor(dummy_storage, input_shape, DataType::BFLOAT16, Layout::TILE);
+                Tensor dummy_tensor = Tensor(dummy_storage, tensor_spec, ReplicateTensor{});
                 ttnn::write_buffer(ttnn::QueueId(op_cq_id), dummy_tensor, {dummy_data});
                 dispatch_ops_to_device(device, dummy_tensor, ttnn::QueueId(op_cq_id));
                 promise->set_value();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_create_tensor.cpp
@@ -63,9 +63,9 @@ void run_create_tensor_test(tt::tt_metal::distributed::MeshDevice* device, const
     auto input_buffer = tt::tt_metal::tensor_impl::allocate_mesh_buffer_on_device(device, tensor_spec);
 
     auto input_storage = tt::tt_metal::DeviceStorage{
-        input_buffer, DistributedTensorConfig{}, {{tt::tt_metal::distributed::MeshCoordinate{0, 0}, tensor_spec}}};
+        input_buffer, ReplicateTensor{}, {{tt::tt_metal::distributed::MeshCoordinate{0, 0}, tensor_spec}}};
 
-    Tensor input_tensor = Tensor(input_storage, input_shape, dtype, Layout::TILE);
+    Tensor input_tensor = Tensor(input_storage, tensor_spec, ReplicateTensor{});
 
     ttnn::write_buffer(io_cq, input_tensor, {host_data});
 

--- a/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_vector_conversion.cpp
@@ -222,7 +222,7 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Roundtrip) {
         EXPECT_EQ(ctor_count, 1);
         EXPECT_EQ(dtor_count, 0);
         {
-            Tensor copy(tensor.get_storage(), tensor.get_tensor_spec());
+            Tensor copy(tensor.get_storage(), tensor.get_tensor_spec(), tensor.get_distributed_tensor_config());
             EXPECT_EQ(ctor_count, 2);
             EXPECT_EQ(dtor_count, 0);
         }
@@ -254,7 +254,7 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Callbacks) {
     EXPECT_EQ(ctor_count, 1);
     EXPECT_EQ(dtor_count, 0);
     {
-        Tensor copy(tensor.get_storage(), tensor.get_tensor_spec());
+        Tensor copy(tensor.get_storage(), tensor.get_tensor_spec(), tensor.get_distributed_tensor_config());
         EXPECT_EQ(ctor_count, 2);
         EXPECT_EQ(dtor_count, 0);
     }

--- a/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_multi_device.cpp
@@ -34,7 +34,7 @@ Tensor create_host_multi_device_tensor(const Tensor& tensor, const ReplicateTens
         specs.push_back(tensor.get_tensor_spec());
     }
 
-    return Tensor{MultiDeviceHostStorage(strategy, owned_buffers, specs), tensor.get_tensor_spec()};
+    return Tensor{MultiDeviceHostStorage(strategy, owned_buffers, specs), tensor.get_tensor_spec(), strategy};
 }
 
 TEST_F(GenericMeshDeviceFixture, TestGetTensorsFromMultiDeviceStorage) {
@@ -52,9 +52,8 @@ TEST_F(GenericMeshDeviceFixture, TestGetDistributedTensorConfigFromMultiDeviceSt
     const auto input_tensor = ttnn::ones(ttnn::Shape({32, 32}), DataType::BFLOAT16);
     const auto replicated_tensor =
         create_host_multi_device_tensor(input_tensor, ReplicateTensor(mesh_device_->num_devices()));
-    const auto distributed_tensor_config = get_distributed_tensor_config_from_tensor(replicated_tensor);
 
-    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(distributed_tensor_config));
+    EXPECT_TRUE(std::holds_alternative<ReplicateTensor>(replicated_tensor.get_distributed_tensor_config()));
 }
 
 }  // namespace ttnn::distributed::test

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -60,7 +60,7 @@ int main() {
     std::cout << "Creating a tensor with bfloat16 data type" << std::endl;
     // TTNN wants us to explicitly specify if the tensor owns the buffer or not. if not, we need to make dman sure that
     // the buffer is not deallocated before the tensor
-    auto buffer = tt::tt_metal::host_buffer::create(create_random_vector_of_bfloat16_native(
+    auto buffer = tt::tt_metal::HostBuffer(create_random_vector_of_bfloat16_native(
         // In number of bytes. so 2 bytes per bfloat16 element
         tensor_width * tensor_height * 2
         //  max = 2, offset = -1, seed = 42. Effectively, the range is [-1, 1]. I know, weird API
@@ -71,7 +71,7 @@ int main() {
     // Now we create a tensor with the buffer we just created
     auto x = tt::tt_metal::Tensor(
         // Let the tensor take ownership of the buffer
-        tt::tt_metal::HostStorage{std::move(buffer)},
+        std::move(buffer),
         // IMPORTANT: SHAPE MUST BE 4D ELSE EVERYTHING WILL BREAK during the PAD operation
         ttnn::Shape({1, 1, tensor_width, tensor_height}),
         // The data type of the tensor

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -348,7 +348,7 @@ Tensor convert_python_tensors_to_tt_tensors(
     auto distributed_tensor_config = get_distributed_tensor_config(strategy);
     auto storage = MultiDeviceHostStorage{distributed_tensor_config, std::move(host_owned_buffers), host_owned_specs};
 
-    auto output = Tensor(std::move(storage), tt_shards.at(0).get_tensor_spec());
+    auto output = Tensor(std::move(storage), tt_shards.at(0).get_tensor_spec(), distributed_tensor_config);
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
@@ -365,7 +365,7 @@ HostBuffer create_row_major_host_buffer(
         if (tensor_spec.layout() == Layout::TILE) {
             auto data = tensor_impl::convert_layout_tile_to_row_major(
                 tensor_spec.physical_shape(), tensor_spec.tile(), tt::stl::MakeConstSpan(host_buffer.view_as<T>()));
-            return host_buffer::create(std::move(data));
+            return HostBuffer(std::move(data));
         }
         return host_buffer;
     }
@@ -382,7 +382,7 @@ HostBuffer create_row_major_host_buffer(
     // See implementation for documentation
     auto logical_data = tensor_impl::decode_tensor_data(std::move(physical_data), tensor_spec);
 
-    return host_buffer::create(std::move(logical_data));
+    return HostBuffer(std::move(logical_data));
 }
 
 HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padded_output) {
@@ -419,7 +419,7 @@ HostBuffer get_host_buffer_from_tensor(const Tensor& tt_tensor, const bool padde
                                                      uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile)
                                                : unpack_bfp4_tiles_into_float_vec(
                                                      uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-                auto input_float_buffer = tt::tt_metal::host_buffer::create<float>(std::move(float_unpacked_data));
+                auto input_float_buffer = tt::tt_metal::HostBuffer(std::move(float_unpacked_data));
                 return create_row_major_host_buffer<float>(input_float_buffer, tensor_spec, padded_output);
             }
             default: {

--- a/ttnn/cpp/ttnn/distributed/api.cpp
+++ b/ttnn/cpp/ttnn/distributed/api.cpp
@@ -48,7 +48,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
         auto& host_storage = std::get<tt::tt_metal::MultiDeviceHostStorage>(tensor.get_storage());
         const Tile tile = tensor.get_tensor_spec().tile();
         for (int i = 0; i < host_storage.num_buffers(); ++i) {
-            tensors.push_back(Tensor{HostStorage{host_storage.get_buffer(i)}, host_storage.specs[i]});
+            tensors.push_back(Tensor{host_storage.get_buffer(i), host_storage.specs[i]});
         }
         return tensors;
     } else if (std::holds_alternative<tt::tt_metal::DeviceStorage>(tensor.get_storage())) {
@@ -58,7 +58,7 @@ std::vector<Tensor> get_device_tensors(const Tensor& tensor) {
             tensors.reserve(device_storage.specs.size());
             for (const auto& [coord, shard_spec] : device_storage.specs) {
                 DeviceStorage shard_storage(mesh_buffer, AllGatherTensor{}, {std::make_pair(coord, shard_spec)});
-                tensors.push_back(Tensor(std::move(shard_storage), shard_spec));
+                tensors.push_back(Tensor(std::move(shard_storage), shard_spec, AllGatherTensor{}));
             }
             return tensors;
         } else {
@@ -103,7 +103,7 @@ Tensor aggregate_as_tensor(
             }
         }
         auto storage = MultiDeviceHostStorage{config, std::move(host_owned_buffers), specs};
-        return Tensor(std::move(storage), reference_shard.get_tensor_spec());
+        return Tensor(std::move(storage), reference_shard.get_tensor_spec(), config);
     } else if (storage_type == StorageType::DEVICE) {
         auto mesh_buffer = std::get<DeviceStorage>(reference_shard.get_storage()).mesh_buffer;
         TT_FATAL(
@@ -127,7 +127,7 @@ Tensor aggregate_as_tensor(
         TT_FATAL(duplicate == specs.end(), "Found a tensor shard at duplicate coordiante {0}", duplicate->first);
 
         auto storage = DeviceStorage(mesh_buffer, AllGatherTensor{}, specs);
-        return Tensor(std::move(storage), reference_shard.get_tensor_spec());
+        return Tensor(std::move(storage), reference_shard.get_tensor_spec(), AllGatherTensor{});
     } else {
         TT_THROW(
             "Unsupported storage type for multi-device tensor: {}",
@@ -143,23 +143,6 @@ std::vector<int> get_t3k_physical_device_ids_ring() {
 
     auto physical_device_ids = instance.get_mapped_physical_device_ids(MeshShape(1, 8));
     return physical_device_ids;
-}
-
-DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor) {
-    if (tensor.storage_type() == StorageType::MULTI_DEVICE_HOST) {
-        const auto* multi_device_host_storage = std::get_if<MultiDeviceHostStorage>(&tensor.get_storage());
-        TT_ASSERT(
-            multi_device_host_storage != nullptr,
-            "Unexpected type {}",
-            tt::stl::get_active_type_name_in_variant(tensor.get_storage()));
-        return multi_device_host_storage->strategy;
-    } else if (tensor.storage_type() == StorageType::DEVICE) {
-        const auto& device_storage = std::get<DeviceStorage>(tensor.get_storage());
-        TT_FATAL(device_storage.mesh_buffer != nullptr, "Device storage must be on a mesh buffer");
-        return device_storage.strategy;
-    } else {
-        TT_THROW("Tensor is not a multi-device tensor");
-    }
 }
 
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/distributed/api.hpp
+++ b/ttnn/cpp/ttnn/distributed/api.hpp
@@ -33,7 +33,4 @@ Tensor aggregate_as_tensor(
 
 std::vector<int> get_t3k_physical_device_ids_ring();
 
-// Returns the distributed tensor config from a tensor.
-tt::tt_metal::DistributedTensorConfig get_distributed_tensor_config_from_tensor(const Tensor& tensor);
-
 }  // namespace ttnn::distributed

--- a/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
+++ b/ttnn/cpp/ttnn/distributed/distributed_tensor_config.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
 #include <unordered_map>
 #include <variant>
 

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/conv_transpose2d.cpp
@@ -66,18 +66,14 @@ Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor,
                 }
             }
         }
-        return Tensor(
-            tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(owned_buffer))},
-            output_shape,
-            dtype,
-            Layout::ROW_MAJOR);
+        return Tensor(tt::tt_metal::HostBuffer(std::move(owned_buffer)), output_shape, dtype, Layout::ROW_MAJOR);
     };
     auto convert_tensor = [&compute](const auto& conv_weight_tensor) {
         return std::visit(
             [&compute](auto&& storage) -> Tensor {
                 using StorageType = std::decay_t<decltype(storage)>;
                 if constexpr (std::is_same_v<StorageType, tt::tt_metal::HostStorage>) {
-                    return compute(tt::tt_metal::host_buffer::get_as<T>(storage.buffer));
+                    return compute(storage.buffer.template view_as<T>());
                 } else {
                     TT_THROW("Unsupported storage type");
                 }

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
@@ -88,27 +88,32 @@ Tensor create_tensor_from_span(
         case DataType::UINT16: {
             auto data = cast<uint16_t, T>(input_buffer);
             return Tensor(
-                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
+                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
+                .to_layout(input_layout);
         }
         case DataType::INT32: {
             auto data = cast<int32_t, T>(input_buffer);
             return Tensor(
-                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
+                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
+                .to_layout(input_layout);
         }
         case DataType::UINT32: {
             auto data = cast<uint32_t, T>(input_buffer);
             return Tensor(
-                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
+                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
+                .to_layout(input_layout);
         }
         case DataType::FLOAT32: {
             auto data = cast<float, T>(input_buffer);
             return Tensor(
-                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
+                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
+                .to_layout(input_layout);
         }
         case DataType::BFLOAT16: {
             auto data = cast<::bfloat16, T>(input_buffer);
             return Tensor(
-                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
+                       tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
+                .to_layout(input_layout);
         }
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {

--- a/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
+++ b/ttnn/cpp/ttnn/operations/core/to_dtype/to_dtype_op.hpp
@@ -32,7 +32,7 @@ inline Tensor convert_to_cpp_supported_dtype(const Tensor& input_tensor) {
 
     auto create_tensor = [&](tt::tt_metal::HostBuffer&& buffer, DataType dtype) -> Tensor {
         return Tensor(
-            tt::tt_metal::HostStorage{std::move(buffer)},
+            std::move(buffer),
             TensorSpec(
                 input_tensor.get_logical_shape(),
                 tt::tt_metal::TensorLayout::fromPaddedShape(
@@ -47,14 +47,12 @@ inline Tensor convert_to_cpp_supported_dtype(const Tensor& input_tensor) {
         tt::stl::Span<const uint32_t> uint32_data = tt::tt_metal::host_buffer::get_as<uint32_t>(buffer);
         auto float_unpacked_data =
             unpack_bfp8_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false);
-        return create_tensor(
-            tt::tt_metal::host_buffer::create<float>(std::move(float_unpacked_data)), DataType::FLOAT32);
+        return create_tensor(tt::tt_metal::HostBuffer(std::move(float_unpacked_data)), DataType::FLOAT32);
     } else if (input_dtype == DataType::BFLOAT4_B) {
         tt::stl::Span<const uint32_t> uint32_data = tt::tt_metal::host_buffer::get_as<uint32_t>(buffer);
         auto float_unpacked_data =
             unpack_bfp4_tiles_into_float_vec(uint32_data, /*row_major_output=*/false, /*is_exp_a=*/false);
-        return create_tensor(
-            tt::tt_metal::host_buffer::create<float>(std::move(float_unpacked_data)), DataType::FLOAT32);
+        return create_tensor(tt::tt_metal::HostBuffer(std::move(float_unpacked_data)), DataType::FLOAT32);
     } else {
         return input_tensor;
     }
@@ -80,19 +78,6 @@ std::vector<NewT> cast(tt::stl::Span<const OldT> input_buffer) {
 }
 
 template <typename T>
-Tensor create_owned_tensor(
-    std::vector<T>&& data, const Shape& logical_shape, const Shape& padded_shape, DataType data_type, Layout layout) {
-    auto buffer = tt::tt_metal::host_buffer::create(std::move(data));
-    auto storage = tt::tt_metal::HostStorage{std::move(buffer)};
-    return Tensor(
-        std::move(storage),
-        TensorSpec(
-            logical_shape,
-            tt::tt_metal::TensorLayout::fromPaddedShape(
-                data_type, tt::tt_metal::PageConfig(layout), MemoryConfig{}, logical_shape, padded_shape)));
-}
-
-template <typename T>
 Tensor create_tensor_from_span(
     tt::stl::Span<const T> input_buffer,
     const Shape& logical_shape,
@@ -102,48 +87,42 @@ Tensor create_tensor_from_span(
     switch (dtype) {
         case DataType::UINT16: {
             auto data = cast<uint16_t, T>(input_buffer);
-            return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
+            return Tensor(
+                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
         }
         case DataType::INT32: {
             auto data = cast<int32_t, T>(input_buffer);
-            return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
+            return Tensor(
+                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
         }
         case DataType::UINT32: {
             auto data = cast<uint32_t, T>(input_buffer);
-            return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
+            return Tensor(
+                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
         }
         case DataType::FLOAT32: {
             auto data = cast<float, T>(input_buffer);
-            return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
+            return Tensor(
+                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
         }
         case DataType::BFLOAT16: {
             auto data = cast<::bfloat16, T>(input_buffer);
-            return create_owned_tensor(std::move(data), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR)
-                .to_layout(input_layout);
+            return Tensor(
+                tt::tt_metal::HostBuffer(std::move(data)), logical_shape, padded_shape, dtype, Layout::ROW_MAJOR);
         }
         case DataType::BFLOAT8_B:
         case DataType::BFLOAT4_B: {
             auto data = cast<float, T>(input_buffer);
-            auto buffer = tt::tt_metal::host_buffer::create<float>(std::move(data));
-            auto tensor = Tensor(
-                              tt::tt_metal::HostStorage{std::move(buffer)},
-                              logical_shape,
-                              padded_shape,
-                              DataType::FLOAT32,
-                              Layout::ROW_MAJOR)
+            auto buffer = tt::tt_metal::HostBuffer(std::move(data));
+            auto tensor = Tensor(std::move(buffer), logical_shape, padded_shape, DataType::FLOAT32, Layout::ROW_MAJOR)
                               .to_layout(Layout::TILE);
             tt::stl::Span<const float> output_float_data = tt::tt_metal::host_buffer::get_as<float>(tensor);
             auto output_packed_data =
                 dtype == DataType::BFLOAT8_B
                     ? pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false)
                     : pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false);
-            auto output_buffer = tt::tt_metal::host_buffer::create<uint32_t>(std::move(output_packed_data));
             return Tensor(
-                tt::tt_metal::HostStorage{std::move(output_buffer)},
+                tt::tt_metal::HostBuffer(std::move(output_packed_data)),
                 logical_shape,
                 padded_shape,
                 dtype,

--- a/ttnn/cpp/ttnn/operations/creation.hpp
+++ b/ttnn/cpp/ttnn/operations/creation.hpp
@@ -64,7 +64,7 @@ Tensor arange_impl(
     }
 
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(owned_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(owned_buffer)),
                       ttnn::Shape{static_cast<uint32_t>(size)},
                       data_type,
                       Layout::ROW_MAJOR)
@@ -89,11 +89,7 @@ Tensor full_impl(
     auto owned_buffer = std::vector<T>(tensor_spec.physical_shape().height() * tensor_spec.physical_shape().width());
     std::fill(std::begin(owned_buffer), std::end(owned_buffer), value);
 
-    Tensor host_tensor(
-        tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(owned_buffer))},
-        shape,
-        data_type,
-        layout);
+    Tensor host_tensor(tt::tt_metal::HostBuffer(std::move(owned_buffer)), shape, data_type, layout);
 
     if (optional_output_tensor.has_value()) {
         tt::tt_metal::write_tensor(host_tensor, *optional_output_tensor, queue_id);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_program_factory.cpp
@@ -40,10 +40,10 @@ operation::ProgramWithCallbacks pad_rm_reader_writer(
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
     uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * a.element_size();
     auto pad_value_const_buffer =
-        tt::tt_metal::host_buffer::create(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
+        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
     const Tensor pad_value_const_tensor =
         Tensor(
-            tt::tt_metal::HostStorage{pad_value_const_buffer},
+            std::move(pad_value_const_buffer),
             ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
             DataType::BFLOAT16,
             Layout::ROW_MAJOR)
@@ -467,12 +467,12 @@ operation::ProgramWithCallbacks pad_rm_reader_writer_multi_core(
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
     uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * a.element_size();
     auto pad_value_const_buffer =
-        tt::tt_metal::host_buffer::create(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
+        tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
     // NOTE: The const buffer is always in L1
     // TODO: make a local buffer for each core?
     const Tensor pad_value_const_tensor =
         Tensor(
-            tt::tt_metal::HostStorage{pad_value_const_buffer},
+            std::move(pad_value_const_buffer),
             ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
             DataType::BFLOAT16,
             Layout::ROW_MAJOR)

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -34,7 +34,7 @@ static Tensor manual_insertion(
     auto host_buffer = tt::tt_metal::host_buffer::get_host_buffer(cpu_tensor);
     auto output =
         Tensor(
-            tt::tt_metal::HostStorage{std::move(host_buffer)},
+            std::move(host_buffer),
             TensorSpec(
                 logical_shape,
                 TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reshape/view.cpp
@@ -60,7 +60,7 @@ Tensor tensor_reshape(
                             new_padded_shape));
                     updated_storage.specs[i] = spec;
                 }
-                return Tensor(updated_storage, new_spec);
+                return Tensor(updated_storage, new_spec, tensor.get_distributed_tensor_config());
             }
             if constexpr (std::is_same_v<T, tt::tt_metal::DeviceStorage>) {
                 auto device_storage = std::get<tt::tt_metal::DeviceStorage>(tensor.get_storage());
@@ -71,7 +71,7 @@ Tensor tensor_reshape(
                         auto page_size_bytes = tensor_spec.compute_page_size_bytes();
                         device_buffer->set_page_size(page_size_bytes);
                         device_storage.update_specs(new_spec);
-                        return Tensor(std::move(device_storage), new_spec);
+                        return Tensor(std::move(device_storage), new_spec, tensor.get_distributed_tensor_config());
                     } else {
                         auto device_buffer = device_storage.get_buffer();
                         tt::tt_metal::ShardSpecBuffer shard_spec_buffer = device_buffer->shard_spec();
@@ -112,14 +112,14 @@ Tensor tensor_reshape(
                         device_buffer->set_page_size(page_size_bytes);
 
                         device_storage.update_specs(upd_spec);
-                        return Tensor(std::move(device_storage), upd_spec);
+                        return Tensor(std::move(device_storage), upd_spec, tensor.get_distributed_tensor_config());
                     }
                 } else {
                     device_storage.update_specs(new_spec);
-                    return Tensor(std::move(device_storage), new_spec);
+                    return Tensor(std::move(device_storage), new_spec, tensor.get_distributed_tensor_config());
                 }
             } else {
-                return Tensor(tensor.get_storage(), new_spec);
+                return Tensor(tensor.get_storage(), new_spec, tensor.get_distributed_tensor_config());
             }
         },
         input_tensor.get_storage());

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -64,7 +64,7 @@ static Tensor index_trilu(
         index += offset;
     }
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -105,7 +105,7 @@ static Tensor index_width(
         }  // dim c
     }  // dim N
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -146,7 +146,7 @@ static Tensor index_height(
         }  // dim C
     }  // dim N
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -186,7 +186,7 @@ static Tensor index_all(
         }  // dim C
     }  // dim N
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -226,11 +226,7 @@ static Tensor mask_padded_input(
             }  // dim H
         }  // dim C
     }  // dim N
-    auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
-                      padded_shape,
-                      data_type,
-                      Layout::ROW_MAJOR)
+    auto output = Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), padded_shape, data_type, Layout::ROW_MAJOR)
                       .to_layout(layout);
     if (device != nullptr) {
         output = output.to_device(device, output_mem_config);
@@ -254,7 +250,7 @@ static Tensor fill_first_val_into_tensor(
         output_buffer[i] = host_buffer[0];
     }
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           input_tensor.get_logical_shape(),
                           TensorLayout::fromPaddedShape(
@@ -289,7 +285,7 @@ static Tensor prod_result_computation_WH_B0(
     }
     output_buffer[0] = result;
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           ttnn::Shape({}),
                           TensorLayout::fromPaddedShape(
@@ -335,7 +331,7 @@ static Tensor index_channel(
         value = 0;
     }  // dim N
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -375,7 +371,7 @@ static Tensor index_batch(
         value = value + 1;
     }  // dim N
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))},
+                      tt::tt_metal::HostBuffer(std::move(output_buffer)),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -402,7 +398,7 @@ static Tensor manual_insertion(
         "Required shape volume must match old shape volume");
     auto input_cpu_tensor = input_tensor.cpu();
     auto output = Tensor(
-                      tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::get_host_buffer(input_cpu_tensor)},
+                      tt::tt_metal::host_buffer::get_host_buffer(input_cpu_tensor),
                       TensorSpec(
                           logical_shape,
                           TensorLayout::fromPaddedShape(
@@ -469,8 +465,7 @@ static Tensor uniform(T low, T high, const ttnn::Shape& shape, const Layout layo
         }
     }
 
-    return Tensor(tt::tt_metal::HostStorage{tt::tt_metal::host_buffer::create(std::move(output_buffer))}, spec)
-        .to_layout(layout);
+    return Tensor(tt::tt_metal::HostBuffer(std::move(output_buffer)), spec).to_layout(layout);
 }
 
 static Tensor random(

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_program_factory_multicore.cpp
@@ -142,8 +142,8 @@ static Tensor create_config_tensor(
         elems_per_core);
 
     ttnn::Shape config_shape({tt::div_up(config_vector.size(), elems_per_core), elems_per_core});
-    auto config_buffer = host_buffer::create<uint16_t>(std::move(config_vector));
-    return Tensor(HostStorage{std::move(config_buffer)}, config_shape, DataType::UINT16, Layout::ROW_MAJOR);
+    auto config_buffer = HostBuffer(std::move(config_vector));
+    return Tensor(std::move(config_buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
 }
 
 operation::ProgramWithCallbacks upsample_multi_core(

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -1185,9 +1185,9 @@ Tensor construct_on_host_config_tensor(
     const auto factor = get_repeat_factor_for_replicating_nhw_config_across_grid(p_config);
     auto repeat_config = replicate_config(config_vector, factor);
 
-    auto config_buffer = tt::tt_metal::host_buffer::create<uint16_t>(std::move(repeat_config));
+    auto config_buffer = tt::tt_metal::HostBuffer(std::move(repeat_config));
     config_shape = ttnn::Shape({config_shape[0] * factor, config_shape[1]});
-    return Tensor(tt::tt_metal::HostStorage{config_buffer}, config_shape, DataType::UINT16, Layout::ROW_MAJOR);
+    return Tensor(std::move(config_buffer), config_shape, DataType::UINT16, Layout::ROW_MAJOR);
 }
 
 Tensor move_config_tensor_to_device(

--- a/ttnn/cpp/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/cpp/ttnn/tensor/host_buffer/functions.hpp
@@ -4,13 +4,9 @@
 
 #pragma once
 
-#include <cstddef>
-#include <vector>
-
 #include <tt_stl/overloaded.hpp>
 #include <tt_stl/reflection.hpp>
 
-#include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace tt::tt_metal {
@@ -39,26 +35,7 @@ void validate_datatype(const Tensor& tensor) {
     }
 }
 
-// TODO: these helpers should not be needed. Migrate the code to work with `HostBuffer` directly.
-template <typename T>
-HostBuffer create(std::vector<T>&& data) {
-    return HostBuffer(std::move(data));
-}
-
-template <typename T>
-HostBuffer create(const std::vector<T>& data) {
-    return HostBuffer(data);
-}
-
-template <typename T>
-HostBuffer create(tt::stl::Span<const T> data) {
-    return HostBuffer(std::vector<T>(data.begin(), data.end()));
-}
-
-template <typename T>
-HostBuffer create(tt::stl::Span<T> data) {
-    return HostBuffer(std::vector<T>(data.begin(), data.end()));
-}
+HostBuffer get_host_buffer(const Tensor& tensor);
 
 template <typename T>
 tt::stl::Span<const T> get_as(const HostBuffer& buffer) {
@@ -69,8 +46,6 @@ template <typename T>
 tt::stl::Span<T> get_as(HostBuffer& buffer) {
     return buffer.view_as<T>();
 }
-
-HostBuffer get_host_buffer(const Tensor& tensor);
 
 template <typename T>
 tt::stl::Span<const T> get_as(const Tensor& tensor) {

--- a/ttnn/cpp/ttnn/tensor/serialization.cpp
+++ b/ttnn/cpp/ttnn/tensor/serialization.cpp
@@ -140,7 +140,7 @@ HostStorage load_host_storage(FILE* input_file) {
     safe_fread(&size, sizeof(size), 1, input_file);
     std::vector<T> data(size);
     safe_fread(data.data(), sizeof(T) * size, 1, input_file);
-    auto buffer = host_buffer::create<T>(std::move(data));
+    auto buffer = HostBuffer(std::move(data));
     return {buffer};
 }
 
@@ -159,7 +159,7 @@ MultiDeviceHostStorage load_multi_device_host_storage(
         safe_fread(&size, sizeof(size), 1, input_file);
         std::vector<T> data(size);
         safe_fread(data.data(), sizeof(T) * size, 1, input_file);
-        HostBuffer buffer = host_buffer::create<T>(std::move(data));
+        HostBuffer buffer = HostBuffer(std::move(data));
         buffers.push_back(std::move(buffer));
         auto spec = load_tensor_spec(input_file);
         specs.push_back(spec);
@@ -176,7 +176,7 @@ MultiDeviceHostStorage load_multi_device_host_storage(
             safe_fread(&size, sizeof(size), 1, input_file);
             std::vector<T> data(size);
             safe_fread(data.data(), sizeof(T) * size, 1, input_file);
-            auto buffer = host_buffer::create<T>(std::move(data));
+            auto buffer = HostBuffer(std::move(data));
             buffers.push_back(std::move(buffer));
         }
         for (std::size_t i = 0; i < num_buffers; ++i) {
@@ -230,14 +230,23 @@ MultiDeviceHostStorage load_multi_device_host_storage(
     }
 }
 
+// Helper type to bundle storage and strategy together.
+struct DistributedStorage {
+    Storage storage;
+    DistributedTensorConfig strategy;
+};
+
 template <typename T>
-Storage load_storage(FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, T device) {
+DistributedStorage load_storage(
+    FILE* input_file, DataType data_type, Layout layout, StorageType storage_type, T device) {
     if (storage_type == StorageType::MULTI_DEVICE_HOST or storage_type == StorageType::DEVICE) {
         if constexpr (std::is_same_v<T, MeshDevice*>) {
-            return load_multi_device_host_storage(input_file, data_type, layout, device);
+            auto multi_device_storage = load_multi_device_host_storage(input_file, data_type, layout, device);
+            const auto strategy = multi_device_storage.strategy;
+            return DistributedStorage{std::move(multi_device_storage), strategy};
         }
     }
-    return load_host_storage(input_file, data_type);
+    return DistributedStorage{load_host_storage(input_file, data_type), ReplicateTensor{}};
 }
 
 template <typename T>
@@ -263,7 +272,7 @@ Tensor load_tensor_helper(const std::string& file_name, T device) {
     StorageType storage_type = StorageType::HOST;
     safe_fread(&storage_type, sizeof(storage_type), 1, input_file);
     auto storage = load_storage(input_file, spec.data_type(), spec.layout(), storage_type, device);
-    Tensor tensor(std::move(storage), spec);
+    Tensor tensor(std::move(storage.storage), spec, storage.strategy);
     if (device != nullptr) {
         tensor = tensor.to_device(device, spec.memory_config());
     }

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -821,4 +821,8 @@ const MemoryConfig& Tensor::memory_config() const { return get_tensor_spec().ten
 
 const std::optional<ShardSpec>& Tensor::shard_spec() const { return this->memory_config().shard_spec(); }
 
+const DistributedTensorConfig& Tensor::distributed_tensor_config() const {
+    return this->tensor_attributes->get_distributed_tensor_config();
+}
+
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -21,6 +21,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/tensor/tensor_impl.hpp"
 #include "ttnn/tensor/tensor_impl_wrapper.hpp"
+#include "ttnn/tensor/host_buffer/host_buffer.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/types.hpp"
 #include <tt-metalium/constants.hpp>
@@ -43,7 +44,7 @@ Tensor create_owned_tensor_from_row_major_data(
     std::vector<T>&& data, const TensorSpec& spec, distributed::MeshDevice* device, ttnn::QueueId cq_id) {
     auto physical_data = tensor_impl::encode_tensor_data(std::move(data), spec);
 
-    Tensor output(HostStorage(host_buffer::create(std::move(physical_data))), spec);
+    Tensor output(HostBuffer(std::move(physical_data)), spec);
 
     if (device != nullptr) {
         output = output.to_device(device, spec.memory_config(), cq_id);
@@ -55,7 +56,11 @@ Tensor create_owned_tensor_from_row_major_data(
 }  // namespace
 
 Tensor::Tensor(
-    Storage storage,
+    HostBuffer buffer, const ttnn::Shape& shape, DataType dtype, Layout layout, const std::optional<Tile>& tile) :
+    Tensor(std::move(buffer), /* logical_shape */ shape, /* padded_shape */ shape, dtype, layout, tile) {}
+
+Tensor::Tensor(
+    HostBuffer buffer,
     const ttnn::Shape& logical_shape,
     const ttnn::Shape& padded_shape,
     DataType dtype,
@@ -70,24 +75,25 @@ Tensor::Tensor(
             tile->get_tile_shape());
     }
 
-    const auto memory_config = std::visit(
-        tt::stl::overloaded{
-            [](const DeviceStorage& s) { return s.memory_config(); },
-            []<typename Other>(const Other&) { return MemoryConfig{}; }},
-        storage);
-
     init(
-        std::move(storage),
+        Storage(std::move(buffer)),
         TensorSpec(
             logical_shape,
             TensorLayout::fromPaddedShape(
-                dtype, PageConfig(layout, tile), memory_config, logical_shape, padded_shape)));
+                dtype, PageConfig(layout, tile), MemoryConfig{}, logical_shape, padded_shape)),
+        ReplicateTensor{});
 }
 
-Tensor::Tensor(Storage storage, TensorSpec tensor_spec) { init(std::move(storage), std::move(tensor_spec)); }
+Tensor::Tensor(HostBuffer storage, TensorSpec tensor_spec) :
+    Tensor(Storage(std::move(storage)), std::move(tensor_spec), ReplicateTensor{}) {}
 
-void Tensor::init(Storage storage, TensorSpec tensor_spec) {
-    tensor_attributes = std::make_shared<TensorAttributes>(std::move(storage), std::move(tensor_spec));
+Tensor::Tensor(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) {
+    init(Storage(std::move(storage)), std::move(tensor_spec), std::move(distributed_tensor_config));
+}
+
+void Tensor::init(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) {
+    tensor_attributes = std::make_shared<TensorAttributes>(
+        std::move(storage), std::move(tensor_spec), std::move(distributed_tensor_config));
 
     ZoneScoped;
     std::visit(
@@ -132,10 +138,6 @@ Tensor::~Tensor() {
     ZoneScoped;
     this->deallocate_impl(/*force=*/false);
 }
-
-Tensor::Tensor(
-    Storage storage, const ttnn::Shape& shape, DataType dtype, Layout layout, const std::optional<Tile>& tile) :
-    Tensor(std::move(storage), /* logical_shape */ shape, /* padded_shape */ shape, dtype, layout, tile) {}
 
 void Tensor::deallocate(bool force) { deallocate_impl(force); }
 
@@ -201,7 +203,6 @@ std::vector<IDevice*> Tensor::get_workers(bool blocking) const {
     return workers;
 }
 
-// Getters - Spin until tensor is populated before querying tensor metadata
 DataType Tensor::get_dtype() const { return dtype(); }
 Layout Tensor::get_layout() const { return layout(); }
 
@@ -214,6 +215,10 @@ const ttnn::Shape& Tensor::get_padded_shape() const { return padded_shape(); }
 const Storage& Tensor::get_storage() const { return this->tensor_attributes->get_storage(); }
 
 Storage& Tensor::get_storage() { return this->tensor_attributes->get_storage(); }
+
+const DistributedTensorConfig& Tensor::get_distributed_tensor_config() const {
+    return this->tensor_attributes->get_distributed_tensor_config();
+}
 
 template <>
 Tensor Tensor::from_span<float>(
@@ -245,7 +250,7 @@ Tensor Tensor::from_span<float>(
                     ? pack_fp32_vec_as_bfp8_tiles(physical_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile)
                     : pack_fp32_vec_as_bfp4_tiles(physical_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
 
-            Tensor tensor(HostStorage(host_buffer::create(std::move(packed_block_floats))), spec);
+            Tensor tensor(HostBuffer(std::move(packed_block_floats)), spec);
             if (device != nullptr) {
                 tensor = tensor.to_device(device, spec.memory_config(), cq_id);
             }
@@ -282,7 +287,7 @@ Tensor Tensor::from_borrowed_data(
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
     HostBuffer data_buffer(buffer, MemoryPin(on_creation_callback, on_destruction_callback));
-    return Tensor(HostStorage(std::move(data_buffer)), shape, convert_to_data_type<T>(), Layout::ROW_MAJOR, tile);
+    return Tensor(std::move(data_buffer), shape, convert_to_data_type<T>(), Layout::ROW_MAJOR, tile);
 }
 
 template <>
@@ -533,7 +538,7 @@ Tensor create_device_tensor(const TensorSpec& tensor_spec, IDevice* device) {
         output = allocate_tensor_on_mesh(tensor_spec, mesh_device);
     } else {
         auto device_buffer = tensor_impl::allocate_buffer_on_device(device, tensor_spec);
-        output = Tensor(DeviceStorage{device_buffer}, tensor_spec);
+        output = Tensor(DeviceStorage{device_buffer}, tensor_spec, ReplicateTensor{});
     }
     output = tt::tt_metal::set_tensor_id(output);
 
@@ -692,7 +697,7 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
         specs.push_back(std::make_pair(coord, tensor_spec));
     }
     DeviceStorage device_storage(std::move(mesh_buffer), ReplicateTensor(), std::move(specs));
-    return Tensor(std::move(device_storage), tensor_spec);
+    return Tensor(std::move(device_storage), tensor_spec, ReplicateTensor{});
 }
 
 void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id) {

--- a/ttnn/cpp/ttnn/tensor/tensor_attributes.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_attributes.cpp
@@ -3,20 +3,67 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <utility>
+#include <variant>
 
+#include "ttnn/distributed/distributed_tensor_config.hpp"
+#include "ttnn/tensor/host_buffer/host_buffer.hpp"
 #include "ttnn/tensor/storage.hpp"
 #include "ttnn/tensor/tensor_attributes.hpp"
 #include "ttnn/tensor/tensor_spec.hpp"
 
 namespace tt::tt_metal {
 
-TensorAttributes::TensorAttributes(TensorSpec tensor_spec) : tensor_spec_(std::move(tensor_spec)) {}
-
-TensorAttributes::TensorAttributes(Storage storage, TensorSpec tensor_spec) :
-    storage_(std::move(storage)), tensor_spec_(std::move(tensor_spec)) {}
+TensorAttributes::TensorAttributes(
+    Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config) :
+    storage_(std::move(storage)),
+    tensor_spec_(std::move(tensor_spec)),
+    distributed_tensor_config_(std::move(distributed_tensor_config)) {
+    if (std::holds_alternative<HostStorage>(storage_)) {
+        TT_FATAL(
+            std::holds_alternative<ReplicateTensor>(distributed_tensor_config_),
+            "Host storage is a single shard that must be in replicated configuration.");
+    }
+}
 
 const Storage& TensorAttributes::get_storage() const { return storage_; }
-const TensorSpec& TensorAttributes::get_tensor_spec() const { return tensor_spec_; }
 Storage& TensorAttributes::get_storage() { return storage_; }
+const TensorSpec& TensorAttributes::get_tensor_spec() const { return tensor_spec_; }
+const DistributedTensorConfig& TensorAttributes::get_distributed_tensor_config() const {
+    return distributed_tensor_config_;
+}
+
+std::vector<distributed::MeshCoordinate> TensorAttributes::determine_distribution(
+    const distributed::MeshShape& mesh_shape) const {
+    const auto coord_range = [this, &mesh_shape]() {
+        if (auto* shard2d_strategy = std::get_if<ShardTensor2D>(&distributed_tensor_config_)) {
+            distributed::MeshShape distribution_shape(shard2d_strategy->shard_mesh.y, shard2d_strategy->shard_mesh.x);
+            return distributed::MeshCoordinateRange(distribution_shape);
+        } else {
+            return distributed::MeshCoordinateRange(mesh_shape);
+        }
+    }();
+
+    const int num_shards = std::visit(
+        tt::stl::overloaded{
+            [&mesh_shape](const HostStorage&) { return mesh_shape.mesh_size(); },
+            [&mesh_shape](const DeviceStorage& s) { return s.specs.size(); },
+            [&mesh_shape](const MultiDeviceHostStorage& s) { return s.buffers.size(); },
+        },
+        storage_);
+
+    TT_FATAL(
+        num_shards <= mesh_shape.mesh_size(),
+        "Number of shards {} exceeds the mesh size {}",
+        num_shards,
+        mesh_shape.mesh_size());
+
+    std::vector<distributed::MeshCoordinate> coords;
+    coords.reserve(num_shards);
+    auto coord_it = coord_range.begin();
+    for (int i = 0; i < num_shards; ++coord_it, ++i) {
+        coords.push_back(*coord_it);
+    }
+    return coords;
+}
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/tensor_attributes.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_attributes.hpp
@@ -13,17 +13,21 @@ namespace tt::tt_metal {
 
 class TensorAttributes : public std::enable_shared_from_this<TensorAttributes> {
 public:
-    explicit TensorAttributes(TensorSpec tensor_spec);
-    TensorAttributes(Storage storage, TensorSpec tensor_spec);
+    TensorAttributes(Storage storage, TensorSpec tensor_spec, DistributedTensorConfig distributed_tensor_config);
 
     // Getters and setters.
     const Storage& get_storage() const;
-    const TensorSpec& get_tensor_spec() const;
     Storage& get_storage();
+    const TensorSpec& get_tensor_spec() const;
+    const DistributedTensorConfig& get_distributed_tensor_config() const;
+
+    // Determines mesh coordinates for the tensor based on the strategy and the mesh shape.
+    std::vector<distributed::MeshCoordinate> determine_distribution(const distributed::MeshShape& mesh_shape) const;
 
 private:
     Storage storage_;
     TensorSpec tensor_spec_;
+    DistributedTensorConfig distributed_tensor_config_;
 };
 
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -110,9 +110,9 @@ Tensor pad_bfloat8_b(
     auto input_float_data =
         unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
 
-    auto input_float_buffer = host_buffer::create<float>(std::move(input_float_data));
+    auto input_float_buffer = HostBuffer(std::move(input_float_data));
     auto float_tensor = Tensor(
-                            HostStorage{std::move(input_float_buffer)},
+                            std::move(input_float_buffer),
                             TensorSpec(
                                 tensor.get_logical_shape(),
                                 TensorLayout::fromPaddedShape(
@@ -127,7 +127,7 @@ Tensor pad_bfloat8_b(
     auto output_float_data = host_buffer::get_as<float>(float_tensor);
     auto output_packed_data =
         pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
-    auto output_uint32_buffer = host_buffer::create<uint32_t>(std::move(output_packed_data));
+    auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     TensorSpec output_spec(
         float_tensor.logical_shape(),
         TensorLayout::fromPaddedShape(
@@ -136,7 +136,7 @@ Tensor pad_bfloat8_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return Tensor(HostStorage{std::move(output_uint32_buffer)}, output_spec);
+    return Tensor(std::move(output_uint32_buffer), output_spec);
 }
 
 Tensor unpad_bfloat8_b(
@@ -148,9 +148,9 @@ Tensor unpad_bfloat8_b(
     auto input_packed_data = host_buffer::get_as<uint32_t>(tensor);
     auto input_float_data =
         unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-    auto input_float_buffer = host_buffer::create<float>(std::move(input_float_data));
+    auto input_float_buffer = HostBuffer(std::move(input_float_data));
     auto float_tensor = Tensor(
-                            HostStorage{std::move(input_float_buffer)},
+                            std::move(input_float_buffer),
                             TensorSpec(
                                 tensor.get_logical_shape(),
                                 TensorLayout::fromPaddedShape(
@@ -165,9 +165,9 @@ Tensor unpad_bfloat8_b(
     auto output_float_data = host_buffer::get_as<float>(float_tensor);
     auto output_packed_data =
         pack_fp32_vec_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
-    auto output_uint32_buffer = host_buffer::create<uint32_t>(std::move(output_packed_data));
+    auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     return Tensor(
-        HostStorage{std::move(output_uint32_buffer)},
+        std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.get_logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -190,9 +190,9 @@ Tensor pad_bfloat4_b(
     auto input_packed_data = host_buffer::get_as<uint32_t>(tensor);
     auto input_float_data =
         unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-    auto input_float_buffer = host_buffer::create<float>(std::move(input_float_data));
+    auto input_float_buffer = HostBuffer(std::move(input_float_data));
     auto float_tensor = Tensor(
-                            HostStorage{std::move(input_float_buffer)},
+                            std::move(input_float_buffer),
                             TensorSpec(
                                 tensor.get_logical_shape(),
                                 TensorLayout::fromPaddedShape(
@@ -207,7 +207,7 @@ Tensor pad_bfloat4_b(
     auto output_float_data = host_buffer::get_as<float>(float_tensor);
     auto output_packed_data =
         pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
-    auto output_uint32_buffer = host_buffer::create<uint32_t>(std::move(output_packed_data));
+    auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     TensorSpec output_spec(
         float_tensor.logical_shape(),
         TensorLayout::fromPaddedShape(
@@ -216,7 +216,7 @@ Tensor pad_bfloat4_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return Tensor(HostStorage{std::move(output_uint32_buffer)}, output_spec);
+    return Tensor(std::move(output_uint32_buffer), output_spec);
 }
 
 Tensor unpad_bfloat4_b(
@@ -228,9 +228,9 @@ Tensor unpad_bfloat4_b(
     auto input_packed_data = host_buffer::get_as<uint32_t>(tensor);
     auto input_float_data =
         unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-    auto input_float_buffer = host_buffer::create<float>(std::move(input_float_data));
+    auto input_float_buffer = HostBuffer(std::move(input_float_data));
     auto float_tensor = Tensor(
-                            HostStorage{std::move(input_float_buffer)},
+                            std::move(input_float_buffer),
                             TensorSpec(
                                 tensor.get_logical_shape(),
                                 TensorLayout::fromPaddedShape(
@@ -245,9 +245,9 @@ Tensor unpad_bfloat4_b(
     auto output_float_data = host_buffer::get_as<float>(float_tensor);
     auto output_packed_data =
         pack_fp32_vec_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
-    auto output_uint32_buffer = host_buffer::create<uint32_t>(std::move(output_packed_data));
+    auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     return Tensor(
-        HostStorage{std::move(output_uint32_buffer)},
+        std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.get_logical_shape(),
             TensorLayout::fromPaddedShape(
@@ -515,8 +515,8 @@ Tensor to_host_helper(const Tensor& tensor, bool blocking = true, ttnn::QueueId 
     } else {
         read_data_from_device_buffer<T>(*device_buffer, data_vec);
     }
-    auto output_buffer = host_buffer::create<T>(std::move(data_vec));
-    return Tensor(HostStorage{std::move(output_buffer)}, tensor.get_tensor_spec());
+    auto output_buffer = HostBuffer(std::move(data_vec));
+    return Tensor(std::move(output_buffer), tensor.get_tensor_spec());
 }
 
 template <typename T>
@@ -571,7 +571,7 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq
             std::vector<T> host_buffer(tensor_size_bytes / sizeof(T));
             {
                 // Track the buffer index, since the order of shards matters
-                buffers[shard_idx] = host_buffer::create<T>(std::move(host_buffer));
+                buffers[shard_idx] = HostBuffer(std::move(host_buffer));
             }
         });
         // Populate tensor specs in storage and initialize the shard_data_transfers
@@ -591,7 +591,7 @@ Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq
     mesh_cq.enqueue_read_shards(shard_data_transfers, mesh_buffer, blocking);
 
     MultiDeviceHostStorage host_storage(storage.strategy, std::move(buffers), std::move(specs));
-    return Tensor(std::move(host_storage), tensor.get_tensor_spec());
+    return Tensor(std::move(host_storage), tensor.get_tensor_spec(), tensor.get_distributed_tensor_config());
 }
 
 template Tensor to_host_mesh_tensor<bfloat16>(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id);
@@ -692,7 +692,7 @@ Tensor to_device(const Tensor& tensor, IDevice* target_device, const MemoryConfi
     TensorSpec tensor_spec(
         tensor.get_logical_shape(), tensor.get_tensor_spec().tensor_layout().with_memory_config(memory_config));
     auto device_buffer = tensor_impl::to_device_buffer<T>(tensor.get_storage(), target_device, tensor_spec, cq_id);
-    return Tensor(DeviceStorage{device_buffer}, tensor_spec);
+    return Tensor(DeviceStorage{device_buffer}, tensor_spec, tensor.get_distributed_tensor_config());
 }
 
 template Tensor to_device<bfloat16>(
@@ -753,37 +753,28 @@ DeviceStorage shard_to_mesh_buffer(
     distributed::MeshDevice* mesh_device,
     const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
     const TensorSpec& tensor_spec,
+    const std::vector<distributed::MeshCoordinate>& coords,
     ttnn::QueueId cq_id) {
     const auto& mesh_shape = mesh_device->shape();
     TT_FATAL(
-        storage.buffers.size() <= mesh_device->num_devices(),
-        "Number of host buffers {} exceeds the number of shards {}",
-        storage.buffers.size(),
-        mesh_device->num_devices());
+        coords.size() == storage.buffers.size(),
+        "Number of shards {} does not match number of buffers {}",
+        coords.size(),
+        storage.buffers.size());
 
     std::vector<distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfers;
     shard_data_transfers.reserve(storage.buffers.size());
 
-    const auto coord_range = [&storage, &mesh_shape]() {
-        if (auto* shard2d_strategy = std::get_if<ShardTensor2D>(&storage.strategy)) {
-            distributed::MeshShape distribution_shape(shard2d_strategy->shard_mesh.y, shard2d_strategy->shard_mesh.x);
-            return distributed::MeshCoordinateRange(distribution_shape);
-        } else {
-            return distributed::MeshCoordinateRange(mesh_shape);
-        }
-    }();
-
     std::vector<std::pair<distributed::MeshCoordinate, TensorSpec>> specs;
     specs.reserve(storage.buffers.size());
-    auto shard_coord = coord_range.begin();
-    for (int i = 0; i < storage.buffers.size(); ++shard_coord, i++) {
+    for (int i = 0; i < storage.buffers.size(); ++i) {
         TensorSpec shard_tensor_spec(
             storage.specs[i].logical_shape(),
             storage.specs[i].tensor_layout().with_memory_config(tensor_spec.memory_config()));
-        specs.push_back(std::make_pair(*shard_coord, shard_tensor_spec));
+        specs.push_back(std::make_pair(coords[i], shard_tensor_spec));
         const auto& shard_host_buffer = storage.buffers[i];
 
-        const auto& shard_buffer = mesh_buffer->get_device_buffer(*shard_coord);
+        const auto& shard_buffer = mesh_buffer->get_device_buffer(coords[i]);
 
         auto data_to_write = host_buffer::get_as<T>(shard_host_buffer);
         const auto expected_packed_buffer_size_bytes = shard_tensor_spec.compute_packed_buffer_size_bytes();
@@ -797,7 +788,7 @@ DeviceStorage shard_to_mesh_buffer(
             expected_packed_buffer_size_bytes <= tensor_spec.compute_packed_buffer_size_bytes(),
             "Shard tensor size exceeds the global tensor size!");
         shard_data_transfers.push_back(distributed::MeshCommandQueue::ShardDataTransfer{
-            .shard_coord = *shard_coord,
+            .shard_coord = coords[i],
             .host_data = const_cast<void*>(reinterpret_cast<const void*>(data_to_write.data())),
             .region = BufferRegion(0, input_size_bytes)});
     }
@@ -805,6 +796,29 @@ DeviceStorage shard_to_mesh_buffer(
     mesh_device->mesh_command_queue(*cq_id).enqueue_write_shards(mesh_buffer, shard_data_transfers, /*blocking=*/false);
 
     return DeviceStorage(mesh_buffer, storage.strategy, std::move(specs));
+}
+
+template <typename T>
+DeviceStorage to_device_mesh_buffer(
+    const Storage& host_storage,
+    const std::shared_ptr<distributed::MeshBuffer>& mesh_buffer,
+    const TensorSpec& tensor_spec,
+    const TensorAttributes& host_tensor_attributes,
+    ttnn::QueueId cq_id) {
+    return std::visit(
+        tt::stl::overloaded{
+            [&mesh_buffer, &tensor_spec, cq_id](const HostStorage& storage) {
+                // Replicate data across devices in a mesh.
+                return replicate_to_mesh_buffer<T>(storage, mesh_buffer->device(), mesh_buffer, tensor_spec, cq_id);
+            },
+            [&mesh_buffer, &tensor_spec, cq_id, &host_tensor_attributes](const MultiDeviceHostStorage& storage) {
+                // Shard multi device host shards across devices in a mesh.
+                auto* mesh_device = mesh_buffer->device();
+                auto coords = host_tensor_attributes.determine_distribution(mesh_device->shape());
+                return shard_to_mesh_buffer<T>(storage, mesh_device, mesh_buffer, tensor_spec, coords, cq_id);
+            },
+            [](const auto& s) -> DeviceStorage { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
+        host_storage);
 }
 
 template <typename T>
@@ -824,20 +838,9 @@ Tensor to_device_mesh_tensor(
         tensor.get_logical_shape(), tensor.get_tensor_spec().tensor_layout().with_memory_config(memory_config));
 
     auto mesh_buffer = allocate_mesh_buffer_on_device(mesh_device, tensor_spec);
-    DeviceStorage mesh_storage = std::visit(
-        tt::stl::overloaded{
-            [&mesh_device, &mesh_buffer, &tensor_spec, cq_id](const HostStorage& storage) {
-                // Replicate data across devices in a mesh.
-                return replicate_to_mesh_buffer<T>(storage, mesh_device, mesh_buffer, tensor_spec, cq_id);
-            },
-            [&mesh_device, &mesh_buffer, &tensor_spec, cq_id](const MultiDeviceHostStorage& storage) {
-                // Shard multi device host shards across devices in a mesh..
-                return shard_to_mesh_buffer<T>(storage, mesh_device, mesh_buffer, tensor_spec, cq_id);
-            },
-            [](const auto& s) -> DeviceStorage { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
-        tensor.get_storage());
-
-    return Tensor(std::move(mesh_storage), tensor_spec);
+    DeviceStorage mesh_storage =
+        to_device_mesh_buffer<T>(tensor.get_storage(), mesh_buffer, tensor_spec, *tensor.tensor_attributes, cq_id);
+    return Tensor(std::move(mesh_storage), tensor_spec, tensor.get_distributed_tensor_config());
 }
 
 template <typename T>
@@ -852,22 +855,10 @@ void copy_to_mesh_tensor(const Tensor& host_tensor, Tensor& mesh_tensor, ttnn::Q
         host_tensor.get_tensor_spec().page_config() == mesh_tensor.get_tensor_spec().page_config(),
         "Host tensor has different page config");
 
-    const auto& tensor_spec = mesh_tensor.get_tensor_spec();
     auto mesh_buffer = std::get<DeviceStorage>(mesh_tensor.get_storage()).mesh_buffer;
-    auto* mesh_device = mesh_buffer->device();
 
-    DeviceStorage mesh_storage = std::visit(
-        tt::stl::overloaded{
-            [mesh_device, &mesh_buffer, &tensor_spec, cq_id](const HostStorage& storage) {
-                // Replicate data across devices in a mesh.
-                return replicate_to_mesh_buffer<T>(storage, mesh_device, mesh_buffer, tensor_spec, cq_id);
-            },
-            [mesh_device, &mesh_buffer, &tensor_spec, cq_id](const MultiDeviceHostStorage& storage) {
-                // Shard multi device host shards across devices in a mesh..
-                return shard_to_mesh_buffer<T>(storage, mesh_device, mesh_buffer, tensor_spec, cq_id);
-            },
-            [](const auto& s) -> DeviceStorage { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
-        host_tensor.get_storage());
+    DeviceStorage mesh_storage = to_device_mesh_buffer<T>(
+        host_tensor.get_storage(), mesh_buffer, mesh_tensor.get_tensor_spec(), *host_tensor.tensor_attributes, cq_id);
 
     mesh_tensor.tensor_attributes->get_storage() = mesh_storage;
 }
@@ -1181,15 +1172,15 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
         tt::stl::overloaded{
             [&convert, target_layout](const HostStorage& storage) -> RetType {
                 const auto input_data = host_buffer::get_as<T>(storage.buffer);
-                auto output_buffer = host_buffer::create<T>(std::move(convert(input_data)));
-                return HostStorage{std::move(output_buffer)};
+                auto output_buffer = HostBuffer(std::move(convert(input_data)));
+                return std::move(output_buffer);
             },
             [&convert, target_layout](const MultiDeviceHostStorage& storage) -> RetType {
                 std::vector<HostBuffer> output_buffers;
                 std::vector<ttnn::TensorSpec> output_specs;
                 for (int i = 0; i < storage.num_buffers(); i++) {
                     const auto input_data = host_buffer::get_as<T>(storage.get_buffer(i));
-                    auto output_buffer = host_buffer::create<T>(std::move(convert(input_data)));
+                    auto output_buffer = HostBuffer(std::move(convert(input_data)));
                     output_buffers.push_back(output_buffer);
                     const auto& prev_spec = storage.specs[i];
                     output_specs.push_back(TensorSpec(
@@ -1217,7 +1208,8 @@ Tensor to_layout(const Tensor& tensor, Layout target_layout) {
                         PageConfig(target_layout, tensor.get_tensor_spec().tile()),
                         MemoryConfig{},
                         tensor.get_logical_shape(),
-                        tensor.get_padded_shape())));
+                        tensor.get_padded_shape())),
+                tensor.get_distributed_tensor_config());
         },
         output_storage);
 }
@@ -1340,16 +1332,16 @@ Tensor pad(
         return output_buffer;
     };
 
-    HostStorage output_storage = std::visit(
+    HostBuffer output_buffer = std::visit(
         tt::stl::overloaded{
             [&pad](const HostStorage& storage) {
                 const auto input_data = host_buffer::get_as<T>(storage.buffer);
-                return HostStorage(host_buffer::create<T>(pad(input_data)));
+                return HostBuffer(pad(input_data));
             },
-            [](const auto& s) -> HostStorage { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
+            [](const auto& s) -> HostBuffer { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
         tensor.get_storage());
     return Tensor(
-        std::move(output_storage),
+        std::move(output_buffer),
         tensor.get_logical_shape(),
         output_padded_shape,
         tensor.get_dtype(),
@@ -1455,16 +1447,16 @@ Tensor unpad(const Tensor& tensor, const ttnn::Shape& output_tensor_start, const
         return output_buffer;
     };
 
-    HostStorage output_storage = std::visit(
+    HostBuffer output_buffer = std::visit(
         tt::stl::overloaded{
             [&unpad](const HostStorage& storage) {
                 const auto input_data = host_buffer::get_as<T>(storage.buffer);
-                return HostStorage(host_buffer::create<T>(unpad(input_data)));
+                return HostBuffer(unpad(input_data));
             },
-            [](const auto& s) -> HostStorage { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
+            [](const auto& s) -> HostBuffer { TT_THROW("Unexpected storage type {}", tt::stl::get_type_name(s)); }},
         tensor.get_storage());
     return Tensor(
-        std::move(output_storage),
+        std::move(output_buffer),
         ttnn::Shape(output_shape),
         tensor.get_dtype(),
         tensor.get_layout(),
@@ -1510,7 +1502,7 @@ Tensor extract_shard(const Tensor& tensor, const uint32_t& core_id) {
 
     auto output_buffer = std::vector<T>(std::move(device_data));
     return Tensor(
-        HostStorage(host_buffer::create<T>(std::move(output_buffer))),
+        HostBuffer(std::move(output_buffer)),
         shard_shape,
         tensor.get_dtype(),
         tensor.get_layout(),

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -108,8 +108,7 @@ Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)
         input_tensors.begin(), input_tensors.end(), std::back_inserter(output_tensors), [&](const auto& device_tensor) {
             return transform_func(device_tensor);
         });
-    return ttnn::distributed::aggregate_as_tensor(
-        output_tensors, ttnn::distributed::get_distributed_tensor_config_from_tensor(tensor));
+    return ttnn::distributed::aggregate_as_tensor(output_tensors, tensor.get_distributed_tensor_config());
 }
 
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable) {
@@ -126,7 +125,7 @@ Tensor get_shard_for_device(const Tensor& tensor, IDevice* target_device, std::o
     return std::visit(
         tt::stl::overloaded{
             [buffer_index](const MultiDeviceHostStorage& s) {
-                return Tensor{HostStorage{s.get_buffer(buffer_index.value())}, s.get_tensor_spec(buffer_index.value())};
+                return Tensor{s.get_buffer(buffer_index.value()), s.get_tensor_spec(buffer_index.value())};
             },
             [&tensor](const HostStorage& s) { return tensor; },
             [&tensor](const DeviceStorage& s) { return tensor; },

--- a/ttnn/cpp/ttnn/tensor/xtensor/partition.cpp
+++ b/ttnn/cpp/ttnn/tensor/xtensor/partition.cpp
@@ -225,7 +225,7 @@ std::vector<Tensor> chunk_impl(
             // Create chunks pinned to the original buffer.
             auto& [data, shape] = chunk;
             tt::tt_metal::HostBuffer chunk_buffer(data, buffer.pin());
-            return Tensor(tt::tt_metal::HostStorage(std::move(chunk_buffer)), TensorSpec(shape, layout));
+            return Tensor(std::move(chunk_buffer), TensorSpec(shape, layout));
         });
         return tensors;
     } else {


### PR DESCRIPTION
### Ticket
#19177

### Problem description
Rollforward https://github.com/tenstorrent/tt-metal/pull/21813, reverted in https://github.com/tenstorrent/tt-metal/commit/d2b0f7647aa677b8b369b22e180717acdcfded74 due to a test failure in `tests/ttnn/unit_tests/operations/reduce/test_cumsum.py`.

### What's changed
The problem was that conversion to dtype didn't convert back to tile layout. This was omitted in the original PR and re-added in the rollforward.

The fix is added in https://github.com/tenstorrent/tt-metal/pull/21905/commits/535ed56a2de783ebedba66ddc772a19dc7018a63

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14933322133)
- [X] New/Existing tests provide coverage for changes