### PR TITLE
Move program-internal types to program_impl.hpp

### DIFF
--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -43,6 +43,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include "llrt.hpp"
 #include "impl/context/metal_context.hpp"
+#include "impl/program/program_impl.hpp"
 #include <tt-metalium/logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -177,7 +178,7 @@ int main(int argc, char** argv) {
             uint32_t programmable_core_index =
                 tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
                     tt_metal::HalProgrammableCoreType::TENSIX);
-            const tt_metal::KernelGroup* kernel_group = program.kernels_on_core(core, programmable_core_index);
+            const tt_metal::KernelGroup* kernel_group = program.impl().kernels_on_core(core, programmable_core_index);
             TT_FATAL(
                 kernel_group != nullptr && kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].has_value() and
                     kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_DM0].has_value() and
@@ -240,7 +241,7 @@ int main(int argc, char** argv) {
                             tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
                                 tt_metal::HalProgrammableCoreType::TENSIX);
                         const tt_metal::KernelGroup* kernel_group =
-                            program.kernels_on_core(core, programmable_core_index);
+                            program.impl().kernels_on_core(core, programmable_core_index);
                         auto compute_kernel = tt_metal::detail::GetKernel(
                             program, kernel_group->kernel_ids[DISPATCH_CLASS_TENSIX_COMPUTE].value());
                         auto riscv0_kernel = tt_metal::detail::GetKernel(

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -21,6 +21,8 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/program_cache.hpp>
 
+class go_msg_t;
+class launch_msg_t;
 namespace tt::tt_metal {
 class SubDeviceManagerTracker;
 

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -11,7 +11,6 @@
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/semaphore.hpp>
 #include <tt-metalium/worker_config_buffer.hpp>
-#include <tt-metalium/dev_msgs.h>
 #include <tt-metalium/program_descriptors.hpp>
 
 namespace tt {
@@ -69,48 +68,6 @@ std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program& program, CBHand
 class Internal_;
 }  // namespace detail
 
-using kernel_id_array_t = std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX>;
-
-struct KernelGroup {
-    uint32_t programmable_core_type_index;
-    CoreRangeSet core_ranges;
-    kernel_id_array_t kernel_ids;
-    uint32_t rta_sizes[DISPATCH_CLASS_MAX];
-    uint32_t total_rta_size;
-    uint32_t kernel_text_offsets[NUM_PROCESSORS_PER_CORE_TYPE];
-    uint32_t kernel_bin_sizes[NUM_PROCESSORS_PER_CORE_TYPE];
-    launch_msg_t launch_msg;
-    go_msg_t go_msg;
-
-    KernelGroup();
-    KernelGroup(
-        const detail::ProgramImpl& program,
-        uint32_t programmable_core_type_index,
-        kernel_id_array_t kernel_ids,
-        bool erisc_is_idle,
-        uint32_t max_local_cb_end_index,
-        uint32_t min_remote_cb_start_index,
-        const CoreRangeSet& new_ranges);
-
-    uint32_t get_programmable_core_type_index() const;
-
-    CoreType get_core_type() const;
-};
-
-// Contains the program's worker memory map
-struct ProgramConfig {
-    uint32_t rta_offset;
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_offsets;
-    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes;
-    uint32_t sem_offset;
-    uint32_t sem_size;
-    uint32_t cb_offset;
-    uint32_t cb_size;
-    uint32_t local_cb_size;
-    uint32_t kernel_text_offset;  // offset of first kernel bin
-    uint32_t kernel_text_size;    // max size of all kernel bins across all kernel groups
-};
-
 // Represents the status of Program Kernel Binaries in Device DRAM with respect to the dispatcher
 enum class ProgramBinaryStatus : uint8_t {
     NotSent = 0,    // Binaries have not been written
@@ -141,18 +98,9 @@ public:
 
     const std::vector<Semaphore>& semaphores() const;
 
-    KernelGroup* kernels_on_core(const CoreCoord& core, uint32_t programmable_core_type_index);
     std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& get_kernels(uint32_t programmable_core_type_index);
     void add_buffer(std::shared_ptr<Buffer> buf);
     void release_buffers();
-    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_core(const CoreCoord& core) const;
-
-    std::vector<std::shared_ptr<CircularBuffer>> circular_buffers_on_corerange(const CoreRange& cr) const;
-
-    std::vector<CoreRange> circular_buffers_unique_coreranges() const;
-
-    std::vector<std::reference_wrapper<const Semaphore>> semaphores_on_core(
-        const CoreCoord& core, CoreType core_type) const;
 
     size_t num_semaphores() const;
     void init_semaphores(
@@ -170,13 +118,10 @@ public:
 
     void finalize_offsets(IDevice* device);
     bool is_finalized() const;
-    void set_finalized();
     ProgramBinaryStatus get_program_binary_status(std::size_t device_id) const;
     void set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status);
     void allocate_kernel_bin_buf_on_device(IDevice* device);
     std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
-
-    ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
 
     // debug/test
     uint32_t get_sem_base_addr(IDevice* device, CoreCoord logical_core, CoreType core_type);
@@ -189,6 +134,7 @@ public:
     void set_kernels_bin_buffer(const std::shared_ptr<Buffer>& buffer);
     uint32_t get_cb_memory_size() const;
     detail::ProgramImpl& impl() { return *pimpl_; }
+    const detail::ProgramImpl& impl() const { return *pimpl_; }
 
 private:
     std::unique_ptr<detail::ProgramImpl> pimpl_;

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -314,7 +314,7 @@ ProgramConfig& MeshWorkloadImpl::get_program_config(uint32_t index) {
     TT_FATAL(
         programs_.size() and is_finalized(),
         "Program Configs can only be queried if a MeshWorkload is populated and finalized.");
-    return programs_.begin()->second.get_program_config(index);
+    return programs_.begin()->second.impl().get_program_config(index);
 }
 
 uint32_t MeshWorkloadImpl::get_sem_base_addr(

--- a/tt_metal/distributed/mesh_workload_impl.hpp
+++ b/tt_metal/distributed/mesh_workload_impl.hpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include "program/program_impl.hpp"
 
 namespace tt::tt_metal::distributed {
 using RuntimeArgsPerCore = std::vector<std::vector<RuntimeArgsData>>;

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -43,6 +43,7 @@
 #include "command_queue.hpp"
 #include "dispatch/command_queue_common.hpp"
 #include "common/core_assignment.hpp"
+#include "program/program_impl.hpp"
 #include "core_coord.hpp"
 #include "device.hpp"
 #include "impl/context/metal_context.hpp"
@@ -1160,8 +1161,8 @@ void Device::init_command_queue_device() {
         const auto& logical_dispatch_cores = logical_cores[index];
         CoreType core_type = hal.get_core_type(index);
         for (const CoreCoord &logical_dispatch_core : logical_dispatch_cores) {
-            launch_msg_t msg = command_queue_program.kernels_on_core(logical_dispatch_core, index)->launch_msg;
-            go_msg_t go_msg = command_queue_program.kernels_on_core(logical_dispatch_core, index)->go_msg;
+            launch_msg_t msg = command_queue_program.impl().kernels_on_core(logical_dispatch_core, index)->launch_msg;
+            go_msg_t go_msg = command_queue_program.impl().kernels_on_core(logical_dispatch_core, index)->go_msg;
             CoreCoord virtual_core = this->virtual_core_from_logical_core(logical_dispatch_core, core_type);
             tt::llrt::write_launch_msg_to_core(this->id(), virtual_core, &msg, &go_msg, this->get_dev_addr(virtual_core, HalL1MemAddrType::LAUNCH));
         }
@@ -1198,8 +1199,9 @@ void Device::init_fabric() {
         CoreType core_type = hal.get_core_type(programmable_core_type_index);
         for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
             launch_msg_t* msg =
-                &fabric_program_->kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
-            go_msg_t* go_msg = &fabric_program_->kernels_on_core(logical_core, programmable_core_type_index)->go_msg;
+                &fabric_program_->impl().kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
+            go_msg_t* go_msg =
+                &fabric_program_->impl().kernels_on_core(logical_core, programmable_core_type_index)->go_msg;
             msg->kernel_config.host_assigned_id = fabric_program_->get_runtime_id();
 
             auto physical_core = this->virtual_core_from_logical_core(logical_core, core_type);

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -444,10 +444,6 @@ KernelGroup* detail::ProgramImpl::kernels_on_core(const CoreCoord& core, uint32_
     return (index == core_to_kernel_group_invalid_index) ? nullptr : kernel_groups_[programmable_core_type_index].at(index).get();
 }
 
-KernelGroup *Program::kernels_on_core(const CoreCoord &core, uint32_t programmable_core_type_index) {
-    return pimpl_->kernels_on_core(core, programmable_core_type_index);
-}
-
 struct KernelGroupInt {
     bool valid;
     kernel_id_array_t kernel_ids;
@@ -767,10 +763,6 @@ std::vector<std::shared_ptr<CircularBuffer>> detail::ProgramImpl::circular_buffe
     return cbs_on_core;
 }
 
-std::vector<std::shared_ptr<CircularBuffer>> Program::circular_buffers_on_core(const CoreCoord &core) const {
-    return pimpl_->circular_buffers_on_core(core);
-}
-
 std::vector<std::shared_ptr<CircularBuffer>> detail::ProgramImpl::circular_buffers_on_corerange(
     const CoreRange& cr) const {
     std::vector<std::shared_ptr<CircularBuffer>> cbs_on_core;
@@ -780,10 +772,6 @@ std::vector<std::shared_ptr<CircularBuffer>> detail::ProgramImpl::circular_buffe
         }
     }
     return cbs_on_core;
-}
-
-std::vector<std::shared_ptr<CircularBuffer>> Program::circular_buffers_on_corerange(const CoreRange &cr) const {
-    return pimpl_->circular_buffers_on_corerange(cr);
 }
 
 std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges() const {
@@ -796,10 +784,6 @@ std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges()
         }
     }
     return core_ranges;
-}
-
-std::vector<CoreRange> Program::circular_buffers_unique_coreranges() const {
-    return pimpl_->circular_buffers_unique_coreranges();
 }
 
 void detail::ProgramImpl::invalidate_circular_buffer_allocation() {
@@ -1187,10 +1171,6 @@ ProgramConfig& detail::ProgramImpl::get_program_config(uint32_t programmable_cor
     return this->program_configs_[programmable_core_type_index];
 }
 
-ProgramConfig& Program::get_program_config(uint32_t programmable_core_type_index) {
-    return pimpl_->get_program_config(programmable_core_type_index);
-}
-
 void detail::ProgramImpl::set_launch_msg_sem_offsets() {
     const auto& hal = MetalContext::instance().hal();
     for (uint32_t kg_type_index = 0; kg_type_index < hal.get_programmable_core_type_count(); kg_type_index++) {
@@ -1428,17 +1408,19 @@ void Program::set_runtime_id(uint64_t id) { pimpl_->set_runtime_id(id); }
 uint32_t Program::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(impl(), device, programmable_core_type);
-    return base_addr +
-           get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
-               .sem_offset;
+    return base_addr + impl()
+                           .get_program_config(
+                               MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
+                           .sem_offset;
 }
 
 uint32_t Program::get_cb_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
     uint32_t base_addr = program_dispatch::program_base_addr_on_core(impl(), device, programmable_core_type);
-    return base_addr +
-           get_program_config(MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
-               .cb_offset;
+    return base_addr + impl()
+                           .get_program_config(
+                               MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type))
+                           .cb_offset;
 }
 
 void detail::ProgramImpl::set_last_used_command_queue_for_testing(CommandQueue* queue) {
@@ -1568,15 +1550,10 @@ std::vector<std::reference_wrapper<const Semaphore>> detail::ProgramImpl::semaph
     return semaphores;
 }
 
-std::vector<std::reference_wrapper<const Semaphore>> Program::semaphores_on_core(const CoreCoord &core, CoreType core_type) const {
-    return pimpl_->semaphores_on_core(core, core_type);
-}
-
 bool detail::ProgramImpl::is_finalized() const { return this->finalized_; }
 void detail::ProgramImpl::set_finalized() { this->finalized_ = true; }
 
 bool Program::is_finalized() const { return pimpl_->is_finalized(); }
-void Program::set_finalized() { pimpl_->set_finalized(); }
 
 ProgramBinaryStatus Program::get_program_binary_status(std::size_t device_id) const { return pimpl_->get_program_binary_status(device_id); }
 void Program::set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status) { pimpl_->set_program_binary_status(device_id, status); }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -58,6 +58,48 @@ void assemble_device_commands(
 
 }
 
+using kernel_id_array_t = std::array<std::optional<KernelHandle>, DISPATCH_CLASS_MAX>;
+
+struct KernelGroup {
+    uint32_t programmable_core_type_index;
+    CoreRangeSet core_ranges;
+    kernel_id_array_t kernel_ids;
+    uint32_t rta_sizes[DISPATCH_CLASS_MAX];
+    uint32_t total_rta_size;
+    uint32_t kernel_text_offsets[NUM_PROCESSORS_PER_CORE_TYPE];
+    uint32_t kernel_bin_sizes[NUM_PROCESSORS_PER_CORE_TYPE];
+    launch_msg_t launch_msg;
+    go_msg_t go_msg;
+
+    KernelGroup();
+    KernelGroup(
+        const detail::ProgramImpl& program,
+        uint32_t programmable_core_type_index,
+        kernel_id_array_t kernel_ids,
+        bool erisc_is_idle,
+        uint32_t max_local_cb_end_index,
+        uint32_t min_remote_cb_start_index,
+        const CoreRangeSet& new_ranges);
+
+    uint32_t get_programmable_core_type_index() const;
+
+    CoreType get_core_type() const;
+};
+
+// Contains the program's worker memory map
+struct ProgramConfig {
+    uint32_t rta_offset;
+    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_offsets;
+    std::array<uint32_t, DISPATCH_CLASS_MAX> crta_sizes;
+    uint32_t sem_offset;
+    uint32_t sem_size;
+    uint32_t cb_offset;
+    uint32_t cb_size;
+    uint32_t local_cb_size;
+    uint32_t kernel_text_offset;  // offset of first kernel bin
+    uint32_t kernel_text_size;    // max size of all kernel bins across all kernel groups
+};
+
 namespace detail {
 
 struct ProgramOffsetsState {

--- a/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
+++ b/tt_metal/programming_examples/profiler/test_multi_op/test_multi_op.cpp
@@ -5,6 +5,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
+#include <hostdevcommon/profiler_common.h>
 
 using namespace tt;
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -122,8 +122,8 @@ DataMovementConfigStatus CheckDataMovementConfig(
     for (const auto& core_range : core_ranges.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
-                const KernelGroup* kernel_group =
-                    program.kernels_on_core(CoreCoord(x, y), hal.get_programmable_core_type_index(programmable_core));
+                const KernelGroup* kernel_group = program.impl().kernels_on_core(
+                    CoreCoord(x, y), hal.get_programmable_core_type_index(programmable_core));
                 if (kernel_group != nullptr) {
                     bool local_noc0_in_use = false;
                     bool local_noc1_in_use = false;
@@ -176,7 +176,7 @@ std::optional<uint32_t> get_semaphore_id(const Program &program, const CoreRange
     for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
         for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
             CoreCoord logical_core(x, y);
-            auto semaphores = program.semaphores_on_core(logical_core, core_type);
+            auto semaphores = program.impl().semaphores_on_core(logical_core, core_type);
             if (semaphores.size() == NUM_SEMAPHORES) {
                 TT_THROW(
                     "Cannot add semaphore on core {}. Max number of semaphores ({}) reached!",
@@ -766,8 +766,9 @@ void LaunchProgram(IDevice* device, Program& program, bool wait_until_cores_done
              programmable_core_type_index++) {
             CoreType core_type = hal.get_core_type(programmable_core_type_index);
             for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
-                launch_msg_t* msg = &program.kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
-                go_msg_t* go_msg = &program.kernels_on_core(logical_core, programmable_core_type_index)->go_msg;
+                launch_msg_t* msg =
+                    &program.impl().kernels_on_core(logical_core, programmable_core_type_index)->launch_msg;
+                go_msg_t* go_msg = &program.impl().kernels_on_core(logical_core, programmable_core_type_index)->go_msg;
                 msg->kernel_config.host_assigned_id = program.get_runtime_id();
 
                 auto physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
@@ -831,18 +832,19 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
         const auto& logical_cores = logical_cores_used_in_program[index];
         CoreType core_type = hal.get_core_type(index);
         for (const auto& logical_core : logical_cores) {
-            KernelGroup* kernel_group = program.kernels_on_core(logical_core, index);
+            KernelGroup* kernel_group = program.impl().kernels_on_core(logical_core, index);
             CoreCoord physical_core = device->virtual_core_from_logical_core(logical_core, core_type);
             ConfigureKernelGroup(program, index, kernel_group, device, logical_core);
             // TODO: add support for CB for ethernet cores
             if (core_type == CoreType::WORKER) {
-                const auto& cbs_on_core = program.circular_buffers_on_core(logical_core);
+                const auto& cbs_on_core = program.impl().circular_buffers_on_core(logical_core);
                 if (cbs_on_core.size()) {
                     // CircularBufferConfigVec -- common across all kernels, so written once to the core
                     std::vector<uint32_t> circular_buffer_config_vec(
-                        program.get_program_config(index).cb_size / sizeof(uint32_t));
+                        program.impl().get_program_config(index).cb_size / sizeof(uint32_t));
 
-                    uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
+                    uint32_t remote_offset_index =
+                        program.impl().get_program_config(index).local_cb_size / sizeof(uint32_t);
                     for (const auto& circular_buffer : cbs_on_core) {
                         for (uint32_t buffer_index : circular_buffer->local_buffer_indices()) {
                             uint32_t base_index = buffer_index * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
@@ -865,7 +867,7 @@ bool ConfigureDeviceWithProgram(IDevice* device, Program& program, bool force_sl
                         }
                     }  // PROF_END("CBS")
                     uint64_t kernel_config_base = hal.get_dev_addr(index, HalL1MemAddrType::KERNEL_CONFIG);
-                    uint64_t addr = kernel_config_base + program.get_program_config(index).cb_offset;
+                    uint64_t addr = kernel_config_base + program.impl().get_program_config(index).cb_offset;
                     llrt::write_hex_vec_to_core(device_id, physical_core, circular_buffer_config_vec, addr);
                 }
             }

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_post_all_gather_op_multi_core.cpp
@@ -409,10 +409,10 @@ tt::tt_metal::operation::ProgramWithCallbacks layernorm_post_allgather_multi_cor
             .set_page_size(tt::CBIndex::c_14, out_single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_out0_config);
 
-    // Log all circular buffers with program.circular_buffers_on_corerange(all_cores), which returns
+    // Log all circular buffers with program.circular_buffers(), which returns
     // std::vector<std::shared_ptr<CircularBuffer>>
 
-    for (const auto& cb : program.circular_buffers_on_corerange(*all_cores.ranges().begin())) {
+    for (const auto& cb : program.circular_buffers()) {
         for (const auto index : cb->buffer_indices()) {
             tt::log_debug("cb_id {}", index);
             tt::log_debug("page_size: {}", cb->page_size(index));

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/multi_core/layernorm_pre_all_gather_op_multi_core.cpp
@@ -233,9 +233,9 @@ operation::ProgramWithCallbacks layernorm_pre_allgather_multi_core(
             .set_page_size(tt::CBIndex::c_14, out_single_tile_size);
     CreateCircularBuffer(program, all_cores, cb_out0_config);
 
-    // Log all circular buffers with program.circular_buffers_on_corerange(all_cores), which returns
+    // Log all circular buffers with program.circular_buffers(), which returns
     // std::vector<std::shared_ptr<CircularBuffer>>
-    for (const auto& cb : program.circular_buffers_on_corerange(*all_cores.ranges().begin())) {
+    for (const auto& cb : program.circular_buffers()) {
         for (const auto index : cb->buffer_indices()) {
             tt::log_debug("cb_id {}", index);
             tt::log_debug("page_size: {}", cb->page_size(index));


### PR DESCRIPTION
### Problem description
KernelGroup and ProgramConfig are dispatch-internal types, so they shouldn't be in api/tt-metalium

### What's changed
Move them into program_impl.hpp. MeshWorkload still depends on them, so add a forward declaration there. Also remove some other internal methods from Program.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes