### PR TITLE
Declare missing dependency

### DIFF
--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(
         TT::Metalium
         xtensor
         FlatBuffers::FlatBuffers
+        Boost::algorithm
 )
 
 ##################################################


### PR DESCRIPTION
### Ticket
#22186

### Problem description
A module is using Boost without declaring its dependency on it.  This breaks the builds on systems where no boost is available system-wide.  Unfortunately the Docker image used in CI has it installed (for efficiency reasons) and so this bug escaped to main.

### What's changed
Declared the dependency.