### PR TITLE
Update CloseDevice to use the same steps as CloseDevices

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -56,7 +56,7 @@ public:
     tt_metal::IDevice* get_active_device(chip_id_t device_id) const;
     std::vector<tt_metal::IDevice*> get_all_active_devices() const;
     bool close_device(chip_id_t device_id);
-    void close_devices(const std::vector<tt_metal::IDevice*>& devices, bool skip_synchronize = false);
+    bool close_devices(const std::vector<tt_metal::IDevice*>& devices, bool skip_synchronize = false);
     bool is_device_active(chip_id_t id) const;
     void init_profiler() const;
     void initialize_fabric_and_dispatch_fw() const;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -670,21 +670,20 @@ bool DevicePool::close_device(chip_id_t device_id) {
     // Currently can only call this on mmio chips, once we split dispatch kernel shutdown
     // from device close, we can call this on remote devices too
     ZoneScoped;
-    tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
-    bool pass = true;
     const auto& mmio_device_id =
         tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
+    std::vector<IDevice*> devices_to_close;
     for (const auto& mmio_controlled_device_id :
          tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(mmio_device_id)) {
         auto device = get_device(mmio_controlled_device_id);
         if (device && device->is_initialized()) {
-            pass &= device->close();
+            devices_to_close.push_back(device);
         }
     }
-    return pass;
+    return close_devices(devices_to_close);
 }
 
-void DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_synchronize) {
+bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_synchronize) {
     // Ordered, because we need to shutdown tunnels from the farthest to the closest.
     std::vector<chip_id_t> devices_to_close;
 
@@ -788,10 +787,12 @@ void DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
     detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
 
     tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
+    bool pass = true;
     for (const auto& dev_id : devices_to_close) {
         auto dev = tt::DevicePool::instance().get_active_device(dev_id);
-        dev->close();
+        pass &= dev->close();
     }
+    return pass;
 }
 
 DevicePool::~DevicePool() {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
- CloseDevices and CloseDevice are not the same
- If you open only device 1 (OpenDevice(1)) and use CloseDevice(1), the remote chip kernels such as fabric wont be terminated properly and subsequent runs will hang

### What's changed
- CloseDevice to just call CloseDevices which is the expected behavior

### Checklist
T3K Fast
https://github.com/tenstorrent/tt-metal/actions/runs/14980888386
APC
https://github.com/tenstorrent/tt-metal/actions/runs/14981862129
BH
https://github.com/tenstorrent/tt-metal/actions/runs/14984720621
T3K
https://github.com/tenstorrent/tt-metal/actions/runs/14981993252
TG
https://github.com/tenstorrent/tt-metal/actions/runs/14981990787