### PR TITLE
Adjust Whisper CI demo target after switching to P100a hosts

### DIFF
--- a/models/demos/whisper/demo/demo.py
+++ b/models/demos/whisper/demo/demo.py
@@ -472,7 +472,7 @@ def test_demo_for_conditional_generation(input_path, ttnn_model, device, num_inp
     )
     if is_ci_env:
         if is_blackhole():
-            expected_perf_metrics = {"prefill_t/s": 7.67, "decode_t/s/u": 92.9}
+            expected_perf_metrics = {"prefill_t/s": 7.67, "decode_t/s/u": 85.0}
         else:  # wormhole_b0
             expected_perf_metrics = {"prefill_t/s": 3.85, "decode_t/s/u": 51.8}
         expected_perf_metrics["decode_t/s"] = expected_perf_metrics["decode_t/s/u"]  # Only supporting batch 1


### PR DESCRIPTION
### Ticket
N/A

### Problem description
- Whisper target needs to be adjusted after CI BH demo runners were switching to P100a instead of P100 scrappy in 97b1a05 (not a real regression, host difference)

### What's changed
- Slightly lowered whisper ci demo t/s/u target

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [x] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes

Blackhole demo tests - https://github.com/tenstorrent/tt-metal/actions/runs/15030828874