### PR TITLE
#21907: Add metallium installation instructions to TTT README.md

### DIFF
--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -15,7 +15,9 @@ The current version is verified to work with the following models:
 - [Mistral-7B-Instruct-v0.3](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3)
 
 ## Dependencies
-TT-Transformers has some additional python dependencies. Install them from:
+
+1. Install [TT-Metalium and TTNN](../../INSTALLING.md).
+2. Install additional python dependencies:
 
 ```
 pip install -r models/tt_transformers/requirements.txt


### PR DESCRIPTION
### Ticket
#21907

### Problem description
It was not clear to users that Metallium must be installed first.

### What's changed
Clarify by adding metallium and linking to install guide in dependencies of ttt readme.