### PR TITLE
#21763: Upload latest containers for upstream tests only if they pass tests

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -186,6 +186,7 @@ jobs:
   push-latest:
     if: ${{ github.ref == 'refs/heads/main' || inputs.tag-as-latest }}
     needs:
+      - get-image-tags
       # REVERT MNEEEEEEEEE - make this depend on tests instead
       - build-images
     permissions:

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -187,8 +187,8 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || inputs.tag-as-latest }}
     needs:
       - get-image-tags
-      # REVERT MNEEEEEEEEE - make this depend on tests instead
-      - build-images
+      - test-wh-6u-image
+      - test-bh-image
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -2,6 +2,11 @@ name: Build test and publish upstream tests
 
 on:
   workflow_dispatch:
+    inputs:
+      tag-as-latest:
+        default: false
+        type: boolean
+        description: "Tag this run as latest"
   schedule:
     - cron: '0 12 * * *'
 
@@ -139,15 +144,6 @@ jobs:
             TEST_COMMAND=${{ matrix.image-config.test-command }}
           tags: ${{ matrix.image-config.image-tag }}
           context: ${{ github.workspace }}
-      - name: Tag and push latest
-        if: ${{ github.ref == 'refs/heads/main' }}
-        run: |
-          IMAGE_NAME="${{ matrix.image-config.image-base-name }}"
-          LATEST_TAG="${IMAGE_NAME}:latest"
-          echo "Tagging ${{ matrix.image-config.image-tag }} as ${LATEST_TAG}"
-          docker pull ${{ matrix.image-config.image-tag }}
-          docker tag ${{ matrix.image-config.image-tag }} ${LATEST_TAG}
-          docker push ${LATEST_TAG}
   test-wh-6u-image:
     needs:
       - get-image-tags
@@ -187,3 +183,38 @@ jobs:
       - name: Run profiler image
         timeout-minutes: 10
         run: docker run -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
+  push-latest:
+    if: ${{ github.ref == 'refs/heads/main' || inputs.tag-as-latest }}
+    needs:
+      - test-wh-6u-image
+      - test-bh-image
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      matrix:
+        image-config:
+          - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-image-tag }}
+            image-base-name: ${{ needs.get-image-tags.outputs.wh-6u-base-image-name }}
+          - image-tag: ${{ needs.get-image-tags.outputs.wh-6u-profiler-image-tag }}
+            image-base-name: ${{ needs.get-image-tags.outputs.wh-6u-profiler-base-image-name }}
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-image-tag }}
+            image-base-name: ${{ needs.get-image-tags.outputs.bh-base-image-name }}
+          - image-tag: ${{ needs.get-image-tags.outputs.bh-profiler-image-tag }}
+            image-base-name: ${{ needs.get-image-tags.outputs.bh-profiler-base-image-name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag and push latest
+        run: |
+          IMAGE_NAME="${{ matrix.image-config.image-base-name }}"
+          LATEST_TAG="${IMAGE_NAME}:latest"
+          echo "Tagging ${{ matrix.image-config.image-tag }} as ${LATEST_TAG}"
+          docker pull ${{ matrix.image-config.image-tag }}
+          docker tag ${{ matrix.image-config.image-tag }} ${LATEST_TAG}
+          docker push ${LATEST_TAG}

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -186,8 +186,8 @@ jobs:
   push-latest:
     if: ${{ github.ref == 'refs/heads/main' || inputs.tag-as-latest }}
     needs:
-      - test-wh-6u-image
-      - test-bh-image
+      # REVERT MNEEEEEEEEE - make this depend on tests instead
+      - build-images
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
### Ticket

#21763 

### Problem description

We should probably only `tag` latest if they actually work.

### What's changed

Split out latest tagging to separate job.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes