### PR TITLE
Split Llama TG perf pipelines to workaround hangs

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -43,21 +43,31 @@ jobs:
           },  # Austin Ho
           {
             name: "Galaxy Llama 70B model perf tests",
-            model-type: "Llama 70B",
             arch: wormhole_b0,
-            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            cmd: './tests/scripts/run_tests.sh --tt-arch wormhole_b0 --pipeline-type tg_llama_model_perf_tg_device --dispatch-mode ""',
-            owner_id: U044T8U8DEF # Johanna Rock
-          },
-          {
-            name: "Llama Galaxy Perf Unit Tests",
-            arch: wormhole_b0,
-            cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
+            cmd: "TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device",
             timeout: 100,
             tracy: true,
             runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
-            owner_id: U071CKL4AFK # Ammar Vora
+            owner_id: U044T8U8DEF # Johanna Rock
           },
+          {
+            name: "Galaxy Llama 70B model dispatch perf tests",
+            arch: wormhole_b0,
+            cmd: "TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch",
+            timeout: 100,
+            tracy: true,
+            runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+            owner_id: U044T8U8DEF # Johanna Rock
+          },
+          # { See GH Issue #22164
+          #   name: "Llama Galaxy Perf Unit Tests",
+          #   arch: wormhole_b0,
+          #   cmd: 'pytest models/demos/llama3_subdevices/tests/tg_perf_unit_tests',
+          #   timeout: 100,
+          #   tracy: true,
+          #   runs-on: ["arch-wormhole_b0", "${{ inputs.topology }}", "${{ inputs.extra-tag }}", "bare-metal", "pipeline-perf"],
+          #   owner_id: U071CKL4AFK # Ammar Vora
+          # },
         ]
     name: ${{ matrix.test-group.name }}
     env:

--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -35,13 +35,13 @@ jobs:
             timeout: 25,
             owner_id: U071CKL4AFK
           }, # Ammar Vora
-          {
-            name: "Llama Galaxy Demo Long Generation Test",
-            arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k mini-stress-test",
-            timeout: 40,
-            owner_id: U044T8U8DEF
-          }, # Johanna Rock
+          # { See GH Issue #22164
+          #   name: "Llama Galaxy Demo Long Generation Test",
+          #   arch: wormhole_b0,
+          #   cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k mini-stress-test",
+          #   timeout: 40,
+          #   owner_id: U044T8U8DEF
+          # }, # Johanna Rock
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
+++ b/models/demos/llama3_subdevices/tests/test_decoder_device_perf.py
@@ -225,7 +225,7 @@ perf_targets = {
     "Untilize_0": {
         "op_name": "Untilize",
         "kernel_duration": 1517.3333333333335,
-        "op_to_op": 996.8888888888889,
+        "op_to_op": 800,
         "non-overlapped-dispatch-time": 3113.6,
         "kernel_duration_relative_margin": 0.2,
         "op_to_op_duration_relative_margin": 0.2,

--- a/tests/scripts/tg/run_tg_model_perf_tests.sh
+++ b/tests/scripts/tg/run_tg_model_perf_tests.sh
@@ -28,28 +28,6 @@ run_tg_cnn_tests() {
   fi
 }
 
-run_tg_llama_70b_model_perf_tests() {
-
-  # Llama3.3-70B
-  llama70b=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
-
-  echo "LOG_METAL: Running run_tg_llama_70b_model_perf_tests"
-
-  # Run kernel and op to op latency test
-  TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device ; fail+=$?
-
-  # Run non-overlapped dispatch perf test
-  TT_METAL_KERNELS_EARLY_RETURN=1 TT_METAL_ENABLE_ERISC_IRAM=1 FAKE_DEVICE=TG LLAMA_DIR=$llama70b pytest models/demos/llama3_subdevices/tests/test_decoder_device_perf.py::test_llama_TG_perf_device_non_overlapped_dispatch ; fail+=$?
-
-  # # Merge all the generated reports
-  # env python3 models/perf/merge_perf_results.py; fail+=$?
-
-  if [[ $fail -ne 0 ]]; then
-    echo "LOG_METAL: run_tg_llama_70b_model_perf_tests failed"
-    exit 1
-  fi
-}
-
 main() {
   # Parse the arguments
   while [[ $# -gt 0 ]]; do
@@ -89,10 +67,8 @@ main() {
     run_tg_llm_tests
   elif [[ "$pipeline_type" == "cnn_model_perf_tg_device" ]]; then
     run_tg_cnn_tests
-  elif [[ "$pipeline_type" == "tg_llama_model_perf_tg_device" ]]; then
-     run_tg_llama_70b_model_perf_tests
   else
-    echo "$pipeline_type is invalid (supported: [cnn_model_perf_tg_device, cnn_model_perf_tg_device, tg_llama_model_perf_tg_device])" 2>&1
+    echo "$pipeline_type is invalid (supported: [cnn_model_perf_tg_device, cnn_model_perf_tg_device])" 2>&1
     exit 1
   fi
 }


### PR DESCRIPTION
### Ticket
- #22164

### Problem description
There are hangs when opening device when there are back-to-back perf test. As such, these tests need to be separated so that there is a reset between each test.

### What's changed
- Split model perf kernel/dispatch tests
- remove op-level perf pipelines (will split this later)
- removed mini-stress-test (no longer needed because coverage from Galaxy Stress test)

### Checklist
- [ ] [TG Pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/15052518790) CI passes (didn't wait for pipelines to run, but you can see that the workflow updates show up)