### PR TITLE
IWYU cleanup in tt_cluster

### DIFF
--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "control_plane.hpp"
+#include "fabric_host_utils.hpp"
+
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/assert.hpp>

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <tt-metalium/fabric_edm_types.hpp>
 #include <tt-metalium/fabric_types.hpp>
+#include <tt-metalium/mesh_graph.hpp>                   // FabricType
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <tt-metalium/erisc_datamover_builder.hpp>
 #include "tt_metal/impl/context/metal_context.hpp"

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include <tt-metalium/control_plane.hpp>
-#include <tt-metalium/dev_msgs.h>
 #include <tt-metalium/fabric_host_interface.h>
 #include <tt-metalium/fabric_types.hpp>
 #include <tt-metalium/metal_soc_descriptor.h>
-#include <tt-metalium/tt_backend_api_types.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -25,8 +22,6 @@
 
 #include "assert.hpp"
 #include "core_coord.hpp"
-#include "llrt/hal.hpp"
-#include "llrt/rtoptions.hpp"
 #include <umd/device/cluster.h>
 #include <umd/device/device_api_metal.h>
 #include <umd/device/tt_cluster_descriptor.h>
@@ -40,9 +35,15 @@
 
 namespace tt {
 enum class ARCH;
+namespace llrt {
+class RunTimeOptions;
+}
 namespace tt_fabric {
 class ControlPlane;
-}  // namespace tt_fabric
+}
+namespace tt_metal {
+class Hal;
+}
 }  // namespace tt
 struct tt_device_params;
 


### PR DESCRIPTION
### Problem description
tt_cluster.hpp has high fanout, its good to keep its include tree minimized.

### What's changed
Forward declare a few things.
Remove some unused includes.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14989909694) CI passes
- [x] New/Existing tests provide coverage for changes