### PR TITLE
#21779: Revert test_prod.py from "Retest and remove skip_for_blackhole for tests (#21780)"

### DIFF
--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -16,6 +16,7 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
 from tests.tt_eager.python_api_testing.sweep_tests.run_pytorch_ci_tests import (
     run_single_pytorch_test,
 )
+from models.utility_functions import skip_for_blackhole
 
 
 mem_configs = [
@@ -28,6 +29,7 @@ mem_configs = [
     "dim",
     (3, 2, 1, 0, -1, -2, -3, -4, None),
 )
+@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("keepdim", [False, True])
 @pytest.mark.parametrize(
     "input_shapes",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21779

### Problem description
Breaking BH post commit with the following error
https://github.com/tenstorrent/tt-metal/actions/runs/14933023452/job/41957917537#step:5:35297
```
sweep tests: tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py#L79
TestProd.test_run_prod_op[dst_mem_config1-input_shapes5-False-2]

AssertionError: prod test failed with input shape [[2, 8, 16, 5, 4]]. Max ATOL Delta: 126.5, Max RTOL Delta: inf, PCC: 0.030315105887526707, PCC check failed
```

### What's changed
Re-disable the test on BH

### Checklist
- [x] BH post commit (sweep test only) https://github.com/tenstorrent/tt-metal/actions/runs/14934261730