### PR TITLE
In Conv2d DRAM, make the output of slice sharded.

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -113,8 +113,8 @@ SliceWidth = ttnn.Conv2dSliceWidth
     (
         (2, 512,  512,  128,   128,   SliceWidth,    4,  ttnn.bfloat8_b, ttnn.bfloat16, (3, 3), (1, 1), (1, 1), (1, 1), 32 * 8,  ttnn.MathFidelity.LoFi  ),
         (2, 64,   64,   384,   64,    SliceHeight,   6,  ttnn.bfloat8_b, ttnn.bfloat16, (4, 4), (2, 2), (1, 1), (1, 1), 0,       ttnn.MathFidelity.LoFi  ),
-        (1, 4,    32,   1024,  1024,  SliceWidth,    4,  ttnn.bfloat8_b, ttnn.bfloat16, (5, 5), (1, 1), (0, 0), (1, 1), 32,      ttnn.MathFidelity.LoFi  ),
-        (1, 64,   128,  992,   992,   SliceWidth,   64,  ttnn.bfloat8_b, ttnn.bfloat16, (2, 2), (1, 1), (0, 0), (1, 1), 32 * 4,  ttnn.MathFidelity.LoFi  ),
+        (1, 4,    32,   1024,  1024,  SliceWidth,    8,  ttnn.bfloat8_b, ttnn.bfloat16, (5, 5), (1, 1), (0, 0), (1, 1), 32,      ttnn.MathFidelity.LoFi  ),
+        (1, 64,   128,  992,   992,   SliceWidth,   64,  ttnn.bfloat8_b, ttnn.bfloat16, (2, 2), (1, 1), (0, 0), (1, 1), 32 * 2,  ttnn.MathFidelity.LoFi  ),
     )
     # fmt: on
 )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -13,6 +13,7 @@
 #include "tt-metalium/constants.hpp"
 #include <tt-metalium/hal.hpp>
 #include "tt-metalium/logger.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
@@ -25,6 +26,7 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/move/move.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
+#include "ttnn/types.hpp"
 
 using namespace tt;
 
@@ -81,15 +83,20 @@ uint32_t get_input_channels_alignment(
         if (input_memory_config.has_value() && input_memory_config->is_sharded()) {
             const uint32_t shard_width = input_memory_config->shard_spec()->shape[1];
             if (shard_width % tt::constants::TILE_WIDTH == 0) {
+                tt::log_info("Input Channels Alignment is {}", tt::constants::TILE_WIDTH);
                 return tt::constants::TILE_WIDTH;
             } else if (shard_width % 16 == 0) {
+                tt::log_info("Input Channels Alignment is {}", 16);
                 return 16U;
             } else if (shard_width % 8 == 0) {
+                tt::log_info("Input Channels Alignment is {}", 8);
                 return 8U;
             } else {
                 return tt::constants::TILE_WIDTH;
             }
         } else {
+            tt::log_info("Input Channels Alignment is {}", 8);
+
             // The minimum valid value for input channels alignment is 8.
             // This requirement comes from the L1 alignment, which is 16 bytes.
             // Since the Halo operation outputs data in row-major layout and the smallest data format used is bfloat16
@@ -155,6 +162,13 @@ ParallelConfig determine_parallel_config(
     uint32_t max_num_cores = compute_grid_size.x * compute_grid_size.y;
     CoreRangeSet grid;
     if (shard_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        tt::log_debug(
+            tt::LogOp,
+            "determine_paralle_config for Height Sharded. out_nhw_ntiles: {}, max_num_cores: {}, "
+            "act_block_h_override_ntiles: {}",
+            out_nhw_ntiles,
+            max_num_cores,
+            act_block_h_override_ntiles);
         uint32_t num_cores_nhw = find_closest_largest_divisor_with_num_padding_and_mult(
             out_nhw_ntiles, max_num_cores, act_block_h_override_ntiles);
         grid = tt::tt_metal::num_cores_to_corerangeset(num_cores_nhw, compute_grid_size, true);
@@ -459,6 +473,64 @@ DeviceComputeKernelConfig get_conv_default_compute_kernel_config(DeviceType* dev
     return init_device_compute_kernel_config(device->arch(), std::nullopt, MathFidelity::HiFi4, true, false, false);
 }
 
+template <typename DeviceType>
+MemoryConfig determine_input_memory_config(
+    const Conv2dConfig& conv_config,
+    uint32_t batch_size,
+    ttnn::Shape input_tensor_shape,
+    ttnn::Shape output_tensor_shape,
+    bool is_mm_conv,
+    DeviceType* device,
+    Layout input_tensor_layout) {
+    TT_FATAL(conv_config.shard_layout.has_value(), "Shard layout must be set in Conv2dConfig.");
+    auto shard_layout = conv_config.shard_layout.value();
+    auto block_shard_orientation =
+        conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+    ParallelConfig parallel_config = determine_parallel_config(
+        shard_layout,
+        batch_size,
+        input_tensor_shape[3],
+        output_tensor_shape[1],
+        output_tensor_shape[2],
+        output_tensor_shape[3],
+        device->compute_with_storage_grid_size(),
+        block_shard_orientation,
+        !is_mm_conv,
+        true,
+        true,
+        conv_config.act_block_h_override);
+    uint32_t input_num_cores_nhw = get_num_cores_nhw_from_parallel_config(parallel_config);
+    uint32_t input_num_cores_c = get_num_cores_channels_from_parallel_config(parallel_config);
+
+    // TT_ASSERT(input_tensor.get_padded_shape() == input_tensor.get_shape());
+    uint32_t tensor_height = input_tensor_shape[0] * input_tensor_shape[1] * input_tensor_shape[2];
+    uint32_t round_up_size = tt::constants::TILE_HEIGHT;
+    if (shard_layout == TensorMemoryLayout::WIDTH_SHARDED && input_tensor_layout == Layout::ROW_MAJOR) {
+        round_up_size = 1;
+    }
+    uint32_t input_tensor_height_snapped_to_tile = tt::round_up(tensor_height, input_num_cores_nhw * round_up_size);
+    TT_ASSERT(input_tensor_height_snapped_to_tile >= tensor_height);
+    const uint32_t input_channels_alignment =
+        get_input_channels_alignment(shard_layout, input_tensor_layout, is_mm_conv, std::nullopt);
+
+    uint32_t input_tensor_width_snapped_to_channels_alignment =
+        tt::round_up(input_tensor_shape[3], input_num_cores_c * input_channels_alignment);
+
+    auto input_padded_shape = ttnn::Shape(
+        {1,
+         1,
+         input_tensor_height_snapped_to_tile,
+         input_tensor_width_snapped_to_channels_alignment});  // TODO: resolve ttnn::types::Shape and
+                                                              // tt::tt_metal::LegacyShape issue to clean up next
+                                                              // line
+    MemoryConfig input_tensor_sharded_memory_config = create_sharded_memory_config_from_parallel_config(
+        ttnn::Shape({input_padded_shape[0], input_padded_shape[1], input_padded_shape[2], input_padded_shape[3]}),
+        parallel_config,
+        round_up_size);
+
+    return input_tensor_sharded_memory_config;
+};
+
 template <typename T>
 static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_shape_and_mem_config(
     T* device,
@@ -581,11 +653,11 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_s
             round_up_size = 1;
         }
         uint32_t input_tensor_height_snapped_to_tile = tt::round_up(tensor_height, input_num_cores_nhw * round_up_size);
-        const uint32_t input_channels_aligment =
+        const uint32_t input_channels_alignment =
             get_input_channels_alignment(shard_layout, input_tensor_.layout(), is_mm_conv, std::nullopt);
         TT_ASSERT(input_tensor_height_snapped_to_tile >= tensor_height);
         uint32_t input_tensor_width_snapped_to_channels_alignment =
-            tt::round_up(input_shape[3], input_num_cores_c * input_channels_aligment);
+            tt::round_up(input_shape[3], input_num_cores_c * input_channels_alignment);
 
         auto input_padded_shape = ttnn::Shape(
             {1,
@@ -1312,6 +1384,24 @@ template std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_resha
     uint32_t out_channel,
     bool is_mm_conv,
     bool auto_shard);
+
+template MemoryConfig determine_input_memory_config<IDevice>(
+    const Conv2dConfig& conv_config,
+    uint32_t batch_size,
+    ttnn::Shape input_tensor_shape,
+    ttnn::Shape output_tensor_shape,
+    bool is_mm_conv,
+    IDevice* device,
+    Layout input_tensor_layout);
+
+template MemoryConfig determine_input_memory_config<MeshDevice>(
+    const Conv2dConfig& conv_config,
+    uint32_t batch_size,
+    ttnn::Shape input_tensor_shape,
+    ttnn::Shape output_tensor_shape,
+    bool is_mm_conv,
+    MeshDevice* device,
+    Layout input_tensor_layout);
 
 template DeviceComputeKernelConfig get_conv_default_compute_kernel_config<tt::tt_metal::IDevice>(
     tt::tt_metal::IDevice* device);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.hpp
@@ -134,6 +134,16 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_s
     bool is_mm_conv);
 
 template <typename DeviceType>
+MemoryConfig determine_input_memory_config(
+    const Conv2dConfig& conv_config,
+    uint32_t batch_size,
+    ttnn::Shape input_tensor_shape,
+    ttnn::Shape output_tensor_shape,
+    bool is_mm_conv,
+    DeviceType* device,
+    Layout input_tensor_layout);
+
+template <typename DeviceType>
 DeviceComputeKernelConfig get_conv_default_compute_kernel_config(DeviceType* device);
 
 Conv2dConfig determine_conv_config_for_auto_shard(

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 #include "dataflow_api.h"
-
+#include "debug/dprint.h"
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t stick_size = get_arg_val<uint32_t>(1);
@@ -13,6 +13,13 @@ void kernel_main() {
     uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(4);
     uint32_t num_read_per_barrier = get_arg_val<uint32_t>(5);
     uint32_t start_id = get_arg_val<uint32_t>(6);
+
+#ifdef DEBUG
+    DPRINT << "src_addr: " << src_addr << ", stick_size: " << stick_size << ", stick_size_offset: " << stick_size_offset
+           << ", num_sticks_per_core: " << num_sticks_per_core
+           << ", num_sticks_per_core_read: " << num_sticks_per_core_read
+           << ", num_read_per_barrier: " << num_read_per_barrier << ", start_id: " << start_id << ENDL();
+#endif
 
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr bool dst0_is_dram = get_compile_time_arg_val(1) == 1;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_program_factory.cpp
@@ -166,6 +166,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
     const Tensor& input_tensor,
     const Tensor& output_tensor,
     const ttnn::Shape& output_tensor_start,
+    const ttnn::Shape& output_tensor_end,
     const std::vector<CoreCoord>& cores,
     uint32_t max_read_size) {
     tt::tt_metal::IDevice* device = input_tensor.device();
@@ -191,14 +192,17 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
     std::vector<uint32_t> num_input_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_output_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);
+    std::vector<uint32_t> size_till_end(num_dims);
 
     std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    std::vector<uint32_t> accumulated_input_total_per_dim(num_dims);
 
     // TODO: Remove first element of these arrays and update kernel accordingly
     // This currently just matches tile version where we iterate over the row as well
     num_input_sticks_per_dim[0] = 1;
     num_output_sticks_per_dim[0] = 0;
     accumulated_total_per_dim[0] = 1;
+    accumulated_input_total_per_dim[0] = 1;
 
     for (int32_t i = 1; i < num_dims; i++) {
         uint32_t num_unpadded_dim = input_shape[-(i + 1)];
@@ -207,6 +211,7 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
         num_input_sticks_per_dim[i] = num_unpadded_dim;
         num_output_sticks_per_dim[i] = num_padded_dim;
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+        accumulated_input_total_per_dim[i] = num_unpadded_dim * accumulated_input_total_per_dim[i - 1];
     }
 
     std::string unpadded_sticks_str = "";
@@ -221,6 +226,10 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
     for (auto& i : accumulated_total_per_dim) {
         accumulated_str += std::to_string(i) + ", ";
     }
+    tt::log_debug("Slice Write Accumulated Sticks: {}", accumulated_str);
+    tt::log_debug("Slice Write Unpadded Sticks: {}", unpadded_sticks_str);
+    tt::log_debug("Slice Write Padded Sticks: {}", padded_sticks_str);
+    tt::log_debug("Accumulated Input : {}", accumulated_input_total_per_dim);
 
     using namespace tt::tt_metal::experimental;
     auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
@@ -283,18 +292,31 @@ SliceWriteRuntimeArgs get_slice_write_runtime_args_rm_sharded_input(
         id_per_dim[0] = num_sticks_read % num_input_sticks_per_dim[0];
         uint32_t unpadded_written = num_sticks_read / num_input_sticks_per_dim[0];
         uint32_t start_id = id_per_dim[0] + start_offset;
+        uint32_t max_num_sticks_this_core = 0;
         for (uint32_t j = 1; j < num_dims; j++) {
             id_per_dim[j] = unpadded_written % num_input_sticks_per_dim[j];
             unpadded_written = unpadded_written / num_input_sticks_per_dim[j];
             start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+            size_till_end[j] = output_tensor_end[-1 - j] - output_tensor_start[-1 - j] - id_per_dim[j] - 1;
+            max_num_sticks_this_core += size_till_end[j] * accumulated_input_total_per_dim[j - 1];
         }
+
         std::vector<uint32_t> writer_kernel_args = common_writer_kernel_args;
         writer_kernel_args[0] += width_offset;
 
+        uint32_t num_sticks_this_core = std::min(num_sticks_per_core, max_num_sticks_this_core + 1);
+
+        tt::log_debug(
+            "Start ID: {}, Start ID per dim : {} , Size till end : {} Num Sticks: {} for Core: {}",
+            start_id,
+            id_per_dim,
+            size_till_end,
+            num_sticks_this_core,
+            core);
         uint32_t addr_offset = 5;  // output buffer addr, output_row_size_bytes, input_row_size_bytes, num_dims
         writer_kernel_args[addr_offset++] = start_id;
-        writer_kernel_args[addr_offset++] = num_sticks_per_core;
-        writer_kernel_args[addr_offset++] = num_sticks_per_core;
+        writer_kernel_args[addr_offset++] = num_sticks_this_core;
+        writer_kernel_args[addr_offset++] = num_sticks_this_core;
         writer_kernel_args[addr_offset] = num_read_per_barrier;
         writer_kernel_args.insert(writer_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
 
@@ -411,8 +433,8 @@ operation::ProgramWithCallbacks slice_write_rm_sharded_input_multi_core(
 
     const auto iter_cores = corerange_to_cores(input_cores, std::nullopt, rm_orientation);
 
-    auto all_runtime_args =
-        get_slice_write_runtime_args_rm_sharded_input(input, output, output_tensor_start, iter_cores, max_read_size);
+    auto all_runtime_args = get_slice_write_runtime_args_rm_sharded_input(
+        input, output, output_tensor_start, output_tensor_end, iter_cores, max_read_size);
 
     uint32_t i = 0;
     for (const auto& core : iter_cores) {
@@ -425,6 +447,7 @@ operation::ProgramWithCallbacks slice_write_rm_sharded_input_multi_core(
                                            unary_reader_kernel_id,
                                            unary_writer_kernel_id,
                                            output_tensor_start,
+                                           output_tensor_end,
                                            max_read_size,
                                            input_cb_handle](
                                               const void* operation,
@@ -438,7 +461,7 @@ operation::ProgramWithCallbacks slice_write_rm_sharded_input_multi_core(
         UpdateDynamicCircularBufferAddress(program, input_cb_handle, *src_tensor.buffer());
 
         auto all_runtime_args = get_slice_write_runtime_args_rm_sharded_input(
-            src_tensor, dst_tensor, output_tensor_start, iter_cores, max_read_size);
+            src_tensor, dst_tensor, output_tensor_start, output_tensor_end, iter_cores, max_read_size);
 
         uint32_t i = 0;
         for (const auto& core : iter_cores) {

--- a/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/sliding_window.cpp
@@ -309,10 +309,6 @@ std::vector<ShardBoundary> generate_shard_boundaries(
         output_index_start = output_index_end + 1;
     }
 
-    for (auto& boundary : shard_boundaries) {
-        log_debug(tt::LogOp, "shard_boundary={}", boundary);
-    };
-
     return shard_boundaries;
 }
 


### PR DESCRIPTION
### Ticket
#17493 

### Problem description
Conv2D DRAM uses the slice op to select the input. It first does a DRAM -> DRAM slice, followed by padding and interleaved to sharding. These extra ops cause poor performance.

### What's changed
Switch to the new experimental op, padded_slice which does slice + padding + sharding in a single kernel for much better performance.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes