### PR TITLE
Fix llama pipelines: timeout and upload checks in model perf

### DIFF
--- a/.github/workflows/tg-model-perf-tests-impl.yaml
+++ b/.github/workflows/tg-model-perf-tests-impl.yaml
@@ -115,7 +115,7 @@ jobs:
           run_args: |
             ${{ matrix.test-group.cmd }}
       - name: Save environment data
-        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests') && !cancelled() }}
+        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests'  || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests') && !cancelled() }}
         uses: ./.github/actions/docker-run
         with:
           docker_image: ${{ inputs.docker-image }}
@@ -127,7 +127,7 @@ jobs:
           install_wheel: true
           run_args: python3 .github/scripts/data_analysis/create_benchmark_with_environment_json.py
       - name: Upload benchmark data
-        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests') && !cancelled() }}
+        if: ${{ (matrix.test-group.name == 'Llama Galaxy Perf Unit Tests' || matrix.test-group.name == 'Galaxy Llama 70B model perf tests' || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests') && !cancelled() }}
         uses: ./.github/actions/upload-data-via-sftp
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
@@ -136,7 +136,7 @@ jobs:
           hostname: ${{ secrets.SFTP_BENCHMARK_WRITER_HOSTNAME }}
       - name: Check perf report exists
         id: check-perf-report
-        if: ${{ !(matrix.test-group.name == 'Llama Galaxy Perf Unit Tests'|| matrix.test-group.name == 'Galaxy Llama 70B model perf tests') && !cancelled() }}
+        if: ${{ !(matrix.test-group.name == 'Llama Galaxy Perf Unit Tests'|| matrix.test-group.name == 'Galaxy Llama 70B model perf tests' || matrix.test-group.name == 'Galaxy Llama 70B model dispatch perf tests') && !cancelled() }}
         run: |
           TODAY=$(date +%Y_%m_%d)
           PERF_REPORT_FILENAME_MODELS="Models_Perf_${TODAY}.csv"

--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -32,7 +32,7 @@ jobs:
             name: "Llama Galaxy Accuracy Test",
             arch: wormhole_b0,
             cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_llama_accuracy.py",
-            timeout: 25,
+            timeout: 30,
             owner_id: U071CKL4AFK
           }, # Ammar Vora
           # { See GH Issue #22164


### PR DESCRIPTION
### Ticket
None

### Problem description
- Accuracy test times out
- Model perf pipelines missing the new dispatch test in ifs (upload to superset, check for perf report)

### What's changed
- Increased time out
- Added dispatch test in checks

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes