### PR TITLE
Add Wide Channels Support for Bilinear Upsample

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -8,29 +8,29 @@
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/pack_untilize.h"
 
-template <uint32_t in_ntiles_c, uint32_t unpA_face_r_dim>
+template <uint32_t tiles_per_reduction, uint32_t unpA_face_r_dim>
 inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_id, const uint32_t out_cb_id) {
-    cb_reserve_back(out_cb_id, in_ntiles_c);
+    cb_reserve_back(out_cb_id, tiles_per_reduction);
     tile_regs_acquire();
     cb_wait_front(in_cb_id, 4);
     unpack_tilizeA_B_block(
         in_cb_id,
         in_scalar_cb_id,
-        in_ntiles_c,
+        tiles_per_reduction,
         0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
         2 /* unpack 2 faces ) */,
         unpA_face_r_dim);
-    for (uint32_t c_i = 0; c_i < in_ntiles_c; ++c_i) {
+    for (uint32_t c_i = 0; c_i < tiles_per_reduction; ++c_i) {
         reduce_tile_math(c_i, 2 /* reduce 2 faces */);
     }
     cb_pop_front(in_cb_id, 4);
 
     tile_regs_wait();
     tile_regs_commit();
-    pack_untilize_dst<in_ntiles_c>(out_cb_id, 1, 0, 1, 2); /* pack 1 row (1x32) */
+    pack_untilize_dst<tiles_per_reduction>(out_cb_id, 1, 0, 1, 2); /* pack 1 row (1x32) */
     tile_regs_release();
 
-    cb_push_back(out_cb_id, in_ntiles_c);
+    cb_push_back(out_cb_id, tiles_per_reduction);
 }
 
 namespace NAMESPACE {

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -8,30 +8,29 @@
 #include "compute_kernel_api/reduce.h"
 #include "compute_kernel_api/pack_untilize.h"
 
-template <uint32_t in_ntiles_c, uint32_t out_ntiles_c, uint32_t unpA_face_r_dim>
-inline void reduce_h_fused(
-    const uint32_t in_cb_id, const uint32_t in_scalar_cb_id, const uint32_t in_ntiles_hwc, const uint32_t out_cb_id) {
-    cb_reserve_back(out_cb_id, 1);
+template <uint32_t in_ntiles_c, uint32_t unpA_face_r_dim>
+inline void reduce_h_fused(const uint32_t in_cb_id, const uint32_t in_scalar_cb_id, const uint32_t out_cb_id) {
+    cb_reserve_back(out_cb_id, in_ntiles_c);
     tile_regs_acquire();
     cb_wait_front(in_cb_id, 4);
     unpack_tilizeA_B_block(
         in_cb_id,
         in_scalar_cb_id,
-        in_ntiles_hwc,
+        in_ntiles_c,
         0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
-        2 /* unpack 1 or 2 faces ) */,
+        2 /* unpack 2 faces ) */,
         unpA_face_r_dim);
     for (uint32_t c_i = 0; c_i < in_ntiles_c; ++c_i) {
-        reduce_tile_math(c_i, 2 /* reduce 1 or 2 faces */);
+        reduce_tile_math(c_i, 2 /* reduce 2 faces */);
     }
     cb_pop_front(in_cb_id, 4);
 
     tile_regs_wait();
     tile_regs_commit();
-    pack_untilize_dst<out_ntiles_c>(out_cb_id, 1, 0, 1, 2); /* pack 1 row (1x16 or 1x32) */
+    pack_untilize_dst<in_ntiles_c>(out_cb_id, 1, 0, 1, 2); /* pack 1 row (1x32) */
     tile_regs_release();
 
-    cb_push_back(out_cb_id, 1);
+    cb_push_back(out_cb_id, in_ntiles_c);
 }
 
 namespace NAMESPACE {
@@ -47,18 +46,30 @@ void MAIN {
     constexpr uint32_t window_size_hw = get_compile_time_arg_val(7);
     constexpr uint32_t out_ntiles_c = get_compile_time_arg_val(8);
     constexpr uint32_t nsticks_per_core_by_nblocks = get_compile_time_arg_val(9);
+    constexpr uint32_t blocks = get_compile_time_arg_val(10);
+
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+
+    constexpr uint32_t max_tiles_per_iter =
+        in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
+    constexpr uint32_t partial_iter_output_tiles =
+        in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
 
     constexpr uint32_t num_output_tiles = out_ntiles_c;  //* nblocks;
-
-    tilizeA_B_reduce_init<false, true>(in_cb_id1, in_scalar_cb_id1, in_ntiles_hwc, out_cb_id, 2, 4);
-    pack_untilize_dst_init_short<num_output_tiles>(out_cb_id, 1, 2); /* pack 1 row (1x16 or 1x32) */
+    tilizeA_B_reduce_init<false, true>(in_cb_id1, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id, 2, 4);
+    pack_untilize_dst_init_short<num_output_tiles>(out_cb_id, 1, 2); /* pack 1 row (1x32) */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
         const uint32_t cb_id = (i % 2 == 0) ? in_cb_id1 : in_cb_id2;
         const uint32_t scalar_cb_id = (i % 2 == 0) ? in_scalar_cb_id1 : in_scalar_cb_id2;
 
-        // Wait for the core to push data in cb
+        for (uint32_t j = 0; j < blocks - 1; j++) {
+            // Wait for the core to push data in cb
+            cb_wait_front(scalar_cb_id, 1);
+            reduce_h_fused<max_tiles_per_iter, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
+            cb_pop_front(scalar_cb_id, 1);
+        }
         cb_wait_front(scalar_cb_id, 1);
-        reduce_h_fused<in_ntiles_c, out_ntiles_c, window_size_hw>(cb_id, scalar_cb_id, in_ntiles_hwc, out_cb_id);
+        reduce_h_fused<partial_iter_output_tiles, window_size_hw>(cb_id, scalar_cb_id, out_cb_id);
         cb_pop_front(scalar_cb_id, 1);
     }
 }  // MAIN

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -161,7 +161,8 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         next_cb_index++, program, all_cores, in_cb_pagesize, in_cb_npages, input_cb_data_format, halo_in.buffer());
 
     // first intermediate CB
-    uint32_t in1_cb_pagesize = std::min(tt::constants::TILE_WIDTH * input.element_size() * 8, input_stick_nbytes);
+    uint32_t in1_cb_pagesize =
+        std::min(tt::constants::TILE_WIDTH * input.element_size() * MAX_TILES_PER_REDUCTION, input_stick_nbytes);
     uint32_t in_cb_id1 = next_cb_index++;
     tt::tt_metal::create_cb(
         in_cb_id1,

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_bilinear_program_factory_multicore.cpp
@@ -77,6 +77,7 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.get_dtype());
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.get_dtype());
 
+    TT_FATAL(input.get_padded_shape()[-1] % 32 == 0, "input channels should be divisible by 32");
     // NOTE: input is assumed to have channels last format: {N, H, W, C}, {N, 1, H * W, C}, {1, 1, N * H * W, C}
     // NOTE: Bfp8_b/TILE is not yet supported
     uint32_t input_stick_nbytes = input.get_padded_shape()[-1] * input.element_size();
@@ -97,6 +98,10 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     uint32_t ncores = shard_spec.num_cores();
     uint32_t ncores_x = device->compute_with_storage_grid_size().x;
     uint32_t ncores_nhw = ncores;
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+    uint32_t input_block_size_bytes = input_stick_nbytes;
+    input_block_size_bytes =
+        std::min(input_block_size_bytes, MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH * input.element_size());
 
     auto out_shard_spec = output.shard_spec().value();
     TT_FATAL(
@@ -148,20 +153,21 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     uint32_t buffering_factor = 2;  // only apply to intermediate buffers
 
     // input data is in a sharded CB
-    uint32_t aligned_input_stick_nbytes = round_up_to_mul32(input_stick_nbytes);
-    uint32_t in_cb_pagesize = aligned_input_stick_nbytes;
+    uint32_t in_cb_pagesize = input_stick_nbytes;
     uint32_t in_cb_npages = halo_shard_shape[0];
+    uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[3] / constants::TILE_WIDTH);
 
     auto [in_cb_id, cb_src0] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, in_cb_pagesize, in_cb_npages, input_cb_data_format, halo_in.buffer());
 
     // first intermediate CB
+    uint32_t in1_cb_pagesize = std::min(tt::constants::TILE_WIDTH * input.element_size() * 8, input_stick_nbytes);
     uint32_t in_cb_id1 = next_cb_index++;
     tt::tt_metal::create_cb(
         in_cb_id1,
         program,
         all_cores,
-        in_cb_pagesize,
+        in1_cb_pagesize,
         4 * buffering_factor,
         input_cb_data_format);  // since 4 pixels per page are needed for intermediate tensor.
 
@@ -188,8 +194,9 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         in_scalar_cb_id2, program, all_cores, in_scalar_cb_pagesize, in_scalar_cb_npages, input_cb_data_format);
 
     // output sharded CB with upsampled data
-    uint32_t out_cb_pagesize = round_up_to_mul32(output_stick_nbytes);  // aligned output stick n bytes
-    uint32_t out_cb_npages = output_nsticks_per_core;
+    uint32_t out_cb_pagesize = tt::constants::TILE_WIDTH * output.element_size();
+    uint32_t out_cb_npages = output.shard_spec().value().shape[0] * in_ntiles_c;
+
     auto [out_cb_id, out_cb] = tt::tt_metal::create_cb(
         next_cb_index++, program, all_cores, out_cb_pagesize, out_cb_npages, output_cb_data_format, output.buffer());
 
@@ -215,6 +222,8 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
     uint32_t y_index_u32 = *reinterpret_cast<uint32_t*>(&y_index);
     uint32_t x_index_compute_u32 = *reinterpret_cast<uint32_t*>(&x_index_compute);
 
+    uint32_t num_input_width_blocks =
+        std::ceil((float)(input_shape[3]) / (MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH));
     std::vector<uint32_t> reader_compile_time_args = {
         in_cb_id,
         in_cb_id1,
@@ -224,6 +233,8 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         y_index_u32,
         x_index_compute_u32,
         1,
+        num_input_width_blocks,
+        input_block_size_bytes,
     };
 
     std::vector<uint32_t> writer_compile_time_args = {
@@ -235,6 +246,8 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         y_index_u32,
         x_index_compute_u32,
         0,
+        num_input_width_blocks,
+        input_block_size_bytes,
     };
 
     string writer_kernel_fname, reader_kernel_fname, compute_kernel_fname;
@@ -245,7 +258,6 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         "ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp");
     compute_kernel_fname = std::string("ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp");
 
-    uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[3] / constants::TILE_WIDTH);
     std::vector<uint32_t> compute_compile_time_args = {
         in_cb_id1,
         in_cb_id2,
@@ -257,6 +269,8 @@ tt::tt_metal::operation::ProgramWithCallbacks bilinear_multi_core(
         scale_factor_h * scale_factor_w,
         (uint32_t)std::ceil((float)output_shape[3] / constants::TILE_WIDTH),
         output_nsticks_per_core,  // loop count with blocks
+        num_input_width_blocks,
+        input_block_size_bytes,
     };
 
     auto reader_kernel = CreateKernel(


### PR DESCRIPTION
 ### Ticket
  https://github.com/tenstorrent/tt-metal/issues/21814
  
 ### Problem description
Bilinear upsample implementation previously did not support channels greater than 256, and was missing a check to ensure the number of channels is a multiple of the tile width (32). This led to failures or incorrect results for certain channel sizes.
  
 ### What's changed
- Added support for wide channels (channels > 256) in the bilinear upsample implementation.
- Updated tests (`test_upsample.py)` to pad the number of channels so only multiples of 32 are passed.
- Added a check in `upsample_bilinear_program_factory_multicore.cpp` to enforce that the number of channels is a multiple of 32, with error handling for unsupported cases.
  
 ### Checklist
  - [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes [Link](https://github.com/tenstorrent/tt-metal/actions/runs/14966894177)
- [X] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml) CI passes[Link1](https://github.com/tenstorrent/tt-metal/actions/runs/14966927109) [Link2](https://github.com/tenstorrent/tt-metal/actions/runs/14966920493)
- [X] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) [Link](https://github.com/tenstorrent/tt-metal/actions/runs/14966934542)
- [X] [Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI same as main [Link](https://github.com/tenstorrent/tt-metal/actions/runs/14966940026)