### PR TITLE
Fix ethernet ubench hang on Blackhole.

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/ethernet_write_worker_latency_ubench_common.hpp
@@ -10,6 +10,7 @@
 #include "debug/assert.h"
 #include "debug/dprint.h"
 #include "eth_ubenchmark_types.hpp"
+#include "risc_common.h"
 
 // #define ENABLE_DEBUG 1
 
@@ -88,6 +89,7 @@ FORCE_INLINE void write_receiver(
 }
 
 FORCE_INLINE bool has_receiver_ack(volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr) {
+    invalidate_l1_cache();
     return buffer_slot_sync_addr->bytes_sent == 0;
 }
 
@@ -165,6 +167,7 @@ FORCE_INLINE uint32_t setup_receiver_buffer(
 FORCE_INLINE uint32_t get_buffer_slot_trid(uint32_t curr_ptr) { return curr_ptr % MAX_NUM_TRANSACTION_ID + 1; }
 
 FORCE_INLINE bool has_incoming_packet(volatile eth_buffer_slot_sync_t* buffer_slot_sync_addr) {
+    invalidate_l1_cache();
     return buffer_slot_sync_addr->bytes_sent != 0;
 }
 


### PR DESCRIPTION
Call `invalidate_l1_cache` before polling `bytes_sent` flag.

### Ticket
#21989 

### Problem description
Polling does not work because a stale value is captured in L1 data cache on Blackhole.

This bug was potentially masked by periodic cache flushing before 70f9142 disabled it.

### What's changed
Invalidate L1 data cache when polling `bytes_sent` flag.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes