### PR TITLE
Assert on page table size in simple_text_demo to avoid OOB array read

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -539,6 +539,13 @@ def test_demo_text(
             max_generated_tokens + max_encoded_prompt_len <= max_seq_len
         ), f"Prompt prefill tokens ({max_encoded_prompt_len}) + maximum number of decoded iterations ({max_generated_tokens}) needs to be <= than max_seq_len ({max_seq_len})"
 
+        if paged_attention:
+            paged_cache_max_seq_len = (
+                page_params["page_block_size"] * page_params["page_max_num_blocks_per_dp"] / batch_size
+            )
+            assert (
+                max_generated_tokens + max_encoded_prompt_len <= paged_cache_max_seq_len
+            ), f"max_generated_tokens ({max_generated_tokens}) needs to be <= than paged_cache_max_seq_len ({paged_cache_max_seq_len})"
         profiler.end(f"preprocess_prefill_inputs", iteration=batch_idx)
 
         # when doing repeating batches, set kv-caches to zero, to avoid context leaking


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21971

### Problem description
When increasing `max_generated_tokens` without increasing the size of the paged cache we hit hangs in WH and BH due to OOB array reads in `paged_update_cache`.

### What's changed
Assert in the demo that the paged cache is large enough to manage the largest prefill user and the number of tokens generated.