### PR TITLE
Implement PIMPL idiom for MeshWorkload

### DIFF
--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -9,7 +9,8 @@
 #include <tt-metalium/mesh_buffer.hpp>
 
 namespace tt::tt_metal::distributed {
-using RuntimeArgsPerCore = std::vector<std::vector<RuntimeArgsData>>;
+
+class MeshWorkloadImpl;
 
 class MeshCommandQueue;
 class FDMeshCommandQueue;
@@ -22,48 +23,15 @@ class MeshWorkload {
     //  - Single Program Multi Device (Completely Homogenous MeshWorkload)
     //  - Multi Program Multi Device (Completely Heterogeneous MeshWorkload)
     // Support for configurable runtime arguments will be added in future versions.
-private:
-    bool runs_on_noc_multicast_only_cores();
-    bool runs_on_noc_unicast_only_cores();
-    void compile(MeshDevice* mesh_device);
-    void load_binaries(MeshCommandQueue& mesh_cq);
-    void generate_dispatch_commands(MeshCommandQueue& mesh_cq);
-    std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
-    std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
-    std::vector<Semaphore>& semaphores();
-    std::vector<uint32_t> get_program_config_sizes();
-    std::unordered_set<SubDeviceId> determine_sub_device_ids(MeshDevice* mesh_device);
-    bool kernel_binary_always_stored_in_ringbuffer();
-    bool is_finalized() const { return this->finalized_; }
-    void set_finalized() { this->finalized_ = true; };
-    ProgramBinaryStatus get_program_binary_status(std::size_t mesh_id) const;
-    void set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status);
-    ProgramConfig& get_program_config(uint32_t index);
-    ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program, uint64_t command_hash);
-    void compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device);
-    void finalize_offsets(MeshDevice* mesh_device);
-
-    std::unordered_map<std::size_t, ProgramBinaryStatus> program_binary_status_;
-    std::shared_ptr<MeshBuffer> kernel_bin_buf_;
-    std::vector<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>> kernels_;
-    std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
-    std::vector<Semaphore> semaphores_;
-    std::unordered_map<MeshCoordinateRange, Program> programs_;
-    bool finalized_ = false;
-    std::unordered_map<MeshCoordinateRange, std::unordered_map<KernelHandle, RuntimeArgsPerCore>> runtime_args_;
-    MeshCommandQueue* last_used_command_queue_ = nullptr;
-
-    template <typename WorkloadType, typename DeviceType>
-    friend uint32_t program_dispatch::program_base_addr_on_core(WorkloadType&, DeviceType, HalProgrammableCoreType);
-    friend FDMeshCommandQueue;
-    friend void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
-
 public:
     // Main User-Facing API building blocks
     MeshWorkload();
+    ~MeshWorkload();
+    MeshWorkload(MeshWorkload&& other) noexcept;
+    MeshWorkload& operator=(MeshWorkload&& other) noexcept;
     void add_program(const MeshCoordinateRange& device_range, Program&& program);
-    std::unordered_map<MeshCoordinateRange, Program>& get_programs() { return programs_; }
-    const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const { return programs_; }
+    std::unordered_map<MeshCoordinateRange, Program>& get_programs();
+    const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const;
 
     // For testing purposes only
     void set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq);
@@ -72,5 +40,16 @@ public:
     uint32_t get_sem_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
     uint32_t get_cb_base_addr(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
     uint32_t get_cb_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
+    MeshWorkloadImpl& impl() { return *pimpl_; }
+
+    // Add public method for usage in program_dispatch::program_base_addr_on_core
+    std::unordered_set<SubDeviceId> determine_sub_device_ids(MeshDevice* mesh_device);
+
+private:
+    std::unique_ptr<MeshWorkloadImpl> pimpl_;
+
+private:
+    friend void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
+    friend FDMeshCommandQueue;
 };
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -42,9 +42,6 @@ public:
     uint32_t get_cb_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
     MeshWorkloadImpl& impl() { return *pimpl_; }
 
-    // Add public method for usage in program_dispatch::program_base_addr_on_core
-    std::unordered_set<SubDeviceId> determine_sub_device_ids(MeshDevice* mesh_device);
-
 private:
     std::unique_ptr<MeshWorkloadImpl> pimpl_;
 

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -48,6 +48,7 @@ uint32_t program_base_addr_on_core(
 
 namespace distributed {
 class MeshWorkload;
+class MeshWorkloadImpl;
 }  // namespace distributed
 
 class JitBuildOptions;
@@ -230,6 +231,7 @@ private:
     friend HWCommandQueue;
     friend EnqueueProgramCommand;
     friend distributed::MeshWorkload;
+    friend distributed::MeshWorkloadImpl;
     friend detail::Internal_;
 };
 

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -8,6 +8,7 @@
 #include "device.hpp"
 #include "mesh_device.hpp"
 #include "mesh_trace.hpp"
+#include "mesh_workload_impl.hpp"
 #include "tt-metalium/program.hpp"
 #include "dispatch/system_memory_manager.hpp"
 
@@ -21,9 +22,9 @@ void AddProgramToMeshWorkload(MeshWorkload& mesh_workload, Program&& program, co
 
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking) {
     if (mesh_cq.device()->using_fast_dispatch()) {
-        mesh_workload.compile(mesh_cq.device());
-        mesh_workload.load_binaries(mesh_cq);
-        mesh_workload.generate_dispatch_commands(mesh_cq);
+        mesh_workload.impl().compile(mesh_cq.device());
+        mesh_workload.impl().load_binaries(mesh_cq);
+        mesh_workload.impl().generate_dispatch_commands(mesh_cq);
     }
     mesh_cq.enqueue_mesh_workload(mesh_workload, blocking);
 }

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -191,7 +191,7 @@ void FDMeshCommandQueue::clear_expected_num_workers_completed() {
 void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) {
     in_use_ = true;
     uint64_t command_hash = *mesh_device_->get_active_sub_device_manager_id();
-    std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.determine_sub_device_ids(mesh_device_);
+    std::unordered_set<SubDeviceId> sub_device_ids = mesh_workload.impl().determine_sub_device_ids(mesh_device_);
     TT_FATAL(sub_device_ids.size() == 1, "Programs must be executed on a single sub-device");
     SubDeviceId sub_device_id = *(sub_device_ids.begin());
     auto mesh_device_id = this->mesh_device_->id();

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -28,6 +28,7 @@
 #include "mesh_config.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_workload.hpp"
+#include "mesh_workload_impl.hpp"
 #include "sub_device/sub_device_manager_tracker.hpp"
 #include "tt-metalium/program.hpp"
 #include "shape2d.hpp"
@@ -199,13 +200,13 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     CoreType dispatch_core_type = dispatch_core_config.get_core_type();
 
     TT_FATAL(
-        mesh_workload.get_program_binary_status(mesh_device_id) != ProgramBinaryStatus::NotSent,
+        mesh_workload.impl().get_program_binary_status(mesh_device_id) != ProgramBinaryStatus::NotSent,
         "Expected program binaries to be written to the MeshDevice.");
 
     // Compute number of workers being used for this workload.
     uint32_t num_workers = 0;
-    bool unicast_go_signals = mesh_workload.runs_on_noc_unicast_only_cores();
-    bool mcast_go_signals = mesh_workload.runs_on_noc_multicast_only_cores();
+    bool unicast_go_signals = mesh_workload.impl().runs_on_noc_unicast_only_cores();
+    bool mcast_go_signals = mesh_workload.impl().runs_on_noc_multicast_only_cores();
 
     uint32_t num_virtual_eth_cores = 0;
 
@@ -230,8 +231,8 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     // Reserve space in the L1 Kernel Config Ring Buffer for this workload.
     program_dispatch::reserve_space_in_kernel_config_buffer(
         this->get_config_buffer_mgr(*sub_device_id),
-        mesh_workload.get_program_config_sizes(),
-        mesh_workload.get_program_binary_status(mesh_device_id),
+        mesh_workload.impl().get_program_config_sizes(),
+        mesh_workload.impl().get_program_binary_status(mesh_device_id),
         num_workers,
         expected_num_workers_completed,
         dispatch_metadata);
@@ -242,7 +243,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     // current device state. Write the finalized program command sequence to each
     // physical device tied to the program.
     for (auto& [device_range, program] : mesh_workload.get_programs()) {
-        auto& program_cmd_seq = mesh_workload.get_dispatch_cmds_for_program(program, command_hash);
+        auto& program_cmd_seq = mesh_workload.impl().get_dispatch_cmds_for_program(program, command_hash);
         program_dispatch::update_program_dispatch_commands(
             program.impl(),
             program_cmd_seq,
@@ -253,7 +254,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             dispatch_core_type,
             sub_device_id,
             dispatch_metadata,
-            mesh_workload.get_program_binary_status(mesh_device_id),
+            mesh_workload.impl().get_program_binary_status(mesh_device_id),
             std::pair<bool, int>(unicast_go_signals, num_virtual_eth_cores));
 
         if (sysmem_manager.get_bypass_mode()) {
@@ -315,7 +316,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         expected_num_workers_completed_[*sub_device_id] += num_workers;
     }
     // From the dispatcher's perspective, binaries are now committed to DRAM
-    mesh_workload.set_program_binary_status(mesh_device_id, ProgramBinaryStatus::Committed);
+    mesh_workload.impl().set_program_binary_status(mesh_device_id, ProgramBinaryStatus::Committed);
     mesh_workload.set_last_used_command_queue_for_testing(this);
 
     if (blocking) {

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -25,6 +25,7 @@
 #include "kernel_types.hpp"
 #include "mesh_coord.hpp"
 #include "mesh_device.hpp"
+#include "mesh_workload_impl.hpp"
 #include "program/program_device_map.hpp"
 #include "program/program_impl.hpp"
 #include "tt-metalium/program.hpp"
@@ -59,14 +60,14 @@ std::optional<MeshCoordinateRange> find_intersection(
 
 }  // namespace
 
-MeshWorkload::MeshWorkload() {
+MeshWorkloadImpl::MeshWorkloadImpl() {
     // A MeshWorkload tracks maintains its own handles to kernels across all
     // encapsulated programs
     kernel_groups_.resize(MetalContext::instance().hal().get_programmable_core_type_count());
     kernels_.resize(MetalContext::instance().hal().get_programmable_core_type_count());
 }
 
-void MeshWorkload::add_program(const MeshCoordinateRange& device_range, Program&& program) {
+void MeshWorkloadImpl::add_program(const MeshCoordinateRange& device_range, Program&& program) {
     auto potential_intersection = find_intersection(programs_, device_range);
     TT_FATAL(
         !potential_intersection,
@@ -76,14 +77,14 @@ void MeshWorkload::add_program(const MeshCoordinateRange& device_range, Program&
     programs_[device_range] = std::move(program);
 }
 
-void MeshWorkload::compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device) {
+void MeshWorkloadImpl::compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device) {
     auto& program = programs_.at(device_range);
     program.compile(mesh_device);
     program.allocate_circular_buffers(mesh_device);
     tt::tt_metal::detail::ValidateCircularBufferRegion(program, mesh_device);
 }
 
-void MeshWorkload::compile(MeshDevice* mesh_device) {
+void MeshWorkloadImpl::compile(MeshDevice* mesh_device) {
     // Multi-Step Compile:
     // 1. Compile Kernel Binaries
     // 2. Allocate and Validate CBs
@@ -102,7 +103,7 @@ void MeshWorkload::compile(MeshDevice* mesh_device) {
     finalize_offsets(mesh_device);
 }
 
-void MeshWorkload::load_binaries(MeshCommandQueue& mesh_cq) {
+void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
     // Load binaries for all programs to their respective devices in
     // the Mesh. Only done when the MeshWorkload is enqueued for the first
     // time.
@@ -171,18 +172,18 @@ void MeshWorkload::load_binaries(MeshCommandQueue& mesh_cq) {
     }
 }
 
-ProgramBinaryStatus MeshWorkload::get_program_binary_status(std::size_t mesh_id) const {
+ProgramBinaryStatus MeshWorkloadImpl::get_program_binary_status(std::size_t mesh_id) const {
     if (program_binary_status_.find(mesh_id) != program_binary_status_.end()) {
         return program_binary_status_.at(mesh_id);
     }
     return ProgramBinaryStatus::NotSent;
 }
 
-void MeshWorkload::set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status) {
+void MeshWorkloadImpl::set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status) {
     program_binary_status_[mesh_id] = status;
 }
 
-void MeshWorkload::generate_dispatch_commands(MeshCommandQueue& mesh_cq) {
+void MeshWorkloadImpl::generate_dispatch_commands(MeshCommandQueue& mesh_cq) {
     // Generate Dispatch Commands for each Program in the MeshWorkload.
     // These commands will be updated based on MeshDevice state when the
     // workload is enqueued.
@@ -192,7 +193,7 @@ void MeshWorkload::generate_dispatch_commands(MeshCommandQueue& mesh_cq) {
     }
 }
 
-bool MeshWorkload::runs_on_noc_multicast_only_cores() {
+bool MeshWorkloadImpl::runs_on_noc_multicast_only_cores() {
     // Return true if any program in the MeshWorkload runs on cores
     // that can be multicasted to
     bool ret = false;
@@ -202,7 +203,7 @@ bool MeshWorkload::runs_on_noc_multicast_only_cores() {
     return ret;
 }
 
-bool MeshWorkload::runs_on_noc_unicast_only_cores() {
+bool MeshWorkloadImpl::runs_on_noc_unicast_only_cores() {
     // Return true if any program in the MeshWorkload runs on cores
     // that can only be unicasted to
     bool ret = false;
@@ -212,7 +213,7 @@ bool MeshWorkload::runs_on_noc_unicast_only_cores() {
     return ret;
 }
 
-bool MeshWorkload::kernel_binary_always_stored_in_ringbuffer() {
+bool MeshWorkloadImpl::kernel_binary_always_stored_in_ringbuffer() {
     // Return true if kernel binaries cannot be placed in a ring buffer for
     // any program in the MeshWorkload
     bool stored_in_ring_buf = true;
@@ -222,7 +223,7 @@ bool MeshWorkload::kernel_binary_always_stored_in_ringbuffer() {
     return stored_in_ring_buf;
 }
 
-std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& MeshWorkload::get_kernels(
+std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& MeshWorkloadImpl::get_kernels(
     uint32_t programmable_core_type_index) {
     // Get all kernels across all programs in the MeshWorkload
     if (kernels_.at(programmable_core_type_index).empty()) {
@@ -238,7 +239,7 @@ std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& MeshWorkload::get_ker
     return kernels_.at(programmable_core_type_index);
 }
 
-std::vector<std::shared_ptr<KernelGroup>>& MeshWorkload::get_kernel_groups(uint32_t programmable_core_type_index) {
+std::vector<std::shared_ptr<KernelGroup>>& MeshWorkloadImpl::get_kernel_groups(uint32_t programmable_core_type_index) {
     // Get all kernel groups across all programs in the MeshWorkload
     if (kernel_groups_.at(programmable_core_type_index).empty()) {
         uint32_t device_range_idx = 0;
@@ -257,7 +258,7 @@ std::vector<std::shared_ptr<KernelGroup>>& MeshWorkload::get_kernel_groups(uint3
     return kernel_groups_.at(programmable_core_type_index);
 }
 
-std::vector<Semaphore>& MeshWorkload::semaphores() {
+std::vector<Semaphore>& MeshWorkloadImpl::semaphores() {
     // Get all semaphores across all programs in the MeshWorkload
     if (not semaphores_.size()) {
         for (auto& [device_range, program] : programs_) {
@@ -267,7 +268,7 @@ std::vector<Semaphore>& MeshWorkload::semaphores() {
     return semaphores_;
 }
 
-std::vector<uint32_t> MeshWorkload::get_program_config_sizes() {
+std::vector<uint32_t> MeshWorkloadImpl::get_program_config_sizes() {
     // Get the config sizes for all L1 Program Data Structures
     std::vector<uint32_t> global_program_config_sizes;
     for (auto& program_on_grid : programs_) {
@@ -284,7 +285,7 @@ std::vector<uint32_t> MeshWorkload::get_program_config_sizes() {
     return global_program_config_sizes;
 }
 
-std::unordered_set<SubDeviceId> MeshWorkload::determine_sub_device_ids(MeshDevice* mesh_device) {
+std::unordered_set<SubDeviceId> MeshWorkloadImpl::determine_sub_device_ids(MeshDevice* mesh_device) {
     // Get the sub device ids for all program across all devices in the Workload
     std::unordered_set<SubDeviceId> sub_devices_;
     for (auto& [device_range, program] : programs_) {
@@ -297,26 +298,26 @@ std::unordered_set<SubDeviceId> MeshWorkload::determine_sub_device_ids(MeshDevic
     return sub_devices_;
 }
 
-ProgramCommandSequence& MeshWorkload::get_dispatch_cmds_for_program(Program& program, uint64_t command_hash) {
+ProgramCommandSequence& MeshWorkloadImpl::get_dispatch_cmds_for_program(Program& program, uint64_t command_hash) {
     // Get the dispatch commands associated with this program
     return program.get_cached_program_command_sequences().at(command_hash);
 }
 
 // The functions below are for testing purposes only
-void MeshWorkload::set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq) {
+void MeshWorkloadImpl::set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq) {
     last_used_command_queue_ = mesh_cq;
 }
 
-MeshCommandQueue* MeshWorkload::get_last_used_command_queue() const { return last_used_command_queue_; }
+MeshCommandQueue* MeshWorkloadImpl::get_last_used_command_queue() const { return last_used_command_queue_; }
 
-ProgramConfig& MeshWorkload::get_program_config(uint32_t index) {
+ProgramConfig& MeshWorkloadImpl::get_program_config(uint32_t index) {
     TT_FATAL(
         programs_.size() and is_finalized(),
         "Program Configs can only be queried if a MeshWorkload is populated and finalized.");
     return programs_.begin()->second.get_program_config(index);
 }
 
-uint32_t MeshWorkload::get_sem_base_addr(
+uint32_t MeshWorkloadImpl::get_sem_base_addr(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
@@ -326,7 +327,7 @@ uint32_t MeshWorkload::get_sem_base_addr(
                .sem_offset;
 }
 
-uint32_t MeshWorkload::get_sem_size(
+uint32_t MeshWorkloadImpl::get_sem_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t sem_size = 0;
     uint32_t program_idx = 0;
@@ -341,7 +342,7 @@ uint32_t MeshWorkload::get_sem_size(
     return sem_size;
 }
 
-uint32_t MeshWorkload::get_cb_base_addr(
+uint32_t MeshWorkloadImpl::get_cb_base_addr(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type =
         ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
@@ -351,7 +352,7 @@ uint32_t MeshWorkload::get_cb_base_addr(
                .cb_offset;
 }
 
-uint32_t MeshWorkload::get_cb_size(
+uint32_t MeshWorkloadImpl::get_cb_size(
     std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
     uint32_t cb_size = 0;
     uint32_t program_idx = 0;
@@ -366,7 +367,7 @@ uint32_t MeshWorkload::get_cb_size(
     return cb_size;
 }
 
-void MeshWorkload::finalize_offsets(MeshDevice* mesh_device) {
+void MeshWorkloadImpl::finalize_offsets(MeshDevice* mesh_device) {
     if (is_finalized()) {
         return;
     }
@@ -395,6 +396,54 @@ void MeshWorkload::finalize_offsets(MeshDevice* mesh_device) {
         mesh_device, kernels_getter, kernel_groups_getter, semaphores_getter, programs);
 
     set_finalized();
+}
+
+// MeshWorkload PIMPL Implementation
+
+MeshWorkload::MeshWorkload() : pimpl_(std::make_unique<MeshWorkloadImpl>()) {}
+MeshWorkload::~MeshWorkload() = default;
+MeshWorkload::MeshWorkload(MeshWorkload&& other) noexcept = default;
+MeshWorkload& MeshWorkload::operator=(MeshWorkload&& other) noexcept = default;
+
+void MeshWorkload::add_program(const MeshCoordinateRange& device_range, Program&& program) {
+    pimpl_->add_program(device_range, std::move(program));
+}
+
+std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() { return pimpl_->get_programs(); }
+
+const std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() const {
+    return pimpl_->get_programs();
+}
+
+// For testing purposes only
+void MeshWorkload::set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq) {
+    pimpl_->set_last_used_command_queue_for_testing(mesh_cq);
+}
+
+MeshCommandQueue* MeshWorkload::get_last_used_command_queue() const { return pimpl_->get_last_used_command_queue(); }
+
+uint32_t MeshWorkload::get_sem_base_addr(
+    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    return pimpl_->get_sem_base_addr(mesh_device, logical_core, core_type);
+}
+
+uint32_t MeshWorkload::get_sem_size(
+    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    return pimpl_->get_sem_size(mesh_device, logical_core, core_type);
+}
+
+uint32_t MeshWorkload::get_cb_base_addr(
+    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    return pimpl_->get_cb_base_addr(mesh_device, logical_core, core_type);
+}
+
+uint32_t MeshWorkload::get_cb_size(
+    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
+    return pimpl_->get_cb_size(mesh_device, logical_core, core_type);
+}
+
+std::unordered_set<SubDeviceId> MeshWorkload::determine_sub_device_ids(MeshDevice* mesh_device) {
+    return pimpl_->determine_sub_device_ids(mesh_device);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -442,8 +442,4 @@ uint32_t MeshWorkload::get_cb_size(
     return pimpl_->get_cb_size(mesh_device, logical_core, core_type);
 }
 
-std::unordered_set<SubDeviceId> MeshWorkload::determine_sub_device_ids(MeshDevice* mesh_device) {
-    return pimpl_->determine_sub_device_ids(mesh_device);
-}
-
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+
+namespace tt::tt_metal::distributed {
+using RuntimeArgsPerCore = std::vector<std::vector<RuntimeArgsData>>;
+
+class MeshCommandQueue;
+class FDMeshCommandQueue;
+void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
+
+class MeshWorkloadImpl {
+    // A MeshWorkload can be fully described using a set of programs mapped to different Logical Device Regions
+    // in a Mesh + configurable runtime Args
+    // The current iteration supports the following compute paradigms:
+    //  - Single Program Multi Device (Completely Homogenous MeshWorkload)
+    //  - Multi Program Multi Device (Completely Heterogeneous MeshWorkload)
+    // Support for configurable runtime arguments will be added in future versions.
+private:
+    bool runs_on_noc_multicast_only_cores();
+    bool runs_on_noc_unicast_only_cores();
+    void compile(MeshDevice* mesh_device);
+    void load_binaries(MeshCommandQueue& mesh_cq);
+    void generate_dispatch_commands(MeshCommandQueue& mesh_cq);
+    std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
+    std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
+    std::vector<Semaphore>& semaphores();
+    std::vector<uint32_t> get_program_config_sizes();
+    bool kernel_binary_always_stored_in_ringbuffer();
+    bool is_finalized() const { return this->finalized_; }
+    void set_finalized() { this->finalized_ = true; };
+    ProgramBinaryStatus get_program_binary_status(std::size_t mesh_id) const;
+    void set_program_binary_status(std::size_t mesh_id, ProgramBinaryStatus status);
+    ProgramConfig& get_program_config(uint32_t index);
+    ProgramCommandSequence& get_dispatch_cmds_for_program(Program& program, uint64_t command_hash);
+    void compile_program(const MeshCoordinateRange& device_range, MeshDevice* mesh_device);
+    void finalize_offsets(MeshDevice* mesh_device);
+
+    std::unordered_map<std::size_t, ProgramBinaryStatus> program_binary_status_;
+    std::shared_ptr<MeshBuffer> kernel_bin_buf_;
+    std::vector<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>> kernels_;
+    std::vector<std::vector<std::shared_ptr<KernelGroup>>> kernel_groups_;
+    std::vector<Semaphore> semaphores_;
+    std::unordered_map<MeshCoordinateRange, Program> programs_;
+    bool finalized_ = false;
+    std::unordered_map<MeshCoordinateRange, std::unordered_map<KernelHandle, RuntimeArgsPerCore>> runtime_args_;
+    MeshCommandQueue* last_used_command_queue_ = nullptr;
+
+    friend void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
+    friend FDMeshCommandQueue;
+    friend class tt::tt_metal::Program;
+
+public:
+    // Main User-Facing API building blocks
+    MeshWorkloadImpl();
+
+    void add_program(const MeshCoordinateRange& device_range, Program&& program);
+    std::unordered_map<MeshCoordinateRange, Program>& get_programs() { return programs_; }
+    const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const { return programs_; }
+
+    // For testing purposes only
+    void set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq);
+    MeshCommandQueue* get_last_used_command_queue() const;
+    uint32_t get_sem_base_addr(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
+    uint32_t get_sem_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
+    uint32_t get_cb_base_addr(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
+    uint32_t get_cb_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
+
+    // Made public for usage in dispatch.cpp
+    std::unordered_set<SubDeviceId> determine_sub_device_ids(MeshDevice* mesh_device);
+};
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -32,6 +32,7 @@ private:
     std::vector<std::shared_ptr<KernelGroup>>& get_kernel_groups(uint32_t programmable_core_type_index);
     std::vector<Semaphore>& semaphores();
     std::vector<uint32_t> get_program_config_sizes();
+    std::unordered_set<SubDeviceId> determine_sub_device_ids(MeshDevice* mesh_device);
     bool kernel_binary_always_stored_in_ringbuffer();
     bool is_finalized() const { return this->finalized_; }
     void set_finalized() { this->finalized_ = true; };
@@ -52,6 +53,8 @@ private:
     std::unordered_map<MeshCoordinateRange, std::unordered_map<KernelHandle, RuntimeArgsPerCore>> runtime_args_;
     MeshCommandQueue* last_used_command_queue_ = nullptr;
 
+    template <typename WorkloadType, typename DeviceType>
+    friend uint32_t program_dispatch::program_base_addr_on_core(WorkloadType&, DeviceType, HalProgrammableCoreType);
     friend void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
     friend FDMeshCommandQueue;
     friend class tt::tt_metal::Program;
@@ -71,8 +74,5 @@ public:
     uint32_t get_sem_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
     uint32_t get_cb_base_addr(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
     uint32_t get_cb_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
-
-    // Made public for usage in dispatch.cpp
-    std::unordered_set<SubDeviceId> determine_sub_device_ids(MeshDevice* mesh_device);
 };
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -61,6 +61,7 @@
 #include "util.hpp"
 #include "vector_aligned.hpp"
 #include "worker_config_buffer.hpp"
+#include "tt_metal/distributed/mesh_workload_impl.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -2191,8 +2192,8 @@ void set_go_signal_noc_data_on_dispatch(
 }
 
 template uint32_t program_base_addr_on_core<ProgramImpl, IDevice*>(ProgramImpl&, IDevice*, HalProgrammableCoreType);
-template uint32_t program_base_addr_on_core<distributed::MeshWorkload, distributed::MeshDevice*>(
-    distributed::MeshWorkload&, distributed::MeshDevice*, HalProgrammableCoreType);
+template uint32_t program_base_addr_on_core<distributed::MeshWorkloadImpl, distributed::MeshDevice*>(
+    distributed::MeshWorkloadImpl&, distributed::MeshDevice*, HalProgrammableCoreType);
 }  // namespace program_dispatch
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -293,6 +293,7 @@ private:
     friend Program;
     friend Internal_;
     friend distributed::MeshWorkload;
+    friend distributed::MeshWorkloadImpl;
 };
 
 }  // namespace detail


### PR DESCRIPTION
### Problem description
`mesh_workload.hpp` is in the public API, and it exposes many internals that don't need to be.
Making matters worse, it forces `dev_msgs.h` into the public API, because of its public dependence on `KernelGroup`.

### What's changed
Implement PIMPL, and deal with fallout due to `friend` usage.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/14992730924) CI passes
- [x] New/Existing tests provide coverage for changes
