### PR TITLE
#21898: modify div test range, clean up div

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -33,7 +33,7 @@ binary_fns = {
     "sub",
     "rsub",
     "mul",
-    "div",
+    "divide",
     "bias_gelu",
 }
 
@@ -135,7 +135,7 @@ def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY
         parameters({"logaddexp", "logaddexp2"}, {floor_lhs_ceil_rhs_cos_post}),
         parameters({"ge", "lt", "le"}, {exp_floor_lhs_exp_rhs, log_lhs_sqrt_abs_post}),
         parameters({"logical_and", "logical_or", "logical_xor", "bias_gelu"}, {log_lhs_sqrt_abs_post}),
-        parameters({"div"}, {exp_post, tanh_post, exp2_post, expm1_post, i0_post, tan_post}),
+        parameters({"divide"}, {exp_post, tanh_post, exp2_post, expm1_post, i0_post, tan_post}),
         parameters({"sub"}, {log_post, log2_post, log10_post}),
         parameters({"ldexp"}, {erfinv_post, tan_post, floor_post, ceil_post}),
         parameters({"squared_difference"}, {erfinv_post, i0_post}),
@@ -149,7 +149,7 @@ def test_binary_scalar_ops(a_shape, b_shape, ttnn_fn, activations, device):
     lhs, rhs, post = ([getattr(ttnn.UnaryOpType, op) for op in ops] for ops in activations)
     golden_lhs, golden_rhs, golden_post = ((activation_fns[op] for op in ops) for ops in activations)
     # make 0 exclusive for rhs of div
-    min, max = (1, 0) if ttnn_fn == "div" else (0, 1)
+    min, max = (1, 0) if ttnn_fn == "divide" else (0, 1)
 
     a_pt, a_tt = rand_bf16_gen(a_shape, device)
     b_pt, b_tt = rand_bf16_gen(b_shape, device, min=min, max=max)
@@ -197,7 +197,7 @@ activation_with_param_fns = {
         (torch.Size([5, 1, 1, 64]), torch.Size([1, 3, 128, 1])),
     ),
 )
-@pytest.mark.parametrize("ttnn_fn", ("add", "sub", "mul", "div"))
+@pytest.mark.parametrize("ttnn_fn", ("add", "sub", "mul", "divide"))
 @pytest.mark.parametrize(
     "post_activations",
     (
@@ -215,7 +215,7 @@ def test_binary_scalar_ops_with_unary_param(a_shape, b_shape, ttnn_fn, post_acti
     post = [(getattr(ttnn.UnaryOpType, op), param) for op, param in post_activations]
     golden_post = ((lambda x: activation_with_param_fns[op](x, param)) for op, param in post_activations)
     # make 0 exclusive for rhs of div
-    min, max = (1, 0) if ttnn_fn == "div" else (0, 1)
+    min, max = (1, 0) if ttnn_fn == "divide" else (0, 1)
 
     a_pt, a_tt = rand_bf16_gen(a_shape, device)
     b_pt, b_tt = rand_bf16_gen(b_shape, device, min=min, max=max)
@@ -512,7 +512,7 @@ def test_binary_sharded_core_grid(device, a_shape, b_shape, sharded_core_grid, m
         ttnn.add,
         ttnn.sub,
         ttnn.mul,
-        ttnn.div,
+        ttnn.divide,
         ttnn.rsub,
         ttnn.eq,
         ttnn.ne,
@@ -580,7 +580,7 @@ def test_binary_sfpu_ops(input_shapes, dtype, ttnn_fn, device):
         ttnn.add,
         ttnn.sub,
         ttnn.mul,
-        ttnn.div,
+        ttnn.divide,
         ttnn.rsub,
         ttnn.eq,
         ttnn.ne,
@@ -762,7 +762,7 @@ binary_inplace_fns = {
     "add_",
     "sub_",
     "mul_",
-    "div_",
+    "divide_",
     "rsub_",
     "gt_",
     "lt_",
@@ -818,7 +818,7 @@ def test_inplace_binary_ops_with_tensor(a_shape, b_shape, ttnn_fn, activations, 
     ttnn_op = getattr(ttnn, ttnn_fn)
     lhs, rhs, post = ([getattr(ttnn.UnaryOpType, op) for op in ops] for ops in activations)
     golden_lhs, golden_rhs, golden_post = ((activation_fns[op] for op in ops) for ops in activations)
-    min, max = (1, 0) if ttnn_fn == "div_" else (0, 1)
+    min, max = (1, 0) if ttnn_fn == "divide_" else (0, 1)
 
     torch_input_tensor_a, input_tensor_a = rand_bf16_gen(a_shape, device)
     torch_input_tensor_b, input_tensor_b = rand_bf16_gen(b_shape, device, min=min, max=max)
@@ -1010,7 +1010,7 @@ def test_inplace_binary_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
         "add_",
         "sub_",
         "mul_",
-        "div_",
+        "divide_",
         "rsub_",
         "gt_",
         "lt_",
@@ -1241,7 +1241,7 @@ def test_binary_sharded_small_tile(a_shape, b_shape, shard_type, shard_size, cor
         ttnn.add,
         ttnn.sub,
         ttnn.mul,
-        # ttnn.div,
+        # ttnn.divide,
         # ttnn.rsub,
         ttnn.eq,
         ttnn.ne,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -13,7 +13,7 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     compare_equal,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import is_grayskull, skip_for_grayskull, skip_for_blackhole
+from models.utility_functions import is_grayskull, skip_for_grayskull
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -185,7 +185,6 @@ def test_binary_subalpha_ttnn(input_shapes, alpha, device):
     assert comp_pass
 
 
-@skip_for_blackhole("Fails on BH. Issue #19642")
 @pytest.mark.parametrize("accurate_mode", [False, True])
 @pytest.mark.parametrize("round_mode", [None, "trunc", "floor"])
 @pytest.mark.parametrize(
@@ -204,8 +203,8 @@ def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
     else:
-        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -200, 150, device)
+        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -120, 200, device)
 
     output_tensor = ttnn.div(input_tensor1, input_tensor2, accurate_mode=accurate_mode, round_mode=round_mode)
     golden_function = ttnn.get_golden_function(ttnn.div)
@@ -233,8 +232,8 @@ def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -1e6, 1e6, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -1e6, -1, device)
     else:
-        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -1e6, 1e6, device)
-        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -1e6, 1e6, device)
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -2e6, 1e6, device)
+        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -1e6, 2e6, device)
 
     output_tensor = ttnn.div(input_tensor1, input_tensor2, accurate_mode=accurate_mode, round_mode=round_mode)
     golden_function = ttnn.get_golden_function(ttnn.div)
@@ -263,8 +262,8 @@ def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
     else:
-        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
-        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
+        in_data1, input_tensor1 = data_gen_with_range(input_shapes, -200, 100, device)
+        in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, 200, device)
 
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_ng_typecast.py
@@ -607,7 +607,7 @@ def test_inplace_sub_typecast_b(input_shapes, device):
         "add",
         "sub",
         "mul",
-        "div",
+        "divide",
         "rsub",
         "gt",
         "lt",
@@ -664,7 +664,7 @@ def test_opt_output_scalar(input_shapes, ttnn_fn, scalar, device):
         "add",
         "sub",
         "mul",
-        "div",
+        "divide",
         "rsub",
         "squared_difference",
     ],
@@ -765,7 +765,7 @@ def test_edgecase_dims_eltwise_scalar_logical(input_shape, scalar, ttnn_fn, memo
         "add",
         "sub",
         "mul",
-        "div",
+        "divide",
         "rsub",
         "squared_difference",
     ],
@@ -782,7 +782,7 @@ def test_edgecase_dims_eltwise_broadcast_matrix_math(input_shapes, ttnn_fn, memo
     torch_input_tensor_a = torch.randn(a_shape, dtype=torch.bfloat16)
     torch_input_tensor_b = torch.randn(b_shape, dtype=torch.bfloat16)
 
-    if ttnn_fn == "div":
+    if ttnn_fn == "divide":
         torch_input_tensor_b[torch_input_tensor_b.abs() < 0.001] = 0.001
 
     input_tensor_a = ttnn.from_torch(
@@ -915,5 +915,5 @@ def test_binary_div(
     input_tensor_b = ttnn.from_torch(
         torch_input_b, layout=input_layout, memory_config=memory_config, dtype=input_dtype, device=device
     )
-    output_tensor = ttnn.div(input_tensor_a, input_tensor_b, dtype=output_dtype, use_legacy=False)
+    output_tensor = ttnn.divide(input_tensor_a, input_tensor_b, dtype=output_dtype, use_legacy=False)
     assert_with_pcc(torch_output, ttnn.to_torch(output_tensor), 0.999)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_ND.py
@@ -45,7 +45,7 @@ import ttnn
         ttnn.add,
         ttnn.sub,
         ttnn.mul,
-        ttnn.div,
+        ttnn.divide,
         ttnn.rsub,
         ttnn.eq,
         ttnn.ne,
@@ -68,7 +68,7 @@ def test_ND_subtile_bcast(device, shapes, ttnn_fn):
 
     torch_input_tensor_a = torch.rand(shapes[0], dtype=torch.bfloat16) * 100 - 50
     torch_input_tensor_b = None
-    if ttnn_fn == ttnn.div:
+    if ttnn_fn == ttnn.divide:
         torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.bfloat16) * 59 + 1
     else:
         torch_input_tensor_b = torch.rand(shapes[1], dtype=torch.bfloat16) * 100 - 50
@@ -112,7 +112,7 @@ def test_ND_subtile_bcast(device, shapes, ttnn_fn):
         ttnn.add,
         ttnn.sub,
         ttnn.mul,
-        ttnn.div,
+        ttnn.divide,
         ttnn.rsub,
         ttnn.eq,
         ttnn.ne,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binaryng_fp32.py
@@ -87,11 +87,11 @@ def test_div_fp32(device):
     #            1.500000000000000]])
     # tt out in torch TorchTensor([[ 0.500150859355927, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,                nan,  0.000000000000000,                inf,
     #            1.499999880790710]])
-    golden_fn = ttnn.get_golden_function(ttnn.div)
+    golden_fn = ttnn.get_golden_function(ttnn.divide)
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_div = ttnn.div(x_tt, y_tt, use_legacy=False)
+    z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=False)
     tt_out = ttnn.to_torch(z_tt_div)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -138,11 +138,11 @@ def test_div_bf16(device):
     #         dtype=torch.bfloat16)
     # tt out in torch TorchTensor([[ 0.500000000000000, -1.000000000000000, -4.000000000000000,  1.000000000000000,                inf,               -inf,  0.000000000000000,  0.000000000000000,  1.500000000000000]],
     #         dtype=torch.bfloat16)
-    golden_fn = ttnn.get_golden_function(ttnn.div)
+    golden_fn = ttnn.get_golden_function(ttnn.divide)
     z_torch = golden_fn(x_torch, y_torch)
     x_tt = ttnn.from_torch(x_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
     y_tt = ttnn.from_torch(y_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    z_tt_div = ttnn.div(x_tt, y_tt, use_legacy=False)  # bf16 runs FPU
+    z_tt_div = ttnn.divide(x_tt, y_tt, use_legacy=False)  # bf16 runs FPU
     tt_out = ttnn.to_torch(z_tt_div)
 
     status = ttnn.pearson_correlation_coefficient(z_torch, tt_out) >= 0.999
@@ -378,7 +378,7 @@ def test_bitwise_right_shift(device):
         ttnn.add,
         ttnn.rsub,
         ttnn.mul,
-        ttnn.div,
+        ttnn.divide,
     ],
 )
 def test_ng_scalar_fp32(device, ttnn_function):

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -282,6 +282,9 @@ Tensor ExecuteDiv::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
     if (not use_legacy.value_or(true)) {
+        TT_FATAL(
+            (!round_mode.has_value() && !accurate_mode),
+            "round_mode, accurate_mode are not valid when passing use_legacy parameter in div");
         return BinaryOperation<BinaryOpType::DIV>::invoke(
             queue_id,
             input_a,
@@ -298,28 +301,28 @@ Tensor ExecuteDiv::invoke(
     TT_FATAL(
         (round_mode == std::nullopt || round_mode == "trunc" || round_mode == "floor"),
         "Incorrect rounding mode (expected None, 'trunc', or 'floor')");
+
     output_tensor = output_tensor.value_or(ttnn::empty_like(input_a));
-    auto arch = input_a.device()->arch();
-    if (arch != tt::ARCH::GRAYSKULL) {
-        DataType input_dtype = input_a.get_dtype();
+    DataType input_dtype = input_a.get_dtype();
+    const bool is_fp32 = input_dtype == DataType::FLOAT32 && input_b.get_dtype() == DataType::FLOAT32;
+    Tensor result;
 
-        // No accurate_mode for FP32 div as inf/nan are handled at kernel level
-        if (input_dtype == DataType::FLOAT32 && input_b.get_dtype() == DataType::FLOAT32) {
-            Tensor result = ttnn::divide(queue_id, input_a, input_b, std::nullopt, output_mem_config, output_tensor);
-            if (round_mode == "trunc") {
-                result = ttnn::trunc(queue_id, result, output_mem_config, output_tensor);
-            } else if (round_mode == "floor") {
-                result = ttnn::floor(queue_id, result, output_mem_config, output_tensor);
-            }
-            return result;
-        }
-
+    // No accurate_mode for FP32 div as inf/nan are handled at kernel level
+    if (is_fp32) {
+        result = ttnn::divide(queue_id, input_a, input_b, std::nullopt, output_mem_config, output_tensor);
+    } else {
         Tensor a = typecast(queue_id, input_a, DataType::FLOAT32);
         Tensor b = typecast(queue_id, input_b, DataType::FLOAT32);
 
         // Div operation without inf/nan handling as reciprocal(0) = 1.7014118346046923e+38 not inf/nan
-        Tensor result =
-            ttnn::multiply(queue_id, a, ttnn::reciprocal(b), std::nullopt, output_mem_config, output_tensor);
+        result = ttnn::multiply(
+            queue_id,
+            a,
+            ttnn::reciprocal(queue_id, b, output_mem_config),
+            std::nullopt,
+            output_mem_config,
+            output_tensor);
+    }
 
         if (round_mode == "trunc") {
             result = ttnn::trunc(queue_id, result, output_mem_config, output_tensor);
@@ -327,15 +330,15 @@ Tensor ExecuteDiv::invoke(
             result = ttnn::floor(queue_id, result, output_mem_config, output_tensor);
         }
 
-        if (!accurate_mode) {  // If input_b is non-zero tensor
-            return typecast(queue_id, result, input_dtype, std::nullopt, output_tensor);
+        if (is_fp32) {
+            return result;
         }
 
-        float t_nan = std::nanf("");
-        float t_inf = std::numeric_limits<float>::infinity();
-        typecast(
-            queue_id,
-            where(
+        // Accurate mode: handle division by zero (inf/nan cases)
+        if (accurate_mode) {
+            float t_nan = std::nanf("");
+            float t_inf = std::numeric_limits<float>::infinity();
+            result = where(
                 queue_id,
                 ttnn::eqz(queue_id, input_b, output_mem_config),
                 ttnn::where(
@@ -348,39 +351,10 @@ Tensor ExecuteDiv::invoke(
                         t_inf,
                         std::nullopt,
                         output_mem_config)),
-                result),
-            input_dtype,
-            std::nullopt,
-            output_tensor);
-        return output_tensor.value();
-    } else {
-        ttnn::divide(queue_id, input_a, input_b, std::nullopt, std::nullopt, output_tensor);
-
-        if (round_mode == "trunc") {
-            ttnn::trunc(queue_id, output_tensor.value(), output_mem_config, output_tensor);
-        } else if (round_mode == "floor") {
-            ttnn::floor(queue_id, output_tensor.value(), output_mem_config, output_tensor);
+                result);
         }
 
-        if (!accurate_mode) {  // If input_b is non-zero tensor
-            return output_tensor.value();
-        }
-
-        float t_nan = std::nanf("");
-        float t_inf = std::numeric_limits<float>::infinity();
-        return ttnn::where(
-            queue_id,
-            ttnn::eqz(queue_id, input_b, output_mem_config),
-            ttnn::where(
-                queue_id,
-                ttnn::eqz(queue_id, input_a, output_mem_config),
-                t_nan,
-                ttnn::multiply(
-                    queue_id, ttnn::sign(input_a, output_mem_config), t_inf, std::nullopt, output_mem_config)),
-            output_tensor.value(),
-            output_mem_config,
-            output_tensor);
-    }
+        return typecast(queue_id, result, input_dtype, std::nullopt, output_tensor);
 }
 
 Tensor _div_no_nan_overload(const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {


### PR DESCRIPTION
### Ticket
Link to Github Issue #21898 #19642

### Problem description
TTNN binary div test inputs are not randomised correctly.  

### What's changed
- updated test range
- removed Grayskull check from ttnn.div 
- modified ttnn.div flow to redirect to device operation if use_legacy flag is passed, perform as composite as when use_legacy is null. ( to turn binary_ng on by default) 
- Enabled test on BH

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/21abdf15-f5f4-4728-b9d7-2d5e5a706311" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15040621123
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15001335649
- [ ] Blackhole Nightly - https://github.com/tenstorrent/tt-metal/actions/runs/15001299116
https://github.com/tenstorrent/tt-metal/actions/runs/15040627908/job/42271688262
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes