### PR TITLE
Remove grayskull from eltwise ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fmod.py
@@ -6,7 +6,6 @@ import torch
 import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_pcc, data_gen_with_range
-from models.utility_functions import skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -45,7 +44,6 @@ def test_bw_unary_fmod(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for binary fmod backward")
 def test_bw_binary_fmod(input_shapes, device):
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
     other_data, other_tensor = data_gen_with_range(input_shapes, -50, 50, device, True)

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_remainder.py
@@ -6,7 +6,6 @@ import torch
 import pytest
 import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import compare_pcc, data_gen_with_range
-from models.utility_functions import skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -46,7 +45,6 @@ def test_bw_unary_remainder(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for binary remainder backward")
 def test_bw_binary_remainder(input_shapes, device):
     grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
     in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)

--- a/tests/ttnn/unit_tests/operations/eltwise/complex/test_complex_conj.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/complex/test_complex_conj.py
@@ -10,14 +10,13 @@ from loguru import logger
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import data_gen_with_range
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal, comp_allclose
 
-from models.utility_functions import is_wormhole_b0, skip_for_grayskull
+from models.utility_functions import is_wormhole_b0
 from tests.ttnn.unit_tests.operations.eltwise.complex.utility_funcs import (
     convert_complex_to_torch_tensor,
     random_complex_tensor,
 )
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "memcfg",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_abs_int.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_abs_int.py
@@ -13,12 +13,11 @@ from tests.sweep_framework.sweep_utils.utils import gen_shapes
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
 
 from tests.ttnn.utils_for_testing import check_with_pcc, start_measuring_time, stop_measuring_time
-from models.utility_functions import torch_random, skip_for_grayskull
+from models.utility_functions import torch_random
 
 random.seed(0)
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shape",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_activation.py
@@ -7,7 +7,6 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_grayskull
 
 
 def run_activation_unary_test(device, h, w, ttnn_function, pcc=0.99):
@@ -50,7 +49,6 @@ def test_log_sigmoid(device, h, w):
     run_activation_unary_test(device, h, w, ttnn.log_sigmoid)
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_mish(device, h, w):
@@ -118,7 +116,6 @@ def run_activation_softplus_test(device, h, w, beta, threshold, ttnn_function, p
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("beta", [-1, 0.5, 1, 2])
@@ -307,7 +304,6 @@ def test_scalarB_leaky_relu(device, h, w, scalar):
     run_activation_test_leaky_relu(device, h, w, scalar, ttnn.leaky_relu)
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize("weight", [-0.5, 1.0, 0.5])
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -9,7 +9,7 @@ import ttnn
 from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     compare_pcc,
 )
-from models.utility_functions import skip_for_grayskull, torch_random
+from models.utility_functions import torch_random
 from itertools import product as parameters
 from functools import partial
 from tests.tt_eager.python_api_testing.sweep_tests.generation_funcs import gen_func_with_cast_tt
@@ -106,7 +106,6 @@ def rand_bf16_gen(shape, device, *, min=0, max=1, memory_config=ttnn.DRAM_MEMORY
     return pt, tt
 
 
-@skip_for_grayskull("Possible accuracy issues with grayskull")
 @pytest.mark.parametrize(
     "a_shape, b_shape",
     (
@@ -496,7 +495,6 @@ def test_binary_sharded_core_grid(device, a_shape, b_shape, sharded_core_grid, m
     assert ttnn.pearson_correlation_coefficient(out_tt_sharded, out_pt) >= 0.99988
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -564,7 +562,6 @@ def test_binary_sfpu_ops(input_shapes, dtype, ttnn_fn, device):
     assert status >= 0.999
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -640,7 +637,6 @@ def test_binary_sfpu_opt_out(input_shapes, dtype, ttnn_fn, device):
     assert status >= 0.999
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -695,7 +691,6 @@ def test_binary_sfpu_bitwise_ops(input_shapes, dtype, ttnn_fn, device):
     assert status >= 0.999
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -811,7 +806,6 @@ binary_inplace_fns = {
         parameters({"mul_"}, {log_lhs_sqrt_abs_post}),
     ),
 )
-@skip_for_grayskull("Possible accuracy issues with grayskull")
 def test_inplace_binary_ops_with_tensor(a_shape, b_shape, ttnn_fn, activations, device):
     torch.manual_seed(0)
 
@@ -930,7 +924,6 @@ def test_bf4b_bf8b(a_shape, b_shape, input_dtype, pcc, ttnn_fn, device):
     assert ttnn.pearson_correlation_coefficient(torch_output_tensor, output_tensor) >= pcc
 
 
-@skip_for_grayskull("Requires wormhole_b0 to run")
 @pytest.mark.parametrize(
     "input_shapes",
     (
@@ -1032,7 +1025,6 @@ def test_inplace_binary_ops_invalid_bcast(a_shape, b_shape, ttnn_fn, device):
         torch.Size([920, 1, 256]),
     ),
 )
-@skip_for_grayskull("Possible accuracy issues with grayskull")
 @pytest.mark.parametrize("scalar", [-0.25, -16.5, 0.0, 0.05, 1.7, 19.0])
 def test_inplace_binary_with_scalar(a_shape, scalar, ttnn_fn, device):
     torch.manual_seed(0)
@@ -1083,7 +1075,6 @@ def test_binary_opt_output_invalid_bcast(a_shape, b_shape, out_shape, ttnn_fn, d
         ttnn_op(input_tensor_a, input_tensor_b, queue_id=cq_id, output_tensor=out_tt, use_legacy=False)
 
 
-@skip_for_grayskull()
 @pytest.mark.parametrize(
     "dtype_pt, dtype_tt",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_composite.py
@@ -13,7 +13,6 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     compare_equal,
 )
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import is_grayskull, skip_for_grayskull
 from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
@@ -196,9 +195,6 @@ def test_binary_subalpha_ttnn(input_shapes, alpha, device):
     ),
 )
 def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
-    if is_grayskull():
-        if round_mode in ["trunc", "floor"]:
-            pytest.skip("does not work for Grayskull -skipping")
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -225,9 +221,6 @@ def test_binary_div_ttnn(accurate_mode, round_mode, input_shapes, device):
     ),
 )
 def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
-    if is_grayskull():
-        if round_mode in ["trunc", "floor"]:
-            pytest.skip("does not work for Grayskull -skipping")
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -1e6, 1e6, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -1e6, -1, device)
@@ -255,9 +248,6 @@ def test_binary_div_ttnn_ci(accurate_mode, round_mode, input_shapes, device):
     ),
 )
 def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
-    if is_grayskull():
-        if round_mode in ["trunc", "floor"]:
-            pytest.skip("does not work for Grayskull -skipping")
     if accurate_mode == False:  # If input_b is non-zero tensor
         in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
         in_data2, input_tensor2 = data_gen_with_range(input_shapes, -150, -1, device)
@@ -295,9 +285,6 @@ def test_binary_div_ttnn_opt(accurate_mode, round_mode, input_shapes, device):
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
 def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, device):
-    if is_grayskull():
-        if round_mode in ["trunc", "floor"]:
-            pytest.skip("does not work for Grayskull -skipping")
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
     output_tensor = ttnn.div(input_tensor1, value, accurate_mode=accurate_mode, round_mode=round_mode)
@@ -320,9 +307,6 @@ def test_binary_div_scalar_ttnn(accurate_mode, round_mode, input_shapes, value, 
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
 def test_binary_div_scalar_ttnn_opt(accurate_mode, round_mode, input_shapes, value, device):
-    if is_grayskull():
-        if round_mode in ["trunc", "floor"]:
-            pytest.skip("does not work for Grayskull -skipping")
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
     _, output_tensor = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -383,7 +367,6 @@ def test_binary_div_no_nan_overload_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
 def test_binary_floor_div_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -350, 100, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
@@ -404,7 +387,6 @@ def test_binary_floor_div_ttnn(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize("value", [-5.1, 0.0, 10.9])
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for Floor")
 def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -100, 100, device)
 
@@ -424,7 +406,6 @@ def test_binary_floor_div_overload_ttnn(input_shapes, value, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_remainder_ttnn(input_shapes, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     in_data2, input_tensor2 = data_gen_with_range(input_shapes, -100, 100, device)
@@ -442,7 +423,6 @@ def test_binary_remainder_ttnn(input_shapes, device):
         [[1, 1, 3, 3], [1, 1, 3, 3]],
     ],
 )
-@skip_for_grayskull("Unsupported for Grayskull")
 def test_shape_remainder(device, shapes):
     torch.manual_seed(0)
     high = 10
@@ -482,7 +462,6 @@ def test_shape_remainder(device, shapes):
     "scalar",
     {random.randint(-100, 100) + 0.5 for _ in range(5)},
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_remainder_ttnn(input_shapes, scalar, device):
     in_data1, input_tensor1 = data_gen_with_range(input_shapes, -150, 150, device)
     output_tensor = ttnn.remainder(input_tensor1, scalar)
@@ -909,7 +888,6 @@ def test_nei_ttnn(input_shapes, scalar, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_gcd_ttnn(input_shapes, device):
     in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
     in_data2 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
@@ -931,7 +909,6 @@ def test_binary_gcd_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_lcm_ttnn(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-32767, 32768, input_shapes, dtype=torch.int32)
@@ -955,7 +932,6 @@ def test_binary_lcm_ttnn(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_gcd_int32(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-2147483647, 2147483648, input_shapes, dtype=torch.int32)
@@ -980,7 +956,6 @@ def test_binary_gcd_int32(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_lcm_pos(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(1, 32768, input_shapes, dtype=torch.int32)
@@ -1005,7 +980,6 @@ def test_binary_lcm_pos(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("#ToDo: GS implementation needs to be done for remainder")
 def test_binary_lcm_neg(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-32767, 0, input_shapes, dtype=torch.int32)
@@ -1068,7 +1042,6 @@ def test_binary_prelu_ttnn(input_shapes, device):
     "scalar",
     {-0.25, -2.7, 0.45, 6.4},
 )
-@skip_for_grayskull()
 def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1105,7 +1078,6 @@ def test_binary_prelu_scalar_ttnn(input_shapes, scalar, device):
         [-1],
     ],
 )
-@skip_for_grayskull()
 def test_binary_prelu_1D_weight(input_shapes, weight, device):
     in_data1 = torch.rand(input_shapes, dtype=torch.bfloat16) * 200 - 100
     input_tensor1 = ttnn.from_torch(in_data1, layout=ttnn.TILE_LAYOUT, device=device)
@@ -1127,7 +1099,6 @@ def test_binary_prelu_1D_weight(input_shapes, weight, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("Unsupported in Grayskull")
 def test_binary_left_shift(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
@@ -1153,7 +1124,6 @@ def test_binary_left_shift(input_shapes, device):
         (torch.Size([1, 3, 320, 384])),
     ),
 )
-@skip_for_grayskull("Unsupported in Grayskull")
 def test_binary_right_shift(input_shapes, device):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
@@ -1183,7 +1153,6 @@ def test_binary_right_shift(input_shapes, device):
     "scalar",
     {random.randint(0, 31)},
 )
-@skip_for_grayskull("Unsupported in Grayskull")
 def test_unary_left_shift(input_shapes, device, scalar):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)
@@ -1211,7 +1180,6 @@ def test_unary_left_shift(input_shapes, device, scalar):
     "scalar",
     {random.randint(0, 31)},
 )
-@skip_for_grayskull("Unsupported in Grayskull")
 def test_unary_right_shift(input_shapes, device, scalar):
     torch.manual_seed(213919)
     in_data1 = torch.randint(-1000, 1000, input_shapes, dtype=torch.int32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_fp32.py
@@ -6,10 +6,8 @@ import torch
 import ttnn
 
 import pytest
-from models.utility_functions import skip_for_grayskull
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -32,7 +30,6 @@ def test_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -54,7 +51,6 @@ def test_int32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -75,7 +71,6 @@ def test_mul_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -102,7 +97,6 @@ def test_div_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -160,7 +154,6 @@ def test_div_bf16(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -181,7 +174,6 @@ def test_pow_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 def test_squared_sum_fp32_activ(device):
     x_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32)
     y_torch = torch.ones([1, 1, 64, 64], dtype=torch.float32) * 4
@@ -195,7 +187,6 @@ def test_squared_sum_fp32_activ(device):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -229,7 +220,6 @@ def test_add_fp32_input_activ(device, ttnn_function, shape):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -250,7 +240,6 @@ def test_logaddexp_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -271,7 +260,6 @@ def test_logaddexp2_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -292,7 +280,6 @@ def test_ldexp_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -313,7 +300,6 @@ def test_bias_gelu_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -334,7 +320,6 @@ def test_squared_difference_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -357,7 +342,6 @@ def test_logical_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -383,7 +367,6 @@ def test_relational_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -406,7 +389,6 @@ def test_bitwise(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -427,7 +409,6 @@ def test_bitwise_left_shift(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sin.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_sin.py
@@ -11,7 +11,6 @@ import traceback
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
-from models.utility_functions import skip_for_grayskull
 
 
 def run_eltwise_sin_tests(
@@ -72,6 +71,5 @@ test_sweep_args = [
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed",
     (test_sweep_args),
 )
-@skip_for_grayskull("Not supported for Grayskull")
 def test_eltwise_sin(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device):
     run_eltwise_sin_tests(input_shape, dtype, dlayout, in_mem_config, out_mem_config, data_seed, device)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_softplus_inf.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_softplus_inf.py
@@ -11,7 +11,6 @@ import traceback
 
 from tests.ttnn.python_api_testing.sweep_tests import ttnn_ops
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
-from models.utility_functions import skip_for_grayskull
 
 
 def run_eltwise_softplus_tests(
@@ -67,7 +66,6 @@ test_sweep_args = [
 ]
 
 
-@skip_for_grayskull("Softplus is not available in Grayskull")
 @pytest.mark.parametrize(
     "input_shape, dtype, dlayout, in_mem_config, out_mem_config, beta, threshold, data_seed",
     (test_sweep_args),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -6,7 +6,6 @@ import pytest
 import torch
 import ttnn
 from functools import partial
-from models.utility_functions import skip_for_grayskull
 
 
 from tests.tt_eager.python_api_testing.sweep_tests import (
@@ -87,7 +86,6 @@ npu_layout = ttnn.Layout.TILE
     "dst_mem_config",
     mem_configs,
 )
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 class TestTypecast:
     def test_run_eltwise_typecast_op(
         self,
@@ -125,7 +123,6 @@ class TestTypecast:
 
 
 @pytest.mark.skip("Issue #17237: Does not work with new mantissa rounding")
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 def test_typecast_bf16_to_bfp8_b(device):
     torch.manual_seed(0)
     shape = [32, 32]
@@ -160,7 +157,6 @@ def print_mismatches(cpu, npu, num_max_print):
 @pytest.mark.parametrize("seed", [0, 2, 4, 6, 8])
 @pytest.mark.parametrize("scale", [1, 2, 4, 8, 16, 32, 64, 128, 256, 512])
 @pytest.mark.parametrize("bias", [0, 1, 2, 4, 8, 16, 32, 64, 128])
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device):
     torch.manual_seed(seed)
     shape = [1024, 1024]
@@ -194,7 +190,6 @@ def test_typecast_bf16_to_bfp8_b_various_input(seed, scale, bias, device):
 @pytest.mark.parametrize("bias", [2])
 # NaN becomes -Inf when converted to bfloat8_b format, skip testing
 @pytest.mark.parametrize("insert_inf, insert_nan", [[True, False]])  # , [False, True], [True, True]])
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, insert_nan, device):
     torch.manual_seed(seed)
     shape = [1024, 1024]
@@ -230,7 +225,6 @@ def test_typecast_bf16_to_bfp8_b_with_inf_nan(seed, scale, bias, insert_inf, ins
     assert passed
 
 
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 def test_typecast_bfp8_b_to_bf16(device):
     torch.manual_seed(0)
     shape = [1024, 1024]
@@ -250,7 +244,6 @@ def test_typecast_bfp8_b_to_bf16(device):
     assert passed
 
 
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 def test_typecast_fp32_to_bfp8_b(device):
     torch.manual_seed(0)
     shape = [32, 32]
@@ -271,7 +264,6 @@ def test_typecast_fp32_to_bfp8_b(device):
     assert passed
 
 
-@skip_for_grayskull("Op not supported for Grayskull, supported for wormhole_b0")
 def test_typecast_bfp8_b_to_fp32(device):
     torch.manual_seed(0)
     shape = [1024, 1024]

--- a/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_fill.py
@@ -9,7 +9,6 @@ import torch
 import ttnn
 
 from tests.ttnn.utils_for_testing import assert_equal
-from models.utility_functions import skip_for_grayskull
 
 
 @pytest.mark.parametrize(
@@ -35,7 +34,6 @@ def test_fill(device, input_shapes, fill_value):
     assert equal_passed
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "input_shapes",
     (

--- a/tests/ttnn/unit_tests/operations/eltwise/test_math.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_math.py
@@ -7,7 +7,6 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import is_grayskull
 
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.utility_functions import torch_random
@@ -77,9 +76,6 @@ def test_lgamma(device, h, w):
 @pytest.mark.parametrize("w", [32])
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.uint16, ttnn.uint32])
 def test_eq(device, h, w, output_dtype):
-    if is_grayskull() and output_dtype in (ttnn.uint16, ttnn.uint32):
-        pytest.skip("GS does not support fp32/uint32/uint16 data types")
-
     torch.manual_seed(0)
 
     same = 50

--- a/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_mul.py
@@ -8,7 +8,6 @@ import torch
 
 import ttnn
 
-from models.utility_functions import skip_for_grayskull
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -103,7 +102,6 @@ def test_multiply_int32_with_scalar(device, input_a, scalar):
 @pytest.mark.parametrize("output_memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("scalar", [0.125])
 @pytest.mark.parametrize("batch_size", [6, 7, 8])
-@skip_for_grayskull()
 def test_multiply_float32_with_scalar_sharded(device, scalar, batch_size, output_memory_config):
     torch.manual_seed(0)
     torch_input_tensor_a = torch.rand((batch_size, 16, 384, 384), dtype=torch.float32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_fp32.py
@@ -6,11 +6,9 @@ import torch
 import ttnn
 
 import pytest
-from models.utility_functions import skip_for_grayskull
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -30,7 +28,6 @@ def test_neg_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -50,7 +47,6 @@ def test_sin_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -70,7 +66,6 @@ def test_cos_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -90,7 +85,6 @@ def test_tan_fp32(device, ttnn_function):
     assert status
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "ttnn_function",
     [
@@ -126,98 +120,84 @@ def run_unary_test(device, h, w, ttnn_function, pcc=0.9999):
     assert_with_pcc(torch_output_tensor, output_tensor, pcc)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_exp(device, h, w):
     run_unary_test(device, h, w, ttnn.exp, pcc=0.9998)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_tanh(device, h, w):
     run_unary_test(device, h, w, ttnn.tanh, pcc=0.993)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_gelu(device, h, w):
     run_unary_test(device, h, w, ttnn.gelu, pcc=0.9996)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_rsqrt(device, h, w):
     run_unary_test(device, h, w, ttnn.rsqrt)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_silu(device, h, w):
     run_unary_test(device, h, w, ttnn.silu)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_log(device, h, w):
     run_unary_test(device, h, w, ttnn.log)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_asin(device, h, w):
     run_unary_test(device, h, w, ttnn.asin, pcc=0.998)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_acos(device, h, w):
     run_unary_test(device, h, w, ttnn.acos, pcc=0.998)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_atan(device, h, w):
     run_unary_test(device, h, w, ttnn.atan)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_sinh(device, h, w):
     run_unary_test(device, h, w, ttnn.sinh)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_asinh(device, h, w):
     run_unary_test(device, h, w, ttnn.asinh, pcc=0.9997)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_cosh(device, h, w):
     run_unary_test(device, h, w, ttnn.cosh, pcc=0.999)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_acosh(device, h, w):
     run_unary_test(device, h, w, ttnn.acosh)
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize("h", [64])
 @pytest.mark.parametrize("w", [128])
 def test_atanh(device, h, w):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i1.py
@@ -7,10 +7,8 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import skip_for_grayskull
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -44,7 +42,6 @@ def test_i1_range(device, shapes):
     assert pcc >= 0.9999
 
 
-@skip_for_grayskull("Unsupported dtype for Grayskull")
 @pytest.mark.parametrize(
     "shapes",
     [

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2153,8 +2153,7 @@ void py_module(py::module& module) {
         ttnn::remainder,
         R"doc(Performs an eltwise-modulus operation.)doc",
         R"doc(\mathrm{{output\_tensor}} = \verb|remainder|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
-        R"doc(BFLOAT16)doc",
-        R"doc(Support provided only for WH_B0.)doc");
+        R"doc(BFLOAT16)doc");
 
     detail::bind_inplace_operation(
         module,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -427,8 +427,6 @@ Tensor run_remainder(
 // Binary remainder will be overloaded by unary remainder in another PR
 Tensor ExecuteBinaryRemainder::invoke(
     const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input_a.device()->arch();
-    TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is supported on Wormhole or Blackhole");
     DataType input_dtype = input_a.get_dtype();
 
     float t_nan = tt::tt_metal::hal::get_nan();
@@ -488,8 +486,6 @@ Tensor ExecuteBinaryFmod::invoke(
 }
 
 Tensor _floor_div_overload(const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input_a.device()->arch();
-    TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is supported on Wormhole");
     if (value == 0) {
         float t_inf = std::numeric_limits<float>::infinity();
         float t_nan = std::nanf("");
@@ -503,8 +499,6 @@ Tensor _floor_div_overload(const Tensor& input_a, float value, const std::option
 }
 
 Tensor _floor_div(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input_a.device()->arch();
-    TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is supported on Wormhole");
     Tensor temp = ttnn::div(input_a, input_b, true, std::nullopt, std::nullopt, output_mem_config);
     Tensor result = ttnn::div(input_a, input_b, true, "floor", std::nullopt, output_mem_config);
     // floor(nan, inf, -inf) = nan, inf, -inf

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp
@@ -77,12 +77,11 @@ BinaryDeviceOperation::program_factory_t BinaryDeviceOperation::select_program_f
     auto width_b = input_shape_b[-1];
 
     if (height_a == height_b and width_a == width_b) {
-        bool device_check = tensor_args.input_tensor_a.device()->arch() != tt::ARCH::GRAYSKULL;
         BinaryOpType op = operation_attributes.binary_op_type;
         DataType dtype1 = tensor_args.input_tensor_a.get_dtype();
         DataType dtype2 = tensor_args.input_tensor_b->get_dtype();
         bool sfpu_op_check = utils::is_binary_sfpu_op(op, dtype1, dtype2);
-        if(device_check && sfpu_op_check){
+        if(sfpu_op_check){
             return ElementWiseMultiCoreSfpu{};
         } else {
             return ElementWiseMultiCore{};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -458,8 +458,7 @@ BinaryNgDeviceOperation::invoke(
 
     DataType dtype_a = input_tensor_a.get_dtype();
     DataType dtype_b = input_tensor_b.get_dtype();
-    bool device_check = input_tensor_a.device()->arch() != tt::ARCH::GRAYSKULL;
-    bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_b) && device_check);
+    bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_b));
     bool is_quant_op = utils::is_quant_op(binary_op_type);
     return {
         operation_attributes_t{
@@ -492,8 +491,7 @@ BinaryNgDeviceOperation::invoke(
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> post_activations) {
     DataType dtype_a = input_tensor_a.get_dtype();
-    bool device_check = input_tensor_a.device()->arch() != tt::ARCH::GRAYSKULL;
-    bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a) && device_check);
+    bool is_sfpu_op = (utils::is_binary_sfpu_op(binary_op_type, dtype_a, dtype_a));
     bool is_quant_op = utils::is_quant_op(binary_op_type);
     return {
         operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_composite_op.cpp
@@ -347,8 +347,6 @@ Tensor ExecuteTrunc::invoke(
     const Tensor& input,
     const std::optional<MemoryConfig>& output_mem_config,
     std::optional<Tensor> output_tensor) {
-    auto arch = input.device()->arch();
-    TT_FATAL(arch != tt::ARCH::GRAYSKULL, "Op is not supported on Grayskull");
     output_tensor = output_tensor.value_or(ttnn::empty_like(input));
     Tensor floor_res = ttnn::floor(queue_id, input, output_mem_config);
     ttnn::where(
@@ -861,9 +859,6 @@ Tensor _normalize_global(const Tensor& y, const std::optional<MemoryConfig>& out
 }
 
 Tensor _frac(const Tensor& input, const std::optional<MemoryConfig>& output_mem_config) {
-    auto arch = input.device()->arch();
-    TT_FATAL(
-        arch == tt::ARCH::WORMHOLE_B0 or arch == tt::ARCH::BLACKHOLE, "Op is only supported on Wormhole or Blackhole");
     Tensor trunc_res = ttnn::trunc(input);
     Tensor result = ttnn::subtract(input, trunc_res, std::nullopt, output_mem_config);
     return result;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -18,35 +18,10 @@ namespace {
 void validate_supported_arch_dtype(
     tt::ARCH arch, DataType input_datatype, DataType output_datatype, UnaryOpType op_type) {
     switch (op_type) {
-        case UnaryOpType::REMAINDER:
-        case UnaryOpType::FLOOR:
-        case UnaryOpType::CEIL:
-        case UnaryOpType::ROUND:
-        case UnaryOpType::LEFT_SHIFT:
-        case UnaryOpType::RIGHT_SHIFT:
-        case UnaryOpType::MAXIMUM:
-        case UnaryOpType::MINIMUM:
-        case UnaryOpType::LOG1P:
-            TT_FATAL(
-                arch != tt::ARCH::GRAYSKULL,
-                "UnaryOpType '{}' is not supported on Grayskull architecture.",
-                static_cast<int>(op_type));
-            break;
-        case UnaryOpType::FILL:
-           if(arch == tt::ARCH::GRAYSKULL){
-                TT_FATAL(
-                    (input_datatype == DataType::BFLOAT16 || input_datatype == DataType::BFLOAT8_B),
-                    "Unsupported dtype {}. On Grayskull only BFLOAT16/BFLOAT8_B are supported", input_datatype);
-                }
-            break;
         case UnaryOpType::BITWISE_XOR:
         case UnaryOpType::BITWISE_NOT:
         case UnaryOpType::BITWISE_AND:
         case UnaryOpType::BITWISE_OR:
-            TT_FATAL(
-                arch != tt::ARCH::GRAYSKULL,
-                "UnaryOpType '{}' is not supported on Grayskull architecture (Bitwise operation).",
-                static_cast<int>(op_type));
             TT_FATAL(
                 input_datatype == DataType::INT32,
                 "Unsupported input data type '{}' for UnaryOpType '{}' (Bitwise operation).",
@@ -68,13 +43,6 @@ void validate_supported_arch_dtype(
                 (output_datatype == DataType::BFLOAT16 || output_datatype == DataType::FLOAT32),
                 "Unsupported output data type '{}' for UnaryOpType '{}' (FMOD operation).",
                 static_cast<int>(output_datatype),
-                static_cast<int>(op_type));
-            break;
-        case UnaryOpType::ABS:
-        case UnaryOpType::ABS_INT32:
-            TT_FATAL(
-                !(arch == tt::ARCH::GRAYSKULL && input_datatype == DataType::INT32),
-                "UnaryOpType '{}' (ABS int32 operation) is not supported on Grayskull architecture.",
                 static_cast<int>(op_type));
             break;
         default: return;

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary.cpp
@@ -28,8 +28,7 @@ inline Tensor unary_impl(
     DataType output_dtype = (op_chain[0].op_type == UnaryOpType::TYPECAST)
                                 ? static_cast<DataType>(op_chain[0].params[1])
                                 : input_tensor.get_dtype();
-    auto arch = input_tensor.device()->arch();
-    bool preserve_fp32_precision = (arch != tt::ARCH::GRAYSKULL) and (input_tensor.get_dtype() == DataType::FLOAT32);
+    bool preserve_fp32_precision = input_tensor.get_dtype() == DataType::FLOAT32;
     bool fp32_dest_acc_en = preserve_fp32_precision or output_dtype == DataType::UINT32 or
                             output_dtype == DataType::INT32 or output_dtype == DataType::FLOAT32 or
                             input_tensor.get_dtype() == DataType::UINT32 or input_tensor.get_dtype() == DataType::INT32;
@@ -243,7 +242,6 @@ Tensor Softplus::invoke(
     const float threshold,
     const std::optional<MemoryConfig>& memory_config,
     const std::optional<Tensor>& optional_output_tensor) {
-    TT_ASSERT(input.device()->arch() != tt::ARCH::GRAYSKULL, "Softplus is not currently supported on Grayskull");
     return detail::unary_impl(
         queue_id,
         input,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_pybind.hpp
@@ -1745,10 +1745,10 @@ void py_module(py::module& module) {
 
     detail::bind_unary_operation(module, ttnn::expm1, R"doc(\mathrm{{output\_tensor}}_i = \verb|expm1|(\mathrm{{input\_tensor}}_i))doc", "", R"doc(BFLOAT16, BFLOAT8_B)doc");
 
-    detail::bind_unary_operation(module, ttnn::floor, R"doc(\mathrm{{output\_tensor}}_i = \verb|floor|(\mathrm{{input\_tensor}}_i))doc", "", R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(Supported only for Wormhole_B0.)doc");
+    detail::bind_unary_operation(module, ttnn::floor, R"doc(\mathrm{{output\_tensor}}_i = \verb|floor|(\mathrm{{input\_tensor}}_i))doc", "", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::eqz, R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ == 0}}))doc", "", R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
-    detail::bind_unary_operation(module, ttnn::ceil, R"doc(\mathrm{{output\_tensor}}_i = \verb|ceil|(\mathrm{{input\_tensor}}_i))doc", "", R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(Supported only for Wormhole_B0.)doc");
-    detail::bind_unary_operation(module, ttnn::mish, R"doc(\mathrm{{output\_tensor}}_i = \verb|mish|(\mathrm{{input\_tensor}}_i))doc", "[Supported range -20 to inf]", R"doc(BFLOAT16, BFLOAT8_B)doc", R"doc(Supported only for Wormhole_B0.)doc");
+    detail::bind_unary_operation(module, ttnn::ceil, R"doc(\mathrm{{output\_tensor}}_i = \verb|ceil|(\mathrm{{input\_tensor}}_i))doc", "", R"doc(BFLOAT16, BFLOAT8_B)doc");
+    detail::bind_unary_operation(module, ttnn::mish, R"doc(\mathrm{{output\_tensor}}_i = \verb|mish|(\mathrm{{input\_tensor}}_i))doc", "[Supported range -20 to inf]", R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_operation(module, ttnn::gez, R"doc(\mathrm{{output\_tensor}}_i = (\mathrm{{input\_tensor_i\ >= 0}}))doc", "", R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
     detail::bind_unary_operation(module, ttnn::gtz, R"doc(\mathrm{{output\_tensor}}_i= (\mathrm{{input\_tensor_i\ > 0}}))doc", "", R"doc(BFLOAT16, BFLOAT8_B, INT32)doc");
 
@@ -1783,7 +1783,6 @@ void py_module(py::module& module) {
     detail::bind_unary_operation(module, ttnn::bitwise_not, R"doc(\mathrm{{output\_tensor}}_i = \verb|bitwise_not|(\mathrm{{input\_tensor}}_i))doc",
     R"doc(Supported input range is [-2147483647, 2147483647].)doc",
     R"doc(INT32)doc",
-    R"doc(Supported for Wormhole_B0 only.)doc",
     R"doc(torch.tensor([[1, 2], [3, 4]], dtype=torch.int32))doc");
     detail::bind_unary_operation(
         module,
@@ -1962,8 +1961,7 @@ void py_module(py::module& module) {
         ttnn::round,
         "decimals", "no. of decimal places to round off to [supported range -6 to 7]",
         R"doc(Round the input tensor to `decimals` decimal places.)doc",
-        R"doc(BFLOAT16, BFLOAT8_B)doc",
-        R"doc(Not supported on Grayskull.)doc");
+        R"doc(BFLOAT16, BFLOAT8_B)doc");
     detail::bind_unary_composite_int(
         module,
         ttnn::polygamma,
@@ -1991,8 +1989,7 @@ void py_module(py::module& module) {
     detail::bind_unary_composite_float_with_default(
         module,
         ttnn::logit,
-        "eps", "eps", 0.0f,  R"doc(BFLOAT16)doc",
-            R"doc(Not available for Wormhole_B0.)doc");
+        "eps", "eps", 0.0f,  R"doc(BFLOAT16)doc");
 
     detail::bind_unary_composite_rpow(
         module,
@@ -2007,7 +2004,7 @@ void py_module(py::module& module) {
     ttnn::rdiv,
     "value", "denominator value which is actually calculated as numerator float value >= 0",
     "round_mode", "rounding_mode value", "None",
-    R"doc(Performs the element-wise division of a scalar ``value`` by a tensor ``input`` and rounds the result using round_mode. Support provided only for Wormhole_B0.
+    R"doc(Performs the element-wise division of a scalar ``value`` by a tensor ``input`` and rounds the result using round_mode.
 
         Input tensor must have BFLOAT16 data type.
 


### PR DESCRIPTION
### Ticket
#22086 

### Problem description
Grayskull is now deprecated, so its functions not needed

### What's changed
Removed all occurrences of grayskull from tests and implementations

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
https://github.com/tenstorrent/tt-metal/actions/runs/15018658346
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
https://github.com/tenstorrent/tt-metal/actions/runs/15018656988
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes