### PR TITLE
#0: `tt::stl::Span` / `tt::stl::StrongType` improvements

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_tilize_untilize.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tilize_untilize.cpp
@@ -425,7 +425,7 @@ TEST_P(TilizeUntilizeTestsFixture, TilizeUntilize) {
             input, shape, from_layout, to_layout, tile_shape, face_shape, transpose_within_face, transpose_of_faces);
 
         auto converted_back = convert_layout(
-            tt::stl::MakeConstSpan(converted),
+            tt::stl::make_const_span(converted),
             shape,
             to_layout,
             from_layout,
@@ -434,7 +434,7 @@ TEST_P(TilizeUntilizeTestsFixture, TilizeUntilize) {
             transpose_within_face,
             transpose_of_faces);
 
-        auto converted_back_span = tt::stl::MakeConstSpan(converted_back);
+        auto converted_back_span = tt::stl::make_const_span(converted_back);
         ASSERT_EQ(input.size(), converted_back.size());
         ASSERT_TRUE(std::equal(input.begin(), input.end(), converted_back_span.begin()));
     };
@@ -488,7 +488,7 @@ TEST_P(ThrowableTilizeUntilizeFixture, TilizeUntilize) {
         using Type = decltype(type);
         std::vector<Type> input(input_size);
 
-        EXPECT_ANY_THROW(convert_layout(tt::stl::MakeConstSpan(input), shape, from_layout, to_layout));
+        EXPECT_ANY_THROW(convert_layout(tt::stl::make_const_span(input), shape, from_layout, to_layout));
     };
 
     // Test all interesting types

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_X_tile.cpp
@@ -87,14 +87,14 @@ void create_test_stimuli(MatmulTileStimuli& stimuli, uint32_t M, uint32_t K, uin
 
     auto activations_tilized = tilize_swizzled(tensor.get_values(), M * 32, K * 32);
     auto activations_tile_layout =
-        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     auto activations_tile_transposed = tt::tt_metal::transpose_tiles(activations, M, K, 1);
     stimuli.a = activations_tile_transposed;
 
     auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);
     auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
     stimuli.w = weights;
 }
@@ -329,7 +329,7 @@ void matmul_tile(
     std::vector<bfloat16> golden = std::move(tensor_vals);
     std::vector<bfloat16> golden_tilized = tilize_swizzled(golden, M * 32, N * 32);
     std::vector<bfloat16> golden_tilized_single =
-        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(golden_tilized));
+        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(golden_tilized));
 
     std::vector<uint32_t> golden_packed(golden_tilized_single.size());
     uint16_t math_fid_mask = 0xFFFF;

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_large_block.cpp
@@ -378,14 +378,14 @@ bool matmul_large_block(
     } else {
         auto activations_tilized = tilize_swizzled(tensor.get_values(), M * 32, K * 32);
         auto activations_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
         activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     }
     fixture->WriteBuffer(device, src0_dram_buffer, activations);
 
     auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
     auto identity_tilized = tilize_swizzled<bfloat16>(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
     fixture->WriteBuffer(device, src1_dram_buffer, weights);
 
@@ -418,7 +418,7 @@ bool matmul_large_block(
             tt_metal::print_faces(result_bfp16, "Result");
         }
     } else {
-        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
         auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
         pass &= (golden == result_untilized);
         if (not pass) {

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_X_dram.cpp
@@ -278,7 +278,7 @@ bool matmul_multi_core_single_dram(tt_metal::IDevice* device) {
 
             auto activations_tilized = tilize_swizzled(activation_slice, per_core_M * 32, K * 32);
             auto activations_tile_layout =
-                convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+                convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
             auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
             auto activations_tile_transposed = tt_metal::transpose_tiles(activations, per_core_M, K, in0_block_w);
             pass &= tt_metal::detail::WriteToDeviceDRAMChannel(
@@ -286,7 +286,7 @@ bool matmul_multi_core_single_dram(tt_metal::IDevice* device) {
 
             auto identity_tilized = tilize_swizzled(weights_slice, K * 32, per_core_N * 32);
             auto weights_tile_layout =
-                convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+                convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
             auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
             pass &= tt_metal::detail::WriteToDeviceDRAMChannel(
                 device, dram_src1_channel_id, dram_buffer_src1_addr, weights);
@@ -343,7 +343,8 @@ bool matmul_multi_core_single_dram(tt_metal::IDevice* device) {
                 per_core_M * per_core_N * single_tile_size,
                 result_vec);
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-            auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+            auto result_flat_layout =
+                convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
             auto result_untilized = untilize_swizzled(result_flat_layout, per_core_M * 32, per_core_N * 32);
             pass &= (per_core_golden == result_untilized);
         }
@@ -508,14 +509,14 @@ bool matmul_multi_core_multi_dram(tt_metal::DispatchFixture* fixture, tt_metal::
     log_debug(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
     auto activations_tilized = tilize_swizzled(tensor.get_values(), M * 32, K * 32);
     auto activations_tile_layout =
-        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
 
     auto activation_buffer =
         tt_metal::Buffer::create(device, activations.size() * sizeof(uint32_t), 1024 * 2, tt_metal::BufferType::DRAM);
     pass &= move_tiles_to_dram(device, activations, M, K, activation_buffer);
     auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
 
     auto weight_buffer =
@@ -569,7 +570,8 @@ bool matmul_multi_core_multi_dram(tt_metal::DispatchFixture* fixture, tt_metal::
             result_vec.insert(result_vec.end(), result_iter, result_iter + 512);
             result_iter += 512;
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-            auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+            auto result_flat_layout =
+                convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
             pass &= (golden_tile == result_flat_layout);
         }

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -467,12 +467,12 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::IDevice* device)
     log_debug(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
     auto activations_tilized = tilize_swizzled(tensor.get_values(), M * 32, K * 32);
     auto activations_tile_layout =
-        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     pass &= move_tiles_to_dram(device, activations, M, K, in0_dram_addr);
 
     auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
     pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
     log_debug(LogTest, "Copying inputs to dram complete");
@@ -526,7 +526,8 @@ bool matmul_multi_core_multi_dram_in0_mcast_in1_mcast(tt_metal::IDevice* device)
             std::vector<uint32_t> result_vec;
             tt_metal::detail::ReadFromDeviceDRAMChannel(device, dram_bank, dram_address, single_tile_size, result_vec);
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-            auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+            auto result_flat_layout =
+                convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
             // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
             // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_multi_core_multi_dram_inX_mcast.cpp
@@ -389,12 +389,12 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::IDevice* device, int in1_o
     log_debug(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
     auto activations_tilized = tilize_swizzled(tensor.get_values(), M * 32, K * 32);
     auto activations_tile_layout =
-        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     pass &= move_tiles_to_dram(device, activations, M, K, in0_dram_addr);
 
     auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
     pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
     log_debug(LogTest, "Copying inputs to dram complete");
@@ -443,7 +443,8 @@ bool matmul_multi_core_multi_dram_inX_mcast(tt_metal::IDevice* device, int in1_o
             std::vector<uint32_t> result_vec;
             tt_metal::detail::ReadFromDeviceDRAMChannel(device, dram_bank, dram_address, single_tile_size, result_vec);
             auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-            auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+            auto result_flat_layout =
+                convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
             // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
             // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));

--- a/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/matmul/test_matmul_single_core.cpp
@@ -229,14 +229,14 @@ bool matmul_single_core(
         shape, tt::deprecated::Initialize::RANDOM, 0, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto activations_tilized = tilize_swizzled(tensor.get_values(), M * 32, K * 32);
     auto activations_tile_layout =
-        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+        convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
     auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
     auto activations_tile_transposed = tt_metal::transpose_tiles(activations, M, K, in0_block_w);
     fixture->WriteBuffer(device, src0_dram_buffer, activations_tile_transposed);
 
     auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
     auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
-    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+    auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
     fixture->WriteBuffer(device, src1_dram_buffer, weights);
 
@@ -252,7 +252,7 @@ bool matmul_single_core(
     fixture->ReadBuffer(device, dst_dram_buffer, result_vec);
 
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
     auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
     auto golden = tt_metal::select_columns(tensor.get_values(), M, K, std::min(K, N));
     pass &= test_utils::is_close_vectors<bfloat16>(golden, result_untilized, [&](const bfloat16& a, const bfloat16& b) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -427,7 +427,7 @@ bool validation_fp16(
     std::vector<uint32_t> result;
     tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result);
-    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
     auto result_untilized = untilize_swizzled(result_flat_layout, kt * 32 / num_blocks * cb_num_blocks, nt * 32);
 
     const auto& values = input_tensor.get_values();
@@ -470,7 +470,7 @@ bool validation_mixed_df(
     tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
 
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result);
-    auto result_untilized_fp16 = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+    auto result_untilized_fp16 = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
 
     std::vector<float> golden_vec(kt * 32 / num_blocks * cb_num_blocks * nt * 32);
     std::vector<float> result_vec_fp16(kt * 32 / num_blocks * cb_num_blocks * nt * 32);
@@ -793,7 +793,7 @@ int main(int argc, char** argv) {
                         num_banks);
                 } else {  // odd layers
                     auto input_vec_tilized = tilize_swizzled(tensor_fp16.get_values(), k, n);
-                    auto input_vec_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(input_vec_tilized));
+                    auto input_vec_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(input_vec_tilized));
                     vector<uint32_t> packed_input_vec_tile_layout =
                         pack_bfloat16_vec_into_uint32_vec(input_vec_tile_layout);
                     input_buffers[i] = create_and_transfer_data_sharded_cb(
@@ -811,7 +811,7 @@ int main(int argc, char** argv) {
             for (uint32_t i = 0; i < num_mixed_df_layers; ++i) {
                 if (i % 2 == 0) {  // even layers
                     auto input_vec_tilized = tilize_swizzled(tensor_fp16.get_values(), k, n);
-                    auto input_vec_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(input_vec_tilized));
+                    auto input_vec_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(input_vec_tilized));
                     vector<uint32_t> packed_input_vec_tile_layout =
                         pack_bfloat16_vec_into_uint32_vec(input_vec_tile_layout);
                     input_buffers[i] = create_and_transfer_data_sharded_cb(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -525,7 +525,7 @@ bool validation_fp16(
     std::vector<uint32_t> result;
     tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result);
-    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
     auto result_untilized = untilize_swizzled(result_flat_layout, mt * 32, nt * 32);
 
     const auto& in0_values = in0_tensor.get_values();
@@ -817,7 +817,7 @@ int main(int argc, char** argv) {
             // in1
             for (uint32_t i = 0; i < num_layers; ++i) {
                 auto input_vec_tilized = tilize_swizzled(in1_tensor_fp16.get_values(), k, n);
-                auto input_vec_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(input_vec_tilized));
+                auto input_vec_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(input_vec_tilized));
                 vector<uint32_t> packed_input_vec_tile_layout =
                     pack_bfloat16_vec_into_uint32_vec(input_vec_tile_layout);
                 in1_buffers[i] = create_and_transfer_data_sharded_cb(
@@ -833,7 +833,7 @@ int main(int argc, char** argv) {
 
             // in0
             auto activations_tilized = tilize_swizzled(in0_tensor_fp16.get_values(), m, k * num_receivers);
-            auto activations_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+            auto activations_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
             vector<uint32_t> activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
             in0_buffer = create_and_transfer_data_sharded_cb(
                 device,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -424,14 +424,14 @@ int main(int argc, char** argv) {
                 // in0
                 auto activations_tilized = tilize_swizzled(tensor_in0_fp16.get_values(), M, K);
                 auto activations_tile_layout =
-                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
                 vector<uint32_t> activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
                 input_buffer0 = create_and_transfer_data_sharded_cb(device, activations, Mt, Kt);
 
                 // in1
                 auto identity_tilized = tilize_swizzled(tensor_in1_fp16.get_values(), K, N);
                 auto weights_tile_layout =
-                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
                 auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
                 input_buffer1 = create_and_transfer_data_sharded_cb(device, weights, Kt, Nt);
 
@@ -1512,7 +1512,7 @@ bool validation_single_core(
     tt::tt_metal::detail::ReadFromBuffer(out_buffer, result);
 
     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result);
-    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+    auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
     auto result_untilized = untilize_swizzled(result_flat_layout, Mt * 32, Nt * 32);
 
     std::vector<float> golden_vec(Mt * Nt * 32 * 32, 0);  // Initialize with zeros

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -1048,14 +1048,14 @@ int main(int argc, char** argv) {
             std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tilized = tilize_swizzled(tensor.get_values(), Mt * 32, Kt * 32);
         auto activations_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         tt_metal::detail::WriteToBuffer(in0_buffer, activations);
 
         auto identity = create_identity_matrix(Kt * 32, Nt * 32, std::min(Kt, Nt) * 32);
         auto identity_tilized = tilize_swizzled(identity, Kt * 32, Nt * 32);
         auto weights_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(in1_buffer, weights);
 
@@ -1126,7 +1126,7 @@ int main(int argc, char** argv) {
         std::vector<uint32_t> result_vec;
         tt_metal::detail::ReadFromBuffer(out_buffer, result_vec);
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
         auto result_untilized = untilize_swizzled(result_flat_layout, Mt * 32, Nt * 32);
 
         auto golden = select_columns(tensor.get_values(), Mt, Kt, Nt);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_local_l1.cpp
@@ -260,14 +260,14 @@ int main(int argc, char** argv) {
                 CoreCoord core = {(std::size_t)c, (std::size_t)r};
                 auto activations_tilized = tilize_swizzled(activation_slice, per_core_Mt * 32, Kt * 32);
                 auto activations_tile_layout =
-                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
                 auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
                 pass &= tt_metal::detail::WriteToDeviceL1(device, core, activations_addr, activations);
                 TT_FATAL(pass, "Error");
 
                 auto identity_tilized = tilize_swizzled(weights_slice, Kt * 32, per_core_Nt * 32);
                 auto weights_tile_layout =
-                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+                    convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
                 auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
                 auto weights_tile_transposed = transpose_tiles(weights, Kt, per_core_Nt, 1);
                 pass &= tt_metal::detail::WriteToDeviceL1(device, core, weights_addr, weights_tile_transposed);
@@ -359,7 +359,7 @@ int main(int argc, char** argv) {
                         device, core, output_addr, cb_output_tiles * single_tile_size, result_vec);
                     auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
                     auto result_flat_layout =
-                        convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+                        convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
                     auto result_untilized = untilize_swizzled(result_flat_layout, per_core_Mt * 32, per_core_Nt * 32);
 
                     if (print_tensor) {

--- a/tests/tt_metal/tt_metal/stl/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/stl/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
         test_any_range.cpp
         test_indestructible.cpp
         test_slotmap.cpp
+        test_span.cpp
         test_strong_type.cpp
 )
 target_include_directories(

--- a/tests/tt_metal/tt_metal/stl/test_span.cpp
+++ b/tests/tt_metal/tt_metal/stl/test_span.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <tt_stl/span.hpp>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <cstdint>
+
+namespace tt::stl {
+namespace {
+
+using ::testing::Eq;
+using ::testing::Pointwise;
+
+TEST(SpanTest, AsBytes) {
+    std::vector<uint32_t> src = {1, 2, 3, 4, 5};
+    std::vector<uint32_t> dst = {0, 0, 0, 0, 0};
+
+    ASSERT_EQ(src.size(), dst.size());
+
+    auto src_span = tt::stl::make_const_span(src);
+    auto dst_span = tt::stl::make_span(dst);
+
+    auto src_bytes = tt::stl::as_bytes(src_span);
+    auto dst_writable_bytes = tt::stl::as_writable_bytes(dst_span);
+
+    EXPECT_EQ(src_bytes.size(), src.size() * sizeof(uint32_t));
+    EXPECT_EQ(dst_writable_bytes.size(), dst.size() * sizeof(uint32_t));
+
+    for (size_t i = 0; i < src_bytes.size(); ++i) {
+        dst_writable_bytes[i] = src_bytes[i];
+    }
+
+    EXPECT_THAT(src, Pointwise(Eq(), dst));
+}
+
+}  // namespace
+}  // namespace tt::stl

--- a/tests/tt_metal/tt_metal/stl/test_strong_type.cpp
+++ b/tests/tt_metal/tt_metal/stl/test_strong_type.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <tt_stl/strong_type.hpp>
 #include <memory>
 #include <set>
@@ -10,8 +10,6 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
-
-#include "gmock/gmock.h"
 
 using MyIntId = tt::stl::StrongType<int, struct MyIntIdTag>;
 using MyStringId = tt::stl::StrongType<std::string, struct MyStringIdTag>;

--- a/tests/tt_metal/tt_metal/test_bfp4_conversion.cpp
+++ b/tests/tt_metal/tt_metal/test_bfp4_conversion.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
 
         std::vector<uint32_t> shape_vec = {1, num_tiles, 32, 32};
         std::vector<float> tiled_fp32_vec = convert_layout(
-            tt::stl::MakeConstSpan(fp32_vec),
+            tt::stl::make_const_span(fp32_vec),
             shape_vec,
             TensorLayoutType::LIN_ROW_MAJOR,
             TensorLayoutType::TILED_NFACES);
@@ -51,12 +51,12 @@ int main(int argc, char** argv) {
         // //                      Validation
         // ////////////////////////////////////////////////////////////////////////////
         std::vector<float> tiled_to_rm_fp32_vec = convert_layout(
-            tt::stl::MakeConstSpan(unpacked_bfp4b_tile_vec_tile_out),
+            tt::stl::make_const_span(unpacked_bfp4b_tile_vec_tile_out),
             shape_vec,
             TensorLayoutType::TILED_NFACES,
             TensorLayoutType::LIN_ROW_MAJOR);
         std::vector<float> rm_to_tiled_fp32_vec = convert_layout(
-            tt::stl::MakeConstSpan(unpacked_bfp4b_tile_vec_rm_out),
+            tt::stl::make_const_span(unpacked_bfp4b_tile_vec_rm_out),
             shape_vec,
             TensorLayoutType::LIN_ROW_MAJOR,
             TensorLayoutType::TILED_NFACES);

--- a/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
+++ b/tests/tt_metal/tt_metal/test_bfp8_conversion.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
 
         std::vector<uint32_t> shape_vec = {1, 1, 32, 32};
         std::vector<float> tiled_fp32_vec = convert_layout(
-            tt::stl::MakeConstSpan(fp32_vec),
+            tt::stl::make_const_span(fp32_vec),
             shape_vec,
             TensorLayoutType::LIN_ROW_MAJOR,
             TensorLayoutType::TILED_NFACES);
@@ -59,12 +59,12 @@ int main(int argc, char** argv) {
         // //                      Validation
         // ////////////////////////////////////////////////////////////////////////////
         std::vector<float> tiled_to_rm_fp32_vec = convert_layout(
-            tt::stl::MakeConstSpan(unpacked_bfp8b_tile_vec_tile_out),
+            tt::stl::make_const_span(unpacked_bfp8b_tile_vec_tile_out),
             shape_vec,
             TensorLayoutType::TILED_NFACES,
             TensorLayoutType::LIN_ROW_MAJOR);
         std::vector<float> rm_to_tiled_fp32_vec = convert_layout(
-            tt::stl::MakeConstSpan(unpacked_bfp8b_tile_vec_rm_out),
+            tt::stl::make_const_span(unpacked_bfp8b_tile_vec_rm_out),
             shape_vec,
             TensorLayoutType::LIN_ROW_MAJOR,
             TensorLayoutType::TILED_NFACES);

--- a/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_multi_core_multi_dram.cpp
@@ -366,12 +366,12 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         pass &= move_tiles_to_dram(device, activations, M, K, src0_dram_addr);
 
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         pass &= move_tiles_to_dram(device, weights, K, N, src1_dram_addr);
         log_info(LogTest, "Copying inputs to dram complete");
@@ -415,7 +415,7 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
                 // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -313,7 +313,7 @@ int main(int argc, char** argv) {
             std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tilized = tilize_swizzled(tensor.get_values(), M * 32, K * 32);
         auto activations_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(activations_tilized));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
@@ -321,7 +321,7 @@ int main(int argc, char** argv) {
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
         auto weights_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity_tilized));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
         tt_metal::detail::WriteToDeviceL1(device, core, source_addresses_in_l1_addr, source_addresses);
@@ -339,7 +339,7 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
         auto result_untilized = untilize_swizzled(result_flat_layout, M * 32, N * 32);
 
         // print_vec(result_bfp16, 128, 128, "Result bfp16");

--- a/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_large_block.cpp
@@ -341,14 +341,14 @@ bool test_matmul_large_block(tt_metal::IDevice* device, bool activations_rm, boo
             activations = pack_bfloat16_vec_into_uint32_vec(tensor.get_values());
         } else {
             auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-            auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+            auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
             activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         }
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
@@ -372,7 +372,7 @@ bool test_matmul_large_block(tt_metal::IDevice* device, bool activations_rm, boo
                 print_faces(result_bfp16, "Result");
             }
         } else {
-            auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+            auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
             auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
             pass &= (tensor.get_values() == result_untilized);
             if (not pass) {

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram.cpp
@@ -373,14 +373,14 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
 
         Buffer activation_buffer(device, activations.size() * sizeof(uint32_t), 1024 * 2, BufferType::DRAM);
         pass &= move_tiles_to_dram(cq, activation_buffer, activations, M, K);
 
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
 
         Buffer weight_buffer(device, weights.size() * sizeof(uint32_t), 1024 * 2, BufferType::DRAM);
@@ -432,7 +432,7 @@ int main(int argc, char** argv) {
                 result_vec.insert(result_vec.end(), result_iter, result_iter + 512);
                 result_iter += 512;
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
 
                 pass &= (golden_tile == result_flat_layout);
             }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast.cpp
@@ -428,12 +428,12 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         pass &= move_tiles_to_dram(device, activations, M, K, in0_dram_addr);
 
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
         log_info(LogTest, "Copying inputs to dram complete");
@@ -490,7 +490,7 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
                 // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in0_mcast_in1_mcast.cpp
@@ -517,12 +517,12 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         pass &= move_tiles_to_dram(device, activations, M, K, in0_dram_addr);
 
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
         log_info(LogTest, "Copying inputs to dram complete");
@@ -585,7 +585,7 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
                 // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_multi_dram_in1_mcast.cpp
@@ -422,12 +422,12 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         log_info(LogTest, "Scattering inputs (activation & weights) to dram channels using tiled layout");
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         pass &= move_tiles_to_dram(device, activations, M, K, in0_dram_addr);
 
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         pass &= move_tiles_to_dram(device, weights, K, N, in1_dram_addr);
         log_info(LogTest, "Copying inputs to dram complete");
@@ -484,7 +484,7 @@ int main(int argc, char** argv) {
                 tt_metal::detail::ReadFromDeviceDRAMChannel(
                     device, dram_bank, dram_address, single_tile_size, result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
 
                 // log_info(LogTest, "Tile id {} on dram bank {}, address {}", tile_id, dram_bank, dram_address);
                 // print_vec(result_flat_layout, 32, 32, "Result - tile#" + std::to_string(tile_id));

--- a/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_core_single_dram.cpp
@@ -334,14 +334,14 @@ int main(int argc, char** argv) {
                 TT_FATAL(dram_buffer_dst_addr + dram_buffer_size_out < 1024 * 1024 * 1024, "Error");
 
                 auto activations_tilized = tilize(activation_slice, per_core_M * 32, K * 32);
-                auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+                auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
                 auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
                 auto activations_tile_transposed = transpose_tiles(activations, per_core_M, K, in0_block_w);
                 pass &= tt_metal::detail::WriteToDeviceDRAMChannel(
                     device, dram_src0_channel_id, dram_buffer_src0_addr, activations_tile_transposed);
 
                 auto identity_tilized = tilize(weights_slice, K * 32, per_core_N * 32);
-                auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+                auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
                 auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
                 pass &= tt_metal::detail::WriteToDeviceDRAMChannel(
                     device, dram_src1_channel_id, dram_buffer_src1_addr, weights);
@@ -398,7 +398,7 @@ int main(int argc, char** argv) {
                     per_core_M * per_core_N * single_tile_size,
                     result_vec);
                 auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-                auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+                auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
                 auto result_untilized = untilize(result_flat_layout, per_core_M * 32, per_core_N * 32);
                 pass &= (per_core_golden == result_untilized);
             }

--- a/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_multi_tile.cpp
@@ -186,14 +186,14 @@ bool run_matmul(const tt::ARCH& arch, const bool with_bias) {
             100,
             std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
@@ -235,7 +235,7 @@ bool run_matmul(const tt::ARCH& arch, const bool with_bias) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
         auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
 
         pass &= (tensor.get_values() == result_untilized);

--- a/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core.cpp
@@ -280,14 +280,14 @@ int main(int argc, char** argv) {
             100,
             std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
@@ -304,7 +304,7 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
         auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
         // print_vec(result_bfp16, 128, 128, "Result bfp16");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(activations_tile_transposed), "Activations tile transpose");

--- a/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_core_small.cpp
@@ -282,14 +282,14 @@ int main(int argc, char** argv) {
             100,
             std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tilized = tilize(tensor.get_values(), M * 32, K * 32);
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(activations_tilized));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize(identity, K * 32, N * 32);
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity_tilized));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
@@ -306,7 +306,7 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
         auto result_untilized = untilize(result_flat_layout, M * 32, N * 32);
         // print_vec(result_bfp16, 128, 128, "Result bfp16");
         // print_faces(unpack_uint32_vec_into_bfloat16_vec(activations_tile_transposed), "Activations tile transpose");

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile.cpp
@@ -118,12 +118,12 @@ int main(int argc, char** argv) {
             0,
             100,
             std::chrono::system_clock::now().time_since_epoch().count());
-        auto activations_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(tensor.get_values()));
+        auto activations_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(tensor.get_values()));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
 
         auto identity = create_identity_matrix(32, 32, 32);  // bflaot16 32x32 identity
-        auto weights_tile_layout = convert_to_tile_layout(tt::stl::MakeConstSpan(identity));
+        auto weights_tile_layout = convert_to_tile_layout(tt::stl::make_const_span(identity));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
@@ -153,7 +153,7 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_to_flat_layout(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_to_flat_layout(tt::stl::make_const_span(result_bfp16));
         pass &= (tensor.get_values() == result_flat_layout);  // src1 is all 0's
         pass &= tt_metal::CloseDevice(device);
 

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -157,12 +157,12 @@ int main(int argc, char** argv) {
             100,
             std::chrono::system_clock::now().time_since_epoch().count());
         auto activations_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(tensor.get_values()));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(tensor.get_values()));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations);
 
         auto identity = create_identity_matrix(32, 32, 32);  // bflaot16 32x32 identity
-        auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity));
+        auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 
@@ -195,7 +195,7 @@ int main(int argc, char** argv) {
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////
         auto result_bfp16 = unpack_uint32_vec_into_bfloat16_vec(result_vec);
-        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::MakeConstSpan(result_bfp16));
+        auto result_flat_layout = convert_layout_tile_nfaces_to_tile_swizzled(tt::stl::make_const_span(result_bfp16));
         pass &= (tensor.get_values() == result_flat_layout);  // src1 is all 0's
         pass &= tt_metal::CloseDevice(device);
 

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -264,7 +264,7 @@ int main(int argc, char** argv) {
             100,
             std::chrono::system_clock::now().time_since_epoch().count());
         auto src0_activations_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(src0_tensor.get_values()));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(src0_tensor.get_values()));
         auto src0_activations = pack_bfloat16_vec_into_uint32_vec(src0_activations_tile_layout);
         tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_activations);
 
@@ -275,7 +275,7 @@ int main(int argc, char** argv) {
             100,
             std::chrono::system_clock::now().time_since_epoch().count());
         auto src1_activations_tile_layout =
-            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(src1_tensor.get_values()));
+            convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(src1_tensor.get_values()));
         auto src1_activations = pack_bfloat16_vec_into_uint32_vec(src1_activations_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, src1_activations);
 
@@ -310,7 +310,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         // Write matmul weights to DRAM
         auto identity = create_identity_matrix(32, 32, 32);  // bflaot16 32x32 identity
-        auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::MakeConstSpan(identity));
+        auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(tt::stl::make_const_span(identity));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
         tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
 

--- a/tests/ttnn/benchmark/cpp/host_tilizer_untilizer/tilizer_untilizer.cpp
+++ b/tests/ttnn/benchmark/cpp/host_tilizer_untilizer/tilizer_untilizer.cpp
@@ -34,7 +34,7 @@ void BM_ConvertLayout_RowMajorToTiledSwizzled(benchmark::State& state) {
     auto& input_data = GetInputData();
     for (auto _ : state) {
         auto out = convert_layout<float>(
-            tt::stl::MakeConstSpan(input_data),
+            tt::stl::make_const_span(input_data),
             shape,
             TensorLayoutType::LIN_ROW_MAJOR,
             TensorLayoutType::TILED_SWIZZLED);
@@ -48,7 +48,10 @@ void BM_ConvertLayout_RowMajorToTiledNfaces(benchmark::State& state) {
     auto& input_data = GetInputData();
     for (auto _ : state) {
         auto out = convert_layout<float>(
-            tt::stl::MakeConstSpan(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
+            tt::stl::make_const_span(input_data),
+            shape,
+            TensorLayoutType::LIN_ROW_MAJOR,
+            TensorLayoutType::TILED_NFACES);
         benchmark::DoNotOptimize(out.data());
         benchmark::ClobberMemory();
     }
@@ -59,11 +62,11 @@ void BM_ConvertLayout_TiledSwizzledToRowMajor(benchmark::State& state) {
     // Pre-convert input_data to TILED_SWIZZLED for a fair benchmark
     auto& input_data = GetInputData();
     static std::vector<float> tiled_data = convert_layout<float>(
-        tt::stl::MakeConstSpan(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_SWIZZLED);
+        tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_SWIZZLED);
 
     for (auto _ : state) {
         auto out = convert_layout<float>(
-            tt::stl::MakeConstSpan(tiled_data),
+            tt::stl::make_const_span(tiled_data),
             shape,
             TensorLayoutType::TILED_SWIZZLED,
             TensorLayoutType::LIN_ROW_MAJOR);
@@ -77,11 +80,11 @@ void BM_ConvertLayout_TiledSwizzledToTiledNFaces(benchmark::State& state) {
     // Pre-convert input_data to TILED_SWIZZLED
     auto& input_data = GetInputData();
     static std::vector<float> tiled_data = convert_layout<float>(
-        tt::stl::MakeConstSpan(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_SWIZZLED);
+        tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_SWIZZLED);
 
     for (auto _ : state) {
         auto out = convert_layout<float>(
-            tt::stl::MakeConstSpan(tiled_data),
+            tt::stl::make_const_span(tiled_data),
             shape,
             TensorLayoutType::TILED_SWIZZLED,
             TensorLayoutType::TILED_NFACES);
@@ -95,11 +98,11 @@ void BM_ConvertLayout_TiledNFacesToRowMajor(benchmark::State& state) {
     // Pre-convert input_data to TILED_NFACES
     auto& input_data = GetInputData();
     static std::vector<float> nfaces_data = convert_layout<float>(
-        tt::stl::MakeConstSpan(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
+        tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
 
     for (auto _ : state) {
         auto out = convert_layout<float>(
-            tt::stl::MakeConstSpan(nfaces_data),
+            tt::stl::make_const_span(nfaces_data),
             shape,
             TensorLayoutType::TILED_NFACES,
             TensorLayoutType::LIN_ROW_MAJOR);
@@ -113,11 +116,11 @@ void BM_ConvertLayout_TiledNFacesToTiledSwizzled(benchmark::State& state) {
     // Pre-convert input_data to TILED_NFACES
     auto& input_data = GetInputData();
     static std::vector<float> nfaces_data = convert_layout<float>(
-        tt::stl::MakeConstSpan(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
+        tt::stl::make_const_span(input_data), shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
 
     for (auto _ : state) {
         auto out = convert_layout<float>(
-            tt::stl::MakeConstSpan(nfaces_data),
+            tt::stl::make_const_span(nfaces_data),
             shape,
             TensorLayoutType::TILED_NFACES,
             TensorLayoutType::TILED_SWIZZLED);

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_sharding.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_sharding.cpp
@@ -141,7 +141,7 @@ TEST_P(ShardWithAlignmentTests, LogicalToPhysical) {
     if (tensor_spec.layout() == Layout::TILE) {
         // TODO: Fix convert_layout_tile_to_row_major to take in vector instead of buffer?
         physical_data = tensor_impl::convert_layout_tile_to_row_major(
-            physical_shape, tensor_spec.tile(), tt::stl::MakeConstSpan(physical_data));
+            physical_shape, tensor_spec.tile(), tt::stl::make_const_span(physical_data));
     }
 
     // auto shape_2d = tensor_spec.logical_2d_shape();
@@ -191,7 +191,7 @@ TEST_P(ShardWithAlignmentTests, PhysicalToLogical) {
     if (tensor_spec.layout() == Layout::TILE) {
         // TODO: Fix convert_layout_row_major_to_tile to take in vector instead of buffer?
         physical_data = tensor_impl::convert_layout_row_major_to_tile(
-            physical_shape, tensor_spec.tile(), tt::stl::MakeConstSpan(physical_data));
+            physical_shape, tensor_spec.tile(), tt::stl::make_const_span(physical_data));
     }
     auto logical_data = tensor_impl::decode_tensor_data(std::move(physical_data), tensor_spec);
 

--- a/tt_metal/tt_metal.cpp
+++ b/tt_metal/tt_metal.cpp
@@ -540,7 +540,7 @@ void WriteToDevice(Buffer& buffer, tt::stl::Span<const uint8_t> host_buffer) {
             const auto virtual_core = buffer.device()->virtual_core_from_logical_core(banks[i], buffer.core_type());
             for (const auto& chunk_mapping_in_bytes : bank_mapping_in_bytes[i]) {
                 // TODO: subspan is in elements; here 1 element is 1 byte (ie. uint8_t) so using bytes here is fine
-                auto chunk_span = tt::stl::MakeConstSpan(
+                auto chunk_span = tt::stl::make_const_span(
                     host_buffer.subspan(chunk_mapping_in_bytes.src, chunk_mapping_in_bytes.size));
                 llrt::write_hex_vec_to_core(
                     buffer.device()->id(), virtual_core, chunk_span, buffer.address() + chunk_mapping_in_bytes.dst);

--- a/tt_stl/tt_stl/span.hpp
+++ b/tt_stl/tt_stl/span.hpp
@@ -93,9 +93,25 @@ template <class R>
 Span(R&&) -> Span<std::remove_reference_t<decltype(*std::begin(std::declval<R&>()))>>;
 
 template <class Container>
-auto MakeConstSpan(const Container& vec) {
+auto make_const_span(const Container& vec) {
     using T = std::remove_reference_t<decltype(*std::begin(std::declval<Container&>()))>;
     return Span<const T>(vec.data(), vec.size());
+}
+
+template <class Container>
+auto make_span(Container& vec) {
+    using T = std::remove_reference_t<decltype(*std::begin(std::declval<Container&>()))>;
+    return Span<T>(vec.data(), vec.size());
+}
+
+template <class T>
+auto as_bytes(Span<T> span) noexcept {
+    return Span<const std::byte>(reinterpret_cast<const std::byte*>(span.data()), span.size_bytes());
+}
+
+template <class T>
+auto as_writable_bytes(Span<T> span) noexcept {
+    return Span<std::byte>(reinterpret_cast<std::byte*>(span.data()), span.size_bytes());
 }
 
 }  // namespace tt::stl

--- a/tt_stl/tt_stl/strong_type.hpp
+++ b/tt_stl/tt_stl/strong_type.hpp
@@ -79,6 +79,7 @@ public:
     constexpr StrongType& operator=(StrongType&&) noexcept = default;
 
     constexpr const T& operator*() const { return value_; }
+    constexpr const T& get() const { return value_; }
 
     // requires() = default on a constexpr function doesn't behave on gcc/clang
     // so it needed the explicit definition to compile.

--- a/ttnn/cpp/ttnn-pybind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-pybind/pytensor.cpp
@@ -364,7 +364,7 @@ HostBuffer create_row_major_host_buffer(
     if (padded_output) {
         if (tensor_spec.layout() == Layout::TILE) {
             auto data = tensor_impl::convert_layout_tile_to_row_major(
-                tensor_spec.physical_shape(), tensor_spec.tile(), tt::stl::MakeConstSpan(host_buffer.view_as<T>()));
+                tensor_spec.physical_shape(), tensor_spec.tile(), tt::stl::make_const_span(host_buffer.view_as<T>()));
             return HostBuffer(std::move(data));
         }
         return host_buffer;

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -1044,7 +1044,7 @@ std::vector<T> encode_tensor_data(std::vector<T>&& logical_data, const TensorSpe
 
     if (tensor_spec.layout() == Layout::TILE) {
         return tensor_impl::convert_layout_row_major_to_tile(
-            physical_shape, tensor_spec.tile(), tt::stl::MakeConstSpan(row_major_physical_data));
+            physical_shape, tensor_spec.tile(), tt::stl::make_const_span(row_major_physical_data));
     }
     return row_major_physical_data;
 }
@@ -1077,7 +1077,7 @@ std::vector<T> decode_tensor_data(std::vector<T>&& physical_data, const TensorSp
     auto row_major_physical_data = [&tensor_spec, &physical_shape](std::vector<T>&& physical_data) {
         if (tensor_spec.layout() == Layout::TILE) {
             return tensor_impl::convert_layout_tile_to_row_major(
-                physical_shape, tensor_spec.tile(), tt::stl::MakeConstSpan(physical_data));
+                physical_shape, tensor_spec.tile(), tt::stl::make_const_span(physical_data));
         } else {
             return std::move(physical_data);
         }


### PR DESCRIPTION
### Ticket
N/A

### What's changed
`as_bytes`, `as_writable_bytes` - requested by tt-train for multi-host

`make_span`, `make_const_span` - lower case for consistency with function names in Metal.

`StrongType::get` overload - received feedback that `operator*` is confusing 

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15008545729)
- [X] New/Existing tests provide coverage for changes