### PR TITLE
Create initial example of how to cache weights onto CIv2 Large File Cache by moving over ttnn falcon7b weights to download it for the single-card profiler regression test

### DIFF
--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -90,7 +90,7 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: "--device /dev/tenstorrent -e TT_GH_CI_INFRA"
     defaults:
       run:
         shell: bash

--- a/conftest.py
+++ b/conftest.py
@@ -110,17 +110,17 @@ class CIv2ModelDownloadUtils_:
     @staticmethod
     def download_from_ci_v2_cache(
         model_path,
-        dest_dir_suffix="",
+        download_dir_suffix="",
         endpoint_prefix="http://large-file-cache.large-file-cache.svc.cluster.local//mldata/model_checkpoints/pytorch/huggingface",
     ):
         assert model_path, f"model_path cannot be empty when downloading - what is wrong with you?: {model_path}"
 
         # RK: Will this be portable? LOL
-        dest_path = Path("/tmp/ttnn_model_cache/") / dest_dir_suffix
+        download_dir = Path("/tmp/ttnn_model_cache/") / download_dir_suffix
 
-        dest_path.mkdir(parents=True, exist_ok=True)
+        download_dir.mkdir(parents=True, exist_ok=True)
 
-        download_dir_str = str(dest_path)
+        download_dir_str = str(download_dir)
 
         # Add trailing slash to model_path if it doesn't have one, as wget
         # seems to not download recursively via subprocess if it doesn't have
@@ -136,7 +136,7 @@ class CIv2ModelDownloadUtils_:
             text=True,
         )
 
-        return dest_path
+        return download_dir / Path(model_path)
 
 
 @pytest.fixture(scope="session")
@@ -156,7 +156,7 @@ def model_location_generator(is_ci_v2_env):
                 not model_subdir
             ), f"model_subdir is set to {model_subdir}, but we don't support further levels of directories in the large file cache in CIv2"
             civ2_download_path = CIv2ModelDownloadUtils_.download_from_ci_v2_cache(
-                model_version, dest_dir_suffix="model_weights"
+                model_version, download_dir_suffix="model_weights"
             )
             logger.info(f"For model location, using CIv2 large file cache: {civ2_download_path}")
             return civ2_download_path

--- a/conftest.py
+++ b/conftest.py
@@ -113,6 +113,8 @@ class CIv2ModelDownloadUtils_:
         dest_dir_suffix="",
         endpoint_prefix="http://large-file-cache.large-file-cache.svc.cluster.local//mldata/model_checkpoints/pytorch/huggingface",
     ):
+        assert model_path, f"model_path cannot be empty when downloading - what is wrong with you?: {model_path}"
+
         # RK: Will this be portable? LOL
         dest_path = Path("/tmp/ttnn_model_cache/") / dest_dir_suffix
 
@@ -120,11 +122,18 @@ class CIv2ModelDownloadUtils_:
 
         download_dir_str = str(dest_path)
 
+        # Add trailing slash to model_path if it doesn't have one, as wget
+        # seems to not download recursively via subprocess if it doesn't have
+        # it
+        if model_path and not model_path.endswith("/"):
+            model_path = model_path + "/"
+
         endpoint = f"{endpoint_prefix}/{model_path}"
 
         subprocess.run(
             ["wget", "-r", "-nH", "-x", "--cut-dirs=5", "-np", "-R", "index.html*", "-P", download_dir_str, endpoint],
             check=True,
+            text=True,
         )
 
         return dest_path

--- a/conftest.py
+++ b/conftest.py
@@ -146,7 +146,7 @@ def model_location_generator(is_ci_v2_env):
         internal_weka_path = Path("/mnt/MLPerf") / model_folder / model_version
         has_internal_weka = internal_weka_path.exists()
 
-        download_from_ci_v2 = download_if_ci_v2
+        download_from_ci_v2 = download_if_ci_v2 and is_ci_v2_env
 
         if download_from_ci_v2:
             assert (

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,7 @@ import multiprocess
 import signal
 import time
 import psutil
+import subprocess
 from datetime import datetime
 
 from loguru import logger
@@ -113,7 +114,7 @@ class CIv2ModelDownloadUtils_:
         endpoint_prefix="http://large-file-cache.large-file-cache.svc.cluster.local//mldata/model_checkpoints/pytorch/huggingface",
     ):
         # RK: Will this be portable? LOL
-        dest_path = pathlib.Path("/tmp/ttnn_model_cache/") / dest_dir_suffix
+        dest_path = Path("/tmp/ttnn_model_cache/") / dest_dir_suffix
 
         dest_path.mkdir(parents=True, exist_ok=True)
 
@@ -122,7 +123,8 @@ class CIv2ModelDownloadUtils_:
         endpoint = f"{endpoint_prefix}/{model_path}"
 
         subprocess.run(
-            ["wget", "-r", "-nH", "-x", "--cut-dirs=5", "-np", "-R", "index.html*", "-P", download_dir_str, endpoint]
+            ["wget", "-r", "-nH", "-x", "--cut-dirs=5", "-np", "-R", "index.html*", "-P", download_dir_str, endpoint],
+            check=True,
         )
 
         return dest_path
@@ -135,7 +137,7 @@ def model_location_generator(is_ci_v2_env):
         internal_weka_path = Path("/mnt/MLPerf") / model_folder / model_version
         has_internal_weka = internal_weka_path.exists()
 
-        download_from_ci_v2 = download_if_ci_v2 and is_ci_v2_env
+        download_from_ci_v2 = download_if_ci_v2
 
         if download_from_ci_v2:
             assert (
@@ -144,7 +146,7 @@ def model_location_generator(is_ci_v2_env):
             assert (
                 not model_subdir
             ), f"model_subdir is set to {model_subdir}, but we don't support further levels of directories in the large file cache in CIv2"
-            civ2_download_path = CIv2ModelDownloadUtils.download_from_ci_v2_cache(
+            civ2_download_path = CIv2ModelDownloadUtils_.download_from_ci_v2_cache(
                 model_version, dest_dir_suffix="model_weights"
             )
             logger.info(f"For model location, using CIv2 large file cache: {civ2_download_path}")

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -65,6 +65,7 @@ def test_falcon_causal_lm(
     expected_pcc,
     model_config_str,
     num_loops,
+    model_location_generator,
 ):
     torch.manual_seed(0)
     batch = device_batch_size * mesh_device.get_num_devices()
@@ -73,10 +74,12 @@ def test_falcon_causal_lm(
     else:
         shard_dim = 0
 
-    configuration = transformers.FalconConfig.from_pretrained(model_version)
+    model_location_or_version = model_location_generator(model_version, download_if_ci_v2=True)
+
+    configuration = transformers.FalconConfig.from_pretrained(model_location_or_version)
     configuration.num_hidden_layers = num_layers
     model = transformers.models.falcon.modeling_falcon.FalconForCausalLM.from_pretrained(
-        model_version, config=configuration
+        model_location_or_version, config=configuration
     ).eval()
     model_config = get_model_config(model_config_str)
     dtype = model_config["DEFAULT_DTYPE"]


### PR DESCRIPTION
### Ticket

#21926 

### Problem description

We want to move off CIv1, which means MLPerf.

But what do about HF weights and ttnn tensor bins?

### What's changed

We use a pytest fixture to `wget` such files and provide them to tests.

We want to assert that these weights exist if a test says it wants to try using LFC in CIv2.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes