### PR TITLE
#18554: Auto-retry on non-main APC branches if only infra errors found

### DIFF
--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -57,11 +57,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MAX_ATTEMPTS=3
-          read original_trigger conclusion <<< $(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --jq '.event + " " + .conclusion')
+          read original_trigger conclusion workflow_name <<< $(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --jq '.event + " " + .conclusion + " " + .name')
+          caller_branch_name=$(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }} --jq '.head_branch')
+          echo "caller workflow branch name: $caller_branch_name"
+
           if [[ "${{ steps.get-run-id-and-attempt.outputs.attempt-number }}" -ge "$MAX_ATTEMPTS" ]]; then
             echo "::notice title=no-continue-max-tries::This workflow has exceeded max tries. Not re-trying"
             should_continue=false
-          elif [[ "$original_trigger" == "workflow_dispatch" ]]; then
+          elif [[ "$original_trigger" == "workflow_dispatch" && "$workflow_name" != "All post-commit tests (with retries)" ]]; then
             echo "::notice title=no-continue-is-on-branch::This workflow was a workflow dispatched on a branch, not main. Not re-trying"
             should_continue=false
           elif [[ "$conclusion" != "failure" ]]; then
@@ -72,13 +75,50 @@ jobs:
           fi
 
           echo "should-continue=$should_continue" >> "$GITHUB_OUTPUT"
-      - name: Re-run failed jobs
+          echo "caller_branch_name=$caller_branch_name" >> "$GITHUB_OUTPUT"
+      - name: Determine if test failures exist
+        id: determine-if-test-failures-exist
         if: ${{ steps.determine-should-continue.outputs.should-continue == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RETRY_WORKFLOW_TOKEN }}
+        shell: bash
+        run: |
+          echo "should_rerun=true" >> "$GITHUB_OUTPUT"
+          # If the caller branch is not main, we need to check for test failures
+          # We only want to re-run if there are no test failures
+          # If the caller branch is main, we can just re-run the workflow
+          if [[ "${{ steps.determine-should-continue.outputs.caller_branch_name }}" != "main" ]]; then
+            echo "Checking for test failures on non-main branch: ${{ steps.determine-should-continue.outputs.caller_branch_name }}"
+
+            while read -r job; do
+              job_id=$(echo "$job" | jq -r '.id')
+              job_conclusion=$(echo "$job" | jq -r '.conclusion')
+
+              # Only read annotations for failed jobs
+              if [[ "$job_conclusion" == "failure" ]]; then
+                echo "Checking annotations for failed job $job_id to see if we have test or infra failures"
+                annotations=$(gh api /repos/tenstorrent/tt-metal/check-runs/$job_id/annotations)
+
+                # Check each annotation for non-infra failures
+                while read -r annotation; do
+                  level=$(echo "$annotation" | jq -r '.annotation_level')
+                  path=$(echo "$annotation" | jq -r '.path')
+
+                  if [[ "$level" == "failure" && "$path" != ".github"* ]]; then
+                    echo "::notice title=no-continue-test-failure::This workflow failed a test on job https://github.com/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/job/$job_id Not re-trying"
+                    echo "should_rerun=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                done < <(echo "$annotations" | jq -c '.[]')
+              fi
+            done < <(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }}/jobs --paginate | jq -c '.jobs[] | {id: .id, conclusion: .conclusion}')
+          fi
+      - name: Re-run failed jobs
+        if: ${{ steps.determine-if-test-failures-exist.outputs.should_rerun == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RETRY_WORKFLOW_TOKEN }}
         run: |
           echo "Re-running jobs here"
-          # gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/timing
           gh api --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -65,7 +65,7 @@ jobs:
             echo "::notice title=no-continue-max-tries::This workflow has exceeded max tries. Not re-trying"
             should_continue=false
           elif [[ "$original_trigger" == "workflow_dispatch" && "$workflow_name" != "All post-commit tests (with retries)" ]]; then
-            echo "::notice title=no-continue-is-on-branch::This workflow was a workflow dispatched on a branch, not main. Not re-trying"
+            echo "::notice title=no-continue-is-on-branch::This workflow was a workflow dispatched on a branch without retries enabled. Not re-trying"
             should_continue=false
           elif [[ "$conclusion" != "failure" ]]; then
             echo "::notice title=no-continue-did-not-fail::This workflow did not fail. Not re-trying"
@@ -105,7 +105,7 @@ jobs:
                   path=$(echo "$annotation" | jq -r '.path')
 
                   if [[ "$level" == "failure" && "$path" != ".github"* ]]; then
-                    echo "::notice title=no-continue-test-failure::This workflow failed a test on job https://github.com/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/job/$job_id Not re-trying"
+                    echo "::notice title=no-continue-test-failure::This workflow failed a test on job https://github.com/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/job/$job_id Not re-running"
                     echo "should_rerun=false" >> "$GITHUB_OUTPUT"
                     exit 0
                   fi

--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -56,7 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          MAX_ATTEMPTS=4
+          MAX_ATTEMPTS=3
           read original_trigger conclusion workflow_name <<< $(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --jq '.event + " " + .conclusion + " " + .name')
           caller_branch_name=$(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }} --jq '.head_branch')
           echo "caller workflow branch name: $caller_branch_name"

--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -56,7 +56,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          MAX_ATTEMPTS=3
+          MAX_ATTEMPTS=4
           read original_trigger conclusion workflow_name <<< $(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --jq '.event + " " + .conclusion + " " + .name')
           caller_branch_name=$(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }} --jq '.head_branch')
           echo "caller workflow branch name: $caller_branch_name"

--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -22,7 +22,7 @@ on:
       with-retries:
         default: false
         type: boolean
-        description: "Re-run failed jobs (max 3)"
+        description: "Re-run failed jobs (max 3). NOTE: Will not re-run jobs if test failures are detected."
   push:
     branches: ["main"]
 


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-metal/issues/18554 and fixes https://github.com/tenstorrent/tt-metal/issues/16945

### Problem description
We currently do not retry APC runs on developer branches, which developers want to have.
However, we don't want to suppress non-deterministic behavior, so retries on APC developer branches should only trigger if job failures are infra-related (i.e. will not retry if at least 1 test failure found)

### What's changed
Enable auto-retry on developer branches for APC only (and only if the retry option is selected). Only perform auto-retry on dev branches if no test failures are detected.
Keep original 3-retries behaviour on APC main branch.

### Checklist
- [x] Infra errors only on dev branch, retry triggered:  https://github.com/tenstorrent/tt-metal/actions/runs/15004871796/job/42160839448#step:6:11
- [x] Non-infra errors on dev branch, no retry triggered: https://github.com/tenstorrent/tt-metal/actions/runs/15005789177/job/42163969905#step:5:42

