### PR TITLE
#0: Add ND sharding support for mesh device/buffer

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
-#include "command_queue_fixture.hpp"
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "dispatch/system_memory_manager.hpp"
 
 #include "tt_metal/test_utils/stimulus.hpp"
 
+#include <tt-metalium/distributed.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/allocator.hpp>
 
@@ -24,7 +25,7 @@ struct BufferDistributionSpecInputs {
     tt::tt_metal::BufferType buffer_type;
 };
 
-struct BufferAllocationExpected {
+struct MeshBufferAllocationExpected {
     std::vector<CoreCoord> cores;
     size_t num_cores;
     size_t num_dev_pages;
@@ -32,7 +33,7 @@ struct BufferAllocationExpected {
     size_t aligned_size_per_bank;
 };
 
-struct BufferReadWriteExpected {
+struct MeshBufferReadWriteExpected {
     using ExplicitCoreMappingInBytes =
         std::pair<std::vector<tt::tt_metal::CoreCoord>, std::vector<tt::tt_metal::DistributionSpec::TargetData>>;
     ExplicitCoreMappingInBytes explicit_core_mapping_in_bytes;
@@ -40,16 +41,16 @@ struct BufferReadWriteExpected {
 
 struct BufferAllocationParams {
     BufferDistributionSpecInputs inputs;
-    BufferAllocationExpected expected;
+    MeshBufferAllocationExpected expected;
 };
 
 struct BufferReadWriteParams {
     BufferDistributionSpecInputs inputs;
-    BufferReadWriteExpected expected;
+    MeshBufferReadWriteExpected expected;
 };
 
-std::shared_ptr<tt::tt_metal::Buffer> create_buffer_from_inputs(
-    const BufferDistributionSpecInputs& inputs, tt::tt_metal::IDevice* device) {
+std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_replicated_mesh_buffer_from_inputs(
+    const BufferDistributionSpecInputs& inputs, tt::tt_metal::distributed::MeshDevice* mesh_device) {
     auto buffer_distribution_spec = tt::tt_metal::BufferDistributionSpec::from_shard_spec(
         inputs.physical_tensor_shape,
         inputs.physical_shard_shape,
@@ -58,9 +59,20 @@ std::shared_ptr<tt::tt_metal::Buffer> create_buffer_from_inputs(
         inputs.shard_orientation);
 
     // These values would be passed from tensor correctly based on PageConfig
-    const auto host_size = inputs.physical_tensor_shape.volume() * inputs.bytes_per_element;
+    const auto host_size_in_bytes = inputs.physical_tensor_shape.volume() * inputs.bytes_per_element;
     const auto page_size = inputs.page_shape.height() * inputs.page_shape.width() * inputs.bytes_per_element;
-    return tt::tt_metal::Buffer::create(device, host_size, page_size, inputs.buffer_type, buffer_distribution_spec);
+
+    // MeshBuffer params
+    const tt::tt_metal::distributed::DeviceLocalBufferConfig device_local_config{
+        .page_size = page_size,
+        .buffer_type = inputs.buffer_type,
+        .buffer_layout = tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+        .buffer_distribution_spec = buffer_distribution_spec,
+    };
+
+    // Mirrors allocate_mesh_buffer_on_device in ttnn
+    const tt::tt_metal::distributed::ReplicatedBufferConfig mesh_buffer_config{.size = host_size_in_bytes};
+    return tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, device_local_config, mesh_device);
 }
 
 }  // namespace distribution_spec_tests
@@ -69,37 +81,42 @@ std::shared_ptr<tt::tt_metal::Buffer> create_buffer_from_inputs(
 using namespace distribution_spec_tests;
 using namespace tt::tt_metal;
 
-class BufferAllocationTests : public CommandQueueSingleCardBufferFixture,
-                              public ::testing::WithParamInterface<BufferAllocationParams> {};
+class MeshBufferAllocationTests : public GenericMeshDeviceFixture,
+                                  public ::testing::WithParamInterface<BufferAllocationParams> {};
 
-TEST_P(BufferAllocationTests, BufferAllocation) {
+TEST_P(MeshBufferAllocationTests, Allocation) {
     const auto& params = GetParam();
 
-    auto buffer = create_buffer_from_inputs(params.inputs, devices_[0]);
+    // Create a replicated mesh buffer across generic mesh device; tests will only use first device
+    const auto mesh_buffer = create_replicated_mesh_buffer_from_inputs(params.inputs, mesh_device_.get());
 
-    // Check that the stored cores in Buffer matches expected cores to be used
-    const auto& [cores, _] = buffer->get_bank_data_mapping();
+    // Extract local single-device buffer (ie. shard_view) concepts for testing
+    const tt::tt_metal::distributed::MeshCoordinate mesh_coordinate{0, 0};
+    const auto shard_view = mesh_buffer->get_device_buffer(mesh_coordinate);
+
+    // Check that the stored cores in local device buffer matches expected cores to be used
+    const auto& [cores, _] = shard_view->get_bank_data_mapping();
     EXPECT_EQ(cores, params.expected.cores);
 
     /* These are the params allocator cares about; check all of them */
-    EXPECT_EQ(buffer->num_cores().value(), params.expected.num_cores);
+    EXPECT_EQ(shard_view->num_cores().value(), params.expected.num_cores);
     // For BufferDistributionSpec, defined as: max number of pages per core * num_cores
-    EXPECT_EQ(buffer->num_dev_pages(), params.expected.num_dev_pages);
+    EXPECT_EQ(shard_view->num_dev_pages(), params.expected.num_dev_pages);
 
     // Alignment is handled internally, not testing that here
-    // In buffer, defined as: num_dev_pages * aligned_page_size
-    EXPECT_EQ(buffer->aligned_size(), params.expected.aligned_size);
-    // In buffer, calculated from: aligned_size, aligned_page_size, num_banks, alignment
-    // TODO: Fix buffer implementation to use aligned_size / num_cores? They should be equal...
-    // - Need to make buffer->num_cores() not optional...
-    EXPECT_EQ(buffer->aligned_size_per_bank(), params.expected.aligned_size_per_bank);
-    EXPECT_EQ(buffer->aligned_size() % buffer->num_cores().value(), 0);
-    EXPECT_EQ(buffer->aligned_size_per_bank(), buffer->aligned_size() / buffer->num_cores().value());
+    // In local device buffer, defined as: num_dev_pages * aligned_page_size
+    EXPECT_EQ(shard_view->aligned_size(), params.expected.aligned_size);
+    // In local device buffer, calculated from: aligned_size, aligned_page_size, num_banks, alignment
+    // TODO: Fix local device buffer implementation to use aligned_size / num_cores? They should be equal...
+    // - Need to make shard_view->num_cores() not optional...
+    EXPECT_EQ(shard_view->aligned_size_per_bank(), params.expected.aligned_size_per_bank);
+    EXPECT_EQ(shard_view->aligned_size() % shard_view->num_cores().value(), 0);
+    EXPECT_EQ(shard_view->aligned_size_per_bank(), shard_view->aligned_size() / shard_view->num_cores().value());
 }
 
 INSTANTIATE_TEST_SUITE_P(
     BufferDistributionSpec,
-    BufferAllocationTests,
+    MeshBufferAllocationTests,
     ::testing::Values(
         // Cut along last two dims; tile layout
         // page size = 32 x 32 x 2 = 2048 bytes (eg. bfloat16, uint16, etc...)
@@ -113,7 +130,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .shard_orientation = ShardOrientation::ROW_MAJOR,
                 .buffer_type = BufferType::L1,
             },
-            BufferAllocationExpected{
+            MeshBufferAllocationExpected{
                 .cores = {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}},
                 .num_cores = 6,
                 .num_dev_pages = 10 * 6,  // Shard shape is 10 pages
@@ -133,7 +150,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .shard_orientation = ShardOrientation::COL_MAJOR,
                 .buffer_type = BufferType::L1,
             },
-            BufferAllocationExpected{
+            MeshBufferAllocationExpected{
                 .cores = {{0, 0}, {0, 1}, {0, 2}, {0, 3}},
                 .num_cores = 4,
                 .num_dev_pages = 384 * 4,  // Shard shape is 384 pages
@@ -153,7 +170,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .shard_orientation = ShardOrientation::ROW_MAJOR,
                 .buffer_type = BufferType::L1,
             },
-            BufferAllocationExpected{
+            MeshBufferAllocationExpected{
                 .cores = {{0, 0}, {1, 0}, {2, 0}, {0, 1}, {1, 1}},
                 .num_cores = 5,
                 .num_dev_pages = 3 * 8 * 5,  // Shard shape is 8 pages; 3 shards max per bank (12 shards over 5 banks)
@@ -173,7 +190,7 @@ INSTANTIATE_TEST_SUITE_P(
                 .shard_orientation = ShardOrientation::COL_MAJOR,
                 .buffer_type = BufferType::L1,
             },
-            BufferAllocationExpected{
+            MeshBufferAllocationExpected{
                 .cores = {{0, 0}, {0, 1}, {1, 0}, {1, 1}},
                 .num_cores = 4,
                 .num_dev_pages = 5 * 120 *
@@ -184,23 +201,34 @@ INSTANTIATE_TEST_SUITE_P(
         })  // Values
 );
 
-class BufferReadWriteTests : public CommandQueueSingleCardBufferFixture,
-                             public ::testing::WithParamInterface<std::tuple<bool, bool, BufferReadWriteParams>> {};
+class MeshBufferReadWriteTests : public GenericMeshDeviceFixture,
+                                 public ::testing::WithParamInterface<std::tuple<bool, bool, BufferReadWriteParams>> {};
 
-TEST_P(BufferReadWriteTests, WriteReadLoopback) {
+TEST_P(MeshBufferReadWriteTests, WriteReadLoopback) {
     const auto& [cq_write, cq_read, params] = GetParam();
 
     // The expected values are assuming 16 byte alignment, which is true for L1 for WH + BH
     // If want to extend tests to DRAM or other alignment, can update expected values to be derived from aligned page
     // size
-    const auto allocator_alignment = devices_[0]->allocator()->get_alignment(params.inputs.buffer_type);
+    const auto allocator_alignment = mesh_device_->allocator()->get_alignment(params.inputs.buffer_type);
     ASSERT_EQ(allocator_alignment, 16);
 
-    auto buffer = create_buffer_from_inputs(params.inputs, devices_[0]);
-    auto device = buffer->device();
-    const DeviceAddr base_address = buffer->address();
+    // Create a replicated mesh buffer across generic mesh device; tests will only use first device
+    const auto mesh_buffer = create_replicated_mesh_buffer_from_inputs(params.inputs, mesh_device_.get());
+
+    // Extract local single-device buffer (ie. shard_view) concepts for testing
+    const tt::tt_metal::distributed::MeshCoordinate mesh_coordinate{0, 0};
+    const auto shard_view = mesh_buffer->get_device_buffer(mesh_coordinate);
+    const auto local_device = shard_view->device();
+    const auto host_size_in_bytes = mesh_buffer->device_local_size();
+    const auto bank_base_address = mesh_buffer->address();
+
+    // Double check that mesh buffer properties match local single-device buffer properties
+    ASSERT_EQ(host_size_in_bytes, shard_view->size());
+    ASSERT_EQ(bank_base_address, shard_view->address());
 
     /* Test is based off of: test_EnqueueWriteBuffer_and_EnqueueReadBuffer
+     * Here, buffer refers to local device buffer or shard view
      * - Initialize buffer and command queue state to 0
      * - Initialize src vector
      * - Write to buffer (with either EnqueueWriteBuffer or WriteToBuffer)
@@ -208,21 +236,22 @@ TEST_P(BufferReadWriteTests, WriteReadLoopback) {
      * - Read from buffer (with either EnqueueReadBuffer or ReadFromBuffer)
      */
 
-    // Initialize buffer to 0
+    // Initialize local device buffer to 0
     {
-        std::vector<uint32_t> zeros_vector(buffer->aligned_size_per_bank() / sizeof(uint32_t), 0);
+        std::vector<uint32_t> zeros_vector(shard_view->aligned_size_per_bank() / sizeof(uint32_t), 0);
         for (const auto& core : corerange_to_cores(params.inputs.grid)) {
-            tt::tt_metal::detail::WriteToDeviceL1(device, core, base_address, zeros_vector, buffer->core_type());
+            tt::tt_metal::detail::WriteToDeviceL1(
+                local_device, core, bank_base_address, zeros_vector, shard_view->core_type());
         }
     }
 
     // Clear out command queue
     {
         uint16_t channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
+            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(local_device->id());
         chip_id_t mmio_device_id =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
-        uint32_t cq_size = device->sysmem_manager().get_cq_size();
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(local_device->id());
+        uint32_t cq_size = local_device->sysmem_manager().get_cq_size();
         uint32_t cq_start = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
             CommandQueueHostAddrType::UNRESERVED);
 
@@ -238,29 +267,39 @@ TEST_P(BufferReadWriteTests, WriteReadLoopback) {
 
     // Create src vector
     const auto src =
-        tt::test_utils::generate_uniform_random_vector<uint8_t>(0, UINT8_MAX, buffer->size() / sizeof(uint8_t));
+        tt::test_utils::generate_uniform_random_vector<uint8_t>(0, UINT8_MAX, host_size_in_bytes / sizeof(uint8_t));
 
     if (cq_write) {
-        tt::log_info("Writing with: EnqueueWriteBuffer");
-        auto& command_queue = device->command_queue();
-        EnqueueWriteBuffer(command_queue, buffer, src.data(), /*blocking=*/false);
-        Finish(command_queue);
+        tt::log_info("Writing with: FDMeshCommandQueue enqueue_write_shards");
+        std::vector<tt::tt_metal::distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfer{{
+            .shard_coord = tt::tt_metal::distributed::MeshCoordinate{0, 0},
+            .host_data = const_cast<void*>(reinterpret_cast<const void*>(src.data())),
+        }};
+        mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, shard_data_transfer, /*blocking=*/false);
+        Finish(mesh_device_->mesh_command_queue());
     } else {
-        tt::log_info("Writing with: WriteToBuffer");
-        tt::tt_metal::detail::WriteToBuffer(buffer, src);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(device->id());
+        tt::log_info("Writing with: WriteToBuffer (equivalent to SDMeshCommandQueue enqueue_write_shards)");
+        tt::tt_metal::detail::WriteToBuffer(*shard_view, src);
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(local_device->id());
     }
 
     // Validate written results are correct per core
     {
         // result_per_core is reassigned inside ReadFromDeviceL1
         std::vector<uint32_t> result_per_core;
+        // src.data() is sufficient since src is already a vector of uint8_t, but this is safer if src creation is
+        // changed to another dtype
         const auto* src_ptr = static_cast<const uint8_t*>(src.data());
 
         const auto& [cores, core_mapping_in_bytes] = params.expected.explicit_core_mapping_in_bytes;
         for (size_t i = 0; i < cores.size(); i++) {
             tt::tt_metal::detail::ReadFromDeviceL1(
-                device, cores[i], base_address, buffer->aligned_size_per_bank(), result_per_core, buffer->core_type());
+                local_device,
+                cores[i],
+                bank_base_address,
+                shard_view->aligned_size_per_bank(),
+                result_per_core,
+                shard_view->core_type());
 
             const auto* result_per_core_ptr = reinterpret_cast<const uint8_t*>(result_per_core.data());
             for (const auto& chunk_mapping_in_bytes : core_mapping_in_bytes[i]) {
@@ -274,16 +313,20 @@ TEST_P(BufferReadWriteTests, WriteReadLoopback) {
         }
     }
 
-    std::vector<uint8_t> dst(buffer->size() / sizeof(uint8_t));
+    // Initialize dst vector
+    std::vector<uint8_t> dst(host_size_in_bytes / sizeof(uint8_t), 0);
 
     if (cq_read) {
-        tt::log_debug("Reading with: EnqueueReadBuffer");
-        auto& command_queue = device->command_queue();
-        EnqueueReadBuffer(command_queue, buffer, dst.data(), /*blocking=*/false);
-        Finish(command_queue);
+        tt::log_info("Reading with: FDMeshCommandQueue enqueue_read_shards");
+        std::vector<tt::tt_metal::distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfer{{
+            .shard_coord = tt::tt_metal::distributed::MeshCoordinate{0, 0},
+            .host_data = const_cast<void*>(reinterpret_cast<const void*>(dst.data())),
+        }};
+        mesh_device_->mesh_command_queue().enqueue_read_shards(shard_data_transfer, mesh_buffer, /*blocking=*/false);
+        Finish(mesh_device_->mesh_command_queue());
     } else {
-        tt::log_info("Reading with: ReadFromBuffer");
-        tt::tt_metal::detail::ReadFromBuffer(buffer, dst);
+        tt::log_info("Reading with: ReadFromBuffer (equivalent to SDMeshCommandQueue enqueue_read_shards)");
+        tt::tt_metal::detail::ReadFromBuffer(*shard_view, dst);
     }
 
     // Validate read results are correct
@@ -292,7 +335,7 @@ TEST_P(BufferReadWriteTests, WriteReadLoopback) {
 
 INSTANTIATE_TEST_SUITE_P(
     BufferDistributionSpec,
-    BufferReadWriteTests,
+    MeshBufferReadWriteTests,
     ::testing::Combine(
         ::testing::Values(true, false),  // cq_write
         ::testing::Values(true, false),  // cq_read
@@ -309,8 +352,8 @@ INSTANTIATE_TEST_SUITE_P(
                     .shard_orientation = ShardOrientation::ROW_MAJOR,
                     .buffer_type = BufferType::L1,
                 },
-                BufferReadWriteExpected{
-                    .explicit_core_mapping_in_bytes = BufferReadWriteExpected::ExplicitCoreMappingInBytes(
+                MeshBufferReadWriteExpected{
+                    .explicit_core_mapping_in_bytes = MeshBufferReadWriteExpected::ExplicitCoreMappingInBytes(
                         {{0, 0}, {1, 0}, {2, 0}, {3, 0}, {0, 1}, {1, 1}, {2, 1}, {3, 1}},
                         {{{0, 0, 2048}, {2048, 2048, 2048}},
                          {{4096, 0, 2048}},
@@ -335,8 +378,8 @@ INSTANTIATE_TEST_SUITE_P(
                     .shard_orientation = ShardOrientation::ROW_MAJOR,
                     .buffer_type = BufferType::L1,
                 },
-                BufferReadWriteExpected{
-                    .explicit_core_mapping_in_bytes = BufferReadWriteExpected::ExplicitCoreMappingInBytes(
+                MeshBufferReadWriteExpected{
+                    .explicit_core_mapping_in_bytes = MeshBufferReadWriteExpected::ExplicitCoreMappingInBytes(
                         {{4, 6}, {5, 6}, {6, 6}, {1, 1}},
                         {{{0, 0, 1088}, {1088, 1088, 1088}, {2176, 3264, 1088}, {3264, 4352, 1088}},
                          {{4352, 0, 1088}, {5440, 1088, 1088}, {6528, 3264, 1088}, {7616, 4352, 1088}},
@@ -356,8 +399,8 @@ INSTANTIATE_TEST_SUITE_P(
                     .shard_orientation = ShardOrientation::ROW_MAJOR,
                     .buffer_type = BufferType::L1,
                 },
-                BufferReadWriteExpected{
-                    .explicit_core_mapping_in_bytes = BufferReadWriteExpected::ExplicitCoreMappingInBytes(
+                MeshBufferReadWriteExpected{
+                    .explicit_core_mapping_in_bytes = MeshBufferReadWriteExpected::ExplicitCoreMappingInBytes(
                         {{0, 0}, {1, 0}},
                         {{{0, 0, 16}, {32, 16, 16}, {64, 32, 16}, {96, 64, 16}, {128, 80, 16}, {160, 96, 16}},
                          {{16, 0, 16}, {48, 16, 16}, {80, 32, 16}, {112, 64, 16}, {144, 80, 16}, {176, 96, 16}}}),
@@ -376,8 +419,8 @@ INSTANTIATE_TEST_SUITE_P(
                     .shard_orientation = ShardOrientation::COL_MAJOR,
                     .buffer_type = BufferType::L1,
                 },
-                BufferReadWriteExpected{
-                    .explicit_core_mapping_in_bytes = BufferReadWriteExpected::ExplicitCoreMappingInBytes(
+                MeshBufferReadWriteExpected{
+                    .explicit_core_mapping_in_bytes = MeshBufferReadWriteExpected::ExplicitCoreMappingInBytes(
                         {{0, 0}, {0, 1}, {0, 2}, {0, 3}, {0, 4}, {1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}},
                         {{{0, 0, 4},
                           {4, 16, 4},
@@ -411,8 +454,8 @@ INSTANTIATE_TEST_SUITE_P(
                     .shard_orientation = ShardOrientation::ROW_MAJOR,
                     .buffer_type = BufferType::L1,
                 },
-                BufferReadWriteExpected{
-                    .explicit_core_mapping_in_bytes = BufferReadWriteExpected::ExplicitCoreMappingInBytes(
+                MeshBufferReadWriteExpected{
+                    .explicit_core_mapping_in_bytes = MeshBufferReadWriteExpected::ExplicitCoreMappingInBytes(
                         {{0, 0}, {1, 0}, {2, 0}, {0, 1}, {1, 1}},
                         {{{0, 0, 2048},
                           {2048, 2048, 2048},

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -192,6 +192,15 @@ class Buffer final {
     };
 
 public:
+    // Buffer::create APIs provide single entry point for creating buffers with ShardSpec or BufferDistributionSpec
+    // - Validation is done in Buffer constructor with validate_buffer_parameters
+    // - Only one of ShardSpec or BufferDistributionSpec can be set
+    // TODO: buffer_layout should not be needed with BufferDistributionSpec since layout is implicit in the spec
+    // - ie. It's possible to fully unify interleaved and sharding
+    // - For now, must pass TensorMemoryLayout::BLOCK_SHARDED (seems like the most sensible option)
+    // TODO: Unify Buffer parameters with MeshBuffer (ie. use DeviceLocalBufferConfig as well)
+    // - BufferDistributionSpec is added to the end with default std::nullopt value to avoid breaking existing usages
+    // - Eventually, do we even need to expose single-device Buffer::create to users?
     static std::shared_ptr<Buffer> create(
         IDevice* device,
         DeviceAddr size,
@@ -200,7 +209,8 @@ public:
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
         std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+        std::optional<SubDeviceId> sub_device_id = std::nullopt,
+        const std::optional<BufferDistributionSpec>& buffer_distribution_spec = std::nullopt);
     static std::shared_ptr<Buffer> create(
         IDevice* device,
         DeviceAddr address,
@@ -210,20 +220,8 @@ public:
         TensorMemoryLayout buffer_layout = TensorMemoryLayout::INTERLEAVED,
         const std::optional<ShardSpecBuffer>& shard_parameter = std::nullopt,
         std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-
-    // Forked APIs for BufferDistributionSpec
-    // - Only usable for tensor allocation in OPs
-    // TODO: Need to support proper read/write for buffers with BufferDistributionSpec
-    static std::shared_ptr<Buffer> create(
-        IDevice* device,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        const BufferDistributionSpec& buffer_distribution_spec,
-        std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-    // TODO: Add create with address or just port over existing one?
+        std::optional<SubDeviceId> sub_device_id = std::nullopt,
+        const std::optional<BufferDistributionSpec>& buffer_distribution_spec = std::nullopt);
 
     Buffer(const Buffer& other) = delete;
     Buffer& operator=(const Buffer& other) = delete;
@@ -352,20 +350,6 @@ private:
     AllocationStatus allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
     bool hooked_allocation_ = false;
     DeviceAddr address_ = 0;
-
-    // Private helper function to commonize code path for buffer creation with either ShardSpecBuffer or
-    // BufferDistributionSpec
-    // TODO: Delete if/when we remove ShardSpecBuffer
-    static std::shared_ptr<Buffer> create_buffer(
-        IDevice* device,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        const BufferType buffer_type,
-        const TensorMemoryLayout buffer_layout,
-        const std::optional<ShardSpecBuffer>& shard_parameters,
-        const std::optional<BufferDistributionSpec>& buffer_distribution_spec,
-        const std::optional<bool> bottom_up,
-        const std::optional<SubDeviceId> sub_device_id);
 
     // These members must be only accessed on the device worker thread
     DeviceAddr page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -77,7 +77,7 @@ template <typename DType>
 void EnqueueWriteMeshBuffer(
     MeshCommandQueue& mesh_cq,
     std::shared_ptr<MeshBuffer>& mesh_buffer,
-    std::vector<DType>& src,
+    const std::vector<DType>& src,
     bool blocking = false) {
     mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, src.data(), blocking);
 }

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -33,6 +33,8 @@ struct DeviceLocalBufferConfig {
     // Must be set for sharded buffer layouts.
     std::optional<ShardSpecBuffer> shard_parameters;
 
+    std::optional<BufferDistributionSpec> buffer_distribution_spec;
+
     // The direction in which memory for this buffer is allocated.
     std::optional<bool> bottom_up;
 };
@@ -79,7 +81,7 @@ class MeshBuffer {
 public:
     static std::shared_ptr<MeshBuffer> create(
         const MeshBufferConfig& mesh_buffer_config,
-        const DeviceLocalBufferConfig& device_local_layout,
+        const DeviceLocalBufferConfig& device_local_config,
         MeshDevice* mesh_device,
         std::optional<DeviceAddr> address = std::nullopt);
     ~MeshBuffer();

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -387,29 +387,89 @@ void FDMeshCommandQueue::finish(tt::stl::Span<const SubDeviceId> sub_device_ids)
 }
 
 void FDMeshCommandQueue::write_shard_to_device(
-    Buffer* shard_view, const void* src, const BufferRegion& region, tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    const MeshBuffer& buffer,
+    const MeshCoordinate& device_coord,
+    const void* src,
+    const std::optional<BufferRegion>& region,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Writes are not supported during trace capture.");
-    auto device = shard_view->device();
-    sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
-    buffer_dispatch::write_to_device_buffer(
-        src, *shard_view, region, id_, expected_num_workers_completed_, this->dispatch_core_type(), sub_device_ids);
+
+    const auto shard_view = buffer.get_device_buffer(device_coord);
+    const auto region_value = region.value_or(BufferRegion(0, shard_view->size()));
+
+    if (shard_view->is_nd_sharded()) {
+        TT_FATAL(
+            shard_view->is_l1(),
+            "Local device shard with BufferDistributionSpec must be L1 for write_shard_to_device!");
+        const auto& [banks, bank_mapping_in_bytes] = shard_view->get_bank_data_mapping();
+        for (size_t i = 0; i < banks.size(); i++) {
+            const auto virtual_core =
+                shard_view->device()->virtual_core_from_logical_core(banks[i], shard_view->core_type());
+            for (const auto& chunk_mapping_in_bytes : bank_mapping_in_bytes[i]) {
+                enqueue_write_shard_to_core(
+                    DeviceMemoryAddress{
+                        .device_coord = device_coord,
+                        .virtual_core_coord = virtual_core,
+                        .address = shard_view->address() + chunk_mapping_in_bytes.dst},
+                    (char*)src + chunk_mapping_in_bytes.src,
+                    chunk_mapping_in_bytes.size,
+                    /*blocking=*/false,
+                    sub_device_ids);
+            }
+        }
+    } else {
+        sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
+        buffer_dispatch::write_to_device_buffer(
+            src,
+            *shard_view,
+            region_value,
+            id_,
+            expected_num_workers_completed_,
+            this->dispatch_core_type(),
+            sub_device_ids);
+    }
 }
 
 void FDMeshCommandQueue::read_shard_from_device(
-    Buffer* shard_view,
+    const MeshBuffer& buffer,
+    const MeshCoordinate& device_coord,
     void* dst,
-    const BufferRegion& region,
+    const std::optional<BufferRegion>& region,
     std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     in_use_ = true;
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
+
+    const auto shard_view = buffer.get_device_buffer(device_coord);
+    const auto region_value = region.value_or(BufferRegion(0, shard_view->size()));
+
     auto device = shard_view->device();
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);
 
-    if (is_sharded(shard_view->buffer_layout())) {
+    if (shard_view->is_nd_sharded()) {
+        TT_FATAL(
+            shard_view->is_l1(),
+            "Local device shard with BufferDistributionSpec must be L1 for read_shard_from_device!");
+        const auto& [banks, bank_mapping_in_bytes] = shard_view->get_bank_data_mapping();
+        for (size_t i = 0; i < banks.size(); i++) {
+            const auto virtual_core =
+                shard_view->device()->virtual_core_from_logical_core(banks[i], shard_view->core_type());
+            for (const auto& chunk_mapping_in_bytes : bank_mapping_in_bytes[i]) {
+                enqueue_read_shard_from_core(
+                    DeviceMemoryAddress{
+                        .device_coord = device_coord,
+                        .virtual_core_coord = virtual_core,
+                        .address = shard_view->address() + chunk_mapping_in_bytes.dst},
+                    (char*)dst + chunk_mapping_in_bytes.src,
+                    chunk_mapping_in_bytes.size,
+                    /*blocking=*/false,
+                    sub_device_ids);
+            }
+        }
+    } else if (is_sharded(shard_view->buffer_layout())) {
         auto dispatch_params = buffer_dispatch::initialize_sharded_buf_read_dispatch_params(
-            *shard_view, id_, expected_num_workers_completed_, region);
+            *shard_view, id_, expected_num_workers_completed_, region_value);
         auto cores = buffer_dispatch::get_cores_for_sharded_buffer(
             dispatch_params.width_split, dispatch_params.buffer_page_mapping, *shard_view);
         for (uint32_t core_id = 0; core_id < shard_view->num_cores(); ++core_id) {
@@ -425,7 +485,7 @@ void FDMeshCommandQueue::read_shard_from_device(
     } else {
         buffer_dispatch::BufferReadDispatchParamsVariant dispatch_params_variant =
             buffer_dispatch::initialize_interleaved_buf_read_dispatch_params(
-                *shard_view, id_, expected_num_workers_completed_, region);
+                *shard_view, id_, expected_num_workers_completed_, region_value);
 
         buffer_dispatch::BufferReadDispatchParams* dispatch_params = std::visit(
             [](auto& val) { return static_cast<buffer_dispatch::BufferReadDispatchParams*>(&val); },

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -152,14 +152,16 @@ private:
 
 protected:
     void write_shard_to_device(
-        Buffer* shard_view,
+        const MeshBuffer& buffer,
+        const MeshCoordinate& device_coord,
         const void* src,
-        const BufferRegion& region,
+        const std::optional<BufferRegion>& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void read_shard_from_device(
-        Buffer* shard_view,
+        const MeshBuffer& buffer,
+        const MeshCoordinate& device_coord,
         void* dst,
-        const BufferRegion& region,
+        const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;
@@ -177,6 +179,8 @@ public:
     WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) override { return config_buffer_mgr_[index]; };
     void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) override;
 
+    // TODO: This will error out for SD mesh command queues
+    // - Need to add equivalent APIs for SD and expose via mesh command queue base or mesh command queue
     void enqueue_write_shard_to_core(
         const DeviceMemoryAddress& address,
         const void* src,

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -100,7 +100,9 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
             device_local_config.buffer_type,
             device_local_config.buffer_layout,
             device_local_config.shard_parameters,
-            device_local_config.bottom_up);
+            device_local_config.bottom_up,
+            /*sub_device_id=*/std::nullopt,  // TODO: sub_device_id is unsupported
+            device_local_config.buffer_distribution_spec);
 
         mesh_buffer = std::shared_ptr<MeshBuffer>(new MeshBuffer(
             mesh_buffer_config, device_local_config, device_local_size, mesh_device, std::move(backing_buffer)));
@@ -124,7 +126,9 @@ void MeshBuffer::initialize_device_buffers() {
             device_local_config_.buffer_type,
             device_local_config_.buffer_layout,
             device_local_config_.shard_parameters,
-            device_local_config_.bottom_up);
+            device_local_config_.bottom_up,
+            /*sub_device_id=*/std::nullopt,  // TODO: sub_device_id is unsupported
+            device_local_config_.buffer_distribution_spec);
         return buffer;
     };
 

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -60,34 +60,36 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
                 for (std::size_t replicated_device_x = 0; replicated_device_x < num_devices_x; replicated_device_x++) {
                     for (std::size_t replicated_device_y = 0; replicated_device_y < num_devices_y;
                          replicated_device_y++) {
-                        auto device_shard_view =
-                            buffer.get_device_buffer(MeshCoordinate(replicated_device_y, replicated_device_x));
-                        const BufferRegion region(0, device_shard_view->size());
-                        this->write_shard_to_device(device_shard_view, shard_data.data(), region);
+                        this->write_shard_to_device(
+                            buffer,
+                            MeshCoordinate(replicated_device_y, replicated_device_x),
+                            shard_data.data(),
+                            /*region=*/std::nullopt);
                     }
                 }
             } else if (height_replicated or width_replicated) {
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     for (auto replicated_device_y = 0; replicated_device_y < num_devices_y; replicated_device_y++) {
-                        auto device_shard_view =
-                            buffer.get_device_buffer(MeshCoordinate(replicated_device_y, device_x));
-                        const BufferRegion region(0, device_shard_view->size());
-                        this->write_shard_to_device(device_shard_view, shard_data.data(), region);
+                        this->write_shard_to_device(
+                            buffer,
+                            MeshCoordinate(replicated_device_y, device_x),
+                            shard_data.data(),
+                            /*region=*/std::nullopt);
                     }
                     device_x++;
                 } else {
                     for (auto replicated_device_x = 0; replicated_device_x < num_devices_x; replicated_device_x++) {
-                        auto device_shard_view =
-                            buffer.get_device_buffer(MeshCoordinate(device_y, replicated_device_x));
-                        const BufferRegion region(0, device_shard_view->size());
-                        this->write_shard_to_device(device_shard_view, shard_data.data(), region);
+                        this->write_shard_to_device(
+                            buffer,
+                            MeshCoordinate(device_y, replicated_device_x),
+                            shard_data.data(),
+                            /*region=*/std::nullopt);
                     }
                     device_y++;
                 }
             } else {
-                auto device_shard_view = buffer.get_device_buffer(MeshCoordinate(device_y, device_x));
-                const BufferRegion region(0, device_shard_view->size());
-                this->write_shard_to_device(device_shard_view, shard_data.data(), region);
+                this->write_shard_to_device(
+                    buffer, MeshCoordinate(device_y, device_x), shard_data.data(), /*region=*/std::nullopt);
                 if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     if (++device_x == num_devices_x) {
                         device_x = 0;
@@ -126,10 +128,13 @@ void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
     std::vector<uint32_t> shard_data = std::vector<uint32_t>(total_write_size_per_shard / sizeof(uint32_t), 0);
     for (std::size_t shard_y = 0; shard_y < num_shards_y; shard_y++) {
         for (std::size_t shard_x = 0; shard_x < num_shards_x; shard_x++) {
-            auto device_shard_view = buffer.get_device_buffer(MeshCoordinate(device_y, device_x));
-            const BufferRegion region(0, device_shard_view->size());
             std::unordered_map<IDevice*, uint32_t> num_txns_per_device = {};
-            this->read_shard_from_device(device_shard_view, shard_data.data(), region, num_txns_per_device);
+            this->read_shard_from_device(
+                buffer,
+                MeshCoordinate(device_y, device_x),
+                shard_data.data(),
+                /*region=*/std::nullopt,
+                num_txns_per_device);
             this->submit_memcpy_request(num_txns_per_device, true);
             uint32_t write_offset = shard_x * single_write_size + shard_y * stride_size_bytes * shard_shape.height();
             uint32_t size_to_write = total_write_size_per_shard;
@@ -168,9 +173,7 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
         // Currently not supported when doing TT-Mesh Native sharding, since we
         // rely on TTNN to perform sharding and call enqueue_write_shards
         auto dispatch_lambda = [this, &buffer, host_data, &region](const MeshCoordinate& coord) {
-            auto device_shard_view = buffer.get_device_buffer(coord);
-            const BufferRegion buffer_region = region.value_or(BufferRegion(0, device_shard_view->size()));
-            this->write_shard_to_device(device_shard_view, host_data, buffer_region);
+            this->write_shard_to_device(buffer, coord, host_data, region);
         };
         for (const auto& coord : device_range) {
             dispatch_thread_pool_->enqueue(
@@ -209,11 +212,8 @@ void MeshCommandQueueBase::enqueue_write_shards(
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     auto dispatch_lambda = [&shard_data_transfers, &buffer, this](uint32_t shard_idx) {
         auto& shard_data_transfer = shard_data_transfers[shard_idx];
-        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
         this->write_shard_to_device(
-            device_shard_view,
-            shard_data_transfer.host_data,
-            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())));
+            *buffer, shard_data_transfer.shard_coord, shard_data_transfer.host_data, shard_data_transfer.region);
     };
 
     for (std::size_t shard_idx = 0; shard_idx < shard_data_transfers.size(); shard_idx++) {
@@ -257,11 +257,11 @@ void MeshCommandQueueBase::enqueue_read_shards(
     // In the long run, the multi-device sharding API in Metal will change, and this will most likely be replaced.
     std::unordered_map<IDevice*, uint32_t> num_txns_per_device = {};
     for (const auto& shard_data_transfer : shard_data_transfers) {
-        auto device_shard_view = buffer->get_device_buffer(shard_data_transfer.shard_coord);
         this->read_shard_from_device(
-            device_shard_view,
+            *buffer,
+            shard_data_transfer.shard_coord,
             shard_data_transfer.host_data,
-            shard_data_transfer.region.value_or(BufferRegion(0, device_shard_view->size())),
+            shard_data_transfer.region,
             num_txns_per_device);
     }
     this->submit_memcpy_request(num_txns_per_device, blocking);

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -17,18 +17,21 @@ protected:
 
     // Helper functions for reading and writing individual shards
     virtual void write_shard_to_device(
-        Buffer* shard_view,
+        const MeshBuffer& buffer,
+        const MeshCoordinate& device_coord,
         const void* src,
-        const BufferRegion& region,
+        const std::optional<BufferRegion>& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void read_shard_from_device(
-        Buffer* shard_view,
+        const MeshBuffer& buffer,
+        const MeshCoordinate& device_coord,
         void* dst,
-        const BufferRegion& region,
+        const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
     virtual void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) = 0;
 
+private:
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
     void read_sharded_buffer(MeshBuffer& buffer, void* dst);

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -14,22 +14,33 @@ SDMeshCommandQueue::SDMeshCommandQueue(MeshDevice* mesh_device, uint32_t id) :
     MeshCommandQueueBase(mesh_device, id, create_passthrough_thread_pool()) {}
 
 void SDMeshCommandQueue::write_shard_to_device(
-    Buffer* shard_view, const void* src, const BufferRegion& region, tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    TT_FATAL(region.offset == 0, "Offset is not supported for slow dispatch");
+    const MeshBuffer& buffer,
+    const MeshCoordinate& device_coord,
+    const void* src,
+    const std::optional<BufferRegion>& region,
+    tt::stl::Span<const SubDeviceId> sub_device_ids) {
+    const auto shard_view = buffer.get_device_buffer(device_coord);
+    const auto region_value = region.value_or(BufferRegion(0, shard_view->size()));
+
+    TT_FATAL(region_value.offset == 0, "Offset is not supported for slow dispatch");
     TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
     tt::tt_metal::detail::WriteToBuffer(
-        *shard_view, tt::stl::Span<const uint8_t>(static_cast<const uint8_t*>(src), region.size));
+        *shard_view, tt::stl::Span<const uint8_t>(static_cast<const uint8_t*>(src), region_value.size));
 }
 
 void SDMeshCommandQueue::read_shard_from_device(
-    Buffer* shard_view,
+    const MeshBuffer& buffer,
+    const MeshCoordinate& device_coord,
     void* dst,
-    const BufferRegion& region,
+    const std::optional<BufferRegion>& region,
     std::unordered_map<IDevice*, uint32_t>&,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
-    TT_FATAL(region.offset == 0, "Offset is not supported for slow dispatch");
+    const auto shard_view = buffer.get_device_buffer(device_coord);
+    const auto region_value = region.value_or(BufferRegion(0, shard_view->size()));
+
+    TT_FATAL(region_value.offset == 0, "Offset is not supported for slow dispatch");
     TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
-    tt::tt_metal::detail::ReadFromBuffer(*shard_view, static_cast<uint8_t*>(dst), region.size);
+    tt::tt_metal::detail::ReadFromBuffer(*shard_view, static_cast<uint8_t*>(dst), region_value.size);
 }
 
 void SDMeshCommandQueue::submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>&, bool) {}

--- a/tt_metal/distributed/sd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.hpp
@@ -11,14 +11,16 @@ namespace tt::tt_metal::distributed {
 class SDMeshCommandQueue final : public MeshCommandQueueBase {
 protected:
     void write_shard_to_device(
-        Buffer* shard_view,
+        const MeshBuffer& buffer,
+        const MeshCoordinate& device_coord,
         const void* src,
-        const BufferRegion& region,
+        const std::optional<BufferRegion>& region,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void read_shard_from_device(
-        Buffer* shard_view,
+        const MeshBuffer& buffer,
+        const MeshCoordinate& device_coord,
         void* dst,
-        const BufferRegion& region,
+        const std::optional<BufferRegion>& region,
         std::unordered_map<IDevice*, uint32_t>& num_txns_per_device,
         tt::stl::Span<const SubDeviceId> sub_device_ids = {}) override;
     void submit_memcpy_request(std::unordered_map<IDevice*, uint32_t>& num_txns_per_device, bool blocking) override;

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.cpp
@@ -102,7 +102,8 @@ void CaptureBufferCreate(
     const TensorMemoryLayout buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters,
     const std::optional<bool> bottom_up,
-    const std::optional<SubDeviceId> sub_device_id) {
+    const std::optional<SubDeviceId> sub_device_id,
+    const std::optional<BufferDistributionSpec>& buffer_distribution_spec) {
     auto& ctx = LightMetalCaptureContext::get();
     auto& fbb = ctx.get_builder();
 

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -87,7 +87,8 @@ void CaptureBufferCreate(
     const TensorMemoryLayout buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_parameters,
     const std::optional<bool> bottom_up,
-    const std::optional<SubDeviceId> sub_device_id);
+    const std::optional<SubDeviceId> sub_device_id,
+    const std::optional<BufferDistributionSpec>& buffer_distribution_spec);
 
 void CaptureBufferDeallocate(const Buffer& buffer);
 void CaptureBufferDelete(const Buffer& buffer);


### PR DESCRIPTION
### Ticket
None

### Problem description
Previous PR added ND sharding support for single-device concepts, but we want to transition to use mesh natively for everything. For tensors, we already moved to use MeshBuffer and Mesh CQs. This PR uplifts ND sharding support to MeshBuffer for creation and relevant Mesh CQ APIs for read/write. Existing ND sharding tests are ported to use mesh device/buffer.

### What's changed
- Updates to MeshBuffer and Mesh CQ APIs:
  * Add optional BufferDistributionSpec to DeviceLocalBufferConfig use for Buffer creation
  * Port over read/write ND sharding logic from HWCommandQueue for FDMeshCommandQueue
    * SDMeshCommandQueue already works since it uses same APIs as before
  * Refactor Mesh CQ base write_shard_to_device and read_shard_from_device
    * Take in mesh buffer and mesh coordinate instead of single-device buffer
    * Take in optional region and move default value logic to within functions
    * This makes APIs compatible with enqueue_write_shard_to_core and enqueue_read_shard_from_core
- Simplify single-device buffer creation paths
  * Unify forked create APIs for ShardSpec and BufferDistributionSpec
  * Remove unused create_buffer helper function
  * Refactor validate_buffer_parameters to always validate shard parameters
- Update existing single-device ND sharding tests to use mesh device/buffer
  * Create replicated mesh buffer with generic mesh device instead of single-device buffer
  * Switch to use Mesh CQ APIs for testing
    * FD Mesh CQ enqueue_write_shards instead of HW CQ EnqueueWriteBuffer
    * FD Mesh CQ enqueue_read_shards instead of HW CQ EnqueueReadBuffer
    * For slow dispatch, keep same low-level WriteToBuffer and ReadFromBuffer for simplicity
      * Underthehood, SD Mesh CQ uses these same APIs
    * WARNING: HWCommandQueue enqueue_write_buffer and enqueue_read_buffer logic for ND sharding is now untested
  * Refactor function/variable names to align with mesh concepts
    * Mainly, buffer -> shard_view and device -> local_device
- Minor cleanup:
  * Change to const ref for src vector in EnqueueWriteMeshBuffer
  * Make write_sharded_buffer and read_sharded_buffer private

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15005772231
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15005778776
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes