### PR TITLE
Add extra-tag to stress test

### DIFF
--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -136,6 +136,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tg-stress.yaml
     with:
+      extra-tag: ${{ inputs.extra-tag }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}


### PR DESCRIPTION
Adding extra-tag feature for stress-test since it's missing.

### Problem description
Unable to pass extra-tag to stress-test inside .github/workflows/pipeline-select-galaxy.yaml

### What's changed
Added extra-tag option inside yaml file.