### PR TITLE
Add uint16 support for bitwise or xor

### DIFF
--- a/tt_metal/include/compute_kernel_api/binary_bitwise_sfpu.h
+++ b/tt_metal/include/compute_kernel_api/binary_bitwise_sfpu.h
@@ -43,12 +43,24 @@ ALWI void bitwise_and_uint16_binary_tile(uint32_t idst0, uint32_t idst1) {
         idst0, idst1)));
 }
 
-ALWI void or_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::OR>(idst0, idst1)));
+ALWI void bitwise_or_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::OR, InstrModLoadStore::INT32>(
+        idst0, idst1)));
 }
 
-ALWI void xor_binary_tile(uint32_t idst0, uint32_t idst1) {
-    MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::XOR>(idst0, idst1)));
+ALWI void bitwise_or_uint16_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::OR, InstrModLoadStore::LO16>(
+        idst0, idst1)));
+}
+
+ALWI void bitwise_xor_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::XOR, InstrModLoadStore::INT32>(
+        idst0, idst1)));
+}
+
+ALWI void bitwise_xor_uint16_binary_tile(uint32_t idst0, uint32_t idst1) {
+    MATH((llk_math_eltwise_binary_sfpu_bitwise<APPROX, ckernel::sfpu::BinaryBitwiseOp::XOR, InstrModLoadStore::LO16>(
+        idst0, idst1)));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1927,7 +1927,7 @@ void py_module(py::module& module) {
         R"doc(Perform bitwise_or operation on :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_or|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
-        R"doc(INT32)doc");
+        R"doc(INT32, UINT16 (range: 0 - 65535))doc");
 
     detail::bind_bitwise_binary_ops_operation(
         module,
@@ -1935,7 +1935,7 @@ void py_module(py::module& module) {
         R"doc(Perform bitwise_xor operation on :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`)doc",
         R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_xor|(\mathrm{{input\_tensor\_a, input\_tensor\_b}}))doc",
         ". ",
-        R"doc(INT32)doc");
+        R"doc(INT32, UINT16 (range: 0 - 65535))doc");
 
     detail::bind_bitwise_binary_ops_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/common/binary_op_utils.cpp
@@ -237,12 +237,22 @@ std::map<std::string, std::string> get_defines_fp32(
             }
             break;
         case BinaryOpType::BITWISE_OR:
-            new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
-            op_name = "or_binary_tile";
+            if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"BITWISE_UINT16_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_or_uint16_binary_tile";
+            } else {
+                new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_or_binary_tile";
+            }
             break;
         case BinaryOpType::BITWISE_XOR:
-            new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
-            op_name = "xor_binary_tile";
+            if (input_a_dtype == DataType::UINT16 && input_b_dtype == DataType::UINT16) {
+                new_defines.insert({"BITWISE_UINT16_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_xor_uint16_binary_tile";
+            } else {
+                new_defines.insert({"BITWISE_INIT", fmt::format("binary_bitwise_tile_init();")});
+                op_name = "bitwise_xor_binary_tile";
+            }
             break;
         case BinaryOpType::LEFT_SHIFT:
             new_defines.insert({"SHIFT_INIT", fmt::format("binary_shift_tile_init();")});

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -44,9 +44,9 @@ namespace utils {
         case BinaryOpType::GCD:
         case BinaryOpType::LCM:
         case BinaryOpType::LEFT_SHIFT:
-        case BinaryOpType::RIGHT_SHIFT:
+        case BinaryOpType::RIGHT_SHIFT: return (a == DataType::INT32 && b == DataType::INT32);
         case BinaryOpType::BITWISE_XOR:
-        case BinaryOpType::BITWISE_OR: return (a == DataType::INT32 && b == DataType::INT32);
+        case BinaryOpType::BITWISE_OR:
         case BinaryOpType::BITWISE_AND: return ((a == DataType::INT32 && b == DataType::INT32) || (a == DataType::UINT16 && b == DataType::UINT16));
         case BinaryOpType::MAXIMUM:
         case BinaryOpType::MINIMUM:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -38,9 +38,9 @@ bool is_binary_sfpu_op(BinaryOpType val, DataType a, DataType b) {
         case LCM:
         case GCD:
         case LEFT_SHIFT:
-        case RIGHT_SHIFT:
+        case RIGHT_SHIFT: return (a == INT32 && b == INT32);
         case BITWISE_XOR:
-        case BITWISE_OR: return (a == INT32 && b == INT32);
+        case BITWISE_OR:
         case BITWISE_AND: return ((a == INT32 && b == INT32) || (a == UINT16 && b == UINT16));
         case QUANT:
         case REQUANT:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_utils.cpp
@@ -336,8 +336,18 @@ std::pair<std::string, std::string> get_sfpu_init_fn(OpConfig::SfpuBinaryOp sfpu
             } else {
                 return {"binary_bitwise_tile_init();", "bitwise_and_binary_tile"};
             }
-        case BITWISE_OR: return {"binary_bitwise_tile_init();", "or_binary_tile"};
-        case BITWISE_XOR: return {"binary_bitwise_tile_init();", "xor_binary_tile"};
+        case BITWISE_OR:
+            if (dtype == DataType::UINT16) {
+                return {"binary_bitwise_tile_init();", "bitwise_or_uint16_binary_tile"};
+            } else {
+                return {"binary_bitwise_tile_init();", "bitwise_or_binary_tile"};
+            }
+        case BITWISE_XOR:
+            if (dtype == DataType::UINT16) {
+                return {"binary_bitwise_tile_init();", "bitwise_xor_uint16_binary_tile"};
+            } else {
+                return {"binary_bitwise_tile_init();", "bitwise_xor_binary_tile"};
+            }
         case MAXIMUM:
             if (dtype == DataType::INT32) {
                 return {"binary_max_tile_init();", "binary_max_int32_tile"};


### PR DESCRIPTION
### Ticket
#21685 
#21707 

### Problem description
uint16 not supported for bitwise or xor

### What's changed
Add uint16 support for bitwise or xor

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/15013335907
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/15019933833
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes