### PR TITLE
Add `ttnn.convert_to_hwc` fused op for converting input tensor to channels last

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_chw.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
+++ b/tests/ttnn/unit_tests/operations/test_convert_to_hwc.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import ttnn
+import torch
+
+from tests.ttnn.utils_for_testing import assert_equal
+
+
+@pytest.mark.parametrize("C", [8, 16])
+@pytest.mark.parametrize(
+    "HW, core_grid, padded_sharded_dim",
+    (
+        (
+            32,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                }
+            ),
+            32,
+        ),
+        (
+            128,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0)),
+                }
+            ),
+            64,
+        ),
+        (
+            168960,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(6, 7)),
+                }
+            ),
+            2688,
+        ),  # UNet Shallow
+    ),
+)
+def test_convert_to_hwc(device, C, HW, core_grid, padded_sharded_dim):
+    device_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    requested_num_cores = core_grid.num_cores()
+    if device_num_cores < requested_num_cores:
+        pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {device_num_cores})")
+
+    input_tensor = torch.randn([1, 1, C, HW], dtype=torch.bfloat16)
+    expected = input_tensor.transpose(2, 3)
+
+    input_shard_shape = (C, padded_sharded_dim)
+    input_shard_spec = ttnn.ShardSpec(core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, input_shard_spec)
+
+    output_shard_shape = (padded_sharded_dim, C)
+    output_shard_spec = ttnn.ShardSpec(core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    input_tensor = ttnn.Tensor(
+        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+    actual = ttnn.to_torch(actual)
+
+    passed, message = assert_equal(expected, actual)
+    assert passed, message
+
+
+@pytest.mark.parametrize("C", [8, 16])
+@pytest.mark.parametrize(
+    "HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim",
+    (
+        (
+            32,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                }
+            ),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0)),
+                }
+            ),
+            32,
+            32,
+        ),
+        (
+            84480,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(5, 0)),
+                }
+            ),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3)),
+                }
+            ),
+            14080,
+            2656,
+        ),
+        (
+            168960,
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 0)),
+                }
+            ),
+            ttnn.CoreRangeSet(
+                {
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 6)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 7), ttnn.CoreCoord(6, 7)),
+                }
+            ),
+            14080,
+            2688,
+        ),  # UNet Shallow
+    ),
+)
+def test_convert_to_hwc_dram(
+    device, C, HW, input_core_grid, output_core_grid, input_padded_sharded_dim, output_padded_sharded_dim
+):
+    worker_num_cores = device.compute_with_storage_grid_size().x * device.compute_with_storage_grid_size().y
+    requested_num_cores = output_core_grid.num_cores()
+    if worker_num_cores < requested_num_cores:
+        pytest.skip(f"Not enough cores to run test case (need {requested_num_cores} but have {worker_num_cores})")
+
+    dram_num_cores = device.dram_grid_size().x * device.dram_grid_size().y
+    requested_num_dram_cores = input_core_grid.num_cores()
+    if dram_num_cores < requested_num_dram_cores:
+        pytest.skip(
+            f"Not enough DRAM cores to run test case (need {requested_num_dram_cores} but have {dram_num_cores})"
+        )
+
+    input_tensor = torch.randn([1, 1, C, HW], dtype=torch.bfloat16)
+    expected = input_tensor.transpose(2, 3)
+
+    input_shard_shape = (C, input_padded_sharded_dim)
+    input_shard_spec = ttnn.ShardSpec(input_core_grid, input_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, input_shard_spec)
+
+    output_shard_shape = (output_padded_sharded_dim, C)
+    output_shard_spec = ttnn.ShardSpec(output_core_grid, output_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    input_tensor = ttnn.Tensor(
+        input_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    actual = ttnn.experimental.convert_to_hwc(input_tensor, memory_config=output_mem_config, dtype=ttnn.bfloat16)
+    actual = ttnn.to_torch(actual)
+
+    passed, message = assert_equal(expected, actual)
+    assert passed, message

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -439,6 +439,9 @@ set(TTNN_OP_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_op.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_program_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/attn_matmul/attn_matmul.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_program_factory.cpp
@@ -942,6 +945,7 @@ set(TTNN_SRC_PYBIND
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/examples/examples_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/bcast_to/bcast_to_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_${PY_BINDING}.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/conv3d/conv3d_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/copy/typecast/typecast_${PY_BINDING}.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp/ttnn/operations/experimental/dropout/dropout_${PY_BINDING}.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory.cpp
@@ -10,6 +10,9 @@
 #include <tt-metalium/util.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
+
+#include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
@@ -528,89 +531,6 @@ operation::ProgramWithCallbacks reshard_multi_core_generic(const Tensor& input, 
     return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
 }
 
-struct WidthShardedRuntimeArgs {
-    uint32_t write_size;
-    uint32_t read_offset;
-    uint32_t bank_id;
-    uint32_t write_offset;
-};
-
-std::tuple<std::vector<std::vector<WidthShardedRuntimeArgs>>, uint32_t, uint32_t, uint32_t>
-compute_width_sharded_reshard_runtime_args(
-    const std::array<uint32_t, 2>& local_shard_shape,
-    const std::array<uint32_t, 2>& remote_shard_shape,
-    const std::vector<CoreCoord>& local_cores,
-    const std::vector<CoreCoord>& remote_cores,
-    const BufferType& remote_buffer_type,
-    const CoreType& remote_core_type,
-    IDevice* device,
-    uint32_t element_size) {
-    const uint32_t num_local_shards = local_cores.size();
-    const uint32_t num_remote_shards = remote_cores.size();
-
-    const uint32_t local_shard_height = local_shard_shape[0];
-    const uint32_t local_shard_width = local_shard_shape[1];
-    const uint32_t remote_shard_height = remote_shard_shape[0];
-    const uint32_t remote_shard_width = remote_shard_shape[1];
-
-    using WidthShardedRuntimeArgsForSingleCore = std::vector<WidthShardedRuntimeArgs>;
-
-    TT_FATAL(local_shard_height == remote_shard_height, "Unexpected mismatch in shard heights");
-
-    const uint32_t total_num_sticks = local_shard_height;
-    const uint32_t local_stride_bytes = element_size * local_shard_width;
-    const uint32_t remote_stride_bytes = element_size * remote_shard_width;
-
-    std::vector<WidthShardedRuntimeArgsForSingleCore> runtime_args_for_each_core;
-
-    bool is_final_transfer = false;
-    uint32_t local_shard_offset = 0;
-    uint32_t remote_shard_offset = 0;
-    uint32_t current_remote_core_idx = 0;
-    for (uint32_t current_local_core_idx = 0; current_local_core_idx < local_cores.size(); current_local_core_idx++) {
-        const auto& core = local_cores[current_local_core_idx];
-        WidthShardedRuntimeArgsForSingleCore core_args;
-        while (local_shard_offset < local_shard_width) {
-            const uint32_t remaining_input = local_shard_width - local_shard_offset;
-            const uint32_t remaining_output = remote_shard_width - remote_shard_offset;
-
-            // The last core might have some garbage in it because of uneven shards
-            is_final_transfer = (current_local_core_idx >= local_cores.size() - 1) &&
-                                (current_remote_core_idx >= remote_cores.size() - 1);
-            const uint32_t transfer_size =
-                is_final_transfer ? remaining_output : std::min(remaining_input, remaining_output);
-
-            const auto bank_id = device->allocator()->get_bank_ids_from_logical_core(
-                remote_buffer_type, remote_cores[current_remote_core_idx])[0];
-            core_args.emplace_back(
-                element_size * transfer_size,
-                element_size * local_shard_offset,
-                bank_id,
-                element_size * remote_shard_offset);
-
-            local_shard_offset += transfer_size;
-            remote_shard_offset += transfer_size;
-
-            // If the current output shard is full, move to the next one
-            if (remote_shard_offset == remote_shard_width) {
-                ++current_remote_core_idx;
-                remote_shard_offset = 0;
-            }
-            if (is_final_transfer) {
-                break;
-            }
-        }
-        local_shard_offset = 0;
-        runtime_args_for_each_core.push_back(core_args);
-    }
-
-    TT_FATAL(
-        runtime_args_for_each_core.size() == num_local_shards,
-        "Expect to have one set of runtime args per local core");  // sanity check
-
-    return {runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes};
-}
-
 template <bool is_reader>
 operation::ProgramWithCallbacks reshard_multi_core_same_height(const Tensor& input, Tensor& output) {
     auto device = input.device();
@@ -664,7 +584,7 @@ operation::ProgramWithCallbacks reshard_multi_core_same_height(const Tensor& inp
 
     // Generate all read/write offsets for each core
     auto [runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes] =
-        compute_width_sharded_reshard_runtime_args(
+        compute_width_sharding_reshard_segments(
             local_shard_spec.shape,
             remote_shard_spec.shape,
             local_cores,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/constants.hpp>
+
 #include "ttnn/tensor/tensor.hpp"
+
+#include "sharded_common.hpp"
 
 namespace ttnn::operations::data_movement::detail {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -42,7 +42,11 @@ compute_width_sharding_reshard_segments(
 
     using WidthShardingReshardSegmentForSingleCore = std::vector<WidthShardingReshardSegment>;
 
-    TT_FATAL(local_shard_height == remote_shard_height, "Unexpected mismatch in shard heights");
+    TT_FATAL(
+        local_shard_height == remote_shard_height,
+        "Unexpected mismatch in shard heights ({} != {}",
+        local_shard_height,
+        remote_shard_height);
 
     const uint32_t total_num_sticks = local_shard_height;
     const uint32_t local_stride_bytes = element_size * local_shard_width;
@@ -93,7 +97,9 @@ compute_width_sharding_reshard_segments(
 
     TT_FATAL(
         runtime_args_for_each_core.size() == num_local_shards,
-        "Expect to have one set of runtime args per local core");  // sanity check
+        "Expect to have one set of runtime args per local core (expected {} but was {})",
+        num_local_shards,
+        runtime_args_for_each_core.size());  // sanity check
 
     return {runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes};
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -22,4 +22,80 @@ uint32_t calculate_starting_idx_h(const Tensor& tensor, uint32_t num_slices, uin
     return starting_tile_in_slice;
 }
 
+std::tuple<std::vector<std::vector<WidthShardingReshardSegment>>, uint32_t, uint32_t, uint32_t>
+compute_width_sharding_reshard_segments(
+    const std::array<uint32_t, 2>& local_shard_shape,
+    const std::array<uint32_t, 2>& remote_shard_shape,
+    const std::vector<CoreCoord>& local_cores,
+    const std::vector<CoreCoord>& remote_cores,
+    const BufferType& remote_buffer_type,
+    const CoreType& remote_core_type,
+    IDevice* device,
+    uint32_t element_size) {
+    const uint32_t num_local_shards = local_cores.size();
+    const uint32_t num_remote_shards = remote_cores.size();
+
+    const uint32_t local_shard_height = local_shard_shape[0];
+    const uint32_t local_shard_width = local_shard_shape[1];
+    const uint32_t remote_shard_height = remote_shard_shape[0];
+    const uint32_t remote_shard_width = remote_shard_shape[1];
+
+    using WidthShardingReshardSegmentForSingleCore = std::vector<WidthShardingReshardSegment>;
+
+    TT_FATAL(local_shard_height == remote_shard_height, "Unexpected mismatch in shard heights");
+
+    const uint32_t total_num_sticks = local_shard_height;
+    const uint32_t local_stride_bytes = element_size * local_shard_width;
+    const uint32_t remote_stride_bytes = element_size * remote_shard_width;
+
+    std::vector<WidthShardingReshardSegmentForSingleCore> runtime_args_for_each_core;
+
+    bool is_final_transfer = false;
+    uint32_t local_shard_offset = 0;
+    uint32_t remote_shard_offset = 0;
+    uint32_t current_remote_core_idx = 0;
+    for (uint32_t current_local_core_idx = 0; current_local_core_idx < local_cores.size(); current_local_core_idx++) {
+        const auto& core = local_cores[current_local_core_idx];
+        WidthShardingReshardSegmentForSingleCore core_args;
+        while (local_shard_offset < local_shard_width) {
+            const uint32_t remaining_input = local_shard_width - local_shard_offset;
+            const uint32_t remaining_output = remote_shard_width - remote_shard_offset;
+
+            // The last core might have some garbage in it because of uneven shards
+            is_final_transfer = (current_local_core_idx >= local_cores.size() - 1) &&
+                                (current_remote_core_idx >= remote_cores.size() - 1);
+            const uint32_t transfer_size =
+                is_final_transfer ? remaining_output : std::min(remaining_input, remaining_output);
+
+            const auto bank_id = device->allocator()->get_bank_ids_from_logical_core(
+                remote_buffer_type, remote_cores[current_remote_core_idx])[0];
+            core_args.emplace_back(
+                element_size * transfer_size,
+                element_size * local_shard_offset,
+                bank_id,
+                element_size * remote_shard_offset);
+
+            local_shard_offset += transfer_size;
+            remote_shard_offset += transfer_size;
+
+            // If the current output shard is full, move to the next one
+            if (remote_shard_offset == remote_shard_width) {
+                ++current_remote_core_idx;
+                remote_shard_offset = 0;
+            }
+            if (is_final_transfer) {
+                break;
+            }
+        }
+        local_shard_offset = 0;
+        runtime_args_for_each_core.push_back(core_args);
+    }
+
+    TT_FATAL(
+        runtime_args_for_each_core.size() == num_local_shards,
+        "Expect to have one set of runtime args per local core");  // sanity check
+
+    return {runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes};
+}
+
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/allocator.hpp>
 
 #include "ttnn/tensor/tensor.hpp"
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -31,9 +31,9 @@ compute_width_sharding_reshard_segments(
     const std::array<uint32_t, 2>& remote_shard_shape,
     const std::vector<CoreCoord>& local_cores,
     const std::vector<CoreCoord>& remote_cores,
-    const BufferType& remote_buffer_type,
+    const tt::tt_metal::BufferType& remote_buffer_type,
     const CoreType& remote_core_type,
-    IDevice* device,
+    tt::tt_metal::IDevice* device,
     uint32_t element_size) {
     const uint32_t num_local_shards = local_cores.size();
     const uint32_t num_remote_shards = remote_cores.size();

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
@@ -14,10 +14,10 @@ namespace ttnn::operations::data_movement::detail {
 uint32_t calculate_starting_idx_h(const Tensor& tensor, uint32_t num_slices, uint32_t slice_index);
 
 struct WidthShardingReshardSegment {
-    uint32_t write_size;
-    uint32_t read_offset;
-    uint32_t bank_id;
-    uint32_t write_offset;
+    uint32_t write_size = 0;
+    uint32_t read_offset = 0;
+    uint32_t bank_id = 0;
+    uint32_t write_offset = 0;
 };
 
 // Precompute a set of reads/writes for each core needed to perform a width-sharded reshard operations

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "ttnn/tensor/tensor.hpp"
-
 #include <tuple>
+
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::operations::data_movement::detail {
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
@@ -6,9 +6,30 @@
 
 #include "ttnn/tensor/tensor.hpp"
 
+#include <tuple>
+
 namespace ttnn::operations::data_movement::detail {
 
 // Utility function
 uint32_t calculate_starting_idx_h(const Tensor& tensor, uint32_t num_slices, uint32_t slice_index);
+
+struct WidthShardingReshardSegment {
+    uint32_t write_size;
+    uint32_t read_offset;
+    uint32_t bank_id;
+    uint32_t write_offset;
+};
+
+// Precompute a set of reads/writes for each core needed to perform a width-sharded reshard operations
+std::tuple<std::vector<std::vector<WidthShardingReshardSegment>>, uint32_t, uint32_t, uint32_t>
+compute_width_sharding_reshard_segments(
+    const std::array<uint32_t, 2>& local_shard_shape,
+    const std::array<uint32_t, 2>& remote_shard_shape,
+    const std::vector<CoreCoord>& local_cores,
+    const std::vector<CoreCoord>& remote_cores,
+    const BufferType& remote_buffer_type,
+    const CoreType& remote_core_type,
+    IDevice* device,
+    uint32_t element_size);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
@@ -27,9 +27,9 @@ compute_width_sharding_reshard_segments(
     const std::array<uint32_t, 2>& remote_shard_shape,
     const std::vector<CoreCoord>& local_cores,
     const std::vector<CoreCoord>& remote_cores,
-    const BufferType& remote_buffer_type,
+    const tt::tt_metal::BufferType& remote_buffer_type,
     const CoreType& remote_core_type,
-    IDevice* device,
+    tt::tt_metal::IDevice* device,
     uint32_t element_size);
 
 }  // namespace ttnn::operations::data_movement::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_to_hwc.hpp"
+
+#include "device/convert_to_hwc_op.hpp"
+#include "ttnn/common/queue_id.hpp"
+
+namespace ttnn::operations::experimental::cnn {
+
+ttnn::Tensor ExecuteConvertToHWC::invoke(
+    QueueId queue_id,
+    const Tensor& a,
+    const std::optional<MemoryConfig>& memory_config,
+    const std::optional<DataType>& dtype) {
+    auto program = ConvertToHWC{memory_config.value_or(a.memory_config()), dtype.value_or(a.dtype())};
+    return tt::tt_metal::operation::run(program, {a}, {}, {}, queue_id).at(0);
+}
+
+}  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ttnn/decorators.hpp>
+#include <ttnn/tensor/tensor.hpp>
+
+namespace ttnn::operations::experimental::cnn {
+
+struct ExecuteConvertToHWC {
+    static ttnn::Tensor invoke(
+        QueueId queue_id,
+        const Tensor& a,
+        const std::optional<MemoryConfig>& memory_config = std::nullopt,
+        const std::optional<DataType>& dtype = std::nullopt);
+};
+
+}  // namespace ttnn::operations::experimental::cnn
+
+namespace ttnn::experimental {
+
+constexpr auto convert_to_hwc = ttnn::register_operation<
+    "ttnn::experimental::convert_to_hwc",
+    ttnn::operations::experimental::cnn::ExecuteConvertToHWC>();
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.cpp
@@ -1,31 +1,31 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "convert_to_chw_pybind.hpp"
+#include "convert_to_hwc_pybind.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "convert_to_chw.hpp"
-#include "ttnn-pybind/decorators.hpp"
+#include "convert_to_hwc.hpp"
+#include "cpp/ttnn-pybind/decorators.hpp"
 
 namespace ttnn::operations::experimental::cnn::detail {
 
 namespace py = pybind11;
 
-void bind_convert_to_chw(py::module& module) {
-    using OperationType = decltype(ttnn::experimental::convert_to_chw);
+void bind_convert_to_hwc(py::module& module) {
+    using OperationType = decltype(ttnn::experimental::convert_to_hwc);
 
     const auto doc = R"doc(
-    Convert a tensor from HWC channel ordering to CHW channel ordering.
+    Convert a tensor from CHW channel ordering to HWC channel ordering.
 
-    The input tensor is expected to be tiled and height-sharded in L1. The output is a row-major width-sharded tensor.
+    The input tensor is expected to be in row-major layout and width-sharded in L1 or DRAM. The output is a row-major height-sharded tensor.
     )doc";
 
     ttnn::bind_registered_operation(
         module,
-        ttnn::experimental::convert_to_chw,
+        ttnn::experimental::convert_to_hwc,
         doc,
         ttnn::pybind_overload_t{
             [](const OperationType& self,

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-pybind/pybind_fwd.hpp"
+
+namespace ttnn::operations::experimental::cnn::detail {
+
+void bind_convert_to_hwc(pybind11::module& module);
+
+}  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -19,7 +19,7 @@ void ConvertToHWC::validate(const std::vector<Tensor>& input_tensors) const {
     const auto& C = shape[-2];
 
     TT_FATAL(shape.size() == 4, "Input shape must be rank 4 (was rank {})", shape.size());
-    TT_FATAL(shape[0] == 1 && shape[1] == 1, "Expected input tensor to be shape [1, 1, C, HW]");
+    TT_FATAL(shape[0] == 1 && shape[1] == 1, "Expected input tensor to be shape [1, 1, C, HW] (shape was {})", shape);
     TT_FATAL(C <= TILE_HEIGHT, "C must be less than or equal to 32 (was {})", C);
 
     TT_FATAL(input.layout() == ROW_MAJOR_LAYOUT, "Input tensor must be in row-major layout");

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_to_hwc_op.hpp"
+
+#include "convert_to_hwc_program_factory.hpp"
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::operations::experimental::cnn {
+
+void ConvertToHWC::validate(const std::vector<Tensor>& input_tensors) const {
+    using namespace tt::constants;
+    TT_FATAL(input_tensors.size() == 1, "Expected 1 input tensor");
+
+    const auto& input = input_tensors.at(0);
+    const auto& shape = input.get_logical_shape();
+    const auto& HW = shape[-1];
+    const auto& C = shape[-2];
+
+    TT_FATAL(shape.size() == 4, "Input shape must be rank 4 (was rank {})", shape.size());
+    TT_FATAL(shape[0] == 1 && shape[1] == 1, "Expected input tensor to be shape [1, 1, C, HW]");
+    TT_FATAL(C <= TILE_HEIGHT, "C must be less than or equal to 32 (was {})", C);
+
+    TT_FATAL(input.layout() == ROW_MAJOR_LAYOUT, "Input tensor must be in row-major layout");
+
+    TT_FATAL(input.is_sharded(), "Input tensor must be sharded");
+
+    TT_FATAL(
+        input.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED,
+        "Input tensor must be width sharded");
+    TT_FATAL(
+        this->memory_config.is_sharded() &&
+            this->memory_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+        "Output tensor must be height sharded");
+}
+
+std::vector<ttnn::TensorSpec> ConvertToHWC::compute_output_specs(const std::vector<Tensor>& input_tensors) const {
+    const auto& shape = input_tensors.at(0).get_logical_shape();
+    const auto B = shape[0];
+    const auto C = shape[2];
+    const auto HW = shape[3];
+    return {TensorSpec(
+        Shape({B, 1, HW, C}),
+        tt::tt_metal::TensorLayout(dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR), memory_config))};
+}
+
+tt::tt_metal::operation::ProgramWithCallbacks ConvertToHWC::create_program(
+    const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const {
+    const auto& a = input_tensors.at(0);
+    auto& output = output_tensors.at(0);
+    return detail::multi_core_convert_to_hwc(a, output);
+}
+}  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -5,6 +5,7 @@
 #include "convert_to_hwc_op.hpp"
 
 #include "convert_to_hwc_program_factory.hpp"
+
 #include <tt-metalium/constants.hpp>
 
 namespace ttnn::operations::experimental::cnn {
@@ -22,7 +23,7 @@ void ConvertToHWC::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(shape[0] == 1 && shape[1] == 1, "Expected input tensor to be shape [1, 1, C, HW] (shape was {})", shape);
     TT_FATAL(C <= TILE_HEIGHT, "C must be less than or equal to 32 (was {})", C);
 
-    TT_FATAL(input.layout() == ROW_MAJOR_LAYOUT, "Input tensor must be in row-major layout");
+    TT_FATAL(input.layout() == Layout::ROW_MAJOR, "Input tensor must be in row-major layout");
 
     TT_FATAL(input.is_sharded(), "Input tensor must be sharded");
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.cpp
@@ -23,7 +23,7 @@ void ConvertToHWC::validate(const std::vector<Tensor>& input_tensors) const {
     TT_FATAL(shape[0] == 1 && shape[1] == 1, "Expected input tensor to be shape [1, 1, C, HW] (shape was {})", shape);
     TT_FATAL(C <= TILE_HEIGHT, "C must be less than or equal to 32 (was {})", C);
 
-    TT_FATAL(input.layout() == Layout::ROW_MAJOR, "Input tensor must be in row-major layout");
+    TT_FATAL(input.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Input tensor must be in row-major layout");
 
     TT_FATAL(input.is_sharded(), "Input tensor must be sharded");
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_op.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/run_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::cnn {
+
+struct ConvertToHWC {
+    tt::tt_metal::MemoryConfig memory_config;
+    tt::tt_metal::DataType dtype;
+
+    void validate(const std::vector<Tensor>& input_tensors) const;
+    std::vector<ttnn::TensorSpec> compute_output_specs(const std::vector<Tensor>& input_tensors) const;
+    tt::tt_metal::operation::ProgramWithCallbacks create_program(
+        const std::vector<Tensor>& input_tensors, std::vector<Tensor>& output_tensors) const;
+};
+
+}  // namespace ttnn::operations::experimental::cnn

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "convert_to_hwc_program_factory.hpp"
+
+#include "tt-metalium/tt_backend_api_types.hpp"
+
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/operations/data_movement/sharded/sharded_common.hpp"
+
+namespace ttnn::operations::experimental::cnn::detail {
+
+using namespace tt::constants;
+
+tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Tensor& a, Tensor& output) {
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
+
+    // If we are pulling from DRAM we infer the shard shape by using the output shard spec
+    const bool is_input_in_dram = a.buffer()->core_type() == CoreType::DRAM;
+    const uint32_t input_shard_height = is_input_in_dram ? output.shard_spec()->shape[1] : a.shard_spec()->shape[0];
+    const uint32_t input_shard_width = is_input_in_dram ? output.shard_spec()->shape[0] : a.shard_spec()->shape[1];
+    const CoreRangeSet input_core_grid = is_input_in_dram ? output.shard_spec()->grid : a.shard_spec()->grid;
+    const std::vector<CoreCoord> input_cores = corerange_to_cores(
+        input_core_grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+
+    TT_FATAL(input_shard_height <= TILE_HEIGHT, "Shard height must be 32 or smaller");
+    TT_FATAL(input_shard_height % 8 == 0, "Shard height must be mutliple of 8");
+    TT_FATAL(input_shard_width % TILE_WIDTH == 0, "Shard width must be multiple of tile width");
+
+    const auto create_circular_buffer = [&program, &input_core_grid](
+                                            uint32_t index,
+                                            uint32_t total_size,
+                                            uint32_t page_size,
+                                            const tt::DataFormat& format,
+                                            tt::tt_metal::Buffer* buffer = nullptr) -> tt::tt_metal::CBHandle {
+        auto config = tt::tt_metal::CircularBufferConfig(total_size, {{index, format}}).set_page_size(index, page_size);
+        if (buffer != nullptr) {
+            config = config.set_globally_allocated_address(*buffer);
+        }
+        return tt::tt_metal::CreateCircularBuffer(program, input_core_grid, config);
+    };
+
+    const tt::DataFormat intermediary_format = tt::DataFormat::Float16_b;
+    const uint32_t intermediary_tile_size = tt::tt_metal::detail::TileSize(intermediary_format);
+
+    const uint32_t cb_in_id = tt::CBIndex::c_0;
+    const tt::DataFormat input_format = tt::tt_metal::datatype_to_dataformat_converter(a.get_dtype());
+    const uint32_t input_element_size = tt::datum_size(input_format);
+    const uint32_t cb_in_page_size = input_shard_width * input_element_size;
+    const uint32_t cb_in_total_size = input_shard_height * cb_in_page_size;
+    const auto cb_in = create_circular_buffer(
+        cb_in_id, cb_in_total_size, cb_in_page_size, input_format, is_input_in_dram ? nullptr : a.buffer());
+
+    const uint32_t cb_in_tiled_id = tt::CBIndex::c_1;
+    const uint32_t cb_in_tiled_total_size = tt::div_up(input_shard_width, TILE_WIDTH) * intermediary_tile_size;
+    const uint32_t cb_in_tiled_page_size = intermediary_tile_size;
+    const auto cb_in_tiled =
+        create_circular_buffer(cb_in_tiled_id, cb_in_tiled_total_size, cb_in_tiled_page_size, intermediary_format);
+
+    const uint32_t cb_in_transpose_total_size = tt::div_up(input_shard_width, TILE_WIDTH) * intermediary_tile_size;
+    const uint32_t cb_in_transpose_page_size = intermediary_tile_size;
+
+    const uint32_t cb_in_transpose_id0 = tt::CBIndex::c_2;
+    const auto cb_in_transpose0 = create_circular_buffer(
+        cb_in_transpose_id0, cb_in_transpose_total_size, cb_in_transpose_page_size, intermediary_format);
+
+    const uint32_t cb_in_transpose_id1 = tt::CBIndex::c_3;
+    const auto cb_in_transpose1 = create_circular_buffer(
+        cb_in_transpose_id1, cb_in_transpose_total_size, cb_in_transpose_page_size, intermediary_format);
+
+    const uint32_t cb_out_id = tt::CBIndex::c_4;
+    const tt::DataFormat output_format = input_format;
+    const uint32_t cb_out_total_size = cb_in_total_size;  // same size as input
+    const uint32_t cb_out_page_size = input_shard_height * input_element_size;
+    const auto cb_out =
+        create_circular_buffer(cb_out_id, cb_out_total_size, cb_out_page_size, output_format, output.buffer());
+
+    const uint32_t total_tiles_per_core = tt::div_up(input_shard_width, TILE_HEIGHT);
+    const uint32_t total_tiles_writer0 = tt::div_up(total_tiles_per_core, 2);
+    const uint32_t total_tiles_writer1 = total_tiles_per_core - total_tiles_writer0;
+    uint32_t output_stride_sticks = TILE_WIDTH;  // needed to stride output address when doing split writers
+
+    const auto dram_input_cores = corerange_to_cores(
+        a.shard_spec()->grid, std::nullopt, a.shard_spec()->orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
+    const auto remote_core_type = a.buffer()->core_type();
+    const auto remote_address = a.buffer()->address();
+    const auto remote_buffer_type = a.buffer()->buffer_type();
+    const auto [runtime_args_for_each_core, _, dram_write_stride_bytes, dram_read_stride_bytes] =
+        data_movement::detail::compute_width_sharding_reshard_segments(
+            {input_shard_height, input_shard_width},
+            a.shard_spec()->shape,  // dram shard shape
+            input_cores,
+            dram_input_cores,
+            remote_buffer_type,
+            remote_core_type,
+            a.device(),
+            2);
+
+    // Split DRAM read across each kernel along tensor height since this is the best way to split work evenly
+    const uint32_t total_num_sticks_kernel_0 = input_shard_height / 2;
+    const uint32_t total_num_sticks_kernel_1 = input_shard_height - total_num_sticks_kernel_0;
+
+    std::vector<uint32_t> writer_compile_time_args0 = {
+        cb_in_id,
+        cb_in_transpose_id0,
+        cb_out_id,
+        input_shard_height,
+        input_shard_width,
+        total_tiles_writer0,
+        output_stride_sticks,
+        0,
+        input_element_size,
+        is_input_in_dram,
+        true,
+        dram_write_stride_bytes,
+        dram_read_stride_bytes,
+        total_num_sticks_kernel_0};
+
+    std::vector<uint32_t> writer_compile_time_args1 = {
+        cb_in_id,
+        cb_in_transpose_id1,
+        cb_out_id,
+        input_shard_height,
+        input_shard_width,
+        total_tiles_writer1,
+        output_stride_sticks,
+        output_stride_sticks,
+        input_element_size,
+        is_input_in_dram,
+        false,
+        dram_write_stride_bytes,
+        dram_read_stride_bytes,
+        total_num_sticks_kernel_1};
+
+    std::vector<uint32_t> compute_compile_time_args = {
+        cb_in_id,
+        cb_in_tiled_id,
+        cb_in_transpose_id0,
+        cb_in_transpose_id1,
+        total_tiles_per_core,
+        input_shard_height,
+        is_input_in_dram};
+
+    auto writer_kernel_id0 = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp",
+        input_core_grid,
+        tt::tt_metal::ReaderDataMovementConfig(writer_compile_time_args0));
+
+    auto writer_kernel_id1 = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp",
+        input_core_grid,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_time_args1));
+
+    auto compute_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp",
+        input_core_grid,
+        tt::tt_metal::ComputeConfig{
+            .math_fidelity = MathFidelity::HiFi4,
+            .fp32_dest_acc_en = false,
+            .math_approx_mode = false,
+            .compile_args = compute_compile_time_args});
+
+    auto set_runtime_args = [cb_in,
+                             cb_out,
+                             is_input_in_dram,
+                             input_cores,
+                             runtime_args_for_each_core,
+                             writer_kernel_id0,
+                             writer_kernel_id1,
+                             total_num_sticks_kernel_0,
+                             total_num_sticks_kernel_1,
+                             remote_address,
+                             dram_read_stride_bytes,
+                             dram_write_stride_bytes](
+                                tt::tt_metal::Program& program, const Tensor& a, const Tensor& output) {
+        if (is_input_in_dram) {
+            for (uint32_t core_idx = 0; core_idx < input_cores.size(); core_idx++) {
+                const auto& args_for_all_segments = runtime_args_for_each_core[core_idx];
+                std::vector<uint32_t> runtime_args_0 = {remote_address, args_for_all_segments.size()};
+                std::vector<uint32_t> runtime_args_1 = {remote_address, args_for_all_segments.size()};
+                for (const auto& args : args_for_all_segments) {
+                    const std::vector<uint32_t> segment_kernel_0 = {
+                        args.write_size, args.read_offset, args.bank_id, args.write_offset};
+                    runtime_args_0.insert(runtime_args_0.end(), segment_kernel_0.begin(), segment_kernel_0.end());
+
+                    // Adjust read and write offsets to the correct stick address because we are splitting work across 2
+                    // kernels
+                    const uint32_t adjusted_read_offset =
+                        args.read_offset + total_num_sticks_kernel_0 * dram_write_stride_bytes;
+                    const uint32_t adjusted_write_offset =
+                        args.write_offset + total_num_sticks_kernel_0 * dram_read_stride_bytes;
+
+                    const std::vector<uint32_t> segment_kernel_1 = {
+                        args.write_size, adjusted_read_offset, args.bank_id, adjusted_write_offset};
+                    runtime_args_1.insert(runtime_args_1.end(), segment_kernel_1.begin(), segment_kernel_1.end());
+                }
+                SetRuntimeArgs(program, writer_kernel_id0, input_cores[core_idx], runtime_args_0);
+                SetRuntimeArgs(program, writer_kernel_id1, input_cores[core_idx], runtime_args_1);
+            }
+        } else {
+            tt::tt_metal::Buffer* a_buffer = a.buffer();
+            UpdateDynamicCircularBufferAddress(program, cb_in, *a_buffer);
+        }
+        tt::tt_metal::Buffer* output_buffer = output.buffer();
+        UpdateDynamicCircularBufferAddress(program, cb_out, *output_buffer);
+    };
+    set_runtime_args(program, a, output);
+
+    auto override_runtime_arguments_callback = [set_runtime_args](
+                                                   const void* operation,
+                                                   tt::tt_metal::Program& program,
+                                                   const std::vector<Tensor>& input_tensors,
+                                                   const std::vector<std::optional<const Tensor>>&,
+                                                   const std::vector<Tensor>& output_tensors) {
+        const auto& output_tensor = output_tensors.at(0);
+        set_runtime_args(program, input_tensors.at(0), output_tensor);
+    };
+
+    return {.program = std::move(program), .override_runtime_arguments_callback = override_runtime_arguments_callback};
+}
+
+}  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_program_factory.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operation.hpp"
+
+namespace ttnn::operations::experimental::cnn::detail {
+
+tt::tt_metal::operation::ProgramWithCallbacks multi_core_convert_to_hwc(const Tensor& a, Tensor& output);
+
+}  // namespace ttnn::operations::experimental::cnn::detail

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/convert_to_hwc.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "compute_kernel_api/pack_untilize.h"
+#include "compute_kernel_api/transpose_wh.h"
+#include "compute_kernel_api/tilize.h"
+
+template <uint32_t BatchSize = 1>
+FORCE_INLINE void transpose(uint32_t cb_in, uint32_t cb_out) {
+    cb_wait_front(cb_in, BatchSize);
+
+    tile_regs_acquire();
+    tile_regs_wait();
+
+    transpose_wh_init_short(cb_in);
+    for (uint32_t i = 0; i < BatchSize; i++) {
+        transpose_wh_tile(cb_in, i, i);
+    }
+
+    cb_reserve_back(cb_out, BatchSize);
+    pack_untilize_dst<1>(cb_out, BatchSize);
+
+    tile_regs_commit();
+    tile_regs_release();
+
+    cb_push_back(cb_out, BatchSize);
+    cb_pop_front(cb_in, BatchSize);
+}
+
+FORCE_INLINE void tilize(
+    uint32_t cb_in, uint32_t total_tiles_per_block, uint32_t total_sticks_per_block, uint32_t cb_out) {
+    cb_wait_front(cb_in, total_sticks_per_block);
+    cb_reserve_back(cb_out, total_tiles_per_block);
+
+    tilize_block(cb_in, total_tiles_per_block, cb_out);
+
+    cb_pop_front(cb_in, total_sticks_per_block);
+    cb_push_back(cb_out, total_tiles_per_block);
+}
+
+namespace NAMESPACE {
+void MAIN {
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_tiled_in = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_transpose_in0 = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_transpose_in1 = get_compile_time_arg_val(3);
+    constexpr uint32_t total_tiles = get_compile_time_arg_val(4);
+    constexpr uint32_t total_sticks_per_block = get_compile_time_arg_val(5);
+    constexpr uint32_t is_input_in_dram = get_compile_time_arg_val(6);
+
+    if constexpr (!is_input_in_dram) {
+        cb_push_back(cb_in, total_sticks_per_block);
+    }
+
+    tilize_init(cb_in, total_tiles, cb_tiled_in);
+    tilize(cb_in, total_tiles, total_sticks_per_block, cb_tiled_in);
+    tilize_uninit(cb_in, cb_tiled_in);
+
+    pack_untilize_init(cb_in, cb_transpose_in0);
+    transpose_wh_init(cb_in, cb_transpose_in0);
+    pack_untilize_dst_init_short<1>(cb_in);
+
+    for (uint32_t idx = 0; idx < total_tiles; idx++) {
+        const uint32_t cb_transpose_in = idx % 2 == 0 ? cb_transpose_in0 : cb_transpose_in1;
+        transpose<1>(cb_tiled_in, cb_transpose_in);
+    }
+    pack_untilize_uninit(cb_transpose_in0);
+}
+}  // namespace NAMESPACE

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/kernels/writer_convert_to_hwc.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dataflow_api.h"
+#include "debug/dprint_pages.h"
+
+constexpr uint32_t TILE_SIZE = 32;
+
+template <uint32_t StickSize, uint32_t PaddedStickSize, uint32_t NumSticks>
+FORCE_INLINE void copy_padded_sticks(uint32_t l1_read_addr, uint32_t& l1_write_addr) {
+    noc_async_read_one_packet_set_state(get_noc_addr(l1_read_addr), StickSize);
+    for (uint32_t row = 0; row < NumSticks; row++) {
+        noc_async_read_one_packet_with_state<true>(l1_read_addr, l1_write_addr);
+        l1_read_addr += PaddedStickSize;
+        l1_write_addr += StickSize;
+    }
+}
+
+template <uint32_t ReadStrideBytes, uint32_t WriteStrideBytes, uint32_t NumSticks>
+FORCE_INLINE void copy_segment_from_dram(
+    uint32_t copy_size,
+    uint32_t base_write_addr,
+    uint32_t write_offset,
+    uint32_t bank_id,
+    uint32_t base_read_addr,
+    uint32_t read_offset) {
+    uint32_t l1_write_addr = base_write_addr + write_offset;
+
+    uint32_t read_addr = base_read_addr + read_offset;
+    uint64_t noc_read_addr = get_noc_addr_from_bank_id<true>(bank_id, read_addr);
+
+    noc_async_read_one_packet_set_state(noc_read_addr, copy_size);
+    for (uint32_t j = 0; j < NumSticks; ++j) {
+        noc_async_read_one_packet_with_state<true>(noc_read_addr, l1_write_addr);
+        l1_write_addr += WriteStrideBytes;
+        noc_read_addr += ReadStrideBytes;
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_in_transpose = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(2);
+    constexpr uint32_t channels = get_compile_time_arg_val(3);  // stick size
+    constexpr uint32_t hw = get_compile_time_arg_val(4);        // total number of sticks to copy into output
+    constexpr uint32_t num_full_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t output_stride_sticks = get_compile_time_arg_val(6);
+    constexpr uint32_t initial_l1_write_stick_offset = get_compile_time_arg_val(7);
+    constexpr uint32_t element_size_bytes = get_compile_time_arg_val(8);
+
+    static_assert(hw % TILE_SIZE == 0, "Shard width must be multiple of tile width");
+
+    constexpr bool is_input_in_dram = get_compile_time_arg_val(9);
+    constexpr bool should_wait = get_compile_time_arg_val(10);
+    constexpr uint32_t dram_write_stride_bytes = get_compile_time_arg_val(11);
+    constexpr uint32_t dram_read_stride_bytes = get_compile_time_arg_val(12);
+    constexpr uint32_t input_sticks_per_core = get_compile_time_arg_val(13);
+
+    if constexpr (is_input_in_dram) {
+        const uint32_t dram_base_read_addr = get_arg_val<uint32_t>(0);
+        const uint32_t num_segments = get_arg_val<uint32_t>(1);
+        tt_l1_ptr uint32_t* args = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
+        uint32_t args_idx = 0;
+        for (uint32_t i = 0; i < num_segments; ++i) {
+            uint32_t copy_size = args[args_idx++];
+            uint32_t write_offset = args[args_idx++];
+            uint32_t bank_id = args[args_idx++];
+            uint32_t read_offset = args[args_idx++];
+            copy_segment_from_dram<dram_read_stride_bytes, dram_write_stride_bytes, input_sticks_per_core>(
+                copy_size, get_write_ptr(cb_in), write_offset, bank_id, dram_base_read_addr, read_offset);
+        }
+        noc_async_read_barrier();
+
+        // One writer must wait until the other has pushed to avoid a race that will trigger a hang
+        if constexpr (should_wait) {
+            cb_wait_front(cb_in, input_sticks_per_core);
+        }
+        cb_push_back(cb_in, input_sticks_per_core);
+    }
+
+    constexpr uint32_t tile_size_stick_bytes = TILE_SIZE * element_size_bytes;
+    constexpr uint32_t channel_size = channels * element_size_bytes;
+
+    constexpr uint32_t l1_write_addr_stride = output_stride_sticks * channel_size;
+    constexpr uint32_t initial_l1_write_addr_offset = initial_l1_write_stick_offset * channel_size;
+
+    const uint32_t base_l1_write_addr = get_write_ptr(cb_out) + initial_l1_write_addr_offset;
+
+    uint32_t l1_write_addr = base_l1_write_addr;
+    for (uint32_t i = 0; i < num_full_tiles; i++) {
+        cb_wait_front(cb_in_transpose, 1);
+        const uint32_t l1_read_addr = get_read_ptr(cb_in_transpose);
+        copy_padded_sticks<channel_size, tile_size_stick_bytes, TILE_SIZE>(l1_read_addr, l1_write_addr);
+        noc_async_read_barrier();
+        cb_pop_front(cb_in_transpose, 1);
+        l1_write_addr += l1_write_addr_stride;  // skip some number of sticks if splitting writers across cores
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_pybind.cpp
@@ -8,6 +8,7 @@
 #include <pybind11/stl.h>
 
 #include "ttnn/operations/experimental/cnn/convert_to_chw/convert_to_chw_pybind.hpp"
+#include "ttnn/operations/experimental/cnn/convert_to_hwc/convert_to_hwc_pybind.hpp"
 #include "ttnn/operations/experimental/conv3d/conv3d_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/argmax/argmax_pybind.hpp"
 #include "ttnn/operations/experimental/reduction/cumprod/cumprod_pybind.hpp"
@@ -85,6 +86,7 @@ void py_module(py::module& module) {
     ssm::detail::bind_hc_sum_reduce(module);
 
     cnn::detail::bind_convert_to_chw(module);
+    cnn::detail::bind_convert_to_hwc(module);
 
     ttnn::operations::experimental::conv3d::detail::py_bind_conv3d(module);
     ttnn::operations::experimental::reduction::cumprod::detail::bind_cumprod_operation(module);


### PR DESCRIPTION
### Summary

This change adds a new operation which can reorder a CNN input tensor from channels-first to channels-last ordering. 

It is intended to work seamlessly with the sliding window ops, plus common CNN 2CQ+trace configurations which typically involve resharding inputs from DRAM to L1.

This operation works with both DRAM width-sharded and L1 width-sharded inputs and produces L1 height-sharded outputs. 

On Shallow UNet-like workloads, this op provides a 2X speedup over the existing solution. This PR does not currently integrate this op with UNet because it is blocked by [#20726](https://github.com/tenstorrent/tt-metal/issues/20726).

Some notes about the changes:
- Because this op implements a fused reshard, I moved the logic which computes all necessary copies from DRAM from in the reshard op to a common location

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15048077065/job/42296462655
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15048078889
- [x] Blackhole nightly: https://github.com/tenstorrent/tt-metal/actions/runs/15139936145/job/42561811888
