### PR TITLE
Relax constraints on Falcon7B perf in CI

### DIFF
--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -553,10 +553,10 @@ def run_falcon_demo_kv(
     # Verify output or perf if expected values are provided
     assert expected_perf_metrics is None or expected_greedy_output_path is None
     if expected_perf_metrics is not None:
-        if num_devices == 32:  # set higher margin to 20% for Galaxy due to larger variance on CI
-            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.20)
+        if num_devices == 32:  # set higher margin as CI is very variable at the moment
+            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.30)
         else:
-            verify_perf(measurements, expected_perf_metrics)
+            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.30)
     elif expected_greedy_output_path is not None:
         if token_check_does_pass:
             logger.info("Output Check Passed!")

--- a/models/demos/falcon7b_common/demo/demo.py
+++ b/models/demos/falcon7b_common/demo/demo.py
@@ -554,9 +554,9 @@ def run_falcon_demo_kv(
     assert expected_perf_metrics is None or expected_greedy_output_path is None
     if expected_perf_metrics is not None:
         if num_devices == 32:  # set higher margin as CI is very variable at the moment
-            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.30)
+            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.50)
         else:
-            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.30)
+            verify_perf(measurements, expected_perf_metrics, high_tol_percentage=1.50)
     elif expected_greedy_output_path is not None:
         if token_check_does_pass:
             logger.info("Output Check Passed!")

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -11,7 +11,7 @@ from models.utility_functions import is_wormhole_b0
 @pytest.mark.parametrize(
     "perf_mode, max_seq_len, expected_perf_metrics, greedy_sampling, expected_greedy_output_path",
     (
-        (True, 128, {"prefill_t/s": 1412, "decode_t/s": 516, "decode_t/s/u": 16.11}, False, None),
+        (True, 128, {"prefill_t/s": 1218, "decode_t/s": 516, "decode_t/s/u": 16.11}, False, None),
         (True, 1024, {"prefill_t/s": 2117, "decode_t/s": 440, "decode_t/s/u": 13.7}, False, None),
         (True, 2048, {"prefill_t/s": 1967, "decode_t/s": 420, "decode_t/s/u": 13.12}, False, None),
         (True, 128, None, False, None),
@@ -33,7 +33,7 @@ from models.utility_functions import is_wormhole_b0
         "default_mode_1024_stochastic",
     ],
 )
-@pytest.mark.parametrize("mesh_device", (1,), indirect=True)
+@pytest.mark.parametrize("mesh_device", (1, 2), indirect=True)
 def test_demo(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
     max_seq_len,

--- a/models/demos/wormhole/falcon7b/demo_wormhole.py
+++ b/models/demos/wormhole/falcon7b/demo_wormhole.py
@@ -33,7 +33,7 @@ from models.utility_functions import is_wormhole_b0
         "default_mode_1024_stochastic",
     ],
 )
-@pytest.mark.parametrize("mesh_device", (1, 2), indirect=True)
+@pytest.mark.parametrize("mesh_device", (1,), indirect=True)
 def test_demo(
     perf_mode,  # Option to measure perf using max seq length (with invalid outputs) and expected perf (t/s)
     max_seq_len,


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21952

### Problem description
Whilst fixing other TTT tests I noticed the falcon7b perf test failing frequently. The CI performance noise is too high for such a short test. The test authors should address this with more loops / longer tests, but for now I have decreased the sensitivity so that this does not artificially cause CI to go red all the time.

### What's changed
Decreased minimum 128 perf to 1200, increased upward sensitivity to 50%

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15018643076) CI passes
- [x] [Single card demo tests](https://github.com/tenstorrent/tt-metal/actions/runs/15017982239/job/42200676824)