### PR TITLE
Fix duplicate PCH bug, ccache, and reduce build dir size by ~90%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+# CMake 3.19: "smartly dropping dependencies of static and object libraries"
+set(CMAKE_OPTIMIZE_DEPENDENCIES TRUE)
+
 if(NOT ENABLE_LIBCXX)
     # required when linking with libstdc++ with clang and gcc
     add_compile_options($<$<COMPILE_LANG_AND_ID:CXX,Clang>:-fsized-deallocation>)
@@ -191,6 +194,8 @@ add_compile_options(
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-local-typedef>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-private-field>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wno-unknown-pragmas>"
+    "$<$<CXX_COMPILER_ID:Clang>:SHELL:-Xclang -fno-pch-timestamp>" # ccache-friendly PCH flag
+    "$<$<CXX_COMPILER_ID:GNU>:-fpch-preprocess>" # ccache-friendly PCH flag
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-array-bounds>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wno-int-in-bool-context>"
@@ -225,6 +230,37 @@ if(ENABLE_CODE_TIMERS)
     add_compile_definitions(TT_ENABLE_CODE_TIMERS)
 endif()
 include(tracy)
+
+add_library(metal_common_pch STATIC)
+add_library(TT::CommonPCH ALIAS metal_common_pch)
+file(GENERATE OUTPUT metal_common_pch.cpp CONTENT "/*dummy pch file*/\n")
+target_sources(metal_common_pch PRIVATE metal_common_pch.cpp)
+
+target_precompile_headers(
+    metal_common_pch
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
+        <fmt/core.h>
+        <fmt/format.h>
+        <nlohmann/json.hpp>
+        <algorithm>
+        <cstddef>
+        <cstdint>
+        <functional>
+        <map>
+        <memory>
+        <tuple>
+        <unordered_map>
+        <variant>
+        <vector>
+)
+
+target_link_libraries(
+    metal_common_pch
+    PRIVATE
+        nlohmann_json::nlohmann_json
+        fmt::fmt-header-only
+)
 
 ############################################################################################################################
 # Build subdirectories

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,6 @@
           "TT_UMD_BUILD_TESTS": {"value": "FALSE"},
           "BUILD_PROGRAMMING_EXAMPLES": {"value": "TRUE"},
           "BUILD_TT_TRAIN": {"value": "TRUE"},
-          "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"},
           "ENABLE_CCACHE": {"value": "TRUE"},
           "TT_UNITY_BUILDS": {"value": "FALSE"}
         },
@@ -27,7 +26,8 @@
         "cacheVariables": {
           "CMAKE_CXX_CLANG_TIDY": {"value": "clang-tidy-17;--warnings-as-errors=*"},
           "CMAKE_VERIFY_INTERFACE_HEADER_SETS": {"value": "TRUE"},
-          "CMAKE_EXPORT_COMPILE_COMMANDS": {"value": "TRUE"}
+          "CMAKE_EXPORT_COMPILE_COMMANDS": {"value": "TRUE"},
+          "CMAKE_DISABLE_PRECOMPILE_HEADERS": {"value": "TRUE"}
         }
       },
       {

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -281,7 +281,6 @@ if [ "$cpm_use_local_packages" = "ON" ]; then
 fi
 
 if [ "$enable_ccache" = "ON" ]; then
-    cmake_args+=("-DCMAKE_DISABLE_PRECOMPILE_HEADERS=TRUE")
     cmake_args+=("-DENABLE_CCACHE=TRUE")
 fi
 

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -11,16 +11,17 @@ function(useCcache)
         return()
     endif()
 
-    # FIXME: Not (yet) coexisting Precompiled headers and ccache
-    #        Extra ccache args (sloppiness) are required for PCH, and we should only be sloppy
-    #        on the files that _use_ PCH.  For now treat the two features as mutually exclusive.
     if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
-        # Be noisy to not mislead people, and also to draw attention to where to come fix it.
-        message(FATAL_ERROR "Ccache is not configured to handle precompiled headers. Don't enable ccache, or disable PCH with CMAKE_DISABLE_PRECOMPILE_HEADERS. Or update the build to handle both together.")
+        message(STATUS "Overriding CCACHE_SLOPPINESS to work with PCH.")
+        set(CCACHE_ENV "CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_mtime,include_file_ctime")
     endif()
 
     if(CMAKE_GENERATOR MATCHES "Ninja")
-        set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE} PARENT_SCOPE)
+        set(CMAKE_CXX_COMPILER_LAUNCHER
+            ${CCACHE_ENV}
+            ${CCACHE_EXECUTABLE}
+            PARENT_SCOPE
+        )
         message(STATUS "ccache enabled")
     endif()
 endfunction()

--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -329,17 +329,7 @@ target_link_libraries(
         FlatBuffers::FlatBuffers
 )
 
-target_precompile_headers(
-    tt_metal
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/tracy/public/tracy/Tracy.hpp
-        <functional>
-        <map>
-        <memory>
-        <unordered_map>
-        <variant>
-        <vector>
-)
+target_precompile_headers(tt_metal REUSE_FROM TT::CommonPCH)
 
 target_include_directories(
     tt_metal

--- a/tt_metal/fabric/CMakeLists.txt
+++ b/tt_metal/fabric/CMakeLists.txt
@@ -52,16 +52,7 @@ target_link_libraries(
         TT::Metalium::HostDevCommon
 )
 
-target_precompile_headers(
-    fabric
-    PRIVATE
-        <functional>
-        <map>
-        <memory>
-        <unordered_map>
-        <variant>
-        <vector>
-)
+target_precompile_headers(fabric REUSE_FROM TT::CommonPCH)
 
 target_compile_options(fabric PRIVATE -Wno-int-to-pointer-cast)
 

--- a/tt_metal/tools/lightmetal_runner/CMakeLists.txt
+++ b/tt_metal/tools/lightmetal_runner/CMakeLists.txt
@@ -21,3 +21,5 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/tools
 )
+
+target_precompile_headers(lightmetal_runner REUSE_FROM TT::CommonPCH)

--- a/tt_metal/tools/mem_bench/CMakeLists.txt
+++ b/tt_metal/tools/mem_bench/CMakeLists.txt
@@ -40,3 +40,5 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/tools
 )
+
+target_precompile_headers(mem_bench REUSE_FROM TT::CommonPCH)

--- a/tt_metal/tools/watcher_dump/CMakeLists.txt
+++ b/tt_metal/tools/watcher_dump/CMakeLists.txt
@@ -21,3 +21,5 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             ${PROJECT_BINARY_DIR}/tools
 )
+
+target_precompile_headers(watcher_dump REUSE_FROM TT::CommonPCH)

--- a/tt_stl/CMakeLists.txt
+++ b/tt_stl/CMakeLists.txt
@@ -36,4 +36,13 @@ target_link_libraries(
         nlohmann_json::nlohmann_json
 )
 
+target_precompile_headers(
+    metal_common_pch # TT::CommonPCH
+    PUBLIC
+        <reflect>
+        tt_stl/reflection.hpp
+)
+
+target_link_libraries(metal_common_pch PRIVATE tt_stl)
+
 install(TARGETS tt_stl EXPORT Metalium FILE_SET api COMPONENT metalium-dev)

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -861,19 +861,7 @@ set(TTNN_PUBLIC_LINK_LIBRARIES
     TT::NN::Core
 )
 
-set(TTNN_PRECOMPILED_HEADERS
-    ${PROJECT_SOURCE_DIR}/tt_stl/tt_stl/reflection.hpp
-    api/ttnn/operation.hpp
-    ${PROJECT_SOURCE_DIR}/tt_metal/third_party/tracy/public/tracy/Tracy.hpp
-    <functional>
-    <map>
-    <memory>
-    <unordered_map>
-    <variant>
-    <vector>
-)
-
-set(PRECOMPILED_HEADER_TARGET "")
+set(PRECOMPILED_HEADER_TARGET "TT::CommonPCH")
 
 ##################################################
 # Collect all the files and folders that TTNN will use


### PR DESCRIPTION
### Ticket
Closes #21940.

### Problem description
PCHs were eating up ~8GB of space in the build directory due to a quirk in how CMake handles them. Lots of duplicates. GCC and Clang build directories are down to ~1G and ~650M respectively with the standard build.

### What's changed
* Added compiler flags for both gcc and clang that make PCHs ccache friendly (source: ccache official docs).
* Added static library target as a carrier for PCHs.
* Added CMAKE_OPTIMIZE_DEPENDENCIES flag.
* Removed ttnn/operation.hpp from PCH list. It was bloating the PCHs noticibly.
* Hooked nlohmann/json and fmt into PCHs.
* GCC and Clang build directories are ~90% smaller with this PCH implementation.
* CCACHE_SLOPPINESS env var set to work with PCH
  `sloppiness = pch_defines,time_macros,include_file_mtime,include_file_ctime`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15144708978?pr=22002)