### PR TITLE
#21988 Use CUSTOM_CACHE_KEY for CPM packages when patches exist

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -68,6 +68,7 @@ CPMAddPackage(
         "YAML_CPP_BUILD_TESTS OFF"
         "YAML_CPP_BUILD_TOOLS OFF"
         "YAML_BUILD_SHARED_LIBS OFF"
+    CUSTOM_CACHE_KEY "0_8_0_patched"
 )
 
 ############################################################################################################################
@@ -135,6 +136,7 @@ CPMAddPackage(
     OPTIONS
         "CMAKE_BUILD_TYPE Release"
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+    CUSTOM_CACHE_KEY "0_12_0_patched"
 )
 
 ############################################################################################################################
@@ -172,6 +174,7 @@ CPMAddPackage(
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "XTL_ENABLE_TESTS OFF"
+    CUSTOM_CACHE_KEY "0_8_0_patched"
 )
 CPMAddPackage(
     NAME xtensor
@@ -182,6 +185,7 @@ CPMAddPackage(
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "XTENSOR_ENABLE_TESTS OFF"
+    CUSTOM_CACHE_KEY "0_26_0_patched"
 )
 CPMAddPackage(
     NAME xtensor-blas
@@ -192,6 +196,7 @@ CPMAddPackage(
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "XTENSOR_ENABLE_TESTS OFF"
+    CUSTOM_CACHE_KEY "0_22_0_patched"
 )
 
 ############################################################################################################################

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -161,6 +161,7 @@ target_link_libraries(
 
 message(STATUS "xtensor_SOURCE_DIR: ${xtensor_SOURCE_DIR}")
 message(STATUS "xtl_SOURCE_DIR: ${xtl_SOURCE_DIR}")
+message(STATUS "xtensor-blas_SOURCE_DIR: ${xtensor-blas_SOURCE_DIR}")
 
 message(STATUS "msgpack_SOURCE_DIR: ${msgpack_SOURCE_DIR}")
 target_include_directories(ttml PUBLIC ${msgpack_SOURCE_DIR}/include)


### PR DESCRIPTION
 ### Ticket  
https://github.com/tenstorrent/tt-metal/issues/21988  


### Problem description

#### Downstream inclusion  
- **Context**:
  - tt-mlir pulls in tt-metal headers
  - tt-metal headers pull CPM-fetched packages
  - So, tt-mlir also has to [pull in the packages](https://github.com/tenstorrent/tt-mlir/blob/main/third_party/CMakeLists.txt#L55).
- **Breakage**: After [upgrading the xtensor package](https://github.com/tenstorrent/tt-metal/pull/20733) in tt-metal, those include-paths became **unstable** across environments (local, CI, FEs, different path checkouts), causing build issues.

#### Root cause  
- CPM builds its cache directory name by hashing all `CPMAddPackage` arguments—including the **patch-file paths**.  
- When tt-metal is cloned into different folders, the relative patch path resolves to different absolute paths, yielding different hashes.

#### Verifying cause 
- svuckovicTT traced the instability to patch arg by [changing](https://github.com/tenstorrent/tt-metal/commit/c73d7dc6494f0c452a500aa4c91a38a16228e577) the patch file location to a [fixed path](https://github.com/tenstorrent/tt-mlir/commit/7e58ad3436546841ce65066c474f8c2b6d80bfb1) under `/tmp` 
- This produced a **stable hash** across all environments.  

### What’s changed

#### Custom cache keys  
- Introduce **explicit, deterministic cache-key suffixes** for any CPM package that applies patches. 
  - As suggested for similar situations in [CPM doc](https://github.com/cpm-cmake/CPM.cmake/blob/d7614381ab270d6c43be65eebd195372fcdf9903/README.md?plain=1#L211C1-L212C1).
- This decouples the download directory name from the local source-tree path.

#### Downstream update  
- tt-mlir will [include new stable path](https://github.com/tenstorrent/tt-mlir/commit/db7bdb5b1b5d1cf9464aa54bf52c882469704c11) e.g.
  ```
  /third_party/tt-metal/src/tt-metal/.cpmcache/xtl/0_8_0_patched
  ```  
- [tt-mlir CI build step](https://github.com/tenstorrent/tt-mlir/actions/runs/14977032975/job/42071923994#step:9:1104) passes with these changes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/14988331290)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes