### PR TITLE
Changed scheduled times for package releases

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Create rc every day at EOD of PST Mon-Fri + night of Sunday to kick off
     # releases for beginning of work week
-    - cron: "0 1,14 * * *"
+    - cron: "0 0 * * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
changed schedule timing for package releases

### What's changed
Now releases a package from twice a day at 1, 14 UTC time to once a day at 0 UTC (after 8PM TO time)

### Checklist
- [ ] Package and Release Pipelines: https://github.com/tenstorrent/tt-metal/actions/runs/15054053102
