### PR TITLE
Increase trace buffer size

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -319,7 +319,7 @@ def run_reduce_scatter_test(
     "device_params",
     [
         {
-            "trace_region_size": 233472,
+            "trace_region_size": 237568,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "fabric_config": ttnn.FabricConfig.FABRIC_1D,
         }


### PR DESCRIPTION
Increase trace buffer size to fix tg nightly test failure.
After 1D/2D fabric code unification changes, trace buffer size requirement has increased.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes