### PR TITLE
Fix syntax issue with GTest query

### DIFF
--- a/tests/tt_metal/tt_fabric/CMakeLists.txt
+++ b/tests/tt_metal/tt_fabric/CMakeLists.txt
@@ -6,6 +6,7 @@ set(UNIT_TESTS_FABRIC_SRC
 )
 
 add_executable(fabric_unit_tests ${UNIT_TESTS_FABRIC_SRC})
+gtest_discover_tests(fabric_unit_tests)
 
 target_link_libraries(
     fabric_unit_tests
@@ -43,6 +44,7 @@ target_link_libraries(
         test_common_libs
 )
 add_executable(test_system_health)
+gtest_discover_tests(test_system_health)
 
 target_include_directories(
     test_system_health_smoke
@@ -59,5 +61,3 @@ set_target_properties(
             ${PROJECT_BINARY_DIR}/test/tt_metal/tt_fabric
 )
 target_link_libraries(test_system_health PRIVATE TT::SystemHealth::Smoke)
-
-gtest_discover_tests(fabric_unit_tests test_system_health)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Sometimes the build fails like this: https://github.com/tenstorrent/tt-metal/actions/runs/15051772475/job/42308096283#step:10:940
I don't know why we'd hit the 5s timeout for having gtest list its tests.  We don't seem to have crazy heavy static objects like that.  And I cannot repro locally.
However, upon inspection we are calling gtest_discover_tests incorrectly.  The method only accepts a single target as per https://cmake.org/cmake/help/latest/module/GoogleTest.html#command:gtest_discover_tests

### What's changed
Call gtest_discover_tests with a single target each time.

No idea if this was the cause of that occasional failure.  Here's hoping.