### PR TITLE
Move ttnn target installation into `ttnn/CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,38 +252,6 @@ install(
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT tar
 )
-if(WITH_PYTHON_BINDINGS)
-    # Install .so into src files for pybinds implementation
-    install(
-        TARGETS
-            ttnn
-        ARCHIVE
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT tar
-    )
-
-    install(
-        TARGETS
-            ttnn
-            DESTINATION
-            ${PROJECT_SOURCE_DIR}/ttnn/ttnn
-            COMPONENT
-            tt_pybinds
-    )
-else()
-    #when we don't build python bindings, we generate a dynamic library ttnncpp
-    install(
-        TARGETS
-            ttnncpp
-        ARCHIVE
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            COMPONENT tar
-    )
-endif()
 
 # FIXME(17578): figure out what bits we actually need to ship and omit the rest
 install(

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -1128,3 +1128,36 @@ if(WITH_PYTHON_BINDINGS)
             "${TARGET_LINK_LIBRARIES_PYBIND}"
     )
 endif()
+
+if(WITH_PYTHON_BINDINGS)
+    # Install .so into src files for pybinds implementation
+    install(
+        TARGETS
+            ttnn
+        ARCHIVE
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT tar
+    )
+
+    install(
+        TARGETS
+            ttnn
+            DESTINATION
+            ${PROJECT_SOURCE_DIR}/ttnn/ttnn
+            COMPONENT
+            tt_pybinds
+    )
+else()
+    #when we don't build python bindings, we generate a dynamic library ttnncpp
+    install(
+        TARGETS
+            ttnncpp
+        ARCHIVE
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT tar
+    )
+endif()


### PR DESCRIPTION
### Problem description
We have a subdirectory for managing `ttnn`, lets keep all things related to ttnn targets inside that directory.

### What's changed
Move `ttnn` installation logic into `ttnn/CMakeLists.txt`

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14990081471) CI passes
- [x] New/Existing tests provide coverage for changes