### PR TITLE
#21368: update get_batch_size and adjust matmul tests

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp
@@ -1643,6 +1643,17 @@ void Matmul::validate(
         [input_tensor_a, input_tensor_b, optional_bias, in0_tile_shape, in1_tile_shape, this](
             const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
+            if constexpr (
+                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCastProgramConfig> ||
+                std::is_same_v<ProgramConfigType, MatmulMultiCoreReuseMultiCast1DProgramConfig>) {
+                TT_FATAL(program_config.in0_block_w != 0, "in0_block_w is 0, which is not valid");
+                TT_FATAL(program_config.out_subblock_h != 0, "out_subblock_h is 0, which is not valid");
+                TT_FATAL(program_config.out_subblock_w != 0, "out_subblock_w is 0, which is not valid");
+                TT_FATAL(program_config.out_block_h != 0, "out_block_h is 0, which is not valid");
+                TT_FATAL(program_config.out_block_w != 0, "out_block_w is 0, which is not valid");
+                TT_FATAL(program_config.per_core_M != 0, "per_core_M is 0, which is not valid");
+                TT_FATAL(program_config.per_core_N != 0, "per_core_N is 0, which is not valid");
+            }
             // TODO: For 1D and 2D mcasts, we don't check if tensor is single core
             // or single row/col We can uplift these variants to skip mcasting to
             // support single core (1D) or single row/col (2D)

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -59,7 +59,7 @@ void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& calla
 template <class T>
 uint32_t get_batch_size(const T& shape) {
     uint32_t result = 1;
-    for (auto i = 0; i < shape.rank() - 2; i++) {
+    for (int i = 0; i < (int)shape.rank() - 2; i++) {
         result *= shape[i];
     }
     return result;


### PR DESCRIPTION
### Ticket
Link to Github Issue #21368

### Problem description
- a lot of matmul unit tests were skipped on BH and to some extent on WH
- get_batch_size did not work on a profile build
- a test that computed program config values passed in zeros for the larger BH grid
- a dot product test made incorrect assumptions about the output
- tiny tiles tests don't work on BH

### What's changed
- fix get_batch_size (need to ensure proper signed usage)
- check for 0s in matmul validate
- remove GS related code in the tests
- remove unneeded skips
- fix the test that was passing in zeros
- fix the dot product test
- add skips for BH for tiny tiles tests - the fix for those tests will be looked at in #22103 

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15029835830
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15029837129/job/42240096865 except for infra issues
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15029838777
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15029840229
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes