### PR TITLE
Update demo_decode.py

### DIFF
--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -33,7 +33,7 @@ TSU_PERF_DROP_LIMIT_COUNT = 20
 
 # Constants for TSU thresholds based on the number of layers
 TSU_THRESHOLDS = {
-    "4U": {1: {"min": 480, "max": 505}, 10: {"min": 195, "max": 215}, 80: {"min": 47, "max": 51}},
+    "4U": {1: {"min": 470, "max": 505}, 10: {"min": 195, "max": 215}, 80: {"min": 47, "max": 51}},
     # TODO: Update thresholds for 6U 10L and 80L based on actual perf when 6U are available and added into CI
     "6U": {1: {"min": 545, "max": 570}, 10: {"min": 230, "max": 250}, 80: {"min": 49, "max": 53}},
 }


### PR DESCRIPTION
### Problem description
Different machines have a bit variable tsu for 1L so tsu goes out of targets
### What's changed
Update 1L perf targets for demo quick due to perf difference along multiple runs.