### PR TITLE
#21422: adjust dram matmul test to work on P100a

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_matmul_dram_sharded.py
@@ -437,7 +437,6 @@ def test_matmul_in1_dram_sharded_with_mm_chain(
     )
 
 
-@skip_for_blackhole("Failing on harvested BH, see #21422")
 @pytest.mark.parametrize("packer_l1_acc", [True, False], ids=["pack_l1", "no_pack_l1"])
 @pytest.mark.parametrize(
     "fp32_acc_mode",
@@ -458,7 +457,7 @@ def test_matmul_in1_dram_sharded_with_mm_chain(
     "M, K, N, activation, in0_sharded, fuse_batch",
     [
         (1024, 1024, 1024, None, True, True),
-        (1024, 8192, 4096, None, False, False),
+        (1024, 4096, 2048, None, False, False),
     ],
 )
 def test_matmul_2d_in1_dram_sharded(
@@ -489,7 +488,7 @@ def test_matmul_2d_in1_dram_sharded(
     in1_shard_shape = [K, N_padded // num_banks]
     bias_shape = [1, 1, N]
     bias_shard_shape = [32, N_padded // num_banks]
-    grid_size = (8, 4)
+    grid_size = (4, 4)
 
     in0_block_h = M // grid_size[1] // 32
     in0_block_w = K // grid_size[0] // 32


### PR DESCRIPTION
### Ticket
Link to Github Issue #21422

### Problem description
BH tests were failing on harvested devices (P100a)

### What's changed
- change the grid size to have dimensions smaller than the smallest dram bank count
- adjust inputs to be small enough to fit in L1 with the reduced grid size
- remove the skip for BH


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/14981002020
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/14981005897 everything passed except for unrelated job due to pipeline issues
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes