### PR TITLE
Fix assert syntax

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -98,10 +98,10 @@ def test_pc_repeat(device, layout, shape, repeat_shape, use_program_cache):
 
         assert_with_pcc(torch_results[i], output, 0.9999)
         if i == 0:
-            base_program_cache_entires = device.num_program_cache_entries()
+            base_program_cache_entries = device.num_program_cache_entries()
         else:
             assert (
-                device.num_program_cache_entries() == base_program_cache_entires
+                device.num_program_cache_entries() == base_program_cache_entries
             ), "program cache entries differ on same configs"
 
 
@@ -111,57 +111,38 @@ def test_pc_repeat(device, layout, shape, repeat_shape, use_program_cache):
 def test_pc_with_different_shapes_in_sequence(device, use_program_cache):
     y = torch.rand((1, 1, 256, 384), dtype=torch.bfloat16)
     y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    base_program_cache_entires = device.num_program_cache_entries()
 
     x = torch.zeros((64, 1, 256, 384), dtype=torch.bfloat16)
     x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     num_iters = 4
     z_tt = x_tt + y_tt
 
-    for i in range(64):
-        z_torch = ttnn.to_torch(z_tt[i : i + 1])
-        assert torch.allclose(z_torch, y, atol=1e-2), f"z_torch[{i}] != y"
-    for _ in range(num_iters):
-        y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-        assert (
-            device.num_program_cache_entries() == base_program_cache_entires
-        ), "program cache entries differ on same configs"
-
-        x = torch.zeros((64, 1, 256, 384), dtype=torch.bfloat16)
-        x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-
-        z_tt = x_tt + y_tt
-
-        for i in range(64):
-            z_torch = ttnn.to_torch(z_tt[i : i + 1])
-            assert torch.allclose(z_torch, y, atol=1e-2), f"z_torch[{i}] != y"
     y = torch.rand((1, 1, 32, 32), dtype=torch.bfloat16)
-
     y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    base_program_cache_entires = device.num_program_cache_entries()
 
     x = torch.zeros((4, 1, 32, 32), dtype=torch.bfloat16)
     x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     ttnn.repeat(y_tt, [4, 1, 1, 1])
     z_tt = ttnn.add(x_tt, y_tt, use_legacy=False)
-    # z_tt = x_tt + y_tt
+    z_tt = x_tt + y_tt
 
     for i in range(num_iters):
         z_torch = ttnn.to_torch(z_tt[i : i + 1])
         assert torch.allclose(z_torch, y, atol=1e-2), f"z_torch[{i}] != y"
     for _ in range(num_iters):
         y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-        assert (
-            device.num_program_cache_entries() == base_program_cache_entires
-        ), "program cache entries differ on same configs"
 
         x = torch.zeros((4, 1, 32, 32), dtype=torch.bfloat16)
         x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
+        base_program_cache_entries = device.num_program_cache_entries()
         ttnn.repeat(y_tt, [4, 1, 1, 1])
+        assert (
+            device.num_program_cache_entries() == base_program_cache_entries
+        ), "program cache entries differ on same configs"
         z_tt = ttnn.add(x_tt, y_tt, use_legacy=False)
-        # z_tt = x_tt + y_tt
+        z_tt = x_tt + y_tt
 
         for i in range(num_iters):
             z_torch = ttnn.to_torch(z_tt[i : i + 1])
@@ -169,19 +150,21 @@ def test_pc_with_different_shapes_in_sequence(device, use_program_cache):
     y = torch.rand((1, 1, 256, 384), dtype=torch.bfloat16)
 
     y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    base_program_cache_entires = device.num_program_cache_entries()
     z_tt = ttnn.repeat(y_tt, ttnn.Shape([64, 1, 1, 1]))
-
     for i in range(64):
         z_torch = ttnn.to_torch(z_tt[i : i + 1])
         assert torch.allclose(z_torch, y, atol=1e-2), f"z_torch[{i}] != y"
+
     for _ in range(num_iters):
         y = torch.rand((1, 1, 256, 384), dtype=torch.bfloat16)
         y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-        assert (
-            device.num_program_cache_entries() == base_program_cache_entires
-        ), "program cache entries differ on same configs"
+
+        base_program_cache_entries = device.num_program_cache_entries()
         z_tt = ttnn.repeat(y_tt, ttnn.Shape([64, 1, 1, 1]))
+
+        assert (
+            device.num_program_cache_entries() == base_program_cache_entries
+        ), "program cache entries differ on same configs"
 
         for i in range(64):
             z_torch = ttnn.to_torch(z_tt[i : i + 1])

--- a/tests/ttnn/unit_tests/operations/test_repeat.py
+++ b/tests/ttnn/unit_tests/operations/test_repeat.py
@@ -101,9 +101,8 @@ def test_pc_repeat(device, layout, shape, repeat_shape, use_program_cache):
             base_program_cache_entires = device.num_program_cache_entries()
         else:
             assert (
-                device.num_program_cache_entries() == base_program_cache_entires,
-                "program cache entries differ on same configs",
-            )
+                device.num_program_cache_entries() == base_program_cache_entires
+            ), "program cache entries differ on same configs"
 
 
 # 17975 test cases
@@ -125,9 +124,8 @@ def test_pc_with_different_shapes_in_sequence(device, use_program_cache):
     for _ in range(num_iters):
         y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
         assert (
-            device.num_program_cache_entries() == base_program_cache_entires,
-            "program cache entries differ on same configs",
-        )
+            device.num_program_cache_entries() == base_program_cache_entires
+        ), "program cache entries differ on same configs"
 
         x = torch.zeros((64, 1, 256, 384), dtype=torch.bfloat16)
         x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -155,9 +153,8 @@ def test_pc_with_different_shapes_in_sequence(device, use_program_cache):
     for _ in range(num_iters):
         y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
         assert (
-            device.num_program_cache_entries() == base_program_cache_entires,
-            "program cache entries differ on same configs",
-        )
+            device.num_program_cache_entries() == base_program_cache_entires
+        ), "program cache entries differ on same configs"
 
         x = torch.zeros((4, 1, 32, 32), dtype=torch.bfloat16)
         x_tt = ttnn.from_torch(x, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
@@ -182,9 +179,8 @@ def test_pc_with_different_shapes_in_sequence(device, use_program_cache):
         y = torch.rand((1, 1, 256, 384), dtype=torch.bfloat16)
         y_tt = ttnn.from_torch(y, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
         assert (
-            device.num_program_cache_entries() == base_program_cache_entires,
-            "program cache entries differ on same configs",
-        )
+            device.num_program_cache_entries() == base_program_cache_entires
+        ), "program cache entries differ on same configs"
         z_tt = ttnn.repeat(y_tt, ttnn.Shape([64, 1, 1, 1]))
 
         for i in range(64):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
These asserts will never fail.
In APC we are told that fact 104 times and that gets noisy in the workflow summary 🙃 

### What's changed
Fixed the syntax

AFM: I modified `test_repeat.py::test_pc_with_different_shapes_in_sequence` to limit its scope to only testing for the caching behavior of `ttnn.repeat`. Previously, in addition to the incorrect `assert` syntax, it made assumptions that the caching behavior of a handful of ops was similar to `ttnn.repeat`. The op flow of that test, which intended to reproduce a bug ticket, remains.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14982030459)