### PR TITLE
#22042: Remove bespoke "buffer_address" functions

### DIFF
--- a/models/demos/llama3_subdevices/tt/llama_ccl.py
+++ b/models/demos/llama3_subdevices/tt/llama_ccl.py
@@ -5,10 +5,6 @@
 import ttnn
 import torch
 
-from models.demos.llama3_subdevices.tt.llama_common import (
-    check_mesh_tensor_alloc,
-)
-
 
 class TT_CCL:
     def __init__(
@@ -114,7 +110,6 @@ class TT_CCL:
             memory_config=intermediate_mem_config,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=[0, 1], mesh_shape=[8, 4]),
         )
-        check_mesh_tensor_alloc(tt_intermediate_tensor)
         tt_intermediate_tensors = [tt_intermediate_tensor]
         return tt_intermediate_tensors
 
@@ -146,7 +141,6 @@ class TT_CCL:
             memory_config=self.model_config["GATHER_USERS_MEMCFG"](list(self.mesh_device.shape)[1]),
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
-        check_mesh_tensor_alloc(tt_buffer)
         persistent_buffers["SDPA"] = tt_buffer
 
         # Layernorm
@@ -166,7 +160,6 @@ class TT_CCL:
             memory_config=tt_stats_sharded_config,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
-        check_mesh_tensor_alloc(tt_buffer)
         persistent_buffers["LAYERNORM"] = tt_buffer
 
         tt_buffer = ttnn.from_torch(
@@ -177,7 +170,6 @@ class TT_CCL:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
-        check_mesh_tensor_alloc(tt_buffer)
         persistent_buffers["SAMPLING"] = tt_buffer
 
         # Binary Mult + Silu
@@ -189,7 +181,6 @@ class TT_CCL:
             memory_config=self.model_config["FF2_IN_RING_MEMCFG"],
             mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
         )
-        check_mesh_tensor_alloc(tt_buffer)
         persistent_buffers["BINARY_MUL"] = tt_buffer
 
         return persistent_buffers
@@ -341,7 +332,6 @@ class TT_CCL:
                         mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                         cache_file_name=self.weight_cache_path / (f"pb_rs_00_{key}_{i}_{seqlen}"),
                     )
-                    check_mesh_tensor_alloc(tt_buffer)
                     tt_buffers.append(tt_buffer)
                 for i in range(2):
                     tt_buffer = ttnn.as_tensor(
@@ -353,7 +343,6 @@ class TT_CCL:
                         mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                         cache_file_name=self.weight_cache_path / (f"pb_rs_01_{key}_{i}_{seqlen}"),
                     )
-                    check_mesh_tensor_alloc(tt_buffer)
                     tt_buffers.append(tt_buffer)
                 for i in range(2):
                     tt_buffer = ttnn.as_tensor(
@@ -365,7 +354,6 @@ class TT_CCL:
                         mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                         cache_file_name=self.weight_cache_path / (f"pb_rs_02_{key}_{i}_{seqlen}"),
                     )
-                    check_mesh_tensor_alloc(tt_buffer)
                     tt_buffers.append(tt_buffer)
                 persistent_buffers[key] = tt_buffers
             persistent_buffers_all[seqlen] = persistent_buffers
@@ -401,7 +389,6 @@ class TT_CCL:
                     mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
                     cache_file_name=self.weight_cache_path / ("pb_ag_" + key + str(seqlen)),
                 )
-                check_mesh_tensor_alloc(tt_buffer)
                 ag_persistent_buffers[key] = tt_buffer
             ag_persistent_buffers_all[seqlen] = ag_persistent_buffers
         return ag_persistent_buffers_all

--- a/models/demos/llama3_subdevices/tt/llama_common.py
+++ b/models/demos/llama3_subdevices/tt/llama_common.py
@@ -23,21 +23,6 @@ class PagedAttentionConfig:
         self.max_num_blocks = max_num_blocks
 
 
-def check_mesh_tensor_alloc(tensor):
-    """
-    Check if the tensor has the same address for all devices.
-    """
-    device_tensors = ttnn.get_device_tensors(tensor)
-    buffer_addr = device_tensors[0].buffer_address()
-
-    if len(device_tensors) > 1:
-        for i in range(1, len(device_tensors)):
-            addr = device_tensors[i].buffer_address()
-            if not addr == buffer_addr:
-                return False
-    return True
-
-
 def encode_prompt_llama_instruct(tokenizer, prompt_text, system_prompt_text=None):
     """<|begin_of_text|><|start_header_id|>system<|end_header_id|>
     {{ system_prompt }}<|eot_id|><|start_header_id|>user<|end_header_id|>

--- a/models/demos/llama3_subdevices/tt/prefetcher_common.py
+++ b/models/demos/llama3_subdevices/tt/prefetcher_common.py
@@ -13,15 +13,6 @@ from models.demos.llama3_subdevices.tt.model_config import (
 global_tt_tensor_address = None
 
 
-def get_buffer_address(tensor):
-    addr = []
-    for i, ten in enumerate(ttnn.get_device_tensors(tensor)):
-        addr.append(ten.buffer_address())
-        if len(addr) > 0:
-            assert addr[i - 1] == addr[i], f"Expected {addr[i-1]} == {addr[i]}"
-    return addr[0]
-
-
 class TtLlamaPrefetcherSetup(LightweightModule):
     def __init__(
         self,
@@ -119,17 +110,9 @@ class TtLlamaPrefetcherSetup(LightweightModule):
                 self.global_cb_size,
             )
 
-    def buffer_address(self, tensor):
-        addr = []
-        for i, ten in enumerate(ttnn.get_device_tensors(tensor)):
-            addr.append(ten.buffer_address())
-            if len(addr) > 0:
-                assert addr[i - 1] == addr[i], f"Expected {addr[i-1]} == {addr[i]}"
-        return addr[0]
-
     def insert_tensor(self, tensor: ttnn.Tensor):
         self.tensors.append(tensor)
-        self.tensor_addrs.append(self.buffer_address(tensor))
+        self.tensor_addrs.append(tensor.buffer_address())
 
     def get_tensor_addrs(self):
         assert (

--- a/models/demos/mobilenetv2/tests/mobilenetv2_e2e_performant.py
+++ b/models/demos/mobilenetv2/tests/mobilenetv2_e2e_performant.py
@@ -13,17 +13,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-# TODO: Create ttnn APIs for this
-ttnn.buffer_address = buffer_address
-
-
 class MobileNetV2Trace2CQ:
     def __init__(self):
         ...
@@ -76,12 +65,12 @@ class MobileNetV2Trace2CQ:
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
         self.op_event = ttnn.record_event(device, 0)
         self.test_infra.output_tensor.deallocate(force=True)
-        trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
+        trace_input_addr = self.test_infra.input_tensor.buffer_address()
         self.tid = ttnn.begin_trace_capture(device, cq_id=0)
         self.test_infra.run()
         self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
         ttnn.end_trace_capture(device, self.tid, cq_id=0)
-        assert trace_input_addr == ttnn.buffer_address(self.input_tensor)
+        assert trace_input_addr == self.input_tensor.buffer_address()
 
     def execute_mobilenetv2_trace_2cqs_inference(self, tt_inputs_host=None):
         ttnn.wait_for_event(1, self.op_event)

--- a/models/demos/mobilenetv2/tests/mobilenetv2_performant.py
+++ b/models/demos/mobilenetv2/tests/mobilenetv2_performant.py
@@ -15,17 +15,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-# TODO: Create ttnn apis for this
-ttnn.buffer_address = buffer_address
-
-
 def run_mobilenetv2_inference(
     device,
     device_batch_size,
@@ -86,12 +75,12 @@ def run_mobilenetv2_trace_inference(
 
     # Capture
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
-    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     tt_image_res = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert trace_input_addr == ttnn.buffer_address(tt_image_res)
+    assert trace_input_addr == tt_image_res.buffer_address()
 
     # More optimized run with caching
     if use_signpost:
@@ -150,12 +139,12 @@ def run_mobilenetv2_trace_2cqs_inference(
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     op_event = ttnn.record_event(device, 0)
     test_infra.dealloc_output()
-    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     input_tensor = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert trace_input_addr == ttnn.buffer_address(input_tensor)
+    assert trace_input_addr == input_tensor.buffer_address()
 
     # More optimized run with caching
     if use_signpost:

--- a/models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py
+++ b/models/demos/segformer/tests/perf/test_perf_segformer_trace_2cq.py
@@ -11,13 +11,6 @@ from models.perf.perf_utils import prep_perf_report
 from models.utility_functions import run_for_wormhole_b0
 
 
-def buffer_address(tensor):
-    addr = []
-    for t in ttnn.get_device_tensors(tensor):
-        addr.append(t.buffer_address())
-    return addr
-
-
 @run_for_wormhole_b0()
 @pytest.mark.models_performance_bare_metal
 @pytest.mark.parametrize(

--- a/models/demos/ttnn_resnet/tests/resnet50_performant_imagenet.py
+++ b/models/demos/ttnn_resnet/tests/resnet50_performant_imagenet.py
@@ -6,17 +6,6 @@ import ttnn
 from models.demos.ttnn_resnet.tests.resnet50_test_infra import create_test_infra
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-# TODO: Create ttnn apis for this
-ttnn.buffer_address = buffer_address
-
-
 class ResNet50Trace2CQ:
     def __init__(self):
         ...
@@ -75,12 +64,12 @@ class ResNet50Trace2CQ:
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
         self.op_event = ttnn.record_event(device, 0)
         self.test_infra.output_tensor.deallocate(force=True)
-        trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
+        trace_input_addr = self.test_infra.input_tensor.buffer_address()
         self.tid = ttnn.begin_trace_capture(device, cq_id=0)
         self.test_infra.run()
         self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
         ttnn.end_trace_capture(device, self.tid, cq_id=0)
-        assert trace_input_addr == ttnn.buffer_address(self.input_tensor)
+        assert trace_input_addr == self.input_tensor.buffer_address()
 
     def execute_resnet50_trace_2cqs_inference(self, tt_inputs_host=None):
         ttnn.wait_for_event(1, self.op_event)

--- a/models/demos/ufld_v2/tests/ufld_v2_e2e_performant.py
+++ b/models/demos/ufld_v2/tests/ufld_v2_e2e_performant.py
@@ -13,16 +13,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-ttnn.buffer_address = buffer_address
-
-
 class UFLDv2Trace2CQ:
     def __init__(self):
         ...
@@ -72,12 +62,12 @@ class UFLDv2Trace2CQ:
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
         self.op_event = ttnn.record_event(device, 0)
         self.test_infra.output_tensor_1.deallocate(force=True)
-        trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
+        trace_input_addr = self.test_infra.input_tensor.buffer_address()
         self.tid = ttnn.begin_trace_capture(device, cq_id=0)
         self.test_infra.run()
         self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
         ttnn.end_trace_capture(device, self.tid, cq_id=0)
-        assert trace_input_addr == ttnn.buffer_address(self.input_tensor)
+        assert trace_input_addr == self.input_tensor.buffer_address()
 
     def execute_ufldv2_trace_2cqs_inference(self, tt_inputs_host=None):
         ttnn.wait_for_event(1, self.op_event)

--- a/models/demos/ufld_v2/tests/ufld_v2_performant.py
+++ b/models/demos/ufld_v2/tests/ufld_v2_performant.py
@@ -14,16 +14,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-ttnn.buffer_address = buffer_address
-
-
 def run_ufld_v2_inference(
     device,
     device_batch_size,
@@ -79,12 +69,12 @@ def run_ufld_v2_trace_inference(
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
 
     test_infra.dealloc_output()
-    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     tt_image_res = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert trace_input_addr == ttnn.buffer_address(tt_image_res)
+    assert trace_input_addr == tt_image_res.buffer_address()
 
     if use_signpost:
         signpost(header="start")
@@ -138,12 +128,12 @@ def ufld_v2_trace_2cqs_inference(
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     op_event = ttnn.record_event(device, 0)
     test_infra.dealloc_output()
-    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     input_tensor = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert trace_input_addr == ttnn.buffer_address(input_tensor)
+    assert trace_input_addr == input_tensor.buffer_address()
 
     if use_signpost:
         signpost(header="start")

--- a/models/demos/vit/tests/vit_performant_imagenet.py
+++ b/models/demos/vit/tests/vit_performant_imagenet.py
@@ -6,17 +6,6 @@ import ttnn
 from models.demos.vit.tests.vit_test_infra import create_test_infra
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-# TODO: Create ttnn apis for this
-ttnn.buffer_address = buffer_address
-
-
 class VitTrace2CQ:
     def __init__(self):
         ...
@@ -68,12 +57,12 @@ class VitTrace2CQ:
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
         self.op_event = ttnn.record_event(device, 0)
         self.test_infra.output_tensor.deallocate(force=True)
-        trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
+        trace_input_addr = self.test_infra.input_tensor.buffer_address()
         self.tid = ttnn.begin_trace_capture(device, cq_id=0)
         self.test_infra.run()
         self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
         ttnn.end_trace_capture(device, self.tid, cq_id=0)
-        assert trace_input_addr == ttnn.buffer_address(self.input_tensor)
+        assert trace_input_addr == self.input_tensor.buffer_address()
 
     def execute_vit_trace_2cqs_inference(self, tt_inputs_host=None):
         ttnn.wait_for_event(1, self.op_event)

--- a/models/demos/yolov8x/tests/yolov8x_e2e_performant.py
+++ b/models/demos/yolov8x/tests/yolov8x_e2e_performant.py
@@ -13,17 +13,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-# TODO: Create ttnn APIs for this
-ttnn.buffer_address = buffer_address
-
-
 class Yolov8xTrace2CQ:
     def __init__(self):
         ...
@@ -76,12 +65,12 @@ class Yolov8xTrace2CQ:
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
         self.op_event = ttnn.record_event(device, 0)
         self.test_infra.output_tensor.deallocate(force=True)
-        trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
+        trace_input_addr = self.test_infra.input_tensor.buffer_address()
         self.tid = ttnn.begin_trace_capture(device, cq_id=0)
         self.test_infra.run()
         self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
         ttnn.end_trace_capture(device, self.tid, cq_id=0)
-        assert trace_input_addr == ttnn.buffer_address(self.input_tensor)
+        assert trace_input_addr == self.input_tensor.buffer_address()
 
     def execute_yolov8x_trace_2cqs_inference(self, tt_inputs_host=None):
         ttnn.wait_for_event(1, self.op_event)

--- a/models/demos/yolov8x/tests/yolov8x_performant.py
+++ b/models/demos/yolov8x/tests/yolov8x_performant.py
@@ -15,17 +15,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-# TODO: Create ttnn apis for this
-ttnn.buffer_address = buffer_address
-
-
 def run_yolov8x_inference(
     device,
     device_batch_size,
@@ -85,12 +74,12 @@ def run_yolov8x_trace_inference(
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
 
     test_infra.dealloc_output()
-    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     tt_image_res = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert trace_input_addr == ttnn.buffer_address(tt_image_res)
+    assert trace_input_addr == tt_image_res.buffer_address()
 
     # More optimized run with caching
     if use_signpost:
@@ -149,12 +138,12 @@ def run_yolov8x_trace_2cqs_inference(
     test_infra.input_tensor = ttnn.to_memory_config(tt_image_res, input_mem_config)
     op_event = ttnn.record_event(device, 0)
     test_infra.dealloc_output()
-    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     input_tensor = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert trace_input_addr == ttnn.buffer_address(input_tensor)
+    assert trace_input_addr == input_tensor.buffer_address()
 
     # More optimized run with caching
     if use_signpost:

--- a/models/experimental/functional_vgg_unet/tests/vgg_unet_e2e_performant.py
+++ b/models/experimental/functional_vgg_unet/tests/vgg_unet_e2e_performant.py
@@ -13,17 +13,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-# TODO: Create ttnn APIs for this
-ttnn.buffer_address = buffer_address
-
-
 class VggUnetTrace2CQ:
     def __init__(self):
         ...
@@ -74,12 +63,12 @@ class VggUnetTrace2CQ:
         self.test_infra.input_tensor = ttnn.to_memory_config(self.tt_image_res, self.input_mem_config)
         self.op_event = ttnn.record_event(device, 0)
         self.test_infra.output_tensor.deallocate(force=True)
-        trace_input_addr = ttnn.buffer_address(self.test_infra.input_tensor)
+        trace_input_addr = self.test_infra.input_tensor.buffer_address()
         self.tid = ttnn.begin_trace_capture(device, cq_id=0)
         self.test_infra.run()
         self.input_tensor = ttnn.allocate_tensor_on_device(spec, device)
         ttnn.end_trace_capture(device, self.tid, cq_id=0)
-        assert trace_input_addr == ttnn.buffer_address(self.input_tensor)
+        assert trace_input_addr == self.input_tensor.buffer_address()
 
     def execute_vgg_unet_trace_2cqs_inference(self, tt_inputs_host=None):
         ttnn.wait_for_event(1, self.op_event)

--- a/models/experimental/functional_vgg_unet/tests/vgg_unet_performant.py
+++ b/models/experimental/functional_vgg_unet/tests/vgg_unet_performant.py
@@ -14,22 +14,6 @@ except ModuleNotFoundError:
     use_signpost = False
 
 
-def buffer_address(tensor):
-    addr = []
-    for ten in ttnn.get_device_tensors(tensor):
-        addr.append(ten.buffer_address())
-    return addr
-
-
-def dump_device_profiler(device):
-    ttnn.DumpDeviceProfiler(device)
-
-
-ttnn.dump_device_profiler = dump_device_profiler
-
-ttnn.buffer_address = buffer_address
-
-
 def run_vgg_unet_inference(
     device,
     model_location_generator,
@@ -90,12 +74,12 @@ def run_vgg_unet_trace_inference(
     # Capture
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     test_infra.dealloc_output()
-    trace_input_addr = ttnn.buffer_address(test_infra.input_tensor)
+    trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()
     tt_image_res = ttnn.allocate_tensor_on_device(spec, device)
     ttnn.end_trace_capture(device, tid, cq_id=0)
-    assert trace_input_addr == ttnn.buffer_address(tt_image_res)
+    assert trace_input_addr == tt_image_res.buffer_address()
 
     # More optimized run with caching
     if use_signpost:

--- a/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_llama_reduce_scatter_async_TG.py
@@ -21,9 +21,6 @@ from tests.ttnn.unit_tests.operations.ccl.test_new_all_reduce import (
     NORM_CRS,
 )
 from tracy import signpost
-from models.demos.llama3_subdevices.tt.llama_common import (
-    check_mesh_tensor_alloc,
-)
 
 PACKET_WORKER_CRS = ttnn.CoreRangeSet(
     [
@@ -194,9 +191,7 @@ def run_reduce_scatter_test(
                     mesh_device, dims=(0, 1), mesh_shape=[num_devices_fracture, num_devices_scatter]
                 ),
             )
-            check_mesh_tensor_alloc(tt_intermediate)
             tt_intermediate_tensors_list.append(tt_intermediate)
-        check_mesh_tensor_alloc(tt_input)
         tt_input_tensors_list.append(tt_input)
 
     ccl_sub_device_crs = subdevice_shard_cores_grid if use_regular_grid is not None else SUB_DEVICE_CRS

--- a/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_new_all_reduce.py
@@ -20,9 +20,6 @@ from models.demos.llama3_subdevices.tt.model_config import (
 )
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from tracy import signpost
-from models.demos.llama3_subdevices.tt.llama_common import (
-    check_mesh_tensor_alloc,
-)
 
 
 SUB_DEVICE_CRS = ttnn.CoreRangeSet(
@@ -154,7 +151,6 @@ def run_all_reduce_impl(
         memory_config=input_mem_config,
         mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, 1), mesh_shape=cluster_shape),
     )
-    check_mesh_tensor_alloc(tt_input_tensor)
 
     intermediate_tensor = torch.zeros(intermediate_shape)
     tt_intermediate_tensors = []
@@ -168,8 +164,6 @@ def run_all_reduce_impl(
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, 1), mesh_shape=cluster_shape),
         )
 
-        # Validate that the tensor is allocated in same location across devices
-        check_mesh_tensor_alloc(tt_intermediate_tensor)
         tt_intermediate_tensors.append(tt_intermediate_tensor)
 
     # All-Reduce Golden

--- a/tests/ttnn/unit_tests/operations/ccl/test_qkv_all_reduce_minimal.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_qkv_all_reduce_minimal.py
@@ -22,9 +22,6 @@ from models.demos.llama3_subdevices.tt.model_config import (
     PREFETCHER_NOC1_GRID,
 )
 from models.demos.llama3_subdevices.tt.model_config import set_tg_attention_config
-from models.demos.llama3_subdevices.tt.llama_common import (
-    check_mesh_tensor_alloc,
-)
 
 LINEAR_TOPOLOGY = True
 if LINEAR_TOPOLOGY:
@@ -149,7 +146,6 @@ def run_all_reduce_qkv_heads_fuse_perf_impl(
             memory_config=input_mem_config,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, 1), mesh_shape=cluster_shape),
         )  # [1, 1, 32, 1280]
-        check_mesh_tensor_alloc(tt_qkv)
 
         intermediate_tensor = torch.zeros(intermediate_shape)
         tt_intermediate_tensors = []
@@ -162,8 +158,6 @@ def run_all_reduce_qkv_heads_fuse_perf_impl(
                 memory_config=intermediate_mem_config,
                 mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, 1), mesh_shape=cluster_shape),
             )
-            # Validate that the tensor is allocated in same location across devices
-            check_mesh_tensor_alloc(tt_intermediate_tensor)
             tt_intermediate_tensors.append(tt_intermediate_tensor)
 
         head_dim = N // (8 + 2 * 1)

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -26,18 +26,6 @@ from tracy import signpost
 from models.demos.llama3_subdevices.tt.prefetcher_common import get_core_ranges
 
 
-def get_buffer_address(tensor):
-    device_tensors = ttnn.get_device_tensors(tensor)
-    buffer_addr = device_tensors[0].buffer_address()
-
-    if len(device_tensors) > 1:
-        for i in range(1, len(device_tensors)):
-            addr = device_tensors[i].buffer_address()
-            assert addr == buffer_addr, f"Expected buffer address on device {i} to be same as device 0"
-
-    return buffer_addr
-
-
 def run_prefetcher_mm(
     device,
     num_tensors,
@@ -159,7 +147,7 @@ def run_prefetcher_mm(
     tt_tensors = tt_tensors_all[:num_tensors]
 
     # Set up the tensor addrs
-    tensor_addrs = torch.tensor([get_buffer_address(x) for x in tt_tensors_all])
+    tensor_addrs = torch.tensor([x.buffer_address() for x in tt_tensors_all])
     tensor_addrs = tensor_addrs.repeat(len(dram_cores), 1)
     tensor_addrs_mem_config = ttnn.MemoryConfig(
         ttnn.TensorMemoryLayout.HEIGHT_SHARDED,

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -1477,12 +1477,8 @@ void pytensor_module(py::module& m_tensor) {
                 return std::visit(
                     tt::stl::overloaded{
                         [](const DeviceStorage& s) -> uint32_t {
-                            if (s.mesh_buffer) {
-                                return s.mesh_buffer->address();
-                            } else {
-                                TT_FATAL(s.buffer != nullptr, "Tensor is not allocated.");
-                                return s.buffer->address();
-                            }
+                            TT_FATAL(s.mesh_buffer != nullptr, "Tensor is not allocated.");
+                            return s.mesh_buffer->address();
                         },
                         [&](auto&&) -> uint32_t {
                             TT_THROW(


### PR DESCRIPTION
### Ticket
#22042

### Problem description
Mesh native backend enforces lock step allocation, which means all device shards have the same address. Currently there is no way to use TTNN in a different mode.

"buffer_address" functions access individual devices shards, which is problematic in light of multi-host project.

### What's changed
Remove all "buffer_address" functions and use `buffer_address` exposed in pybind.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15007781746)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15007779117)
- [X] [Single card perf](https://github.com/tenstorrent/tt-metal/actions/runs/15007784881)
- [X] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15011058794)
- [x] New/Existing tests provide coverage for changes