### PR TITLE
#21161: Add support for fabric to launch kernels for intermesh routing

### DIFF
--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -56,6 +56,8 @@ public:
 
     stl::Span<const chip_id_t> get_intra_chip_neighbors(
         mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;
+    std::unordered_map<mesh_id_t, std::vector<chip_id_t>> get_chip_neighbors(
+        mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;
 
     routing_plane_id_t get_routing_plane_id(chan_id_t eth_chan_id) const;
 

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -57,7 +57,7 @@ void append_fabric_connection_rt_args(
     const auto& fabric_context = control_plane->get_fabric_context();
     auto topology = fabric_context.get_fabric_topology();
     bool is_2d_fabric = topology == Topology::Mesh;
-    if (is_2d_fabric) {
+    if (!is_2d_fabric) {
         TT_FATAL(
             src_mesh_id == dst_mesh_id,
             "Currently only the chips on the same mesh are supported for 1D fabric. Src mesh id: {}, Dst mesh id: {}",

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -16,26 +16,30 @@
 
 namespace tt::tt_fabric {
 
-bool FabricContext::check_for_wrap_around_mesh() const {
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {
-        // skip wrapping around mesh for TG since the corner chips connected to the gateway will be
-        // using that link to route dispatch or any other traffic
-        return false;
-    }
+std::unordered_map<mesh_id_t, bool> FabricContext::check_for_wrap_around_mesh() const {
+    std::unordered_map<mesh_id_t, bool> wrap_around_mesh;
 
     auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    auto mesh_id = control_plane->get_user_physical_mesh_ids()[0];
-
-    // we can wrap around mesh if the corner chip (logical chip 0) has exactly 2 connections
-    const uint32_t corner_chip_id = 0;
-    uint32_t corner_chip_connections = 0;
-    for (const auto& direction : FabricContext::routing_directions) {
-        if (!control_plane->get_intra_chip_neighbors(mesh_id, corner_chip_id, direction).empty()) {
-            corner_chip_connections++;
+    auto mesh_ids = control_plane->get_user_physical_mesh_ids();
+    for (const auto& mesh_id : mesh_ids) {
+        if (tt::tt_metal::MetalContext::instance().get_cluster().get_cluster_type() == tt::ClusterType::TG) {
+            // skip wrapping around mesh for TG since the corner chips connected to the gateway will be
+            // using that link to route dispatch or any other traffic
+            wrap_around_mesh[mesh_id] = false;
+            continue;
         }
-    }
+        // we can wrap around mesh if the corner chip (logical chip 0) has exactly 2 connections
+        const uint32_t corner_chip_id = 0;
+        uint32_t corner_chip_connections = 0;
+        for (const auto& direction : FabricContext::routing_directions) {
+            if (!control_plane->get_intra_chip_neighbors(mesh_id, corner_chip_id, direction).empty()) {
+                corner_chip_connections++;
+            }
+        }
 
-    return (corner_chip_connections == 2);
+        wrap_around_mesh[mesh_id] = (corner_chip_connections == 2);
+    }
+    return wrap_around_mesh;
 }
 
 tt::tt_fabric::Topology FabricContext::get_topology() const {
@@ -91,7 +95,11 @@ FabricContext::FabricContext(tt::tt_metal::FabricConfig fabric_config) {
     }
 }
 
-bool FabricContext::is_wrap_around_mesh() const { return this->wrap_around_mesh_; }
+bool FabricContext::is_wrap_around_mesh(mesh_id_t mesh_id) const {
+    auto it = this->wrap_around_mesh_.find(mesh_id);
+    TT_FATAL(it != this->wrap_around_mesh_.end(), "Querying wrap around mesh for an unknown mesh id");
+    return it->second;
+}
 
 tt::tt_fabric::Topology FabricContext::get_fabric_topology() const { return this->topology_; }
 

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -22,7 +22,7 @@ public:
     explicit FabricContext(tt::tt_metal::FabricConfig fabric_config);
     ~FabricContext() = default;
 
-    bool is_wrap_around_mesh() const;
+    bool is_wrap_around_mesh(mesh_id_t mesh_id) const;
 
     tt::tt_fabric::Topology get_fabric_topology() const;
 
@@ -47,7 +47,7 @@ public:
     std::pair<uint32_t, uint32_t> get_fabric_router_termination_address_and_signal() const;
 
 private:
-    bool check_for_wrap_around_mesh() const;
+    std::unordered_map<mesh_id_t, bool> check_for_wrap_around_mesh() const;
     tt::tt_fabric::Topology get_topology() const;
     size_t get_packet_header_size_bytes() const;
     size_t get_max_payload_size_bytes() const;
@@ -55,7 +55,7 @@ private:
     bool initialized_ = false;
     tt::tt_metal::FabricConfig fabric_config_{};
 
-    bool wrap_around_mesh_ = false;
+    std::unordered_map<mesh_id_t, bool> wrap_around_mesh_;
     tt::tt_fabric::Topology topology_{};
     size_t packet_header_size_bytes_ = 0;
     size_t max_payload_size_bytes_ = 0;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1092,6 +1092,7 @@ void build_tt_fabric_program(
 
     std::unordered_map<RoutingDirection, std::set<chan_id_t>> active_fabric_eth_channels;
     std::unordered_map<RoutingDirection, chip_id_t> chip_neighbors;
+    uint32_t num_intra_chip_neighbors = 0;
 
     for (const auto& direction : tt::tt_fabric::FabricContext::routing_directions) {
         auto active_eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
@@ -1099,24 +1100,21 @@ void build_tt_fabric_program(
         if (active_eth_chans.empty()) {
             continue;
         }
-
-        auto neighbors = control_plane->get_intra_chip_neighbors(mesh_chip_id.first, mesh_chip_id.second, direction);
-        if (!neighbors.empty()) {
-            // assume same neighbor per direction
-            std::pair<mesh_id_t, chip_id_t> neighbor_mesh_chip_id = {mesh_chip_id.first, neighbors[0]};
-            chip_neighbors[direction] = control_plane->get_physical_chip_id_from_mesh_chip_id(neighbor_mesh_chip_id);
-        } else if (neighbors.empty() && is_TG) {
-            // if active eth channels are found but no neighbor on the same mesh, then the neighbor should be the
-            // gateway
-            TT_FATAL(
-                active_eth_chans.size() == 1, "Found more than one active eth link b/w mmio and remote chip on TG");
-            auto neighbor_chip_id =
-                tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device->id());
-            TT_FATAL(device->id() != neighbor_chip_id, "Remote and mmio chip id shouldnt be the same");
-            chip_neighbors[direction] = neighbor_chip_id;
-        } else {
-            continue;
+        auto neighbors = control_plane->get_chip_neighbors(mesh_chip_id.first, mesh_chip_id.second, direction);
+        auto intra_chip_neighbors = neighbors.find(mesh_chip_id.first);
+        if (intra_chip_neighbors != neighbors.end()) {
+            num_intra_chip_neighbors += intra_chip_neighbors->second.size();
         }
+        TT_FATAL(!neighbors.empty(), "No neighbors found for direction {} but has active eth channels", direction);
+
+        // assume same neighbor per direction
+        TT_FATAL(neighbors.size() == 1, "Multiple neighbor meshes per direction is unsupported");
+        TT_FATAL(
+            std::set<chip_id_t>(neighbors.begin()->second.begin(), neighbors.begin()->second.end()).size() == 1,
+            "Multiple neighbors per direction is currently unsupported");
+        std::pair<mesh_id_t, chip_id_t> neighbor_mesh_chip_id = {
+            neighbors.begin()->first, neighbors.begin()->second[0]};
+        chip_neighbors[direction] = control_plane->get_physical_chip_id_from_mesh_chip_id(neighbor_mesh_chip_id);
 
         active_fabric_eth_channels.insert({direction, active_eth_chans});
     }
@@ -1126,17 +1124,16 @@ void build_tt_fabric_program(
         return;
     }
 
-    const bool wrap_around_mesh = fabric_context.is_wrap_around_mesh();
+    const bool wrap_around_mesh = fabric_context.is_wrap_around_mesh(mesh_chip_id.first);
     const auto topology = fabric_context.get_fabric_topology();
 
-    for (const auto& [direction, remote_chip_id] : chip_neighbors) {
-        bool is_dateline = check_dateline(
-            *control_plane,
-            topology,
-            mesh_chip_id.first,
-            mesh_chip_id.second,
-            control_plane->get_mesh_chip_id_from_physical_chip_id(remote_chip_id).second,
-            wrap_around_mesh);
+    for (const auto& [direction, remote_physical_chip_id] : chip_neighbors) {
+        auto [remote_mesh_id, remote_chip_id] =
+            control_plane->get_mesh_chip_id_from_physical_chip_id(remote_physical_chip_id);
+        bool is_dateline =
+            remote_mesh_id == mesh_chip_id.first &&
+            check_dateline(
+                *control_plane, topology, mesh_chip_id.first, mesh_chip_id.second, remote_chip_id, wrap_around_mesh);
 
         for (const auto& eth_chan : active_fabric_eth_channels[direction]) {
             auto eth_logical_core = soc_desc.get_eth_core_for_channel(eth_chan, CoordSystem::LOGICAL);
@@ -1145,7 +1142,7 @@ void build_tt_fabric_program(
                 *fabric_program_ptr,
                 eth_logical_core,
                 device->id(),
-                remote_chip_id,
+                remote_physical_chip_id,
                 edm_config,
                 true,  /* enable_persistent_mode */
                 false, /* build_in_worker_connection_mode */
@@ -1197,8 +1194,8 @@ void build_tt_fabric_program(
         }
     };
 
-    // if the wrap aroud mesh flag is set and this chip is a corner chip, fold the internal connections
-    if (wrap_around_mesh && chip_neighbors.size() == 2) {
+    // if the wrap around mesh flag is set and this chip is a corner chip, fold the internal connections
+    if (wrap_around_mesh && num_intra_chip_neighbors == 2) {
         auto it = chip_neighbors.begin();
         auto dir1 = it->first;
         it++;


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21161

### Problem description
Fabric did not support intermesh connections/routing.

### What's changed
Fix bug in control plane populating duplicate router connections for intermesh.
Add support for fabric to launch routers for intermesh routing.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15077260172
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [x] New/Existing tests provide coverage for changes
T3K Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15077263060
TG Unit: https://github.com/tenstorrent/tt-metal/actions/runs/15077272310