### PR TITLE
Added a way to meassure performance under different conditions

### DIFF
--- a/models/demos/bert/demo/demo.py
+++ b/models/demos/bert/demo/demo.py
@@ -50,6 +50,7 @@ def run_bert_question_and_answering_inference(
     bert,
     model_location_generator,
     input_path,
+    iterations,
 ):
     disable_persistent_kernel_cache()
 
@@ -73,95 +74,107 @@ def run_bert_question_and_answering_inference(
     else:
         raise ValueError(f"Unknown bert: {bert}")
 
-    profiler.start(f"preprocessing_parameter")
-    parameters = preprocess_model_parameters(
-        model_name=tt_model_name,
-        initialize_model=lambda: transformers.BertForQuestionAnswering.from_pretrained(
-            model_name, torchscript=False
-        ).eval(),
-        custom_preprocessor=bert.custom_preprocessor,
-        device=device,
-    )
-    profiler.end(f"preprocessing_parameter")
+    device.disable_and_clear_program_cache()
 
-    context, question = load_inputs(input_path, batch_size)
+    for iteration in range(iterations):
+        profiler.start(f"iteration_{iteration}")
+        profiler.start(f"preprocessing_parameter")
+        parameters = preprocess_model_parameters(
+            model_name=tt_model_name,
+            initialize_model=lambda: transformers.BertForQuestionAnswering.from_pretrained(
+                model_name, torchscript=False
+            ).eval(),
+            custom_preprocessor=bert.custom_preprocessor,
+            device=device,
+        )
+        profiler.end(f"preprocessing_parameter")
 
-    preprocess_params, _, postprocess_params = nlp._sanitize_parameters()
-    preprocess_params["max_seq_len"] = sequence_size
-    inputs = nlp._args_parser({"context": context, "question": question})
-    preprocessed_inputs = []
-    for i in range(batch_size):
-        model_input = next(nlp.preprocess(inputs[0][i], **preprocess_params))
-        single_input = {
-            "example": model_input["example"],
-            "inputs": model_input,
+        context, question = load_inputs(input_path, batch_size)
+
+        preprocess_params, _, postprocess_params = nlp._sanitize_parameters()
+        preprocess_params["max_seq_len"] = sequence_size
+        inputs = nlp._args_parser({"context": context, "question": question})
+        preprocessed_inputs = []
+        for i in range(batch_size):
+            model_input = next(nlp.preprocess(inputs[0][i], **preprocess_params))
+            single_input = {
+                "example": model_input["example"],
+                "inputs": model_input,
+            }
+            preprocessed_inputs.append(single_input)
+
+        bert_input = tokenizer.batch_encode_plus(
+            zip(question, context),
+            max_length=sequence_size,
+            padding="max_length",
+            truncation=True,
+            return_attention_mask=True,
+            return_token_type_ids=True,
+            return_tensors="pt",
+        )
+
+        position_ids = positional_ids(config, bert_input.input_ids)
+        profiler.start(f"preprocessing_input")
+        ttnn_bert_inputs = bert.preprocess_inputs(
+            bert_input["input_ids"],
+            bert_input["token_type_ids"],
+            position_ids,
+            bert_input["attention_mask"],
+            device=device,
+        )
+        profiler.end(f"preprocessing_input")
+
+        profiler.start(f"inference_time")
+        tt_output = bert.bert_for_question_answering(
+            config,
+            *ttnn_bert_inputs,
+            parameters=parameters,
+        )
+        profiler.end(f"inference_time")
+
+        profiler.start(f"inference_result_to_torch")
+        tt_output = (
+            ttnn.to_torch(ttnn.from_device(tt_output)).reshape(batch_size, 1, sequence_size, -1).to(torch.float32)
+        )
+
+        tt_start_logits = tt_output[..., :, 0].squeeze(1)
+        tt_end_logits = tt_output[..., :, 1].squeeze(1)
+        profiler.end(f"inference_result_to_torch")
+        profiler.start(f"post_processing_output_to_string")
+        model_answers = {}
+        for i in range(batch_size):
+            tt_res = {
+                "start": tt_start_logits[i],
+                "end": tt_end_logits[i],
+                "example": preprocessed_inputs[i]["example"],
+                **preprocessed_inputs[i]["inputs"],
+            }
+
+            tt_answer = nlp.postprocess([tt_res], **postprocess_params)
+
+            logger.info(f"answer: {tt_answer['answer']}\n")
+            model_answers[i] = tt_answer["answer"]
+
+        profiler.end("post_processing_output_to_string")
+        profiler.end(f"iteration_{iteration}")
+        measurements = {
+            "preprocessing_parameter": profiler.get("preprocessing_parameter"),
+            "preprocessing_input": profiler.get("preprocessing_input"),
+            "inference_time": profiler.get("inference_time"),
+            "post_processing": profiler.get("post_processing_output_to_string"),
+            "inference_result_to_torch": profiler.get("inference_result_to_torch"),
+            "iteration": profiler.get(f"iteration_{iteration}"),
         }
-        preprocessed_inputs.append(single_input)
 
-    bert_input = tokenizer.batch_encode_plus(
-        zip(question, context),
-        max_length=sequence_size,
-        padding="max_length",
-        truncation=True,
-        return_attention_mask=True,
-        return_token_type_ids=True,
-        return_tensors="pt",
-    )
-
-    position_ids = positional_ids(config, bert_input.input_ids)
-    profiler.start(f"preprocessing_input")
-    ttnn_bert_inputs = bert.preprocess_inputs(
-        bert_input["input_ids"],
-        bert_input["token_type_ids"],
-        position_ids,
-        bert_input["attention_mask"],
-        device=device,
-    )
-    profiler.end(f"preprocessing_input")
-
-    profiler.start(f"inference_time")
-    tt_output = bert.bert_for_question_answering(
-        config,
-        *ttnn_bert_inputs,
-        parameters=parameters,
-    )
-    profiler.end(f"inference_time")
-
-    tt_output = ttnn.to_torch(ttnn.from_device(tt_output)).reshape(batch_size, 1, sequence_size, -1).to(torch.float32)
-
-    tt_start_logits = tt_output[..., :, 0].squeeze(1)
-    tt_end_logits = tt_output[..., :, 1].squeeze(1)
-
-    model_answers = {}
-    profiler.start("post_processing_output_to_string")
-    for i in range(batch_size):
-        tt_res = {
-            "start": tt_start_logits[i],
-            "end": tt_end_logits[i],
-            "example": preprocessed_inputs[i]["example"],
-            **preprocessed_inputs[i]["inputs"],
-        }
-
-        tt_answer = nlp.postprocess([tt_res], **postprocess_params)
-
-        logger.info(f"answer: {tt_answer['answer']}\n")
-        model_answers[i] = tt_answer["answer"]
-
-    profiler.end("post_processing_output_to_string")
-
-    measurements = {
-        "preprocessing_parameter": profiler.get("preprocessing_parameter"),
-        "preprocessing_input": profiler.get("preprocessing_input"),
-        "inference_time": profiler.get("inference_time"),
-        "post_processing": profiler.get("post_processing_output_to_string"),
-    }
-
-    logger.info(f"tt_model_name: {tt_model_name}")
-    logger.info(f"preprocessing_parameter: {measurements['preprocessing_parameter']} s")
-    logger.info(f"preprocessing_input: {measurements['preprocessing_input']} s")
-    logger.info(f"inference_time: {measurements['inference_time']} s")
-    logger.info(f"post_processing : {measurements['post_processing']} s")
-
+        logger.info(f"tt_model_name: {tt_model_name}")
+        logger.info(f"preprocessing_parameter Iteration {iteration}: {measurements['preprocessing_parameter']} s")
+        logger.info(f"preprocessing_input Iteration {iteration}: {measurements['preprocessing_input']} s")
+        logger.info(f"inference_time Iteration {iteration}: {measurements['inference_time']} s")
+        logger.info(f"post_processing Iteration {iteration}: {measurements['post_processing']} s")
+        logger.info(f"inference_result_to_torch Iteration {iteration}: {measurements['inference_result_to_torch']} s")
+        logger.info(f"iteration_{iteration} total time: {measurements['iteration']} s")
+        profiler.clear()
+        device.enable_program_cache()
     return measurements
 
 
@@ -289,6 +302,7 @@ def test_demo(
         bert=bert,
         model_location_generator=model_location_generator,
         input_path=input_path,
+        iterations=5,
     )
 
 


### PR DESCRIPTION

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22039)

### Problem description
Right now the metrics we provide for bert are not really clear or final. We don't have cached scenarios or metrics for the whole run.

### What's changed
Added iterations over the models to present how the model behaves under different circumstances such as:
no cache
cold cache
warm cache

Each model implementation will show more specific data

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes