### PR TITLE
#21448: Fix FMOD Documentation

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -1241,11 +1241,15 @@ void bind_binary_overload_operation(
     py::module& module,
     const binary_operation_t& operation,
     const std::string& description,
+    const std::string& math,
     const std::string& supported_dtype = "BFLOAT16",
     const std::string& note = " ") {
     auto doc = fmt::format(
         R"doc(
         {2}
+
+        .. math::
+            {3}
 
         Args:
             input_tensor_a (ttnn.Tensor): the input tensor.
@@ -1266,20 +1270,22 @@ void bind_binary_overload_operation(
                * - Dtypes
                  - Layouts
                  - Ranks
-               * - {3}
+               * - {4}
                  - TILE
                  - 2, 3, 4
 
-            {4}
+            {5}
 
         Example:
             >>> tensor1 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> tensor2 = ttnn.from_torch(torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device)
             >>> output = {1}(tensor1, tensor2/scalar)
+
         )doc",
         operation.base_name(),
         operation.python_fully_qualified_name(),
         description,
+        math,
         supported_dtype,
         note);
 
@@ -2138,14 +2144,16 @@ void py_module(py::module& module) {
     detail::bind_binary_overload_operation(
         module,
         ttnn::fmod,
-        R"doc(Performs an eltwise-fmod operation. Formula : a - a.div(b, rounding_mode=trunc) * b.)doc",
-        R"doc(BFLOAT16)doc",
+        R"doc(Performs an eltwise-fmod operation.)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|fmod|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
+        R"doc(BFLOAT16, FLOAT32)doc",
         R"doc(Support provided only for WH_B0.)doc");
 
     detail::bind_binary_overload_operation(
         module,
         ttnn::remainder,
-        R"doc(Performs an eltwise-modulus operation. Formula : a - a.div(b, rounding_mode=floor) * b.)doc",
+        R"doc(Performs an eltwise-modulus operation.)doc",
+        R"doc(\mathrm{{output\_tensor}} = \verb|remainder|(\mathrm{{input\_tensor\_a,input\_tensor\_b}}))doc",
         R"doc(BFLOAT16)doc",
         R"doc(Support provided only for WH_B0.)doc");
 


### PR DESCRIPTION
### Ticket
#21448

### Problem description
Existing documentation :
<img width="935" alt="Screenshot 2025-05-16 at 3 34 57 PM" src="https://github.com/user-attachments/assets/5e7d0689-c7e9-4d04-8789-961b6b42940c" />

### What's changed
Fixed Documentation
<img width="858" alt="Screenshot 2025-05-16 at 3 31 50 PM" src="https://github.com/user-attachments/assets/6f88916d-a244-402b-a7ea-82a954edf28c" />
<img width="850" alt="Screenshot 2025-05-16 at 3 32 01 PM" src="https://github.com/user-attachments/assets/3c8d5f19-f9c0-43a0-b88d-ecf652ddcbb3" />


### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)