### PR TITLE
Mark rmsnorm test as xfail until resolution to unblock APC

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rmsnorm.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rmsnorm.py
@@ -128,7 +128,7 @@ def run_rmsnorm_tests(test_id, dtype, in0_mem_config, out_mem_config, device):
 )
 @pytest.mark.parametrize(
     "test_id",
-    (0, 1, 2),
+    (0, 1, pytest.param(2, marks=pytest.mark.xfail(reason="GH Issue #22069"))),
     ids=["RMSN", "RMSN_G", "RMSN_GB"],
 )
 def test_rmsnorm_test(test_id, dtype, in0_mem_config, out_mem_config, device):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22069

### Problem description
RMS Norm unit test failing intermittently in post commit pipelines.

### What's changed
Initial triage did not yield a good repro.
Temporarily mark them xfail to keep APC stable.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15032587064
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes