### PR TITLE
#21982: Store trace commands so they can be optimized at end of record

### DIFF
--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -136,7 +136,7 @@ public:
     const detail::ProgramImpl& impl() const { return *pimpl_; }
 
 private:
-    std::unique_ptr<detail::ProgramImpl> pimpl_;
+    std::shared_ptr<detail::ProgramImpl> pimpl_;
 
     friend CBHandle CreateCircularBuffer(
         Program& program,

--- a/tt_metal/api/tt-metalium/program.hpp
+++ b/tt_metal/api/tt-metalium/program.hpp
@@ -132,11 +132,12 @@ public:
     const std::vector<SubDeviceId>& determine_sub_device_ids(const IDevice* device);
     void set_kernels_bin_buffer(const std::shared_ptr<Buffer>& buffer);
     uint32_t get_cb_memory_size() const;
-    detail::ProgramImpl& impl() { return *pimpl_; }
-    const detail::ProgramImpl& impl() const { return *pimpl_; }
+    detail::ProgramImpl& impl() { return *internal_; }
+    const detail::ProgramImpl& impl() const { return *internal_; }
 
 private:
-    std::shared_ptr<detail::ProgramImpl> pimpl_;
+    // The internal ProgramImpl may outlive the Program object if it's in-use by a command queue.
+    std::shared_ptr<detail::ProgramImpl> internal_;
 
     friend CBHandle CreateCircularBuffer(
         Program& program,

--- a/tt_metal/impl/dispatch/hardware_command_queue.hpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.hpp
@@ -31,6 +31,7 @@
 #include <umd/device/tt_core_coordinates.h>
 #include "vector_aligned.hpp"
 #include "worker_config_buffer.hpp"
+#include "trace/trace_node.hpp"
 
 namespace tt {
 namespace tt_metal {
@@ -125,6 +126,8 @@ private:
     std::shared_ptr<TraceDescriptor> trace_ctx_;
     std::thread completion_queue_thread_;
     SystemMemoryManager& manager_;
+
+    std::vector<TraceNode> trace_nodes_;
 
     // Shared across all CommandQueue instances for a Device.
     std::shared_ptr<DispatchArray<LaunchMessageRingBufferState>> worker_launch_message_buffer_state_;

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -1944,6 +1944,131 @@ void update_program_dispatch_commands(
     }
 }
 
+void update_traced_program_dispatch_commands(
+    const TraceNode& trace_node,
+    ProgramCommandSequence& cached_program_command_sequence,
+    uint32_t multicast_cores_launch_message_wptr,
+    uint32_t unicast_cores_launch_message_wptr,
+    uint32_t expected_num_workers_completed,
+    CoreCoord dispatch_core,
+    CoreType dispatch_core_type,
+    SubDeviceId sub_device_id,
+    const ProgramDispatchMetadata& dispatch_md,
+    ProgramBinaryStatus program_binary_status,
+    std::pair<bool, int> unicast_go_signal_update) {
+    uint32_t i = 0;
+    ZoneScopedN("program_loaded_on_device");
+    const ProgramImpl& program = *trace_node.program;
+
+    static constexpr uint32_t wait_count_offset = (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, wait.count));
+    static constexpr uint32_t tensix_l1_write_offset_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset1));
+    static constexpr uint32_t eth_l1_write_offset_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.offset2));
+    static constexpr uint32_t program_host_id_offset =
+        (sizeof(CQPrefetchCmd) + offsetof(CQDispatchCmd, set_write_offset.program_host_id));
+    // Update Stall Command Sequence
+    if (program_binary_status != ProgramBinaryStatus::Committed) {
+        // Program binary is in flight. Issue a Prefetch Stall
+        cached_program_command_sequence.current_stall_seq_idx = UncachedStallSequenceIdx;
+    } else {
+        // Program Binary is in DRAM. Prefetcher does not need to stall before reading
+        // binary
+        cached_program_command_sequence.current_stall_seq_idx = CachedStallSequenceIdx;
+    }
+
+    auto& curr_stall_seq_idx = cached_program_command_sequence.current_stall_seq_idx;
+    cached_program_command_sequence.stall_command_sequences[curr_stall_seq_idx].update_cmd_sequence(
+        wait_count_offset, &(dispatch_md.sync_count), sizeof(uint32_t));
+
+    // Update preamble based on kernel config ring buffer slot
+    const auto& hal = MetalContext::instance().hal();
+    cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
+        tensix_l1_write_offset_offset,
+        &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)],
+        sizeof(uint32_t));
+    // May truncate to fit the space.
+    static_assert(
+        std::is_same_v<uint16_t, decltype(std::declval<CQDispatchCmd>().set_write_offset.program_host_id)>,
+        "program_host_id type should be uint16_t");
+    uint16_t runtime_id = trace_node.program_runtime_id;
+    cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
+        program_host_id_offset, &runtime_id, sizeof(runtime_id));
+    if (hal.get_programmable_core_type_count() >= 2) {
+        cached_program_command_sequence.preamble_command_sequence.update_cmd_sequence(
+            eth_l1_write_offset_offset,
+            &dispatch_md.kernel_config_addrs[hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)],
+            sizeof(uint32_t));
+    }
+
+    // Update CB Configs
+    uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
+    TT_ASSERT(
+        trace_node.cb_configs_payloads.size() ==
+        cached_program_command_sequence.circular_buffers_on_core_ranges.size());
+    for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
+        uint32_t* cb_config_payload = cached_program_command_sequence.cb_configs_payloads[i];
+        const uint32_t* cb_config_payload_from_trace = trace_node.cb_configs_payloads[i].data();
+        std::memcpy(
+            cb_config_payload,
+            cb_config_payload_from_trace,
+            trace_node.cb_configs_payloads[i].size() * sizeof(uint32_t));
+        i++;
+    }
+    // Update RTAs.
+    TT_ASSERT(cached_program_command_sequence.rta_updates.size() == trace_node.rta_data.size());
+    for (size_t i = 0; i < cached_program_command_sequence.rta_updates.size(); i++) {
+        auto& rta_update = cached_program_command_sequence.rta_updates[i];
+        memcpy(rta_update.dst, trace_node.rta_data[i].data(), rta_update.size);
+    }
+
+    // Update launch messages
+    for (auto& launch_msg : cached_program_command_sequence.launch_messages) {
+        for (uint32_t i = 0; i < dispatch_md.kernel_config_addrs.size(); i++) {
+            launch_msg->kernel_config.kernel_config_base[i] = dispatch_md.kernel_config_addrs[i].addr;
+        }
+        launch_msg->kernel_config.host_assigned_id = trace_node.program_runtime_id;
+    }
+    // Update launch message addresses to reflect new launch_msg slot in ring buffer
+    uint32_t multicast_cores_launch_msg_addr =
+        hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::LAUNCH) +
+        multicast_cores_launch_message_wptr * sizeof(launch_msg_t);
+    for (auto launch_msg_cmd_ptr : cached_program_command_sequence.launch_msg_write_packed_cmd_ptrs) {
+        launch_msg_cmd_ptr->addr = multicast_cores_launch_msg_addr;
+    }
+    if (cached_program_command_sequence.unicast_launch_msg_write_packed_cmd_ptrs.size()) {
+        uint32_t unicast_cores_launch_message_addr =
+            hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH) +
+            unicast_cores_launch_message_wptr * sizeof(launch_msg_t);
+        for (auto launch_msg_cmd_ptr : cached_program_command_sequence.unicast_launch_msg_write_packed_cmd_ptrs) {
+            launch_msg_cmd_ptr->addr = unicast_cores_launch_message_addr;
+        }
+    }
+    // Update go signal to reflect potentially modified dispatch core and new wait count
+    go_msg_t run_program_go_signal;
+    run_program_go_signal.signal = RUN_MSG_GO;
+    run_program_go_signal.master_x = (uint8_t)dispatch_core.x;
+    run_program_go_signal.master_y = (uint8_t)dispatch_core.y;
+    run_program_go_signal.dispatch_message_offset = MetalContext::instance()
+                                                        .dispatch_mem_map(dispatch_core_type)
+                                                        .get_dispatch_message_update_offset(*sub_device_id);
+    cached_program_command_sequence.mcast_go_signal_cmd_ptr->go_signal =
+        *reinterpret_cast<uint32_t*>(&run_program_go_signal);
+    cached_program_command_sequence.mcast_go_signal_cmd_ptr->wait_count = expected_num_workers_completed;
+    // Update the number of unicast txns based on user provided parameter
+    // This is required when a MeshWorkload uses ethernet cores on a set of devices
+    // where the number of active eth cores is heterogenous across devices.
+    // Update the number of unicast txns to eth cores to match the minimum number of cores
+    // across devices (specified by user)
+    if (unicast_go_signal_update.first) {
+        TT_FATAL(
+            unicast_go_signal_update.second > 0,
+            "Must specify a valid number of cores to unicast the go signal to when updating dispatch commands");
+        cached_program_command_sequence.mcast_go_signal_cmd_ptr->num_unicast_txns = unicast_go_signal_update.second;
+    }
+}
+
 void write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,
     SystemMemoryManager& manager,
@@ -2029,6 +2154,62 @@ void write_program_command_sequence(
         manager.fetch_queue_reserve_back(command_queue_id);
         manager.fetch_queue_write(one_shot_fetch_size, command_queue_id);
     }
+}
+
+TraceNode create_trace_node(ProgramImpl& program, IDevice* device) {
+    std::vector<SubDeviceId> sub_device_ids{program.determine_sub_device_ids(device)};
+    program.generate_trace_dispatch_commands(device);
+    uint64_t command_hash = *device->get_active_sub_device_manager_id();
+
+    // By using the traced command sequence, we know the RTA data source-of-truth isn't this command sequence (it's in a
+    // regular cached program command sequence), so rta_updates includes all the RTAs.
+    auto& cached_program_command_sequence = program.get_trace_cached_program_command_sequences().at(command_hash);
+    std::vector<std::vector<uint8_t>> rta_data;
+    for (auto& update : cached_program_command_sequence.rta_updates) {
+        rta_data.push_back(std::vector<uint8_t>(
+            static_cast<const uint8_t*>(update.src), static_cast<const uint8_t*>(update.src) + update.size));
+    }
+
+    std::vector<std::vector<uint32_t>> all_cb_configs_payloads;
+    const auto& hal = MetalContext::instance().hal();
+    uint32_t index = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+    uint32_t remote_offset_index = program.get_program_config(index).local_cb_size / sizeof(uint32_t);
+    for (const auto& cbs_on_core_range : cached_program_command_sequence.circular_buffers_on_core_ranges) {
+        all_cb_configs_payloads.push_back(
+            std::vector<uint32_t>(NUM_CIRCULAR_BUFFERS * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG));
+        auto& cb_config_payload = all_cb_configs_payloads.back();
+        uint32_t first_unused_index = 0;
+        for (const std::shared_ptr<CircularBuffer>& cb : cbs_on_core_range) {
+            const uint32_t cb_address = cb->address();
+            const uint32_t cb_size = cb->size();
+            for (const auto& buffer_index : cb->local_buffer_indices()) {
+                // 1 cmd for all 32 buffer indices, populate with real data for specified indices
+
+                // cb config payload
+                uint32_t base_index = UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * buffer_index;
+                cb_config_payload[base_index] = cb_address;
+                cb_config_payload[base_index + 1] = cb_size;
+                cb_config_payload[base_index + 2] = cb->num_pages(buffer_index);
+                cb_config_payload[base_index + 3] = cb->page_size(buffer_index);
+                first_unused_index = std::max(first_unused_index, base_index + 4);
+            }
+            for (const auto& buffer_index : cb->remote_buffer_indices()) {
+                const uint32_t base_index = remote_offset_index + (NUM_CIRCULAR_BUFFERS - 1 - buffer_index) *
+                                                                      UINT32_WORDS_PER_REMOTE_CIRCULAR_BUFFER_CONFIG;
+                cb_config_payload[base_index] = cb->config_address();
+                cb_config_payload[base_index + 1] = cb->page_size(buffer_index);
+                first_unused_index = std::max(first_unused_index, base_index + 2);
+            }
+        }
+        cb_config_payload.resize(first_unused_index);
+    }
+
+    return TraceNode{
+        program.shared_from_this(),
+        program.get_runtime_id(),
+        sub_device_ids[0],
+        std::move(rta_data),
+        std::move(all_cb_configs_payloads)};
 }
 
 KernelHandle get_device_local_kernel_handle(KernelHandle kernel_handle) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -2020,7 +2020,7 @@ void update_traced_program_dispatch_commands(
     TT_ASSERT(cached_program_command_sequence.rta_updates.size() == trace_node.rta_data.size());
     for (size_t i = 0; i < cached_program_command_sequence.rta_updates.size(); i++) {
         auto& rta_update = cached_program_command_sequence.rta_updates[i];
-        memcpy(rta_update.dst, trace_node.rta_data[i].data(), rta_update.size);
+        std::memcpy(rta_update.dst, trace_node.rta_data[i].data(), rta_update.size);
     }
 
     // Update launch messages

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -23,6 +23,7 @@
 #include "program_impl.hpp"
 #include "sub_device_types.hpp"
 #include "dispatch/worker_config_buffer.hpp"
+#include "trace/trace_node.hpp"
 
 enum class CoreType;
 
@@ -119,6 +120,21 @@ void update_program_dispatch_commands(
     const ProgramDispatchMetadata& dispatch_md,
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update = {false, -1});
+
+void update_traced_program_dispatch_commands(
+    const TraceNode& node,
+    ProgramCommandSequence& cached_program_command_sequence,
+    uint32_t multicast_cores_launch_message_wptr,
+    uint32_t unicast_cores_launch_message_wptr,
+    uint32_t expected_num_workers_completed,
+    CoreCoord dispatch_core,
+    CoreType dispatch_core_type,
+    SubDeviceId sub_device_id,
+    const ProgramDispatchMetadata& dispatch_md,
+    ProgramBinaryStatus program_binary_status,
+    std::pair<bool, int> unicast_go_signal_update = {false, -1});
+
+TraceNode create_trace_node(detail::ProgramImpl& program, IDevice* device);
 
 void write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -166,7 +166,7 @@ size_t KernelCompileHash(const std::shared_ptr<Kernel>& kernel, JitBuildOptions&
 namespace detail {
 
 KernelHandle AddKernel (Program &program, const std::shared_ptr<Kernel>& kernel, const HalProgrammableCoreType core_type) {
-    return program.pimpl_->add_kernel(std::move(kernel), core_type);
+    return program.internal_->add_kernel(std::move(kernel), core_type);
 }
 
 std::shared_ptr<Kernel> GetKernel(const Program &program, KernelHandle kernel_id) {
@@ -174,12 +174,12 @@ std::shared_ptr<Kernel> GetKernel(const Program &program, KernelHandle kernel_id
 }
 
 std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program &program, CBHandle id) {
-    return program.pimpl_->get_circular_buffer(id);
+    return program.internal_->get_circular_buffer(id);
 }
 
 // Checks that circular buffers do not grow into L1 buffer space
 void ValidateCircularBufferRegion(const Program &program, const IDevice* device) {
-    program.pimpl_->validate_circular_buffer_region(device);
+    program.internal_->validate_circular_buffer_region(device);
 }
 
 void EnablePersistentKernelCache() { enable_persistent_kernel_cache = true; }
@@ -191,7 +191,7 @@ class Internal_ {
        using map_type = decltype(detail::ProgramImpl::circular_buffer_by_id_);
 
        static const map_type& get_circular_buffers_by_id(const Program& program) noexcept {
-           return program.pimpl_->circular_buffer_by_id_;
+           return program.internal_->circular_buffer_by_id_;
        }
 };
 
@@ -217,17 +217,17 @@ detail::ProgramImpl::ProgramImpl() :
     program_config_sizes_.resize(programmable_core_count_ + 2);
 }
 
-Program::Program() : pimpl_(std::make_shared<detail::ProgramImpl>()) {
+Program::Program() : internal_(std::make_shared<detail::ProgramImpl>()) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureProgramConstructor, *this);
 }
 
-Program::Program(const ProgramDescriptor& descriptor) : pimpl_(std::make_shared<detail::ProgramImpl>()) {
+Program::Program(const ProgramDescriptor& descriptor) : internal_(std::make_shared<detail::ProgramImpl>()) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureProgramConstructor, *this);
 
     for (auto& cb_descriptor : descriptor.cbs) {
-        pimpl_->add_circular_buffer_(std::make_shared<CircularBuffer>(cb_descriptor));
+        internal_->add_circular_buffer_(std::make_shared<CircularBuffer>(cb_descriptor));
     }
 
     for (size_t i = 0; i < descriptor.semaphores.size(); i++) {
@@ -335,7 +335,7 @@ std::shared_ptr<Kernel> detail::ProgramImpl::get_kernel(KernelHandle kernel_id) 
     return nullptr;
 }
 
-std::shared_ptr<Kernel> Program::get_kernel(KernelHandle kernel_id) const { return pimpl_->get_kernel(kernel_id); }
+std::shared_ptr<Kernel> Program::get_kernel(KernelHandle kernel_id) const { return internal_->get_kernel(kernel_id); }
 
 KernelGroup::KernelGroup() : core_ranges(CoreRangeSet()) {}
 
@@ -427,7 +427,7 @@ std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& detail::ProgramImpl::
 }
 
 std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>& Program::get_kernels(uint32_t programmable_core_type_index) {
-    return pimpl_->get_kernels(programmable_core_type_index);
+    return internal_->get_kernels(programmable_core_type_index);
 }
 
 KernelGroup* detail::ProgramImpl::kernels_on_core(const CoreCoord& core, uint32_t programmable_core_type_index) {
@@ -729,14 +729,14 @@ CBHandle detail::ProgramImpl::add_circular_buffer(
 }
 
 CBHandle Program::add_circular_buffer(const CoreRangeSet &core_range_set, const CircularBufferConfig &config) {
-    return pimpl_->add_circular_buffer(core_range_set, config);
+    return internal_->add_circular_buffer(core_range_set, config);
 }
 
 CBHandle Program::add_circular_buffer(
     const CoreRangeSet& core_range_set,
     const CircularBufferConfig& config,
     const experimental::GlobalCircularBuffer& global_circular_buffer) {
-    return pimpl_->add_circular_buffer(core_range_set, config, global_circular_buffer);
+    return internal_->add_circular_buffer(core_range_set, config, global_circular_buffer);
 }
 
 std::shared_ptr<CircularBuffer> detail::ProgramImpl::get_circular_buffer(CBHandle cb_id) const {
@@ -790,9 +790,9 @@ void detail::ProgramImpl::invalidate_circular_buffer_allocation() {
     this->local_circular_buffer_allocation_needed_ = true;
 }
 
-void Program::invalidate_circular_buffer_allocation() { pimpl_->invalidate_circular_buffer_allocation(); }
+void Program::invalidate_circular_buffer_allocation() { internal_->invalidate_circular_buffer_allocation(); }
 
-uint32_t Program::get_cb_memory_size() const { return pimpl_->get_cb_memory_size(); }
+uint32_t Program::get_cb_memory_size() const { return internal_->get_cb_memory_size(); }
 uint32_t detail::ProgramImpl::get_cb_memory_size() const {
     uint32_t total_cb_size = 0;
     for (const auto& circular_buffer : this->circular_buffers_) {
@@ -845,7 +845,7 @@ void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
     this->local_circular_buffer_allocation_needed_ = false;
 }
 
-void Program::allocate_circular_buffers(const IDevice* device) { pimpl_->allocate_circular_buffers(device); }
+void Program::allocate_circular_buffers(const IDevice* device) { internal_->allocate_circular_buffers(device); }
 
 void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device) {
     //ZoneScoped;
@@ -881,7 +881,7 @@ void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device)
 
 size_t detail::ProgramImpl::num_semaphores() const { return semaphores_.size(); }
 
-size_t Program::num_semaphores() const { return pimpl_->num_semaphores(); }
+size_t Program::num_semaphores() const { return internal_->num_semaphores(); }
 
 void detail::ProgramImpl::init_semaphores(
     const IDevice& device, const CoreCoord& logical_core, uint32_t programmable_core_type_index) const {
@@ -900,7 +900,7 @@ void detail::ProgramImpl::init_semaphores(
 }
 
 void Program::init_semaphores(const IDevice &device, const CoreCoord &logical_core, uint32_t programmable_core_type_index) const {
-    pimpl_->init_semaphores(device, logical_core, programmable_core_type_index);
+    internal_->init_semaphores(device, logical_core, programmable_core_type_index);
 }
 
 void detail::ProgramImpl::add_semaphore(
@@ -910,7 +910,7 @@ void detail::ProgramImpl::add_semaphore(
 }
 
 void Program::add_semaphore(const CoreRangeSet &crs, uint32_t semaphore_id, uint32_t init_value, CoreType core_type) {
-    pimpl_->add_semaphore(crs, semaphore_id, init_value, core_type);
+    internal_->add_semaphore(crs, semaphore_id, init_value, core_type);
 }
 
 std::vector<std::vector<CoreCoord>> detail::ProgramImpl::logical_cores() const {
@@ -933,7 +933,7 @@ std::vector<std::vector<CoreCoord>> detail::ProgramImpl::logical_cores() const {
     return cores_in_program;
 }
 
-std::vector<std::vector<CoreCoord>> Program::logical_cores() const { return pimpl_->logical_cores(); }
+std::vector<std::vector<CoreCoord>> Program::logical_cores() const { return internal_->logical_cores(); }
 
 void detail::ProgramImpl::set_remote_circular_buffer_init(const std::shared_ptr<Kernel>& kernel) const {
     const auto& kernel_defines = kernel->defines();
@@ -1254,11 +1254,11 @@ void Program::generate_dispatch_commands(IDevice* device) {
         // id into the device hash, to always assert on programs being reused across devices.
         device_hash = (device_hash << 32) | (device->id());
     }
-    if (!pimpl_->is_cached()) {
-        pimpl_->set_cached(device_hash);
+    if (!internal_->is_cached()) {
+        internal_->set_cached(device_hash);
     } else {
         TT_FATAL(
-            *pimpl_->get_cached() == device_hash,
+            *internal_->get_cached() == device_hash,
             "Enqueueing a Program across devices with different cores harvested is not supported, unless coordinate "
             "virtualization is enabled (only enabled on Wormhole and above).");
     }
@@ -1307,7 +1307,9 @@ void ProgramImpl::generate_trace_dispatch_commands(IDevice* device) {
     }
 }
 
-void Program::allocate_kernel_bin_buf_on_device(IDevice* device) { pimpl_->allocate_kernel_bin_buf_on_device(device); }
+void Program::allocate_kernel_bin_buf_on_device(IDevice* device) {
+    internal_->allocate_kernel_bin_buf_on_device(device);
+}
 
 void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     //ZoneScoped;
@@ -1428,11 +1430,11 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     compiled_.insert(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key);
 }
 
-void Program::compile(IDevice* device, bool force_slow_dispatch) { pimpl_->compile(device, force_slow_dispatch); }
+void Program::compile(IDevice* device, bool force_slow_dispatch) { internal_->compile(device, force_slow_dispatch); }
 
 void detail::ProgramImpl::set_runtime_id(uint64_t id) { this->runtime_id = id; }
 
-void Program::set_runtime_id(uint64_t id) { pimpl_->set_runtime_id(id); }
+void Program::set_runtime_id(uint64_t id) { internal_->set_runtime_id(id); }
 
 uint32_t Program::get_sem_base_addr(IDevice* device, CoreCoord /*logical_core*/, CoreType core_type) {
     HalProgrammableCoreType programmable_core_type = ::tt::tt_metal::detail::hal_programmable_core_type_from_core_type(core_type);
@@ -1461,10 +1463,10 @@ CommandQueue* detail::ProgramImpl::get_last_used_command_queue() const {
 }
 
 void Program::set_last_used_command_queue_for_testing(CommandQueue* queue) {
-    pimpl_->set_last_used_command_queue_for_testing(queue);
+    internal_->set_last_used_command_queue_for_testing(queue);
 }
 
-CommandQueue* Program::get_last_used_command_queue() const { return pimpl_->get_last_used_command_queue(); }
+CommandQueue* Program::get_last_used_command_queue() const { return internal_->get_last_used_command_queue(); }
 
 uint32_t detail::ProgramImpl::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
     CoreCoord virtual_core = device->virtual_core_from_logical_core(logical_core, core_type);
@@ -1475,7 +1477,7 @@ uint32_t detail::ProgramImpl::get_sem_size(IDevice* device, CoreCoord logical_co
 }
 
 uint32_t Program::get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
-    return pimpl_->get_sem_size(device, logical_core, core_type);
+    return internal_->get_sem_size(device, logical_core, core_type);
 }
 
 uint32_t detail::ProgramImpl::get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
@@ -1487,7 +1489,7 @@ uint32_t detail::ProgramImpl::get_cb_size(IDevice* device, CoreCoord logical_cor
 }
 
 uint32_t Program::get_cb_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const {
-    return pimpl_->get_cb_size(device, logical_core, core_type);
+    return internal_->get_cb_size(device, logical_core, core_type);
 }
 
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
@@ -1499,7 +1501,7 @@ bool detail::ProgramImpl::runs_on_noc_unicast_only_cores() {
                 .empty());
 }
 
-bool Program::runs_on_noc_unicast_only_cores() { return pimpl_->runs_on_noc_unicast_only_cores(); }
+bool Program::runs_on_noc_unicast_only_cores() { return internal_->runs_on_noc_unicast_only_cores(); }
 
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
 bool detail::ProgramImpl::runs_on_noc_multicast_only_cores() {
@@ -1510,7 +1512,7 @@ bool detail::ProgramImpl::runs_on_noc_multicast_only_cores() {
                 .empty());
 }
 
-bool Program::runs_on_noc_multicast_only_cores() { return pimpl_->runs_on_noc_multicast_only_cores(); }
+bool Program::runs_on_noc_multicast_only_cores() { return internal_->runs_on_noc_multicast_only_cores(); }
 
 bool detail::ProgramImpl::kernel_binary_always_stored_in_ringbuffer() {
     // Active ethernet cores use a fixed address for the kernel binary, because they don't have enough memory to have
@@ -1523,7 +1525,7 @@ bool detail::ProgramImpl::kernel_binary_always_stored_in_ringbuffer() {
 }
 
 bool Program::kernel_binary_always_stored_in_ringbuffer() {
-    return pimpl_->kernel_binary_always_stored_in_ringbuffer();
+    return internal_->kernel_binary_always_stored_in_ringbuffer();
 }
 
 Program::Program(Program &&other) noexcept = default;
@@ -1534,11 +1536,11 @@ Program::~Program() noexcept = default;
 
 uint64_t detail::ProgramImpl::get_id() const { return this->id; }
 
-uint64_t Program::get_id() const { return pimpl_->get_id(); }
+uint64_t Program::get_id() const { return internal_->get_id(); }
 
 uint64_t detail::ProgramImpl::get_runtime_id() const { return this->runtime_id; }
 
-uint64_t Program::get_runtime_id() const { return pimpl_->get_runtime_id(); }
+uint64_t Program::get_runtime_id() const { return internal_->get_runtime_id(); }
 
 size_t detail::ProgramImpl::num_kernels() const {
     size_t count = 0;
@@ -1548,25 +1550,27 @@ size_t detail::ProgramImpl::num_kernels() const {
     return count;
 }
 
-size_t Program::num_kernels() const { return pimpl_->num_kernels(); }
+size_t Program::num_kernels() const { return internal_->num_kernels(); }
 
 const std::vector<std::shared_ptr<CircularBuffer>>& detail::ProgramImpl::circular_buffers() const {
     return circular_buffers_;
 }
 
-const std::vector<std::shared_ptr<CircularBuffer>> &Program::circular_buffers() const { return pimpl_->circular_buffers(); }
+const std::vector<std::shared_ptr<CircularBuffer>>& Program::circular_buffers() const {
+    return internal_->circular_buffers();
+}
 
 const std::vector<Semaphore>& detail::ProgramImpl::semaphores() const { return semaphores_; }
 
-const std::vector< Semaphore > & Program::semaphores() const { return pimpl_->semaphores(); }
+const std::vector<Semaphore>& Program::semaphores() const { return internal_->semaphores(); }
 
 void detail::ProgramImpl::add_buffer(std::shared_ptr<Buffer> buf) { owned_buffer_pool.push_back(std::move(buf)); }
 
-void Program::add_buffer(std::shared_ptr<Buffer> buf) { pimpl_->add_buffer(std::move(buf)); }
+void Program::add_buffer(std::shared_ptr<Buffer> buf) { internal_->add_buffer(std::move(buf)); }
 
 void detail::ProgramImpl::release_buffers() { owned_buffer_pool = {}; }
 
-void Program::release_buffers() { pimpl_->release_buffers(); }
+void Program::release_buffers() { internal_->release_buffers(); }
 
 std::vector<std::reference_wrapper<const Semaphore>> detail::ProgramImpl::semaphores_on_core(
     const CoreCoord& core, CoreType core_type) const {
@@ -1582,12 +1586,18 @@ std::vector<std::reference_wrapper<const Semaphore>> detail::ProgramImpl::semaph
 bool detail::ProgramImpl::is_finalized() const { return this->finalized_; }
 void detail::ProgramImpl::set_finalized() { this->finalized_ = true; }
 
-bool Program::is_finalized() const { return pimpl_->is_finalized(); }
+bool Program::is_finalized() const { return internal_->is_finalized(); }
 
-ProgramBinaryStatus Program::get_program_binary_status(std::size_t device_id) const { return pimpl_->get_program_binary_status(device_id); }
-void Program::set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status) { pimpl_->set_program_binary_status(device_id, status); }
+ProgramBinaryStatus Program::get_program_binary_status(std::size_t device_id) const {
+    return internal_->get_program_binary_status(device_id);
+}
+void Program::set_program_binary_status(std::size_t device_id, ProgramBinaryStatus status) {
+    internal_->set_program_binary_status(device_id, status);
+}
 
-const std::vector<SubDeviceId> &Program::determine_sub_device_ids(const IDevice* device) { return pimpl_->determine_sub_device_ids(device); }
+const std::vector<SubDeviceId>& Program::determine_sub_device_ids(const IDevice* device) {
+    return internal_->determine_sub_device_ids(device);
+}
 
 const ProgramTransferInfo& detail::ProgramImpl::get_program_transfer_info() const noexcept {
     return program_transfer_info;
@@ -1601,11 +1611,11 @@ std::shared_ptr<Buffer> ProgramImpl::get_kernels_buffer(IDevice* device) const n
 }
 
 void Program::set_kernels_bin_buffer(const std::shared_ptr<Buffer>& buffer) {
-    pimpl_->kernels_buffer_.insert({buffer->device()->id(), buffer});
+    internal_->kernels_buffer_.insert({buffer->device()->id(), buffer});
 }
 
 std::unordered_map<uint64_t, ProgramCommandSequence> &Program::get_cached_program_command_sequences() noexcept {
-    return pimpl_->cached_program_command_sequences_;
+    return internal_->cached_program_command_sequences_;
 }
 
 void detail::ProgramImpl::set_program_offsets_and_sizes(uint32_t index, const ProgramOffsetsState& state) {
@@ -1633,7 +1643,7 @@ void detail::ProgramImpl::set_program_attrs_across_core_types(IDevice* device) {
     }
 }
 
-void Program::finalize_offsets(IDevice* device) { pimpl_->finalize_offsets(device); }
+void Program::finalize_offsets(IDevice* device) { internal_->finalize_offsets(device); }
 
 using KernelsGetter = std::function<std::unordered_map<KernelHandle, std::shared_ptr<Kernel>>&(uint32_t index)>;
 using KernelGroupsGetter = std::function<std::vector<std::shared_ptr<KernelGroup>>&(uint32_t index)>;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -130,7 +130,7 @@ using KernelsGetter = std::function<std::unordered_map<KernelHandle, std::shared
 using KernelGroupsGetter = std::function<std::vector<std::shared_ptr<KernelGroup>>&(uint32_t index)>;
 using SemaphoresGetter = std::function<const std::vector<Semaphore>&()>;
 
-class ProgramImpl {
+class ProgramImpl : public std::enable_shared_from_this<ProgramImpl> {
 public:
     ProgramImpl();
 
@@ -184,7 +184,11 @@ public:
     }
     std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
     ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
+    const ProgramConfig& get_program_config(uint32_t programmable_core_type_index) const;
     const std::vector<SubDeviceId>& determine_sub_device_ids(const IDevice* device);
+
+    void generate_trace_dispatch_commands(IDevice* device);
+    std::unordered_map<uint64_t, ProgramCommandSequence>& get_trace_cached_program_command_sequences() noexcept;
 
     // debug/test
     uint32_t get_sem_size(IDevice* device, CoreCoord logical_core, CoreType core_type) const;
@@ -281,6 +285,7 @@ private:
 
     // The rta_updates from one cached command sequence may reference data in another cached command sequence.
     std::unordered_map<uint64_t, ProgramCommandSequence> cached_program_command_sequences_;
+    std::unordered_map<uint64_t, ProgramCommandSequence> trace_cached_program_command_sequences_;
 
     friend std::shared_ptr<CircularBuffer> GetCircularBuffer(const Program& program, CBHandle id);
     friend void ValidateCircularBufferRegion(const Program& program, const IDevice* device);

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -130,6 +130,7 @@ using KernelsGetter = std::function<std::unordered_map<KernelHandle, std::shared
 using KernelGroupsGetter = std::function<std::vector<std::shared_ptr<KernelGroup>>&(uint32_t index)>;
 using SemaphoresGetter = std::function<const std::vector<Semaphore>&()>;
 
+// The internal implementation of the Program class. Program is a view of this class that's usable by API clients.
 class ProgramImpl : public std::enable_shared_from_this<ProgramImpl> {
 public:
     ProgramImpl();

--- a/tt_metal/impl/trace/trace_node.hpp
+++ b/tt_metal/impl/trace/trace_node.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "program/program_impl.hpp"
+
+namespace tt::tt_metal {
+
+// This struct contains all the information needed to execute a program on a device.
+struct TraceNode {
+    std::shared_ptr<detail::ProgramImpl> program;
+    uint32_t program_runtime_id;
+    SubDeviceId sub_device_id;
+
+    // Matches rta_updates in the ProgramCommandSequence
+    std::vector<std::vector<uint8_t>> rta_data;
+    // Matches cb_configs_payloads in the ProgramCommandSequence
+    std::vector<std::vector<uint32_t>> cb_configs_payloads;
+};
+
+}  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
#21982 

### Problem description
Currently traced programs generate dispatch commands immediately, and those commands are stored in a buffer that's used when tracing is finished. This prevents us from doing complex optimizations of the trace commands, such as combining dispatch commands for multiple programs together, or caching a program based on the future number of uses in the trace.

### What's changed
When tracing, all information about the current instantiation of a program is saved in a TraceNode (including a shared_ptr to the ProgramImpl). We tracing finishes, we walk the TraceNodes and generate the actual dispatch commands.

At the moment this won't help performance, since we use the exact same set of dispatch commands either way. It's also not yet implemented for MeshWorkload.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes