### PR TITLE
#21182: Update GCD,LCM Documentation with correct supported range

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary_pybind.cpp
@@ -2040,7 +2040,7 @@ void py_module(py::module& module) {
         module,
         ttnn::gcd,
         R"doc(Computes Greatest common divisor of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`.
-        [supported range -1024 to 1024].)doc",
+        [supported range [-2147483647, 2147483648]].)doc",
         R"doc(\mathrm{output\_tensor}_i = \verb|gcd|\left(\mathrm{input\_tensor\_a}_i , \mathrm{input\_tensor\_b}_i\right)
         )doc",
         R"doc(INT32)doc",
@@ -2052,7 +2052,7 @@ void py_module(py::module& module) {
         module,
         ttnn::lcm,
         R"doc(Computes Least common multiple of :attr:`input_tensor_a` and :attr:`input_tensor_b` and returns the tensor with the same layout as :attr:`input_tensor_a`.
-        [supported range -1024 to 1024].)doc",
+        [supported range [-32767, 32768]].)doc",
         R"doc(\mathrm{output\_tensor}_i = \verb|lcm|\left(\mathrm{input\_tensor\_a}_i , \mathrm{input\_tensor\_b}_i\right)
         )doc",
         R"doc(INT32)doc",


### PR DESCRIPTION
### Ticket
#21182

### Problem description
As mentioned [here](https://github.com/tenstorrent/tt-metal/issues/21182#issuecomment-2865564589), Supported range has changed and tested in PR #21860, but is not updated in the documents

### What's changed
Updated the documentation with working range
<img width="851" alt="Screenshot 2025-05-17 at 8 08 23 AM" src="https://github.com/user-attachments/assets/7620b3e2-1714-46ee-b481-c491e3745b17" />
<img width="856" alt="Screenshot 2025-05-17 at 8 08 43 AM" src="https://github.com/user-attachments/assets/d06be81c-da2e-4217-94b8-a91222f576c7" />

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15080727978) CI passes