### PR TITLE
#0: Add new mesh descriptor and tests for splitting a 4x2 mesh into two 2x2 meshes

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -26,7 +26,6 @@ TEST_F(ControlPlaneFixture, TestTGMeshGraphInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestTGControlPlaneInit) {
-    tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
@@ -47,7 +46,6 @@ TEST_F(ControlPlaneFixture, TestTGMeshAPIs) {
 }
 
 TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
-    tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path tg_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/tg_mesh_graph_descriptor.yaml";
@@ -67,7 +65,6 @@ TEST_F(ControlPlaneFixture, TestT3kMeshGraphInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
-    tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
@@ -76,7 +73,6 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
 }
 
 TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
-    tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path t3k_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/t3k_mesh_graph_descriptor.yaml";
@@ -92,8 +88,46 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
     }
 }
 
+TEST_F(ControlPlaneFixture, TestT3kSplitMeshGraphInit) {
+    const std::filesystem::path t3k_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/t3k_split_mesh_graph_descriptor.yaml";
+    auto mesh_graph_desc = std::make_unique<MeshGraph>(t3k_mesh_graph_desc_path.string());
+}
+
+TEST_F(ControlPlaneFixture, TestT3kSplitMeshControlPlaneInit) {
+    const std::filesystem::path t3k_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/t3k_split_mesh_graph_descriptor.yaml";
+    auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+}
+
+TEST_F(ControlPlaneFixture, TestT3kSplitMeshFabricRoutes) {
+    const std::filesystem::path t3k_mesh_graph_desc_path =
+        std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
+        "tt_metal/fabric/mesh_graph_descriptors/t3k_split_mesh_graph_descriptor.yaml";
+    auto control_plane = std::make_unique<ControlPlane>(t3k_mesh_graph_desc_path.string());
+    control_plane->configure_routing_tables_for_fabric_ethernet_channels();
+    auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 0);
+    for (auto chan : valid_chans) {
+        auto path = control_plane->get_fabric_route(0, 0, 0, 3, chan);
+    }
+    valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 1, 1);
+    for (auto chan : valid_chans) {
+        auto path = control_plane->get_fabric_route(0, 1, 1, 2, chan);
+    }
+    valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 0);
+    for (auto chan : valid_chans) {
+        auto path = control_plane->get_fabric_route(0, 0, 1, 3, chan);
+    }
+    valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(1, 2, 1);
+    for (auto chan : valid_chans) {
+        auto path = control_plane->get_fabric_route(1, 2, 0, 2, chan);
+    }
+}
+
 TEST_F(ControlPlaneFixture, TestQuantaGalaxyControlPlaneInit) {
-    tt::tt_metal::detail::InitializeFabricConfig(tt::tt_metal::FabricConfig::FABRIC_2D);
     const std::filesystem::path quanta_galaxy_mesh_graph_desc_path =
         std::filesystem::path(tt::tt_metal::MetalContext::instance().rtoptions().get_root_dir()) /
         "tt_metal/fabric/mesh_graph_descriptors/quanta_galaxy_mesh_graph_descriptor.yaml";

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -126,9 +126,6 @@ ControlPlane::ControlPlane(const std::string& mesh_graph_desc_file) {
 
     // Initialize the control plane routers based on mesh graph
     this->initialize_from_mesh_graph_desc_file(mesh_graph_desc_file);
-
-    // Printing, only enabled with log_debug
-    this->print_ethernet_channels();
 }
 
 chip_id_t ControlPlane::get_physical_chip_id_from_eth_coord(const eth_coord_t& eth_coord) const {
@@ -374,6 +371,21 @@ void ControlPlane::initialize_from_mesh_graph_desc_file(const std::string& mesh_
         this->logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back(
             this->get_mesh_physical_chip_ids(mesh_ns_size, mesh_ew_size, nw_chip_physical_id));
         this->validate_mesh_connections(0);
+    } else if (mesh_graph_desc_filename == "t3k_split_mesh_graph_descriptor.yaml") {
+        this->logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back({
+            this->get_physical_chip_id_from_eth_coord({0, 0, 0, 0, 0}),
+            this->get_physical_chip_id_from_eth_coord({0, 1, 0, 0, 0}),
+            this->get_physical_chip_id_from_eth_coord({0, 0, 1, 0, 0}),
+            this->get_physical_chip_id_from_eth_coord({0, 1, 1, 0, 0}),
+        });
+        this->logical_mesh_chip_id_to_physical_chip_id_mapping_.push_back({
+            this->get_physical_chip_id_from_eth_coord({0, 2, 0, 0, 0}),
+            this->get_physical_chip_id_from_eth_coord({0, 3, 0, 0, 0}),
+            this->get_physical_chip_id_from_eth_coord({0, 2, 1, 0, 0}),
+            this->get_physical_chip_id_from_eth_coord({0, 3, 1, 0, 0}),
+        });
+        this->validate_mesh_connections(0);
+        this->validate_mesh_connections(1);
     } else if (
         mesh_graph_desc_filename == "t3k_mesh_graph_descriptor.yaml" ||
         mesh_graph_desc_filename == "n150_mesh_graph_descriptor.yaml" ||

--- a/tt_metal/fabric/mesh_graph_descriptors/t3k_split_mesh_graph_descriptor.yaml
+++ b/tt_metal/fabric/mesh_graph_descriptors/t3k_split_mesh_graph_descriptor.yaml
@@ -1,0 +1,40 @@
+ChipSpec: {
+  arch: wormhole_b0,
+  ethernet_ports: {
+    N: 2,
+    E: 2,
+    S: 2,
+    W: 2,
+  }
+}
+
+
+Board: [
+  { name: 2x2,
+    type: Mesh,
+    topology: [2, 2]}
+]
+
+Mesh: [
+{
+  id: 0,
+  board: 2x2,
+  topology: [1, 1],
+  host_mapping: [[]]},
+{
+  id: 1,
+  board: 2x2,
+  topology: [1, 1],
+  host_mapping: [[]]}
+]
+
+Graph: [
+  [[0, E0], [1, W0]],
+  [[0, E1], [1, W1]],
+  [[0, E2], [1, W2]],
+  [[0, E3], [1, W3]],
+  [[1, W0], [0, E0]],
+  [[1, W1], [0, E1]],
+  [[1, W2], [0, E2]],
+  [[1, W3], [0, E3]]
+]


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Want to add testing for intermesh support. Start with a single host T3K that splits its 4x2 mesh into two 2x2 meshes.

### What's changed
Add a new mesh graph descriptor to interpret a 4x2 machine as two 2x2 meshes and add tests that test intermesh routing between the two through control plane.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15028825147
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes