### PR TITLE
Update transformers dependency to 4.46.3 to support latest HF models

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -47,7 +47,7 @@ networkx==3.1
 torchvision==0.17.1+cpu
 torchmetrics==1.3.1
 torch-fidelity==0.3.0
-transformers==4.38.0
+transformers==4.46.3
 xlsxwriter==3.0.8
 tiktoken==0.3.3
 tqdm==4.66.3


### PR DESCRIPTION
### Problem description
Recent models require a more recent version of the transformers library. This needs to be update in the requirements to avoid customers having to install extra TT-Transformer requirements.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15049315150)
- [ ] [Single demo](https://github.com/tenstorrent/tt-metal/actions/runs/15049316499)


TODO: Some models rely on old functions that were deprecated from huggingface 😢 
Example: Falcon7B: https://github.com/tenstorrent/tt-metal/actions/runs/15052266476/job/42313744301

```
models/demos/falcon7b_common/demo/demo.py:15: in <module>
    from transformers.generation.utils import top_k_top_p_filtering
E   ImportError: cannot import name 'top_k_top_p_filtering' from 'transformers.generation.utils'
```