### PR TITLE
[DM]: Refactoring dataflow api

### DIFF
--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -884,7 +884,7 @@ FORCE_INLINE void noc_async_read_page(
     */
     RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, s.page_size, -1);
 
-    s.noc_async_read_page(id, dst_local_l1_addr, offset, noc);
+    noc_async_read(s.get_noc_addr(id, offset), dst_local_l1_addr, s.page_size, noc);
 }
 
 template <bool DRAM, uint32_t tile_hw>
@@ -900,7 +900,188 @@ FORCE_INLINE void noc_async_read_tile(
     */
     RECORD_NOC_EVENT_WITH_ID(NocEventType::READ, id, s.page_size, -1);
 
-    s.noc_async_read_tile(id, dst_local_l1_addr, offset, noc);
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
+    }
+    uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
+    uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
+    uint32_t src_addr = s.get_addr(id, bank_offset_index, bank_index, offset);
+    uint32_t src_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
+
+    WAYPOINT("NRTW");
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, get_noc_addr_helper(src_noc_xy, src_addr), dst_local_l1_addr, s.page_size);
+    while (!noc_cmd_buf_ready(noc, read_cmd_buf));
+    WAYPOINT("NRTD");
+
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        uint32_t noc_rd_cmd_field =
+            NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
+        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CTRL, noc_rd_cmd_field);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_LO, dst_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_LO, src_addr);            // (uint32_t)src_addr
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_AT_LEN_BE, s.page_size);            // len_bytes
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        noc_reads_num_issued[noc] += 1;
+    }
+}
+
+template <bool DRAM, uint32_t tile_hw>
+FORCE_INLINE void noc_async_write_tile(
+    const uint32_t id,
+    const InterleavedAddrGenFast<DRAM, tile_hw>& s,
+    std::uint32_t src_local_l1_addr,
+    uint8_t noc = noc_index) {
+    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, s.page_size, NOC_UNICAST_WRITE_VC);
+
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
+    }
+    uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
+    uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
+    uint32_t dest_addr = s.get_addr(id, bank_offset_index, bank_index);
+    uint32_t dest_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
+
+    WAYPOINT("NWTW");
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(
+        noc, get_noc_addr_helper(dest_noc_xy, dest_addr), src_local_l1_addr, s.page_size);
+    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    WAYPOINT("NWTD");
+
+    constexpr uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
+                                       NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
+                                       0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
+                                       0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
+                                       NOC_CMD_RESP_MARKED;
+
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, dest_addr);            // (uint32_t)dest_addr
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_COORDINATE, dest_noc_xy);  // dest_addr >> 32
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, s.page_size);            // len_bytes
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        noc_nonposted_writes_num_issued[noc] += 1;
+        noc_nonposted_writes_acked[noc] += 1;  // num_dests
+    }
+}
+
+template <bool DRAM>
+FORCE_INLINE void noc_async_read_page(
+    const uint32_t id,
+    const InterleavedPow2AddrGenFast<DRAM>& s,
+    std::uint32_t dst_local_l1_addr,
+    uint32_t offset = 0,
+    uint8_t noc = noc_index) {
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
+    }
+    uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
+    uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
+    uint32_t src_addr = s.get_addr(id, bank_offset_index, bank_index, offset);
+    uint32_t src_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
+
+    WAYPOINT("NRPW");
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(
+        noc, get_noc_addr_helper(src_noc_xy, src_addr), dst_local_l1_addr, 1 << s.aligned_log_base_2_of_page_size);
+    while (!noc_cmd_buf_ready(noc, read_cmd_buf));
+    WAYPOINT("NRPD");
+
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        uint32_t noc_rd_cmd_field =
+            NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
+        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CTRL, noc_rd_cmd_field);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_LO, dst_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_LO, src_addr);            // (uint32_t)src_addr
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_AT_LEN_BE, 1 << s.aligned_log_base_2_of_page_size);  // len_bytes
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        noc_reads_num_issued[noc] += 1;
+    }
+}
+
+template <bool DRAM>
+FORCE_INLINE void noc_async_read_partial_page(
+    const uint32_t id,
+    const InterleavedPow2AddrGenFast<DRAM>& s,
+    std::uint32_t dst_local_l1_addr,
+    const uint32_t size,
+    const uint32_t offset,
+    uint8_t noc = noc_index) {
+    // Note: This is not used anywhere in tt-metal
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
+    }
+    uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
+    uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
+    uint32_t src_addr = s.get_addr(id, bank_offset_index, bank_index, offset);
+    uint32_t src_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
+
+    WAYPOINT("RP1W");
+    while (!noc_cmd_buf_ready(noc, read_cmd_buf));
+    WAYPOINT("RP1D");
+    DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, get_noc_addr_helper(src_noc_xy, src_addr), dst_local_l1_addr, size);
+
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        uint32_t noc_rd_cmd_field =
+            NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
+        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CTRL, noc_rd_cmd_field);
+    }
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_LO, dst_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_LO, src_addr);            // (uint32_t)src_addr
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_AT_LEN_BE, size);                   // len_bytes
+    NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        noc_reads_num_issued[noc] += 1;
+    }
+}
+
+template <bool DRAM>
+FORCE_INLINE void noc_async_write_page(
+    const uint32_t id,
+    const InterleavedPow2AddrGenFast<DRAM>& s,
+    std::uint32_t src_local_l1_addr,
+    const uint32_t write_size_bytes,
+    const uint32_t offset = 0,
+    uint8_t noc = noc_index) {
+    // Note: This is not used anywhere in tt-metal
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+        inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
+    }
+    uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
+    uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
+    uint32_t dest_addr = s.get_addr(id, bank_offset_index, bank_index, offset);
+    uint32_t dest_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
+
+    WAYPOINT("NWPW");
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(
+        noc, get_noc_addr_helper(dest_noc_xy, dest_addr), src_local_l1_addr, write_size_bytes);
+    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    WAYPOINT("NWPD");
+
+    constexpr uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
+                                       NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
+                                       0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
+                                       0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
+                                       NOC_CMD_RESP_MARKED;
+
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, dest_addr);            // (uint32_t)dest_addr
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_COORDINATE, dest_noc_xy);  // dest_addr >> 32
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, write_size_bytes);       // len_bytes
+    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        noc_nonposted_writes_num_issued[noc] += 1;
+        noc_nonposted_writes_acked[noc] += 1;  // num_dests
+    }
 }
 
 // clang-format off
@@ -939,17 +1120,6 @@ inline void noc_async_write(
             noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true);
         WAYPOINT("NAWD");
     }
-}
-
-template <bool DRAM, uint32_t tile_hw>
-FORCE_INLINE void noc_async_write_tile(
-    const uint32_t id,
-    const InterleavedAddrGenFast<DRAM, tile_hw>& s,
-    std::uint32_t src_local_l1_addr,
-    uint8_t noc = noc_index) {
-    RECORD_NOC_EVENT_WITH_ID(NocEventType::WRITE_, id, s.page_size, NOC_UNICAST_WRITE_VC);
-
-    s.noc_async_write_tile(id, src_local_l1_addr, noc);
 }
 
 template <ProgrammableCoreType type = ProgrammableCoreType::TENSIX>

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/dataflow_api_addrgen.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/dataflow_api_addrgen.h
+++ b/tt_metal/hw/inc/dataflow_api_addrgen.h
@@ -248,21 +248,6 @@ struct InterleavedAddrGen {
         uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
         return noc_addr;
     }
-
-    FORCE_INLINE
-    void noc_async_read_page(
-        const uint32_t id, const uint32_t dest_addr, const uint32_t offset = 0, uint8_t noc = noc_index) const {
-        uint64_t src_noc_addr = this->get_noc_addr(id, offset);
-        uint32_t dst_local_l1_addr = dest_addr;
-        uint32_t size = this->page_size;
-        // RECORD_NOC_EVENT_WITH_ADDR(NocEventType::READ, src_noc_addr, size, -1); // TODO: need to fix circular
-        // dependency to uncomment this line
-
-        WAYPOINT("NARW");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, src_noc_addr, dst_local_l1_addr, size);
-        ncrisc_noc_fast_read_any_len<noc_mode>(noc, read_cmd_buf, src_noc_addr, dst_local_l1_addr, size);
-        WAYPOINT("NARD");
-    }
 };
 
 template <bool DRAM>
@@ -325,75 +310,8 @@ struct InterleavedAddrGenFast {
         uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
         return noc_addr;
     }
-
-    FORCE_INLINE
-    void noc_async_read_tile(
-        const uint32_t id, uint32_t dest_addr, const uint32_t offset = 0, uint8_t noc = noc_index) const {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
-        }
-        uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
-        uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
-        uint32_t src_addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t src_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        WAYPOINT("NRTW");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, this->page_size);
-        while (!noc_cmd_buf_ready(noc, read_cmd_buf));
-        WAYPOINT("NRTD");
-
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            uint32_t noc_rd_cmd_field =
-                NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
-            NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CTRL, noc_rd_cmd_field);
-        }
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_LO, dest_addr);
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_LO, src_addr);            // (uint32_t)src_addr
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_AT_LEN_BE, this->page_size);        // len_bytes
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
-            noc_reads_num_issued[noc] += 1;
-        }
-    }
-
-    FORCE_INLINE
-    void noc_async_write_tile(const uint32_t id, uint32_t src_addr, uint8_t noc = noc_index) const {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
-        }
-        uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
-        uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
-        uint32_t dest_addr = this->get_addr(id, bank_offset_index, bank_index);
-        uint32_t dest_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        WAYPOINT("NWTW");
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(
-            noc, get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr, this->page_size);
-        while (!noc_cmd_buf_ready(noc, write_cmd_buf));
-        WAYPOINT("NWTD");
-
-        constexpr uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
-                                           NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
-                                           0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
-                                           0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
-                                           NOC_CMD_RESP_MARKED;
-
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_addr);
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, dest_addr);            // (uint32_t)dest_addr
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_COORDINATE, dest_noc_xy);  // dest_addr >> 32
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, this->page_size);        // len_bytes
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
-            noc_nonposted_writes_num_issued[noc] += 1;
-            noc_nonposted_writes_acked[noc] += 1;  // num_dests
-        }
-    }
 };
 
-// TODO: add noc_async_write_page
 // TODO: need static assert + host assert that page size <= 8192, hard constraint
 template <bool DRAM>
 struct InterleavedPow2AddrGenFast {
@@ -424,114 +342,6 @@ struct InterleavedPow2AddrGenFast {
 
         uint64_t noc_addr = get_noc_addr_helper(noc_xy, addr);
         return noc_addr;
-    }
-
-    FORCE_INLINE
-    void noc_async_read_page(
-        const uint32_t id, uint32_t dest_addr, const uint32_t offset = 0, uint8_t noc = noc_index) const {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
-        }
-        uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
-        uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
-        uint32_t src_addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t src_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        WAYPOINT("NRPW");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(
-            noc, get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, 1 << this->aligned_log_base_2_of_page_size);
-        while (!noc_cmd_buf_ready(noc, read_cmd_buf));
-        WAYPOINT("NRPD");
-
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            uint32_t noc_rd_cmd_field =
-                NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
-            NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CTRL, noc_rd_cmd_field);
-        }
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_LO, dest_addr);
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_LO, src_addr);            // (uint32_t)src_addr
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
-        NOC_CMD_BUF_WRITE_REG(
-            noc, read_cmd_buf, NOC_AT_LEN_BE, 1 << this->aligned_log_base_2_of_page_size);  // len_bytes
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
-            noc_reads_num_issued[noc] += 1;
-        }
-    }
-
-    FORCE_INLINE
-    void noc_async_read_partial_page(
-        const uint32_t id,
-        uint32_t dest_addr,
-        const uint32_t size,
-        const uint32_t offset,
-        uint8_t noc = noc_index) const {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            inc_noc_counter_val<proc_type, NocBarrierType::READS_NUM_ISSUED>(noc, 1);
-        }
-        uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
-        uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
-        uint32_t src_addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t src_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        WAYPOINT("RP1W");
-        while (!noc_cmd_buf_ready(noc, read_cmd_buf));
-        WAYPOINT("RP1D");
-        DEBUG_SANITIZE_NOC_READ_TRANSACTION(noc, get_noc_addr_helper(src_noc_xy, src_addr), dest_addr, size);
-
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            uint32_t noc_rd_cmd_field =
-                NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1);
-            NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CTRL, noc_rd_cmd_field);
-        }
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_RET_ADDR_LO, dest_addr);
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_LO, src_addr);            // (uint32_t)src_addr
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_TARG_ADDR_COORDINATE, src_noc_xy);  // src_addr >> 32
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_AT_LEN_BE, size);                   // len_bytes
-        NOC_CMD_BUF_WRITE_REG(noc, read_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
-            noc_reads_num_issued[noc] += 1;
-        }
-    }
-
-    FORCE_INLINE
-    void noc_async_write_page(
-        const uint32_t id,
-        uint32_t src_addr,
-        const uint32_t write_size_bytes,
-        const uint32_t offset = 0,
-        uint8_t noc = noc_index) const {
-        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
-            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
-        }
-        uint32_t bank_offset_index = interleaved_addr_gen::get_bank_offset_index<DRAM>(id);
-        uint32_t bank_index = interleaved_addr_gen::get_bank_index<DRAM>(id, bank_offset_index);
-        uint32_t dest_addr = this->get_addr(id, bank_offset_index, bank_index, offset);
-        uint32_t dest_noc_xy = interleaved_addr_gen::get_noc_xy<DRAM>(bank_index, noc);
-
-        WAYPOINT("NWPW");
-        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(
-            noc, get_noc_addr_helper(dest_noc_xy, dest_addr), src_addr, write_size_bytes);
-        while (!noc_cmd_buf_ready(noc, write_cmd_buf));
-        WAYPOINT("NWPD");
-
-        constexpr uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC |
-                                           NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
-                                           0x0 |  // (linked ? NOC_CMD_VC_LINKED : 0x0)
-                                           0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
-                                           NOC_CMD_RESP_MARKED;
-
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_addr);
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, dest_addr);            // (uint32_t)dest_addr
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_COORDINATE, dest_noc_xy);  // dest_addr >> 32
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, write_size_bytes);       // len_bytes
-        NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
-        if constexpr (noc_mode == DM_DEDICATED_NOC) {
-            noc_nonposted_writes_num_issued[noc] += 1;
-            noc_nonposted_writes_acked[noc] += 1;  // num_dests
-        }
     }
 };
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_bmm_single_core_bias.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_bmm_single_core_bias.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_bmm_single_core_bias.hpp
+++ b/ttnn/cpp/ttnn/deprecated/tt_dnn/kernels/dataflow/reader_bmm_single_core_bias.hpp
@@ -20,7 +20,7 @@ FORCE_INLINE void read_bias(
     cb_reserve_back(bias_cb_id, bias_ntiles);
     uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
     for (uint32_t bias_tile = 0; bias_tile < bias_ntiles; ++bias_tile) {
-        s_bias.noc_async_read_page(bias_tile, bias_l1_addr);
+        noc_async_read_page(bias_tile, s_bias, bias_l1_addr);
         bias_l1_addr += bias_pagesize;
     }
     noc_async_read_barrier();
@@ -41,7 +41,7 @@ FORCE_INLINE void read_bias_with_offset(
     cb_reserve_back(bias_cb_id, bias_ntiles);
     uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
     for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
-        s_bias.noc_async_read_page(bias_tile, bias_l1_addr);
+        noc_async_read_page(bias_tile, s_bias, bias_l1_addr);
         bias_l1_addr += bias_pagesize;
     }
     noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -203,7 +203,7 @@ void kernel_main() {
                             for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
                                  ++weight_tile_w_i) {
                                 // DPRINT << "weight_tile_id=" << weight_tile_id << ENDL();
-                                s_weight.noc_async_read_tile(weight_tile_id, weight_write_l1_addr);
+                                noc_async_read_tile(weight_tile_id, s_weight, weight_write_l1_addr);
                                 weight_write_l1_addr += weight_tile_nbytes;
                                 weights_block_size_bytes += weight_tile_nbytes;
                                 weight_tile_id += 1;
@@ -271,7 +271,7 @@ void kernel_main() {
                 uint32_t bias_start_address = bias_l1_addr;
                 uint32_t bias_block_size_bytes = 0;
                 for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
-                    s_bias.noc_async_read_tile(bias_tile, bias_l1_addr);
+                    noc_async_read_tile(bias_tile, s_bias, bias_l1_addr);
                     bias_l1_addr += bias_pagesize;
                     bias_block_size_bytes += bias_pagesize;
                 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -91,7 +91,7 @@ void kernel_main() {
                             // loop over output channels, width of the output/weights.
                             for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles;
                                  ++weight_tile_w_i) {
-                                s_weight.noc_async_read_tile(weight_tile_id, weight_write_l1_addr);
+                                noc_async_read_tile(weight_tile_id, s_weight, weight_write_l1_addr);
                                 weight_write_l1_addr += weight_tile_nbytes;
                                 weights_block_size_bytes += weight_tile_nbytes;
                                 weight_tile_id += 1;
@@ -111,7 +111,7 @@ void kernel_main() {
                 cb_reserve_back(bias_cb_id, weight_block_width_ntiles);
                 uint32_t bias_l1_addr = get_write_ptr(bias_cb_id);
                 for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
-                    s_bias.noc_async_read_tile(bias_start_tile_id, bias_l1_addr);
+                    noc_async_read_tile(bias_start_tile_id, s_bias, bias_l1_addr);
                     bias_l1_addr += bias_pagesize;
                     bias_start_tile_id += 1;
                 }

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp
@@ -125,7 +125,7 @@ void kernel_main() {
                     uint32_t weight_tile_id = weight_current_block_start_tile_id;
                     // loop over weight block tiles along w
                     for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
-                        s_weight.noc_async_read_tile(weight_tile_id, weight_write_l1_addr);
+                        noc_async_read_tile(weight_tile_id, s_weight, weight_write_l1_addr);
                         weight_write_l1_addr += weight_tile_nbytes;
                         weights_block_size_bytes += weight_tile_nbytes;
                         weight_tile_id += 1;
@@ -185,7 +185,7 @@ void kernel_main() {
                 uint32_t bias_start_address = bias_l1_addr;
                 uint32_t bias_block_size_bytes = 0;
                 for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
-                    s_bias.noc_async_read_tile(bias_tile, bias_l1_addr);
+                    noc_async_read_tile(bias_tile, s_bias, bias_l1_addr);
                     bias_l1_addr += bias_pagesize;
                     bias_block_size_bytes += bias_pagesize;
                 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21970)

### Problem description
In `dataflow_api_addrgen.h`, some address generator classes such as `InterleavedAddrGen` have methods performing noc operations. These either implement the noc operations themselves or issue calls to `dataflow_api.h` which causes a circular dependency. The [resolution](https://github.com/tenstorrent/tt-metal/blob/2aceab13b8e3ccfe9450e75dd5915d5be7893b44/tt_metal/hw/inc/dataflow_api_addrgen.h#L219) to this makes Doxygen complain, effectively preventing us from integrating address generating functions into our docs. Furthermore, some of these methods have corresponding [functions](https://github.com/tenstorrent/tt-metal/blob/2aceab13b8e3ccfe9450e75dd5915d5be7893b44/tt_metal/hw/inc/dataflow_api.h#L873) in `dataflow_api.h` whose only purpose is to call these methods. `dataflow_api.h` functions are already enabled in our docs and our goal is to enable address generation functions as well. 

### What's changed
Moved the implementation of these class methods into `dataflow_api.h` to have a clear distinction between address generator and noc instruction functions. This removes duplicate of code and the circular dependency between the two files, allowing Doxygen to pass. Made necessary changes up the stack for any kernel using these functions.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15197126904) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15197130260) CI with demo tests passes
- [ ] Sweep tests (if fixed)