### PR TITLE
[DM]: Testing for "One from All" primitive

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/data_movement/CMakeLists.txt
@@ -4,6 +4,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/one_to_all/test_one_to_all.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/one_to_one/test_one_to_one.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/one_from_one/test_one_from_one.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/one_from_all/test_one_from_all.cpp
 )
 
 add_executable(unit_tests_data_movement ${UNIT_TESTS_DATA_MOVEMENT_SRC})

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -8,7 +8,7 @@ This test suite addresses the functionality and performance (i.e. bandwidth) of 
 | DRAM Unary    | 0-3   | Transactions between DRAM and a single Tensix core.                                  |
 | One to One    | 4     | Write transactions between two Tensix cores.                                         |
 | One From One  | 5     | Read transactions between two Tensix cores.                                          |
-| One From All  | 6     | Read transactions between one gatherer Tensix core and multiple sender Tensix cores. |
+| One From All  | 15    | Read transactions between one gatherer Tensix core and multiple sender Tensix cores. |
 
 ## Running Tests
 ### C++ Gtests

--- a/tests/tt_metal/tt_metal/data_movement/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/README.md
@@ -3,11 +3,12 @@
 This test suite addresses the functionality and performance (i.e. bandwidth) of various data movement scenarios.
 
 ## Tests in the Test Suite
-| Name          | ID(s) | Description                                          |
-| ----------    | ----- | ---------------------------------------------------- |
-| DRAM Unary    | 0-3   | Transactions between DRAM and a single Tensix core.  |
-| One to One    | 4     | Write transactions between two Tensix cores.         |
-| One From One  | 5     | Read transactions between two Tensix cores.          |
+| Name          | ID(s) | Description                                                                          |
+| ----------    | ----- | ------------------------------------------------------------------------------------ |
+| DRAM Unary    | 0-3   | Transactions between DRAM and a single Tensix core.                                  |
+| One to One    | 4     | Write transactions between two Tensix cores.                                         |
+| One From One  | 5     | Read transactions between two Tensix cores.                                          |
+| One From All  | 6     | Read transactions between one gatherer Tensix core and multiple sender Tensix cores. |
 
 ## Running Tests
 ### C++ Gtests

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
@@ -1,0 +1,29 @@
+# One From All Core Data Movement Tests # TODO
+
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
+
+## Test Flow
+Sharded L1 buffers are created on two Tensix cores: one requestor and one responder core. Data is written into the L1 buffer on the responder core. The requestor kernel issues read NOC transactions to request a transfer of this data from the L1 buffer of the responder core to the L1 buffer of its core. A read barrier is placed after these transactions in order to ensure data validity.
+
+Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
+
+Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
+
+## Test Parameters
+| Parameter                 | Data Type             | Description |
+| ------------------------- | --------------------- | ----------- |
+| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
+| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
+| transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
+| page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format            | DataFormat            | Data format data that will be moved. |
+| master_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
+| slave_core_coord          | CoreCoord             | Logical coordinates for the receiver core. |
+| virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
+| noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
+
+## Test Cases
+Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
+Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
+
+1. One From One Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. Sweeps values that are multiples of 2 (including 1) in the range [1, 64] for both parameters.

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/README.md
@@ -1,29 +1,29 @@
-# One From All Core Data Movement Tests # TODO
+# One From All Core Data Movement Tests
 
-This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between two Tensix cores.
+This test suite implements tests that measure the functionality and performance (i.e. bandwidth) of data movement transactions between a gatherer Tensix core and a grid of sender Tensix cores.
 
 ## Test Flow
-Sharded L1 buffers are created on two Tensix cores: one requestor and one responder core. Data is written into the L1 buffer on the responder core. The requestor kernel issues read NOC transactions to request a transfer of this data from the L1 buffer of the responder core to the L1 buffer of its core. A read barrier is placed after these transactions in order to ensure data validity.
+Sharded L1 buffers are created on both the gatherer core and on all the sender cores -making sure that the sender core buffers have a total size equal to the size of the gatherer core buffer. Data is written into the L1 buffer of the sender cores. The gatherer kernel issues read NOC transactions to request a transfer of this data to its L1 buffer. A read barrier is placed after these transactions in order to ensure data validity.
 
 Test attributes such as transaction sizes and number of transactions as well as latency measures like kernel and pre-determined scope cycles are recorded by the profiler. Resulting data is cross-checked with original data and validated through a pcc check.
 
 Test expectations are that pcc checks pass and sufficient test attribute data is captured by the profiler for higher level bandwidth/regression checks.
 
 ## Test Parameters
-| Parameter                 | Data Type             | Description |
-| ------------------------- | --------------------- | ----------- |
-| test_id                   | uint32_t              | Test id for signifying different test cases. Can be used for grouping different tests. |
-| num_of_transactions       | uint32_t              | Number of noc transactions/calls that will be issued. |
-| transaction_size_pages    | uint32_t              | Size of the issued noc transactions in pages. |
-| page_size_bytes           | uint32_t              | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
-| l1_data_format            | DataFormat            | Data format data that will be moved. |
-| master_core_coord         | CoreCoord             | Logical coordinates for the sender core. |
-| slave_core_coord          | CoreCoord             | Logical coordinates for the receiver core. |
-| virtual_channel           | N/A                   | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
-| noc                       | N/A                   | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
+| Parameter              | Data Type    | Description |
+| ---------------------- | ------------ | ----------- |
+| test_id                | uint32_t     | Test id for signifying different test cases. Can be used for grouping different tests. |
+| num_of_transactions    | uint32_t     | Number of noc transactions/calls that will be issued. |
+| transaction_size_pages | uint32_t     | Size of the issued noc transactions in pages. |
+| page_size_bytes        | uint32_t     | Size of a page in bytes. Arbitrary value with a minimum of flit size per architecture. |
+| l1_data_format         | DataFormat   | Data format data that will be moved. |
+| master_core_coord      | CoreCoord    | Logical coordinates for the gatherer core. |
+| subordinate_core_set   | CoreRangeSet | Set of logical coordinates for the sender cores. |
+| virtual_channel        | N/A          | (1) Option to specify unicast VC for each transaction, (2) Option for a sub-test that uses a separate VC for each transaction (TODO)|
+| noc                    | N/A          | Specify which NOC to use for the test, (1) Use only one specified NOC, (2) Use both NOCs (TODO)|
 
 ## Test Cases
 Each test case uses bfloat16 as L1 data format and flit size (32B for WH, 64B for BH) as page size.
 Each test case has multiple runs, and each run has a unique runtime host id, assigned by a global counter.
 
-1. One From One Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. Sweeps values that are multiples of 2 (including 1) in the range [1, 64] for both parameters.
+1. One From All Packet Sizes: Tests different number of transactions and transaction sizes by varying the num_of_transactions and transaction_size_pages parameters. Sweeps values that are multiples of 2 (including 1) in the range [1, 64] for both parameters (skips cases where total data size exceeds L1 capacity). Uses master logical coordinate (0,0) and a grid of 16 subordinate cores: (1,1)-(4,4).

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include "dataflow_api.h"
+#include "debug/dprint.h"
+
+// L1 to L1 request
+void kernel_main() {
+    uint32_t dst_addr = get_compile_time_arg_val(0);
+    constexpr uint32_t num_of_transactions = get_compile_time_arg_val(1);
+    constexpr uint32_t transaction_num_pages = get_compile_time_arg_val(2);
+    constexpr uint32_t page_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t test_id = get_compile_time_arg_val(4);
+    constexpr uint32_t total_slave_cores = get_compile_time_arg_val(5);
+
+    std::array<uint32_t, total_slave_cores> slave_l1_byte_addresses;
+    std::array<std::array<uint32_t, 2>, total_slave_cores> responder_coords;
+    uint32_t rt_args_idx = 0;
+    for (uint32_t i = 0; i < total_slave_cores; i++) {
+        slave_l1_byte_addresses[i] = get_arg_val<uint32_t>(rt_args_idx++);
+        responder_coords[i][0] = get_arg_val<uint32_t>(rt_args_idx++);
+        responder_coords[i][1] = get_arg_val<uint32_t>(rt_args_idx++);
+    }
+
+    constexpr uint32_t transaction_size_bytes = transaction_num_pages * page_size_bytes;
+    constexpr uint32_t slave_size_bytes = num_of_transactions * transaction_num_pages * page_size_bytes;
+
+    DeviceTimestampedData("Number of transactions", num_of_transactions);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes * total_slave_cores);
+    DeviceTimestampedData("Test id", test_id);
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        for (uint32_t i = 0; i < num_of_transactions; i++) {
+            uint32_t slave_addr_offset = 0;
+            for (uint32_t j = 0; j < total_slave_cores; j++) {
+                uint64_t src_noc_addr =
+                    get_noc_addr(responder_coords[j][0], responder_coords[j][1], slave_l1_byte_addresses[j]);
+
+                noc_async_read(src_noc_addr, dst_addr + slave_addr_offset, transaction_size_bytes);
+
+                slave_l1_byte_addresses[j] += transaction_size_bytes;
+                slave_addr_offset += slave_size_bytes;
+            }
+            dst_addr += transaction_size_bytes;
+        }
+        noc_async_read_barrier();
+    }
+}

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
@@ -13,36 +13,36 @@ void kernel_main() {
     constexpr uint32_t transaction_num_pages = get_compile_time_arg_val(2);
     constexpr uint32_t page_size_bytes = get_compile_time_arg_val(3);
     constexpr uint32_t test_id = get_compile_time_arg_val(4);
-    constexpr uint32_t total_slave_cores = get_compile_time_arg_val(5);
+    constexpr uint32_t total_subordinate_cores = get_compile_time_arg_val(5);
 
-    std::array<uint32_t, total_slave_cores> slave_l1_byte_addresses;
-    std::array<std::array<uint32_t, 2>, total_slave_cores> responder_coords;
+    std::array<uint32_t, total_subordinate_cores> subordinate_l1_byte_addresses;
+    std::array<std::array<uint32_t, 2>, total_subordinate_cores> responder_coords;
     uint32_t rt_args_idx = 0;
-    for (uint32_t i = 0; i < total_slave_cores; i++) {
-        slave_l1_byte_addresses[i] = get_arg_val<uint32_t>(rt_args_idx++);
+    for (uint32_t i = 0; i < total_subordinate_cores; i++) {
+        subordinate_l1_byte_addresses[i] = get_arg_val<uint32_t>(rt_args_idx++);
         responder_coords[i][0] = get_arg_val<uint32_t>(rt_args_idx++);
         responder_coords[i][1] = get_arg_val<uint32_t>(rt_args_idx++);
     }
 
     constexpr uint32_t transaction_size_bytes = transaction_num_pages * page_size_bytes;
-    constexpr uint32_t slave_size_bytes = num_of_transactions * transaction_num_pages * page_size_bytes;
+    constexpr uint32_t subordinate_size_bytes = num_of_transactions * transaction_num_pages * page_size_bytes;
 
     DeviceTimestampedData("Number of transactions", num_of_transactions);
-    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes * total_slave_cores);
+    DeviceTimestampedData("Transaction size in bytes", transaction_size_bytes * total_subordinate_cores);
     DeviceTimestampedData("Test id", test_id);
 
     {
         DeviceZoneScopedN("RISCV1");
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            uint32_t slave_addr_offset = 0;
-            for (uint32_t j = 0; j < total_slave_cores; j++) {
+            uint32_t subordinate_addr_offset = 0;
+            for (uint32_t j = 0; j < total_subordinate_cores; j++) {
                 uint64_t src_noc_addr =
-                    get_noc_addr(responder_coords[j][0], responder_coords[j][1], slave_l1_byte_addresses[j]);
+                    get_noc_addr(responder_coords[j][0], responder_coords[j][1], subordinate_l1_byte_addresses[j]);
 
-                noc_async_read(src_noc_addr, dst_addr + slave_addr_offset, transaction_size_bytes);
+                noc_async_read(src_noc_addr, dst_addr + subordinate_addr_offset, transaction_size_bytes);
 
-                slave_l1_byte_addresses[j] += transaction_size_bytes;
-                slave_addr_offset += slave_size_bytes;
+                subordinate_l1_byte_addresses[j] += transaction_size_bytes;
+                subordinate_addr_offset += subordinate_size_bytes;
             }
             dst_addr += transaction_size_bytes;
         }

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -177,7 +177,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
              transaction_size_pages *= 2) {
             if (num_of_transactions * transaction_size_pages * page_size_bytes * total_slave_cores >= 1024 * 1024) {
-                break;
+                continue;
             }
 
             // Test config

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -161,10 +161,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
     // Parameters
     uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages = 64;
-    uint32_t page_size_bytes = 32;  // =Flit size: 32 bytes for WH, 64 for BH
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes *= 2;
-    }
+    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     // Cores
     CoreCoord master_core_coord = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -156,7 +156,7 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
 }
 }  // namespace unit_tests::dm::core_to_core
 
-/* ========== Test case for one from all data movement; Test id = 6 ========== */
+/* ========== Test case for one from all data movement; Test id = 15 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
     // Parameters
     uint32_t max_transactions = 256;
@@ -180,7 +180,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
 
             // Test config
             unit_tests::dm::core_to_core::OneFromAllConfig test_config = {
-                .test_id = 6,
+                .test_id = 15,
                 .master_core_coord = master_core_coord,
                 .subordinate_core_set = subordinate_core_set,
                 .num_of_transactions = num_of_transactions,

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "device_fixture.hpp"
+#include "hal.hpp"
+#include "tt_metal/test_utils/comparison.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "tt_metal/test_utils/print_helpers.hpp"
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt;
+using namespace tt::test_utils;
+
+namespace unit_tests::dm::core_to_core {
+// Test config, i.e. test parameters
+struct OneFromAllConfig {
+    uint32_t test_id = 0;
+    CoreCoord master_core_coord = CoreCoord();
+    CoreRangeSet slave_core_set;
+    uint32_t num_of_transactions = 0;
+    uint32_t transaction_size_pages = 0;
+    uint32_t page_size_bytes = 0;
+    DataFormat l1_data_format = DataFormat::Invalid;
+
+    // TODO: Add the following parameters
+    //  1. Virtual Channel
+    //  2. Which NOC to use
+};
+
+/// @brief Does Gatherer Core --> L1 Responder Cores --> L1 Gatherer Core
+/// @param device
+/// @param test_config - Configuration of the test -- see struct
+/// @return
+bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
+    // Program
+    Program program = CreateProgram();
+
+    // Sharded L1 buffers
+    CoreRangeSet master_core_set({CoreRange(test_config.master_core_coord)});
+    size_t total_slave_cores = test_config.slave_core_set.num_cores();
+
+    const size_t total_size_bytes = test_config.num_of_transactions * test_config.transaction_size_pages *
+                                    test_config.page_size_bytes * total_slave_cores;
+    const size_t total_size_pages =
+        test_config.num_of_transactions * test_config.transaction_size_pages * total_slave_cores;
+
+    auto master_shard_parameters = ShardSpecBuffer(
+        master_core_set,
+        {1, total_size_bytes / 2},
+        ShardOrientation::ROW_MAJOR,
+        {1, test_config.page_size_bytes / 2},
+        {1, total_size_pages});
+    auto master_l1_buffer = CreateBuffer(ShardedBufferConfig{
+        .device = device,
+        .size = total_size_bytes,
+        .page_size = test_config.page_size_bytes,
+        .buffer_type = BufferType::L1,
+        .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
+        .shard_parameters = std::move(master_shard_parameters),
+    });
+    uint32_t master_l1_byte_address = master_l1_buffer->address();
+
+    const size_t slave_size_bytes =
+        test_config.num_of_transactions * test_config.transaction_size_pages * test_config.page_size_bytes;
+    const size_t slave_size_pages = test_config.num_of_transactions * test_config.transaction_size_pages;
+
+    // Compile-time arguments for kernels
+    vector<uint32_t> gatherer_compile_args = {
+        (uint32_t)master_l1_byte_address,
+        (uint32_t)test_config.num_of_transactions,
+        (uint32_t)test_config.transaction_size_pages,
+        (uint32_t)test_config.page_size_bytes,
+        (uint32_t)test_config.test_id,
+        (uint32_t)total_slave_cores,
+    };
+
+    // Kernels
+    auto gatherer_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp",
+        master_core_set,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = gatherer_compile_args});
+
+    // Runtime Arguments
+    vector<uint32_t> master_runtime_args;
+
+    // Create buffers for each slave core and add to runtime args
+    vector<shared_ptr<Buffer>> slave_l1_buffers;
+    for (auto& core : corerange_to_cores(test_config.slave_core_set)) {
+        auto slave_shard_parameters = ShardSpecBuffer(
+            CoreRangeSet({CoreRange(core)}),
+            {1, slave_size_bytes / 2},
+            ShardOrientation::ROW_MAJOR,
+            {1, test_config.page_size_bytes / 2},
+            {1, slave_size_pages});
+        ShardedBufferConfig slave_buffer_config{
+            .device = device,
+            .size = slave_size_bytes,
+            .page_size = test_config.page_size_bytes,
+            .buffer_type = BufferType::L1,
+            .buffer_layout = TensorMemoryLayout::WIDTH_SHARDED,
+            .shard_parameters = std::move(slave_shard_parameters),
+        };
+        auto slave_l1_buffer = CreateBuffer(slave_buffer_config);
+        slave_l1_buffers.push_back(slave_l1_buffer);
+        master_runtime_args.push_back((uint32_t)slave_l1_buffer->address());
+
+        CoreCoord physical_core = device->worker_core_from_logical_core(core);
+        master_runtime_args.push_back(physical_core.x);
+        master_runtime_args.push_back(physical_core.y);
+    }
+    SetRuntimeArgs(program, gatherer_kernel, master_core_set, master_runtime_args);
+
+    // Assign unique id
+    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, runtime_host_id);
+    program.set_runtime_id(runtime_host_id++);
+
+    // Input
+    vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        -100.0f, 100.0f, total_size_bytes / bfloat16::SIZEOF, chrono::system_clock::now().time_since_epoch().count());
+
+    // Golden output
+    vector<uint32_t> packed_golden = packed_input;
+    vector<uint32_t> packed_output;
+
+    // Launch program and record outputs
+    for (size_t i = 0; i < total_slave_cores; i++) {
+        auto begin = packed_input.data() + i * slave_size_bytes / sizeof(uint32_t);
+        auto end = packed_input.data() + (i + 1) * slave_size_bytes / sizeof(uint32_t);
+        detail::WriteToBuffer(slave_l1_buffers[i], vector<uint32_t>(begin, end));
+    }
+    MetalContext::instance().get_cluster().l1_barrier(device->id());
+
+    detail::LaunchProgram(device, program);
+    detail::ReadFromBuffer(master_l1_buffer, packed_output);
+
+    // Results comparison
+    bool pcc = is_close_packed_vectors<bfloat16, uint32_t>(
+        packed_output, packed_golden, [&](const bfloat16& a, const bfloat16& b) { return is_close(a, b); });
+
+    if (!pcc) {
+        log_error("PCC Check failed");
+        log_info("Golden vector");
+        print_vector<uint32_t>(packed_golden);
+        log_info("Output vector");
+        print_vector<uint32_t>(packed_output);
+    }
+
+    return pcc;
+}
+}  // namespace unit_tests::dm::core_to_core
+
+/* ========== Test case for one from all data movement; Test id = 6 ========== */
+TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
+    // Parameters
+    uint32_t max_transactions = 64;
+    uint32_t max_transaction_size_pages = 64;
+    uint32_t page_size_bytes = 32;  // =Flit size: 32 bytes for WH, 64 for BH
+    if (arch_ == tt::ARCH::BLACKHOLE) {
+        page_size_bytes *= 2;
+    }
+
+    // Cores
+    CoreCoord master_core_coord = {0, 0};
+    CoreRangeSet slave_core_set = {CoreRange(CoreCoord(1, 1), CoreCoord(4, 4))};
+    size_t total_slave_cores = slave_core_set.num_cores();
+
+    uint32_t l1_size = 1024 * 1024;  // 1MB
+
+    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 2) {
+        for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
+             transaction_size_pages *= 2) {
+            if (num_of_transactions * transaction_size_pages * page_size_bytes * total_slave_cores >= 1024 * 1024) {
+                break;
+            }
+
+            // Test config
+            unit_tests::dm::core_to_core::OneFromAllConfig test_config = {
+                .test_id = 6,
+                .master_core_coord = master_core_coord,
+                .slave_core_set = slave_core_set,
+                .num_of_transactions = num_of_transactions,
+                .transaction_size_pages = transaction_size_pages,
+                .page_size_bytes = page_size_bytes,
+                .l1_data_format = DataFormat::Float16_b,
+            };
+
+            // Run
+            for (unsigned int id = 0; id < num_devices_; id++) {
+                EXPECT_TRUE(run_dm(devices_.at(id), test_config));
+            }
+        }
+    }
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "device_fixture.hpp"
-#include "hal.hpp"
 #include "tt_metal/test_utils/comparison.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
+#include "dm_common.hpp"
 
 namespace tt::tt_metal {
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -159,7 +159,7 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
 /* ========== Test case for one from all data movement; Test id = 6 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
     // Parameters
-    uint32_t max_transactions = 64;
+    uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages = 64;
     uint32_t page_size_bytes = 32;  // =Flit size: 32 bytes for WH, 64 for BH
     if (arch_ == tt::ARCH::BLACKHOLE) {
@@ -173,7 +173,7 @@ TEST_F(DeviceFixture, TensixDataMovementOneFromAllPacketSizes) {
 
     uint32_t l1_size = 1024 * 1024;  // 1MB
 
-    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 2) {
+    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
              transaction_size_pages *= 2) {
             if (num_of_transactions * transaction_size_pages * page_size_bytes * total_subordinate_cores >=

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/test_one_from_all.cpp
@@ -118,8 +118,8 @@ bool run_dm(IDevice* device, const OneFromAllConfig& test_config) {
     SetRuntimeArgs(program, gatherer_kernel, master_core_set, master_runtime_args);
 
     // Assign unique id
-    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, runtime_host_id);
-    program.set_runtime_id(runtime_host_id++);
+    log_info("Running Test ID: {}, Run ID: {}", test_config.test_id, unit_tests::dm::runtime_host_id);
+    program.set_runtime_id(unit_tests::dm::runtime_host_id++);
 
     // Input
     vector<uint32_t> packed_input = generate_packed_uniform_random_vector<uint32_t, bfloat16>(

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -141,6 +141,9 @@ test_bounds = {
         14: {
             "riscv_0": {"latency": {"lower": 200, "upper": 100000}, "bandwidth": 0.04},
         },
+        15: {
+            "riscv_1": {"latency": {"lower": 800, "upper": 35000}, "bandwidth": 1.19},
+        },
     },
 }
 
@@ -294,7 +297,7 @@ def performance_check(dm_stats, arch="blackhole", verbose=False):
                 results_bounds[test_id] = {
                     riscv: {"latency": {"lower": float("inf"), "upper": 0}, "bandwidth": float("inf")}
                 }
-            else:
+            elif riscv not in results_bounds[test_id].keys():
                 results_bounds[test_id][riscv] = {
                     "latency": {"lower": float("inf"), "upper": 0},
                     "bandwidth": float("inf"),
@@ -360,9 +363,6 @@ def performance_check(dm_stats, arch="blackhole", verbose=False):
 
 def print_stats(dm_stats):
     # Print stats per runtime host id
-    for i in range(len(dm_stats["riscv_1"]["analysis"]["series"])):
-        run_host_id = dm_stats["riscv_1"]["analysis"]["series"][i]["duration_type"][0]["run_host_id"]
-
     for riscv1_run, riscv0_run in itertools.zip_longest(
         dm_stats["riscv_1"]["analysis"]["series"], dm_stats["riscv_0"]["analysis"]["series"], fillvalue=None
     ):

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -145,7 +145,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 200, "upper": 100000}, "bandwidth": 0.04},
         },
         15: {
-            "riscv_1": {"latency": {"lower": 800, "upper": 35000}, "bandwidth": 1.19},
+            "riscv_1": {"latency": {"lower": 800, "upper": 135000}, "bandwidth": 1.19},
         },
     },
 }

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -32,6 +32,7 @@ test_id_to_name = {
     12: "One to All Multicast Linked 2x2 Packet Sizes",
     13: "One to All Multicast Linked 5x5 Packet Sizes",
     14: "One to All Multicast Linked 11x10 Packet Sizes",
+    15: "One from All Packet Sizes",
 }
 
 # Correspondng test bounds for each arch, test id, riscv core

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -91,7 +91,7 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 200, "upper": 100000}, "bandwidth": 0.04},
         },
         15: {
-            "riscv_1": {"latency": {"lower": 700, "upper": 30000}, "bandwidth": 0.7},
+            "riscv_1": {"latency": {"lower": 700, "upper": 120000}, "bandwidth": 0.7},
         },
     },
     "blackhole": {

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -89,6 +89,9 @@ test_bounds = {
         14: {
             "riscv_0": {"latency": {"lower": 200, "upper": 100000}, "bandwidth": 0.04},
         },
+        15: {
+            "riscv_1": {"latency": {"lower": 700, "upper": 30000}, "bandwidth": 0.7},
+        },
     },
     "blackhole": {
         0: {


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/19278)

### Problem description
Add a “one‑from‑all” primitive data‑movement test that exercises one core gathering data from multiple remote cores. Determine the effective aggregate read bandwidth when a single core (gatherer) retrieves data from multiple cores, representing a many‑to‑one communication scenario.

### What's changed
Enabled one core from multiple cores testing in the data movement test suite. Further generalization of parameters (i.e. VC and NOC) as well as test sweeps for these parameters are required.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15029619215) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15048179558) CI with demo tests passes (if applicable)
- [x] New/Existing tests provide coverage for changes