### PR TITLE
Integrate VAE Decoder into SDv1-4 demo

### DIFF
--- a/models/demos/wormhole/stable_diffusion/demo/demo.py
+++ b/models/demos/wormhole/stable_diffusion/demo/demo.py
@@ -219,21 +219,18 @@ def run_demo_inference(device, reset_seeds, input_path, num_prompts, num_inferen
 
             iter += 1
 
-        latents = ttnn.to_torch(ttnn_latents).to(torch.float32)
-
         # scale and decode the image latents with vae
-        latents = 1 / 0.18215 * latents
+        latents = 1 / 0.18215 * ttnn_latents
 
         # on blackhole, we use the original vae decoder until #20760 is fixed
         if not is_blackhole():
-            latents_tt = ttnn.from_torch(
-                latents.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
-            )
-            ttnn_output = tt_vae.decode(latents_tt)
+            latents = ttnn.permute(latents, [0, 2, 3, 1])
+            ttnn_output = tt_vae.decode(latents)
             ttnn_output = ttnn.reshape(ttnn_output, [1, image_size[0], image_size[1], ttnn_output.shape[3]])
             ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
             image = ttnn.to_torch(ttnn_output)
         else:
+            latents = ttnn.to_torch(latents).to(torch.float32)
             image = vae.decode(latents).sample
 
         profiler.end(f"inference_prompt_{i}")
@@ -403,21 +400,18 @@ def run_interactive_demo_inference(device, num_inference_steps, image_size=(256,
             iter += 1
         print(f"Time taken for {iter} iterations: total: {total_accum:.3f}")
 
-        latents = ttnn.to_torch(ttnn_latents).to(torch.float32)
-
         # scale and decode the image latents with vae
-        latents = 1 / 0.18215 * latents
+        latents = 1 / 0.18215 * ttnn_latents
 
         # on blackhole, we use the original vae decoder until #20760 is fixed
         if not is_blackhole():
-            latents_tt = ttnn.from_torch(
-                latents.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
-            )
-            ttnn_output = tt_vae.decode(latents_tt)
+            latents = ttnn.permute(latents, [0, 2, 3, 1])
+            ttnn_output = tt_vae.decode(latents)
             ttnn_output = ttnn.reshape(ttnn_output, [1, image_size[0], image_size[1], ttnn_output.shape[3]])
             ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
             image = ttnn.to_torch(ttnn_output)
         else:
+            latents = ttnn.to_torch(latents).to(torch.float32)
             image = vae.decode(latents).sample
 
         # Image post-processing
@@ -574,20 +568,18 @@ def run_demo_inference_diffusiondb(
 
             iter += 1
 
-        latents = ttnn.to_torch(ttnn_latents).to(torch.float32)
         # scale and decode the image latents with vae
-        latents = 1 / 0.18215 * latents
+        latents = 1 / 0.18215 * ttnn_latents
 
         # on blackhole, we use the original vae decoder until #20760 is fixed
         if not is_blackhole():
-            latents_tt = ttnn.from_torch(
-                latents.permute([0, 2, 3, 1]), device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16
-            )
-            ttnn_output = tt_vae.decode(latents_tt)
+            latents = ttnn.permute(latents, [0, 2, 3, 1])
+            ttnn_output = tt_vae.decode(latents)
             ttnn_output = ttnn.reshape(ttnn_output, [1, image_size[0], image_size[1], ttnn_output.shape[3]])
             ttnn_output = ttnn.permute(ttnn_output, [0, 3, 1, 2])
             image = ttnn.to_torch(ttnn_output)
         else:
+            latents = ttnn.to_torch(latents).to(torch.float32)
             image = vae.decode(latents).sample
 
         # Image post-processing

--- a/models/demos/wormhole/stable_diffusion/tests/test_demo.py
+++ b/models/demos/wormhole/stable_diffusion/tests/test_demo.py
@@ -9,7 +9,7 @@ from models.demos.wormhole.stable_diffusion.demo.demo import run_demo_inference_
 
 
 @pytest.mark.timeout(600)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 11 * 8192}], indirect=True)
 @pytest.mark.parametrize(
     "input_path",
     (("models/demos/wormhole/stable_diffusion/demo/input_data.json"),),
@@ -34,7 +34,7 @@ def test_demo_sd(device, reset_seeds, input_path, num_prompts, num_inference_ste
 
 
 @pytest.mark.timeout(600)
-@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 11 * 8192}], indirect=True)
 @pytest.mark.parametrize(
     "num_prompts",
     ((1),),


### PR DESCRIPTION
### Ticket
[#21688](https://github.com/tenstorrent/tt-metal/issues/21688)
### Problem description
Currently host VAE is used for SDv1-4

### What's changed
- Integrated on device VAE Decoder into Stable Diffusion v1-4 demo

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15016317262)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/workflows/fast-dispatch-full-regressions-and-models.yaml) CI [passes](https://github.com/tenstorrent/tt-metal/actions/runs/15019651491)