### PR TITLE
#16945: Enable auto-retry on developer APC branches

### DIFF
--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -56,12 +56,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           MAX_ATTEMPTS=3
-          read original_trigger conclusion <<< $(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --jq '.event + " " + .conclusion')
+          read original_trigger conclusion workflow_name <<< $(gh api /repos/tenstorrent/tt-metal/actions/runs/${{ steps.get-run-id-and-attempt.outputs.run-id }}/attempts/${{ steps.get-run-id-and-attempt.outputs.attempt-number }} --jq '.event + " " + .conclusion + " " + .name')
           if [[ "${{ steps.get-run-id-and-attempt.outputs.attempt-number }}" -ge "$MAX_ATTEMPTS" ]]; then
             echo "::notice title=no-continue-max-tries::This workflow has exceeded max tries. Not re-trying"
             should_continue=false
-          elif [[ "$original_trigger" == "workflow_dispatch" ]]; then
-            echo "::notice title=no-continue-is-on-branch::This workflow was a workflow dispatched on a branch, not main. Not re-trying"
+          elif [[ "$original_trigger" == "workflow_dispatch" && "$workflow_name" != "All post-commit tests (with retries)" ]]; then
+            echo "::notice title=no-continue-is-on-branch::This workflow was a workflow dispatched on a branch without retries enabled, not main. Not re-trying"
             should_continue=false
           elif [[ "$conclusion" != "failure" ]]; then
             echo "::notice title=no-continue-did-not-fail::This workflow did not fail. Not re-trying"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/16945

### Problem description
APC on branches doesn't retry even if the checkbox is ticked.

### What's changed
Enable auto-retry when retry checkbox is ticked for APC workflow dispatches.

### Checklist
- [ ] New/Existing tests provide coverage for changes
No retry: https://github.com/tenstorrent/tt-metal/actions/runs/14977531110/job/42073514851#step:4:22