### PR TITLE
Add cache invalidations for whisper on p100a

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/compute_common.hpp
@@ -268,6 +268,7 @@ void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
     cb_wait_front(in0_cb, num_tiles);
     cb_wait_front(in1_cb, num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
+        invalidate_l1_cache();
         acquire_dst();
         mul_tiles(in0_cb, in1_cb, 0, i, 0);
         cb_pop_front(in0_cb, 1);
@@ -289,6 +290,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
     cb_reserve_back(out_cb, num_tiles);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
+        invalidate_l1_cache();
         acquire_dst();
         sub_tiles(in0_cb, in1_cb, i, i, 0);
         exp_tile<EXP_APPROX_MODE>(0);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21210

### Problem description
Whisper on P100A was hanging on top of f74db1f8d545a77ce66ba61fb469713a52f43bf9 with L1 cache enabled (it is default enabled)

### What's changed
@skhorasganiTT  is not able to reproduce the hang on main but pushing these fixes in. `invalidate_l1_cache()` is needed in places where the riscs are polling L1. 

Steps to debug l1 cache hangs on BH:
1. Disable the L1 cache on all riscs to see if hang goes away. If hang is still present then it is not l1 cache related. If hang goes away then:
2. Run with L1 cache enabled + Watcher to narrow down hang (additional Watcher features besides waypoints likely need to be disabled)
3. Watcher might indicate where a kernel is stuck in a loop. See example calls to `invalidate_l1_cache()` in `dataflow_api.h` where it is called as L1 is polled.
4. If source of hang is not obvious then disable L1 cache risc by risc to narrow down where the hang could be occurring

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14986689745) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14986696873) CI with demo tests passes (if applicable)