### PR TITLE
FORCE_INLINE init

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/fabric_mux_bandwidth_golden.csv
+++ b/tests/tt_metal/microbenchmarks/ethernet/fabric_mux_bandwidth_golden.csv
@@ -1,7 +1,7 @@
 Test name,Num full size channels,Num header only channels,Num buffers full size channel,Num buffers header only channel,Num packets,Packet payload size bytes,Num full size channel iters,Num iters b/w teardown checks,Bandwidth (B/c)
-full_size_channels,1,0,8,0,10000,4096,1,32,9.63445
-full_size_channels,2,0,8,0,10000,4096,1,32,9.48998
-full_size_channels,4,0,8,0,10000,4096,1,32,9.62938
+full_size_channels,1,0,8,0,10000,4096,1,32,9.91359
+full_size_channels,2,0,8,0,10000,4096,1,32,9.3868
+full_size_channels,4,0,8,0,10000,4096,1,32,9.50695
 full_size_channels,8,0,8,0,10000,4096,1,32,9.65443
 full_size_channel_packet_size,8,0,8,0,10000,16,1,32,0.158602
 full_size_channel_packet_size,8,0,8,0,10000,1024,1,32,3.13676

--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_worker_adapters.hpp
@@ -92,7 +92,7 @@ struct WorkerToFabricEdmSenderImpl {
             write_at_cmd_buf);
     }
 
-    void init(
+    FORCE_INLINE void init(
         bool connected_to_persistent_fabric,
         uint8_t direction,
         uint8_t edm_worker_x,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The new init function is causing a slight perf degradation in the perf benchmarks

### What's changed
Add FORCE_INLINE to the EDM Init function to make sure it's getting inlined
Update fabric mux golden csv values

### Checklist
Fabric benchmark pipeline
https://github.com/tenstorrent/tt-metal/actions/runs/15051865376