### PR TITLE
#22169: Integrate distributed host buffer into TTNN

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_host_buffer.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_host_buffer.cpp
@@ -19,16 +19,21 @@ using ::testing::Eq;
 using ::testing::IsEmpty;
 using ::testing::Pointwise;
 using ::testing::SizeIs;
+using ::testing::UnorderedElementsAre;
 
 TEST(DistributedHostBufferTest, OwnedLifecycle) {
-    // TODO: #21604 - Is "allocate" / "deallocate" meaningful for host buffers?
-    auto buffer = DistributedHostBuffer::create(3);
+    distributed::MeshShape global_shape(3);
+    distributed::MeshShape local_shape(3);
+    distributed::MeshCoordinate local_offset(0);
 
-    EXPECT_FALSE(buffer.is_allocated());
+    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
 
-    buffer.emplace_shard(0, HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(1, HostBuffer(std::vector<int>{4, 5, 6}));
-    buffer.emplace_shard(2, HostBuffer(std::vector<int>{7, 8, 9}));
+    EXPECT_EQ(buffer.shape().mesh_size(), 3);
+    EXPECT_TRUE(buffer.is_allocated());
+
+    buffer.emplace_shard(distributed::MeshCoordinate(0), HostBuffer(std::vector<int>{1, 2, 3}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1), HostBuffer(std::vector<int>{4, 5, 6}));
+    buffer.emplace_shard(distributed::MeshCoordinate(2), HostBuffer(std::vector<int>{7, 8, 9}));
 
     EXPECT_TRUE(buffer.is_allocated());
 
@@ -37,7 +42,7 @@ TEST(DistributedHostBufferTest, OwnedLifecycle) {
     EXPECT_FALSE(buffer.is_allocated());
 }
 
-TEST(DistributedHostBufferTest, ShardedWithInvalidLocalShape) {
+TEST(DistributedHostBufferTest, WithInvalidLocalShape) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(2, 4);  // 2x4 > 2x3
     distributed::MeshCoordinate local_offset(0, 0);
@@ -45,7 +50,7 @@ TEST(DistributedHostBufferTest, ShardedWithInvalidLocalShape) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, ShardedWithInvalidLocalOffset) {
+TEST(DistributedHostBufferTest, WithInvalidLocalOffset) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(1, 2);
     distributed::MeshCoordinate local_offset(2, 0);  // Offset 2 in first dimension exceeds global shape
@@ -53,7 +58,7 @@ TEST(DistributedHostBufferTest, ShardedWithInvalidLocalOffset) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, ShardedWithInvalidCombination) {
+TEST(DistributedHostBufferTest, WithInvalidCombination) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(1, 2);
     distributed::MeshCoordinate local_offset(1, 2);  // Offset + shape exceeds global shape
@@ -61,7 +66,7 @@ TEST(DistributedHostBufferTest, ShardedWithInvalidCombination) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, ShardedWithDimensionMismatch) {
+TEST(DistributedHostBufferTest, WithDimensionMismatch) {
     distributed::MeshShape global_shape(2, 3);
     distributed::MeshShape local_shape(1, 1, 1);  // 3D shape vs 2D global shape
     distributed::MeshCoordinate local_offset(1, 0);
@@ -69,96 +74,94 @@ TEST(DistributedHostBufferTest, ShardedWithDimensionMismatch) {
     EXPECT_ANY_THROW(DistributedHostBuffer::create(global_shape, local_shape, local_offset));
 }
 
-TEST(DistributedHostBufferTest, ShardedGetBuffer) {
-    auto buffer = DistributedHostBuffer::create(3);
+TEST(DistributedHostBufferTest, GetBuffer) {
+    distributed::MeshShape global_shape(3);
+    distributed::MeshShape local_shape(3);
+    distributed::MeshCoordinate local_offset(0);
 
-    buffer.emplace_shard(0, HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(1, HostBuffer(std::vector<int>{4, 5, 6}));
-    buffer.emplace_shard(2, HostBuffer(std::vector<int>{7, 8, 9}));
+    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
 
-    auto optional_buffer = buffer.get_shard(0);
+    buffer.emplace_shard(distributed::MeshCoordinate(0), HostBuffer(std::vector<int>{1, 2, 3}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1), HostBuffer(std::vector<int>{4, 5, 6}));
+    buffer.emplace_shard(distributed::MeshCoordinate(2), HostBuffer(std::vector<int>{7, 8, 9}));
+
+    auto optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {1, 2, 3}));
 
-    optional_buffer = buffer.get_shard(1);
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {4, 5, 6}));
 
-    optional_buffer = buffer.get_shard(2);
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(2));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {7, 8, 9}));
 
     // Out of global bounds.
-    EXPECT_ANY_THROW(buffer.get_shard(3));
+    EXPECT_ANY_THROW(buffer.get_shard(distributed::MeshCoordinate(3)));
 }
 
-TEST(DistributedHostBufferTest, ShardedWithMeshShape) {
+TEST(DistributedHostBufferTest, WithLocalMeshShape) {
     distributed::MeshShape global_shape(2, 3);
-    distributed::MeshShape local_shape(2, 3);  // Full shape
-    distributed::MeshCoordinate local_offset(0, 0);
+    distributed::MeshShape local_shape(2, 1);
+    distributed::MeshCoordinate local_offset(0, 1);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+    EXPECT_EQ(buffer.shape().mesh_size(), 6);  // 2×3 = 6
 
-    for (int i = 0; i < 6; ++i) {
-        buffer.emplace_shard(i, HostBuffer(std::vector<int>{i * 3 + 1, i * 3 + 2, i * 3 + 3}));
-    }
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), HostBuffer(std::vector<int>{1, 2, 3}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 1), HostBuffer(std::vector<int>{4, 5, 6}));
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 2), HostBuffer(std::vector<int>{7, 8, 9}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), HostBuffer(std::vector<int>{10, 11, 12}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 1), HostBuffer(std::vector<int>{13, 14, 15}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 2), HostBuffer(std::vector<int>{16, 17, 18}));
 
-    for (int i = 0; i < 6; ++i) {
-        auto optional_buffer = buffer.get_shard(i);
-        ASSERT_TRUE(optional_buffer.has_value());
-        EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {i * 3 + 1, i * 3 + 2, i * 3 + 3}));
-    }
+    EXPECT_THAT(
+        buffer.shard_coords(),
+        UnorderedElementsAre(
+            distributed::MeshCoordinate(0, 0),
+            distributed::MeshCoordinate(0, 1),
+            distributed::MeshCoordinate(0, 2),
+            distributed::MeshCoordinate(1, 0),
+            distributed::MeshCoordinate(1, 1),
+            distributed::MeshCoordinate(1, 2)));
 
-    // Out of global bounds.
-    EXPECT_ANY_THROW(buffer.get_shard(6));
-}
-
-TEST(DistributedHostBufferTest, ShardedWithLocalMeshShape) {
-    distributed::MeshShape global_shape(2, 3);
-    distributed::MeshShape local_shape(1, 2);
-    distributed::MeshCoordinate local_offset(1, 0);
-
-    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
-
-    // Create and emplace all buffers
-    for (int i = 0; i < 6; ++i) {
-        // Try to emplace all buffers - only the ones in our local shard will succeed
-        buffer.emplace_shard(i, HostBuffer(std::vector<int>{i * 3 + 1, i * 3 + 2, i * 3 + 3}));
-    }
-
-    auto optional_buffer = buffer.get_shard(0);
+    auto optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0, 0));
     EXPECT_FALSE(optional_buffer.has_value());
 
-    optional_buffer = buffer.get_shard(1);
-    EXPECT_FALSE(optional_buffer.has_value());
-
-    optional_buffer = buffer.get_shard(2);
-    EXPECT_FALSE(optional_buffer.has_value());
-
-    optional_buffer = buffer.get_shard(3);
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0, 1));
     ASSERT_TRUE(optional_buffer.has_value());
-    EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {10, 11, 12}));
+    EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {4, 5, 6}));
 
-    optional_buffer = buffer.get_shard(4);
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(0, 2));
+    EXPECT_FALSE(optional_buffer.has_value());
+
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1, 0));
+    EXPECT_FALSE(optional_buffer.has_value());
+
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1, 1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {13, 14, 15}));
 
-    optional_buffer = buffer.get_shard(5);
+    optional_buffer = buffer.get_shard(distributed::MeshCoordinate(1, 2));
     EXPECT_FALSE(optional_buffer.has_value());
 
     // Out of global bounds.
-    EXPECT_ANY_THROW(buffer.get_shard(6));
+    EXPECT_ANY_THROW(buffer.get_shard(distributed::MeshCoordinate(2, 0)));
 }
 
-TEST(DistributedHostBufferTest, ShardedTransform) {
-    auto buffer = DistributedHostBuffer::create(2);
+TEST(DistributedHostBufferTest, Transform) {
+    distributed::MeshShape global_shape(2);
+    distributed::MeshShape local_shape(2);
+    distributed::MeshCoordinate local_offset(0);
 
-    buffer.emplace_shard(0, HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(1, HostBuffer(std::vector<int>{4, 5, 6}));
+    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+    EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
-    std::vector<size_t> indices;
-    buffer.transform([&indices](const HostBuffer& buffer, size_t index) {
-        indices.push_back(index);
+    buffer.emplace_shard(distributed::MeshCoordinate(0), HostBuffer(std::vector<int>{1, 2, 3}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1), HostBuffer(std::vector<int>{4, 5, 6}));
+
+    auto transformed_buffer = buffer.transform([](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
         std::vector<int> new_data(span.begin(), span.end());
         for (auto& val : new_data) {
@@ -167,32 +170,28 @@ TEST(DistributedHostBufferTest, ShardedTransform) {
         return HostBuffer(std::move(new_data));
     });
 
-    EXPECT_THAT(indices, ElementsAre(0, 1));
-
-    auto optional_buffer = buffer.get_shard(0);
+    auto optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {2, 4, 6}));
 
-    optional_buffer = buffer.get_shard(1);
+    optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(1));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {8, 10, 12}));
 }
 
-TEST(DistributedHostBufferTest, ShardedWithLocalShapeTransform) {
+TEST(DistributedHostBufferTest, TransformWithLocalShape) {
     distributed::MeshShape global_shape(3, 1);
     distributed::MeshShape local_shape(2, 1);
     distributed::MeshCoordinate local_offset(1, 0);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+    EXPECT_EQ(buffer.shape().mesh_size(), 3);  // 3×1 = 3
 
-    // Emplace buffers - only indices 1 and 2 are within our local shard
-    for (int i = 0; i < 3; ++i) {
-        buffer.emplace_shard(i, HostBuffer(std::vector<int>{i * 3 + 1, i * 3 + 2, i * 3 + 3}));
-    }
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), HostBuffer(std::vector<int>{1, 2, 3}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), HostBuffer(std::vector<int>{4, 5, 6}));
+    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), HostBuffer(std::vector<int>{7, 8, 9}));
 
-    std::vector<size_t> indices;
-    buffer.transform([&indices](const HostBuffer& buffer, size_t index) {
-        indices.push_back(index);
+    auto transformed_buffer = buffer.transform([](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
         std::vector<int> new_data(span.begin(), span.end());
         for (auto& val : new_data) {
@@ -201,58 +200,55 @@ TEST(DistributedHostBufferTest, ShardedWithLocalShapeTransform) {
         return HostBuffer(std::move(new_data));
     });
 
-    EXPECT_THAT(indices, ElementsAre(0, 1));  // Local indices, not global
-
-    auto optional_buffer = buffer.get_shard(1);
+    auto optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(1, 0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {8, 10, 12}));
 
-    optional_buffer = buffer.get_shard(2);
+    optional_buffer = transformed_buffer.get_shard(distributed::MeshCoordinate(2, 0));
     ASSERT_TRUE(optional_buffer.has_value());
     EXPECT_THAT(optional_buffer->view_as<int>(), Pointwise(Eq(), {14, 16, 18}));
 }
 
-TEST(DistributedHostBufferTest, ShardedApply) {
-    auto buffer = DistributedHostBuffer::create(2);
+TEST(DistributedHostBufferTest, Apply) {
+    distributed::MeshShape global_shape(2);
+    distributed::MeshShape local_shape(2);
+    distributed::MeshCoordinate local_offset(0);
 
-    buffer.emplace_shard(0, HostBuffer(std::vector<int>{1, 2, 3}));
-    buffer.emplace_shard(1, HostBuffer(std::vector<int>{4, 5, 6}));
+    auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+    EXPECT_EQ(buffer.shape().mesh_size(), 2);
 
-    std::vector<size_t> indices;
+    buffer.emplace_shard(distributed::MeshCoordinate(0), HostBuffer(std::vector<int>{1, 2, 3}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1), HostBuffer(std::vector<int>{4, 5, 6}));
+
     std::vector<std::vector<int>> values;
-    buffer.apply([&indices, &values](const HostBuffer& buffer, size_t index) {
-        indices.push_back(index);
+    buffer.apply([&values](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
         values.push_back(std::vector<int>(span.begin(), span.end()));
     });
 
-    EXPECT_THAT(indices, ElementsAre(0, 1));
     ASSERT_THAT(values, SizeIs(2));
     EXPECT_THAT(values[0], ElementsAre(1, 2, 3));
     EXPECT_THAT(values[1], ElementsAre(4, 5, 6));
 }
 
-TEST(DistributedHostBufferTest, ShardedWithLocalShapeApply) {
+TEST(DistributedHostBufferTest, ApplyWithLocalShape) {
     distributed::MeshShape global_shape(3, 1);
     distributed::MeshShape local_shape(2, 1);
     distributed::MeshCoordinate local_offset(1, 0);
 
     auto buffer = DistributedHostBuffer::create(global_shape, local_shape, local_offset);
+    EXPECT_EQ(buffer.shape().mesh_size(), 3);  // 3×1 = 3
 
-    // Emplace buffers - only indices 1 and 2 are within our local shard
-    for (int i = 0; i < 3; ++i) {
-        buffer.emplace_shard(i, HostBuffer(std::vector<int>{i * 3 + 1, i * 3 + 2, i * 3 + 3}));
-    }
+    buffer.emplace_shard(distributed::MeshCoordinate(0, 0), HostBuffer(std::vector<int>{1, 2, 3}));
+    buffer.emplace_shard(distributed::MeshCoordinate(1, 0), HostBuffer(std::vector<int>{4, 5, 6}));
+    buffer.emplace_shard(distributed::MeshCoordinate(2, 0), HostBuffer(std::vector<int>{7, 8, 9}));
 
-    std::vector<size_t> indices;
     std::vector<std::vector<int>> values;
-    buffer.apply([&indices, &values](const HostBuffer& buffer, size_t index) {
-        indices.push_back(index);
+    buffer.apply([&values](const HostBuffer& buffer) {
         auto span = buffer.view_as<int>();
         values.push_back(std::vector<int>(span.begin(), span.end()));
     });
 
-    EXPECT_THAT(indices, ElementsAre(0, 1));  // Local indices
     ASSERT_THAT(values, SizeIs(2));
     EXPECT_THAT(values[0], ElementsAre(4, 5, 6));  // Global index 1
     EXPECT_THAT(values[1], ElementsAre(7, 8, 9));  // Global index 2

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/assert.hpp>
 
 #include <functional>
+#include <unordered_set>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -26,11 +27,6 @@ public:
     DistributedHostBuffer(DistributedHostBuffer&&) = default;
     DistributedHostBuffer& operator=(DistributedHostBuffer&&) = default;
 
-    // Creates a buffer of the provided `global_size`, spanning a single host.
-    // TODO: remove in the long term. For now, this is supporting TTNN's "MultiDeviceHostStorage" API that does not
-    // include the shape.
-    static DistributedHostBuffer create(size_t global_size);
-
     // Creates a multi-host distributed buffer with the specified parameters.
     // The size of `global_buffers` indicates the global size of the buffer; `local_shape` and `local_offset` must be
     // consistent with the global shape. `global_buffers` that are remote to this host will be deallocated and ignored
@@ -40,30 +36,32 @@ public:
         const distributed::MeshShape& local_shape,
         const distributed::MeshCoordinate& local_offset);
 
-    // TODO: use `MeshCoordinate` to specify `linear_index`. Currently, the problem is that on creation of "multi host
-    // device" buffer in TTNN, the shape is not specified, so we cannot onboard `DistributedHostBuffer` to use
-    // coordinate system natively.
-
-    // Returns the shard at the specified `linear_index`.
+    // Returns the shard at the specified `coord`.
     // Returns `std::nullopt` if the index is out of local bounds.
     // Throws if the index is out of global bounds.
-    std::optional<HostBuffer> get_shard(size_t linear_index) const;
+    std::optional<HostBuffer> get_shard(const distributed::MeshCoordinate& coord) const;
 
-    // Emplaces the shard at the specified `linear_index`.
+    // Emplaces the shard at the specified `coord`.
     // No-op if the index is out of local bounds.
     // Throws if the index is out of global bounds.
-    void emplace_shard(size_t linear_index, HostBuffer buffer);
+    void emplace_shard(const distributed::MeshCoordinate& coord, HostBuffer buffer);
 
     // `transform` and `apply` functions abstract away the details of the underlying data storage.
     // `linear_index` will be supplied by `DistributedHostBuffer` to indicate the position of the buffer.
     // For global multi-host buffers, these functions will only be invoked for the local shards.
     //
     // TODO: provide an optional way to parallelize the operation.
-    using TransformFn = std::function<HostBuffer(const HostBuffer& buffer, size_t linear_index)>;
-    void transform(const TransformFn& fn);
+    using TransformFn = std::function<HostBuffer(const HostBuffer& buffer)>;
+    DistributedHostBuffer transform(const TransformFn& fn) const;
 
-    using ApplyFn = std::function<void(const HostBuffer& buffer, size_t linear_index)>;
-    void apply(const ApplyFn& fn);
+    using ApplyFn = std::function<void(const HostBuffer& buffer)>;
+    void apply(const ApplyFn& fn) const;
+
+    // Returns the global shape of the buffer.
+    distributed::MeshShape shape() const;
+
+    // Returns the coordinates of populated shards in the buffer.
+    std::unordered_set<distributed::MeshCoordinate> shard_coords() const;
 
     // Returns true if the buffer is allocated.
     bool is_allocated() const;
@@ -72,12 +70,20 @@ public:
     void deallocate();
 
 private:
-    DistributedHostBuffer(
-        std::function<std::optional<size_t>(size_t)> global_to_local_index, std::vector<HostBuffer> local_buffers) :
-        global_to_local_index_(std::move(global_to_local_index)), local_buffers_(std::move(local_buffers)) {}
+    std::optional<distributed::MeshCoordinate> global_to_local(const distributed::MeshCoordinate& coord) const;
 
-    std::function<std::optional<size_t>(size_t)> global_to_local_index_;
-    std::vector<HostBuffer> local_buffers_;
+    DistributedHostBuffer(
+        distributed::MeshShape global_shape,
+        distributed::MeshCoordinate local_offset,
+        distributed::MeshContainer<HostBuffer> local_buffers) :
+        global_shape_(std::move(global_shape)),
+        local_offset_(std::move(local_offset)),
+        local_buffers_(std::move(local_buffers)) {}
+
+    distributed::MeshShape global_shape_;
+    distributed::MeshCoordinate local_offset_;
+    distributed::MeshContainer<HostBuffer> local_buffers_;
+    std::unordered_set<distributed::MeshCoordinate> populated_shards_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -99,12 +99,8 @@ public:
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<ShardDataTransfer>& shard_data_transfers,
         bool blocking) = 0;
-    // TODO: remove `host_buffer_shape` once it is integrated into `DistributedHostBuffer` directly.
     virtual void enqueue_write(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const DistributedHostBuffer& host_buffer,
-        const MeshShape& host_buffer_shape,
-        bool blocking) = 0;
+        const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
 
     // MeshBuffer Read APIs
     virtual void enqueue_read_mesh_buffer(
@@ -114,9 +110,11 @@ public:
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking) = 0;
     // TODO: does "enqueue" make sense anymore? Return the object by value instead.
-    // TODO: specify a way to "filter" shards we are interested in?
     virtual void enqueue_read(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer, DistributedHostBuffer& host_buffer, bool blocking) = 0;
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        DistributedHostBuffer& host_buffer,
+        const std::optional<std::unordered_set<MeshCoordinate>>& shards,
+        bool blocking) = 0;
 
     virtual MeshEvent enqueue_record_event(
         tt::stl::Span<const SubDeviceId> sub_device_ids = {},

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -12,11 +12,6 @@
 
 namespace tt::tt_metal {
 
-DistributedHostBuffer DistributedHostBuffer::create(size_t global_size) {
-    return DistributedHostBuffer(
-        [](size_t global_index) { return global_index; }, std::vector<HostBuffer>(global_size));
-}
-
 DistributedHostBuffer DistributedHostBuffer::create(
     const distributed::MeshShape& global_shape,
     const distributed::MeshShape& local_shape,
@@ -42,62 +37,86 @@ DistributedHostBuffer DistributedHostBuffer::create(
             global_shape[dim]);
     }
 
-    auto global_to_local_index = [global_shape, local_shape, local_offset](size_t global_idx) -> std::optional<size_t> {
-        TT_FATAL(
-            global_idx < global_shape.mesh_size(),
-            "Global index {} is out of bounds for global shape {}",
-            global_idx,
-            global_shape);
+    return DistributedHostBuffer(
+        std::move(global_shape),
+        std::move(local_offset),
+        distributed::MeshContainer<HostBuffer>(local_shape, HostBuffer()));
+}
 
-        size_t local_idx = 0;
-        size_t remaining = global_idx;
-        for (size_t dim = 0; dim < global_shape.dims(); ++dim) {
-            const uint32_t coord = remaining / global_shape.get_stride(dim);
-            remaining %= global_shape.get_stride(dim);
-
-            if (coord < local_offset[dim] || coord >= local_offset[dim] + local_shape[dim]) {
-                return std::nullopt;
-            }
-
-            local_idx += (coord - local_offset[dim]) * local_shape.get_stride(dim);
+std::optional<distributed::MeshCoordinate> DistributedHostBuffer::global_to_local(
+    const distributed::MeshCoordinate& coord) const {
+    const auto& local_shape = local_buffers_.shape();
+    tt::stl::SmallVector<uint32_t> local_coord(coord.dims());
+    for (size_t dim = 0; dim < coord.dims(); ++dim) {
+        if (coord[dim] < local_offset_[dim] || coord[dim] >= local_offset_[dim] + local_shape[dim]) {
+            return std::nullopt;
         }
-
-        return local_idx;
-    };
-    return DistributedHostBuffer(std::move(global_to_local_index), std::vector<HostBuffer>(local_shape.mesh_size()));
+        local_coord[dim] = coord[dim] - local_offset_[dim];
+    }
+    return distributed::MeshCoordinate(local_coord);
 }
 
-std::optional<HostBuffer> DistributedHostBuffer::get_shard(size_t linear_index) const {
-    const auto local_index = global_to_local_index_(linear_index);
-    return local_index.has_value() ? std::make_optional(local_buffers_.at(local_index.value())) : std::nullopt;
+std::optional<HostBuffer> DistributedHostBuffer::get_shard(const distributed::MeshCoordinate& coord) const {
+    TT_FATAL(
+        distributed::MeshCoordinateRange(global_shape_).contains(coord),
+        "Coordinate {} is outside the global shape bounds {}",
+        coord,
+        global_shape_);
+
+    auto local_coord_opt = global_to_local(coord);
+    return local_coord_opt.has_value() ? std::optional<HostBuffer>(local_buffers_.at(*local_coord_opt)) : std::nullopt;
 }
 
-void DistributedHostBuffer::emplace_shard(size_t linear_index, HostBuffer buffer) {
-    const auto local_index = global_to_local_index_(linear_index);
-    if (local_index.has_value()) {
-        local_buffers_.at(local_index.value()) = std::move(buffer);
+void DistributedHostBuffer::emplace_shard(const distributed::MeshCoordinate& coord, HostBuffer buffer) {
+    TT_FATAL(
+        distributed::MeshCoordinateRange(global_shape_).contains(coord),
+        "Coordinate {} is outside the global shape bounds {}",
+        coord,
+        global_shape_);
+
+    populated_shards_.insert(coord);
+    auto local_coord_opt = global_to_local(coord);
+    if (local_coord_opt.has_value()) {
+        local_buffers_.at(*local_coord_opt) = std::move(buffer);
     }
 }
 
-void DistributedHostBuffer::transform(const TransformFn& fn) {
-    for (size_t i = 0; i < local_buffers_.size(); ++i) {
-        local_buffers_.at(i) = fn(local_buffers_.at(i), i);
+DistributedHostBuffer DistributedHostBuffer::transform(const TransformFn& fn) const {
+    std::vector<HostBuffer> transformed_buffers;
+    transformed_buffers.reserve(local_buffers_.shape().mesh_size());
+    for (const auto& local_buffer : local_buffers_.values()) {
+        transformed_buffers.push_back(fn(local_buffer));
     }
+    DistributedHostBuffer transformed_buffer(
+        global_shape_,
+        local_offset_,
+        distributed::MeshContainer<HostBuffer>(local_buffers_.shape(), std::move(transformed_buffers)));
+    return transformed_buffer;
 }
 
-void DistributedHostBuffer::apply(const ApplyFn& fn) {
-    for (size_t i = 0; i < local_buffers_.size(); ++i) {
-        fn(local_buffers_.at(i), i);
+void DistributedHostBuffer::apply(const ApplyFn& fn) const {
+    for (const auto& local_buffer : local_buffers_.values()) {
+        fn(local_buffer);
     }
 }
 
 bool DistributedHostBuffer::is_allocated() const {
-    return std::all_of(
-        local_buffers_.begin(), local_buffers_.end(), [](const HostBuffer& b) { return b.is_allocated(); });
+    for (const auto& populated_coord : populated_shards_) {
+        if (auto shard = get_shard(populated_coord); shard.has_value() && !shard->is_allocated()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+distributed::MeshShape DistributedHostBuffer::shape() const { return global_shape_; }
+
+std::unordered_set<distributed::MeshCoordinate> DistributedHostBuffer::shard_coords() const {
+    return populated_shards_;
 }
 
 void DistributedHostBuffer::deallocate() {
-    for (auto& buffer : local_buffers_) {
+    for (auto& buffer : local_buffers_.values()) {
         buffer.deallocate();
     }
 }

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -55,7 +55,6 @@ public:
     void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const DistributedHostBuffer& host_buffer,
-        const MeshShape& host_buffer_shape,
         bool blocking) override;
 
     // MeshBuffer Read APIs
@@ -64,9 +63,11 @@ public:
         const std::vector<ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking) override;
-
     void enqueue_read(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer, DistributedHostBuffer& host_buffer, bool blocking) override;
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        DistributedHostBuffer& host_buffer,
+        const std::optional<std::unordered_set<MeshCoordinate>>& shards,
+        bool blocking) override;
 };
 
 }  // namespace tt::tt_metal::distributed


### PR DESCRIPTION
### Ticket
#22169

### Problem description
Integrate `DistributedHostBuffer` in TTNN

### What's changed
Chose the approach of extending `MultiDeviceHostStorage` with a different buffer type:
* The main limitation that prevents unification upfront are existing interfaces that rely on linear indexing of buffers. E.g. when reading tensor data from disk, the buffers are linearized and are "shapeless".
* Another limitation that requires a separate change is enforcing equal tensor specs across tensor shards. In multi-host Ops need to be run in lock-step - local hosts cannot know what remote hosts are doing with their local tensor shards, if the data isn't even.

For the time being, code that processes `MultiDeviceHostStorage` is forked in 2 versions - the one that processes `std::vector<HostBuffer>`, and the new path that processes `DistributedHostBuffer`.
* The eventual goal is to make `TensorSpec` even, and move host-side buffer processing under `DistributedHostBuffer::transform`. Ops wouldn't need to know if the storage is distributed, local, single or multi-shard.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15052613313)
- [ ] New/Existing tests provide coverage for changes