### PR TITLE
Simplify querying of dispatch related cores

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -286,7 +286,7 @@ def test_dispatch_cores():
 @skip_for_grayskull()
 def test_ethernet_dispatch_cores():
     REF_COUNT_DICT = {
-        "Ethernet CQ Dispatch": [700, 910, 2100],
+        "Ethernet CQ Dispatch": [700, 1400, 2100],
         "Ethernet CQ Prefetch": [600, 2500],
     }
     devicesData = run_device_profiler_test(

--- a/tt_metal/api/tt-metalium/device.hpp
+++ b/tt_metal/api/tt-metalium/device.hpp
@@ -214,7 +214,6 @@ public:
     virtual void reset_sub_device_stall_group() = 0;
     virtual uint32_t num_sub_devices() const = 0;
     virtual uint32_t num_virtual_eth_cores(SubDeviceId sub_device_id) = 0;
-    virtual bool dispatch_firmware_active() const = 0;
 
     // TODO #15944: Temporary api until migration to actual fabric is complete
     virtual std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -217,10 +217,6 @@ private:
     void clear_l1_state();
     void clear_dram_state();
     void clear_launch_messages_on_eth_cores();
-    void get_associated_dispatch_virtual_cores(
-        std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>>& my_dispatch_cores,
-        std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>>& other_dispatch_cores);
-
     void generate_device_bank_to_noc_tables();
 
     void mark_allocations_unsafe();

--- a/tt_metal/api/tt-metalium/device_impl.hpp
+++ b/tt_metal/api/tt-metalium/device_impl.hpp
@@ -184,7 +184,6 @@ public:
     void set_sub_device_stall_group(tt::stl::Span<const SubDeviceId> sub_device_ids) override;
     void reset_sub_device_stall_group() override;
     uint32_t num_sub_devices() const override;
-    bool dispatch_firmware_active() const override { return dispatch_firmware_active_; };
     // TODO #15944: Temporary api until migration to actual fabric is complete
     std::tuple<SubDeviceManagerId, SubDeviceId> create_sub_device_manager_with_fabric(
         tt::stl::Span<const SubDevice> sub_devices, DeviceAddr local_l1_size) override;
@@ -232,10 +231,6 @@ private:
     std::unique_ptr<SubDeviceManagerTracker> sub_device_manager_tracker_;
 
     bool initialized_ = false;
-    // This variable tracks the state of dispatch firmware on device.
-    // It is set to true when dispatch firmware is launched, and reset
-    // after the terimnate command is sent.
-    bool dispatch_firmware_active_ = false;
 
     std::vector<std::unique_ptr<Program>> command_queue_programs_;
     bool using_fast_dispatch_ = false;

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -58,6 +58,8 @@ public:
     bool close_device(chip_id_t device_id);
     bool close_devices(const std::vector<tt_metal::IDevice*>& devices, bool skip_synchronize = false);
     bool is_device_active(chip_id_t id) const;
+    // True if dispatch firmware is active on this device pool
+    bool is_dispatch_firmware_active() const;
     void init_profiler() const;
     void initialize_fabric_and_dispatch_fw() const;
 
@@ -72,6 +74,10 @@ private:
     bool using_fast_dispatch;
     bool init_profiler_ = true;
     bool initialize_fabric_and_dispatch_fw_ = false;
+    // This variable tracks the state of dispatch firmware on device.
+    // It is set to true when dispatch firmware is launched, and reset
+    // after the terimnate command is sent.
+    bool dispatch_firmware_active_ = false;
 
     std::mutex lock;
     std::vector<std::unique_ptr<tt_metal::IDevice>> devices;

--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -96,6 +96,7 @@ private:
     void add_devices_to_pool(const std::vector<chip_id_t>& device_ids);
     void wait_for_fabric_router_sync() const;
     tt_metal::IDevice* get_device(chip_id_t id) const;
+    void teardown_fd(const std::unordered_set<chip_id_t>& devices_to_close);
 
     static DevicePool* _inst;
 };

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -185,7 +185,6 @@ public:
     uint32_t get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const override;
     SystemMemoryManager& sysmem_manager() override;
     CommandQueue& command_queue(size_t cq_id = 0) override;
-    bool dispatch_firmware_active() const override;
 
     // Trace APIs
     void begin_trace(const uint8_t cq_id, const uint32_t tid) override;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -706,11 +706,6 @@ CommandQueue& MeshDevice::command_queue(size_t cq_id) {
     return reference_device()->command_queue(cq_id);
 }
 
-bool MeshDevice::dispatch_firmware_active() const {
-    return validate_and_get_reference_value(
-        scoped_devices_->root_devices(), [](const auto& device) { return device->dispatch_firmware_active(); });
-}
-
 // Trace management
 void MeshDevice::begin_trace(const uint8_t cq_id, const uint32_t tid) {
     TT_THROW("begin_trace() is not supported on MeshDevice");

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -992,7 +992,6 @@ void Device::init_command_queue_device() {
             sub_device_manager_tracker_->get_active_sub_device_manager()->num_sub_devices(),
             sub_device_manager_tracker_->get_active_sub_device_manager()->noc_mcast_unicast_data());
     }
-    dispatch_firmware_active_ = true;
 }
 
 void Device::init_fabric() {
@@ -1090,8 +1089,6 @@ bool Device::close() {
     if (not this->initialized_) {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
     }
-
-    dispatch_firmware_active_ = false;
 
     tt_metal::detail::DumpDeviceProfileResults(this, ProfilerDumpState::LAST_CLOSE_DEVICE);
 

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -167,173 +167,6 @@ uint32_t Device::num_worker_cores(HalProgrammableCoreType core_type, SubDeviceId
     return sub_device_manager_tracker_->get_active_sub_device_manager()->sub_device(sub_device_id).num_cores(core_type);
 }
 
-/* Get all dispatch cores associated with this device. On return, my_dispatch_cores contains dispatch cores used by
- * this device (split between cores on this device itself and if this is a remote device, the mmio device dispatch
- * cores being used by this device). On return, other_dispatch_cores contains dispatch cores on this device that are
- * used by other (remote) devices.
-*/
-void Device::get_associated_dispatch_virtual_cores(
-    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> &my_dispatch_cores,
-    std::unordered_map<chip_id_t,std::unordered_set<CoreCoord>> &other_dispatch_cores) {
-    if (this->is_mmio_capable()) {
-        for (const chip_id_t& device_id :
-             tt::tt_metal::MetalContext::instance().get_cluster().get_devices_controlled_by_mmio_device(this->id_)) {
-            uint8_t num_hw_cqs = this->num_hw_cqs();
-            uint16_t curr_channel =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
-            CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-            for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-                if (device_id == this->id_) {
-                    //mmio device.
-                    bool dispatch_hd_allocated = false;
-                    CoreCoord virtual_core_dispatch_hd;
-                    if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
-                            device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_location =
-                            MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
-                                device_id, curr_channel, cq_id);
-                        virtual_core_dispatch_hd = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
-                        my_dispatch_cores[this->id_].insert(virtual_core_dispatch_hd);
-                        dispatch_hd_allocated = true;
-                        log_debug(tt::LogMetal, "MMIO Device Dispatch core: Logical: {} - Physical: {}", dispatch_location.str(), virtual_core_dispatch_hd.str());
-                    }
-                    // Include dispatch_s in the dispatch core location set, if its not on the same core as dispatch_hd
-                    if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_s_core_allocated(
-                            device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_s_location =
-                            MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(
-                                device_id, curr_channel, cq_id);
-                        CoreCoord virtual_core_dispatch_s = this->virtual_core_from_logical_core(dispatch_s_location, dispatch_core_type);
-                        if ((!dispatch_hd_allocated) or (virtual_core_dispatch_s != virtual_core_dispatch_hd)) {
-                            my_dispatch_cores[dispatch_s_location.chip].insert(virtual_core_dispatch_s);
-                        }
-                    }
-                    if (MetalContext::instance().get_dispatch_core_manager().is_prefetcher_core_allocated(
-                            device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair prefetch_location =
-                            MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
-                                device_id, curr_channel, cq_id);
-                        CoreCoord virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
-                        my_dispatch_cores[this->id_].insert(virtual_core);
-                        log_debug(tt::LogMetal, "MMIO Device Prefetch core: Logical: {} - Physical: {}", prefetch_location.str(), virtual_core.str());
-                    }
-                } else if (tt::DevicePool::instance().is_device_active(device_id)) {
-                    //non mmio devices serviced by this mmio capable device.
-                    //skip remote dispatch cores only if respective remote device is active.
-                    if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
-                            device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair dispatch_location =
-                            MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
-                                device_id, curr_channel, cq_id);
-                        CoreCoord virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
-                        other_dispatch_cores[this->id_].insert(virtual_core);
-                        log_debug(tt::LogMetal, "Remote Device Dispatch core: Logical: {} - Physical: {} will keep running on MMIO Device.", dispatch_location.str(), virtual_core.str());
-                    }
-                    if (MetalContext::instance().get_dispatch_core_manager().is_prefetcher_core_allocated(
-                            device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair prefetch_location =
-                            MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
-                                device_id, curr_channel, cq_id);
-                        CoreCoord virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
-                        other_dispatch_cores[this->id_].insert(virtual_core);
-                        log_debug(tt::LogMetal, "Remote Device Prefetch core: Logical: {} - Physical: {} will keep running on MMIO Device.", prefetch_location.str(), virtual_core.str());
-                    }
-                    if (MetalContext::instance().get_dispatch_core_manager().is_mux_core_allocated(
-                            device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair mux_location = MetalContext::instance().get_dispatch_core_manager().mux_core(
-                            device_id, curr_channel, cq_id);
-                        CoreCoord virtual_core = this->virtual_core_from_logical_core(mux_location, dispatch_core_type);
-                        other_dispatch_cores[this->id_].insert(virtual_core);
-                        log_debug(tt::LogMetal, "Remote Device Mux core: Logical: {} - Physical: {} will keep running on MMIO Device.", mux_location.str(), virtual_core.str());
-                    }
-                    if (MetalContext::instance().get_dispatch_core_manager().is_demux_core_allocated(
-                            device_id, curr_channel, cq_id)) {
-                        tt_cxy_pair demux_location = MetalContext::instance().get_dispatch_core_manager().demux_core(
-                            device_id, curr_channel, cq_id);
-                        CoreCoord virtual_core = this->virtual_core_from_logical_core(demux_location, dispatch_core_type);
-                        other_dispatch_cores[this->id_].insert(virtual_core);
-                        log_debug(tt::LogMetal, "Remote Device Demux core: Logical: {} - Physical: {} will keep running on MMIO Device.", demux_location.str(), virtual_core.str());
-                    }
-                }
-            }
-        }
-    } else {
-        //remote device that is active
-        uint8_t num_hw_cqs = this->num_hw_cqs();
-        auto device_id = this->id_;
-        uint16_t curr_channel =
-            tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
-        CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            if (MetalContext::instance().get_dispatch_core_manager().is_dispatcher_core_allocated(
-                    device_id, curr_channel, cq_id)) {
-                tt_cxy_pair dispatch_location = MetalContext::instance().get_dispatch_core_manager().dispatcher_core(
-                    device_id, curr_channel, cq_id);
-                CoreCoord virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
-                my_dispatch_cores[dispatch_location.chip].insert(virtual_core);
-                log_debug(tt::LogMetal, "Remote Device Dispatch core: Logical: {} - Physical: {} will be reset on MMIO Device.", dispatch_location.str(), virtual_core.str());
-            }
-            if (MetalContext::instance().get_dispatch_core_manager().is_prefetcher_core_allocated(
-                    device_id, curr_channel, cq_id)) {
-                tt_cxy_pair prefetch_location = MetalContext::instance().get_dispatch_core_manager().prefetcher_core(
-                    device_id, curr_channel, cq_id);
-                CoreCoord virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
-                my_dispatch_cores[prefetch_location.chip].insert(virtual_core);
-                log_debug(tt::LogMetal, "Remote Device Prefetch core: Logical: {} - Physical: {} will be reset on MMIO Device.", prefetch_location.str(), virtual_core.str());
-            }
-            if (MetalContext::instance().get_dispatch_core_manager().is_mux_core_allocated(
-                    device_id, curr_channel, cq_id)) {
-                tt_cxy_pair mux_location =
-                    MetalContext::instance().get_dispatch_core_manager().mux_core(device_id, curr_channel, cq_id);
-                CoreCoord virtual_core = this->virtual_core_from_logical_core(mux_location, dispatch_core_type);
-                my_dispatch_cores[mux_location.chip].insert(virtual_core);
-                log_debug(tt::LogMetal, "Remote Device Mux core: Logical: {} - Physical: {} will be reset on MMIO Device.", mux_location.str(), virtual_core.str());
-            }
-            if (MetalContext::instance().get_dispatch_core_manager().is_demux_core_allocated(
-                    device_id, curr_channel, cq_id)) {
-                tt_cxy_pair demux_location =
-                    MetalContext::instance().get_dispatch_core_manager().demux_core(device_id, curr_channel, cq_id);
-                CoreCoord virtual_core = this->virtual_core_from_logical_core(demux_location, dispatch_core_type);
-                my_dispatch_cores[demux_location.chip].insert(virtual_core);
-                log_debug(tt::LogMetal, "Remote Device Demux core: Logical: {} - Physical: {} will be reset on MMIO Device.", demux_location.str(), virtual_core.str());
-            }
-        }
-        CoreCoord virtual_core;
-        tt_cxy_pair mux_location =
-            MetalContext::instance().get_dispatch_core_manager().mux_d_core(device_id, curr_channel, 0);
-        virtual_core = this->virtual_core_from_logical_core(mux_location, dispatch_core_type);
-        my_dispatch_cores[mux_location.chip].insert(virtual_core);
-        tt_cxy_pair demux_location =
-            MetalContext::instance().get_dispatch_core_manager().demux_d_core(device_id, curr_channel, 0);
-        virtual_core = this->virtual_core_from_logical_core(demux_location, dispatch_core_type);
-        my_dispatch_cores[demux_location.chip].insert(virtual_core);
-        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            tt_cxy_pair prefetch_location =
-                MetalContext::instance().get_dispatch_core_manager().prefetcher_d_core(device_id, curr_channel, cq_id);
-            virtual_core = this->virtual_core_from_logical_core(prefetch_location, dispatch_core_type);
-            my_dispatch_cores[prefetch_location.chip].insert(virtual_core);
-        }
-        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            tt_cxy_pair dispatch_location =
-                MetalContext::instance().get_dispatch_core_manager().dispatcher_d_core(device_id, curr_channel, cq_id);
-            virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
-            my_dispatch_cores[dispatch_location.chip].insert(virtual_core);
-        }
-        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-            // Include dispatch_s in the dispatch core location set, if its not on the same core as dispatch_d
-            tt_cxy_pair dispatch_location =
-                MetalContext::instance().get_dispatch_core_manager().dispatcher_d_core(device_id, curr_channel, cq_id);
-            virtual_core = this->virtual_core_from_logical_core(dispatch_location, dispatch_core_type);
-            tt_cxy_pair dispatch_s_location =
-                MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(device_id, curr_channel, cq_id);
-            CoreCoord virtual_core_dispatch_s = this->virtual_core_from_logical_core(dispatch_s_location, dispatch_core_type);
-            if (virtual_core_dispatch_s != virtual_core) {
-                my_dispatch_cores[dispatch_s_location.chip].insert(virtual_core_dispatch_s);
-            }
-        }
-    }
-}
-
 void Device::initialize_cluster() {
     ZoneScoped;
     if (tt_metal::MetalContext::instance().rtoptions().get_clear_l1()) {
@@ -657,76 +490,66 @@ void Device::reset_cores() {
         return (data[0] != 0);
     };
 
+    auto get_active_erisc_launch_flag_addr = [&]() {
+        auto core_type_idx =
+            MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
+        std::uint32_t launch_erisc_addr =
+            tt::tt_metal::MetalContext::instance().hal().get_jit_build_config(core_type_idx, 0, 0).fw_launch_addr;
+        return launch_erisc_addr;
+    };
+
+    // Send exit_erisc_kernel to the launch message
+    auto erisc_send_exit_signal = [&](CoreCoord virtual_core, bool is_idle_eth) {
+        go_msg_t go_msg;
+        std::memset(&go_msg, 0, sizeof(go_msg_t));
+        log_info(
+            tt::LogMetal,
+            "While initializing device {}, {} ethernet dispatch core {} detected as still "
+            "running, issuing exit signal.",
+            this->id(),
+            is_idle_eth ? "idle" : "active",
+            virtual_core.str());
+
+        DeviceAddr launch_addr = hal.get_dev_addr(
+            is_idle_eth ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH,
+            HalL1MemAddrType::LAUNCH);
+
+        std::vector<uint32_t> data(sizeof(launch_msg_t) / sizeof(uint32_t));
+        data = tt::llrt::read_hex_vec_from_core(this->id(), virtual_core, launch_addr, sizeof(launch_msg_t));
+
+        launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
+        launch_msg->kernel_config.exit_erisc_kernel = 1;
+        llrt::write_launch_msg_to_core(this->id(), virtual_core, launch_msg, &go_msg, launch_addr, false);
+
+        if (!is_idle_eth) {
+            // Active
+            std::vector<uint32_t> clear_flag_data = {0};
+            tt::llrt::write_hex_vec_to_core(
+                this->id(), virtual_core, clear_flag_data, get_active_erisc_launch_flag_addr());
+        }
+    };
+
     auto mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_);
     // Assert worker cores + dispatch cores, in case they were in a bad state from before.
-    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> dispatch_cores, other_dispatch_cores, device_to_early_exit_cores;
-    go_msg_t go_msg;
-    std::memset(&go_msg, 0, sizeof(go_msg_t));
+    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> device_to_early_exit_cores;
+
+    // Active ethernet
     if (hal.get_eth_fw_is_cooperative()) {
         for (const auto& eth_core : this->get_active_ethernet_cores()) {
             CoreCoord virtual_core = this->ethernet_core_from_logical_core(eth_core);
             if (erisc_app_still_running(virtual_core)) {
-                std::vector<uint32_t> data(sizeof(launch_msg_t) / sizeof(uint32_t));
-                DeviceAddr launch_addr =
-                    hal.get_dev_addr(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::LAUNCH);
-
-                data = tt::llrt::read_hex_vec_from_core(this->id(), virtual_core, launch_addr, sizeof(launch_msg_t));
-                launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
-                log_info(
-                    tt::LogMetal,
-                    "While initializing Device {}, active ethernet core {} on Device {} detected as still running, "
-                    "issuing exit signal.",
-                    this->id(),
-                    virtual_core.str(),
-                    this->id());
-                launch_msg->kernel_config.exit_erisc_kernel = 1;
-                llrt::write_launch_msg_to_core(this->id(), virtual_core, launch_msg, &go_msg, launch_addr, false);
+                erisc_send_exit_signal(virtual_core, false /* is_idle_eth */);
                 device_to_early_exit_cores[this->id()].insert(virtual_core);
-
-                // Clear launch erisc flag
-                auto core_type_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH);
-                std::uint32_t launch_erisc_addr = tt::tt_metal::MetalContext::instance()
-                                                      .hal()
-                                                      .get_jit_build_config(core_type_idx, 0, 0)
-                                                      .fw_launch_addr;
-                std::vector<uint32_t> clear_flag_data = {0};
-                tt::llrt::write_hex_vec_to_core(this->id(), virtual_core, clear_flag_data, launch_erisc_addr);
             }
         }
     }
 
-    this->get_associated_dispatch_virtual_cores(dispatch_cores, other_dispatch_cores);
-    // Ignore other_dispatch_cores, they will be reset by the devices that use them.
-    for (auto &id_and_cores : dispatch_cores) {
-        for (auto it = id_and_cores.second.begin(); it != id_and_cores.second.end(); it++) {
-            const auto &virtual_core = *it;
-            // For new FD init, we've already initialized dispatch cores on other devices, so don't reset here.
-            if (id_and_cores.first != this->id())
-                continue;
-
-            // Only need to manually reset ethernet dispatch cores, tensix cores are all reset below.
-            if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(
-                    virtual_core, id_and_cores.first)) {
-                // Ethernet cores won't be reset, so just signal the dispatch cores to early exit.
-                if (erisc_app_still_running(virtual_core)) {
-                    log_info(
-                        tt::LogMetal,
-                        "While initializing device {}, idle ethernet dispatch core {} on Device {} detected as still "
-                        "running, issuing exit signal.",
-                        this->id(),
-                        virtual_core.str(),
-                        id_and_cores.first);
-                    std::vector<uint32_t> data(sizeof(launch_msg_t) / sizeof(uint32_t));
-                    DeviceAddr launch_addr =
-                        hal.get_dev_addr(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::LAUNCH);
-                    data = tt::llrt::read_hex_vec_from_core(
-                        id_and_cores.first, virtual_core, launch_addr, sizeof(launch_msg_t));
-                    launch_msg_t* launch_msg = (launch_msg_t*)(&data[0]);
-                    launch_msg->kernel_config.exit_erisc_kernel = 1;
-                    llrt::write_launch_msg_to_core(id_and_cores.first, virtual_core, launch_msg, &go_msg, launch_addr, false);
-                    device_to_early_exit_cores[id_and_cores.first].insert(virtual_core);
-                }
-            }
+    // Idle ethernet
+    for (const auto& eth_core : this->get_inactive_ethernet_cores()) {
+        CoreCoord virtual_core = this->ethernet_core_from_logical_core(eth_core);
+        if (erisc_app_still_running(virtual_core)) {
+            erisc_send_exit_signal(virtual_core, true /* is_idle_eth */);
+            device_to_early_exit_cores[this->id()].insert(virtual_core);
         }
     }
 
@@ -751,13 +574,9 @@ void Device::reset_cores() {
         for (uint32_t x = 0; x < grid_size.x; x++) {
             CoreCoord logical_core(x, y);
             CoreCoord worker_core = this->worker_core_from_logical_core(logical_core);
-
-            // Don't reset dispatch cores for other devices, in case they're still running.
-            if (other_dispatch_cores[this->id_].find(worker_core) == other_dispatch_cores[this->id_].end()) {
-                if (this->storage_only_cores_.find(logical_core) == this->storage_only_cores_.end()) {
-                    tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
-                        tt_cxy_pair(this->id(), worker_core));
-                }
+            if (this->storage_only_cores_.find(logical_core) == this->storage_only_cores_.end()) {
+                tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
+                    tt_cxy_pair(this->id(), worker_core));
             }
         }
     }
@@ -1267,6 +1086,7 @@ bool Device::initialize(
 }
 
 bool Device::close() {
+    constexpr uint32_t k_DeviceTimeoutMs = 300000;  // 5 minutes
     log_info(tt::LogMetal, "Closing device {}", this->id_);
     if (not this->initialized_) {
         TT_THROW("Cannot close device {} that has not been initialized!", this->id_);
@@ -1288,14 +1108,10 @@ bool Device::close() {
 
     sub_device_manager_tracker_.reset(nullptr);
 
-    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> not_done_dispatch_cores;
-    std::unordered_map<chip_id_t, std::unordered_set<CoreCoord>> cores_to_skip;
-    this->get_associated_dispatch_virtual_cores(not_done_dispatch_cores, cores_to_skip);
-
-    auto mmio_device_id = tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_);
-    std::unordered_set<CoreCoord> wait_for_cores = not_done_dispatch_cores[mmio_device_id];
-
-    llrt::internal_::wait_until_cores_done(mmio_device_id, RUN_MSG_GO, wait_for_cores);
+    // Wait for dispatch cores on this device to complete
+    auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(this->id_);
+    llrt::internal_::wait_until_cores_done(this->id(), RUN_MSG_GO, dispatch_cores, k_DeviceTimeoutMs);
+    // Remaining cores in dispatch_cores have not closed in time
 
     DprintServerDetach(this->id());
     watcher_detach(this->id());
@@ -1307,7 +1123,7 @@ bool Device::close() {
             CoreCoord logical_core(x, y);
             CoreCoord worker_core = this->worker_core_from_logical_core(logical_core);
 
-            if (cores_to_skip[mmio_device_id].find(worker_core) == cores_to_skip[mmio_device_id].end()) {
+            if (!dispatch_cores.contains(worker_core)) {
                 if (this->storage_only_cores_.find(logical_core) == this->storage_only_cores_.end()) {
                     tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(
                         tt_cxy_pair(this->id(), worker_core));
@@ -1330,9 +1146,11 @@ bool Device::close() {
         }
     }
 
+    const auto mmio_device_id =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->id_);
+    // Additional reset when for remaining cores that have not closed properly
     if (this->id_ != mmio_device_id) {
-        for (auto it = not_done_dispatch_cores[mmio_device_id].begin(); it != not_done_dispatch_cores[mmio_device_id].end(); it++) {
-            const auto &virtual_core = *it;
+        for (const auto virtual_core : dispatch_cores) {
             if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, this->id_)) {
                 log_debug(tt::LogMetal, "Ethernet dispatch core {} on Device {} is idle. Closing Device {}", virtual_core.str(), mmio_device_id, this->id());
             } else {

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -25,7 +25,6 @@
 #include "fabric_host_interface.h"
 #include "fabric_types.hpp"
 #include "hal.hpp"
-#include "hal_types.hpp"
 #include "host_api.hpp"
 #include "logger.hpp"
 #include "profiler_types.hpp"
@@ -37,12 +36,21 @@
 #include "tt_metal/impl/debug/noc_logging.hpp"
 #include "tt_metal/impl/debug/watcher_server.hpp"
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/dispatch/system_memory_manager.hpp"
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/tt_core_coordinates.h>
 
 using namespace tt::tt_metal;
 
 namespace tt {
+
+namespace llrt {
+
+namespace internal_ {
+void wait_until_cores_done(
+    chip_id_t device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms);
+}  // namespace internal_
+}  // namespace llrt
 
 namespace device_cpu_allocator {
 std::unordered_map<int, std::vector<uint32_t>> get_cpu_cores_per_numa_node(std::unordered_set<uint32_t>& free_cores) {
@@ -684,6 +692,20 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
         }
     }
 
+    detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
+
+    tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
+    for (const auto& dev_id : devices_to_close) {
+        auto dev = tt::DevicePool::instance().get_active_device(dev_id);
+        dev->close();
+    }
+
+    // Terminate sent to each device. Wait for dispatch to finish
+    for (const auto& dev_id : devices_to_close) {
+        auto dispatch_cores = tt::tt_metal::get_virtual_dispatch_cores(dev_id);
+        tt::llrt::internal_::wait_until_cores_done(dev_id, RUN_MSG_GO, dispatch_cores, 0);
+    }
+
     // Terminate fabric routers
     const auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (tt::tt_fabric::is_tt_fabric_config(fabric_config) || tt::tt_fabric::is_2d_fabric_config(fabric_config)) {
@@ -705,22 +727,22 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
         }
     }
 
-    detail::ProfilerSync(ProfilerSyncState::CLOSE_DEVICE);
-
-    tt::tt_metal::MetalContext::instance().get_cluster().set_internal_routing_info_for_ethernet_cores(false);
-    bool pass = true;
-    for (const auto& dev_id : devices_to_close) {
-        auto dev = tt::DevicePool::instance().get_active_device(dev_id);
-        pass &= dev->close();
-    }
     // At this point the routing core clients (dispatch) have been terminated
     // Terminate worker routing cores on device. Remaining ethernet cores will get reset during init
     for (const auto& dev_id : devices_to_close) {
+        const auto mmio_device_id =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev_id);
         auto routing_cores = tt::tt_metal::get_virtual_dispatch_routing_cores(dev_id);
         for (const auto& core : routing_cores) {
             if (tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(core, dev_id)) {
                 continue;
             }
+            log_debug(
+                tt::LogMetal,
+                "Resetting dispatch routing core {} on Device {} when closing Device {}",
+                core.str(),
+                mmio_device_id,
+                dev_id);
             tt::tt_metal::MetalContext::instance().get_cluster().assert_risc_reset_at_core(tt_cxy_pair(dev_id, core));
         }
     }

--- a/tt_metal/impl/dispatch/kernel_config/demux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/demux.cpp
@@ -30,6 +30,8 @@ void DemuxKernel::GenerateStaticConfigs() {
         servicing_device_id_);  // TODO: this can be mmio
     logical_core_ = MetalContext::instance().get_dispatch_core_manager().demux_core(
         servicing_device_id_, channel, placement_cq_id_);
+    kernel_type_ = FDKernelType::ROUTING;
+
     static_config_.endpoint_id_start_index = 0xD1;
     static_config_.rx_queue_start_addr_words = my_dispatch_constants.dispatch_buffer_base() >> 4;
     static_config_.rx_queue_size_words = 0x10000 >> 4;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.hpp
@@ -108,6 +108,7 @@ public:
         } else if (d_variant) {
             this->logical_core_ = core_manager.dispatcher_d_core(device_id, channel, cq_id);
         }
+        this->kernel_type_ = FDKernelType::DISPATCH;
     }
 
     void CreateKernel() override;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -39,6 +39,7 @@ public:
             tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_id);
         this->logical_core_ = tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(
             device_id, channel, cq_id_);
+        this->kernel_type_ = FDKernelType::DISPATCH;
     }
     void CreateKernel() override;
     void GenerateStaticConfigs() override;

--- a/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_router.cpp
@@ -25,6 +25,8 @@ using namespace tt::tt_metal;
 
 void EthRouterKernel::GenerateStaticConfigs() {
     auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
+    kernel_type_ = FDKernelType::ROUTING;
+
     if (as_mux_) {
         uint16_t channel = tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(
             servicing_device_id_);  // TODO: can be mmio

--- a/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/eth_tunneler.cpp
@@ -40,6 +40,8 @@ void EthTunnelerKernel::GenerateStaticConfigs() {
         logical_core_ =
             MetalContext::instance().get_dispatch_core_manager().us_tunneler_core_local(device_->id(), channel, cq_id_);
     }
+    kernel_type_ = FDKernelType::ROUTING;
+
     static_config_.endpoint_id_start_index = 0xDACADACA;
     static_config_.in_queue_start_addr_words = 0x19A00 >> 4;
     // Input queue size can be extended based on number of tunnel lanes

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -14,7 +14,7 @@
 
 namespace tt::tt_metal {
 
-void FabricRouterVC::GenerateStaticConfigs() {}
+void FabricRouterVC::GenerateStaticConfigs() { kernel_type_ = FDKernelType::VIRTUAL; }
 
 void FabricRouterVC::GenerateDependentConfigs() {
     // Provide router details to upstream and downstream kernels

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -37,6 +37,13 @@ struct noc_selection_t {
     tt::tt_metal::NOC downstream_noc;    // For communicating with downstream dispatch modules
 };
 
+enum class FDKernelType : uint32_t {
+    UNSET = 0,
+    VIRTUAL,   // Not a real kernel
+    DISPATCH,  // Dispatch kernels
+    ROUTING,   // Routing/Tunneling kernels
+};
+
 static std::vector<string> dispatch_kernel_file_names = {
     "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",        // PREFETCH
     "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",        // PREFETCH_HD
@@ -113,6 +120,7 @@ public:
     virtual CoreType GetCoreType() {
         return tt::tt_metal::MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
     }
+    FDKernelType GetKernelType() { return kernel_type_; }
     tt_cxy_pair GetLogicalCore() { return logical_core_; }
     tt_cxy_pair GetVirtualCore() {
         return tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
@@ -153,6 +161,7 @@ protected:
     tt::tt_metal::IDevice* device_ = nullptr;  // Set at configuration time by AddDeviceAndProgram()
     tt::tt_metal::Program* program_ = nullptr;
     tt_cxy_pair logical_core_;
+    FDKernelType kernel_type_;
     chip_id_t device_id_;
     chip_id_t servicing_device_id_;  // Remote chip that this PREFETCH_H/DISPATCH_H is servicing
     int node_id_;

--- a/tt_metal/impl/dispatch/kernel_config/mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/mux.cpp
@@ -6,7 +6,6 @@
 #include <host_api.hpp>
 #include <map>
 #include <string>
-#include <utility>
 #include <variant>
 #include <vector>
 
@@ -18,7 +17,6 @@
 #include "dispatch/dispatch_settings.hpp"
 #include "dispatch_core_common.hpp"
 #include "eth_tunneler.hpp"
-#include "hal.hpp"
 #include "utils.hpp"
 
 using namespace tt::tt_metal;
@@ -28,6 +26,7 @@ void MuxKernel::GenerateStaticConfigs() {
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
     logical_core_ =
         MetalContext::instance().get_dispatch_core_manager().mux_d_core(device_->id(), channel, this->cq_id_);
+    kernel_type_ = FDKernelType::ROUTING;
     auto& my_dispatch_constants = MetalContext::instance().dispatch_mem_map(GetCoreType());
     static_config_.reserved = 0;
     static_config_.rx_queue_start_addr_words = my_dispatch_constants.dispatch_buffer_base() >> 4;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.hpp
@@ -100,6 +100,7 @@ public:
         } else if (d_variant) {
             this->logical_core_ = core_manager.prefetcher_d_core(device_id, channel, cq_id);
         }
+        this->kernel_type_ = FDKernelType::DISPATCH;
     }
     void CreateKernel() override;
     void GenerateStaticConfigs() override;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <initializer_list>
 #include <map>
+#include <typeinfo>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -880,6 +881,10 @@ std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
 
     // Register core coordinates for this device
     for (auto node_and_kernel : node_id_to_kernel) {
+        if (node_and_kernel->GetDeviceId() != device->id()) {
+            continue;
+        }
+
         switch (node_and_kernel->GetKernelType()) {
             case FDKernelType::DISPATCH: dispatch_cores[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
             case FDKernelType::ROUTING: routing_cores[device->id()].insert(node_and_kernel->GetVirtualCore()); break;
@@ -889,8 +894,9 @@ std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
             default:
                 TT_FATAL(
                     false,
-                    "Unknown kernel type {} on Device {}",
+                    "Unknown kernel type {} {} on Device {}",
                     magic_enum::enum_name(node_and_kernel->GetKernelType()),
+                    typeid(*node_and_kernel).name(),
                     device->id());
                 break;
         }

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -893,9 +893,8 @@ std::unique_ptr<Program> create_and_compile_cq_program(IDevice* device) {
             case FDKernelType::VIRTUAL:
                 // Not a real kernel
                 break;
-            default:
-                TT_FATAL(
-                    false,
+            case FDKernelType::UNSET:
+                TT_THROW(
                     "Unknown kernel type {} {} on Device {}",
                     magic_enum::enum_name(node_and_kernel->GetKernelType()),
                     typeid(*node_and_kernel).name(),

--- a/tt_metal/impl/dispatch/topology.hpp
+++ b/tt_metal/impl/dispatch/topology.hpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <vector>
 
+#include "core_coord.hpp"
 #include "data_types.hpp"
 #include "tt-metalium/program.hpp"
 #include "tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp"
@@ -59,5 +60,11 @@ std::unique_ptr<tt::tt_metal::Program> create_and_compile_fabric_program(tt::tt_
 
 // Perform additional configuration (writing to specific L1 addresses, etc.) for fabric kernels on this device.
 void configure_fabric_cores(tt::tt_metal::IDevice* device);
+
+// Return the virtual dispatch cores running on a given device
+const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(chip_id_t dev_id);
+
+// Return the virtual cores used for dispatch routing/tunneling on a given device
+const std::unordered_set<CoreCoord>& get_virtual_dispatch_routing_cores(chip_id_t dev_id);
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -5,6 +5,7 @@
 #include "dev_msgs.h"
 #include <device.hpp>
 #include <distributed.hpp>
+#include "device_pool.hpp"
 #include "tools/profiler/event_metadata.hpp"
 #include "distributed/fd_mesh_command_queue.hpp"
 #include <host_api.hpp>
@@ -35,6 +36,7 @@
 #include <umd/device/tt_core_coordinates.h>
 #include <umd/device/types/arch.h>
 #include <umd/device/types/xy_pair.h>
+#include <tt-metalium/device_pool.hpp>
 
 namespace tt {
 
@@ -45,7 +47,7 @@ static kernel_profiler::PacketTypes get_packet_type(uint32_t timer_id) {
 }
 
 void issue_fd_write_to_profiler_buffer(distributed::AnyBuffer& buffer, IDevice* device, std::vector<uint32_t>& data) {
-    TT_ASSERT(device->dispatch_firmware_active());
+    TT_ASSERT(tt::DevicePool::instance().is_dispatch_firmware_active());
     if (auto mesh_device = device->get_mesh_device()) {
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
         distributed::WriteShard(mesh_device->mesh_command_queue(), buffer.get_mesh_buffer(), data, device_coord, true);
@@ -56,7 +58,7 @@ void issue_fd_write_to_profiler_buffer(distributed::AnyBuffer& buffer, IDevice* 
 
 void issue_fd_read_from_profiler_buffer(
     const distributed::AnyBuffer& buffer, IDevice* device, std::vector<uint32_t>& host_data) {
-    TT_ASSERT(device->dispatch_firmware_active());
+    TT_ASSERT(tt::DevicePool::instance().is_dispatch_firmware_active());
     if (auto mesh_device = device->get_mesh_device()) {
         const distributed::MeshCoordinate device_coord = mesh_device->get_view().find_device(device->id());
         distributed::ReadShard(
@@ -71,7 +73,7 @@ std::vector<uint32_t> read_control_buffer_from_core(
     std::vector<uint32_t> control_buffer;
     profiler_msg_t* profiler_msg =
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    if (device->dispatch_firmware_active()) {
+    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
             if (core_type == HalProgrammableCoreType::TENSIX) {
                 distributed::FDMeshCommandQueue& mesh_cq =
@@ -118,7 +120,7 @@ void write_control_buffer_to_core(
     const std::vector<uint32_t>& control_buffer) {
     profiler_msg_t* profiler_msg =
         MetalContext::instance().hal().get_dev_addr<profiler_msg_t*>(core_type, HalL1MemAddrType::PROFILER);
-    if (device->dispatch_firmware_active()) {
+    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
             if (core_type == HalProgrammableCoreType::TENSIX) {
                 distributed::FDMeshCommandQueue& mesh_cq =

--- a/tt_metal/impl/profiler/tt_metal_profiler.cpp
+++ b/tt_metal/impl/profiler/tt_metal_profiler.cpp
@@ -56,6 +56,7 @@
 #include "profiler_state.hpp"
 #include "profiler_types.hpp"
 #include "tt-metalium/program.hpp"
+#include <tt-metalium/device_pool.hpp>
 #include "rtoptions.hpp"
 #include "tracy/Tracy.hpp"
 #include "tracy/TracyTTDevice.hpp"
@@ -181,7 +182,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
             .defines = kernel_defines});
 
     // Using MeshDevice APIs if the current device is managed by MeshDevice
-    if (device->dispatch_firmware_active()) {
+    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
             auto device_coord = mesh_device->get_view().find_device(device_id);
             distributed::MeshWorkload workload;
@@ -220,7 +221,7 @@ void syncDeviceHost(IDevice* device, CoreCoord logical_core, bool doHeader) {
             &sinceStart, tt_cxy_pair(device_id, core), control_addr);
         writeTimes[i] = (TracyGetCpuTime() - writeStart);
     }
-    if (device->dispatch_firmware_active()) {
+    if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
         if (auto mesh_device = device->get_mesh_device()) {
             mesh_device->mesh_command_queue().finish();
         } else {
@@ -750,7 +751,7 @@ void InitDeviceProfiler(IDevice* device) {
 
         std::vector<uint32_t> inputs_DRAM(output_dram_buffer_ptr->size() / sizeof(uint32_t), 0);
 
-        if (device->dispatch_firmware_active()) {
+        if (tt::DevicePool::instance().is_dispatch_firmware_active()) {
             issue_fd_write_to_profiler_buffer(profiler.output_dram_buffer, device, inputs_DRAM);
         } else {
             tt_metal::detail::WriteToBuffer(*(profiler.output_dram_buffer.get_buffer()), inputs_DRAM);

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -246,7 +246,8 @@ void wait_until_cores_done(
 
         // Print not-done cores
         if (loop_count % 1000 == 0) {
-            log_debug(tt::LogMetal, "Not done phys cores: {}", fmt::join(not_done_phys_cores, " "));
+            log_debug(
+                tt::LogMetal, "Device {}: Not done phys cores: {}", device_id, fmt::join(not_done_phys_cores, " "));
             usleep(100000);
         }
 
@@ -256,7 +257,7 @@ void wait_until_cores_done(
             bool is_done = llrt::internal_::check_if_riscs_on_specified_core_done(device_id, phys_core, run_state);
 
             if (is_done) {
-                log_debug(tt::LogMetal, "Phys cores just done: {}", phys_core.str());
+                log_debug(tt::LogMetal, "Device {}: Phys cores just done: {}", device_id, phys_core.str());
                 it = not_done_phys_cores.erase(it);
             } else {
                 ++it;

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -14,34 +14,34 @@ int main() {
     constexpr CoreCoord core = {0, 0};
     int device_id = 0;
     IDevice* device = CreateDevice(device_id);
-    CommandQueue& cq = device->command_queue();
-    Program program = CreateProgram();
+    // CommandQueue& cq = device->command_queue();
+    // Program program = CreateProgram();
 
-    // Configure and Create Void DataMovement Kernels
+    // // Configure and Create Void DataMovement Kernels
 
-    KernelHandle void_dataflow_kernel_noc0_id = CreateKernel(
-        program,
-        "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    // KernelHandle void_dataflow_kernel_noc0_id = CreateKernel(
+    //     program,
+    //     "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
+    //     core,
+    //     DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    KernelHandle void_dataflow_kernel_noc1_id = CreateKernel(
-        program,
-        "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    // KernelHandle void_dataflow_kernel_noc1_id = CreateKernel(
+    //     program,
+    //     "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
+    //     core,
+    //     DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    // Configure Program and Start Program Execution on Device
+    // // Configure Program and Start Program Execution on Device
 
-    SetRuntimeArgs(program, void_dataflow_kernel_noc0_id, core, {});
-    SetRuntimeArgs(program, void_dataflow_kernel_noc1_id, core, {});
-    EnqueueProgram(cq, program, false);
-    printf("Hello, Core {0, 0} on Device 0, I am sending you some data. Standby awaiting communication.\n");
+    // SetRuntimeArgs(program, void_dataflow_kernel_noc0_id, core, {});
+    // SetRuntimeArgs(program, void_dataflow_kernel_noc1_id, core, {});
+    // EnqueueProgram(cq, program, false);
+    // printf("Hello, Core {0, 0} on Device 0, I am sending you some data. Standby awaiting communication.\n");
 
-    // Wait Until Program Finishes, Print "Hello World!", and Close Device
+    // // Wait Until Program Finishes, Print "Hello World!", and Close Device
 
-    Finish(cq);
-    printf("Thank you, Core {0, 0} on Device 0, for the completed task.\n");
+    // Finish(cq);
+    // printf("Thank you, Core {0, 0} on Device 0, for the completed task.\n");
     CloseDevice(device);
 
     return 0;

--- a/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datamovement_kernel/hello_world_datamovement_kernel.cpp
@@ -14,34 +14,34 @@ int main() {
     constexpr CoreCoord core = {0, 0};
     int device_id = 0;
     IDevice* device = CreateDevice(device_id);
-    // CommandQueue& cq = device->command_queue();
-    // Program program = CreateProgram();
+    CommandQueue& cq = device->command_queue();
+    Program program = CreateProgram();
 
-    // // Configure and Create Void DataMovement Kernels
+    // Configure and Create Void DataMovement Kernels
 
-    // KernelHandle void_dataflow_kernel_noc0_id = CreateKernel(
-    //     program,
-    //     "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
-    //     core,
-    //     DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    KernelHandle void_dataflow_kernel_noc0_id = CreateKernel(
+        program,
+        "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    // KernelHandle void_dataflow_kernel_noc1_id = CreateKernel(
-    //     program,
-    //     "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
-    //     core,
-    //     DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    KernelHandle void_dataflow_kernel_noc1_id = CreateKernel(
+        program,
+        "tt_metal/programming_examples/hello_world_datamovement_kernel/kernels/dataflow/void_dataflow_kernel.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
 
-    // // Configure Program and Start Program Execution on Device
+    // Configure Program and Start Program Execution on Device
 
-    // SetRuntimeArgs(program, void_dataflow_kernel_noc0_id, core, {});
-    // SetRuntimeArgs(program, void_dataflow_kernel_noc1_id, core, {});
-    // EnqueueProgram(cq, program, false);
-    // printf("Hello, Core {0, 0} on Device 0, I am sending you some data. Standby awaiting communication.\n");
+    SetRuntimeArgs(program, void_dataflow_kernel_noc0_id, core, {});
+    SetRuntimeArgs(program, void_dataflow_kernel_noc1_id, core, {});
+    EnqueueProgram(cq, program, false);
+    printf("Hello, Core {0, 0} on Device 0, I am sending you some data. Standby awaiting communication.\n");
 
-    // // Wait Until Program Finishes, Print "Hello World!", and Close Device
+    // Wait Until Program Finishes, Print "Hello World!", and Close Device
 
-    // Finish(cq);
-    // printf("Thank you, Core {0, 0} on Device 0, for the completed task.\n");
+    Finish(cq);
+    printf("Thank you, Core {0, 0} on Device 0, for the completed task.\n");
     CloseDevice(device);
 
     return 0;


### PR DESCRIPTION
### Ticket
#18726

### Problem description
- Simplify device init reset/close. For FD on Fabric, we need to be able to stall on dispatch, then stall on mux, and finally terminate fabric.
- It's difficult to do this right now with the current implementation because dispatch core manager can query by servicing device id but not which device the core has been allocated on.

### What's changed
- Topology to register which cores have been used for dispatch or routing
- Simplify device termination.
  - Device level: assert all worker / non dispatch / routing cores to be done.
  - Device pool level: Terminate dispatch kernels. Stall for all dispatch cores on the MMIO chip to be done. and then terminate the fabric routers. Once the MMIO chip cores are done it means the remote ones are done as well because at the end of the dispatch kernels it syncs for other dispatch kernels to return all credits.
- Remove get_associated_dispatch_virtual_cores from Device
- Moved `is_dispatch_firmware_active_` from Device to DevicePool

### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15142164071
BH
https://github.com/tenstorrent/tt-metal/actions/runs/15142169958
T3k
https://github.com/tenstorrent/tt-metal/actions/runs/15052398907
https://github.com/tenstorrent/tt-metal/actions/runs/15077426660
TG
https://github.com/tenstorrent/tt-metal/actions/runs/15073424560