### PR TITLE
Fix sdpa hang due to get_tile()

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -250,9 +250,6 @@ void MAIN {
                     cb_pop_front(cb_m_in, Sq_chunk_t);
                     copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
                     copy_block(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
-#ifndef ARCH_WORMHOLE
-                    UNPACK(asm volatile("fence"));  // #19201 BH hang workaround
-#endif
                 }
             }
 


### PR DESCRIPTION
### Ticket
**https://github.com/tenstorrent/tt-metal/issues/19201**

Problem description

The unpacker in _llk_unpack_get_tile function used to do mailbox_writes and then post (increment) a semaphore. It is possible for math and pack thread to read the mailboxes and try to get (decrement) a semaphore which is already zero, thus dropping the decrements. Then later on in _llk_unpack_release_tile the unpacker would wait for the semaphore to be zero, but since the decrements were dropped it would get stuck.

What's changed

The order of doing the mailbox write and semaphore post has been changed, so the packer and math thread would only try to decrement the semaphore after the sempahore post since that happens before the mailbox write now which will happen before packer and math thread can decrement since their execution is depedent on the mailbox read.

This PR uplifts several LLK changes the relevant one being:

Fix ordering of mailbox_write and semaphore_post in unpack_get_tile (https://github.com/tenstorrent/tt-llk/pull/185)
Add DataType instruction modifier template for bitwise ops (https://github.com/tenstorrent/tt-llk/pull/188)


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes