### PR TITLE
#21875: add BH skip for failing attn matmul tests

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_attn_matmul.py
@@ -7,8 +7,7 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import comp_pcc
-from models.utility_functions import is_grayskull
+from models.utility_functions import comp_pcc, skip_for_blackhole
 import ttnn
 
 
@@ -30,6 +29,7 @@ def generate_input_shapes():
     yield [q_len, q_heads, batch_size, K], [batch_size, kv_heads, K, seq_len]
 
 
+@skip_for_blackhole("Bad pcc on BH. Issue #21875")
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
@@ -64,7 +64,6 @@ def test_attn_matmul(num_loops, in0_dtype, in1_dtype, out_dtype, device):
             assert allclose, f"FAILED: {output}"
 
 
-@pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("num_loops", [20])
 def test_attn_matmul_fp32(num_loops, in_dtype, device):
@@ -103,6 +102,7 @@ def test_attn_matmul_fp32(num_loops, in_dtype, device):
             assert allclose, f"FAILED: {output}"
 
 
+@skip_for_blackhole("Bad pcc on BH. Issue #21875")
 @pytest.mark.parametrize("in0_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("out_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
@@ -334,7 +334,6 @@ def test_group_attn_matmul_with_program_cache(
     assert num_cache_entries == 1
 
 
-@pytest.mark.skipif(is_grayskull(), reason="GS does not support fp32")
 @pytest.mark.parametrize("in_dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize(
     "shard_orientation",


### PR DESCRIPTION
### Ticket
Link to Github Issue #21875

### Problem description
- there seems to be a timing issue with attn matmul on BH p150a after an llk fix was applied to partially fix problems in sdpa decode BH hangs in llama

### What's changed
- skip the tests until an investigation can be done

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A