### PR TITLE
Increase buffering in dateline edm

### DIFF
--- a/tests/tt_metal/microbenchmarks/ethernet/fabric_edm_bandwidth_golden.csv
+++ b/tests/tt_metal/microbenchmarks/ethernet/fabric_edm_bandwidth_golden.csv
@@ -6,8 +6,10 @@ mcast_FullRing,noc_unicast_write,2048,4,1,False,False,False,3.8789005970924775,1
 mcast_FullRing,noc_unicast_write,4096,4,1,False,False,False,6.463968526701578,1578117.3160892525
 mcast_FullRing,noc_unicast_write,4096,4,2,False,False,False,6.369396195780156,1555028.3681103897
 mcast_FullRing,noc_unicast_write,16,8,1,False,False,False,0.02798334424354788,None
-mcast_FullRing,noc_unicast_write,2048,8,1,False,False,False,2.775,None
+mcast_FullRing,noc_unicast_write,2048,8,1,False,False,False,2.567435108686534,None
 mcast_FullRing,noc_unicast_write,4096,8,1,False,False,False,5.193611184406907,1267971.4805680925
+unicast_FullRing,noc_unicast_write,4096,4,1,False,False,False,6.860580766139613,1674946.476108304
+unicast_FullRing,noc_unicast_write,4096,4,2,False,False,False,6.808208705105963,1662160.3283950107
 mcast_SaturateChipToChipRing,noc_unicast_write,16,4,1,False,False,False,0.03719374481643661,2324609.0510272877
 mcast_SaturateChipToChipRing,noc_unicast_write,2048,4,1,False,False,False,4.319495779858247,2109128.7987589096
 mcast_SaturateChipToChipRing,noc_unicast_write,4096,4,1,False,False,False,7.714125507353006,1883331.422693605

--- a/tests/tt_metal/microbenchmarks/ethernet/fabric_edm_bandwidth_golden_6u.csv
+++ b/tests/tt_metal/microbenchmarks/ethernet/fabric_edm_bandwidth_golden_6u.csv
@@ -15,6 +15,10 @@ mcast_FullRing,noc_unicast_write,4096,8,1,False,False,False,8.114582592926963,19
 mcast_FullRing,noc_unicast_write,4096,8,2,False,False,False,8.004229154179717,1954157.5083446575
 mcast_FullRing,noc_unicast_write,4096,8,3,False,False,False,7.2323915641815635,1765720.5967240145
 mcast_FullRing,noc_unicast_write,4096,8,4,False,False,False,6.628114436619606,1618192.0011278335
+unicast_FullRing,noc_unicast_write,4096,4,1,False,False,False,9.749781010778078,2380317.6295844917
+unicast_FullRing,noc_unicast_write,4096,4,2,False,False,False,9.727558423565087,2374892.193253195
+unicast_FullRing,noc_unicast_write,4096,4,3,False,False,False,9.671812756349674,2361282.411218182
+unicast_FullRing,noc_unicast_write,4096,4,4,False,False,False,9.167627335232602,2238190.267390772
 mcast_SaturateChipToChipRing,noc_unicast_write,16,4,1,False,False,False,0.03962130779453892,2476331.7371586827
 mcast_SaturateChipToChipRing,noc_unicast_write,2048,4,1,False,False,False,5.063485760297881,2472405.15639545
 mcast_SaturateChipToChipRing,noc_unicast_write,4096,4,1,False,False,False,10.054452741181708,2454700.3762650653

--- a/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
+++ b/tests/tt_metal/microbenchmarks/ethernet/test_fabric_edm_bandwidth.py
@@ -523,6 +523,34 @@ def test_fabric_8chip_multi_link_edm_mcast_full_ring_bw(
     )
 
 
+@pytest.mark.parametrize("num_messages", [200000])
+@pytest.mark.parametrize("num_op_invocations", [1])
+@pytest.mark.parametrize("line_sync", [True])
+@pytest.mark.parametrize("line_size", [4])
+@pytest.mark.parametrize("num_links", [1, 2, 3, 4])
+@pytest.mark.parametrize("packet_size", [4096])
+def test_fabric_4chip_multi_link_edm_unicast_full_ring_bw(
+    num_messages,
+    num_links,
+    num_op_invocations,
+    line_sync,
+    line_size,
+    packet_size,
+):
+    run_fabric_edm(
+        is_unicast=True,
+        num_messages=num_messages,
+        noc_message_type="noc_unicast_write",
+        num_links=num_links,
+        num_op_invocations=num_op_invocations,
+        line_sync=line_sync,
+        line_size=line_size,
+        packet_size=packet_size,
+        fabric_mode=FabricTestMode.FullRing,
+        disable_sends_for_interior_workers=False,
+    )
+
+
 # expected_Mpps = expected millions of packets per second
 @pytest.mark.ubench_quick_tests
 @pytest.mark.parametrize("num_messages", [200000])

--- a/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
+++ b/tt_metal/api/tt-metalium/erisc_datamover_builder.hpp
@@ -111,7 +111,8 @@ struct FabricEriscDatamoverConfig {
     std::size_t buffer_region_start;
     std::size_t available_channel_buffering_space;
 
-    FabricEriscDatamoverConfig(std::size_t channel_buffer_size_bytes, Topology topology = Topology::Linear);
+    FabricEriscDatamoverConfig(
+        std::size_t channel_buffer_size_bytes, Topology topology = Topology::Linear, bool is_dateline = false);
 
     std::size_t channel_buffer_size_bytes = 0;
 

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -198,7 +198,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     constexpr std::array<std::pair<size_t, size_t>, 2> ring_buffer_slot_options = {
         std::pair<size_t, size_t>{8, 8}, std::pair<size_t, size_t>{4, 8}};
     constexpr std::array<std::pair<size_t, size_t>, 2> ring_buffer_slot_options_dateline = {
-        std::pair<size_t, size_t>{8, 24}, std::pair<size_t, size_t>{8, 16}};
+        std::pair<size_t, size_t>{8, 16}, std::pair<size_t, size_t>{8, 8}};
 
     size_t num_sender_buffer_slots;
     size_t num_receiver_buffer_slots;
@@ -223,8 +223,8 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     auto num_alive_sender_channels = is_dateline ? this->num_used_sender_channels - 1 : this->num_used_sender_channels;
     auto num_alive_receiver_channels =
         is_dateline ? this->num_used_receiver_channels - 1 : this->num_used_receiver_channels;
-    auto non_dataline_sender_channel_idx = 2;
-    auto non_dataline_receiver_channel_idx = 0;
+    auto non_dateline_sender_channel_idx = 2;
+    auto non_dateline_receiver_channel_idx = 0;
 
     if (topology == Topology::Ring) {
         if (is_dateline) {
@@ -270,13 +270,13 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         available_channel_buffering_space);
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
-        bool skip_current_channel = (i == non_dataline_sender_channel_idx && is_dateline);
+        bool skip_current_channel = (i == non_dateline_sender_channel_idx && is_dateline);
         this->sender_channels_num_buffers[i] = skip_current_channel ? 0 : num_sender_buffer_slots;
         this->sender_channels_size_bytes[i] =
             skip_current_channel ? 0 : channel_buffer_size_bytes * num_sender_buffer_slots;
     }
     for (uint32_t i = 0; i < this->num_used_receiver_channels; i++) {
-        bool skip_current_channel = (i == non_dataline_receiver_channel_idx && is_dateline);
+        bool skip_current_channel = (i == non_dateline_receiver_channel_idx && is_dateline);
         this->receiver_channels_num_buffers[i] = skip_current_channel ? 0 : num_receiver_buffer_slots;
         this->receiver_channels_size_bytes[i] =
             skip_current_channel ? 0 : channel_buffer_size_bytes * num_receiver_buffer_slots;
@@ -297,7 +297,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
     log_trace(tt::LogOp, "Available channel buffering space: {}", this->available_channel_buffering_space);
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
-        bool skip_current_channel = (i == non_dataline_sender_channel_idx && is_dateline);
+        bool skip_current_channel = (i == non_dateline_sender_channel_idx && is_dateline);
         if (!skip_current_channel) {
             TT_FATAL(
                 this->sender_channels_size_bytes[i] > 0,
@@ -306,7 +306,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         }
     }
     for (uint32_t i = 0; i < this->num_used_receiver_channels; i++) {
-        bool skip_current_channel = (i == non_dataline_receiver_channel_idx && is_dateline);
+        bool skip_current_channel = (i == non_dateline_receiver_channel_idx && is_dateline);
         if (!skip_current_channel) {
             TT_FATAL(
                 this->receiver_channels_size_bytes[i] > 0,

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -274,15 +274,12 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
         this->sender_channels_num_buffers[i] = skip_current_channel ? 0 : num_sender_buffer_slots;
         this->sender_channels_size_bytes[i] =
             skip_current_channel ? 0 : channel_buffer_size_bytes * num_sender_buffer_slots;
-
-        tt::log_info("Sender {} channel_size: {}", i, this->sender_channels_size_bytes[i]);
     }
     for (uint32_t i = 0; i < this->num_used_receiver_channels; i++) {
         bool skip_current_channel = (i == non_dataline_receiver_channel_idx && is_dateline);
         this->receiver_channels_num_buffers[i] = skip_current_channel ? 0 : num_receiver_buffer_slots;
         this->receiver_channels_size_bytes[i] =
             skip_current_channel ? 0 : channel_buffer_size_bytes * num_receiver_buffer_slots;
-        tt::log_info("Receiver {} channel_size: {}", i, this->receiver_channels_size_bytes[i]);
     }
 
     uint32_t buffer_addr = buffer_region_start;
@@ -493,6 +490,10 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_compile_time_args() const
     size_t sender_channel_num_buffers = this->sender_channels_num_buffers[0];
     size_t receiver_channel_num_buffers =
         this->dateline_connection ? this->receiver_channels_num_buffers[1] : this->receiver_channels_num_buffers[0];
+
+    TT_FATAL(sender_channel_num_buffers > 0, "Sender channel num buffers must be greater than 0");
+    TT_FATAL(receiver_channel_num_buffers > 0, "Receiver channel num buffers must be greater than 0");
+
     auto ct_args = std::vector<uint32_t>{
         num_sender_channels,
         num_receiver_channels,

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -229,7 +229,7 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
                                                   size_t num_alive_receiver_channels,
                                                   size_t& num_sender_buffer_slots,
                                                   size_t& num_receiver_buffer_slots) {
-        // change the reveiver buffer slots for dateline, and keep the sender buffer slots the same as non-dateline,
+        // change the receiver buffer slots for dateline, and keep the sender buffer slots the same as non-dateline,
         // since the sender buffer slots should be kept the same across all edms
         size_t non_dateline_num_sender_buffer_slots = 0;
         size_t non_dateline_num_receiver_buffer_slots = 0;
@@ -296,6 +296,9 @@ FabricEriscDatamoverConfig::FabricEriscDatamoverConfig(
 
     for (uint32_t i = 0; i < this->num_used_sender_channels; i++) {
         // skip sender channel 2 for dateline edm and set the buffer size to 0
+        // Dateline connections have some channels that are unused because there
+        // is not legal data path to feed into them. Therefore we can "skip" them and receover
+        // the buffering space in L1 for other channels.
         bool skip_current_channel = (i == non_dateline_sender_channel_idx && is_dateline);
         this->sender_channels_num_buffers[i] = skip_current_channel ? 0 : num_sender_buffer_slots;
         this->sender_channels_size_bytes[i] =

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -111,14 +111,14 @@ size_t FabricContext::get_fabric_max_payload_size_bytes() const { return this->m
 
 size_t FabricContext::get_fabric_channel_buffer_size_bytes() const { return this->channel_buffer_size_bytes_; }
 
-tt::tt_fabric::FabricEriscDatamoverConfig& FabricContext::get_fabric_router_config() const {
-    TT_FATAL(this->router_config_ != nullptr, "Error, fabric router config is uninitialized");
-    return *this->router_config_.get();
-};
-
-tt::tt_fabric::FabricEriscDatamoverConfig FabricContext::get_fabric_dateline_router_config() const {
-    TT_FATAL(this->dateline_router_config_ != nullptr, "Error, fabric dateline router config is uninitialized");
-    return *this->dateline_router_config_.get();
+tt::tt_fabric::FabricEriscDatamoverConfig& FabricContext::get_fabric_router_config(bool is_dateline) const {
+    if (is_dateline) {
+        TT_FATAL(this->dateline_router_config_ != nullptr, "Error, fabric dateline router config is uninitialized");
+        return *this->dateline_router_config_.get();
+    } else {
+        TT_FATAL(this->router_config_ != nullptr, "Error, fabric router config is uninitialized");
+        return *this->router_config_.get();
+    }
 };
 
 void FabricContext::set_num_fabric_initialized_routers(chip_id_t chip_id, size_t num_routers) {

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -114,6 +114,10 @@ tt::tt_fabric::FabricEriscDatamoverConfig& FabricContext::get_fabric_router_conf
     return *this->router_config_.get();
 };
 
+tt::tt_fabric::FabricEriscDatamoverConfig FabricContext::get_fabric_router_config(bool is_dateline) const {
+    return tt::tt_fabric::FabricEriscDatamoverConfig(this->channel_buffer_size_bytes_, this->topology_, is_dateline);
+};
+
 void FabricContext::set_num_fabric_initialized_routers(chip_id_t chip_id, size_t num_routers) {
     auto it = this->num_initialized_routers_.find(chip_id);
     TT_FATAL(

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -89,6 +89,8 @@ FabricContext::FabricContext(tt::tt_metal::FabricConfig fabric_config) {
     if (is_tt_fabric_config(this->fabric_config_)) {
         this->router_config_ = std::make_unique<tt::tt_fabric::FabricEriscDatamoverConfig>(
             this->channel_buffer_size_bytes_, this->topology_);
+        this->dateline_router_config_ = std::make_unique<tt::tt_fabric::FabricEriscDatamoverConfig>(
+            this->channel_buffer_size_bytes_, this->topology_, true);
         set_routing_mode(this->topology_, this->fabric_config_);
     } else {
         this->router_config_ = nullptr;
@@ -114,8 +116,9 @@ tt::tt_fabric::FabricEriscDatamoverConfig& FabricContext::get_fabric_router_conf
     return *this->router_config_.get();
 };
 
-tt::tt_fabric::FabricEriscDatamoverConfig FabricContext::get_fabric_router_config(bool is_dateline) const {
-    return tt::tt_fabric::FabricEriscDatamoverConfig(this->channel_buffer_size_bytes_, this->topology_, is_dateline);
+tt::tt_fabric::FabricEriscDatamoverConfig FabricContext::get_fabric_dateline_router_config() const {
+    TT_FATAL(this->dateline_router_config_ != nullptr, "Error, fabric dateline router config is uninitialized");
+    return *this->dateline_router_config_.get();
 };
 
 void FabricContext::set_num_fabric_initialized_routers(chip_id_t chip_id, size_t num_routers) {

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -30,8 +30,7 @@ public:
     size_t get_fabric_max_payload_size_bytes() const;
     size_t get_fabric_channel_buffer_size_bytes() const;
 
-    tt::tt_fabric::FabricEriscDatamoverConfig& get_fabric_router_config() const;
-    tt::tt_fabric::FabricEriscDatamoverConfig get_fabric_dateline_router_config() const;
+    tt::tt_fabric::FabricEriscDatamoverConfig& get_fabric_router_config(bool is_dateline = false) const;
 
     void set_num_fabric_initialized_routers(chip_id_t chip_id, size_t num_routers);
     uint32_t get_num_fabric_initialized_routers(chip_id_t chip_id) const;

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -31,7 +31,7 @@ public:
     size_t get_fabric_channel_buffer_size_bytes() const;
 
     tt::tt_fabric::FabricEriscDatamoverConfig& get_fabric_router_config() const;
-    tt::tt_fabric::FabricEriscDatamoverConfig get_fabric_router_config(bool is_dateline) const;
+    tt::tt_fabric::FabricEriscDatamoverConfig get_fabric_dateline_router_config() const;
 
     void set_num_fabric_initialized_routers(chip_id_t chip_id, size_t num_routers);
     uint32_t get_num_fabric_initialized_routers(chip_id_t chip_id) const;
@@ -62,6 +62,7 @@ private:
     size_t max_payload_size_bytes_ = 0;
     size_t channel_buffer_size_bytes_ = 0;
     std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig> router_config_ = nullptr;
+    std::unique_ptr<tt::tt_fabric::FabricEriscDatamoverConfig> dateline_router_config_ = nullptr;
     std::unordered_map<chip_id_t, chan_id_t> master_router_chans_{};
     std::unordered_map<chip_id_t, uint32_t> num_initialized_routers_{};
 };

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -31,6 +31,7 @@ public:
     size_t get_fabric_channel_buffer_size_bytes() const;
 
     tt::tt_fabric::FabricEriscDatamoverConfig& get_fabric_router_config() const;
+    tt::tt_fabric::FabricEriscDatamoverConfig get_fabric_router_config(bool is_dateline) const;
 
     void set_num_fabric_initialized_routers(chip_id_t chip_id, size_t num_routers);
     uint32_t get_num_fabric_initialized_routers(chip_id_t chip_id) const;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1150,6 +1150,8 @@ void build_tt_fabric_program(
             check_dateline(
                 *control_plane, topology, mesh_chip_id.first, mesh_chip_id.second, remote_chip_id, wrap_around_mesh);
 
+        const auto& curr_edm_config = fabric_context.get_fabric_router_config(is_dateline);
+
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
             auto edm_builder = tt::tt_fabric::FabricEriscDatamoverBuilder::build(
@@ -1158,7 +1160,7 @@ void build_tt_fabric_program(
                 eth_logical_core,
                 device->id(),
                 remote_physical_chip_id,
-                edm_config,
+                curr_edm_config,
                 true,  /* enable_persistent_mode */
                 false, /* build_in_worker_connection_mode */
                 is_dateline,

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1150,7 +1150,8 @@ void build_tt_fabric_program(
             check_dateline(
                 *control_plane, topology, mesh_chip_id.first, mesh_chip_id.second, remote_chip_id, wrap_around_mesh);
 
-        const auto& curr_edm_config = fabric_context.get_fabric_router_config(is_dateline);
+        const auto& curr_edm_config = is_dateline ? fabric_context.get_fabric_dateline_router_config()
+                                                  : fabric_context.get_fabric_router_config();
 
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1150,8 +1150,7 @@ void build_tt_fabric_program(
             check_dateline(
                 *control_plane, topology, mesh_chip_id.first, mesh_chip_id.second, remote_chip_id, wrap_around_mesh);
 
-        const auto& curr_edm_config = is_dateline ? fabric_context.get_fabric_dateline_router_config()
-                                                  : fabric_context.get_fabric_router_config();
+        const auto& curr_edm_config = fabric_context.get_fabric_router_config(is_dateline);
 
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -124,11 +124,15 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
             edm_builders_forward_direction[src_device->id()].reserve(local_link_cores.size());
             edm_builders_backward_direction[dest_device->id()].reserve(local_link_cores.size());
             for (size_t l = 0; l < this->num_links; l++) {
+                const auto curr_edm_config =
+                    tt::tt_fabric::FabricEriscDatamoverConfig(edm_buffer_size, topology, dateline);
                 log_trace(
                     tt::LogOp,
                     "Building forward direction EDM on chip {} on link {}",
                     src_device->id(),
                     edm_builders_forward_direction[src_device->id()].size());
+                tt::log_info(
+                    "src_device {}, dest_device {}, is_dateline {}", src_device->id(), dest_device->id(), dateline);
                 edm_builders_forward_direction[src_device->id()].push_back(
                     tt::tt_fabric::FabricEriscDatamoverBuilder::build(
                         src_device,
@@ -136,7 +140,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                         local_link_cores[l],
                         src_device->id(),
                         dest_device->id(),
-                        config,
+                        curr_edm_config,
                         enable_persistent_mode,
                         build_in_worker_connection_mode,
                         dateline));
@@ -153,7 +157,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                         remote_link_cores[l],
                         dest_device->id(),
                         src_device->id(),
-                        config,
+                        curr_edm_config,
                         enable_persistent_mode,
                         build_in_worker_connection_mode,
                         dateline));

--- a/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/erisc_datamover_builder_helper.cpp
@@ -131,7 +131,7 @@ EdmLineFabricOpInterface::EdmLineFabricOpInterface(
                     "Building forward direction EDM on chip {} on link {}",
                     src_device->id(),
                     edm_builders_forward_direction[src_device->id()].size());
-                tt::log_info(
+                tt::log_debug(
                     "src_device {}, dest_device {}, is_dateline {}", src_device->id(), dest_device->id(), dateline);
                 edm_builders_forward_direction[src_device->id()].push_back(
                     tt::tt_fabric::FabricEriscDatamoverBuilder::build(


### PR DESCRIPTION
There's extra buffering can be done on edm dateline connections, we need to increase the buffer slots to compensate for the long latency on qsfp ethernet links.


Ring test has slight improvement, about 1%. for one of the test but not much on others, as they are not fast enough to actually expose the latency overhead
[bandwidth_summary_ring.csv](https://github.com/user-attachments/files/20249707/bandwidth_summary_ring.csv)

new added test show 2.8% improve, from 9.48 to 9.75

### Checklist
- [x] [All post commit]  https://github.com/tenstorrent/tt-metal/actions/runs/15141825044/job/42568226195
- [x] ubench https://github.com/tenstorrent/tt-metal/actions/runs/15141834994 updated golden
- [x] TG demo https://github.com/tenstorrent/tt-metal/actions/runs/15141817789