### PR TITLE
Fix warning

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -28,7 +28,7 @@ CPMAddPackage(
         "BOOST_ENABLE_CMAKE ON"
         "BOOST_SKIP_INSTALL_RULES ON"
         "BUILD_SHARED_LIBS OFF"
-        "BOOST_INCLUDE_LIBRARIES core\\\;container\\\;smart_ptr\\\;interprocess\\\;asio\\\;lockfree\\\;"
+        "BOOST_INCLUDE_LIBRARIES core\\\;container\\\;smart_ptr\\\;interprocess\\\;asio\\\;lockfree"
     FIND_PACKAGE_ARGUMENTS "CONFIG REQUIRED"
 )
 


### PR DESCRIPTION
### Ticket
#22060

### Problem description
There's a warning.  It should be cleaned up.

### What's changed
Remove the trailing delimiter that causes an empty entry in the list.