### PR TITLE
[DM]: Pytest plot enhancements

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/test_unary_dram.cpp
@@ -149,20 +149,21 @@ bool run_dm(IDevice* device, const DramConfig& test_config) {
 /* ========== Test case for varying transaction numbers and sizes; Test id = 0 ========== */
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPacketSizes) {
     // Parameters
-    uint32_t max_transactions = 64;            // Bound for testing different number of transactions
+    uint32_t max_transactions = 256;           // Bound for testing different number of transactions
     uint32_t max_transaction_size_pages = 64;  // Bound for testing different transaction sizes
-    uint32_t page_size_bytes = 32;            // Page size in bytes (=flit size): 32 bytes for WH, 64 for BH
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes *= 2;
-    }
+    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     // Cores
     CoreRange core_range({0, 0}, {0, 0});
     CoreRangeSet core_range_set({core_range});
 
-    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 2) {
+    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
              transaction_size_pages *= 2) {
+            if (num_of_transactions * transaction_size_pages * page_size_bytes >= 1024 * 1024) {
+                continue;
+            }
+
             // Test config
             unit_tests::dm::dram::DramConfig test_config = {
                 .test_id = 0,
@@ -184,10 +185,7 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedPacketSizes) {
 TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedCoreLocations) {
     uint32_t num_of_transactions = 1;     // Bound for testing different number of transactions
     uint32_t transaction_size_pages = 1;  // Bound for testing different transaction sizes
-    uint32_t page_size_bytes = 32;        // Page size in bytes (=flit size): 32 bytes for WH, 64 for BH
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes *= 2;
-    }
+    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     for (unsigned int id = 0; id < num_devices_; id++) {
         // Cores
@@ -218,10 +216,7 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMInterleavedCoreLocations) {
 TEST_F(DeviceFixture, TensixDataMovementDRAMSharded) {
     // Parameters
     uint32_t max_tensor_dim_pages = 1;  // Arbitrary tensor for sharding
-    uint32_t page_size_bytes = 32;      // Page size in bytes (=flit size): 32 bytes for WH, 64 for BH
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes *= 2;
-    }
+    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     // 2 * 1024 * 1024 * 1024   = dram bank size / max shard size
     // x * x * 64        = shard size where x is one dim of tensor_shape_in_pages
@@ -274,10 +269,7 @@ TEST_F(DeviceFixture, TensixDataMovementDRAMDirectedIdeal) {
     // Parameters
     uint32_t num_of_transactions = 180;
     uint32_t transaction_size_pages = 4 * 32;
-    uint32_t page_size_bytes = 32;  // (=flit size): 32 bytes for WH, 64 for BH
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes *= 2;
-    }
+    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
     // Max transaction size = 4 * 32 pages = 128 * 32 bytes = 4096 bytes for WH; 8192 bytes for BH
     // Max total transaction size = 180 * 8192 bytes = 1474560 bytes = 1.4 MB = L1 capacity
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/test_one_from_one.cpp
@@ -139,20 +139,21 @@ bool run_dm(IDevice* device, const OneFromOneConfig& test_config) {
 /* ========== Test case for one from one data movement; Test id = 5 ========== */
 TEST_F(DeviceFixture, TensixDataMovementOneFromOnePacketSizes) {
     // Parameters
-    uint32_t max_transactions = 64;
+    uint32_t max_transactions = 256;
     uint32_t max_transaction_size_pages = 64;
-    uint32_t page_size_bytes = 32;  // =Flit size: 32 bytes for WH, 64 for BH
-    if (arch_ == tt::ARCH::BLACKHOLE) {
-        page_size_bytes *= 2;
-    }
+    uint32_t page_size_bytes = arch_ == tt::ARCH::BLACKHOLE ? 64 : 32;  // =Flit size: 32 bytes for WH, 64 for BH
 
     // Cores
     CoreCoord master_core_coord = {0, 0};
     CoreCoord subordinate_core_coord = {1, 1};
 
-    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 2) {
+    for (uint32_t num_of_transactions = 1; num_of_transactions <= max_transactions; num_of_transactions *= 4) {
         for (uint32_t transaction_size_pages = 1; transaction_size_pages <= max_transaction_size_pages;
              transaction_size_pages *= 2) {
+            if (num_of_transactions * transaction_size_pages * page_size_bytes >= 1024 * 1024) {
+                continue;
+            }
+
             // Test config
             unit_tests::dm::core_to_core::OneFromOneConfig test_config = {
                 .test_id = 5,

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -471,12 +471,21 @@ def plot_dm_stats(dm_stats, output_file="dm_stats_plot.png", arch="blackhole"):
 
         # Plot durations
         ax = axes[0]
-        ax.plot(riscv_1_durations, label="RISCV 1 Duration (cycles)", marker="o")
-        ax.plot(riscv_0_durations, label="RISCV 0 Duration (cycles)", marker="o")
+        lines = []
+        labels = []
+        if riscv_1_durations:
+            (line1,) = ax.plot(riscv_1_durations, label="RISCV 1 Duration (cycles)", marker="o")
+            lines.append(line1)
+            labels.append("RISCV 1 Duration (cycles)")
+        if riscv_0_durations:
+            (line0,) = ax.plot(riscv_0_durations, label="RISCV 0 Duration (cycles)", marker="o")
+            lines.append(line0)
+            labels.append("RISCV 0 Duration (cycles)")
         ax.set_xlabel("Index")
         ax.set_ylabel("Duration (cycles)")
         ax.set_title("Kernel Durations")
-        ax.legend()
+        if lines:
+            ax.legend(lines, labels)
         ax.grid()
 
         # Plot size of data transferred vs bandwidth

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -100,8 +100,8 @@ test_bounds = {
     },
     "blackhole": {
         0: {
-            "riscv_1": {"latency": {"lower": 500, "upper": 42000}, "bandwidth": 0.12},
-            "riscv_0": {"latency": {"lower": 400, "upper": 28000}, "bandwidth": 0.15},
+            "riscv_1": {"latency": {"lower": 400, "upper": 17000}, "bandwidth": 0.12},
+            "riscv_0": {"latency": {"lower": 300, "upper": 16000}, "bandwidth": 0.15},
         },
         1: {
             "riscv_1": {"latency": {"lower": 300, "upper": 700}, "bandwidth": 0.17},
@@ -116,11 +116,11 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 34},
         },
         4: {
-            "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},
-            "riscv_0": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
+            "riscv_1": {"latency": {"lower": 800, "upper": 12000}, "bandwidth": 0.04},
+            "riscv_0": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},
         },
         5: {
-            "riscv_1": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
+            "riscv_1": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},
         },
         6: {
             "riscv_0": {"latency": {"lower": 200, "upper": 70000}, "bandwidth": 0.4},
@@ -181,7 +181,7 @@ def run_dm_tests(profile, verbose, gtest_filter, plot, report, arch_name):
 
     # Plot results
     if plot:
-        plot_dm_stats(dm_stats)
+        plot_dm_stats(dm_stats, arch=arch)
 
     # Export results to csv
     if report:
@@ -393,7 +393,7 @@ def print_stats(dm_stats):
         logger.info("")
 
 
-def plot_dm_stats(dm_stats, output_file="dm_stats_plot.png"):
+def plot_dm_stats(dm_stats, output_file="dm_stats_plot.png", arch="blackhole"):
     # Extract data for plotting
     riscv_1_series = dm_stats["riscv_1"]["analysis"]["series"]
     riscv_0_series = dm_stats["riscv_0"]["analysis"]["series"]
@@ -406,6 +406,9 @@ def plot_dm_stats(dm_stats, output_file="dm_stats_plot.png"):
         test_ids.add(attributes["Test id"])
 
     test_ids = sorted(test_ids)  # Sort for consistent ordering
+
+    # Set noc_width based on architecture
+    noc_width = 32 if arch == "wormhole_b0" else 64
 
     # Create the main figure
     fig = plt.figure(layout="constrained", figsize=(18, 6 * len(test_ids)))
@@ -421,7 +424,7 @@ def plot_dm_stats(dm_stats, output_file="dm_stats_plot.png"):
         subfig.suptitle(test_name, fontsize=16, weight="bold")
 
         # Create subplots within the subfigure
-        axes = subfig.subplots(1, 3)
+        axes = subfig.subplots(1, 2)
 
         # Filter data for the current Test id
         riscv_1_filtered = [
@@ -439,26 +442,32 @@ def plot_dm_stats(dm_stats, output_file="dm_stats_plot.png"):
         riscv_1_durations = [entry["duration_cycles"] for entry in riscv_1_filtered]
         riscv_0_durations = [entry["duration_cycles"] for entry in riscv_0_filtered]
 
-        riscv_1_bandwidths = []
-        riscv_0_bandwidths = []
         riscv_1_data_sizes = []
         riscv_0_data_sizes = []
+        riscv_1_bandwidths = []
+        riscv_0_bandwidths = []
+        riscv_1_transactions = []
+        riscv_0_transactions = []
 
         for entry in riscv_1_filtered:
             runtime_host_id = entry["duration_type"][0]["run_host_id"]
             attributes = dm_stats["riscv_1"]["attributes"][runtime_host_id]
             transaction_size = attributes["Transaction size in bytes"]
-            bandwidth = attributes["Number of transactions"] * transaction_size / entry["duration_cycles"]
-            riscv_1_bandwidths.append(bandwidth)
+            num_transactions = attributes["Number of transactions"]
+            bandwidth = num_transactions * transaction_size / entry["duration_cycles"]
             riscv_1_data_sizes.append(transaction_size)
+            riscv_1_bandwidths.append(bandwidth)
+            riscv_1_transactions.append(num_transactions)
 
         for entry in riscv_0_filtered:
             runtime_host_id = entry["duration_type"][0]["run_host_id"]
             attributes = dm_stats["riscv_0"]["attributes"][runtime_host_id]
             transaction_size = attributes["Transaction size in bytes"]
-            bandwidth = attributes["Number of transactions"] * transaction_size / entry["duration_cycles"]
-            riscv_0_bandwidths.append(bandwidth)
+            num_transactions = attributes["Number of transactions"]
+            bandwidth = num_transactions * transaction_size / entry["duration_cycles"]
             riscv_0_data_sizes.append(transaction_size)
+            riscv_0_bandwidths.append(bandwidth)
+            riscv_0_transactions.append(num_transactions)
 
         # Plot durations
         ax = axes[0]
@@ -470,25 +479,50 @@ def plot_dm_stats(dm_stats, output_file="dm_stats_plot.png"):
         ax.legend()
         ax.grid()
 
-        # Plot bandwidth
-        ax = axes[1]
-        ax.plot(riscv_1_bandwidths, label="RISCV 1 Bandwidth (bytes/cycle)", marker="o")
-        ax.plot(riscv_0_bandwidths, label="RISCV 0 Bandwidth (bytes/cycle)", marker="o")
-        ax.set_xlabel("Index")
-        ax.set_ylabel("Bandwidth (bytes/cycle)")
-        ax.set_title("Bandwidth Comparison")
-        ax.legend()
-        ax.grid()
-
         # Plot size of data transferred vs bandwidth
-        ax = axes[2]
-        ax.scatter(riscv_1_data_sizes, riscv_1_bandwidths, label="RISCV 1", marker="o")
-        ax.scatter(riscv_0_data_sizes, riscv_0_bandwidths, label="RISCV 0", marker="o")
+        ax = axes[1]
+        unique_transactions = sorted(set(riscv_1_transactions + riscv_0_transactions))  # Ensure ascending order
+        for num_transactions in unique_transactions:
+            # Group and plot RISCV 1 data
+            riscv_1_grouped = [
+                (size, bw)
+                for size, bw, trans in zip(riscv_1_data_sizes, riscv_1_bandwidths, riscv_1_transactions)
+                if trans == num_transactions
+            ]
+            if riscv_1_grouped:
+                sizes, bws = zip(*riscv_1_grouped)
+                ax.plot(sizes, bws, label=f"RISCV 1 (Transactions={num_transactions})", marker="o")
+
+            # Group and plot RISCV 0 data
+            riscv_0_grouped = [
+                (size, bw)
+                for size, bw, trans in zip(riscv_0_data_sizes, riscv_0_bandwidths, riscv_0_transactions)
+                if trans == num_transactions
+            ]
+            if riscv_0_grouped:
+                sizes, bws = zip(*riscv_0_grouped)
+                ax.plot(sizes, bws, label=f"RISCV 0 (Transactions={num_transactions})", marker="o")
+
+        # Add theoretical max bandwidth curve
+        transaction_sizes = sorted(set(riscv_1_data_sizes + riscv_0_data_sizes))
+        max_bandwidths = [noc_width * ((size / noc_width) / ((size / noc_width) + 1)) for size in transaction_sizes]
+        ax.plot(transaction_sizes, max_bandwidths, label="Theoretical Max BW", linestyle="--", color="black")
+
         ax.set_xlabel("Transaction Size (bytes)")
         ax.set_ylabel("Bandwidth (bytes/cycle)")
         ax.set_title("Data Size vs Bandwidth")
         ax.legend()
         ax.grid()
+
+        # Add a comment section below the plots
+        subfig.text(
+            0.5,
+            0.01,
+            f"Comments: Add observations or explanations here for {test_name}.",
+            ha="center",
+            fontsize=10,
+            style="italic",
+        )
 
     # Save the combined plot
     plt.savefig(output_file)

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -115,7 +115,6 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 42000, "upper": 44000}, "bandwidth": 34},
         },
         4: {
-            "riscv_1": {"latency": {"lower": 800, "upper": 12000}, "bandwidth": 0.04},
             "riscv_0": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},
         },
         5: {

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -42,8 +42,8 @@ test_id_to_name = {
 test_bounds = {
     "wormhole_b0": {
         0: {
-            "riscv_1": {"latency": {"lower": 500, "upper": 42000}, "bandwidth": 0.12},
-            "riscv_0": {"latency": {"lower": 400, "upper": 28000}, "bandwidth": 0.15},
+            "riscv_1": {"latency": {"lower": 300, "upper": 24000}, "bandwidth": 0.08},
+            "riscv_0": {"latency": {"lower": 300, "upper": 25000}, "bandwidth": 0.07},
         },
         1: {
             "riscv_1": {"latency": {"lower": 400, "upper": 700}, "bandwidth": 0.19},
@@ -58,11 +58,10 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 33000, "upper": 35000}, "bandwidth": 21},
         },
         4: {
-            "riscv_1": {"latency": {"lower": 4000, "upper": 12000}, "bandwidth": 0.007},
-            "riscv_0": {"latency": {"lower": 300, "upper": 4700}, "bandwidth": 0.17},
+            "riscv_0": {"latency": {"lower": 200, "upper": 18000}, "bandwidth": 0.1},
         },
         5: {
-            "riscv_1": {"latency": {"lower": 200, "upper": 5000}, "bandwidth": 0.1},
+            "riscv_1": {"latency": {"lower": 200, "upper": 19000}, "bandwidth": 0.1},
         },
         6: {
             "riscv_0": {"latency": {"lower": 200, "upper": 70000}, "bandwidth": 0.4},


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21983)

### Problem description
Enhancements to the plots produced by the data movement pytest.

### What's changed
Point by point breakdown of changes:
1. Removed the bandwidth plot. Now we only have two plots per test.
2. Datapoints with same number of transactions in the last plot are grouped under one color and connected with a line.
3. Theoretical max bandwidth curve is added to the last plot.
4. Comment section added under the plots of each test.
5. Post profiler script behaves weirdly when a kernel is on run on a RISCV but not profiled. Instead of removing zones, we should remove kernels that don't need to be profiled or that aren't necessary for the test. Removed unused RISCVs from the plot legends.
6. Extended max number of transactions to 256 and iteration step increased to 4 for each test in the test suite. Checks added to make sure required total size doesn't exceed L1 capacity. Test bounds updated in the pytest for each of the changed tests.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15124814749) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15075072755) CI with demo tests passes (if applicable)