### PR TITLE
#21737: Add resnet test to BH upstream pipelines

### DIFF
--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -23,6 +23,7 @@ test_suite_bh_single_pcie_metal_unit_tests() {
 test_suite_bh_single_pcie_small_ml_model_tests() {
     echo "[upstream-tests] Running BH upstream small model tests"
     pytest --disable-warnings --input-path="models/demos/whisper/demo/dataset/conditional_generation" models/demos/whisper/demo/demo.py::test_demo_for_conditional_generation
+    pytest models/demos/blackhole/resnet50/tests/upstream_pipeline
 }
 
 # Define test suite mappings for different hardware topologies

--- a/models/demos/blackhole/resnet50/tests/resnet_test_utils.py
+++ b/models/demos/blackhole/resnet50/tests/resnet_test_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/blackhole/resnet50/tests/resnet_test_utils.py
+++ b/models/demos/blackhole/resnet50/tests/resnet_test_utils.py
@@ -1,0 +1,11 @@
+import pytest
+
+from models.utility_functions import is_blackhole
+
+
+def skip_resnet_if_blackhole_p100(device):
+    is_p100 = (
+        is_blackhole() and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130
+    )
+    if is_p100:
+        pytest.skip("Expected to run only on blackhole devices with 130 cores (unharvested grid), see #21319")

--- a/models/demos/blackhole/resnet50/tests/resnet_test_utils.py
+++ b/models/demos/blackhole/resnet50/tests/resnet_test_utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from models.utility_functions import is_blackhole

--- a/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_functional_resnet50_batch32.py
+++ b/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_functional_resnet50_batch32.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_functional_resnet50_batch32.py
+++ b/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_functional_resnet50_batch32.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import ttnn
+from tests.ttnn.integration_tests.resnet.test_ttnn_functional_resnet50 import run_resnet_50
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True)
+@pytest.mark.parametrize(
+    "batch_size, act_dtype, weight_dtype, math_fidelity",
+    ((32, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.MathFidelity.LoFi),),
+)
+@pytest.mark.parametrize(
+    "use_pretrained_weight",
+    [
+        True,
+    ],
+    ids=[
+        "pretrained_weight_true",
+    ],
+)
+def test_resnet_50(
+    device,
+    use_program_cache,
+    batch_size,
+    act_dtype,
+    weight_dtype,
+    math_fidelity,
+    use_pretrained_weight,
+    model_location_generator,
+):
+    run_resnet_50(
+        device,
+        use_program_cache,
+        batch_size,
+        act_dtype,
+        weight_dtype,
+        math_fidelity,
+        use_pretrained_weight,
+        model_location_generator,
+    )

--- a/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_perf_e2e_resnet50_batch32.py
+++ b/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_perf_e2e_resnet50_batch32.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_perf_e2e_resnet50_batch32.py
+++ b/models/demos/blackhole/resnet50/tests/upstream_pipeline/test_perf_e2e_resnet50_batch32.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.demos.blackhole.resnet50.tests.resnet_test_utils import skip_resnet_if_blackhole_p100
+from models.demos.ttnn_resnet.tests.perf_e2e_resnet50 import run_perf_resnet
+from models.utility_functions import run_for_blackhole
+
+
+@run_for_blackhole()
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.parametrize(
+    "device_params", [{"l1_small_size": 32768, "num_command_queues": 2, "trace_region_size": 2777088}], indirect=True
+)
+@pytest.mark.parametrize(
+    "batch_size, expected_inference_time, expected_compile_time",
+    ((32, 0.003, 30),),
+)
+def test_perf_trace_2cqs(
+    device,
+    use_program_cache,
+    batch_size,
+    expected_inference_time,
+    expected_compile_time,
+    hf_cat_image_sample_input,
+    model_location_generator,
+):
+    skip_resnet_if_blackhole_p100(device)
+    run_perf_resnet(
+        batch_size,
+        expected_inference_time,
+        expected_compile_time,
+        hf_cat_image_sample_input,
+        device,
+        "resnet50_trace_2cqs",
+        model_location_generator,
+    )

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
+++ b/tests/ttnn/integration_tests/resnet/test_ttnn_functional_resnet50.py
@@ -5,6 +5,7 @@
 import pytest
 import ttnn
 
+from models.demos.blackhole.resnet50.tests.resnet_test_utils import skip_resnet_if_blackhole_p100
 from models.demos.ttnn_resnet.tests.resnet50_test_infra import create_test_infra
 from models.utility_functions import is_blackhole
 
@@ -25,8 +26,7 @@ def run_resnet_50(
     if batch_size > 16 and not is_blackhole():
         pytest.skip("Batch size > 16 is not supported on non-blackhole devices")
 
-    if is_blackhole() and device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y != 130:
-        pytest.skip("Expected to run only on blackhole devices with 130 cores (unharvested grid), see #21319")
+    skip_resnet_if_blackhole_p100(device)
 
     test_infra = create_test_infra(
         device,


### PR DESCRIPTION
### Ticket
#21737

### What's changed
Added BH tests to upstream pipelines.

### Checklist
Upstream pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/15187413179 - bh jobs passing 
Frequent ttnn and model: https://github.com/tenstorrent/tt-metal/actions/runs/15213549260