### PR TITLE
[skip ci] fix tags on llama perf tests

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -45,7 +45,7 @@ jobs:
             name: "Galaxy Llama 70B model perf tests",
             model-type: "Llama 70B",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "in-service", "bare-metal", "pipeline-perf"],
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
             cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
             owner_id: U044T8U8DEF # Johanna Rock
           },


### PR DESCRIPTION
### Ticket


### Problem description
CYO pipeline was not able to target llama perf tests with specific machine

### What's changed

### Checklist