### PR TITLE
#21604: Get rid of the concept of host-side buffer allocation/deallocation

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_host_buffer.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_host_buffer.cpp
@@ -20,21 +20,12 @@ using ::testing::IsEmpty;
 using ::testing::Pointwise;
 using ::testing::SizeIs;
 
-TEST(DistributedHostBufferTest, OwnedLifecycle) {
-    // TODO: #21604 - Is "allocate" / "deallocate" meaningful for host buffers?
+TEST(DistributedHostBufferTest, Basic) {
     auto buffer = DistributedHostBuffer::create(3);
-
-    EXPECT_FALSE(buffer.is_allocated());
 
     buffer.emplace_shard(0, HostBuffer(std::vector<int>{1, 2, 3}));
     buffer.emplace_shard(1, HostBuffer(std::vector<int>{4, 5, 6}));
     buffer.emplace_shard(2, HostBuffer(std::vector<int>{7, 8, 9}));
-
-    EXPECT_TRUE(buffer.is_allocated());
-
-    buffer.deallocate();
-
-    EXPECT_FALSE(buffer.is_allocated());
 }
 
 TEST(DistributedHostBufferTest, ShardedWithInvalidLocalShape) {

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -65,12 +65,6 @@ public:
     using ApplyFn = std::function<void(const HostBuffer& buffer, size_t linear_index)>;
     void apply(const ApplyFn& fn);
 
-    // Returns true if the buffer is allocated.
-    bool is_allocated() const;
-
-    // Deallocates the underlying data storage.
-    void deallocate();
-
 private:
     DistributedHostBuffer(
         std::function<std::optional<size_t>(size_t)> global_to_local_index, std::vector<HostBuffer> local_buffers) :

--- a/tt_metal/api/tt-metalium/host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/host_buffer.hpp
@@ -62,9 +62,6 @@ public:
     template <typename T>
     tt::stl::Span<const T> view_as() const&& = delete;
 
-    // Returns true if the data buffer is allocated.
-    bool is_allocated() const;
-
     // Returns true if the data buffer is borrowed.
     bool is_borrowed() const;
 
@@ -74,9 +71,6 @@ public:
     // Returns a pin for the data buffer.
     // The data won't be freed until the pin is destroyed.
     MemoryPin pin() const;
-
-    // Deallocates the data buffer.
-    void deallocate();
 
 private:
     MemoryPin pin_;

--- a/tt_metal/common/host_buffer.cpp
+++ b/tt_metal/common/host_buffer.cpp
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/memory_pin.hpp>
 #include <tt_stl/span.hpp>
 #include <tt_stl/overloaded.hpp>
 
-#include <functional>
 #include <memory>
-#include <typeinfo>
 #include <utility>
-#include <variant>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -47,8 +43,6 @@ tt::stl::Span<std::byte> HostBuffer::view_bytes() & noexcept { return view_; }
 
 tt::stl::Span<const std::byte> HostBuffer::view_bytes() const& noexcept { return view_; }
 
-bool HostBuffer::is_allocated() const { return pin_ != nullptr; }
-
 bool HostBuffer::is_borrowed() const { return is_borrowed_; }
 
 HostBuffer HostBuffer::deep_copy() const {
@@ -62,13 +56,6 @@ HostBuffer HostBuffer::deep_copy() const {
 }
 
 MemoryPin HostBuffer::pin() const { return pin_; }
-
-void HostBuffer::deallocate() {
-    pin_ = MemoryPin();
-    view_ = tt::stl::Span<std::byte>();
-    type_info_ = nullptr;
-    is_borrowed_ = false;
-}
 
 bool operator==(const HostBuffer& a, const HostBuffer& b) noexcept {
     auto a_view = a.view_bytes();

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -91,15 +91,4 @@ void DistributedHostBuffer::apply(const ApplyFn& fn) {
     }
 }
 
-bool DistributedHostBuffer::is_allocated() const {
-    return std::all_of(
-        local_buffers_.begin(), local_buffers_.end(), [](const HostBuffer& b) { return b.is_allocated(); });
-}
-
-void DistributedHostBuffer::deallocate() {
-    for (auto& buffer : local_buffers_) {
-        buffer.deallocate();
-    }
-}
-
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -86,14 +86,4 @@ TensorSpec MultiDeviceHostStorage::get_tensor_spec(int spec_index) const {
 
 size_t MultiDeviceHostStorage::num_buffers() const { return buffers_.size(); }
 
-bool MultiDeviceHostStorage::is_allocated() const {
-    return std::all_of(buffers_.begin(), buffers_.end(), [](auto&& buffer) { return buffer.is_allocated(); });
-}
-
-void MultiDeviceHostStorage::deallocate() {
-    for (auto& buffer : buffers_) {
-        buffer.deallocate();
-    }
-}
-
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_buffer.hpp>
+#include <tuple>
 
 #include "tt-metalium/distributed_host_buffer.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -21,8 +22,6 @@ struct HostStorage {
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
-
-    bool is_allocated() const { return buffer.is_allocated(); }
 };
 
 struct DeviceStorage {
@@ -71,12 +70,6 @@ public:
 
     // Returns the number of `HostBuffer`s in the storage;
     size_t num_buffers() const;
-
-    // Returns true if all `HostBuffer`s are allocated;
-    bool is_allocated() const;
-
-    // Deallocates all `HostBuffer`s;
-    void deallocate();
 
 private:
     std::vector<HostBuffer> buffers_;

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -488,7 +488,8 @@ bool Tensor::is_allocated() const {
     auto output = std::visit(
         tt::stl::overloaded{
             [](const DeviceStorage& storage) { return storage.is_allocated(); },
-            [](const auto&) { return true; },
+            [](const HostStorage&) { return true; },
+            [](const MultiDeviceHostStorage&) { return true; },
         },
         this->get_storage());
     return output;

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -166,6 +166,8 @@ public:
     std::string write_to_string() const;
     void print() const;
 
+    // Deallocates device-side Tensor storage.
+    // If the tensor is on host, does nothing.
     void deallocate(bool force = false);
 
     std::vector<IDevice*> get_workers(bool blocking = false) const;

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -502,10 +502,10 @@ std::string to_string<bfloat4_b>(
 
 template <typename T>
 Tensor to_host_helper(const Tensor& tensor, bool blocking = true, ttnn::QueueId cq_id = ttnn::DefaultQueueId) {
-    TT_ASSERT(tensor.is_allocated(), "Buffer must be allocated on device!");
+    TT_FATAL(tensor.is_allocated(), "Buffer must be allocated on device!");
     auto device_buffer = tensor.buffer();
     auto device = tensor.device();
-    TT_ASSERT(device != nullptr && "Need device to be set copy data from device to host!");
+    TT_FATAL(device != nullptr, "Need device to be set copy data from device to host!");
     uint32_t size_in_bytes = device_buffer->size();
     std::vector<T> data_vec;
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
@@ -547,7 +547,7 @@ Tensor to_host<bfloat8_b>(const Tensor& tensor, bool blocking, ttnn::QueueId cq_
 
 template <typename T>
 Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id) {
-    TT_ASSERT(tensor.is_allocated(), "Buffer must be allocated on device!");
+    TT_FATAL(tensor.is_allocated(), "Buffer must be allocated on device!");
     const auto& storage = std::get<DeviceStorage>(tensor.get_storage());
     const auto& mesh_buffer = storage.mesh_buffer;
     ttnn::MeshDevice* device = mesh_buffer->device();
@@ -687,7 +687,6 @@ Tensor to_device(const Tensor& tensor, IDevice* target_device, const MemoryConfi
     }
     TT_FATAL(tensor.storage_type() != StorageType::DEVICE, "Tensor is already on device!");
     TT_FATAL(target_device != nullptr, "Need target device in order to move tensor to device!");
-    TT_FATAL(tensor.is_allocated(), "Need data to exist in order to move it to device");
 
     TensorSpec tensor_spec(
         tensor.get_logical_shape(), tensor.get_tensor_spec().tensor_layout().with_memory_config(memory_config));
@@ -832,7 +831,6 @@ Tensor to_device_mesh_tensor(
     }
 
     TT_FATAL(mesh_device != nullptr, "Need target device in order to move tensor to device!");
-    TT_FATAL(tensor.is_allocated(), "Need data to exist in order to move it to device");
 
     TensorSpec tensor_spec(
         tensor.get_logical_shape(), tensor.get_tensor_spec().tensor_layout().with_memory_config(memory_config));
@@ -847,7 +845,7 @@ template <typename T>
 void copy_to_mesh_tensor(const Tensor& host_tensor, Tensor& mesh_tensor, ttnn::QueueId cq_id) {
     TT_FATAL(host_tensor.storage_type() != StorageType::DEVICE, "Host tensor is on device.");
     TT_FATAL(mesh_tensor.storage_type() == StorageType::DEVICE, "Mesh tensor is not on device.");
-    TT_FATAL(mesh_tensor.is_allocated(), "Need data to exist in order to move it to device");
+    TT_FATAL(mesh_tensor.is_allocated(), "Buffer must be allocated on device.");
 
     TT_FATAL(host_tensor.get_logical_shape() == mesh_tensor.get_logical_shape(), "Host tensor has different shape");
     TT_FATAL(host_tensor.get_dtype() == mesh_tensor.get_dtype(), "Host tensor has different dtype");


### PR DESCRIPTION
### Ticket
#21604

### Problem description
Host-side buffers use `std::vector<T>` and there is no explicit allocation.

Forced-deallocation doesn't work (the underlying `std::shared_ptr` with the data doesn't support this), is unsafe (creating possibility for the new "dangling" state), and is unnecessary overall. The data blocks will be cached by a memory allocator anyways, so we are not actually force-deallocating anything even if we try.

Overall, these features unnecessarily complicate host-side processing of tensor storage, so it is best to remove them.

### What's changed
Remove methods responsible for host-side deallocation, and any host-side "is allocated".

If the storage is on host:
* In `Tensor::is_allocated`, return true.
* In `Tensor::deallocate`, don't do anything.

### Checklist
- [X] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15054826051)
- [X] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15054829636)
- [x] New/Existing tests provide coverage for changes