### PR TITLE
Remove noexcept DevicePool::initialize

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -51,7 +51,7 @@ public:
         size_t worker_l1_size = DEFAULT_WORKER_L1_SIZE,
         bool init_profiler = true,
         bool use_max_eth_core_count_on_all_devices = false,
-        bool initialize_fabric_and_dispatch_fw = true) noexcept;
+        bool initialize_fabric_and_dispatch_fw = true);
 
     tt_metal::IDevice* get_active_device(chip_id_t device_id) const;
     std::vector<tt_metal::IDevice*> get_all_active_devices() const;

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -220,7 +220,7 @@ void DevicePool::initialize(
     size_t worker_l1_size,
     bool init_profiler,
     bool use_max_eth_core_count_on_all_devices,
-    bool initialize_fabric_and_dispatch_fw) noexcept {
+    bool initialize_fabric_and_dispatch_fw) {
     // Issue #19729: use_max_eth_core_count_on_all_devices is a workaround
     // to allow TT-Mesh Workload dispatch to target active ethernet cores.
     ZoneScoped;


### PR DESCRIPTION
### Ticket

### Problem description
When failures happen in UMD, the noexcept clause prevents us from getting the original stack trace.
noexcept is wrong here, it doesn't make sense to have it on functions which call into another library.
I've lost an hour to figure out why, even in debug build, I get wrong stack trace when something throws. Hopefully this will save time for somebody in the future.

### What's changed
- Remove noexcept from DevicePool::initialize

### Checklist
No testing needed