### PR TITLE
Assert page capacity in tests

### DIFF
--- a/models/tt_transformers/tests/test_accuracy.py
+++ b/models/tt_transformers/tests/test_accuracy.py
@@ -10,7 +10,12 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.tt_transformers.tt.common import PagedAttentionConfig, get_prefill_rot_mat, preprocess_inputs_prefill
+from models.tt_transformers.tt.common import (
+    PagedAttentionConfig,
+    get_prefill_rot_mat,
+    preprocess_inputs_prefill,
+    validate_paged_attention_capacity,
+)
 from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
 
@@ -181,6 +186,12 @@ def test_tt_model_acc(
         paged_attention_config = PagedAttentionConfig(
             block_size=page_params["page_block_size"],
             max_num_blocks=page_params["page_max_num_blocks"],
+        )
+        validate_paged_attention_capacity(
+            page_block_size=page_params["page_block_size"],
+            page_max_num_blocks=page_params["page_max_num_blocks"],
+            batch_size=batch_size,
+            required_tokens_per_user=prefill_len + decode_len,
         )
         # Implied shuffling of blocks
         permutation = torch.randperm(paged_attention_config.max_num_blocks)

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -533,3 +533,12 @@ def create_tt_model(
     tt_kv_cache = [l.attention.layer_past for l in model.layers] if paged_attention_config else None
 
     return tt_model_args, model, tt_kv_cache, state_dict
+
+
+def validate_paged_attention_capacity(page_block_size, page_max_num_blocks, batch_size, required_tokens_per_user):
+    available_tokens_per_user = (page_block_size * page_max_num_blocks) / batch_size
+    assert required_tokens_per_user <= available_tokens_per_user, (
+        f"PagedAttention underprovisioned: "
+        f"requires {required_tokens_per_user} tokens/user but only {available_tokens_per_user:.0f} available "
+        f"(block_size={page_block_size}, blocks={page_max_num_blocks}, batch_size={batch_size})"
+    )


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21055

### Problem description
When increasing the number of generated tokens and prompt without increasing the page cache, we get ~0% accuracy results. This seemed to cause the accuracy drop in the ticket above.

### What's changed
Moved the assertion from https://github.com/tenstorrent/tt-metal/pull/22014 into a common place, and used that assertion also for the accuracy test.