### PR TITLE
Revert "Fix sdpa hang due to get_tile()"

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -250,6 +250,9 @@ void MAIN {
                     cb_pop_front(cb_m_in, Sq_chunk_t);
                     copy_block(cb_cur_max, cb_prev_max, Sq_chunk_t);
                     copy_block(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
+#ifndef ARCH_WORMHOLE
+                    UNPACK(asm volatile("fence"));  // #19201 BH hang workaround
+#endif
                 }
             }
 


### PR DESCRIPTION
Reverts tenstorrent/tt-metal#21976

Seems main is broken since this landed.  Reverting to get it green and can be investigated without pressure.