### PR TITLE
Update test_prefetcher_perf_TG.py

### DIFF
--- a/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_prefetcher_perf_TG.py
+++ b/models/demos/llama3_subdevices/tests/tg_perf_unit_tests/test_prefetcher_perf_TG.py
@@ -29,7 +29,7 @@ def calculate_bytes(shape, dtype):
 @pytest.mark.parametrize(
     "bw_target",
     [
-        214.0,
+        200.0,
     ],
 )
 @pytest.mark.models_device_performance_bare_metal


### PR DESCRIPTION
Update test_prefetcher BW since it's executed on 4U with reduced DRAM BW.

### Problem description
Machines in CI are with reduced DRAM BW and it causes prefetcher to regress BW as well. 

### What's changed
Prefetcher BW target decreased 214 -> 200GB/s.
### Checklist
- [ ] [Model perf Test](https://github.com/tenstorrent/tt-metal/actions/runs/15057671873/job/42327271415#step:9:28513) Failing pipeline due to target