### PR TITLE
Support sharded row major embeddding

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/test_embedding.py
@@ -413,6 +413,65 @@ def test_tg_llama_sharded_embedding(
     output_tensor = ttnn.reshape(
         output_tensor,
         ttnn.Shape((batch_size, 1, hidden_embedding_dim)),
+        ttnn.Shape((batch_size, 32, hidden_embedding_dim)),
     )
     output_tensor = ttnn.to_torch(output_tensor)
     assert_with_pcc(output_tensor, torch_output_tensor[:, 0, :].unsqueeze(1))
+
+
+@run_for_wormhole_b0()
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}],
+    indirect=True,
+)
+def test_tg_llama_sharded_rm_embedding(device, use_program_cache):
+    torch.manual_seed(1234)
+    unharvested_grid_size = (7, 10)
+    compute_grid_size = device.compute_with_storage_grid_size()
+    if unharvested_grid_size[0] > compute_grid_size.x or unharvested_grid_size[1] > compute_grid_size.y:
+        pytest.skip(f"Need {unharvested_grid_size} grid size to run this test but core grid is {compute_grid_size}")
+    batch_size = 8
+    vocabulary_size = 4096
+    hidden_embedding_dim = 128
+    torch_input_tensor = torch.randint(0, vocabulary_size - 1, (1, batch_size))
+    torch_weights = torch.randn(vocabulary_size, hidden_embedding_dim)
+    torch_output_tensor = torch.nn.functional.embedding(torch_input_tensor, torch_weights)
+
+    start_core = ttnn.CoreCoord(1, 0)
+    core_grid = ttnn.CoreRangeSet(
+        [
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(3, 9)),
+            ttnn.CoreRange(ttnn.CoreCoord(5, 0), ttnn.CoreCoord(6, 9)),
+        ]
+    )
+    num_cores = batch_size
+    shard_grid = ttnn.num_cores_to_corerangeset_in_subcoregrids(start_core, num_cores, core_grid, row_wise=True)
+    shard_spec = ttnn.ShardSpec(
+        shard_grid,
+        (batch_size // num_cores, hidden_embedding_dim),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    output_mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        shard_spec,
+    )
+
+    input_tensor = ttnn.as_tensor(
+        torch_input_tensor, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    weights = ttnn.as_tensor(
+        torch_weights,
+        device=device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    for i in range(2):
+        output_tensor = ttnn.embedding(
+            input_tensor, weights, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=output_mem_config
+        )
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_with_pcc(output_tensor, torch_output_tensor)
+    assert device.num_program_cache_entries() == 1

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -40,7 +40,6 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
             TT_FATAL(weights.get_padded_shape()[-1] % shard_spec->shape[1] == 0, "Number of columns in table {} must be factor of shard width {}", weights.get_padded_shape()[-1], shard_spec->shape[1]);
         }
     } else {
-        TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED, "Embedding only supports interleaved RM outputs");
         TT_FATAL(!is_block_float(this->output_dtype), "Output cannot be a block float dtype when not tilized");
     }
     if(a.get_layout() == Layout::ROW_MAJOR) {

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -40,13 +40,13 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
             TT_FATAL(weights.get_padded_shape()[-1] % shard_spec->shape[1] == 0, "Number of columns in table {} must be factor of shard width {}", weights.get_padded_shape()[-1], shard_spec->shape[1]);
         }
     } else {
+        if (is_sharded(this->output_mem_config.memory_layout())) {
+            TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED, "Embedding only supports height sharded Row Major outputs");
+        }
         TT_FATAL(!is_block_float(this->output_dtype), "Output cannot be a block float dtype when not tilized");
     }
     if(a.get_layout() == Layout::ROW_MAJOR) {
         TT_FATAL(a.get_padded_shape()[1] == 1 && a.get_padded_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
-        if (is_sharded(this->output_mem_config.memory_layout())) {
-            TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED, "Embedding only supports height sharded Row Major outputs");
-        }
     }
     switch (this->embeddings_type) {
         case EmbeddingsType::PADDED: TT_FATAL(this->pad_token.has_value(), "Pad token must be specified when PADDED Embeddings Type is specified"); break;

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -44,6 +44,9 @@ void Embeddings::validate(const std::vector<Tensor> &input_tensors) const {
     }
     if(a.get_layout() == Layout::ROW_MAJOR) {
         TT_FATAL(a.get_padded_shape()[1] == 1 && a.get_padded_shape()[2] == 1, "Only dim 0 && 3 for the input can be non 1");
+        if (is_sharded(this->output_mem_config.memory_layout())) {
+            TT_FATAL(this->output_mem_config.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED, "Embedding only supports height sharded Row Major outputs");
+        }
     }
     switch (this->embeddings_type) {
         case EmbeddingsType::PADDED: TT_FATAL(this->pad_token.has_value(), "Pad token must be specified when PADDED Embeddings Type is specified"); break;

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_program_factory.hpp
@@ -403,6 +403,8 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     bool weights_is_dram = weights.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
     bool out_is_dram = output.buffer()->buffer_type() == tt_metal::BufferType::DRAM ? 1 : 0;
 
+    bool output_sharded = is_sharded(output.buffer()->buffer_layout());
+
     uint32_t input_element_size_bytes = a.element_size();
     uint32_t weights_element_size_bytes = weights.element_size();
     uint32_t output_element_size_bytes = output.element_size();
@@ -433,8 +435,28 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_blocks_per_core_group_1, num_blocks_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, problem_size);
+    uint32_t num_cores, num_blocks_per_core_group_1, num_blocks_per_core_group_2;
+    CoreRangeSet all_cores, core_group_1, core_group_2;
+    bool row_major;
+    if (output_sharded) {
+        const auto& shard_spec = output.shard_spec().value();
+        all_cores = shard_spec.grid;
+        core_group_1 = all_cores;
+        num_cores = all_cores.num_cores();
+        num_blocks_per_core_group_1 = shard_spec.shape[0];
+        num_blocks_per_core_group_2 = 0;
+        row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
+    } else {
+        std::tie(
+            num_cores,
+            all_cores,
+            core_group_1,
+            core_group_2,
+            num_blocks_per_core_group_1,
+            num_blocks_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, problem_size);
+        row_major = false;
+    }
     uint32_t g1_numcores = core_group_1.num_cores();
     uint32_t g2_numcores = core_group_2.num_cores();
 
@@ -444,12 +466,15 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     tt::DataFormat weights_cb_data_format = tt_metal::datatype_to_dataformat_converter(weights.get_dtype());
     tt::DataFormat output_cb_data_format = tt_metal::datatype_to_dataformat_converter(output.get_dtype());
 
-    constexpr uint32_t src0_cb_index = CBIndex::c_0;
+    constexpr uint32_t out_cb_index = CBIndex::c_0;
     uint32_t rounded_weight_page_size = round_up_to_mul32(weight_page_size);
-    tt_metal::CircularBufferConfig cb_src0_config =
-        tt_metal::CircularBufferConfig(2 * rounded_weight_page_size, {{src0_cb_index, weights_cb_data_format}})
-            .set_page_size(src0_cb_index, rounded_weight_page_size);
-    auto cb_src0 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src0_config);
+    tt_metal::CircularBufferConfig cb_out_config =
+        tt_metal::CircularBufferConfig(rounded_weight_page_size, {{out_cb_index, weights_cb_data_format}})
+            .set_page_size(out_cb_index, rounded_weight_page_size);
+    if (output_sharded) {
+        cb_out_config.set_globally_allocated_address(*out_buffer);
+    }
+    auto cb_out = tt_metal::CreateCircularBuffer(program, all_cores, cb_out_config);
 
     constexpr uint32_t src1_cb_index = CBIndex::c_1;
     uint32_t index_page_size = round_up_to_mul32(input_element_size_bytes);
@@ -457,8 +482,6 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
         tt_metal::CircularBufferConfig(block_height * index_page_size, {{src1_cb_index, input_cb_data_format}})
             .set_page_size(src1_cb_index, block_height * index_page_size);
     auto cb_src1 = tt_metal::CreateCircularBuffer(program, all_cores, cb_src1_config);
-
-    constexpr uint32_t output_cb_index = src0_cb_index;
 
     constexpr uint32_t src2_cb_index = CBIndex::c_2;
     if (embeddings_type == EmbeddingsType::PADDED) {
@@ -478,7 +501,7 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     // Create Kernels
     // reader
     std::vector<uint32_t> embedding_compile_time_args = {
-        (std::uint32_t)src0_cb_index,
+        (std::uint32_t)out_cb_index,
         (std::uint32_t)src1_cb_index,
         (std::uint32_t)src2_cb_index,
         (std::uint32_t)in0_is_dram,
@@ -508,23 +531,27 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     bool output_stick_size_is_power_of_two = is_power_of_two_at_least_32(output_page_size);
     uint32_t output_log2_stick_size =
         output_stick_size_is_power_of_two ? (std::uint32_t)std::log2(output_page_size) : 0;
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)out_is_dram,
-        (std::uint32_t)output_stick_size_is_power_of_two,
-        (std::uint32_t)output_log2_stick_size};
 
     // Tilized writer
-    auto writer_kernel_id = tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp",
-        all_cores,
-        tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    KernelHandle writer_kernel_id = 0;
+    if (!output_sharded) {
+        std::vector<uint32_t> writer_compile_time_args = {
+            (std::uint32_t)out_cb_index,
+            (std::uint32_t)out_is_dram,
+            (std::uint32_t)output_stick_size_is_power_of_two,
+            (std::uint32_t)output_log2_stick_size};
+
+        writer_kernel_id = tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp",
+            all_cores,
+            tt_metal::WriterDataMovementConfig(writer_compile_time_args));
+    }
 
     uint32_t input_offset = 0;
     uint32_t weight_offset = 0;
 
-    auto cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, false);
+    auto cores = corerange_to_cores(all_cores, std::nullopt, row_major);
     std::vector<uint32_t> reader_runtime_args = {
         (std::uint32_t)a.buffer()->address(),
         (std::uint32_t)weights.buffer()->address(),
@@ -555,7 +582,7 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
         }
 
         // Writer
-        {
+        if (!output_sharded) {
             writer_runtime_args[2] = local_num_blocks;
             writer_runtime_args[3] = input_offset;
             tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_runtime_args);
@@ -565,15 +592,20 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
     }
 
     auto override_runtime_arguments_callback =
-        [reader_kernel_id, writer_kernel_id, cores](
+        [reader_kernel_id, writer_kernel_id, cores, cb_out, output_sharded](
             const void* operation,
             Program& program,
             const std::vector<Tensor>& input_tensors,
             const std::vector<std::optional<const Tensor>>& optional_input_tensors,
             const std::vector<Tensor>& output_tensors) {
-            auto output_buffer_address = output_tensors.at(0).buffer()->address();
+            auto output_buffer = output_tensors.at(0).buffer();
+            auto output_buffer_address = output_buffer->address();
             auto input_buffer_address = input_tensors.at(0).buffer()->address();
             auto weights_buffer_address = input_tensors.at(1).buffer()->address();
+
+            if (output_sharded) {
+                UpdateDynamicCircularBufferAddress(program, cb_out, *output_buffer);
+            }
 
             auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
             auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
@@ -585,7 +617,7 @@ tt::tt_metal::operation::ProgramWithCallbacks embeddings_rm(
                     runtime_args[1] = weights_buffer_address;
                 }
 
-                {
+                if (!output_sharded) {
                     auto& runtime_args = writer_runtime_args[core.x][core.y];
                     runtime_args[0] = output_buffer_address;
                 }


### PR DESCRIPTION
### Problem description
Presently, ttnn.embedding Op doesn't support sharded row major output. This PR modifies existing row_major program factory to support sharded outputs.

### What's changed
1. updated embedding_rm program factory
2. added pytest for row major llama case
3. fixed tiled embedding pytest

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15009461018) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes