### PR TITLE
#18485: skip gather and sort tests that fail on BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -5,11 +5,11 @@
 import pytest
 import torch
 import ttnn
-from models.utility_functions import skip_for_grayskull
+from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@skip_for_grayskull()
+@skip_for_blackhole("Sort needs to be tested and is failing on BH. Issue #22146")
 @pytest.mark.parametrize(
     "shape, dim, descending",
     [
@@ -49,7 +49,7 @@ def test_sort_standard(shape, dim, descending, device):
         assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
 
-@skip_for_grayskull()
+@skip_for_blackhole("Sort needs to be tested and is failing on BH. Issue #22146")
 @pytest.mark.parametrize(
     "shape, dim, descending",
     [

--- a/tests/ttnn/unit_tests/operations/test_gather.py
+++ b/tests/ttnn/unit_tests/operations/test_gather.py
@@ -5,9 +5,11 @@
 import pytest
 import torch
 import ttnn
+from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
+@skip_for_blackhole("Gather needs to be tested and is failing on BH. Issue #22147")
 @pytest.mark.parametrize(
     "input_shape, index_shape, dim",
     [
@@ -52,6 +54,7 @@ def test_gather_general(input_shape, index_shape, dim, device):
     assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
 
 
+@skip_for_blackhole("Gather needs to be tested and is failing on BH. Issue #22147")
 @pytest.mark.parametrize(
     "input_shape, index_shape, dim",
     [
@@ -83,6 +86,7 @@ def test_gather_preallocated_output(input_shape, index_shape, dim, device):
     assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_output))
 
 
+@skip_for_blackhole("Gather needs to be tested and is failing on BH. Issue #22147")
 @pytest.mark.parametrize(
     "input_shape, index_shape, dim",
     [
@@ -111,6 +115,7 @@ def test_gather_multicore_cases(input_shape, index_shape, dim, device):
     assert_with_pcc(torch_gather, ttnn.to_torch(ttnn_gather))
 
 
+@skip_for_blackhole("Gather needs to be tested and is failing on BH. Issue #22147")
 @pytest.mark.parametrize(
     "input_shape, index_shape, dim, torch_input_datatype, ttnn_input_datatype, ttnn_index_datatype",
     [


### PR DESCRIPTION
### Ticket
Link to Github Issue #18485

### Problem description
- gather and sort tests were not tested on BH and don't work on BH

### What's changed
- skip the tests on BH

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15049008233 anything touched looks good 
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [x] New/Existing tests provide coverage for changes