### PR TITLE
Multi-device Eltwise and TM stress tests

### DIFF
--- a/.github/workflows/ttnn-stress-tests.yaml
+++ b/.github/workflows/ttnn-stress-tests.yaml
@@ -17,6 +17,8 @@ on:
           - N300
           - P100
           - P150
+          - config-tg
+          - config-t3000
       timeout:
         required: false
         type: number

--- a/tests/ttnn/stress_tests/test_eltwise.py
+++ b/tests/ttnn/stress_tests/test_eltwise.py
@@ -9,6 +9,7 @@ import ttnn
 from ttnn.device import get_device_core_grid, is_blackhole, is_wormhole_b0
 
 NUM_REPEATS = 5
+NUM_DEVICES = ttnn.distributed.get_num_pcie_devices()
 
 ##### WORMMHOLE #######
 L1_INPUT_SHAPE_WH = (10_000, 8, 8)
@@ -30,6 +31,7 @@ def eltwise_input_shapes(test_case: str):
         raise RuntimeError("Unidentifiable device")
 
 
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
 @pytest.mark.parametrize(
     "shape_memory_config",
     [
@@ -37,16 +39,16 @@ def eltwise_input_shapes(test_case: str):
         (eltwise_input_shapes("dram"), ttnn.DRAM_MEMORY_CONFIG),
     ],
 )
-def test_stress_binary(device, use_program_cache, shape_memory_config):
+def test_stress_binary(mesh_device, use_program_cache, shape_memory_config):
     input_shape, memory_config = shape_memory_config
     for _ in range(NUM_REPEATS):
         torch_input_tensor1 = torch.randn(input_shape, dtype=torch.bfloat16)
         torch_input_tensor2 = torch.randn(input_shape, dtype=torch.bfloat16)
         input_tensor1 = ttnn.from_torch(
-            torch_input_tensor1, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device
+            torch_input_tensor1, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=mesh_device
         )
         input_tensor2 = ttnn.from_torch(
-            torch_input_tensor2, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device
+            torch_input_tensor2, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=mesh_device
         )
 
         output_tensor = ttnn.add(input_tensor1, input_tensor2)
@@ -60,6 +62,7 @@ def test_stress_binary(device, use_program_cache, shape_memory_config):
     assert True
 
 
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
 @pytest.mark.parametrize(
     "shape_memory_config",
     [
@@ -67,12 +70,12 @@ def test_stress_binary(device, use_program_cache, shape_memory_config):
         (eltwise_input_shapes("dram"), ttnn.DRAM_MEMORY_CONFIG),
     ],
 )
-def test_stress_unary(device, use_program_cache, shape_memory_config):
+def test_stress_unary(mesh_device, use_program_cache, shape_memory_config):
     input_shape, memory_config = shape_memory_config
     for _ in range(NUM_REPEATS):
         torch_input_tensor = torch.randn(input_shape, dtype=torch.bfloat16)
         input_tensor = ttnn.from_torch(
-            torch_input_tensor, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=device
+            torch_input_tensor, layout=ttnn.TILE_LAYOUT, memory_config=memory_config, device=mesh_device
         )
 
         output_tensor = ttnn.silu(input_tensor)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21531

### Problem description
- Stress tests that run on multi-device systems were desired

### What's changed
- Eltwise and TM stress tests now operate on mesh tensors that automatically occupy all available devices

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes