### PR TITLE
Conv2d: Handle edge case when split_reader enabled with act_block_h=1

### DIFF
--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -559,6 +559,15 @@ Result conv2d_L1(
             }
         }
 
+        bool enable_split_reader = conv_config.enable_split_reader;
+        if (enable_split_reader && opt_conv_op_block_config.act_block_h_ntiles == 1) {
+            // If the activation block height is 1, we can enable split reader.
+            enable_split_reader = false;
+            log_warning(
+                tt::LogOp,
+                "Conv2D: Split reader was requested by the user, but it can't be support with just one tile per core "
+                "in activation matrix height.");
+        }
         // call conv micro op
         auto conv_output = optimized_conv_new(
             input_tensor_post_tm,
@@ -577,7 +586,7 @@ Result conv2d_L1(
             compute_config,
             conv_config.enable_act_double_buffer,
             conv_config.enable_weights_double_buffer,
-            conv_config.enable_split_reader);
+            enable_split_reader);
 
         if (memory_config.has_value() && memory_config.value() != conv_output.memory_config()) {
             conv_output = ttnn::to_memory_config(conv_output, memory_config.value(), std::nullopt);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -561,7 +561,7 @@ Result conv2d_L1(
 
         bool enable_split_reader = conv_config.enable_split_reader;
         if (enable_split_reader && opt_conv_op_block_config.act_block_h_ntiles == 1) {
-            // If the activation block height is 1, we can enable split reader.
+            // If the activation block height is 1, we can't enable split reader.
             enable_split_reader = false;
             log_warning(
                 tt::LogOp,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -418,8 +418,8 @@ OptimizedConvBlockConfig determine_per_core_conv_block_config(
     uint32_t act_block_w_ntiles = act_block_w / 32;
     uint32_t out_block_h_ntiles = conv_op_parallel_config.per_core_out_matrix_height_ntile;
     uint32_t weight_block_w_ntiles = conv_op_parallel_config.per_core_out_matrix_width_ntile;
-    auto [out_subblock_h_ntiles, out_subblock_w_ntiles] =
-        determine_largest_subblock_size(act_block_h_ntiles, weight_block_w_ntiles, fp32_accum, split_reader_enabled);
+    auto [out_subblock_h_ntiles, out_subblock_w_ntiles] = determine_largest_subblock_size(
+        act_block_h_ntiles, weight_block_w_ntiles, fp32_accum, act_block_h_ntiles > 1 && split_reader_enabled);
     return {
         .act_block_h_ntiles = act_block_h_ntiles,
         .act_block_w_ntiles = act_block_w_ntiles,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.hpp
@@ -75,7 +75,7 @@ struct Conv2dConfig {
     bool enable_weights_double_buffer = false;
 
     // Only for height sharding.
-    // Increases perf. Act_block_h should be a multiple of 64, if true
+    // Increases perf if op is reader bound. Act_block_h should be >= 64, if true
     bool enable_split_reader = false;
 
     bool enable_subblock_padding = false;


### PR DESCRIPTION
Issue #22145

When activation matrix height is only one tile per core (act_block_h=1), split_reader optimization cannot parallelize work effectively. Previously, this edge case would trigger an assertion failure.

This change:
- Gracefully disables split_reader when act_block_h=1 is detected
- Logs a warning to inform users their split_reader setting was overridden
- Maintains optimal performance (no performance regression)

The warning helps users understand the configuration limitation without affecting functionality or performance.
With this change op will gracefully disable the split_reader and log a warning.
Warning is just to inform the user that split_reader flag wasn't respected but no perf is left on the table.

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22145)

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15068642419) CI passes
- [x] [Blackhole nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/15068647196 CI with demo tests passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15068651130) CI passes (if applicable)
- [x] [Nightly tt-metal l2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15068663454)