### PR TITLE
Reductions - Squeeze Outputs, Add Correction Support to std and var

### DIFF
--- a/models/demos/grayskull/t5/tt/ttnn_functional_t5.py
+++ b/models/demos/grayskull/t5/tt/ttnn_functional_t5.py
@@ -90,6 +90,7 @@ def t5_layer_norm(config, hidden_states, *, weight):
     averaged_squared_hidden_states = ttnn.mean(
         squared_hidden_states,
         dim=-1,
+        keepdim=True,
     )
 
     variance = averaged_squared_hidden_states + config.layer_norm_epsilon

--- a/models/demos/grayskull/t5/tt/ttnn_optimized_functional_t5.py
+++ b/models/demos/grayskull/t5/tt/ttnn_optimized_functional_t5.py
@@ -90,7 +90,7 @@ def t5_layer_norm(config, hidden_states, *, weight):
     # return ttnn.rms_norm(hidden_states, weight, epsilon=config.layer_norm_epsilon)
 
     squared_hidden_states = ttnn.pow(hidden_states, 2)
-    averaged_squared_hidden_states = ttnn.mean(squared_hidden_states, dim=-1)
+    averaged_squared_hidden_states = ttnn.mean(squared_hidden_states, dim=-1, keepdim=True)
 
     variance = averaged_squared_hidden_states + config.layer_norm_epsilon
     std = ttnn.rsqrt(variance)

--- a/models/demos/segformer/tt/ttnn_segformer_for_image_classification.py
+++ b/models/demos/segformer/tt/ttnn_segformer_for_image_classification.py
@@ -46,7 +46,7 @@ class TtSegformerForImageClassification:
         sequence_output = outputs[0]
         batch_size = sequence_output.shape[0]
         sequence_output = ttnn.reshape(sequence_output, (batch_size, -1, self.config.hidden_sizes[-1]))
-        sequence_output = ttnn.mean(sequence_output, dim=1)
+        sequence_output = ttnn.mean(sequence_output, dim=1, keepdim=True)
         sequence_output = ttnn.squeeze(sequence_output, dim=0)
         logits = ttnn.linear(
             sequence_output,

--- a/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm.py
@@ -151,14 +151,14 @@ class TtDistributedLayernorm:
             total_count += count_local
             counts.append(count_local)
 
-            meanx_local = ttnn.sum(xs[i], 3, scaler=1.0 / counts[i])
+            meanx_local = ttnn.sum(xs[i], dim=3, keepdim=True, scaler=1.0 / counts[i])
             meanxs.append(meanx_local)
 
         # meanx2 = torch.mean(torch.square(xs), dim=-1, keepdim=True)
         meanx2s = []
         for i in range(num_devices):
             x2_local = ttnn.pow(xs[i], 2)
-            meanx2_local = ttnn.sum(x2_local, dim=3, scaler=1.0 / counts[i])
+            meanx2_local = ttnn.sum(x2_local, dim=3, keepdim=True, scaler=1.0 / counts[i])
             meanx2s.append(meanx2_local)
 
         # AllReduce meanx and meanx2
@@ -180,6 +180,7 @@ class TtDistributedLayernorm:
                 ttnn.sum(
                     meanxs[i],
                     dim=3,
+                    keepdim=True,
                     scaler=1.0 / total_count,
                 )
             )
@@ -202,6 +203,7 @@ class TtDistributedLayernorm:
                 ttnn.sum(
                     meanx2s[i],
                     dim=3,
+                    keepdim=True,
                     scaler=1.0 / total_count,
                 )
             )

--- a/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm_dlnp1.py
+++ b/models/demos/t3000/falcon40b/tests/unit_tests/distributed_layernorm/test_distributed_layernorm_dlnp1.py
@@ -62,14 +62,14 @@ class TtDistributedLayernormDLNP1:
             total_count += count_local
             counts.append(count_local)
 
-            meanx_local = ttnn.sum(xs[i], dim=3, scaler=1.0 / counts[i])
+            meanx_local = ttnn.sum(xs[i], keepdim=True, dim=3, scaler=1.0 / counts[i])
             meanxs.append(meanx_local)
 
         # meanx2 = torch.mean(torch.square(xs), dim=-1, keepdim=True)
         meanx2s = []
         for i in range(num_devices):
             x2_local = ttnn.pow(xs[i], 2)
-            meanx2_local = ttnn.sum(x2_local, dim=3, scaler=1.0 / counts[i])
+            meanx2_local = ttnn.sum(x2_local, keepdim=True, dim=3, scaler=1.0 / counts[i])
             meanx2s.append(meanx2_local)
 
         # Weighted meanx to number of samples per device

--- a/models/demos/t3000/llama2_70b/tt/llama_common.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_common.py
@@ -205,7 +205,7 @@ def get_weight_cache_path_galaxy(base_cache_path, tensor_str, device_idx, num_de
 def rms_decomp(x, norm_weight, eps):
     squared = ttnn.pow(x, 2)
     # mean_squared = tt_lib.tensor.mean(squared, )
-    sum_squared = ttnn.sum(squared, 3)
+    sum_squared = ttnn.sum(squared, dim=3, keepdim=True)
     # Tensor is 1,1,32,1+31 now
     mean_squared = ttnn.multiply(sum_squared, (1 / x.shape[-1]))
     mean_squared_eps = ttnn.add(mean_squared, eps)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -61,7 +61,7 @@ class TtMoeLayer(LightweightModule):
             device=mesh_device,
             mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
-        self.top8_mask_11B_64 = ttnn.sum(self.top8_mask_11B_64, dim=2)
+        self.top8_mask_11B_64 = ttnn.sum(self.top8_mask_11B_64, dim=2, keepdim=True)
 
         top2_mask = torch.full((1, 1, 1, 32), fill_value=torch.finfo(torch.float).min)
         top2_mask[:, :, :, :2] = 0.0
@@ -72,7 +72,7 @@ class TtMoeLayer(LightweightModule):
             device=mesh_device,
             mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
-        self.top2_mask_11BB = ttnn.sum(self.top2_mask_11BB, dim=2)
+        self.top2_mask_11BB = ttnn.sum(self.top2_mask_11BB, dim=2, keepdim=True)
 
         reduce_mask_torch = torch.zeros(1, 1, self.tile_size, self.tile_size * 8)
         for i in range(self.tile_size):
@@ -113,7 +113,7 @@ class TtMoeLayer(LightweightModule):
             topk_values, topk_indices = ttnn.topk(gate_logits_1SB8, 32)
             topk_values = ttnn.add(topk_values, self.top2_mask_11BB)
             mask_B2 = ttnn.eqz(topk_indices)
-            weights_1SB1 = ttnn.sum(ttnn.softmax(topk_values, dim=-1) * mask_B2, dim=3)
+            weights_1SB1 = ttnn.sum(ttnn.softmax(topk_values, dim=-1, keepdim=True) * mask_B2, dim=3)
 
             topk_values.deallocate(True)
             topk_indices.deallocate(True)

--- a/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
+++ b/models/demos/t3000/mixtral8x7b/tt/mixtral_moe.py
@@ -113,7 +113,7 @@ class TtMoeLayer(LightweightModule):
             topk_values, topk_indices = ttnn.topk(gate_logits_1SB8, 32)
             topk_values = ttnn.add(topk_values, self.top2_mask_11BB)
             mask_B2 = ttnn.eqz(topk_indices)
-            weights_1SB1 = ttnn.sum(ttnn.softmax(topk_values, dim=-1, keepdim=True) * mask_B2, dim=3)
+            weights_1SB1 = ttnn.sum(ttnn.softmax(topk_values, dim=-1) * mask_B2, dim=3, keepdim=True)
 
             topk_values.deallocate(True)
             topk_indices.deallocate(True)

--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -307,7 +307,7 @@ def run_demo_whisper_for_audio_classification_inference(input_path, ttnn_model, 
         hidden_states = ttnn.matmul(encoder_outputs, parameters.projector.weight)
         hidden_states = ttnn.add(hidden_states, parameters.projector.bias)
 
-        pooled_output = ttnn.mean(hidden_states, dim=-2)
+        pooled_output = ttnn.mean(hidden_states, dim=-2, keepdim=True)
 
         logits = ttnn.matmul(pooled_output, parameters.classifier.weight)
         logits = ttnn.add(logits, parameters.classifier.bias)
@@ -359,7 +359,7 @@ def run_demo_whisper_for_audio_classification_dataset(ttnn_model, device):
     hidden_states = ttnn.matmul(encoder_outputs, parameters.projector.weight)
     hidden_states = ttnn.add(hidden_states, parameters.projector.bias)
 
-    pooled_output = ttnn.mean(hidden_states, dim=-2)
+    pooled_output = ttnn.mean(hidden_states, dim=-2, keepdim=True)
 
     logits = ttnn.matmul(pooled_output, parameters.classifier.weight)
     logits = ttnn.add(logits, parameters.classifier.bias)

--- a/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
+++ b/models/demos/wormhole/stable_diffusion/sd_helper_funcs.py
@@ -112,7 +112,7 @@ class TtLMSDiscreteScheduler:
         derivative_tensor = derivative_tensor * lms_coeffs
         if derivative_tensor.shape[0] > 1:
             derivative_tensor = ttnn.permute(derivative_tensor, (3, 1, 2, 0))
-            derivative_tensor = ttnn.sum(derivative_tensor, dim=-1)
+            derivative_tensor = ttnn.sum(derivative_tensor, dim=-1, keepdim=True)
             derivative_tensor = ttnn.permute(derivative_tensor, (3, 1, 2, 0))
         prev_sample = sample + derivative_tensor
 

--- a/models/experimental/bert/fused_ops/layernorm.py
+++ b/models/experimental/bert/fused_ops/layernorm.py
@@ -109,13 +109,13 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
             H_ = overrideH
 
         # first compute the mean (m)
-        means = ttnn.sum(x, 3, scalar=1.0 / W)  # -> NCH1
+        means = ttnn.sum(x, dim=3, keepdim=True, scalar=1.0 / W)  # -> NCH1
         x_minus_mean = ttnn.subtract(x, means)  # need to blank out the H for non-multiple of 32
         if False and refx is not None:
             ry, rmean, rvar, rstd, rinvstd, ry1 = ref_ln(refx, refgamma, refbeta)
 
         var = ttnn.mul(x_minus_mean, x_minus_mean)  # (x-m)^2
-        var_redW = ttnn.sum(var, 3)  # sum[(x-m)^2]
+        var_redW = ttnn.sum(var, dim=3, keepdim=True)  # sum[(x-m)^2]
 
         scaler = 1 / W
         var_scaler_ = ttnn.fill_rm(1, 1, roundup32(H), 32, H_, 1, epsilon_, scaler, 0)
@@ -148,8 +148,8 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
         W = x.padded_shape[3]
 
         # first compute the mean (m)
-        redW = ttnn.sum(x, 3, scalar=1.0 / W)  # -> NCH1
-        mean = ttnn.sum(redW, 2)  # -> NC11 (HW reduce doesn't behave well with small scaler)
+        redW = ttnn.sum(x, dim=3, keepdim=True, scalar=1.0 / W)  # -> NCH1
+        mean = ttnn.sum(redW, dim=2, keepdim=True)  # -> NC11 (HW reduce doesn't behave well with small scaler)
         x_minus_mean0 = ttnn.subtract(x, mean)  # need to blank out the H for non-multiple of 32
 
         hmasku = ttnn.fill_ones_rm(N, C, H, 32, 1, 1, x)  # generate a H-mask with mask[h, w] = 1.0 where h,w < 1
@@ -157,8 +157,8 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
         x_minus_mean = ttnn.multiply(x_minus_mean0, hmaskt)  # zero out (x-m) for h>=H_, h<H
 
         var = ttnn.mul(x_minus_mean, x_minus_mean)  # (x-m)^2
-        var_redW = ttnn.sum(var, 3)  # sum[(x-m)^2]
-        var_redHW = ttnn.sum(var_redW, 2)  # sum[(x-m)^2]
+        var_redW = ttnn.sum(var, dim=3, keepdim=True)  # sum[(x-m)^2]
+        var_redHW = ttnn.sum(var_redW, dim=2, keepdim=True)  # sum[(x-m)^2]
         var_div_n1 = ttnn.multiply(var_redHW, var_scaler_)  # *= 1/(everything not batch)
         var_plus_eps = ttnn.add(var_div_n1, epsilon_)
 

--- a/models/experimental/bert_large_perf/fused_ops/layernorm.py
+++ b/models/experimental/bert_large_perf/fused_ops/layernorm.py
@@ -126,13 +126,13 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
             H_ = overrideH
 
         # first compute the mean (m)
-        means = ttnn.sum(x, 3, scalar=1.0 / W)  # -> NCH1
+        means = ttnn.sum(x, dim=3, keepdim=True, scalar=1.0 / W)  # -> NCH1
         x_minus_mean = ttnn.subtract(x, means)  # need to blank out the H for non-multiple of 32
         if False and refx is not None:
             ry, rmean, rvar, rstd, rinvstd, ry1 = ref_ln(refx, refgamma, refbeta)
 
         var = ttnn.mul(x_minus_mean, x_minus_mean)  # (x-m)^2
-        var_redW = ttnn.sum(var, 3)  # sum[(x-m)^2]
+        var_redW = ttnn.sum(var, dim=3, keepdim=True)  # sum[(x-m)^2]
 
         # print(f"layernorm_1d_ var_scaler shape {var_scaler.padded_shape} H {H} H_ {H_} W {W}")
 
@@ -163,8 +163,8 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
         W = x.padded_shape[3]
 
         # first compute the mean (m)
-        redW = ttnn.sum(x, 3, scalar=1.0 / W)  # -> NCH1
-        mean = ttnn.sum(redW, 2)  # -> NC11 (HW reduce doesn't behave well with small scaler)
+        redW = ttnn.sum(x, dim=3, keepdim=True, scalar=1.0 / W)  # -> NCH1
+        mean = ttnn.sum(redW, dim=2, keepdim=True)  # -> NC11 (HW reduce doesn't behave well with small scaler)
         x_minus_mean0 = ttnn.subtract(x, mean)  # need to blank out the H for non-multiple of 32
 
         hmasku = ttnn.fill_ones_rm(N, C, H, 32, 1, 1, x)  # generate a H-mask with mask[h, w] = 1.0 where h,w < 1
@@ -174,8 +174,8 @@ def Layernorm(gamma: float, beta: float, epsilon: float, H, W, device, num_dims=
         print(f"layernorm_2d_ hmasku shape {hmasku.padded_shape}")
 
         var = ttnn.mul(x_minus_mean, x_minus_mean)  # (x-m)^2
-        var_redW = ttnn.sum(var, 3)  # sum[(x-m)^2]
-        var_redHW = ttnn.sum(var_redW, 2)  # sum[(x-m)^2]
+        var_redW = ttnn.sum(var, dim=3, keepdim=True)  # sum[(x-m)^2]
+        var_redHW = ttnn.sum(var_redW, dim=2, keepdim=True)  # sum[(x-m)^2]
         var_div_n1 = ttnn.multiply(var_redHW, var_scaler_)  # *= 1/(everything not batch)
         var_plus_eps = ttnn.add(var_div_n1, epsilon_)
 

--- a/models/experimental/grok/tt/grok_moe.py
+++ b/models/experimental/grok/tt/grok_moe.py
@@ -120,7 +120,7 @@ class TtMoeLayer(LightweightModule):
         # tlog('our_topk_indices', ttl_topk_indices)
         ttl_topk_values = ttl_topk_values * self.top2_mask_11BB  # masked unwanted ones to 0
         mask_B2 = ttnn.eq(self.expert_mask_11BB, ttl_topk_indices)  # Each device masks for its own expert index 1-8
-        weights_1SB1 = ttnn.sum(ttl_topk_values * mask_B2, dim=3)
+        weights_1SB1 = ttnn.sum(ttl_topk_values * mask_B2, dim=3, keepdim=True)
 
         # MLP and masking
         weights = expert_i_HH(input_i_1SBH)

--- a/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tt/ttnn_yolov8s_world.py
@@ -421,7 +421,7 @@ class TtMaxSigmoidAttnBlock:
         ttnn.deallocate(guide)
         aw = ttnn.reshape(aw, (batch, m, height, width, n))
 
-        aw = ttnn.max(aw, dim=-1)
+        aw = ttnn.max(aw, dim=-1, keepdim=True)
         aw = ttnn.permute(aw, (0, 1, 2, 4, 3))  # To increase the perfomance of squeeze operation
         aw = ttnn.squeeze(aw, -2)  # If the above permute is removed use ttnn.squeeze(aw, -1)
         aw = ttnn.div(aw, (self.hc**0.5))

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytests/tt_dnn/test_prod.py
@@ -29,7 +29,6 @@ mem_configs = [
     "dim",
     (3, 2, 1, 0, -1, -2, -3, -4, None),
 )
-@skip_for_blackhole("Mismatching on BH, see #12349")
 @pytest.mark.parametrize("keepdim", [False, True])
 @pytest.mark.parametrize(
     "input_shapes",

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -53,7 +53,7 @@ def std_hw(x, *args, **kwargs):
 
 
 def mean_hw(x, *args, **kwargs):
-    return torch.mean(x, [2, 3], keepdim=True)
+    return torch.mean(x, [2, 3])
 
 
 def normalize_hw(x, *args, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -53,7 +53,7 @@ def std_hw(x, *args, **kwargs):
 
 
 def mean_hw(x, *args, **kwargs):
-    return torch.mean(x, [2, 3])
+    return torch.mean(x, [2, 3], keepdim=True)
 
 
 def normalize_hw(x, *args, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -86,7 +86,7 @@ def normalize_global(x, *args, **kwargs):
 
 # Ternary Ops
 def sum(x, *args, dim, **kwargs):
-    return torch.sum(x, dim=dim, keepdim=True)
+    return torch.sum(x, dim=dim)
 
 
 def where(x, y, z, *args, **kwargs):

--- a/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/pytorch_ops.py
@@ -1233,15 +1233,15 @@ def outer(x, y, *args, **kwargs):
     return torch.outer(x.squeeze(), y.squeeze())
 
 
-def reduce_sum(x, dims=None, keepdim=True, *args, **kwargs):
+def reduce_sum(x, dims=None, keepdim=False, *args, **kwargs):
     return torch.sum(x, dims, keepdim)
 
 
-def reduce_max(x, dims=None, keepdim=True, *args, **kwargs):
+def reduce_max(x, dims=None, keepdim=False, *args, **kwargs):
     return torch.amax(x, dims, keepdim)
 
 
-def reduce_min(x, dims=None, keepdim=True, *args, **kwargs):
+def reduce_min(x, dims=None, keepdim=False, *args, **kwargs):
     return torch.amin(x, dims, keepdim)
 
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1583,7 +1583,6 @@ def reduce_max_w(x, *args, device, dtype, layout, input_mem_config, output_mem_c
     t1 = ttnn.max(t0, 3, memory_config=output_mem_config)
 
     output = tt2torch_tensor(t1)
-    print("TT output", output)
 
     return output
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -368,7 +368,6 @@ def mean_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_config
     t0 = setup_tt_tensor(x, device, layout[0], input_mem_config[0], dtype[0])
     t1 = ttnn.mean(t0, [2, 3], memory_config=output_mem_config)
     output = tt2torch_tensor(t1)
-    output = output[:, :, 0, 0]
 
     return output
 

--- a/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
+++ b/tests/tt_eager/python_api_testing/sweep_tests/tt_lib_ops.py
@@ -1545,8 +1545,7 @@ def reduce_sum_h(x, *args, device, dtype, layout, input_mem_config, output_mem_c
     t1 = ttnn.sum(t0, 2, memory_config=output_mem_config)
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1, :]
+    return output
 
 
 @setup_host_and_device
@@ -1556,8 +1555,7 @@ def reduce_sum_w(x, *args, device, dtype, layout, input_mem_config, output_mem_c
 
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :, :1]
+    return output
 
 
 @setup_host_and_device
@@ -1567,8 +1565,7 @@ def reduce_sum_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_
 
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1, :1]
+    return output
 
 
 @setup_host_and_device
@@ -1578,8 +1575,7 @@ def reduce_max_h(x, *args, device, dtype, layout, input_mem_config, output_mem_c
 
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1, :]
+    return output
 
 
 @setup_host_and_device
@@ -1588,9 +1584,9 @@ def reduce_max_w(x, *args, device, dtype, layout, input_mem_config, output_mem_c
     t1 = ttnn.max(t0, 3, memory_config=output_mem_config)
 
     output = tt2torch_tensor(t1)
+    print("TT output", output)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1]
+    return output
 
 
 @setup_host_and_device
@@ -1600,8 +1596,7 @@ def reduce_max_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_
 
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1, :1]
+    return output
 
 
 @setup_host_and_device
@@ -1611,8 +1606,7 @@ def reduce_min_h(x, *args, device, dtype, layout, input_mem_config, output_mem_c
 
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1, :]
+    return output
 
 
 @setup_host_and_device
@@ -1622,8 +1616,7 @@ def reduce_min_w(x, *args, device, dtype, layout, input_mem_config, output_mem_c
 
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1]
+    return output
 
 
 @setup_host_and_device
@@ -1633,8 +1626,7 @@ def reduce_min_hw(x, *args, device, dtype, layout, input_mem_config, output_mem_
 
     output = tt2torch_tensor(t1)
 
-    # Slice out the 0 values from reduction
-    return output[..., :1, :1]
+    return output
 
 
 @setup_host_and_device
@@ -1645,10 +1637,6 @@ def sum(x, *args, dim, device, dtype, layout, input_mem_config, output_mem_confi
 
     output = tt2torch_tensor(t1)
 
-    if dim == 2:
-        output = output[:, :, :1, :]
-    elif dim == 3:
-        output = output[:, :, :, :1]
     return output
 
 

--- a/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mae.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mae.py
@@ -68,7 +68,7 @@ class TestMAELoss:
         pt_mae_output = loss(ref_data.to(torch.float32), pred_data.to(torch.float32))
 
         comp_pass_a, comp_out_a = comparison_funcs.comp_allclose(
-            pt_mae_output, torch.tensor(tt_mae_output[0, 0, 0, 0]), atol=1e-1, rtol=1e-1
+            pt_mae_output, torch.tensor(tt_mae_output), atol=1e-1, rtol=1e-1
         )
 
         logger.debug(comp_out_a)
@@ -94,7 +94,7 @@ class TestMAELoss:
         pt_mae_output = loss(ref_data.to(torch.float32), pred_data.to(torch.float32))
 
         comp_pass_a, comp_out_a = comparison_funcs.comp_allclose(
-            pt_mae_output, torch.tensor(tt_mae_output[0, 0, 0, 0]), atol=1e-1, rtol=1e-1
+            pt_mae_output, torch.tensor(tt_mae_output), atol=1e-1, rtol=1e-1
         )
 
         logger.debug(comp_out_a)

--- a/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mse.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/loss_ops/test_loss_mse.py
@@ -66,9 +66,7 @@ class TestMSELoss:
 
         loss = torch.nn.MSELoss(reduction="sum")
         pt_mse_output = loss(ref_data.to(torch.float32), pred_data.to(torch.float32))
-        comp_pass_a, comp_out_a = comparison_funcs.comp_allclose(
-            pt_mse_output, torch.tensor(tt_mse_output[0, 0, 0, 0]), atol=1e-1, rtol=1e-1
-        )
+        comp_pass_a, comp_out_a = comparison_funcs.comp_allclose(pt_mse_output, tt_mse_output, atol=1e-1, rtol=1e-1)
 
         logger.debug(comp_out_a)
         assert comp_pass_a
@@ -91,9 +89,7 @@ class TestMSELoss:
 
         loss = torch.nn.MSELoss(reduction="mean")
         pt_mse_output = loss(ref_data.to(torch.float32), pred_data.to(torch.float32))
-        comp_pass_a, comp_out_a = comparison_funcs.comp_allclose(
-            pt_mse_output, torch.tensor(tt_mse_output[0, 0, 0, 0]), atol=1e-1, rtol=1e-1
-        )
+        comp_pass_a, comp_out_a = comparison_funcs.comp_allclose(pt_mse_output, tt_mse_output, atol=1e-1, rtol=1e-1)
 
         logger.debug(comp_out_a)
         assert comp_pass_a

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1852,9 +1852,9 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
             interleaved_mem_config,
         )
 
-    tt_got_back = yt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()[:, :, :1, :]
+    tt_got_back = yt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
-    y = torch.max(x, 2, True)[0]
+    y = torch.max(x, 2)
 
     if dtype == ttnn.bfloat16:
         passing, output = comp_equal(y, tt_got_back)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1854,7 +1854,7 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
 
     tt_got_back = yt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
-    y = torch.max(x, 2)[0]
+    y = torch.amax(x, 2)
 
     if dtype == ttnn.bfloat16:
         passing, output = comp_equal(y, tt_got_back)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sharded.py
@@ -1854,7 +1854,7 @@ def test_sharded_reduce_h(N, in_sharded, out_sharded, dtype, device, function_le
 
     tt_got_back = yt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
 
-    y = torch.max(x, 2)
+    y = torch.max(x, 2)[0]
 
     if dtype == ttnn.bfloat16:
         passing, output = comp_equal(y, tt_got_back)

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_sum.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_sum.py
@@ -34,7 +34,7 @@ def test_sum_for_dim_hw(device, use_program_cache, shape_dim):
     # print(f"x.sum = {value}")
 
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
-    tt_npu = ttnn.sum(dev_x, dim)
+    tt_npu = ttnn.sum(dev_x, dim=dim, keepdim=True)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
     assert torch.equal(tt_dev[0, 0, 0, 0], torch.Tensor([value]).bfloat16()[0])
 
@@ -60,9 +60,9 @@ def test_sum_global(device, use_program_cache, shape):
     input_shape = (N, C, H, W)
     x = 1.0 + torch.ones(input_shape).bfloat16()
 
-    value = x.sum()
+    torch_output = x.sum()
 
     dev_x = ttnn.Tensor(x, ttnn.DataType.BFLOAT16).to(ttnn.Layout.TILE).to(device)
     tt_npu = ttnn.sum(dev_x)
     tt_dev = tt_npu.cpu().to(ttnn.Layout.ROW_MAJOR).to_torch()
-    assert torch.equal(tt_dev[0, 0, 0, 0].bfloat16(), torch.Tensor([value]).bfloat16()[0])
+    assert torch.equal(tt_dev.bfloat16(), torch_output.bfloat16())

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
@@ -33,12 +33,12 @@ def prelu(x, *args, **kwargs):
 
 def max(x, *args, **kwargs):
     dim = kwargs.pop("dim")
-    return torch.max(x, dim=dim[0], keepdim=True).values
+    return torch.max(x, dim=dim[0]).values
 
 
 def min(x, *args, **kwargs):
     dim = kwargs.pop("dim")
-    return torch.min(x, dim=dim[0], keepdim=True).values
+    return torch.min(x, dim=dim[0]).values
 
 
 def eltwise_max(x, y, *args, **kwargs):

--- a/tests/ttnn/unit_tests/operations/reduce/test_max.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_max.py
@@ -19,7 +19,7 @@ def test_max(device, batch_size, h, w, dim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
-    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim, keepdim=True)
+    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -42,7 +42,7 @@ def test_max_4d(device, batch_size1, batch_size2, h, w, dim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size1, batch_size2, h, w), -100, 100, dtype=torch.bfloat16)
-    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim, keepdim=True)
+    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -62,7 +62,7 @@ def test_max_2d(device, h, w, dim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((h, w), -100, 100, dtype=torch.bfloat16)
-    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim, keepdim=True)
+    torch_output_tensor, _ = torch.max(torch_input_tensor, dim=dim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
@@ -88,7 +88,7 @@ def test_max_global(device, batch_size, h, w):
 
     output_tensor = ttnn.max(input_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor[0, 0, 0]
+    output_tensor = output_tensor
 
     assert_with_pcc(torch_output_tensor, output_tensor)
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -16,15 +16,17 @@ from models.utility_functions import skip_for_grayskull, torch_random
 @pytest.mark.parametrize("h", [32, 64])
 @pytest.mark.parametrize("w", [32, 64])
 @pytest.mark.parametrize("dim", [-1, -2])
-def test_std(device, batch_size, h, w, dim):
+@pytest.mark.parametrize("correction", [True, False])
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_std(device, batch_size, h, w, dim, correction, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.std(torch_input_tensor, dim=dim, keepdim=True)
+    torch_output_tensor = torch.std(torch_input_tensor, dim=dim, keepdim=keepdim, correction=correction)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.std(input_tensor, dim=dim)
+    output_tensor = ttnn.std(input_tensor, dim=dim, keepdim=keepdim, correction=correction)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
@@ -37,15 +39,16 @@ def test_std(device, batch_size, h, w, dim):
 @pytest.mark.parametrize("w", [32, 64])
 @pytest.mark.parametrize("dim", [None, [], -1, -2])
 @pytest.mark.parametrize("keepdim", [True])
-def test_var(device, batch_size, h, w, dim, keepdim):
+@pytest.mark.parametrize("correction", [True, False])
+def test_var(device, batch_size, h, w, dim, keepdim, correction):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((batch_size, h, w), dtype=torch.bfloat16)
-    torch_output_tensor = torch.var(torch_input_tensor, dim=dim, keepdim=keepdim)
+    torch_output_tensor = torch.var(torch_input_tensor, dim=dim, keepdim=keepdim, correction=correction)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.var(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.var(input_tensor, dim=dim, keepdim=keepdim, correction=correction)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
@@ -404,7 +407,7 @@ def test_sum_2d_tensor_dims(device, h, w, dim, keepdim):
 @pytest.mark.parametrize("h", [37])
 @pytest.mark.parametrize("w", [63])
 @pytest.mark.parametrize("dim", [None, [], 0, 2, [0, 1], [1, 3], [0, 1, 2], [1, 2, 3], [0, 1, 2, 3]])
-@pytest.mark.parametrize("keepdim", [True])
+@pytest.mark.parametrize("keepdim", [True, False])
 def test_mean_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
     torch.manual_seed(0)
 
@@ -425,7 +428,7 @@ def test_mean_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 @pytest.mark.parametrize("h", [31])
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("dim", [[0, 2], [0, 1, 2]])
-@pytest.mark.parametrize("keepdim", [True])
+@pytest.mark.parametrize("keepdim", [True, False])
 def test_mean_3d_tensor_dims(device, c, h, w, dim, keepdim):
     torch.manual_seed(0)
 
@@ -445,7 +448,7 @@ def test_mean_3d_tensor_dims(device, c, h, w, dim, keepdim):
 @pytest.mark.parametrize("h", [41])
 @pytest.mark.parametrize("w", [31])
 @pytest.mark.parametrize("dim", [0, 1, [0, 1]])
-@pytest.mark.parametrize("keepdim", [True])
+@pytest.mark.parametrize("keepdim", [True, False])
 def test_mean_2d_tensor_dims(device, h, w, dim, keepdim):
     torch.manual_seed(0)
 
@@ -491,7 +494,7 @@ def run_maxpool(device, input_shape, kernel_size, stride, padding, dilation):
 
 def run_reduce_sum_h(device, batch_size, h, w, dim):
     torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.bfloat16)
-    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=True, dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     output_tensor = ttnn.mean(input_tensor, dim=dim)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_mean.py
@@ -15,15 +15,16 @@ from models.utility_functions import torch_random, comp_allclose
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2])
-def test_mean(device, batch_size, h, w, dim):
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_mean(device, batch_size, h, w, dim, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -1, 1, dtype=torch.bfloat16)
-    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=True, dtype=torch.bfloat16)
+    torch_output_tensor = torch.mean(torch_input_tensor, dim=dim, keepdim=keepdim, dtype=torch.bfloat16)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
     ttnn.fill_implicit_tile_padding(input_tensor, 42)  # garbage padding to test that mean removes it
 
-    output_tensor = ttnn.mean(input_tensor, dim=dim)
+    output_tensor = ttnn.mean(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_min.py
@@ -15,15 +15,16 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2])
-def test_min(device, batch_size, h, w, dim):
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_min(device, batch_size, h, w, dim, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
-    torch_output_tensor, _ = torch.min(torch_input_tensor, dim=dim, keepdim=True)
+    torch_output_tensor, _ = torch.min(torch_input_tensor, dim=dim, keepdim=keepdim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.min(input_tensor, dim=dim)
+    output_tensor = ttnn.min(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
@@ -47,6 +48,6 @@ def test_min_global(device, batch_size, h, w):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor[0, 0, 0]
+    output_tensor = output_tensor
 
     assert_with_pcc(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_sum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sum.py
@@ -15,15 +15,16 @@ from models.utility_functions import torch_random
 @pytest.mark.parametrize("h", [32, 64, 41, 37])
 @pytest.mark.parametrize("w", [32, 64, 31, 63])
 @pytest.mark.parametrize("dim", [-1, -2, (2, 1)])
-def test_sum(device, batch_size, h, w, dim):
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_sum(device, batch_size, h, w, dim, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch_random((batch_size, h, w), -100, 100, dtype=torch.bfloat16)
-    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=True)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.sum(input_tensor, dim=dim)
+    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
     output_tensor = ttnn.to_layout(output_tensor, ttnn.TILE_LAYOUT)
     output_tensor = ttnn.from_device(output_tensor)
 
@@ -47,7 +48,7 @@ def test_sum_global(device, batch_size, h, w):
     output_tensor = ttnn.from_device(output_tensor)
 
     output_tensor = ttnn.to_torch(output_tensor)
-    output_tensor = output_tensor[0, 0, 0]
+    output_tensor = output_tensor
 
     assert_with_pcc(torch_output_tensor, output_tensor)
 
@@ -60,12 +61,11 @@ def test_sum_global(device, batch_size, h, w):
 def test_sum_4d(device, n, c, h, w, dim):
     torch.manual_seed(0)
 
-    keepdim = True
     torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.float32)
-    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim, keepdim=keepdim)
+    torch_output_tensor = torch.sum(torch_input_tensor, dim=dim)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
 
-    output_tensor = ttnn.sum(input_tensor, dim=dim, keepdim=keepdim)
+    output_tensor = ttnn.sum(input_tensor, dim=dim)
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.99)

--- a/tests/ttnn/unit_tests/operations/test_losses.py
+++ b/tests/ttnn/unit_tests/operations/test_losses.py
@@ -47,9 +47,6 @@ def test_mse_loss(device, input_shapes, loss_mode):
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    if loss_mode[0] != "none":
-        output_tensor = output_tensor[0, 0, 0, 0]
-
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)
 
 
@@ -88,8 +85,5 @@ def test_l1_loss(device, input_shapes, loss_mode):
     output_tensor = ttnn.l1_loss(input_tensor_a, input_tensor_b, reduction=loss_mode[1])
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
-
-    if loss_mode[0] != "none":
-        output_tensor = output_tensor[0, 0, 0, 0]
 
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9999)

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -41,9 +41,9 @@ Tensor loss_function(
 
     switch (reduce_mode) {
         case LossReductionMode::SUM:
-            return ttnn::sum(result, std::nullopt, true, memory_config.value_or(ref.memory_config()));
+            return ttnn::sum(result, std::nullopt, false, memory_config.value_or(ref.memory_config()));
         case LossReductionMode::MEAN:
-            return ttnn::mean(result, std::nullopt, true, memory_config.value_or(ref.memory_config()));
+            return ttnn::mean(result, std::nullopt, false, memory_config.value_or(ref.memory_config()));
         case LossReductionMode::NONE:
         default:
             // TODO: old code indicated this path is unsupported, but the all post commit test pipeline uses this path.

--- a/ttnn/cpp/ttnn/operations/loss/loss.cpp
+++ b/ttnn/cpp/ttnn/operations/loss/loss.cpp
@@ -41,9 +41,11 @@ Tensor loss_function(
 
     switch (reduce_mode) {
         case LossReductionMode::SUM:
-            return ttnn::sum(result, std::nullopt, false, memory_config.value_or(ref.memory_config()));
+            return ttnn::sum(
+                result, /*dim=*/std::nullopt, /*keepdim=*/false, memory_config.value_or(ref.memory_config()));
         case LossReductionMode::MEAN:
-            return ttnn::mean(result, std::nullopt, false, memory_config.value_or(ref.memory_config()));
+            return ttnn::mean(
+                result, /*dim=*/std::nullopt, /*keepdim=*/false, memory_config.value_or(ref.memory_config()));
         case LossReductionMode::NONE:
         default:
             // TODO: old code indicated this path is unsupported, but the all post commit test pipeline uses this path.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -350,6 +350,7 @@ static Tensor std_var_impl(
     if (correction) {
         reduced_volume -= 1;
     }
+    TT_FATAL(reduced_volume > 0, "Reduction is performed on too few elements, yielding divisor of {}", reduced_volume);
 
     scalar /= reduced_volume;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -320,7 +320,8 @@ static Tensor std_var_impl(
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
     float scalar,
-    const ttnn::SmallVector<int>& non_height_width_dims) {
+    const ttnn::SmallVector<int>& non_height_width_dims,
+    bool correction) {
     using ttnn::operations::experimental::auto_format::AutoFormat;
     auto input_shape = input_tensor_arg.get_logical_shape();
     auto rank = input_shape.size();
@@ -344,6 +345,12 @@ static Tensor std_var_impl(
     for (int axis : dim) {
         reduced_volume *= input_shape[axis];
     }
+
+    // Bessel's correction (i.e. divisor of N-1)
+    if (correction) {
+        reduced_volume -= 1;
+    }
+
     scalar /= reduced_volume;
 
     auto mean_tensor = reduce_impl<ReduceType::Sum>(
@@ -400,7 +407,8 @@ Tensor Reduce<reduce_type>::invoke(
     const bool keepdim,
     const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    float scalar) {
+    float scalar,
+    bool correction) {
     ttnn::SmallVector<int> dim = generate_reduce_dim(input_tensor_arg, dim_arg);
     float pad_value = get_pad_value(reduce_type);
     bool is_tiled = input_tensor_arg.get_layout() == TILE_LAYOUT;
@@ -429,7 +437,14 @@ Tensor Reduce<reduce_type>::invoke(
     }
     if constexpr (reduce_type == ReduceType::Std || reduce_type == ReduceType::Var) {
         return std_var_impl<reduce_type>(
-            input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, non_height_width_dims);
+            input_tensor,
+            dim,
+            keepdim,
+            memory_config_arg,
+            compute_kernel_config,
+            scalar,
+            non_height_width_dims,
+            correction);
     }
     return reduce_impl<reduce_type>(
         input_tensor, dim, keepdim, memory_config_arg, compute_kernel_config, scalar, non_height_width_dims);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -27,7 +27,7 @@ struct Reduce {
     static Tensor invoke(
         const Tensor& input_tensor_arg,
         const std::optional<std::variant<int, ttnn::SmallVector<int>>>& dim_arg = std::nullopt,
-        const bool keepdim = true,
+        const bool keepdim = false,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
         float scalar = 1.0f,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.hpp
@@ -30,7 +30,8 @@ struct Reduce {
         const bool keepdim = true,
         const std::optional<MemoryConfig>& memory_config_arg = std::nullopt,
         const std::optional<DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-        float scalar = 1.0f);
+        float scalar = 1.0f,
+        bool correction = true);
 };
 
 // Entry point for pool op, which uses non-standard tensors that cannot be padded.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -45,7 +45,8 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,
-            py::arg("scalar") = 1.0f});
+            py::arg("scalar") = 1.0f,
+            py::arg("correction") = true});
 }
 
 }  // namespace ttnn::operations::reduction::detail

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_pybind.hpp
@@ -41,7 +41,7 @@ void bind_reduction_operation(py::module& module, const reduction_operation_t& o
         ttnn::pybind_arguments_t{
             py::arg("input_tensor"),
             py::arg("dim") = std::nullopt,
-            py::arg("keepdim") = true,
+            py::arg("keepdim") = false,
             py::kw_only(),
             py::arg("memory_config") = std::nullopt,
             py::arg("compute_kernel_config") = std::nullopt,


### PR DESCRIPTION
### Ticket
#16928 - loss gives unsqueezed tensors  
#12937 - var does not support correction flag

### Problem description
This PR addresses a few issues:

1. TTNN sum/mean loss operations always returned unsqueezed tensors (e.g., [1,1,1,1]), while PyTorch always returned scalars (0D).
2. Generic reductions had a default of `keepdim=True` while PyTorch defaulted to `False`. This resulted in TTNN producing unsqueezed tensors when compared to PyTorch when run with otherwise identical inputs.
3. The `std` and `var` reductions did not support Bessel's correction, with no `correction` argument. Their implementation corresponded to keeping `correction=False`. 
4. Prod had very low PCC for specific dimensions on >4D tensors on Blackhole, causing failures in BH CI.

### What's changed

1. Loss mean/sum reductions match PyTorch and always squeeze outputs to 0D now. Tests are updated.
2. Generic reduces will also default to `keepdim=False`, and tests were updated.
3. A new `correction` argument was added for use in `std` and `var` reductions, which defaults to `true` to match PyTorch. Parameter is added to unit tests.
4. Prod PCC issues seem to be caused by identity permutations. These are okay on WH but are problematic on BH. Updated prod to prevent it from performing identity permutations, and removed the BH skip on `test_prod`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14951383832)
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14951380544)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14984596733) (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14984594490)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14984594490) 
- [x] New/Existing tests provide coverage for changes