### PR TITLE
Fix uninitialized vars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ add_compile_options(
     -fvisibility-inlines-hidden
     -Wall
     -Werror
+    "$<$<CXX_COMPILER_ID:Clang>:-Wconditional-uninitialized>"
     # The following list is not indicative of what we _desire_ only the status quo to build.
     -Wno-deprecated-declarations
     # Vars that are used only in Asserts will appear as dead stores in builds

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,16 @@
         "cacheVariables": {
           "CMAKE_CXX_CLANG_TIDY": {"value": "clang-tidy-17;--fix"}
         }
+      },
+      {
+        "name": "gcc",
+        "inherits": "default",
+        "description": "Build with GCC",
+        "binaryDir": "${sourceDir}/.build/gcc",
+        "cacheVariables": {
+          "BUILD_TT_TRAIN": {"value": "OFF"}
+        },
+        "toolchainFile": "cmake/x86_64-linux-gcc-12-toolchain.cmake"
       }
     ],
     "buildPresets": [
@@ -45,6 +55,12 @@
         "name": "dev",
         "configurePreset": "default",
         "configuration": "RelWithDebInfo",
+        "targets": ["all"]
+      },
+      {
+        "name": "dev-gcc",
+        "configurePreset": "gcc",
+        "configuration": "Release",
         "targets": ["all"]
       },
       {

--- a/cmake/tracy.cmake
+++ b/cmake/tracy.cmake
@@ -28,7 +28,13 @@ set_target_properties(
 )
 
 target_compile_definitions(TracyClient PUBLIC TRACY_ENABLE)
-target_compile_options(TracyClient PUBLIC -fno-omit-frame-pointer)
+target_compile_options(
+    TracyClient
+    PUBLIC
+        -fno-omit-frame-pointer
+    PRIVATE
+        "$<$<CXX_COMPILER_ID:Clang>:-Wno-conditional-uninitialized>" # FIXME: Fix this upstream
+)
 target_link_options(TracyClient PUBLIC -rdynamic)
 
 # Our current fork of tracy does not have CMake support for these subdirectories

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -155,8 +155,8 @@ std::vector<chip_id_t> get_physical_chip_sequence(uint32_t num_seq_chips) {
 
     if (chip_0_neigbors.size() == 2) {
         // find the other neighbor chip and direction
-        tt_fabric::RoutingDirection other_chip_dir;
-        chip_id_t other_chip;
+        tt_fabric::RoutingDirection other_chip_dir{};
+        chip_id_t other_chip{};
         for (const auto& [dir, chip] : chip_0_neigbors) {
             if (chip != 0) {
                 other_chip_dir = dir;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -127,7 +127,7 @@ void RunTest(WatcherFixture* fixture, IDevice* device) {
         }
     }
     if (has_idle_eth_cores) {
-        KernelHandle ierisc_kid0, ierisc_kid1;
+        KernelHandle ierisc_kid0{}, ierisc_kid1{};
         std::set<CoreRange> eth_core_ranges;
         for (const auto& core : device->get_inactive_ethernet_cores()) {
             eth_core_ranges.insert(CoreRange(core, core));

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -133,8 +133,8 @@ void run_single_core_tilize_program(tt_metal::IDevice* device, const TestConfig&
     auto cb_src0 = tt_metal::CreateCircularBuffer(program, core, cb_src0_config);
 
     std::shared_ptr<tt_metal::Buffer> src1_dram_buffer;
-    uint32_t dram_buffer_src1_addr;
-    CoreCoord dram_src1_noc_xy;
+    uint32_t dram_buffer_src1_addr{};
+    CoreCoord dram_src1_noc_xy{};
 
     if (test_config.tilize_type.has_value() && test_config.tilize_type == TilizeType::UNPACK_A_B) {
         src1_dram_buffer = CreateBuffer(input_dram_config);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -409,7 +409,7 @@ struct test_board_t {
 
         for (auto& [chip_id, neighbor_cnt] : n_hop_neighbors_cnt) {
             uint32_t temp_neighbor_cnt = UINT32_MAX;
-            chip_id_t selected_chip_id;
+            chip_id_t selected_chip_id{};
 
             // check if the key exists, since it could have been erased if the chip id has already been picked
             if (!chip_n_hop_neighbors.contains(chip_id)) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -324,7 +324,7 @@ int main(int argc, char** argv) {
         bool router_core_found = false;
         CoreCoord router_logical_core;
         CoreCoord router_phys_core;
-        routing_plane_id_t routing_plane;
+        routing_plane_id_t routing_plane{};
         CoreCoord gk_phys_core;
         uint32_t routing_table_addr =
             device_map[test_device_id_l]->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);

--- a/tt_metal/impl/dispatch/debug_tools.cpp
+++ b/tt_metal/impl/dispatch/debug_tools.cpp
@@ -334,7 +334,7 @@ void dump_completion_queue_entries(
         cq_interface.id,
         completion_write_ptr,
         completion_read_ptr);
-    uint32_t last_span_start;
+    uint32_t last_span_start{};
     bool last_span_invalid = false;
     print_progress_bar(0.0, true);
     for (uint32_t page_offset = 0; page_offset < completion_q_bytes;) {  // page_offset increment at end of loop
@@ -430,7 +430,7 @@ void dump_issue_queue_entries(
         cq_interface.id,
         issue_write_ptr,
         issue_read_ptr);
-    uint32_t last_span_start;
+    uint32_t last_span_start{};
     bool last_span_invalid = false;
     print_progress_bar(0.0, true);
     uint32_t first_page_addr = issue_q_base_addr - (issue_q_base_addr % DispatchSettings::TRANSFER_PAGE_SIZE);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -618,7 +618,7 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
             uint32_t index_offset = 0;
             for (auto mmio_device_id : mmio_devices) {
                 // Find the corresponding remote chip
-                chip_id_t remote_device_id;
+                chip_id_t remote_device_id{};
                 bool found_remote = false;
                 for (auto id : remote_devices) {
                     if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(id) ==
@@ -720,7 +720,7 @@ void populate_fd_kernels(const std::vector<DispatchKernelNode>& nodes) {
     // For kernels on mmio chip, need to confirm which remote device each is servicing
     std::map<chip_id_t, uint32_t> device_id_to_tunnel_stop;
     std::map<chip_id_t, std::vector<chip_id_t>> mmio_device_id_to_serviced_devices;
-    uint32_t tunnel_depth;
+    uint32_t tunnel_depth{};
     for (auto mmio_device_id : mmio_device_ids) {
         if (tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(mmio_device_id) !=
             mmio_device_id) {

--- a/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
+++ b/tt_metal/llrt/blackhole/bh_hal_tensix.cpp
@@ -69,8 +69,8 @@ HalCoreInfoType create_tensix_mem_map() {
         uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
         for (size_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
-            DeviceAddr fw_base, local_init, fw_launch;
-            uint32_t fw_launch_value;
+            DeviceAddr fw_base{}, local_init{}, fw_launch{};
+            uint32_t fw_launch_value{};
             switch (processor_class_idx) {
                 case 0: {
                     fw_base = MEM_BRISC_FIRMWARE_BASE;

--- a/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
+++ b/tt_metal/llrt/wormhole/wh_hal_tensix.cpp
@@ -66,8 +66,8 @@ HalCoreInfoType create_tensix_mem_map() {
         std::uint32_t num_processors = processor_class_idx == (NumTensixDispatchClasses - 1) ? 3 : 1;
         processor_types.resize(num_processors);
         for (std::size_t processor_type_idx = 0; processor_type_idx < processor_types.size(); processor_type_idx++) {
-            DeviceAddr fw_base, local_init, fw_launch;
-            uint32_t fw_launch_value;
+            DeviceAddr fw_base{}, local_init{}, fw_launch{};
+            uint32_t fw_launch_value{};
             switch (processor_class_idx) {
                 case 0: {
                     fw_base = MEM_BRISC_FIRMWARE_BASE;

--- a/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
+++ b/ttnn/cpp/ttnn/mesh_device_operation_utils.hpp
@@ -73,7 +73,7 @@ inline bool is_subset_of(const std::vector<MeshCoordinate>& a, const std::vector
     // Check if b_set is a subset of a_set
     // This is true if every range in b_set is completely contained in some range
     // in a_set
-    bool is_subset;
+    bool is_subset = false;
     for (const auto& b_range : b_set.ranges()) {
         is_subset = false;
         for (const auto& a_range : a_set.ranges()) {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -483,7 +483,7 @@ static std::tuple<ttnn::Shape, ttnn::MemoryConfig, bool> get_conv_padded_input_s
         (!input_tensor_on_device || input_tensor_.is_sharded()) || conv_config.shard_layout.has_value(),
         "Tensor must be sharded or shard_layout must be set.");
 
-    TensorMemoryLayout shard_layout;
+    TensorMemoryLayout shard_layout{};
     if (conv_config.shard_layout.has_value()) {
         shard_layout = conv_config.shard_layout.value();
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -203,7 +203,7 @@ ttnn::MemoryConfig create_sharded_memory_config(
     auto rank = logical_shape.rank();
     TT_FATAL(rank >= 2, "rank of tensor to shard must be at least 2.");
 
-    ttnn::TensorMemoryLayout tensor_memory_layout;
+    ttnn::TensorMemoryLayout tensor_memory_layout{};
     if (strategy == ShardStrategy::BLOCK) {
         tensor_memory_layout = ttnn::TensorMemoryLayout::BLOCK_SHARDED;
     } else if (strategy == ShardStrategy::WIDTH) {

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/host/reshape_tiled_program_factory.cpp
@@ -161,7 +161,7 @@ std::vector<SegmentMapData> reshape_map_output_page(
 
     TileIterator output_tile_iterator(ho_0, wo_0, ho_sz, wo_sz);
 
-    uint32_t prev_offset_i, prev_offset_o, prev_page_idx_i;
+    uint32_t prev_offset_i{}, prev_offset_o{}, prev_page_idx_i{};
 
     // TODO there are properties of the mapping we could take advantage of to avoid some computation.
     while (output_tile_iterator.next()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_program_factory.cpp
@@ -1240,7 +1240,7 @@ operation::ProgramWithCallbacks transpose_hc_multi_core_sharded(const Tensor& a,
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_time_args, reader_defines));
 
-    tt::tt_metal::KernelHandle writer_kernel_id;
+    tt::tt_metal::KernelHandle writer_kernel_id{};
     if (is_special_case) {
         std::vector<uint32_t> writer_compile_time_args = {
             (std::uint32_t)src0_cb_index, (std::uint32_t)output_cb_index, (std::uint32_t)stick_size_bytes};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -234,7 +234,7 @@ void set_or_update_runtime_arguments(
     const uint32_t tile_width = c.tensor_spec().tile().get_width();
     const uint32_t tile_hw = tile_height * tile_width;
     const uint32_t c_num_tiles = c.volume() / tile_hw;
-    uint32_t c_shard_height, c_shard_width, num_shards_per_width;
+    uint32_t c_shard_height{}, c_shard_width{}, num_shards_per_width{};
 
     ShardShapeGenerator a_shard_shape_generator;
     ShardShapeGenerator b_shard_shape_generator;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
CI is plagued with non-deterministic failures.  These are time consuming to track down.  We should eliminate any potential source of N-D that we easily can to shrink the surface area for such bugs.

### What's changed
* Enabled a compiler warning that tells us that we might use an uninitialized variable.
* Fix the detected instances

Probably is low that any of these are the cause of bugs we're seeing, but at least now we can rule them out.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14979803715)