### PR TITLE
 Fix the order of DRAM buffer and profiler control buffer read

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -215,7 +215,7 @@ def test_dispatch_cores():
     RISC_COUNT = 1
     ZONE_COUNT = 37
     REF_COUNT_DICT = {
-        "Tensix CQ Dispatch": [250, 1000, 2000],
+        "Tensix CQ Dispatch": [400, 1000, 2000],
         "Tensix CQ Prefetch": [400, 1000, 4000],
         "dispatch_total_cq_cmd_op_time": [103],
         "dispatch_go_send_wait_time": [103],
@@ -286,7 +286,7 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [700, 1400, 2100],
+        "Ethernet CQ Dispatch": [322, 1400, 2100],
         "Ethernet CQ Prefetch": [600, 2500],
     }
     devicesData = run_device_profiler_test(

--- a/tt_metal/impl/profiler/profiler.hpp
+++ b/tt_metal/impl/profiler/profiler.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -138,6 +138,15 @@ private:
     CoreCoord getPhysicalAddressFromVirtual(chip_id_t device_id, const CoreCoord& c) const;
 
     ZoneDetails getZoneDetails(uint16_t timer_id) const;
+
+    // Storage for all core's control buffers
+    std::unordered_map<CoreCoord, std::vector<uint32_t>> core_control_buffers;
+
+    // Read all control buffers
+    void readControlBuffers(IDevice* device, const CoreCoord& worker_core, const ProfilerDumpState state);
+
+    // reset control buffers
+    void resetControlBuffers(IDevice* device, const CoreCoord& worker_core, const ProfilerDumpState state);
 
     // Dumping profile result to file
     void logPacketData(

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <core_descriptor.hpp>
@@ -748,14 +748,6 @@ void InitDeviceProfiler(IDevice* device) {
         std::vector<uint32_t> control_buffer(kernel_profiler::PROFILER_L1_CONTROL_VECTOR_SIZE, 0);
         control_buffer[kernel_profiler::DRAM_PROFILER_ADDRESS] = output_dram_buffer_ptr->address();
         setControlBuffer(device, control_buffer);
-
-        std::vector<uint32_t> inputs_DRAM(output_dram_buffer_ptr->size() / sizeof(uint32_t), 0);
-
-        if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
-            issue_fd_write_to_profiler_buffer(profiler.output_dram_buffer, device, inputs_DRAM);
-        } else {
-            tt_metal::detail::WriteToBuffer(*(profiler.output_dram_buffer.get_buffer()), inputs_DRAM);
-        }
     }
 #endif
 }
@@ -892,8 +884,6 @@ void DumpDeviceProfileResults(
                 // last owner. Sync program also contains a buffer so it is safter to release it here
                 tt_metal_device_profiler_map.at(device_id).output_dram_buffer = {};
                 tt_metal_device_profiler_map.at(device_id).sync_program.reset();
-            } else {
-                InitDeviceProfiler(device);
             }
             if (tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_tracy_mid_run_push()) {
                 tt_metal_device_profiler_map.at(device_id).pushTracyDeviceResults();


### PR DESCRIPTION
### Ticket
#21928 

### Problem description
Dispatch core profiling was loosing important zones because of the wrong order on reading the DRAM buffer and control buffer. This became important when buffers were read and written to using FD. Dispatch cores accumulated zones as part of the FD RW commands.

### What's changed
First read the control buffers on all cores
Second read the DRAM buffer
Third reset the control buffers

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15175499294)
- [x] [T3K profiler](https://github.com/tenstorrent/tt-metal/actions/runs/15171952584)
- [x] [BH post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15210380222)
- [x] [ubenchmark](https://github.com/tenstorrent/tt-metal/actions/runs/15210380222)
- [x] [device perf](https://github.com/tenstorrent/tt-metal/actions/runs/15196704637)