### PR TITLE
#22090: Clean up `Tensor` getters for various attributes

### DIFF
--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -515,8 +515,9 @@ StorageType Tensor::storage_type() const {
 ttnn::Shape Tensor::strides() const { return ttnn::Shape(tt::tt_metal::compute_strides(this->get_padded_shape())); }
 
 uint32_t Tensor::volume() const { return get_padded_shape().volume(); }
-
-uint32_t Tensor::get_logical_volume() const { return get_logical_shape().volume(); }
+uint64_t Tensor::logical_volume() const { return get_logical_shape().volume(); }
+uint64_t Tensor::padded_volume() const { return get_padded_shape().volume(); }
+uint64_t Tensor::get_logical_volume() const { return get_logical_shape().volume(); }
 
 bool Tensor::is_scalar() const {
     const ttnn::Shape logical_shape = this->get_logical_shape();
@@ -771,6 +772,7 @@ Tensor set_tensor_id(const Tensor& tensor) {
 };
 
 const Storage& Tensor::storage() const { return this->tensor_attributes->get_storage(); }
+Storage& Tensor::storage() { return this->tensor_attributes->get_storage(); }
 
 const ttnn::Shape& Tensor::logical_shape() const { return this->tensor_attributes->get_tensor_spec().logical_shape(); }
 

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -181,30 +181,31 @@ public:
     // ======================================================================================
     //                                      Getters
     // ======================================================================================
-    // TODO: remove either get_<x> or <x> getters. They are now equivalent.
-    const Storage& get_storage() const;
-    Storage& get_storage();
-    DataType get_dtype() const;
-    Layout get_layout() const;
-    const ttnn::Shape& get_logical_shape() const;
-    const ttnn::Shape& get_padded_shape() const;
-    const TensorSpec& get_tensor_spec() const;
-    uint32_t get_logical_volume() const;
-    const DistributedTensorConfig& get_distributed_tensor_config() const;
+    // TODO: #22090 - Remove the following getters, after giving clients enough time to migrate.
+    [[deprecated("Use storage() instead")]] const Storage& get_storage() const;
+    [[deprecated("Use storage() instead")]] Storage& get_storage();
+    [[deprecated("Use dtype() instead")]] DataType get_dtype() const;
+    [[deprecated("Use layout() instead")]] Layout get_layout() const;
+    [[deprecated("Use logical_shape() instead")]] const ttnn::Shape& get_logical_shape() const;
+    [[deprecated("Use padded_shape() instead")]] const ttnn::Shape& get_padded_shape() const;
+    [[deprecated("Use tensor_spec() instead")]] const TensorSpec& get_tensor_spec() const;
+    [[deprecated("Use logical_volume() instead")]] uint64_t get_logical_volume() const;
+    [[deprecated("Use padded_volume() instead")]] uint32_t volume() const;
+    [[deprecated("Use distributed_tensor_config() instead")]] const DistributedTensorConfig&
+    get_distributed_tensor_config() const;
 
-    // ======================================================================================
-    // Non-Blocking Getters. Query attributes directly, without waiting for worker completion
-    // ======================================================================================
     const Storage& storage() const;
-    const ttnn::Shape& logical_shape() const;
-    const ttnn::Shape& padded_shape() const;
+    Storage& storage();
     DataType dtype() const;
     Layout layout() const;
+    const ttnn::Shape& logical_shape() const;
+    const ttnn::Shape& padded_shape() const;
     const TensorSpec& tensor_spec() const;
-    uint32_t volume() const;
+    uint64_t logical_volume() const;
+    uint64_t padded_volume() const;
+    const DistributedTensorConfig& distributed_tensor_config() const;
     const MemoryConfig& memory_config() const;
     const std::optional<ShardSpec>& shard_spec() const;
-    const DistributedTensorConfig& distributed_tensor_config() const;
 
     // ======================================================================================
     //                                      Extra Helper Functions


### PR DESCRIPTION
### Ticket
#22090

### Problem description
The `get_<x>` were used in async runtime, and are no longer needed.

### What's changed
Removing all of the legacy getters in one go is going to break clients, so the first step is to mark them as deprectated.

Other minor change:
* Added overloads for `logical_volume` and `padded_volume` (as opposed to just one "volume" which is ambiguous). Used `uint64_t`, since this is the actual type returned by `Shape::volume`. It is not inconceivable that we can get overflows with uint32_t.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15026608572)
- [x] New/Existing tests provide coverage for changes