### PR TITLE
#21099: Get rid of tensor 'workers'

### DIFF
--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -46,9 +46,10 @@ public:
     // Can be safely passed between threads when the tensor is copied
     std::shared_ptr<TensorAttributes> tensor_attributes = nullptr;
 
-    // Tensor gets worker queue handle through the device
+    // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
+    // If not set, the tensor can either be on host or allocated on a single device.
+    // TODO: #21099 - This won't be needed after the migration to MeshDevice is complete.
     std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
-    std::optional<IDevice*> device_ = std::nullopt;
 
     // ======================================================================================
     //                                  Hi Level APIs

--- a/ttnn/api/ttnn/tensor/tensor.hpp
+++ b/ttnn/api/ttnn/tensor/tensor.hpp
@@ -48,7 +48,7 @@ public:
 
     // Tensor gets worker queue handle through the device
     std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
-    std::vector<IDevice*> workers = {};
+    std::optional<IDevice*> device_ = std::nullopt;
 
     // ======================================================================================
     //                                  Hi Level APIs
@@ -168,8 +168,6 @@ public:
 
     void deallocate(bool force = false);
 
-    std::vector<IDevice*> get_workers(bool blocking = false) const;
-
     Tensor extract_shard(const CoreCoord& core) const;
     Tensor extract_shard(const uint32_t& core_id) const;
 
@@ -232,6 +230,8 @@ public:
     // TODO: #21099 - Remove the overload `mesh_device()`, and instead use `device()`.
     distributed::MeshDevice* mesh_device() const;
 
+    // Returns the device the tensor is allocated on.
+    // Throws if the tensor is not allocated on a device.
     IDevice* device() const;
 
     std::vector<IDevice*> active_physical_devices() const;

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -50,12 +50,6 @@ Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)
 // Given a multi-device host tensor and a callable, applies the function to all per-device tensors.
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable);
 
-// This function is used in legacy context of launching per-device work via push_work threads.
-// This won't be supported. In the long-term, tensor shards for Device tensors should be referred to using
-// `MeshCoordinate`.
-[[deprecated]] Tensor get_shard_for_device(
-    const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index = std::nullopt);
-
 template <class T>
 uint32_t get_batch_size(const T& shape) {
     uint32_t result = 1;

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -21,11 +21,9 @@ void write_buffer(
             tt::tt_metal::memcpy(cq, device_tensors[i], src.at(i).get(), region);
         }
     } else {
-        for (const auto worker : dst.get_workers()) {
-            auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
-            auto shard = tt::tt_metal::get_shard_for_device(dst, worker);
-            tt::tt_metal::memcpy(worker->command_queue(*cq_id), shard, src_for_device.get(), region);
-        }
+        auto* worker = dst.device();
+        auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
+        tt::tt_metal::memcpy(worker->command_queue(*cq_id), dst, src_for_device.get(), region);
     }
 }
 
@@ -44,11 +42,9 @@ void read_buffer(
             tt::tt_metal::memcpy(cq, dst.at(i).get(), device_tensors[i], region);
         }
     } else {
-        for (const auto worker : src.get_workers()) {
-            auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
-            const auto& shard = tt::tt_metal::get_shard_for_device(src, worker);
-            tt::tt_metal::memcpy(worker->command_queue(*cq_id), dst_for_device.get(), shard, region, blocking);
-        }
+        auto* worker = src.device();
+        auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
+        tt::tt_metal::memcpy(worker->command_queue(*cq_id), dst_for_device.get(), src, region, blocking);
     }
 }
 

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -21,9 +21,9 @@ void write_buffer(
             tt::tt_metal::memcpy(cq, device_tensors[i], src.at(i).get(), region);
         }
     } else {
-        auto* worker = dst.device();
-        auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
-        tt::tt_metal::memcpy(worker->command_queue(*cq_id), dst, src_for_device.get(), region);
+        auto* dst_device = dst.device();
+        auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(dst_device->id());
+        tt::tt_metal::memcpy(dst_device->command_queue(*cq_id), dst, src_for_device.get(), region);
     }
 }
 
@@ -42,9 +42,9 @@ void read_buffer(
             tt::tt_metal::memcpy(cq, dst.at(i).get(), device_tensors[i], region);
         }
     } else {
-        auto* worker = src.device();
-        auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
-        tt::tt_metal::memcpy(worker->command_queue(*cq_id), dst_for_device.get(), src, region, blocking);
+        auto* src_device = src.device();
+        auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(src_device->id());
+        tt::tt_metal::memcpy(src_device->command_queue(*cq_id), dst_for_device.get(), src, region, blocking);
     }
 }
 

--- a/ttnn/core/run_operation.cpp
+++ b/ttnn/core/run_operation.cpp
@@ -25,14 +25,13 @@ namespace detail {
 
 IDevice* get_device(const Tensors& input_tensors, const OptionalConstTensors& optional_input_tensors) {
     for (auto& input_tensor : input_tensors) {
-        if (std::holds_alternative<DeviceStorage>(input_tensor.tensor_attributes->get_storage())) {
-            return input_tensor.workers.at(0);
+        if (input_tensor.storage_type() == StorageType::DEVICE) {
+            return input_tensor.device_storage().get_device();
         }
     }
     for (auto& optional_input_tensor : optional_input_tensors) {
-        if (optional_input_tensor.has_value() and
-            std::holds_alternative<DeviceStorage>(optional_input_tensor.value().tensor_attributes->get_storage())) {
-            return optional_input_tensor.value().workers.at(0);
+        if (optional_input_tensor.has_value() and optional_input_tensor->storage_type() == StorageType::DEVICE) {
+            return optional_input_tensor->device_storage().get_device();
         }
     }
     auto device = ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice();

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -94,43 +94,37 @@ void Tensor::init(Storage storage, TensorSpec tensor_spec, DistributedTensorConf
     tensor_attributes = std::make_shared<TensorAttributes>(
         std::move(storage), std::move(tensor_spec), std::move(distributed_tensor_config));
 
-    ZoneScoped;
-    std::visit(
-        [&](auto&& storage) {
-            using StorageType = std::decay_t<decltype(storage)>;
-            if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
-                if (storage.mesh_buffer != nullptr) {
-                    mesh_device_ = storage.mesh_buffer->device();
-                }
-                workers = {storage.get_device()};
-            }
-        },
-        tensor_attributes->get_storage());
+    if (auto* device_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage())) {
+        if (device_storage->mesh_buffer != nullptr) {
+            mesh_device_ = device_storage->mesh_buffer->device();
+        }
+        device_ = device_storage->get_device();
+    }
 }
 
 Tensor& Tensor::operator=(const Tensor& other) {
     this->tensor_id = other.tensor_id;
     if (this->tensor_attributes != other.tensor_attributes) {
-        this->workers = other.workers;
         this->tensor_attributes = other.tensor_attributes;
     }
     this->mesh_device_ = other.mesh_device_;
+    this->device_ = other.device_;
     return *this;
 }
 
 Tensor& Tensor::operator=(Tensor&& other) noexcept {
     this->tensor_id = std::move(other.tensor_id);
     if (this->tensor_attributes != other.tensor_attributes) {
-        this->workers = std::move(other.workers);
         this->tensor_attributes = std::move(other.tensor_attributes);
     }
     this->mesh_device_ = std::move(other.mesh_device_);
+    this->device_ = std::move(other.device_);
     return *this;
 }
 
-Tensor::Tensor(const Tensor& other) :
-    tensor_id(other.tensor_id), workers(other.workers), tensor_attributes(other.tensor_attributes) {
+Tensor::Tensor(const Tensor& other) : tensor_id(other.tensor_id), tensor_attributes(other.tensor_attributes) {
     this->mesh_device_ = other.mesh_device_;
+    this->device_ = other.device_;
 }
 
 Tensor::~Tensor() {
@@ -168,34 +162,6 @@ void Tensor::deallocate_impl(bool force) {
             this->tensor_attributes->get_storage());
     }
     // GraphTracker::instance().track_function_end();
-}
-
-std::vector<IDevice*> Tensor::get_workers(bool blocking) const {
-    ZoneScoped;
-    // Initialize an empty worker vector (remains empty for host side storage)
-    std::vector<IDevice*> workers = {};
-
-    std::visit(
-        [this, blocking, &workers](auto&& storage) {
-            using StorageType = std::decay_t<decltype(storage)>;
-            // Assign workers only to device tensors
-            if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
-                // Either explictly syncing or workers are pre-populated (this will happen for device tensors if using
-                // the correct APIs).
-                TT_FATAL(
-                    blocking or (this->workers.size() == 1),
-                    "Worker Handles for tensor must be populated or blocking = true must be set in get_workers().");
-                if (this->workers.size() != 1) {
-                    // Not populated - sync.
-                    workers = std::vector<IDevice*>{this->device()};
-                } else {
-                    // Already populated.
-                    workers = this->workers;
-                }
-            }
-        },
-        this->tensor_attributes->get_storage());
-    return workers;
 }
 
 DataType Tensor::get_dtype() const { return dtype(); }
@@ -697,9 +663,7 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
 }
 
 void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id) {
-    // Top level wrapper to copy a host tensor to a preallocated device tensor
-    TT_ASSERT(device_tensor.workers.size(), "Workers must be specified for device_tensor in write_tensor");
-
+    TT_FATAL(device_tensor.storage_type() == StorageType::DEVICE, "Destination tensor must be on device");
     TT_FATAL(
         host_tensor.storage_type() == StorageType::HOST or host_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST,
         "write_tensor only supports host_tensor to device_tensor data transfer");
@@ -710,41 +674,39 @@ void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id
         return;
     }
 
-    for (int worker_index = 0; worker_index < device_tensor.workers.size(); ++worker_index) {
-        TT_FATAL(
-            device_tensor.storage_type() == StorageType::DEVICE,
-            "write_tensor only supports host_tensor to device_tensor data transfer");
-        TT_FATAL(host_tensor.get_logical_shape() == device_tensor.get_logical_shape(), "Error");
-        TT_FATAL(host_tensor.get_dtype() == device_tensor.get_dtype(), "Error");
-        TT_FATAL(host_tensor.get_tensor_spec().page_config() == device_tensor.get_tensor_spec().page_config(), "Error");
-        std::visit(
-            tt::stl::overloaded{
-                [cq_id, &host_tensor, &device_tensor](const DeviceStorage& device_storage) {
-                    // Copying from host to a single device.
-                    const void* host_data = std::visit(
-                        tt::stl::overloaded{
-                            [](const HostStorage& host_storage) -> const void* {
-                                return host_storage.buffer.view_bytes().data();
-                            },
-                            [](const MultiDeviceHostStorage& host_storage) -> const void* {
-                                TT_ASSERT(
-                                    host_storage.num_buffers() == 1,
-                                    "Cannot copy multi-buffer host storage to a single device");
-                                auto buffer = host_storage.get_buffer(0);
-                                return buffer.view_bytes().data();
-                            },
-                            [](auto&&) -> const void* { TT_THROW("Unreachable"); },
+    TT_FATAL(
+        device_tensor.storage_type() == StorageType::DEVICE,
+        "write_tensor only supports host_tensor to device_tensor data transfer");
+    TT_FATAL(host_tensor.get_logical_shape() == device_tensor.get_logical_shape(), "Error");
+    TT_FATAL(host_tensor.get_dtype() == device_tensor.get_dtype(), "Error");
+    TT_FATAL(host_tensor.get_tensor_spec().page_config() == device_tensor.get_tensor_spec().page_config(), "Error");
+    std::visit(
+        tt::stl::overloaded{
+            [cq_id, &host_tensor, &device_tensor](const DeviceStorage& device_storage) {
+                // Copying from host to a single device.
+                const void* host_data = std::visit(
+                    tt::stl::overloaded{
+                        [](const HostStorage& host_storage) -> const void* {
+                            return host_storage.buffer.view_bytes().data();
                         },
-                        host_tensor.get_storage());
-                    if (auto mesh_device = device_tensor.mesh_device()) {
-                        tt::tt_metal::memcpy(mesh_device->mesh_command_queue(*cq_id), device_tensor, host_data);
-                    } else {
-                        tt::tt_metal::memcpy(device_tensor.device()->command_queue(*cq_id), device_tensor, host_data);
-                    }
-                },
-                [](auto&& s) { TT_THROW("Unreachable"); }},
-            device_tensor.get_storage());
-    }
+                        [](const MultiDeviceHostStorage& host_storage) -> const void* {
+                            TT_ASSERT(
+                                host_storage.num_buffers() == 1,
+                                "Cannot copy multi-buffer host storage to a single device");
+                            auto buffer = host_storage.get_buffer(0);
+                            return buffer.view_bytes().data();
+                        },
+                        [](auto&&) -> const void* { TT_THROW("Unreachable"); },
+                    },
+                    host_tensor.get_storage());
+                if (auto mesh_device = device_tensor.mesh_device()) {
+                    tt::tt_metal::memcpy(mesh_device->mesh_command_queue(*cq_id), device_tensor, host_data);
+                } else {
+                    tt::tt_metal::memcpy(device_tensor.device()->command_queue(*cq_id), device_tensor, host_data);
+                }
+            },
+            [](auto&& s) { TT_THROW("Unreachable"); }},
+        device_tensor.get_storage());
 }
 
 std::vector<IDevice*> Tensor::active_physical_devices() const {

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -98,7 +98,6 @@ void Tensor::init(Storage storage, TensorSpec tensor_spec, DistributedTensorConf
         if (device_storage->mesh_buffer != nullptr) {
             mesh_device_ = device_storage->mesh_buffer->device();
         }
-        device_ = device_storage->get_device();
     }
 }
 
@@ -108,7 +107,6 @@ Tensor& Tensor::operator=(const Tensor& other) {
         this->tensor_attributes = other.tensor_attributes;
     }
     this->mesh_device_ = other.mesh_device_;
-    this->device_ = other.device_;
     return *this;
 }
 
@@ -118,13 +116,11 @@ Tensor& Tensor::operator=(Tensor&& other) noexcept {
         this->tensor_attributes = std::move(other.tensor_attributes);
     }
     this->mesh_device_ = std::move(other.mesh_device_);
-    this->device_ = std::move(other.device_);
     return *this;
 }
 
 Tensor::Tensor(const Tensor& other) : tensor_id(other.tensor_id), tensor_attributes(other.tensor_attributes) {
     this->mesh_device_ = other.mesh_device_;
-    this->device_ = other.device_;
 }
 
 Tensor::~Tensor() {

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -73,17 +73,6 @@ Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id) {
         return output;
     }
 
-    auto workers = input_tensor.get_workers(blocking);
-    if (not workers.size()) {
-        // Tensor is on host and does not have a worker group.
-        // Return immediately. If this is a result of .cpu() called twice,
-        // tensor accessors will stall until tensor is populated.
-        auto output = tt::tt_metal::set_tensor_id(input_tensor);
-        GraphTracker::instance().track_function_end(output);
-        return output;
-    }
-
-    TT_FATAL(workers.size() == 1, "Unexpected number of workers");
     Tensor host_tensor = tensor_impl::to_host_wrapper(input_tensor, blocking, cq_id);
     host_tensor = tt::tt_metal::set_tensor_id(host_tensor);
     GraphTracker::instance().track_function_end(host_tensor);

--- a/ttnn/core/tensor/tensor_utils.cpp
+++ b/ttnn/core/tensor/tensor_utils.cpp
@@ -128,20 +128,6 @@ void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& calla
     }
 }
 
-Tensor get_shard_for_device(const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index) {
-    ZoneScopedN("GetShardForDevice");
-    auto& storage = tensor.tensor_attributes->get_storage();
-    return std::visit(
-        tt::stl::overloaded{
-            [buffer_index](const MultiDeviceHostStorage& s) {
-                return Tensor{s.get_buffer(buffer_index.value()), s.get_tensor_spec(buffer_index.value())};
-            },
-            [&tensor](const HostStorage& s) { return tensor; },
-            [&tensor](const DeviceStorage& s) { return tensor; },
-        },
-        storage);
-}
-
 ShardDivisionSpec compute_shard_division_spec(const Shape2D& shape, const Shape2D& shard_shape) {
     const auto num_shards_height = tt::div_up(shape.height(), shard_shape.height());
     const auto last_shard_height =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -43,7 +43,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     const std::optional<size_t> num_preferred_links,
     std::optional<tt::tt_metal::SubDeviceId> worker_subdevice_id_opt) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
-    uint32_t dim = find_scatter_dim(input_tensor.get_padded_shape(), input_tensor.get_workers().size());
+    uint32_t dim = find_scatter_dim(input_tensor.get_padded_shape(), 1);
     ttnn::Tensor scattered_tensor = ttnn::operations::experimental::ccl::reduce_scatter(
         input_tensor,
         dim,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -43,7 +43,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     const std::optional<size_t> num_preferred_links,
     std::optional<tt::tt_metal::SubDeviceId> worker_subdevice_id_opt) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
-    uint32_t dim = find_scatter_dim(input_tensor.get_padded_shape(), 1);
+    uint32_t dim = find_scatter_dim(input_tensor.get_padded_shape(), input_tensor.active_physical_devices().size());
     ttnn::Tensor scattered_tensor = ttnn::operations::experimental::ccl::reduce_scatter(
         input_tensor,
         dim,


### PR DESCRIPTION
### Ticket
#21099

### Problem description
Currently, Tensor 'workers' are initialized for device-side tensors with a single `IDevice*` (either `MeshDevice` or `Device` in rare cases for tests that need to be updated).

There is never more than 1 worker.

### What's changed
Replace "get workers" API with just getting `Tensor::device()` in a handful of instances.
Remove `get_shard_for_device` as it was used in only one place.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15054026826)
- [x] [T3K tests](https://github.com/tenstorrent/tt-metal/actions/runs/15054033785)
- [x] [TG tests](https://github.com/tenstorrent/tt-metal/actions/runs/15054037386)
- [x] New/Existing tests provide coverage for changes

Ran `tests/ttnn/unit_tests/operations/ccl/test_all_reduce_async.py` locally on T3K and it passes