### PR TITLE
#21088: Workaround for to_layout memory overwrite

### DIFF
--- a/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_unet_2d_condition_model.py
@@ -16,7 +16,6 @@ from models.demos.wormhole.stable_diffusion.custom_preprocessing import custom_p
 from models.demos.wormhole.stable_diffusion.tt.ttnn_functional_unet_2d_condition_model_new_conv import (
     UNet2DConditionModel as UNet2D,
 )
-from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 scheduler = LMSDiscreteScheduler(
@@ -49,7 +48,6 @@ def unsqueeze_all_params_to_4d(params):
     return params
 
 
-@skip_for_blackhole("Failing on harvested BH, see #21088")
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768}], ids=["device_params=l1_small_size_24576"], indirect=True
 )


### PR DESCRIPTION
### Ticket
#21088 

### Problem description
PCC errors on full Unet component of SD 1.4 on P100. 


### What's changed
`to_layout` op rewrites some memory when called on sharded. Adding a workaround to move tensor to interleaved first.
The op issue is #22013.

### Checklist
[WH] Device perf: https://github.com/tenstorrent/tt-metal/actions/runs/14974301806 ✅ 
[WH] Model perf: https://github.com/tenstorrent/tt-metal/actions/runs/14974297244 ✅ (other test failing)
[WH] Frequent ttnn and model: https://github.com/tenstorrent/tt-metal/actions/runs/14997794314 ⚙️ 
[WH] Demo: https://github.com/tenstorrent/tt-metal/actions/runs/14995977894 ⚙️ 

[BH] Post commit: https://github.com/tenstorrent/tt-metal/actions/runs/14974290669 ✅ (other test failing)