### PR TITLE
Fix types in topology assert

### DIFF
--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -583,16 +583,17 @@ std::vector<DispatchKernelNode> generate_nodes(const std::set<chip_id_t>& device
 
                 // Pull nodes from the template, updating their index and device id
                 for (DispatchKernelNode node : *nodes_for_one_mmio) {
+                    int32_t num_devices = template_id_to_device_id.size();
                     TT_ASSERT(
-                        node.device_id < template_id_to_device_id.size(),
+                        node.device_id < num_devices,
                         "Device id {} out of bounds (max = {})",
                         node.device_id,
-                        template_id_to_device_id.size());
+                        num_devices);
                     TT_ASSERT(
-                        node.servicing_device_id < template_id_to_device_id.size(),
+                        node.servicing_device_id < num_devices,
                         "Servicing device id {} out of bounds (max = {})",
                         node.servicing_device_id,
-                        template_id_to_device_id.size());
+                        num_devices);
                     node.device_id = template_id_to_device_id[node.device_id];
                     node.servicing_device_id = template_id_to_device_id[node.servicing_device_id];
                     increment_node_ids(node, index_offset);


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
```
E       RuntimeError: TT_ASSERT @ /localdev/rdraskic/tt-metal/tt_metal/impl/dispatch/topology.cpp:595: node.servicing_device_id < template_id_to_device_id.size()                        
E       info:                                                                                                                                                                            
E       Servicing device id -1 out of bounds (max = 9)                                                                                                                                   
```

I got this triggered in debug. Looks like -1 is allowed for `node.servicing_device_id`, but it got triggered due to cast to unsigned.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15047004224) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes