### PR TITLE
#19609: Fix eltwise backward ops

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_div.py
@@ -34,9 +34,13 @@ from models.utility_functions import (
     ),
 )
 def test_bw_div_binary(input_shapes, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    high = 100
+    low = -100
+    other_data = torch.rand(input_shapes, requires_grad=True).bfloat16() * (high - low) + low
+    other_data[other_data == 0] = 1.0
+    other_tensor = ttnn.from_torch(other_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)
@@ -56,9 +60,13 @@ def test_bw_div_binary(input_shapes, round_mode, device):
     ),
 )
 def test_bw_div_binary_default(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+    high = 100
+    low = -100
+    other_data = torch.rand(input_shapes, requires_grad=True).bfloat16() * (high - low) + low
+    other_data[other_data == 0] = 1.0
+    other_tensor = ttnn.from_torch(other_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
     golden_tensor = golden_function(grad_data, in_data, other_data)
@@ -87,7 +95,7 @@ def test_bw_div_binary_default(input_shapes, device):
 @pytest.mark.parametrize("scalar", [0.0])
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
@@ -116,8 +124,8 @@ def test_bw_unary_div_0(input_shapes, scalar, round_mode, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_unary_div(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar, round_mode=round_mode)
     golden_function = ttnn.get_golden_function(ttnn.div_bw)
@@ -138,7 +146,7 @@ def test_bw_unary_div(input_shapes, scalar, round_mode, device):
 @pytest.mark.parametrize("scalar", [0.0])
 @pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_bw_unary_div_0_default(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
     grad_data, grad_tensor = data_gen_with_val(input_shapes, device, False, val=0)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar)
@@ -160,8 +168,8 @@ def test_bw_unary_div_0_default(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_unary_div_default(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1, 1, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar)
 
@@ -182,8 +190,12 @@ def test_bw_unary_div_default(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_unary_div_bf8b(input_shapes, scalar, device):
-    in_data, input_tensor = data_gen_with_range_dtype(input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b)
-    grad_data, grad_tensor = data_gen_with_range_dtype(input_shapes, -1, 1, device, False, False, ttnn.bfloat8_b)
+    in_data, input_tensor = data_gen_with_range_dtype(
+        input_shapes, -100, 100, device, True, False, ttnn.bfloat8_b, seed=0
+    )
+    grad_data, grad_tensor = data_gen_with_range_dtype(
+        input_shapes, -1, 1, device, False, False, ttnn.bfloat8_b, seed=1
+    )
 
     tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, scalar)
 
@@ -212,8 +224,8 @@ def test_bw_unary_div_bf8b(input_shapes, scalar, device):
 )
 @pytest.mark.parametrize("scalar", [0.05, 1.0, 0.5, 0.12, 0.0, -0.05, -1.0, -0.5, -0.12])
 def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, 5, device, seed=1)
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
 
@@ -247,9 +259,13 @@ def test_bw_div_scalar_opt_output(input_shapes, scalar, round_mode, device):
 )
 @pytest.mark.parametrize("are_required_outputs", [[True, True], [True, False], [False, True]])
 def test_bw_div_opt(input_shapes, round_mode, are_required_outputs, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=1)
+    high = 100
+    low = -100
+    other_data = torch.rand(input_shapes, requires_grad=True).bfloat16() * (high - low) + low
+    other_data[other_data == 0] = 1.0
+    other_tensor = ttnn.from_torch(other_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     input_grad = None
     other_grad = None
@@ -284,3 +300,35 @@ def test_bw_div_opt(input_shapes, round_mode, are_required_outputs, device):
         if are_required_outputs[i]:
             status = status & compare_pcc([tt_output_tensor_on_device[i]], [golden_tensor[i]])
     assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "round_mode",
+    (
+        None,
+        "trunc",
+        "floor",
+    ),
+)
+def test_bw_binary_div_inf_cases(input_shapes, round_mode, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data = torch.zeros(input_shapes, dtype=torch.bfloat16, requires_grad=True)
+    other_tensor = ttnn.from_torch(other_data, layout=ttnn.TILE_LAYOUT, device=device)
+
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+
+    tt_output_tensor_on_device = ttnn.div_bw(grad_tensor, input_tensor, other_tensor, round_mode=round_mode)
+
+    golden_function = ttnn.get_golden_function(ttnn.div_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data, round_mode)
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fmod.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_fmod.py
@@ -25,8 +25,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_unary_fmod(input_shapes, scalar, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.fmod_bw(grad_tensor, input_tensor, scalar)
 
@@ -45,9 +45,39 @@ def test_bw_unary_fmod(input_shapes, scalar, device):
     ),
 )
 def test_bw_binary_fmod(input_shapes, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -50, 50, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+
+    high = 50
+    low = -50
+    other_data = torch.rand(input_shapes, requires_grad=True).bfloat16() * (high - low) + low
+    other_data[other_data == 0] = 1.0
+    other_tensor = ttnn.from_torch(other_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True, seed=1)
+
+    tt_output_tensor_on_device = ttnn.fmod_bw(grad_tensor, input_tensor, other_tensor)
+
+    golden_function = ttnn.get_golden_function(ttnn.fmod_bw)
+    golden_tensor = golden_function(grad_data, in_data, other_data)
+
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+def test_bw_binary_fmod_inf_cases(input_shapes, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    other_data = torch.zeros(input_shapes, dtype=torch.bfloat16, requires_grad=True)
+    other_tensor = ttnn.from_torch(other_data, layout=ttnn.TILE_LAYOUT, device=device)
+
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.fmod_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_remainder.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_remainder.py
@@ -26,8 +26,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import comp
     ),
 )
 def test_bw_unary_remainder(input_shapes, scalar, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -10, 10, device, True, seed=1)
 
     tt_output_tensor_on_device = ttnn.remainder_bw(grad_tensor, input_tensor, scalar)
 
@@ -46,9 +46,14 @@ def test_bw_unary_remainder(input_shapes, scalar, device):
     ),
 )
 def test_bw_binary_remainder(input_shapes, device):
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True)
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    other_data, other_tensor = data_gen_with_range(input_shapes, -50, 50, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -30, 30, device, True, seed=0)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=1)
+
+    high = 50
+    low = -50
+    other_data = torch.rand(input_shapes, requires_grad=True).bfloat16() * (high - low) + low
+    other_data[other_data == 0] = 1.0
+    other_tensor = ttnn.from_torch(other_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
 
     tt_output_tensor_on_device = ttnn.remainder_bw(grad_tensor, input_tensor, other_tensor)
 

--- a/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/utility_funcs.py
@@ -10,6 +10,8 @@ from tests.tt_eager.python_api_testing.sweep_tests import (
     comparison_funcs,
 )
 
+DEFAULT_SEED = 213919
+
 
 def data_gen_with_range_batch_norm(
     input_shapes,
@@ -48,7 +50,7 @@ def data_gen_pt_tt(input_shapes, device, required_grad=False):
     return pt_tensor, tt_tensor
 
 
-def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is_row_major=False, seed=213919):
+def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is_row_major=False, seed=DEFAULT_SEED):
     assert high > low, "Incorrect range provided"
     torch.manual_seed(seed)
     pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
@@ -60,11 +62,21 @@ def data_gen_with_range(input_shapes, low, high, device, required_grad=False, is
 
 
 def data_gen_with_range_dtype(
-    input_shapes, low, high, device, required_grad=False, is_row_major=False, ttnn_dtype=ttnn.bfloat16
+    input_shapes,
+    low,
+    high,
+    device,
+    required_grad=False,
+    is_row_major=False,
+    ttnn_dtype=ttnn.bfloat16,
+    seed=DEFAULT_SEED,
 ):
     assert high > low, "Incorrect range provided"
-    torch.manual_seed(213919)
-    pt_tensor = torch.rand(input_shapes, requires_grad=required_grad).bfloat16() * (high - low) + low
+    torch.manual_seed(seed)
+
+    torch_dtype = torch.float32 if ttnn_dtype == ttnn.float32 else torch.bfloat16
+
+    pt_tensor = torch.rand(input_shapes, dtype=torch_dtype, requires_grad=required_grad) * (high - low) + low
     if is_row_major:
         tt_tensor = ttnn.Tensor(pt_tensor, ttnn_dtype).to(ttnn.ROW_MAJOR_LAYOUT).to(device)
     else:

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -394,13 +394,7 @@ std::vector<Tensor> ExecuteBackwardRemainder::invoke(
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     grad_tensor.emplace_back(grad);
-    Tensor result_div = ttnn::floor(ttnn::add(
-        ttnn::multiply(input, ttnn::reciprocal(other), std::nullopt, output_mem_config),
-        0.005f,
-        std::nullopt,
-        output_mem_config));
-    result_div =
-        ttnn::where(ttnn::eq(input, other, std::nullopt, output_mem_config), 1.0f, result_div, output_mem_config);
+    Tensor result_div = ttnn::div(input, other, true, "floor", std::nullopt, output_mem_config);
     Tensor grad_b = ttnn::multiply(ttnn::neg(grad), result_div, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;
@@ -420,18 +414,7 @@ std::vector<Tensor> ExecuteBackwardFmod::invoke(
     const std::optional<MemoryConfig>& output_mem_config) {
     std::vector<Tensor> grad_tensor;
     grad_tensor.emplace_back(grad);
-    Tensor sign = ttnn::multiply(
-        ttnn::sign(input, output_mem_config), ttnn::sign(other, output_mem_config), std::nullopt, output_mem_config);
-    Tensor result_div = ttnn::trunc(ttnn::add(
-        ttnn::multiply(input, ttnn::reciprocal(other), std::nullopt, output_mem_config),
-        0.005f,
-        std::nullopt,
-        output_mem_config));
-    result_div = ttnn::where(
-        ttnn::eq(ttnn::abs(input), ttnn::abs(other), std::nullopt, output_mem_config),
-        sign,
-        result_div,
-        output_mem_config);
+    Tensor result_div = ttnn::div(input, other, true, "trunc", std::nullopt, output_mem_config);
     Tensor grad_b = ttnn::multiply(ttnn::neg(grad), result_div, std::nullopt, output_mem_config);
     grad_tensor.emplace_back(grad_b);
     return grad_tensor;


### PR DESCRIPTION
### Ticket
Link to Github Issue #19609 

### Problem description
Tests failing on backward eltwise operations

### What's changed
- Backward Div , Backward fmod, Backward remainder : The PCC issue was due to incorrect comparison of inf values caused by division-by-zero cases. To address this, zeros in the main test inputs have been replaced with ones, and a separate test has been added specifically to cover division-by-zero scenarios. This resolves the PCC failure without changing data types.

### Checklist
- [x] All post commit CI