### PR TITLE
Move FW build + L1/DRAM clear from Device init to MetalContext init

### DIFF
--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -87,9 +87,6 @@ void MetalContext::initialize(
 }
 
 void MetalContext::teardown() {
-    if (not initialized_) {
-        return;
-    }
     initialized_ = false;
 
     for (auto& mem_map : dispatch_mem_map_) {
@@ -99,7 +96,6 @@ void MetalContext::teardown() {
     }
     dispatch_query_manager_.reset();
     dispatch_core_manager_.reset();
-    log_warning("MetalContext::teardown() finished.");
 }
 
 MetalContext& MetalContext::instance() {
@@ -117,7 +113,6 @@ MetalContext::MetalContext() {
 MetalContext::~MetalContext() {
     cluster_.reset();
     hal_.reset();
-    log_warning("MetalContext::~MetalContext() finished.");
 }
 
 llrt::RunTimeOptions& MetalContext::rtoptions() { return rtoptions_; }

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -13,14 +13,18 @@
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include "tt_metal/llrt/llrt.hpp"
 #include "tt_metal/llrt/get_platform_architecture.hpp"
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_metal.hpp>
 
 namespace tt::tt_metal {
 
 void MetalContext::initialize(
     const DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs, const BankMapping& l1_bank_remap) {
+    // Settings that affect FW build can also trigger a re-initialization
+    auto fw_compile_hash = std::hash<std::string>{}(rtoptions_.get_compile_hash_string());
     if (initialized_) {
         if (this->dispatch_core_config_ != dispatch_core_config or num_hw_cqs != this->num_hw_cqs_ or
-            l1_bank_remap != this->l1_bank_remap_) {
+            l1_bank_remap != this->l1_bank_remap_ or fw_compile_hash != this->fw_compile_hash_) {
             log_warning("Closing and re-initializing MetalContext with new parameters.");
             teardown();
         } else {
@@ -33,6 +37,7 @@ void MetalContext::initialize(
     dispatch_core_config_ = dispatch_core_config;
     num_hw_cqs_ = num_hw_cqs;
     l1_bank_remap_ = l1_bank_remap;
+    fw_compile_hash_ = fw_compile_hash;
 
     // Initialize dispatch state
     dispatch_core_manager_ = std::make_unique<dispatch_core_manager>(dispatch_core_config, num_hw_cqs);
@@ -45,12 +50,46 @@ void MetalContext::initialize(
         std::make_unique<DispatchMemMap>(CoreType::ETH, num_hw_cqs);
 
     // TODO: Move FW, fabric, dispatch init here
+    auto all_devices = cluster_->all_chip_ids();
+    for (chip_id_t device_id : all_devices) {
+        // Clear L1/DRAM if requested
+        if (rtoptions_.get_clear_l1()) {
+            clear_l1_state(device_id);
+        }
+        if (rtoptions_.get_clear_dram()) {
+            clear_dram_state(device_id);
+        }
+        int ai_clk = cluster_->get_device_aiclk(device_id);
+        log_info(tt::LogMetal, "AI CLK for device {} is:   {} MHz", device_id, ai_clk);
 
-    // Register teardown function
-    std::atexit([]() { MetalContext::instance().teardown(); });
+        // Create build env for this device, and build FW if it's not built already
+        BuildEnvManager::get_instance().add_build_env(device_id, num_hw_cqs_);
+        uint32_t fw_build_key = BuildEnvManager::get_instance().get_device_build_env(device_id).build_key;
+        if (!firmware_built_keys_.contains(fw_build_key)) {
+            BuildEnvManager::get_instance().build_firmware(device_id);
+            firmware_built_keys_.insert(fw_build_key);
+        }
+
+        // Clear the entire launch message ring buffer on ethernet cores before application firmware is activated.
+        // This is required since ethernet cores context switch between application and routing firmware.
+        // If ERISC application firmware is activated before the launch messages are cleared, it can enter an undefined
+        // state by reading a corrupted launch message. Routing firmware will never run in this case, causing UMD issued
+        // transactions to hang.
+        // TODO: run this alongside FW init
+        // clear_launch_messages_on_eth_cores(device_id);
+    }
+
+    // Register teardown function, but only once.
+    if (not teardown_registered_) {
+        std::atexit([]() { MetalContext::instance().teardown(); });
+        teardown_registered_ = true;
+    }
 }
 
 void MetalContext::teardown() {
+    if (not initialized_) {
+        return;
+    }
     initialized_ = false;
 
     for (auto& mem_map : dispatch_mem_map_) {
@@ -118,6 +157,83 @@ const DispatchMemMap& MetalContext::dispatch_mem_map(const CoreType& core_type) 
     auto& mem_map = dispatch_mem_map_[magic_enum::enum_integer(core_type)];
     TT_FATAL(mem_map, "Tried to get dispatch_mem_map for {} before intializing it.", core_type);
     return *mem_map;
+}
+
+void MetalContext::clear_l1_state(chip_id_t device_id) {
+    log_debug(tt::LogMetal, "Clearing L1 for device {}", device_id);
+    // Clear all clearable Tensix and Eth L1
+    CoreCoord logical_grid_size = cluster_->get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    uint32_t l1_size_per_core = cluster_->get_soc_desc(device_id).worker_l1_size;
+    TT_ASSERT(l1_size_per_core % sizeof(uint32_t) == 0);
+    std::vector<uint32_t> zero_vec(l1_size_per_core / sizeof(uint32_t), 0);
+    constexpr uint32_t start_address = 0;
+    for (uint32_t x = 0; x < logical_grid_size.x; x++) {
+        for (uint32_t y = 0; y < logical_grid_size.y; y++) {
+            CoreCoord logical_core(x, y);
+            auto virtual_core =
+                cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_core, CoreType::WORKER);
+            tt::llrt::write_hex_vec_to_core(device_id, virtual_core, zero_vec, start_address);
+        }
+    }
+
+    // Clear erisc unreserved L1
+    for (const auto& eth_core : cluster_->get_active_ethernet_cores(device_id)) {
+        static uint32_t zero_vec_size = tt::tt_metal::hal::get_erisc_l1_unreserved_size();
+        auto zero_vec_addr = tt::tt_metal::hal::get_erisc_l1_unreserved_base();
+
+        static std::vector<uint32_t> zero_vec(zero_vec_size / sizeof(uint32_t), 0);
+
+        CoreCoord virtual_core =
+            cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, eth_core, CoreType::ETH);
+        llrt::write_hex_vec_to_core(device_id, virtual_core, zero_vec, zero_vec_addr);
+    }
+    // TODO: clear idle eriscs as well
+    cluster_->l1_barrier(device_id);
+}
+
+void MetalContext::clear_dram_state(chip_id_t device_id) {
+    log_debug(tt::LogMetal, "Clearing DRAM for device {}", device_id);
+
+    auto dram_size_per_channel = cluster_->get_soc_desc(device_id).dram_view_size;
+    auto num_dram_channels = cluster_->get_soc_desc(device_id).get_num_dram_views();
+    TT_ASSERT(dram_size_per_channel % sizeof(uint32_t) == 0);
+    constexpr uint32_t start_address = 0;
+    std::vector<uint32_t> zero_vec(dram_size_per_channel / sizeof(uint32_t), 0);
+    for (int channel = 0; channel < num_dram_channels; ++channel) {
+        tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
+            zero_vec, tt_target_dram{device_id, channel, 0}, start_address);
+
+        cluster_->dram_barrier(device_id);
+    }
+}
+
+void MetalContext::clear_launch_messages_on_eth_cores(chip_id_t device_id) {
+    launch_msg_t launch_msg;
+    go_msg_t go_msg;
+    go_msg.signal = RUN_MSG_INIT;
+    std::memset(&launch_msg, 0, sizeof(launch_msg_t));
+    std::vector<launch_msg_t> init_launch_msg_data(launch_msg_buffer_num_entries, launch_msg);
+
+    auto clear_ethernet_core = [&](const CoreCoord& logical_eth_core) {
+        CoreCoord virtual_eth_core =
+            cluster_->get_virtual_coordinate_from_logical_coordinates(device_id, logical_eth_core, CoreType::ETH);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            init_launch_msg_data.data(),
+            launch_msg_buffer_num_entries * sizeof(launch_msg_t),
+            tt_cxy_pair(device_id, virtual_eth_core),
+            hal_->get_dev_addr(get_programmable_core_type(virtual_eth_core, device_id), HalL1MemAddrType::LAUNCH));
+        uint32_t go_addr =
+            hal_->get_dev_addr(get_programmable_core_type(virtual_eth_core, device_id), HalL1MemAddrType::GO_MSG);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_core(
+            &go_msg, sizeof(go_msg_t), tt_cxy_pair(device_id, virtual_eth_core), go_addr);
+    };
+
+    for (const auto& eth_core : cluster_->get_active_ethernet_cores(device_id)) {
+        clear_ethernet_core(eth_core);
+    }
+    for (const auto& eth_core : cluster_->get_inactive_ethernet_cores(device_id)) {
+        clear_ethernet_core(eth_core);
+    }
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -196,7 +196,7 @@ void MetalContext::clear_dram_state(chip_id_t device_id) {
     std::vector<uint32_t> zero_vec(dram_size_per_channel / sizeof(uint32_t), 0);
     for (int channel = 0; channel < num_dram_channels; ++channel) {
         tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
-            zero_vec, tt_target_dram{device_id, channel, 0}, start_address);
+            zero_vec, device_id, channel, start_address);
 
         cluster_->dram_barrier(device_id);
     }

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -55,11 +55,20 @@ private:
     ~MetalContext();
     void teardown();
 
+    void clear_l1_state(chip_id_t device_id);
+    void clear_dram_state(chip_id_t device_id);
+    void clear_launch_messages_on_eth_cores(chip_id_t device_id);
+
     bool initialized_ = false;
+    bool teardown_registered_ = false;
 
     uint8_t num_hw_cqs_ = 0;
     BankMapping l1_bank_remap_;
     DispatchCoreConfig dispatch_core_config_;
+    size_t fw_compile_hash_ = 0;  // To check if FW recompilation is needed
+
+    // Used to track which FW has been built already
+    std::unordered_set<uint32_t> firmware_built_keys_;
 
     llrt::RunTimeOptions rtoptions_;
     std::unique_ptr<Cluster> cluster_;

--- a/tt_metal/impl/context/metal_context.hpp
+++ b/tt_metal/impl/context/metal_context.hpp
@@ -53,6 +53,7 @@ private:
     friend class tt::stl::Indestructible<MetalContext>;
     MetalContext();
     ~MetalContext();
+    void teardown();
 
     bool initialized_ = false;
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1245,8 +1245,8 @@ bool Device::initialize(
         hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
             hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - worker_l1_size,
         max_alignment);
-    BuildEnvManager::get_instance().add_build_env(this->id(), this->num_hw_cqs());
-    this->initialize_cluster();
+    // BuildEnvManager::get_instance().add_build_env(this->id(), this->num_hw_cqs());
+    // this->initialize_cluster();
     this->initialize_default_sub_device_state(
         l1_small_size, trace_region_size, worker_l1_unreserved_start, l1_bank_remap);
     this->generate_device_bank_to_noc_tables();

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1245,8 +1245,6 @@ bool Device::initialize(
         hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
             hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - worker_l1_size,
         max_alignment);
-    // BuildEnvManager::get_instance().add_build_env(this->id(), this->num_hw_cqs());
-    // this->initialize_cluster();
     this->initialize_default_sub_device_state(
         l1_small_size, trace_region_size, worker_l1_unreserved_start, l1_bank_remap);
     this->generate_device_bank_to_noc_tables();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -382,24 +382,24 @@ void DevicePool::activate_device(chip_id_t id) {
             worker_core_thread_core,
             completion_queue_reader_core,
             this->worker_l1_size);
-        if (!this->firmware_built_keys.contains(
+        /*if (!this->firmware_built_keys.contains(
                 BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)) {
             BuildEnvManager::get_instance().build_firmware(device->build_id());
             this->firmware_built_keys.insert(
                 BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
-        }
+        }*/
         this->devices.emplace_back(std::unique_ptr<IDevice>(device));
     } else {
         log_debug(tt::LogMetal, "DevicePool re-initialize device {}", id);
         if (not device->is_initialized()) {
             device->initialize(
                 num_hw_cqs, this->l1_small_size, this->trace_region_size, this->worker_l1_size, this->l1_bank_remap);
-            if (!this->firmware_built_keys.contains(
+            /*if (!this->firmware_built_keys.contains(
                     BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)) {
                 BuildEnvManager::get_instance().build_firmware(device->build_id());
                 this->firmware_built_keys.insert(
                     BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
-            }
+            }*/
         } else {
             TT_THROW("Cannot re-initialize device {}, must first call close()", id);
         }

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -382,24 +382,12 @@ void DevicePool::activate_device(chip_id_t id) {
             worker_core_thread_core,
             completion_queue_reader_core,
             this->worker_l1_size);
-        /*if (!this->firmware_built_keys.contains(
-                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)) {
-            BuildEnvManager::get_instance().build_firmware(device->build_id());
-            this->firmware_built_keys.insert(
-                BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
-        }*/
         this->devices.emplace_back(std::unique_ptr<IDevice>(device));
     } else {
         log_debug(tt::LogMetal, "DevicePool re-initialize device {}", id);
         if (not device->is_initialized()) {
             device->initialize(
                 num_hw_cqs, this->l1_small_size, this->trace_region_size, this->worker_l1_size, this->l1_bank_remap);
-            /*if (!this->firmware_built_keys.contains(
-                    BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key)) {
-                BuildEnvManager::get_instance().build_firmware(device->build_id());
-                this->firmware_built_keys.insert(
-                    BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
-            }*/
         } else {
             TT_THROW("Cannot re-initialize device {}, must first call close()", id);
         }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -147,13 +147,7 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions&
         build_key,
         std::to_string(std::hash<tt_hlk_desc>{}(build_options.hlk_desc)),
         kernel->compute_hash(),
-        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled());
-
-    for (int i = 0; i < llrt::RunTimeDebugFeatureCount; i++) {
-        compile_hash_str += "_";
-        compile_hash_str +=
-            tt::tt_metal::MetalContext::instance().rtoptions().get_feature_hash_string((llrt::RunTimeDebugFeatures)i);
-    }
+        tt::tt_metal::MetalContext::instance().rtoptions().get_compile_hash_string());
     size_t compile_hash = std::hash<std::string>{}(compile_hash_str);
 
 #ifdef GENERATE_HASH_LOG

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -278,7 +278,7 @@ public:
     inline void set_validate_kernel_binaries(bool val) { validate_kernel_binaries = val; }
 
     // Returns the string representation for hash computation.
-    inline std::string get_feature_hash_string(RunTimeDebugFeatures feature) {
+    inline std::string get_feature_hash_string(RunTimeDebugFeatures feature) const {
         switch (feature) {
             case RunTimeDebugFeatureDprint: return std::to_string(get_feature_enabled(feature));
             case RunTimeDebugFeatureReadDebugDelay:
@@ -292,6 +292,14 @@ public:
             case RunTimeDebugFeatureDisableL1DataCache: return std::to_string(get_feature_enabled(feature));
             default: return "";
         }
+    }
+    inline std::string get_compile_hash_string() const {
+        std::string compile_hash_str = fmt::format("{}_{}", get_watcher_enabled(), get_kernels_early_return());
+        for (int i = 0; i < RunTimeDebugFeatureCount; i++) {
+            compile_hash_str += "_";
+            compile_hash_str += get_feature_hash_string((llrt::RunTimeDebugFeatures)i);
+        }
+        return compile_hash_str;
     }
 
     // Used for both watcher and dprint servers, this dev option (no corresponding env var) sets

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -104,6 +104,8 @@ public:
 
     size_t number_of_devices() const { return this->cluster_desc_->get_number_of_chips(); }
 
+    const std::unordered_set<chip_id_t>& all_chip_ids() const { return this->cluster_desc_->get_all_chips(); };
+
     size_t number_of_pci_devices() const { return this->cluster_desc_->get_chips_with_mmio().size(); }
 
     // TODO: UMD will eventually consolidate ethernet coordinates and unique ids, we can remove the ethernet coord


### PR DESCRIPTION
First part of moving device init/teardown into MetalContext. More to come, but want to split into smaller PRs for stability reasons.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/15002046706 (profiler tests failing on main as well)