### PR TITLE
[skip ci] Add retries to apc debug

### DIFF
--- a/.github/workflows/_auto-retry-post-commit.yaml
+++ b/.github/workflows/_auto-retry-post-commit.yaml
@@ -18,6 +18,7 @@ on:
       # We push to main, but not part of APC. TGs are flaky so we are going
       # to want to to
       - "zzz TG Quick tests"
+      - "apc nightly debug run"
     types:
       - completed
 


### PR DESCRIPTION
### Ticket

Ask from @bbradelTT 

### Problem description

Looks like APC Debug is flaky too (ofc, runners die)

### What's changed

Add to retries

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes