### PR TITLE
#21099: Rollforward  "Get rid of tensor 'workers'"

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_distributed_host_buffer.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_distributed_host_buffer.cpp
@@ -20,21 +20,12 @@ using ::testing::IsEmpty;
 using ::testing::Pointwise;
 using ::testing::SizeIs;
 
-TEST(DistributedHostBufferTest, OwnedLifecycle) {
-    // TODO: #21604 - Is "allocate" / "deallocate" meaningful for host buffers?
+TEST(DistributedHostBufferTest, Basic) {
     auto buffer = DistributedHostBuffer::create(3);
-
-    EXPECT_FALSE(buffer.is_allocated());
 
     buffer.emplace_shard(0, HostBuffer(std::vector<int>{1, 2, 3}));
     buffer.emplace_shard(1, HostBuffer(std::vector<int>{4, 5, 6}));
     buffer.emplace_shard(2, HostBuffer(std::vector<int>{7, 8, 9}));
-
-    EXPECT_TRUE(buffer.is_allocated());
-
-    buffer.deallocate();
-
-    EXPECT_FALSE(buffer.is_allocated());
 }
 
 TEST(DistributedHostBufferTest, ShardedWithInvalidLocalShape) {

--- a/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/distributed_host_buffer.hpp
@@ -65,12 +65,6 @@ public:
     using ApplyFn = std::function<void(const HostBuffer& buffer, size_t linear_index)>;
     void apply(const ApplyFn& fn);
 
-    // Returns true if the buffer is allocated.
-    bool is_allocated() const;
-
-    // Deallocates the underlying data storage.
-    void deallocate();
-
 private:
     DistributedHostBuffer(
         std::function<std::optional<size_t>(size_t)> global_to_local_index, std::vector<HostBuffer> local_buffers) :

--- a/tt_metal/api/tt-metalium/host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/host_buffer.hpp
@@ -62,9 +62,6 @@ public:
     template <typename T>
     tt::stl::Span<const T> view_as() const&& = delete;
 
-    // Returns true if the data buffer is allocated.
-    bool is_allocated() const;
-
     // Returns true if the data buffer is borrowed.
     bool is_borrowed() const;
 
@@ -74,9 +71,6 @@ public:
     // Returns a pin for the data buffer.
     // The data won't be freed until the pin is destroyed.
     MemoryPin pin() const;
-
-    // Deallocates the data buffer.
-    void deallocate();
 
 private:
     MemoryPin pin_;

--- a/tt_metal/common/host_buffer.cpp
+++ b/tt_metal/common/host_buffer.cpp
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/memory_pin.hpp>
 #include <tt_stl/span.hpp>
 #include <tt_stl/overloaded.hpp>
 
-#include <functional>
 #include <memory>
-#include <typeinfo>
 #include <utility>
-#include <variant>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -47,8 +43,6 @@ tt::stl::Span<std::byte> HostBuffer::view_bytes() & noexcept { return view_; }
 
 tt::stl::Span<const std::byte> HostBuffer::view_bytes() const& noexcept { return view_; }
 
-bool HostBuffer::is_allocated() const { return pin_ != nullptr; }
-
 bool HostBuffer::is_borrowed() const { return is_borrowed_; }
 
 HostBuffer HostBuffer::deep_copy() const {
@@ -62,13 +56,6 @@ HostBuffer HostBuffer::deep_copy() const {
 }
 
 MemoryPin HostBuffer::pin() const { return pin_; }
-
-void HostBuffer::deallocate() {
-    pin_ = MemoryPin();
-    view_ = tt::stl::Span<std::byte>();
-    type_info_ = nullptr;
-    is_borrowed_ = false;
-}
 
 bool operator==(const HostBuffer& a, const HostBuffer& b) noexcept {
     auto a_view = a.view_bytes();

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -91,15 +91,4 @@ void DistributedHostBuffer::apply(const ApplyFn& fn) {
     }
 }
 
-bool DistributedHostBuffer::is_allocated() const {
-    return std::all_of(
-        local_buffers_.begin(), local_buffers_.end(), [](const HostBuffer& b) { return b.is_allocated(); });
-}
-
-void DistributedHostBuffer::deallocate() {
-    for (auto& buffer : local_buffers_) {
-        buffer.deallocate();
-    }
-}
-
 }  // namespace tt::tt_metal

--- a/ttnn/core/async_runtime.cpp
+++ b/ttnn/core/async_runtime.cpp
@@ -21,11 +21,9 @@ void write_buffer(
             tt::tt_metal::memcpy(cq, device_tensors[i], src.at(i).get(), region);
         }
     } else {
-        for (const auto worker : dst.get_workers()) {
-            auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(worker->id());
-            auto shard = tt::tt_metal::get_shard_for_device(dst, worker);
-            tt::tt_metal::memcpy(worker->command_queue(*cq_id), shard, src_for_device.get(), region);
-        }
+        auto* dst_device = dst.device();
+        auto src_for_device = (src.size() == 1) ? src.at(0) : src.at(dst_device->id());
+        tt::tt_metal::memcpy(dst_device->command_queue(*cq_id), dst, src_for_device.get(), region);
     }
 }
 
@@ -44,11 +42,9 @@ void read_buffer(
             tt::tt_metal::memcpy(cq, dst.at(i).get(), device_tensors[i], region);
         }
     } else {
-        for (const auto worker : src.get_workers()) {
-            auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(worker->id());
-            const auto& shard = tt::tt_metal::get_shard_for_device(src, worker);
-            tt::tt_metal::memcpy(worker->command_queue(*cq_id), dst_for_device.get(), shard, region, blocking);
-        }
+        auto* src_device = src.device();
+        auto dst_for_device = (dst.size() == 1) ? dst.at(0) : dst.at(src_device->id());
+        tt::tt_metal::memcpy(src_device->command_queue(*cq_id), dst_for_device.get(), src, region, blocking);
     }
 }
 

--- a/ttnn/core/run_operation.cpp
+++ b/ttnn/core/run_operation.cpp
@@ -25,14 +25,13 @@ namespace detail {
 
 IDevice* get_device(const Tensors& input_tensors, const OptionalConstTensors& optional_input_tensors) {
     for (auto& input_tensor : input_tensors) {
-        if (std::holds_alternative<DeviceStorage>(input_tensor.tensor_attributes->get_storage())) {
-            return input_tensor.workers.at(0);
+        if (input_tensor.storage_type() == StorageType::DEVICE) {
+            return input_tensor.device_storage().get_device();
         }
     }
     for (auto& optional_input_tensor : optional_input_tensors) {
-        if (optional_input_tensor.has_value() and
-            std::holds_alternative<DeviceStorage>(optional_input_tensor.value().tensor_attributes->get_storage())) {
-            return optional_input_tensor.value().workers.at(0);
+        if (optional_input_tensor.has_value() and optional_input_tensor->storage_type() == StorageType::DEVICE) {
+            return optional_input_tensor->device_storage().get_device();
         }
     }
     auto device = ttnn::operations::experimental::auto_format::AutoFormat::GetDefaultDevice();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.cpp
@@ -43,7 +43,7 @@ ttnn::Tensor ExecuteAllReduceAsync::invoke(
     const std::optional<size_t> num_preferred_links,
     std::optional<tt::tt_metal::SubDeviceId> worker_subdevice_id_opt) {
     MemoryConfig out_memory_config = memory_config.value_or(input_tensor.memory_config());
-    uint32_t dim = find_scatter_dim(input_tensor.get_padded_shape(), input_tensor.get_workers().size());
+    uint32_t dim = find_scatter_dim(input_tensor.get_padded_shape(), input_tensor.active_physical_devices().size());
     ttnn::Tensor scattered_tensor = ttnn::operations::experimental::ccl::reduce_scatter(
         input_tensor,
         dim,

--- a/ttnn/cpp/ttnn/tensor/storage.cpp
+++ b/ttnn/cpp/ttnn/tensor/storage.cpp
@@ -86,14 +86,4 @@ TensorSpec MultiDeviceHostStorage::get_tensor_spec(int spec_index) const {
 
 size_t MultiDeviceHostStorage::num_buffers() const { return buffers_.size(); }
 
-bool MultiDeviceHostStorage::is_allocated() const {
-    return std::all_of(buffers_.begin(), buffers_.end(), [](auto&& buffer) { return buffer.is_allocated(); });
-}
-
-void MultiDeviceHostStorage::deallocate() {
-    for (auto& buffer : buffers_) {
-        buffer.deallocate();
-    }
-}
-
 }  // namespace tt::tt_metal

--- a/ttnn/cpp/ttnn/tensor/storage.hpp
+++ b/ttnn/cpp/ttnn/tensor/storage.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/host_buffer.hpp>
+#include <tuple>
 
 #include "tt-metalium/distributed_host_buffer.hpp"
 #include "ttnn/tensor/types.hpp"
@@ -21,8 +22,6 @@ struct HostStorage {
 
     static constexpr auto attribute_names = std::forward_as_tuple();
     auto attribute_values() const { return std::forward_as_tuple(); }
-
-    bool is_allocated() const { return buffer.is_allocated(); }
 };
 
 struct DeviceStorage {
@@ -71,12 +70,6 @@ public:
 
     // Returns the number of `HostBuffer`s in the storage;
     size_t num_buffers() const;
-
-    // Returns true if all `HostBuffer`s are allocated;
-    bool is_allocated() const;
-
-    // Deallocates all `HostBuffer`s;
-    void deallocate();
 
 private:
     std::vector<HostBuffer> buffers_;

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -94,24 +94,15 @@ void Tensor::init(Storage storage, TensorSpec tensor_spec, DistributedTensorConf
     tensor_attributes = std::make_shared<TensorAttributes>(
         std::move(storage), std::move(tensor_spec), std::move(distributed_tensor_config));
 
-    ZoneScoped;
-    std::visit(
-        [&](auto&& storage) {
-            using StorageType = std::decay_t<decltype(storage)>;
-            if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
-                if (storage.mesh_buffer != nullptr) {
-                    mesh_device_ = storage.mesh_buffer->device();
-                }
-                workers = {storage.get_device()};
-            }
-        },
-        tensor_attributes->get_storage());
+    if (auto* device_storage = std::get_if<DeviceStorage>(&tensor_attributes->get_storage());
+        device_storage != nullptr && device_storage->mesh_buffer != nullptr) {
+        mesh_device_ = device_storage->mesh_buffer->device();
+    }
 }
 
 Tensor& Tensor::operator=(const Tensor& other) {
     this->tensor_id = other.tensor_id;
     if (this->tensor_attributes != other.tensor_attributes) {
-        this->workers = other.workers;
         this->tensor_attributes = other.tensor_attributes;
     }
     this->mesh_device_ = other.mesh_device_;
@@ -121,15 +112,13 @@ Tensor& Tensor::operator=(const Tensor& other) {
 Tensor& Tensor::operator=(Tensor&& other) noexcept {
     this->tensor_id = std::move(other.tensor_id);
     if (this->tensor_attributes != other.tensor_attributes) {
-        this->workers = std::move(other.workers);
         this->tensor_attributes = std::move(other.tensor_attributes);
     }
     this->mesh_device_ = std::move(other.mesh_device_);
     return *this;
 }
 
-Tensor::Tensor(const Tensor& other) :
-    tensor_id(other.tensor_id), workers(other.workers), tensor_attributes(other.tensor_attributes) {
+Tensor::Tensor(const Tensor& other) : tensor_id(other.tensor_id), tensor_attributes(other.tensor_attributes) {
     this->mesh_device_ = other.mesh_device_;
 }
 
@@ -166,34 +155,6 @@ void Tensor::deallocate_impl(bool force) {
             this->tensor_attributes->get_storage());
     }
     // GraphTracker::instance().track_function_end();
-}
-
-std::vector<IDevice*> Tensor::get_workers(bool blocking) const {
-    ZoneScoped;
-    // Initialize an empty worker vector (remains empty for host side storage)
-    std::vector<IDevice*> workers = {};
-
-    std::visit(
-        [this, blocking, &workers](auto&& storage) {
-            using StorageType = std::decay_t<decltype(storage)>;
-            // Assign workers only to device tensors
-            if constexpr (std::is_same_v<StorageType, DeviceStorage>) {
-                // Either explictly syncing or workers are pre-populated (this will happen for device tensors if using
-                // the correct APIs).
-                TT_FATAL(
-                    blocking or (this->workers.size() == 1),
-                    "Worker Handles for tensor must be populated or blocking = true must be set in get_workers().");
-                if (this->workers.size() != 1) {
-                    // Not populated - sync.
-                    workers = std::vector<IDevice*>{this->device()};
-                } else {
-                    // Already populated.
-                    workers = this->workers;
-                }
-            }
-        },
-        this->tensor_attributes->get_storage());
-    return workers;
 }
 
 DataType Tensor::get_dtype() const { return dtype(); }
@@ -701,9 +662,7 @@ Tensor allocate_tensor_on_mesh(const TensorSpec& tensor_spec, distributed::MeshD
 }
 
 void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id) {
-    // Top level wrapper to copy a host tensor to a preallocated device tensor
-    TT_ASSERT(device_tensor.workers.size(), "Workers must be specified for device_tensor in write_tensor");
-
+    TT_FATAL(device_tensor.storage_type() == StorageType::DEVICE, "Destination tensor must be on device");
     TT_FATAL(
         host_tensor.storage_type() == StorageType::HOST or host_tensor.storage_type() == StorageType::MULTI_DEVICE_HOST,
         "write_tensor only supports host_tensor to device_tensor data transfer");
@@ -714,41 +673,36 @@ void write_tensor(const Tensor& host_tensor, Tensor device_tensor, QueueId cq_id
         return;
     }
 
-    for (int worker_index = 0; worker_index < device_tensor.workers.size(); ++worker_index) {
-        TT_FATAL(
-            device_tensor.storage_type() == StorageType::DEVICE,
-            "write_tensor only supports host_tensor to device_tensor data transfer");
-        TT_FATAL(host_tensor.get_logical_shape() == device_tensor.get_logical_shape(), "Error");
-        TT_FATAL(host_tensor.get_dtype() == device_tensor.get_dtype(), "Error");
-        TT_FATAL(host_tensor.get_tensor_spec().page_config() == device_tensor.get_tensor_spec().page_config(), "Error");
-        std::visit(
-            tt::stl::overloaded{
-                [cq_id, &host_tensor, &device_tensor](const DeviceStorage& device_storage) {
-                    // Copying from host to a single device.
-                    const void* host_data = std::visit(
-                        tt::stl::overloaded{
-                            [](const HostStorage& host_storage) -> const void* {
-                                return host_storage.buffer.view_bytes().data();
-                            },
-                            [](const MultiDeviceHostStorage& host_storage) -> const void* {
-                                TT_ASSERT(
-                                    host_storage.num_buffers() == 1,
-                                    "Cannot copy multi-buffer host storage to a single device");
-                                auto buffer = host_storage.get_buffer(0);
-                                return buffer.view_bytes().data();
-                            },
-                            [](auto&&) -> const void* { TT_THROW("Unreachable"); },
+    TT_FATAL(host_tensor.get_logical_shape() == device_tensor.get_logical_shape(), "Error");
+    TT_FATAL(host_tensor.get_dtype() == device_tensor.get_dtype(), "Error");
+    TT_FATAL(host_tensor.get_tensor_spec().page_config() == device_tensor.get_tensor_spec().page_config(), "Error");
+    std::visit(
+        tt::stl::overloaded{
+            [cq_id, &host_tensor, &device_tensor](const DeviceStorage& device_storage) {
+                // Copying from host to a single device.
+                const void* host_data = std::visit(
+                    tt::stl::overloaded{
+                        [](const HostStorage& host_storage) -> const void* {
+                            return host_storage.buffer.view_bytes().data();
                         },
-                        host_tensor.get_storage());
-                    if (auto mesh_device = device_tensor.mesh_device()) {
-                        tt::tt_metal::memcpy(mesh_device->mesh_command_queue(*cq_id), device_tensor, host_data);
-                    } else {
-                        tt::tt_metal::memcpy(device_tensor.device()->command_queue(*cq_id), device_tensor, host_data);
-                    }
-                },
-                [](auto&& s) { TT_THROW("Unreachable"); }},
-            device_tensor.get_storage());
-    }
+                        [](const MultiDeviceHostStorage& host_storage) -> const void* {
+                            TT_ASSERT(
+                                host_storage.num_buffers() == 1,
+                                "Cannot copy multi-buffer host storage to a single device");
+                            auto buffer = host_storage.get_buffer(0);
+                            return buffer.view_bytes().data();
+                        },
+                        [](auto&&) -> const void* { TT_THROW("Unreachable"); },
+                    },
+                    host_tensor.get_storage());
+                if (auto mesh_device = device_tensor.mesh_device()) {
+                    tt::tt_metal::memcpy(mesh_device->mesh_command_queue(*cq_id), device_tensor, host_data);
+                } else {
+                    tt::tt_metal::memcpy(device_tensor.device()->command_queue(*cq_id), device_tensor, host_data);
+                }
+            },
+            [](auto&& s) { TT_THROW("Unreachable"); }},
+        device_tensor.get_storage());
 }
 
 std::vector<IDevice*> Tensor::active_physical_devices() const {

--- a/ttnn/cpp/ttnn/tensor/tensor.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.cpp
@@ -488,7 +488,8 @@ bool Tensor::is_allocated() const {
     auto output = std::visit(
         tt::stl::overloaded{
             [](const DeviceStorage& storage) { return storage.is_allocated(); },
-            [](const auto&) { return true; },
+            [](const HostStorage&) { return true; },
+            [](const MultiDeviceHostStorage&) { return true; },
         },
         this->get_storage());
     return output;

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -46,9 +46,10 @@ public:
     // Can be safely passed between threads when the tensor is copied
     std::shared_ptr<TensorAttributes> tensor_attributes = nullptr;
 
-    // Tensor gets worker queue handle through the device
+    // Shorthand for checking if this Tensor is allocated on MeshDevice. If set, is never nullptr.
+    // If not set, the tensor can either be on host or allocated on a single device.
+    // TODO: #21099 - This won't be needed after the migration to MeshDevice is complete.
     std::optional<distributed::MeshDevice*> mesh_device_ = std::nullopt;
-    std::vector<IDevice*> workers = {};
 
     // ======================================================================================
     //                                  Hi Level APIs
@@ -170,8 +171,6 @@ public:
     // If the tensor is on host, does nothing.
     void deallocate(bool force = false);
 
-    std::vector<IDevice*> get_workers(bool blocking = false) const;
-
     Tensor extract_shard(const CoreCoord& core) const;
     Tensor extract_shard(const uint32_t& core_id) const;
 
@@ -234,6 +233,8 @@ public:
     // TODO: #21099 - Remove the overload `mesh_device()`, and instead use `device()`.
     distributed::MeshDevice* mesh_device() const;
 
+    // Returns the device the tensor is allocated on.
+    // Throws if the tensor is not allocated on a device.
     IDevice* device() const;
 
     std::vector<IDevice*> active_physical_devices() const;

--- a/ttnn/cpp/ttnn/tensor/tensor.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor.hpp
@@ -166,6 +166,8 @@ public:
     std::string write_to_string() const;
     void print() const;
 
+    // Deallocates device-side Tensor storage.
+    // If the tensor is on host, does nothing.
     void deallocate(bool force = false);
 
     std::vector<IDevice*> get_workers(bool blocking = false) const;

--- a/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_impl.cpp
@@ -502,10 +502,10 @@ std::string to_string<bfloat4_b>(
 
 template <typename T>
 Tensor to_host_helper(const Tensor& tensor, bool blocking = true, ttnn::QueueId cq_id = ttnn::DefaultQueueId) {
-    TT_ASSERT(tensor.is_allocated(), "Buffer must be allocated on device!");
+    TT_FATAL(tensor.is_allocated(), "Buffer must be allocated on device!");
     auto device_buffer = tensor.buffer();
     auto device = tensor.device();
-    TT_ASSERT(device != nullptr && "Need device to be set copy data from device to host!");
+    TT_FATAL(device != nullptr, "Need device to be set copy data from device to host!");
     uint32_t size_in_bytes = device_buffer->size();
     std::vector<T> data_vec;
     const char* TT_METAL_SLOW_DISPATCH_MODE = std::getenv("TT_METAL_SLOW_DISPATCH_MODE");
@@ -547,7 +547,7 @@ Tensor to_host<bfloat8_b>(const Tensor& tensor, bool blocking, ttnn::QueueId cq_
 
 template <typename T>
 Tensor to_host_mesh_tensor(const Tensor& tensor, bool blocking, ttnn::QueueId cq_id) {
-    TT_ASSERT(tensor.is_allocated(), "Buffer must be allocated on device!");
+    TT_FATAL(tensor.is_allocated(), "Buffer must be allocated on device!");
     const auto& storage = std::get<DeviceStorage>(tensor.get_storage());
     const auto& mesh_buffer = storage.mesh_buffer;
     ttnn::MeshDevice* device = mesh_buffer->device();
@@ -687,7 +687,6 @@ Tensor to_device(const Tensor& tensor, IDevice* target_device, const MemoryConfi
     }
     TT_FATAL(tensor.storage_type() != StorageType::DEVICE, "Tensor is already on device!");
     TT_FATAL(target_device != nullptr, "Need target device in order to move tensor to device!");
-    TT_FATAL(tensor.is_allocated(), "Need data to exist in order to move it to device");
 
     TensorSpec tensor_spec(
         tensor.get_logical_shape(), tensor.get_tensor_spec().tensor_layout().with_memory_config(memory_config));
@@ -832,7 +831,6 @@ Tensor to_device_mesh_tensor(
     }
 
     TT_FATAL(mesh_device != nullptr, "Need target device in order to move tensor to device!");
-    TT_FATAL(tensor.is_allocated(), "Need data to exist in order to move it to device");
 
     TensorSpec tensor_spec(
         tensor.get_logical_shape(), tensor.get_tensor_spec().tensor_layout().with_memory_config(memory_config));
@@ -847,7 +845,7 @@ template <typename T>
 void copy_to_mesh_tensor(const Tensor& host_tensor, Tensor& mesh_tensor, ttnn::QueueId cq_id) {
     TT_FATAL(host_tensor.storage_type() != StorageType::DEVICE, "Host tensor is on device.");
     TT_FATAL(mesh_tensor.storage_type() == StorageType::DEVICE, "Mesh tensor is not on device.");
-    TT_FATAL(mesh_tensor.is_allocated(), "Need data to exist in order to move it to device");
+    TT_FATAL(mesh_tensor.is_allocated(), "Buffer must be allocated on device.");
 
     TT_FATAL(host_tensor.get_logical_shape() == mesh_tensor.get_logical_shape(), "Host tensor has different shape");
     TT_FATAL(host_tensor.get_dtype() == mesh_tensor.get_dtype(), "Host tensor has different dtype");

--- a/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_ops.cpp
@@ -73,17 +73,6 @@ Tensor tensor_cpu(const Tensor& input_tensor, bool blocking, QueueId cq_id) {
         return output;
     }
 
-    auto workers = input_tensor.get_workers(blocking);
-    if (not workers.size()) {
-        // Tensor is on host and does not have a worker group.
-        // Return immediately. If this is a result of .cpu() called twice,
-        // tensor accessors will stall until tensor is populated.
-        auto output = tt::tt_metal::set_tensor_id(input_tensor);
-        GraphTracker::instance().track_function_end(output);
-        return output;
-    }
-
-    TT_FATAL(workers.size() == 1, "Unexpected number of workers");
     Tensor host_tensor = tensor_impl::to_host_wrapper(input_tensor, blocking, cq_id);
     host_tensor = tt::tt_metal::set_tensor_id(host_tensor);
     GraphTracker::instance().track_function_end(host_tensor);

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.cpp
@@ -128,20 +128,6 @@ void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& calla
     }
 }
 
-Tensor get_shard_for_device(const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index) {
-    ZoneScopedN("GetShardForDevice");
-    auto& storage = tensor.tensor_attributes->get_storage();
-    return std::visit(
-        tt::stl::overloaded{
-            [buffer_index](const MultiDeviceHostStorage& s) {
-                return Tensor{s.get_buffer(buffer_index.value()), s.get_tensor_spec(buffer_index.value())};
-            },
-            [&tensor](const HostStorage& s) { return tensor; },
-            [&tensor](const DeviceStorage& s) { return tensor; },
-        },
-        storage);
-}
-
 ShardDivisionSpec compute_shard_division_spec(const Shape2D& shape, const Shape2D& shard_shape) {
     const auto num_shards_height = tt::div_up(shape.height(), shard_shape.height());
     const auto last_shard_height =

--- a/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/cpp/ttnn/tensor/tensor_utils.hpp
@@ -50,12 +50,6 @@ Tensor transform(const Tensor& tensor, const std::function<Tensor(const Tensor&)
 // Given a multi-device host tensor and a callable, applies the function to all per-device tensors.
 void apply(const Tensor& tensor, const std::function<void(const Tensor&)>& callable);
 
-// This function is used in legacy context of launching per-device work via push_work threads.
-// This won't be supported. In the long-term, tensor shards for Device tensors should be referred to using
-// `MeshCoordinate`.
-[[deprecated]] Tensor get_shard_for_device(
-    const Tensor& tensor, IDevice* target_device, std::optional<int> buffer_index = std::nullopt);
-
 template <class T>
 uint32_t get_batch_size(const T& shape) {
     uint32_t result = 1;


### PR DESCRIPTION
Revert https://github.com/tenstorrent/tt-metal/commit/0176b3bea0d4d4f0d296d73870e545a69c48a551

The commit was reverted due to an unrelated issue in the parent commit.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes