### PR TITLE
Add network=host option for containerized workflows

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -29,7 +29,9 @@ jobs:
       volumes:
         - /work
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: --device /dev/tenstorrent
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -35,7 +35,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build-and-unit-tests.yaml
+++ b/.github/workflows/build-and-unit-tests.yaml
@@ -68,7 +68,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -163,6 +163,7 @@ jobs:
       options: >
         --group-add 1457
         --tmpfs /tmp
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -82,6 +82,7 @@ jobs:
       options: >
         --group-add 1457
         --tmpfs /tmp
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/conda-post-commit.yaml
+++ b/.github/workflows/conda-post-commit.yaml
@@ -103,7 +103,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/cpp-post-commit.yaml
+++ b/.github/workflows/cpp-post-commit.yaml
@@ -67,7 +67,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -53,7 +53,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
+++ b/.github/workflows/fast-dispatch-build-and-unit-tests.yaml
@@ -56,7 +56,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -96,7 +96,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/models-post-commit.yaml
+++ b/.github/workflows/models-post-commit.yaml
@@ -49,7 +49,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash
@@ -99,7 +101,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -42,7 +42,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-release-image.yaml
+++ b/.github/workflows/publish-release-image.yaml
@@ -91,7 +91,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run-profiler-regression.yaml
+++ b/.github/workflows/run-profiler-regression.yaml
@@ -90,7 +90,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -24,7 +24,9 @@ jobs:
       volumes:
         - /work
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: --device /dev/tenstorrent
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -33,7 +33,9 @@ jobs:
       volumes:
         - /work
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: --device /dev/tenstorrent
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/t3000-fast-tests-impl.yaml
+++ b/.github/workflows/t3000-fast-tests-impl.yaml
@@ -44,7 +44,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/t3000-frequent-tests-impl.yaml
+++ b/.github/workflows/t3000-frequent-tests-impl.yaml
@@ -57,7 +57,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/t3000-nightly-tests-impl.yaml
+++ b/.github/workflows/t3000-nightly-tests-impl.yaml
@@ -45,7 +45,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/t3000-perplexity-tests-impl.yaml
+++ b/.github/workflows/t3000-perplexity-tests-impl.yaml
@@ -49,7 +49,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/t3000-profiler-tests-impl.yaml
+++ b/.github/workflows/t3000-profiler-tests-impl.yaml
@@ -44,7 +44,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/t3000-unit-tests-impl.yaml
+++ b/.github/workflows/t3000-unit-tests-impl.yaml
@@ -58,7 +58,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tg-demo-tests-impl.yaml
+++ b/.github/workflows/tg-demo-tests-impl.yaml
@@ -49,7 +49,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tg-frequent-tests-impl.yaml
+++ b/.github/workflows/tg-frequent-tests-impl.yaml
@@ -50,7 +50,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -61,7 +61,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -45,7 +45,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: --device /dev/tenstorrent
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash
@@ -89,7 +91,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: --device /dev/tenstorrent
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -47,7 +47,9 @@ jobs:
         - /work
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: --device /dev/tenstorrent
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash
@@ -94,7 +96,9 @@ jobs:
         - /work
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: --device /dev/tenstorrent
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tg-unit-tests-impl.yaml
+++ b/.github/workflows/tg-unit-tests-impl.yaml
@@ -45,7 +45,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash
@@ -104,7 +106,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - ${{ matrix.test-group.mlperf && '/mnt/MLPerf:/mnt/MLPerf:ro' || '/donotmount:/donotmount:ro' }}
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tt-metal-l2-nightly-impl.yaml
+++ b/.github/workflows/tt-metal-l2-nightly-impl.yaml
@@ -48,7 +48,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tt-train-post-commit.yaml
+++ b/.github/workflows/tt-train-post-commit.yaml
@@ -46,7 +46,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ttnn-post-commit.yaml
+++ b/.github/workflows/ttnn-post-commit.yaml
@@ -113,7 +113,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -635,7 +635,9 @@ jobs:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/MLPerf:/mnt/MLPerf:ro
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -37,7 +37,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -37,7 +37,9 @@ jobs:
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -44,7 +44,9 @@ jobs:
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-      options: "--device /dev/tenstorrent"
+      options: >
+        --device /dev/tenstorrent
+        --network=host
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### Problem description
We have introduced many containerized workflows.
We allows default settings for docker network isolation.

🔧 Default Docker Networking (bridge mode)
When you run a job in GitHub Actions (or any Docker CI setup) without --network=host, the container uses the default bridge network.

This introduces several problems:
1. Veth Churn & Performance Overhead
Each container gets a virtual ethernet (veth) pair.

Rapid container creation/destruction (typical in CI) leads to:

High churn in kernel's veth and iptables tables.

Resource contention (especially if many containers are run concurrently).

Kernel log (dmesg) often shows allocations, queue setup, and eventual OOM or crash if the system is under memory or descriptor pressure.

2. DNS Resolution Instability
DNS resolution in bridge mode relies on docker0 and the embedded DNS proxy.

Under high load or container reuse:

DNS lookups fail intermittently.

apt, pip, and external services (like S3, PyPI, etc.) become flaky.

Worse in systems with aggressive container GC or when runners are shared across CI/dev.

3. Unnecessary NAT Overhead
Bridge networking uses NAT, which:

Adds latency.

Interferes with TCP connection tracking.

Increases CPU usage due to conntrack processing.

In CI where containers pull large models, talk to local services, or hit public endpoints, this can slow things down significantly.

4. Difficult Debugging
Tools inside the container (like ping, curl, or netstat) may behave differently than on host.

Ports exposed on host (localhost:port) are not reachable from inside container unless explicitly mapped.

This causes extra friction when debugging flaky jobs or reproducing failures.

5. No Benefit if Isolation Not Needed
If you're not running untrusted code or parallel conflicting jobs, network isolation adds no value.

Using --network=host simplifies setup, improves stability, and matches the host environment more closely.

✅ Summary
If you don’t need strict network isolation, using --network=host avoids flakiness, improves performance, and reduces complexity in CI pipelines — especially when you're:

Pulling from remote services

Sharing large caches/artifacts

Connecting to host services (e.g., local databases, model caches, etc.)

### What's changed
Use `network=host` everywhere it makes sense.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15031457939) CI passes
- [ ] New/Existing tests provide coverage for changes