### PR TITLE
#22206: Add generic ShardedAccessor for interacting with ND sharded buffers

### DIFF
--- a/tests/ttnn/benchmark/cpp/CMakeLists.txt
+++ b/tests/ttnn/benchmark/cpp/CMakeLists.txt
@@ -13,7 +13,7 @@ foreach(TEST_SRC ${BENCHMARK_SRCS})
         ${TEST_TARGET}
         PUBLIC
             ttnn
-            test_metal_common_libs
+            test_common_libs
             benchmark::benchmark
     )
     target_include_directories(

--- a/tests/ttnn/unit_tests/gtests/CMakeLists.txt
+++ b/tests/ttnn/unit_tests/gtests/CMakeLists.txt
@@ -37,6 +37,11 @@ set(TTNN_FABRIC_EDM_SRC ${CMAKE_CURRENT_SOURCE_DIR}/ccl/test_fabric_edm.cpp)
 set(TTNN_CCL_MULTI_TENSOR_UNIT_TESTS_SRC ${CMAKE_CURRENT_SOURCE_DIR}/ccl/test_multi_tensor_ccl.cpp)
 set(TTNN_1D_FABRIC_LATENCY_TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/ccl/test_1d_fabric_loopback_latency.cpp)
 
+set(TTNN_ACCESSOR_UNIT_TESTS_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/accessor/test_sharded_accessor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/accessor/test_sharded_accessor_on_device.cpp
+)
+
 set(TTNN_TENSOR_UNIT_TESTS_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/common_tensor_test_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/test_create_tensor.cpp
@@ -60,6 +65,7 @@ add_executable(unit_tests_ttnn_ccl_ops ${TTNN_CCL_OP_TESTS_SRC})
 add_executable(unit_tests_ttnn_fabric_edm ${TTNN_FABRIC_EDM_SRC})
 add_executable(unit_tests_ttnn_ccl_multi_tensor ${TTNN_CCL_MULTI_TENSOR_UNIT_TESTS_SRC})
 add_executable(unit_tests_ttnn_1d_fabric_latency ${TTNN_1D_FABRIC_LATENCY_TEST_SRC})
+add_executable(unit_tests_ttnn_accessor ${TTNN_ACCESSOR_UNIT_TESTS_SRC})
 add_executable(unit_tests_ttnn_tensor ${TTNN_TENSOR_UNIT_TESTS_SRC})
 add_executable(
     test_ccl_multi_cq_multi_device
@@ -82,6 +88,7 @@ setup_ttnn_test_target(unit_tests_ttnn_ccl_ops)
 setup_ttnn_test_target(unit_tests_ttnn_fabric_edm)
 setup_ttnn_test_target(unit_tests_ttnn_ccl_multi_tensor)
 setup_ttnn_test_target(unit_tests_ttnn_1d_fabric_latency)
+setup_ttnn_test_target(unit_tests_ttnn_accessor)
 setup_ttnn_test_target(unit_tests_ttnn_tensor)
 setup_ttnn_test_target(test_ccl_multi_cq_multi_device)
 setup_ttnn_test_target(unit_tests_ttnn_emitc)

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_reshard.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/reader_reshard.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "accessor/sharded_accessor.h"
+
+void kernel_main() {
+    const uint32_t bank_base_address = get_arg_val<uint32_t>(0);
+
+    // The compile-time args are set up like this to highlight how you can use compile_time_args_skip
+    // Recommended usage is to place the sequential compile-time args for distribution spec at the end
+    constexpr uint32_t rank = get_compile_time_arg_val(0);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(1);
+    constexpr uint32_t base_idx = 2;
+
+    using input_dspec = distribution_spec_t<base_idx, rank, num_banks>;
+    constexpr uint32_t new_base_idx = base_idx + compile_time_args_skip<input_dspec>;
+
+    constexpr uint32_t cb_id = get_compile_time_arg_val(new_base_idx);
+    // TODO: Expose generic interface to get page size for cb operand
+    // - get_tile_size(cb_id) only works for tile layout
+    constexpr uint32_t page_size = get_compile_time_arg_val(new_base_idx + 1);
+
+    auto sharded_accessor = ShardedAccessor<input_dspec, page_size>{.bank_base_address = bank_base_address};
+
+    constexpr uint32_t one_tile = 1;
+    for (size_t i = 0; i < input_dspec::tensor_volume; ++i) {
+        cb_reserve_back(cb_id, one_tile);
+        uint32_t l1_write_addr = get_write_ptr(cb_id);
+        sharded_accessor.noc_async_read_page(i, l1_write_addr);
+        noc_async_read_barrier();
+        cb_push_back(cb_id, one_tile);
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_reshard.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/writer_reshard.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "accessor/sharded_accessor.h"
+
+void kernel_main() {
+    const uint32_t bank_base_address = get_arg_val<uint32_t>(0);
+
+    // The compile-time args are set up like this to highlight how you can use compile_time_args_skip
+    // Recommended usage is to place the sequential compile-time args for distribution spec at the end
+    constexpr uint32_t rank = get_compile_time_arg_val(0);
+    constexpr uint32_t num_banks = get_compile_time_arg_val(1);
+    constexpr uint32_t base_idx = 2;
+
+    using output_dspec = distribution_spec_t<base_idx, rank, num_banks>;
+    constexpr uint32_t new_base_idx = base_idx + compile_time_args_skip<output_dspec>;
+
+    constexpr uint32_t cb_id = get_compile_time_arg_val(new_base_idx);
+    // TODO: Expose generic interface to get page size for cb operand
+    // - get_tile_size(cb_id) only works for tile layout
+    constexpr uint32_t page_size = get_compile_time_arg_val(new_base_idx + 1);
+
+    auto sharded_accessor = ShardedAccessor<output_dspec, page_size>{.bank_base_address = bank_base_address};
+
+    constexpr uint32_t one_tile = 1;
+    for (size_t i = 0; i < output_dspec::tensor_volume; ++i) {
+        cb_wait_front(cb_id, one_tile);
+        uint32_t l1_read_addr = get_read_ptr(cb_id);
+        sharded_accessor.noc_async_write_page(i, l1_read_addr);
+        noc_async_write_barrier();
+        cb_pop_front(cb_id, one_tile);
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor.cpp
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include <fmt/format.h>
+
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+#include <tt-metalium/shape.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/buffer_distribution_spec.hpp>
+
+#include "ttnn/cpp/ttnn/operations/sharding_utilities.hpp"
+
+// Defines to include tt_metal/hw/inc/accessor/sharded_accessor.h but won't need these
+#if !(defined(KERNEL_BUILD) || defined(FW_BUILD))
+
+template <int N>
+constexpr auto get_ct_arg();
+#define get_compile_time_arg_val(arg_idx) get_ct_arg<arg_idx>()
+
+#define noc_index 0
+#define ASSERT(condition, ...)
+#define FORCE_INLINE inline __attribute__((always_inline))
+#endif
+
+#include "tt_metal/hw/inc/accessor/sharded_accessor.h"
+
+#undef get_compile_time_arg_val
+#undef noc_index
+#undef ASSERT
+#undef FORCE_INLINE
+
+// If inputs are passed as constexpr arrays, we can use this style to directly create the structs
+// Example:
+//    constexpr std::array<uint32_t, 3> tensor_shape_array_1 = {1, 2, 3};
+//    USING_STRUCT_FROM_ARRAY_WRAPPER(ShapeWrapper, tensor_shape_1, tensor_shape_array);
+//    static_assert(std::is_same_v<tensor_shape_1, ShapeWrapper<1, 2, 3>>);
+template <template <size_t...> class Wrapper, typename F, size_t... Is>
+constexpr auto make_struct_from_array_wrapper(F, std::index_sequence<Is...>) -> Wrapper<F{}()[Is]...>;
+
+#define USING_STRUCT_FROM_ARRAY_WRAPPER(Wrapper, name, arr) \
+    struct name##_fn {                                      \
+        constexpr auto operator()() const { return (arr); } \
+    };                                                      \
+    using name =                                            \
+        decltype(make_struct_from_array_wrapper<Wrapper>(name##_fn{}, std::make_index_sequence<(arr).size()>{}))
+
+namespace sharded_accessor_tests {
+
+template <typename DSpecT>
+struct ShardedAccessorInputs {
+    using dspec = DSpecT;
+};
+
+template <size_t Rank>
+struct ExpectedDSpec {
+    std::array<uint32_t, Rank> tensor_strides;
+    size_t tensor_volume;
+
+    std::array<uint32_t, Rank> shard_strides;
+    size_t shard_volume;
+
+    std::array<uint32_t, Rank> shard_grid;
+    std::array<uint32_t, Rank> shard_grid_strides;
+};
+
+struct ExpectedBankAndOffset {
+    size_t page_id;
+    size_t bank_id;
+    size_t bank_offset;
+};
+
+template <ExpectedDSpec ExpectedDSpecVal, ExpectedBankAndOffset... ExpectedBankAndOffsetVals>
+struct ShardedAccessorExpected {
+    static constexpr auto dspec = ExpectedDSpecVal;
+    static constexpr auto bank_and_offset =
+        std::array<ExpectedBankAndOffset, sizeof...(ExpectedBankAndOffsetVals)>{ExpectedBankAndOffsetVals...};
+};
+
+template <typename Inputs, typename Expected>
+struct ShardedAccessorParams {
+    using inputs = Inputs;
+    using expected = Expected;
+};
+
+namespace params {
+
+constexpr size_t rank_1 = 2;
+constexpr size_t num_banks_1 = 4;
+constexpr std::array<uint32_t, rank_1> tensor_shape_array_1 = {2, 3};
+constexpr std::array<uint32_t, rank_1> shard_shape_array_1 = {1, 2};
+constexpr std::array<uint32_t, num_banks_1> bank_coord_array_1{};
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::ShapeWrapper, tensor_shape_1, tensor_shape_array_1);
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::ShapeWrapper, shard_shape_1, shard_shape_array_1);
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::BankCoordWrapper, bank_coords_1, bank_coord_array_1);
+
+using test_params_1 = ShardedAccessorParams<
+    ShardedAccessorInputs<::detail::DistributionSpec<tensor_shape_1, shard_shape_1, bank_coords_1>>,
+    ShardedAccessorExpected<
+        ExpectedDSpec<rank_1>{
+            .tensor_strides = {3, 1},
+            .tensor_volume = 6,
+            .shard_strides = {2, 1},
+            .shard_volume = 2,
+            .shard_grid = {2, 2},
+            .shard_grid_strides = {2, 1}},
+        ExpectedBankAndOffset{.page_id = 0, .bank_id = 0, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 1, .bank_id = 0, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 2, .bank_id = 1, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 3, .bank_id = 2, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 4, .bank_id = 2, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 5, .bank_id = 3, .bank_offset = 0}>>;
+
+constexpr size_t rank_2 = 4;
+constexpr size_t num_banks_2 = 6;
+constexpr std::array<uint32_t, rank_2> tensor_shape_array_2 = {2, 1, 3, 4};
+constexpr std::array<uint32_t, rank_2> shard_shape_array_2 = {2, 2, 1, 2};
+constexpr std::array<uint32_t, num_banks_2> bank_coord_array_2{};
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::ShapeWrapper, tensor_shape_2, tensor_shape_array_2);
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::ShapeWrapper, shard_shape_2, shard_shape_array_2);
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::BankCoordWrapper, bank_coords_2, bank_coord_array_2);
+
+using test_params_2 = ShardedAccessorParams<
+    ShardedAccessorInputs<::detail::DistributionSpec<tensor_shape_2, shard_shape_2, bank_coords_2>>,
+    ShardedAccessorExpected<
+        ExpectedDSpec<rank_2>{
+            .tensor_strides = {12, 12, 4, 1},
+            .tensor_volume = 24,
+            .shard_strides = {4, 2, 2, 1},
+            .shard_volume = 8,
+            .shard_grid = {1, 1, 3, 2},
+            .shard_grid_strides = {6, 6, 2, 1}},
+        ExpectedBankAndOffset{.page_id = 0, .bank_id = 0, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 1, .bank_id = 0, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 2, .bank_id = 1, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 3, .bank_id = 1, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 4, .bank_id = 2, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 5, .bank_id = 2, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 6, .bank_id = 3, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 7, .bank_id = 3, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 8, .bank_id = 4, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 9, .bank_id = 4, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 10, .bank_id = 5, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 11, .bank_id = 5, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 12, .bank_id = 0, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 13, .bank_id = 0, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 14, .bank_id = 1, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 15, .bank_id = 1, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 16, .bank_id = 2, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 17, .bank_id = 2, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 18, .bank_id = 3, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 19, .bank_id = 3, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 20, .bank_id = 4, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 21, .bank_id = 4, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 22, .bank_id = 5, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 23, .bank_id = 5, .bank_offset = 5}>>;
+
+constexpr size_t rank_3 = 4;
+constexpr size_t num_banks_3 = 5;
+constexpr std::array<uint32_t, rank_3> tensor_shape_array_3 = {2, 1, 3, 4};
+constexpr std::array<uint32_t, rank_3> shard_shape_array_3 = {2, 2, 1, 2};
+constexpr std::array<uint32_t, num_banks_3> bank_coord_array_3{};
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::ShapeWrapper, tensor_shape_3, tensor_shape_array_3);
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::ShapeWrapper, shard_shape_3, shard_shape_array_3);
+USING_STRUCT_FROM_ARRAY_WRAPPER(::detail::BankCoordWrapper, bank_coords_3, bank_coord_array_3);
+
+using test_params_3 = ShardedAccessorParams<
+    ShardedAccessorInputs<::detail::DistributionSpec<tensor_shape_3, shard_shape_3, bank_coords_3>>,
+    ShardedAccessorExpected<
+        ExpectedDSpec<rank_3>{
+            .tensor_strides = {12, 12, 4, 1},
+            .tensor_volume = 24,
+            .shard_strides = {4, 2, 2, 1},
+            .shard_volume = 8,
+            .shard_grid = {1, 1, 3, 2},
+            .shard_grid_strides = {6, 6, 2, 1}},
+        ExpectedBankAndOffset{.page_id = 0, .bank_id = 0, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 1, .bank_id = 0, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 2, .bank_id = 1, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 3, .bank_id = 1, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 4, .bank_id = 2, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 5, .bank_id = 2, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 6, .bank_id = 3, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 7, .bank_id = 3, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 8, .bank_id = 4, .bank_offset = 0},
+        ExpectedBankAndOffset{.page_id = 9, .bank_id = 4, .bank_offset = 1},
+        ExpectedBankAndOffset{.page_id = 10, .bank_id = 0, .bank_offset = 8},
+        ExpectedBankAndOffset{.page_id = 11, .bank_id = 0, .bank_offset = 9},
+        ExpectedBankAndOffset{.page_id = 12, .bank_id = 0, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 13, .bank_id = 0, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 14, .bank_id = 1, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 15, .bank_id = 1, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 16, .bank_id = 2, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 17, .bank_id = 2, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 18, .bank_id = 3, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 19, .bank_id = 3, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 20, .bank_id = 4, .bank_offset = 4},
+        ExpectedBankAndOffset{.page_id = 21, .bank_id = 4, .bank_offset = 5},
+        ExpectedBankAndOffset{.page_id = 22, .bank_id = 0, .bank_offset = 12},
+        ExpectedBankAndOffset{.page_id = 23, .bank_id = 0, .bank_offset = 13}>>;
+
+}  // namespace params
+
+}  // namespace sharded_accessor_tests
+
+using namespace sharded_accessor_tests;
+using namespace tt::tt_metal;
+
+template <typename T>
+class ShardedAccessorTests : public ::testing::Test {};
+
+using test_params_t = ::testing::Types<params::test_params_1, params::test_params_2, params::test_params_3>;
+TYPED_TEST_SUITE(ShardedAccessorTests, test_params_t);
+
+TYPED_TEST(ShardedAccessorTests, PageLookUp) {
+    using dspec_t = TypeParam::inputs::dspec;
+    constexpr auto dspec_val = dspec_t{};
+    using expected = TypeParam::expected;
+
+    // Create sharded accessor
+    auto sharded_accessor = ShardedAccessor<dspec_t, 0>{.bank_base_address = 0};
+
+    // Check that the computed values in DSpec match the expected values
+    ASSERT_EQ(dspec_val.tensor_strides, expected::dspec.tensor_strides);
+    ASSERT_EQ(dspec_val.tensor_volume, expected::dspec.tensor_volume);
+    ASSERT_EQ(dspec_val.shard_strides, expected::dspec.shard_strides);
+    ASSERT_EQ(dspec_val.shard_volume, expected::dspec.shard_volume);
+    ASSERT_EQ(dspec_val.shard_grid, expected::dspec.shard_grid);
+    ASSERT_EQ(dspec_val.shard_grid_strides, expected::dspec.shard_grid_strides);
+
+    // Check that the computed bank and offset values match the expected values
+    for (const auto& expected_bank_and_offset : expected::bank_and_offset) {
+        auto [bank_id, bank_offset] = sharded_accessor.get_bank_and_offset(expected_bank_and_offset.page_id);
+        EXPECT_EQ(bank_id, expected_bank_and_offset.bank_id);
+        EXPECT_EQ(bank_offset, expected_bank_and_offset.bank_offset);
+    }
+}

--- a/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor_on_device.cpp
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include <fmt/format.h>
+
+#include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+
+#include <tt-metalium/shape.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/buffer_distribution_spec.hpp>
+
+#include "ttnn/cpp/ttnn/operations/sharding_utilities.hpp"
+
+namespace sharded_accessor_device_tests {
+
+struct InputOutputBufferParams {
+    tt::tt_metal::Shape physical_tensor_shape;
+    tt::tt_metal::Shape2D page_shape;
+    float bytes_per_element;
+    tt::DataFormat data_format;  // Used for setting up CBs
+
+    struct DistributionSpecParams {
+        tt::tt_metal::Shape physical_shard_shape;
+        tt::tt_metal::CoreRangeSet grid;
+        tt::tt_metal::ShardOrientation shard_orientation;
+        tt::tt_metal::BufferType buffer_type;
+    };
+    DistributionSpecParams input_shard_spec;
+    DistributionSpecParams output_shard_spec;
+};
+
+std::array<std::shared_ptr<tt::tt_metal::distributed::MeshBuffer>, 2>
+create_replicated_input_and_output_mesh_buffers_from_inputs(
+    const InputOutputBufferParams& inputs, tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    // These values would be passed from tensor correctly based on PageConfig
+    const auto host_size_in_bytes = inputs.physical_tensor_shape.volume() * inputs.bytes_per_element;
+    const auto page_size = inputs.page_shape.height() * inputs.page_shape.width() * inputs.bytes_per_element;
+
+    // Mirrors allocate_mesh_buffer_on_device in ttnn
+    const tt::tt_metal::distributed::ReplicatedBufferConfig mesh_buffer_config{.size = host_size_in_bytes};
+
+    // Create input mesh buffer
+    auto input_buffer_distribution_spec = tt::tt_metal::BufferDistributionSpec::from_shard_spec(
+        inputs.physical_tensor_shape,
+        inputs.input_shard_spec.physical_shard_shape,
+        inputs.page_shape,
+        inputs.input_shard_spec.grid,
+        inputs.input_shard_spec.shard_orientation);
+    const tt::tt_metal::distributed::DeviceLocalBufferConfig input_device_local_config{
+        .page_size = page_size,
+        .buffer_type = inputs.input_shard_spec.buffer_type,
+        .buffer_layout = tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+        .buffer_distribution_spec = input_buffer_distribution_spec,
+    };
+    const auto input_mesh_buffer =
+        tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, input_device_local_config, mesh_device);
+
+    // Create output mesh buffer
+    auto output_buffer_distribution_spec = tt::tt_metal::BufferDistributionSpec::from_shard_spec(
+        inputs.physical_tensor_shape,
+        inputs.input_shard_spec.physical_shard_shape,
+        inputs.page_shape,
+        inputs.output_shard_spec.grid,
+        inputs.output_shard_spec.shard_orientation);
+    const tt::tt_metal::distributed::DeviceLocalBufferConfig output_device_local_config{
+        .page_size = page_size,
+        .buffer_type = inputs.output_shard_spec.buffer_type,
+        .buffer_layout = tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED,
+        .buffer_distribution_spec = output_buffer_distribution_spec,
+    };
+    const auto output_mesh_buffer =
+        tt::tt_metal::distributed::MeshBuffer::create(mesh_buffer_config, output_device_local_config, mesh_device);
+
+    return {input_mesh_buffer, output_mesh_buffer};
+}
+
+}  // namespace sharded_accessor_device_tests
+
+using namespace sharded_accessor_device_tests;
+using namespace tt::tt_metal;
+
+class ShardedAccessorTestsOnDevice : public GenericMeshDeviceFixture,
+                                     public ::testing::WithParamInterface<InputOutputBufferParams> {};
+
+TEST_P(ShardedAccessorTestsOnDevice, SingleCoreReshard) {
+    const auto& params = GetParam();
+
+    // Create input and output replicated mesh buffers across generic mesh device; tests will only use first device
+    const auto [input_mesh_buffer, output_mesh_buffer] =
+        create_replicated_input_and_output_mesh_buffers_from_inputs(params, mesh_device_.get());
+
+    // Extract local single-device buffer (ie. shard_view) concepts for testing
+    const tt::tt_metal::distributed::MeshCoordinate mesh_coordinate{0, 0};
+    const auto input_shard_view = input_mesh_buffer->get_device_buffer(mesh_coordinate);
+    const auto output_shard_view = output_mesh_buffer->get_device_buffer(mesh_coordinate);
+    const auto local_device = input_shard_view->device();
+
+    const auto host_size_in_bytes = input_mesh_buffer->device_local_size();
+    ASSERT_EQ(host_size_in_bytes, output_mesh_buffer->device_local_size());
+
+    const auto input_bank_base_address = input_mesh_buffer->address();
+    const auto output_bank_base_address = output_mesh_buffer->address();
+    ASSERT_NE(input_bank_base_address, output_bank_base_address);
+
+    // Input and output buffers may not have the same aligned size per bank
+    // Initialize input local device buffers to 0
+    {
+        std::vector<uint32_t> zeros_vector(input_shard_view->aligned_size_per_bank() / sizeof(uint32_t), 0);
+        for (const auto& core : corerange_to_cores(params.input_shard_spec.grid)) {
+            tt::tt_metal::detail::WriteToDeviceL1(
+                local_device, core, input_bank_base_address, zeros_vector, input_shard_view->core_type());
+        }
+    }
+
+    // Initialize output local device buffers to 0
+    {
+        std::vector<uint32_t> zeros_vector(output_shard_view->aligned_size_per_bank() / sizeof(uint32_t), 0);
+        for (const auto& core : corerange_to_cores(params.output_shard_spec.grid)) {
+            tt::tt_metal::detail::WriteToDeviceL1(
+                local_device, core, output_bank_base_address, zeros_vector, output_shard_view->core_type());
+        }
+    }
+
+    // Create src vector
+    const auto src =
+        tt::test_utils::generate_uniform_random_vector<uint8_t>(0, UINT8_MAX, host_size_in_bytes / sizeof(uint8_t));
+
+    {
+        tt::log_info("Writing input buffer to device");
+        std::vector<tt::tt_metal::distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfer{{
+            .shard_coord = tt::tt_metal::distributed::MeshCoordinate{0, 0},
+            .host_data = const_cast<void*>(reinterpret_cast<const void*>(src.data())),
+        }};
+        mesh_device_->mesh_command_queue().enqueue_write_shards(
+            input_mesh_buffer, shard_data_transfer, /*blocking=*/false);
+        Finish(mesh_device_->mesh_command_queue());
+    }
+
+    /* CREATE AND LAUNCH PROGRAM ON DEVICE
+     * - This program uses reader and writer kernel to copy input buffer to output buffer using sharded accessors.
+     * - Inside the reader and writer kernels, loop through total volume (in pages) of the tensor to complete the copy.
+     * - This is essentially a single-core reshard OP.
+     * - TODO: One major restriction is that page size must be the same for both input and output buffers.
+     *   - For tile layout, can use UNPACK / PACK to convert between different data formats and page sizes.
+     *   - For row major layout, need to handle shard shapes with different widths (ie. last dim) properly
+     */
+    {
+        tt::log_info("Creating single-core reshard program");
+        auto program = CreateProgram();
+
+        constexpr CoreCoord grid = {0, 0};
+        const auto data_format = params.data_format;
+
+        // Setup circular buffer for reading and writing to buffers
+        // TODO: Expose aligned page size to mesh buffer?
+        TT_FATAL(
+            input_shard_view->aligned_page_size() == output_shard_view->aligned_page_size(),
+            "Input and output mesh buffers must have the same aligned page size!");
+        const auto aligned_page_size = input_shard_view->aligned_page_size();
+        constexpr auto num_tiles = 2;  // Double buffered for perf, but it doesn't really matter for this test
+        CBHandle cb_in0_idx = tt::CBIndex::c_0;
+        auto c_in0_config = CircularBufferConfig(aligned_page_size * num_tiles, {{cb_in0_idx, data_format}})
+                                .set_page_size(cb_in0_idx, aligned_page_size);
+        auto cb_in0_id = CreateCircularBuffer(program, grid, c_in0_config);
+
+        // Set up compile-time args for reader kernel
+        const auto& input_buffer_distribution_spec =
+            input_mesh_buffer->device_local_config().buffer_distribution_spec.value();
+        const auto input_sharded_accessor_args = tt::tt_metal::sharded_accessor_utils::get_sharded_accessor_args(
+            *mesh_device_, input_buffer_distribution_spec, input_shard_view->core_type());
+        std::vector<uint32_t> input_compile_time_args = {
+            input_sharded_accessor_args.rank, input_sharded_accessor_args.num_banks};
+        input_compile_time_args.insert(
+            input_compile_time_args.end(),
+            input_sharded_accessor_args.shapes_and_bank_coords.cbegin(),
+            input_sharded_accessor_args.shapes_and_bank_coords.cend());
+        input_compile_time_args.push_back(cb_in0_idx);
+        input_compile_time_args.push_back(aligned_page_size);
+
+        // Set up compile-time args for writer  kernel
+        const auto& output_buffer_distribution_spec =
+            output_mesh_buffer->device_local_config().buffer_distribution_spec.value();
+        const auto output_sharded_accessor_args = tt::tt_metal::sharded_accessor_utils::get_sharded_accessor_args(
+            *mesh_device_, output_buffer_distribution_spec, output_shard_view->core_type());
+        std::vector<uint32_t> output_compile_time_args = {
+            output_sharded_accessor_args.rank, output_sharded_accessor_args.num_banks};
+        output_compile_time_args.insert(
+            output_compile_time_args.end(),
+            output_sharded_accessor_args.shapes_and_bank_coords.cbegin(),
+            output_sharded_accessor_args.shapes_and_bank_coords.cend());
+        output_compile_time_args.push_back(cb_in0_idx);
+        output_compile_time_args.push_back(aligned_page_size);
+
+        // Create reader kernel
+        KernelHandle reader_kernel_id = CreateKernel(
+            program,
+            "tests/ttnn/unit_tests/gtests/accessor/kernels/reader_reshard.cpp",
+            grid,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::RISCV_0_default,
+                .compile_args = input_compile_time_args});
+
+        // Create writer kernel
+        KernelHandle writer_kernel_id = CreateKernel(
+            program,
+            "tests/ttnn/unit_tests/gtests/accessor/kernels/writer_reshard.cpp",
+            grid,
+            DataMovementConfig{
+                .processor = DataMovementProcessor::RISCV_1,
+                .noc = NOC::RISCV_1_default,
+                .compile_args = output_compile_time_args});
+
+        // Set up runtime args for reader kernel
+        std::vector<uint32_t> input_runtime_args = {
+            input_bank_base_address,
+        };
+        SetRuntimeArgs(program, reader_kernel_id, grid, input_runtime_args);
+
+        // Set up runtime args for writer kernel
+        std::vector<uint32_t> output_runtime_args = {
+            output_bank_base_address,
+        };
+        SetRuntimeArgs(program, writer_kernel_id, grid, output_runtime_args);
+
+        // Launch program
+        auto mesh_work_load = tt::tt_metal::distributed::CreateMeshWorkload();
+        AddProgramToMeshWorkload(
+            mesh_work_load, std::move(program), (tt::tt_metal::distributed::MeshCoordinateRange)mesh_coordinate);
+        EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_work_load, false);
+
+        // Wait for program to finish
+        tt::log_info("Program launched!");
+        Finish(mesh_device_->mesh_command_queue());
+        tt::log_info("Program finished!");
+    }
+
+    // Initialize dst vector
+    std::vector<uint8_t> dst(host_size_in_bytes / sizeof(uint8_t), 0);
+
+    // Validate output buffer matches src vector
+    {
+        tt::log_info("Validating output buffer matches src vector");
+        std::vector<tt::tt_metal::distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfer{{
+            .shard_coord = tt::tt_metal::distributed::MeshCoordinate{0, 0},
+            .host_data = const_cast<void*>(reinterpret_cast<const void*>(dst.data())),
+        }};
+        mesh_device_->mesh_command_queue().enqueue_read_shards(
+            shard_data_transfer, output_mesh_buffer, /*blocking=*/false);
+        Finish(mesh_device_->mesh_command_queue());
+
+        // Validate read results are correct
+        EXPECT_EQ(src, dst);
+    }
+
+    // Validate input buffer matches src vector (ie. unmodified after kernel read/writes)
+    {
+        tt::log_info("Validating input buffer matches src vector (as a sanity check)");
+        std::vector<tt::tt_metal::distributed::MeshCommandQueue::ShardDataTransfer> shard_data_transfer{{
+            .shard_coord = tt::tt_metal::distributed::MeshCoordinate{0, 0},
+            .host_data = const_cast<void*>(reinterpret_cast<const void*>(dst.data())),
+        }};
+        mesh_device_->mesh_command_queue().enqueue_read_shards(
+            shard_data_transfer, input_mesh_buffer, /*blocking=*/false);
+        Finish(mesh_device_->mesh_command_queue());
+
+        // Validate read results are correct
+        EXPECT_EQ(src, dst);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ShardedAccessorTests,
+    ShardedAccessorTestsOnDevice,
+    // Test cases are similar to MeshBufferReadWriteTests in test_buffer_distribution_spec.cpp
+    // - Output distribution spec is something different from input distribution spec
+    ::testing::Values(
+        // BLOCK sharding; tile layout
+        // page size = 32 x 32 x 2 = 2048 bytes (eg. bfloat16, uint16, etc...)
+        InputOutputBufferParams{
+            .physical_tensor_shape = tt::tt_metal::Shape{2, 64, 96},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+
+            .input_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{1, 32, 64},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+            .output_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{2, 32, 32},
+                    .grid = CoreRangeSet(CoreRange({4, 4}, {5, 5})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        // HEIGHT sharding with padding along shard width + random CoreRangeSet; tile layout
+        // page size = 32 x 32 x 1.0625 = 1088 bytes (eg. bfloat8_b)
+        InputOutputBufferParams{
+            .physical_tensor_shape = tt::tt_metal::Shape{2, 128, 64},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 1.0625,  // Headers for block float amortized over elements
+            .data_format = tt::DataFormat::Bfp8,
+
+            .input_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{1, 64, 96},
+                    .grid = CoreRangeSet(tt::stl::Span<const CoreRange>(
+                        {CoreRange({4, 6}, {6, 6}), CoreRange({1, 1}, {1, 1}), CoreRange({0, 3}, {3, 3})})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+            .output_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{1, 32, 32},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {5, 5})),
+                    .shard_orientation = ShardOrientation::COL_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        // WIDTH sharding with padding along shard height; row major layout with aligned page size
+        // page size = 1 x 16 x 1 = 16 bytes (eg. uint8, int8, etc...)
+        InputOutputBufferParams{
+            .physical_tensor_shape = tt::tt_metal::Shape{2, 3, 32},
+            .page_shape = tt::tt_metal::Shape2D{1, 16},
+            .bytes_per_element = 1,
+            .data_format = tt::DataFormat::UInt8,
+
+            .input_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{2, 4, 16},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+            .output_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{1, 3, 16},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {2, 2})),
+                    .shard_orientation = ShardOrientation::COL_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        // ND sharding with multiple shards per bank; row major layout with non-aligned page size
+        // Coaslescing possible based on shard spec but must be noncoalesced due to non-aligned pages
+        // page size = 1 x 4 x 1 = 4 bytes (eg. uint8, int8, etc...)
+        InputOutputBufferParams{
+            .physical_tensor_shape = tt::tt_metal::Shape{3, 2, 2, 3, 4},
+            .page_shape = tt::tt_metal::Shape2D{1, 4},
+            .bytes_per_element = 1,
+            .data_format = tt::DataFormat::UInt8,
+
+            .input_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{1, 1, 2, 2, 4},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {1, 4})),
+                    .shard_orientation = ShardOrientation::COL_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+            .output_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{3, 3, 1, 1, 4},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {1, 1})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        // ND sharding with multiple shards per bank; tile layout
+        // page size = 32 x 32 x 2 = 2048 bytes (eg. bfloat16, uint16, etc...)
+        InputOutputBufferParams{
+            .physical_tensor_shape = tt::tt_metal::Shape{5, 2, 2, 64, 96},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::UInt16,
+
+            .input_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{1, 1, 2, 64, 64},
+                    .grid = CoreRangeSet(
+                        tt::stl::Span<const CoreRange>({CoreRange({0, 0}, {2, 0}), CoreRange({0, 1}, {1, 1})})),
+                    .shard_orientation = ShardOrientation::COL_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+            .output_shard_spec =
+                InputOutputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{5, 1, 1, 96, 32},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        }));

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,6 +19,9 @@ public:
         const Shape2D& page_shape,
         const CoreRangeSet& corerangeset,
         const ShardOrientation shard_orientation);
+
+    tt::tt_metal::Shape get_tensor_shape_in_pages() const { return page_distribution_spec_.get_tensor_shape(); }
+    tt::tt_metal::Shape get_shard_shape_in_pages() const { return page_distribution_spec_.get_shard_shape(); }
 
     size_t num_dev_pages_per_core() const {
         return page_distribution_spec_.get_shard_shape().volume() *

--- a/tt_metal/api/tt-metalium/distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/distribution_spec.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,7 @@ public:
     static DistributionSpec from_shard_shape(
         const tt::tt_metal::Shape& tensor_shape, const tt::tt_metal::Shape& shard_shape, size_t num_targets);
 
+    tt::tt_metal::Shape get_tensor_shape() const { return tensor_shape_; }
     tt::tt_metal::Shape get_shard_shape() const { return shard_shape_; }
     size_t get_num_targets() const { return num_targets_; }
     size_t get_max_num_shards_per_target() const { return max_num_shards_per_target_; }

--- a/tt_metal/hw/inc/accessor/detail.h
+++ b/tt_metal/hw/inc/accessor/detail.h
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace detail {
+
+template <size_t... Dims>
+struct ShapeWrapper {
+    // Check that rank is > 0
+    static constexpr size_t rank = sizeof...(Dims);
+    static_assert(rank > 0, "Shape rank must be greater than 0!");
+
+    // Check that all Dims are > 0
+    static_assert(((Dims > 0) && ...), "Shape dims must be greater than 0!");
+
+    static constexpr std::array<uint32_t, rank> shape = {Dims...};
+
+    // Compute shape properities at compile time
+    static constexpr std::pair<size_t, std::array<uint32_t, rank>> compute_volume_and_strides(
+        const std::array<uint32_t, rank>& shape) {
+        std::array<uint32_t, rank> strides = {};
+        uint32_t stride = 1;
+        for (int i = rank - 1; i >= 0; --i) {
+            strides[i] = stride;
+            stride *= shape[i];
+        }
+        return {strides[0] * shape[0], strides};
+    }
+
+    // Compiler should optimize out the second call
+    static constexpr auto volume = compute_volume_and_strides(shape).first;
+    static constexpr auto strides = compute_volume_and_strides(shape).second;
+};
+
+template <size_t... PackedCoords>
+struct BankCoordWrapper {
+    static constexpr size_t num_banks = sizeof...(PackedCoords);
+    // TODO: Each bank coord is packed as one uint32_t (ie. (16 bits) <x> | (16 bits) <y>)
+    // This can be optimized to be 8 bits per coord, so we pack two bank coords in one uint32_t compile time arg
+    static constexpr std::array<uint32_t, num_banks> packed_xy_coords = {PackedCoords...};
+};
+
+//
+template <template <size_t...> class Wrapper, size_t BASE_IDX, size_t... Is>
+constexpr auto make_struct_from_sequence_wrapper(std::index_sequence<Is...>)
+    -> Wrapper<get_compile_time_arg_val(BASE_IDX + Is)...>;
+
+template <template <size_t...> class Wrapper, size_t base, size_t rank>
+using struct_sequence_wrapper_t =
+    decltype(make_struct_from_sequence_wrapper<Wrapper, base>(std::make_index_sequence<rank>{}));
+
+template <typename TensorShape, typename ShardShape, typename BankCoords>
+struct DistributionSpec {
+    static_assert(TensorShape::rank == ShardShape::rank, "Tensor and shard shapes must have the same rank!");
+    static constexpr auto rank = TensorShape::rank;
+    static_assert(rank > 0, "Tensor and shard shape ranks must be greater than 0!");
+
+    static constexpr auto tensor_shape = TensorShape::shape;
+    static constexpr auto tensor_strides = TensorShape::strides;
+    static constexpr auto tensor_volume = TensorShape::volume;
+
+    static constexpr auto shard_shape = ShardShape::shape;
+    static constexpr auto shard_strides = ShardShape::strides;
+    static constexpr auto shard_volume = ShardShape::volume;
+
+    // Compute shard grid and shard grid strides at compile time
+    static constexpr std::pair<std::array<uint32_t, rank>, std::array<uint32_t, rank>> compute_shard_grid_and_strides(
+        const std::array<uint32_t, rank>& tensor_shape, const std::array<uint32_t, rank>& shard_shape) {
+        std::array<uint32_t, rank> shard_grid = {};
+        std::array<uint32_t, rank> shard_grid_strides = {};
+        uint32_t stride = 1;
+        for (int i = rank - 1; i >= 0; --i) {
+            shard_grid[i] = (tensor_shape[i] - 1) / shard_shape[i] + 1;  // div_up
+            shard_grid_strides[i] = stride;
+            stride *= shard_grid[i];
+        }
+        return {shard_grid, shard_grid_strides};
+    }
+
+    // Compiler should optimize out the second call
+    // NOTE: shard_grid is not really needed, but probably more idiomatic to keep it with shard_grid_strides
+    static constexpr auto shard_grid = compute_shard_grid_and_strides(tensor_shape, shard_shape).first;
+    static constexpr auto shard_grid_strides = compute_shard_grid_and_strides(tensor_shape, shard_shape).second;
+
+    static constexpr auto num_banks = BankCoords::num_banks;
+    static constexpr auto packed_xy_coords = BankCoords::packed_xy_coords;
+    // Check that the number of shards is greater than or equal to the number of banks
+    // Here, shard_grid_strides[0] * shard_grid[0] is the total number of shards
+    static_assert(
+        shard_grid_strides[0] * shard_grid[0] >= num_banks,
+        "Number of shards must be greater than or equal to number of banks!");
+};
+
+template <size_t BASE, size_t RANK, size_t NUM_BANKS>
+struct DistributionSpecWrapper {
+    using dspec = DistributionSpec<
+        struct_sequence_wrapper_t<ShapeWrapper, BASE, RANK>,
+        struct_sequence_wrapper_t<ShapeWrapper, BASE + RANK, RANK>,
+        struct_sequence_wrapper_t<BankCoordWrapper, BASE + 2 * RANK, NUM_BANKS>>;
+};
+
+}  // namespace detail

--- a/tt_metal/hw/inc/accessor/sharded_accessor.h
+++ b/tt_metal/hw/inc/accessor/sharded_accessor.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "detail.h"
+
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+#include "dataflow_api.h"
+#endif
+
+template <size_t BASE, size_t RANK, size_t NUM_BANKS>
+using distribution_spec_t = typename detail::DistributionSpecWrapper<BASE, RANK, NUM_BANKS>::dspec;
+
+template <typename DSpec>
+constexpr auto compile_time_args_skip = DSpec::rank * 2 + DSpec::num_banks;
+
+template <typename DSpec, size_t PageSize>
+struct ShardedAccessor {
+    static constexpr DSpec dspec{};
+    static constexpr auto page_size = PageSize;
+
+    // Runtime args
+    const size_t bank_base_address;
+
+    // Helpers
+    struct PageMapping {
+        size_t bank_id;
+        size_t bank_page_offset;
+    };
+
+    PageMapping get_bank_and_offset(uint32_t page_id) const {
+        // Check that page_id is within bounds
+        ASSERT(page_id < dspec.tensor_volume);
+        // TODO: Should be possible to directly implement get_bank_and_offset logic with page_id and skip computing the
+        // page_coord
+        std::array<uint32_t, dspec.rank> page_coord;
+        for (int i = dspec.rank - 1; i >= 0; --i) {
+            page_coord[i] = page_id % dspec.tensor_shape[i];
+            page_id /= dspec.tensor_shape[i];
+        }
+        return get_bank_and_offset(page_coord);
+    }
+
+    PageMapping get_bank_and_offset(const std::array<uint32_t, dspec.rank> page_coord) const {
+        // Flattened shard id is used to compute the bank id and shard id within a bank
+        // - First, get the shard coordinate with page_coord[i] / dspec.shard_shape[i]
+        // - Then, multiply by the shard grid strides and accumulate
+        // - Repeat for all dims
+        // Page offset within shard refers to the offset within the shard the page belongs to
+        // - First, get the page coordinate within the shard with page_coord[i] % dspec.shard_shape[i]
+        // - Then, multiple by the shard strides and accumulate
+        // - Repeat for all dims
+        // Final page offset within the bank is simply: bank_shard_id * shard_volume + page_offset_within_shard
+
+        size_t flattened_shard_id = 0;
+        size_t page_offset_within_shard = 0;
+        for (size_t i = 0; i < dspec.rank; ++i) {
+            // Check that page_coord is within bounds
+            ASSERT(page_coord[i] < dspec.tensor_shape[i]);
+            flattened_shard_id += (page_coord[i] / dspec.shard_shape[i]) * dspec.shard_grid_strides[i];
+            page_offset_within_shard += (page_coord[i] % dspec.shard_shape[i]) * dspec.shard_strides[i];
+        }
+
+        // NOTE: This assumes shards are round-robin assigned across banks
+        size_t bank_id = flattened_shard_id % dspec.num_banks;
+        size_t bank_shard_id = flattened_shard_id / dspec.num_banks;
+
+        size_t bank_page_offset = bank_shard_id * dspec.shard_volume + page_offset_within_shard;
+
+        return {bank_id, bank_page_offset};
+    }
+
+    // NOC APIs
+    FORCE_INLINE
+    std::uint64_t get_noc_addr(const uint32_t id, uint8_t noc = noc_index) const {
+        const auto [bank_id, bank_offset] = this->get_bank_and_offset(id);
+        return NOC_XY_ADDR(
+            DYNAMIC_NOC_X(noc, (dspec.packed_xy_coords[bank_id] >> 16) & 0xFFFF),
+            DYNAMIC_NOC_Y(noc, dspec.packed_xy_coords[bank_id] & 0xFFFF),
+            bank_base_address + bank_offset * page_size);
+    }
+
+    FORCE_INLINE
+    void noc_async_read_page(const uint32_t id, const uint32_t dest_addr, uint8_t noc = noc_index) const {
+        noc_async_read(get_noc_addr(id, noc), dest_addr, page_size, noc);
+    }
+
+    FORCE_INLINE
+    void noc_async_write_page(const uint32_t id, const uint32_t src_addr, uint8_t noc = noc_index) const {
+        noc_async_write(src_addr, get_noc_addr(id, noc), page_size, noc);
+    }
+};

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -245,7 +245,7 @@ struct ShardedAddrGen {
     FORCE_INLINE
     void noc_async_read_page(
         const uint32_t id, const uint32_t dest_addr, const uint32_t offset = 0, uint8_t noc = noc_index) const {
-        noc_async_read(this->get_noc_addr(id, offset), dest_addr, CONSTANT_ARGS.page_size_jump, noc);
+        noc_async_read(this->get_noc_addr(id, offset, noc), dest_addr, CONSTANT_ARGS.page_size_jump, noc);
     }
 };
 }  // namespace experimental

--- a/ttnn/cpp/ttnn/operations/sharding_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/sharding_utilities.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,7 @@
 
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
 
 namespace tt::tt_metal {
 
@@ -87,5 +88,19 @@ ShardingConfig get_specs_for_sharding_partition(
     uint32_t window_w,
     uint32_t pad_h,
     uint32_t pad_w);
+
+namespace sharded_accessor_utils {
+
+struct ShardedAccessorArgs {
+    size_t rank;
+    size_t num_banks;
+    std::vector<uint32_t> shapes_and_bank_coords;
+};
+ShardedAccessorArgs get_sharded_accessor_args(
+    const distributed::MeshDevice& mesh_device,
+    const BufferDistributionSpec& buffer_distribution_spec,
+    const CoreType& bank_type);
+
+}  // namespace sharded_accessor_utils
 
 }  // namespace tt::tt_metal


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22206)

### Problem description
ND sharded buffers are now supported in TTNN and tt-metal. There are two remaining pieces of work for complete end-to-end functionality:
- Support in tensors
- Support in kernels

This PR addresses the latter by introducing a generic `ShardedAccessor` for interacting with ND sharded buffers on device. As a proof of functionality, `tests/ttnn/unit_tests/gtests/accessor/test_sharded_accessor_on_device.cpp` implements a single-core reshard program/OP to demonstrate how the accessor can be used.

### What's changed
- Core implementation:
  - Add compile-time DistributionSpec for kernel usage
  - Add ShardedAccessor for page lookup and reading/writing (similar to exisitng address generators)
  - Add get_sharded_accessor_args util for generating sequential kernel args
- Add basic single-core reshard program and kernels to demonstrate usage
- Add shape getters to BufferDistributionSpec and DistributionSpec

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes: https://github.com/tenstorrent/tt-metal/actions/runs/15218606019
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable): https://github.com/tenstorrent/tt-metal/actions/runs/15197686118
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes