### PR TITLE
Pick Source/Destination devices randomly for 2D Fabric

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -698,21 +698,11 @@ TEST_F(Fabric2DPushFixture, DISABLED_TestAsyncWrite) { RunAsyncWriteTest(this, f
 
 TEST_F(Fabric2DPullFixture, TestAsyncRawWrite) { RunAsyncWriteTest(this, fabric_mode::PULL, true); }
 
-TEST_F(Fabric2DPushFixture, TestUnicastRaw1HopE) { RunTestUnicastRaw(this, 1); }
-
-TEST_F(Fabric2DPushFixture, TestUnicastRaw2HopE) { RunTestUnicastRaw(this, 2); }
-
-TEST_F(Fabric2DPushFixture, TestUnicastRaw1HopW) { RunTestUnicastRaw(this, 1, RoutingDirection::W); }
-
-TEST_F(Fabric2DPushFixture, TestUnicastRaw2HopW) { RunTestUnicastRaw(this, 2, RoutingDirection::W); }
-
-TEST_F(Fabric2DPushFixture, TestUnicastRaw1HopN) { RunTestUnicastRaw(this, 1, RoutingDirection::N); }
-
-TEST_F(Fabric2DPushFixture, TestUnicastRaw2HopN) { RunTestUnicastRaw(this, 2, RoutingDirection::N); }
-
-TEST_F(Fabric2DPushFixture, TestUnicastRaw1HopS) { RunTestUnicastRaw(this, 1, RoutingDirection::S); }
-
-TEST_F(Fabric2DPushFixture, TestUnicastRaw2HopS) { RunTestUnicastRaw(this, 2, RoutingDirection::S); }
+TEST_F(Fabric2DPushFixture, TestUnicastRaw) {
+    for (uint32_t i = 0; i < 10; i++) {
+        RunTestUnicastRaw(this);
+    }
+}
 
 TEST_F(Fabric2DPushFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
 


### PR DESCRIPTION
Update the fabric test to randomly pick source/destination device when testing tt-fabric with 2D routing.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes