### PR TITLE
sfpi v6.11.1 xz compression

### DIFF
--- a/tt_metal/hw/CMakeLists.txt
+++ b/tt_metal/hw/CMakeLists.txt
@@ -41,13 +41,13 @@ foreach(tuple ${SFPI})
             set(SFPI_VERSION "${value}")
         elseif(key STREQUAL "sfpi_url")
             set(SFPI_URL "${value}")
-        elseif(key STREQUAL "sfpi_${SFPI_arch_os}_tgz_md5")
-            set(SFPI_TGZ_MD5 "${value}")
+        elseif(key STREQUAL "sfpi_${SFPI_arch_os}_txz_md5")
+            set(SFPI_TXZ_MD5 "${value}")
         endif()
     endif()
 endforeach()
 
-if(NOT DEFINED SFPI_TGZ_MD5)
+if(NOT DEFINED SFPI_TXZ_MD5)
     message(FATAL_ERROR "SFPI tarball for ${SFPI_arch_os} is not available")
 endif()
 
@@ -55,8 +55,8 @@ include(FetchContent)
 FetchContent_Declare(
     sfpi
     URL
-        "${SFPI_URL}/${SFPI_VERSION}/sfpi-${SFPI_arch_os}.tgz"
-    URL_HASH "MD5=${SFPI_TGZ_MD5}"
+        "${SFPI_URL}/${SFPI_VERSION}/sfpi-${SFPI_arch_os}.txz"
+    URL_HASH "MD5=${SFPI_TXZ_MD5}"
     SOURCE_DIR
     "${PROJECT_SOURCE_DIR}/runtime/sfpi"
 )

--- a/tt_metal/sfpi-version.sh
+++ b/tt_metal/sfpi-version.sh
@@ -1,7 +1,7 @@
 # set SFPI release version information
-sfpi_version=v6.11.0
+sfpi_version=v6.11.1
 sfpi_url=https://github.com/tenstorrent/sfpi/releases/download
-sfpi_x86_64_Linux_tgz_md5=806f11a6b55cecfe0190671b0cb47776
-sfpi_x86_64_Linux_deb_md5=825fc8c7a82b62e70f836e5d5272122c
-sfpi_aarch64_Linux_tgz_md5=29025a436350e940a4c6088eef1ba500
-sfpi_aarch64_Linux_deb_md5=62034570bc71cc53c210143919baf259
+sfpi_x86_64_Linux_txz_md5=14ade50b3fdf3fff5078195332edc15a
+sfpi_x86_64_Linux_deb_md5=93803c538ba87357df22b87b0d7c62ed
+sfpi_aarch64_Linux_tar_md5=517a64489eb87653f554f94e46a2bf17
+sfpi_aarch64_Linux_deb_md5=7bef7babb7c19f241adc6c3998aebe4d


### PR DESCRIPTION
### Ticket
NA

### Problem description
1) I flubbed the GS-ectomy, failing to checkin the submodule changes :(
2) XZ compression is much better than gzip (reported by a user)

### What's changed
*) committed the submodule updates
*) compress with XZ -- the tarball is now a similar size to the Debian package

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes