### PR TITLE
[tt-train] Fixing errors and lots of warnings in main

### DIFF
--- a/tt-train/sources/examples/linear_regression_ddp/main.cpp
+++ b/tt-train/sources/examples/linear_regression_ddp/main.cpp
@@ -86,7 +86,7 @@ int main() {
             optimizer.zero_grad();
             auto output = (*model)(data);
             auto loss = ttml::ops::mse_loss(output, targets);
-            fmt::print("Loss shape: {}\n", loss->get_value().get_logical_shape());
+            fmt::print("Loss shape: {}\n", loss->get_value().logical_shape());
             auto mesh_shape = device->shape();
             ttml::core::MeshToXTensorVariant<float> identity_composer =
                 ttml::core::VectorMeshToXTensor<float>(mesh_shape);

--- a/tt-train/sources/examples/nano_gpt/main.cpp
+++ b/tt-train/sources/examples/nano_gpt/main.cpp
@@ -74,7 +74,7 @@ uint64_t get_number_of_parameters(Model &model, bool enable_tp) {
     uint64_t num_params = 0;
     for (const auto &[name, tensor_ptr] : parameters) {
         auto tensor = tensor_ptr->get_value();
-        auto params_in_tensor = tensor.get_logical_volume();
+        auto params_in_tensor = tensor.logical_volume();
         if (enable_tp && (contains(name, "fc") || contains(name, "linear"))) {
             num_params += params_in_tensor * num_devices;
         } else {
@@ -837,7 +837,7 @@ int main(int argc, char **argv) {
             loss->backward();
             ttml::autograd::ctx().reset_graph();
 
-            auto samples = features->get_value().get_logical_shape()[0];
+            auto samples = features->get_value().logical_shape()[0];
             gradient_accumulator_helper.update(loss_float, samples);
 
             if (gradient_accumulator_helper.should_step()) {

--- a/tt-train/sources/examples/sample_app/main.cpp
+++ b/tt-train/sources/examples/sample_app/main.cpp
@@ -14,7 +14,7 @@ void print_tensor(const tt::tt_metal::Tensor& tensor) {
     // but we are using TILE layout. The printed format WILL NOT be correct. But good enough for a demo
 
     // Get the shape of the tensor
-    auto shape = tensor.get_logical_shape();
+    auto shape = tensor.logical_shape();
     // compyte the size of the tensor
     size_t size = 1;
     for (size_t i = 0; i < shape.size(); i++) size *= shape[i];

--- a/tt-train/sources/ttml/CMakeLists.txt
+++ b/tt-train/sources/ttml/CMakeLists.txt
@@ -74,6 +74,7 @@ if(NOT TARGET Metalium::Metal)
         "$ENV{TT_METAL_HOME}/tt_stl"
         # TTNN
         "$ENV{TT_METAL_HOME}/ttnn"
+        "$ENV{TT_METAL_HOME}/ttnn/api"
         "$ENV{TT_METAL_HOME}/ttnn/cpp"
         "$ENV{TT_METAL_HOME}/ttnn/cpp/ttnn/deprecated"
         "${reflect_SOURCE_DIR}"

--- a/tt-train/sources/ttml/autograd/autocast_tensor.cpp
+++ b/tt-train/sources/ttml/autograd/autocast_tensor.cpp
@@ -9,7 +9,7 @@
 namespace {
 
 inline bool is_castable_tensor(const tt::tt_metal::Tensor &tensor) {
-    return tensor.get_dtype() == ttnn::DataType::FLOAT32;
+    return tensor.dtype() == ttnn::DataType::FLOAT32;
 }
 
 }  // namespace
@@ -17,7 +17,7 @@ inline bool is_castable_tensor(const tt::tt_metal::Tensor &tensor) {
 namespace ttml::autograd {
 
 void AutocastTensor::set_tensor(const tt::tt_metal::Tensor &tensor) {
-    if (tensor.get_dtype() == ttnn::DataType::FLOAT32) {
+    if (tensor.dtype() == ttnn::DataType::FLOAT32) {
         m_full_precision_tensor = tensor;
         m_half_precision_tensor = ttnn::typecast(tensor, ttnn::DataType::BFLOAT16);
         return;

--- a/tt-train/sources/ttml/autograd/tensor.cpp
+++ b/tt-train/sources/ttml/autograd/tensor.cpp
@@ -34,18 +34,18 @@ Tensor::Tensor(const tt::tt_metal::Tensor& value, bool requires_grad) : m_value(
 
 void Tensor::add_grad(const tt::tt_metal::Tensor& grad) {
     if (!is_grad_initialized()) {
-        auto value_shape = m_value.get_tensor().get_logical_shape();
-        if (grad.get_logical_shape() != value_shape) {
+        auto value_shape = m_value.get_tensor().logical_shape();
+        if (grad.logical_shape() != value_shape) {
             throw std::logic_error(fmt::format(
-                "Shapes of gradients are not equal. Expected: {}, got: {}", value_shape, grad.get_logical_shape()));
+                "Shapes of gradients are not equal. Expected: {}, got: {}", value_shape, grad.logical_shape()));
         }
 
         m_grad = grad;
         return;
     }
 
-    const auto& grad_shape = grad.get_logical_shape();
-    const auto& m_grad_shape = m_grad.get_logical_shape();
+    const auto& grad_shape = grad.logical_shape();
+    const auto& m_grad_shape = m_grad.logical_shape();
     if (grad_shape != m_grad_shape) {
         throw std::logic_error(
             fmt::format("Shapes of gradients are not equal. Expected: {}, got: {}", m_grad_shape, grad_shape));
@@ -111,13 +111,13 @@ void Tensor::set_value(const tt::tt_metal::Tensor& value) {
 
 void Tensor::set_grad(const tt::tt_metal::Tensor& grad) {
     if (core::is_tensor_initialized(grad)) {
-        auto grad_shape = grad.get_logical_shape();
-        auto value_shape = m_value.get_tensor().get_logical_shape();
+        auto grad_shape = grad.logical_shape();
+        auto value_shape = m_value.get_tensor().logical_shape();
         if (grad_shape != value_shape) {
             throw std::logic_error(fmt::format(
                 "Shapes of gradients are not equal. Expected: {}, got: {}",
-                m_value.get_tensor().get_logical_shape(),
-                grad.get_logical_shape()));
+                m_value.get_tensor().logical_shape(),
+                grad.logical_shape()));
         }
     }
     m_grad = grad;
@@ -152,7 +152,7 @@ const std::optional<NodeId>& Tensor::get_node() const {
 }
 
 const ttnn::Shape& Tensor::get_shape() const {
-    return get_value().get_logical_shape();
+    return get_value().logical_shape();
 }
 
 uint32_t Tensor::get_rank() const {

--- a/tt-train/sources/ttml/core/tt_tensor_utils.cpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.cpp
@@ -31,7 +31,7 @@ T get_median(std::vector<T>& vec) {
 
 template <typename T>
 void print_tensor_stats_(const tt::tt_metal::Tensor& tensor, const std::string& name) {
-    auto tensor_shape = tensor.get_logical_shape();
+    auto tensor_shape = tensor.logical_shape();
     auto tensor_vec = tensor.to_vector<T>();
 
     auto median = get_median(tensor_vec);
@@ -107,18 +107,18 @@ std::vector<tt::tt_metal::HostBuffer> get_as(const ttnn::Tensor& tensor) {
                 throw std::runtime_error("Tensor must be on host");
             }
         },
-        tensor.get_storage());
+        tensor.storage());
 }
 
 }  // namespace
 namespace ttml::core {
 
 tt::tt_metal::Tensor zeros_like(const tt::tt_metal::Tensor& tensor) {
-    return ttnn::moreh_full_like(tensor, 0.F, tensor.get_dtype(), tensor.get_layout(), tensor.memory_config());
+    return ttnn::moreh_full_like(tensor, 0.F, tensor.dtype(), tensor.layout(), tensor.memory_config());
 }
 
 tt::tt_metal::Tensor ones_like(const tt::tt_metal::Tensor& tensor) {
-    return ttnn::moreh_full_like(tensor, 1.F, tensor.get_dtype(), tensor.get_layout(), tensor.memory_config());
+    return ttnn::moreh_full_like(tensor, 1.F, tensor.dtype(), tensor.layout(), tensor.memory_config());
 }
 
 tt::tt_metal::Tensor empty(
@@ -303,7 +303,7 @@ ttnn::Shape create_shape(const std::array<uint32_t, 4>& args) {
 }
 
 void print_tensor_stats(const tt::tt_metal::Tensor& tensor, const std::string& name) {
-    if (tensor.get_dtype() == ttnn::DataType::BFLOAT16 || tensor.get_dtype() == ttnn::DataType::FLOAT32) {
+    if (tensor.dtype() == ttnn::DataType::BFLOAT16 || tensor.dtype() == ttnn::DataType::FLOAT32) {
         print_tensor_stats_<float>(tensor, name);
     } else {
         print_tensor_stats_<uint32_t>(tensor, name);

--- a/tt-train/sources/ttml/core/tt_tensor_utils.hpp
+++ b/tt-train/sources/ttml/core/tt_tensor_utils.hpp
@@ -61,7 +61,7 @@ template <class T = float, ttnn::DataType TensorType = ttnn::DataType::BFLOAT16>
 template <class T = float>
 [[nodiscard]] xt::xarray<T> to_xtensor(const tt::tt_metal::Tensor& tensor) {
     auto vec = tensor.to_vector<T>();
-    const auto& shape = tensor.get_logical_shape();
+    const auto& shape = tensor.logical_shape();
     std::vector<size_t> shape_vec(shape.cbegin(), shape.cend());
     // adapt creates view of the vector, but return will copy this data anyway (by creation of xt::array)
     return xt::adapt(vec, shape_vec);

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_device_operation.cpp
@@ -39,18 +39,18 @@ void CrossEntropyForwardDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(tensor.buffer() != nullptr, "Tensor '{}' must be allocated on device (buffer is null).", name);
 
         TT_FATAL(
-            tensor.get_layout() == required_layout,
+            tensor.layout() == required_layout,
             "Tensor '{}' must have layout '{}', but got '{}'",
             name,
             magic_enum::enum_name(required_layout),
-            magic_enum::enum_name(tensor.get_layout()));
+            magic_enum::enum_name(tensor.layout()));
 
         TT_FATAL(
-            tensor.get_dtype() == required_dtype,
+            tensor.dtype() == required_dtype,
             "Tensor '{}' must have data type '{}', but got '{}'",
             name,
             magic_enum::enum_name(required_dtype),
-            magic_enum::enum_name(tensor.get_dtype()));
+            magic_enum::enum_name(tensor.dtype()));
 
         TT_FATAL(
             tensor.memory_config().memory_layout() == ttnn::TensorMemoryLayout::INTERLEAVED,
@@ -76,14 +76,14 @@ void CrossEntropyForwardDeviceOperation::validate_on_program_cache_miss(
 CrossEntropyForwardDeviceOperation::spec_return_value_t CrossEntropyForwardDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     if (tensor_args.preallocated_output.has_value()) {
-        return tensor_args.preallocated_output->get_tensor_spec();
+        return tensor_args.preallocated_output->tensor_spec();
     }
-    auto input_logical_shape = tensor_args.input.get_logical_shape();
+    auto input_logical_shape = tensor_args.input.logical_shape();
     input_logical_shape[-1] = 1U;
     return ttnn::TensorSpec(
         ttnn::Shape(input_logical_shape),
         tt::tt_metal::TensorLayout(
-            tensor_args.input.get_dtype(), tt::tt_metal::Layout::TILE, tensor_args.input.memory_config()));
+            tensor_args.input.dtype(), tt::tt_metal::Layout::TILE, tensor_args.input.memory_config()));
 }
 
 CrossEntropyForwardDeviceOperation::tensor_return_value_t CrossEntropyForwardDeviceOperation::create_output_tensors(
@@ -104,7 +104,7 @@ CrossEntropyForwardDeviceOperation::tensor_return_value_t CrossEntropyForwardDev
 tt::stl::hash::hash_t CrossEntropyForwardDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input_tensor = tensor_args.input;
-    const auto& input_logical_shape = input_tensor.get_logical_shape();
+    const auto& input_logical_shape = input_tensor.logical_shape();
     auto program_factory = select_program_factory(args, tensor_args);
     auto hash = tt::tt_metal::operation::hash_operation<CrossEntropyForwardDeviceOperation>(
         args, program_factory.index(), input_tensor.dtype(), input_logical_shape);

--- a/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/cross_entropy_fw/device/cross_entropy_fw_program_factory.cpp
@@ -211,14 +211,14 @@ CrossEntropyForwardProgramFactory::cached_program_t CrossEntropyForwardProgramFa
 
     tt::tt_metal::Program program{};
 
-    tt::DataFormat input_data_format = datatype_to_dataformat_converter(input.get_dtype());
+    tt::DataFormat input_data_format = datatype_to_dataformat_converter(input.dtype());
     TT_FATAL(input_data_format == tt::DataFormat::Float16_b, "Input data format must be Float16_b");
 
     uint32_t bfloat16_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
     uint32_t float32_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float32);
 
-    auto padded_tensor_shape = input.get_padded_shape();
-    auto padded_tensor_volume = input.volume();
+    auto padded_tensor_shape = input.padded_shape();
+    auto padded_tensor_volume = input.padded_volume();
 
     TT_FATAL(
         padded_tensor_volume % tt::constants::TILE_HW == 0, "Padded input tensor volume must be divisible by TILE_HW");
@@ -231,7 +231,7 @@ CrossEntropyForwardProgramFactory::cached_program_t CrossEntropyForwardProgramFa
     uint32_t total_rows_to_process = NC * Ht;
 
     // get size of target indexes inner dimension
-    uint32_t target_indexes_inner_dim_size = target.get_logical_shape()[-1] * target.element_size();
+    uint32_t target_indexes_inner_dim_size = target.logical_shape()[-1] * target.element_size();
     // read target indexes by pages(32 indexes in page)
     uint32_t uint32_read_page_size = tt::datum_size(tt::DataFormat::UInt32) * kPageElementsNumber;
 
@@ -241,7 +241,7 @@ CrossEntropyForwardProgramFactory::cached_program_t CrossEntropyForwardProgramFa
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
     // get the number of inner dimension
-    uint32_t num_inner = input.get_logical_shape()[-1];  // (N, 1, C, H)
+    uint32_t num_inner = input.logical_shape()[-1];  // (N, 1, C, H)
 
     // mask_w - this mask used to avoid calculation of extra data(data which will be added to create full tile 32x32)??
     uint32_t mask_w = num_inner % tt::constants::TILE_WIDTH;  // width index of first trash value in tile

--- a/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.cpp
@@ -210,14 +210,14 @@ RMSNormForwardProgramFactory::cached_program_t RMSNormForwardProgramFactory::cre
 
     tt::tt_metal::Program program{};
 
-    tt::DataFormat input_data_format = datatype_to_dataformat_converter(input.get_dtype());
+    tt::DataFormat input_data_format = datatype_to_dataformat_converter(input.dtype());
     TT_FATAL(input_data_format == tt::DataFormat::Float16_b, "Input data format must be Float16_b");
 
     uint32_t bfloat16_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float16_b);
     uint32_t float32_single_tile_size_bytes = tt::tt_metal::detail::TileSize(tt::DataFormat::Float32);
 
-    auto padded_tensor_shape = input.get_padded_shape();
-    auto padded_tensor_volume = input.volume();
+    auto padded_tensor_shape = input.padded_shape();
+    auto padded_tensor_volume = input.padded_volume();
     TT_FATAL(
         padded_tensor_volume % tt::constants::TILE_HW == 0, "Padded input tensor volume must be divisible by TILE_HW");
     TT_FATAL(padded_tensor_shape.rank() == 4U, "Input tensor must be 4D");
@@ -230,7 +230,7 @@ RMSNormForwardProgramFactory::cached_program_t RMSNormForwardProgramFactory::cre
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
-    uint32_t num_inner = input.get_logical_shape()[-1];
+    uint32_t num_inner = input.logical_shape()[-1];
 
     // compile arguments
     uint32_t packed_scaler = pack_two_bfloat16_to_uint32(1.F / static_cast<float>(num_inner));

--- a/tt-train/sources/ttml/models/common/transformer_common.cpp
+++ b/tt-train/sources/ttml/models/common/transformer_common.cpp
@@ -13,9 +13,9 @@ void initialize_weights_gpt2(autograd::ModuleBase& model) {
     for (auto& [name, tensor_ptr] : params) {
         const auto& tensor = tensor_ptr->get_value();
         if (name.find("weight") != std::string::npos) {
-            init::normal_init(tensor_ptr, tensor.get_logical_shape(), {0.F, 0.02F});
+            init::normal_init(tensor_ptr, tensor.logical_shape(), {0.F, 0.02F});
         } else if (name.find("bias") != std::string::npos) {
-            init::constant_init(tensor_ptr, tensor.get_logical_shape(), 0.F);
+            init::constant_init(tensor_ptr, tensor.logical_shape(), 0.F);
         }
     }
 }
@@ -27,11 +27,11 @@ void initialize_weights_he_kaiming_normal(autograd::ModuleBase& model) {
         if (name.find("weight") != std::string::npos) {
             auto mean = 0.0F;
             // take penultimate dimension as the input dim.
-            auto fan_in = tensor.get_logical_shape()[-2];
+            auto fan_in = tensor.logical_shape()[-2];
             auto stddev = std::sqrt(2.0F / fan_in);
-            init::normal_init(tensor_ptr, tensor.get_logical_shape(), {mean, stddev});
+            init::normal_init(tensor_ptr, tensor.logical_shape(), {mean, stddev});
         } else if (name.find("bias") != std::string::npos) {
-            init::constant_init(tensor_ptr, tensor.get_logical_shape(), 0.F);
+            init::constant_init(tensor_ptr, tensor.logical_shape(), 0.F);
         }
     }
 }

--- a/tt-train/sources/ttml/models/distributed/gpt2.cpp
+++ b/tt-train/sources/ttml/models/distributed/gpt2.cpp
@@ -28,7 +28,7 @@ void weights_initialization(DistributedTransformer& model) {
     for (auto& [name, tensor_ptr] : params) {
         const auto& tensor = tensor_ptr->get_value();
         if (name.find("weight") != std::string::npos) {
-            auto tensor_shape = tensor.get_logical_shape();
+            auto tensor_shape = tensor.logical_shape();
             auto* device = &autograd::ctx().get_device();
             auto num_devices = static_cast<uint32_t>(device->num_devices());
             tensor_shape[0] *= num_devices;
@@ -37,7 +37,7 @@ void weights_initialization(DistributedTransformer& model) {
             tensor_ptr->set_value(
                 core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight_xtensor, device, shard_composer));
         } else if (name.find("bias") != std::string::npos) {
-            init::constant_init(tensor_ptr, tensor.get_logical_shape(), 0.F);
+            init::constant_init(tensor_ptr, tensor.logical_shape(), 0.F);
         }
     }
 }

--- a/tt-train/sources/ttml/models/distributed/llama.cpp
+++ b/tt-train/sources/ttml/models/distributed/llama.cpp
@@ -23,7 +23,7 @@ void initialize_weights(DistributedLlama& model) {
     for (auto& [name, tensor_ptr] : params) {
         const auto& tensor = tensor_ptr->get_value();
         if (name.find("weight") != std::string::npos) {
-            auto tensor_shape = tensor.get_logical_shape();
+            auto tensor_shape = tensor.logical_shape();
             auto* device = &autograd::ctx().get_device();
             auto num_devices = static_cast<uint32_t>(device->num_devices());
             tensor_shape[0] *= num_devices;
@@ -32,7 +32,7 @@ void initialize_weights(DistributedLlama& model) {
             tensor_ptr->set_value(
                 core::from_xtensor<float, ttnn::DataType::BFLOAT16>(weight_xtensor, device, shard_composer));
         } else if (name.find("bias") != std::string::npos) {
-            init::constant_init(tensor_ptr, tensor.get_logical_shape(), 0.F);
+            init::constant_init(tensor_ptr, tensor.logical_shape(), 0.F);
         }
     }
 }

--- a/tt-train/sources/ttml/modules/embedding_module.cpp
+++ b/tt-train/sources/ttml/modules/embedding_module.cpp
@@ -37,7 +37,7 @@ Embedding::Embedding(uint32_t num_embeddings, uint32_t embedding_dim) {
 }
 
 autograd::TensorPtr Embedding::operator()(const autograd::TensorPtr& tensor) {
-    auto sentence_size = tensor->get_value().get_logical_shape()[-1];
+    auto sentence_size = tensor->get_value().logical_shape()[-1];
     if (sentence_size % TILE_HEIGHT != 0 || sentence_size % TILE_WIDTH != 0) {
         throw std::logic_error(fmt::format(
             "sentence_size must be a multiple of TILE_HEIGHT and TILE_WIDTH, current sentence_size {}", sentence_size));

--- a/tt-train/sources/ttml/modules/linear_module.cpp
+++ b/tt-train/sources/ttml/modules/linear_module.cpp
@@ -53,7 +53,7 @@ LinearLayer::LinearLayer(uint32_t in_features, uint32_t out_features, bool has_b
 
 LinearLayer::LinearLayer(const autograd::TensorPtr& weight, bool has_bias) : m_weight(weight) {
     if (has_bias) {
-        auto weight_shape = m_weight->get_value().get_logical_shape();
+        auto weight_shape = m_weight->get_value().logical_shape();
         uint32_t in_features = weight_shape[3];
         uint32_t out_features = weight_shape[2];
         m_bias = create_bias(in_features, out_features);

--- a/tt-train/sources/ttml/modules/lora_linear_module.cpp
+++ b/tt-train/sources/ttml/modules/lora_linear_module.cpp
@@ -85,7 +85,7 @@ LoRALinearLayer::LoRALinearLayer(const LoRALayerConfig& config, const autograd::
     m_weight(weight) {
     m_weight->set_requires_grad(false);
     m_scale = config.alpha / static_cast<float>(config.rank);
-    auto weight_shape = m_weight->get_value().get_logical_shape();
+    auto weight_shape = m_weight->get_value().logical_shape();
     uint32_t in_features = weight_shape[3];
     uint32_t out_features = weight_shape[2];
     m_lora_a = create_lora_a(config.rank, out_features);

--- a/tt-train/sources/ttml/modules/positional_embeddings.cpp
+++ b/tt-train/sources/ttml/modules/positional_embeddings.cpp
@@ -49,7 +49,7 @@ PositionalEmbedding::PositionalEmbedding(const PositionalEmbeddingConfig& config
 
 autograd::TensorPtr PositionalEmbedding::operator()(const autograd::TensorPtr& input) {
     auto input_tensor = input->get_value();
-    auto input_shape = input_tensor.get_logical_shape();
+    auto input_shape = input_tensor.logical_shape();
     if (input_shape.rank() != 4) {
         throw std::runtime_error(
             "PositionalEmbedding: input tensor must have 4 dimensions. Got rank " + std::to_string(input_shape.rank()));
@@ -87,7 +87,7 @@ TrainablePositionalEmbedding::TrainablePositionalEmbedding(const PositionalEmbed
 
 autograd::TensorPtr TrainablePositionalEmbedding::operator()(const autograd::TensorPtr& input) {
     auto input_tensor = input->get_value();
-    auto input_shape = input_tensor.get_logical_shape();
+    auto input_shape = input_tensor.logical_shape();
     if (input_shape.rank() != 4) {
         throw std::runtime_error(
             "TrainablePositionalEmbedding: input tensor must have 4 dimensions. Got rank " +

--- a/tt-train/sources/ttml/ops/binary_ops.cpp
+++ b/tt-train/sources/ttml/ops/binary_ops.cpp
@@ -25,8 +25,8 @@ namespace ttml::ops {
 namespace {
 
 bool was_broadcasted(const autograd::TensorPtr& input, const ttnn::Tensor& grad) {
-    auto input_shape = input->get_value().get_logical_shape();
-    auto grad_shape = grad.get_logical_shape();
+    auto input_shape = input->get_value().logical_shape();
+    auto grad_shape = grad.logical_shape();
     if (input_shape.rank() != grad_shape.rank()) {
         return false;
     }
@@ -42,8 +42,8 @@ bool was_broadcasted(const autograd::TensorPtr& input, const ttnn::Tensor& grad)
 
 ttnn::SmallVector<int64_t> get_broadcast_dimensions(const autograd::TensorPtr& input, const ttnn::Tensor& grad) {
     ttnn::SmallVector<int64_t> broadcast_dims;
-    auto input_shape = input->get_value().get_logical_shape();
-    auto grad_shape = grad.get_logical_shape();
+    auto input_shape = input->get_value().logical_shape();
+    auto grad_shape = grad.logical_shape();
     for (size_t i = 0; i < input_shape.size(); ++i) {
         if (input_shape[i] != grad_shape[i]) {
             broadcast_dims.push_back(static_cast<int64_t>(i));

--- a/tt-train/sources/ttml/ops/embedding_op.cpp
+++ b/tt-train/sources/ttml/ops/embedding_op.cpp
@@ -19,7 +19,7 @@ autograd::TensorPtr embedding_op(const autograd::TensorPtr& tensor, const autogr
 
     auto embeddings =
         ttnn::embedding(tensor->get_value(), weight_tensor, /* pad_token */ std::nullopt, ttnn::Layout::TILE);
-    auto embeddings_shape = embeddings.get_logical_shape();
+    auto embeddings_shape = embeddings.logical_shape();
     auto batch_size = embeddings_shape[0];
     auto sentence_size = embeddings_shape[1];
     auto embedding_dim = embeddings_shape[2];
@@ -28,9 +28,9 @@ autograd::TensorPtr embedding_op(const autograd::TensorPtr& tensor, const autogr
 
     autograd::GradFunction grad = [tensor, weight, out]() {
         auto out_grad = out->get_grad();
-        auto tensor_shape = tensor->get_value().get_logical_shape();
+        auto tensor_shape = tensor->get_value().logical_shape();
         out_grad = ttnn::reshape(
-            out_grad, core::create_shape({1, 1, tensor_shape[0] * tensor_shape[-1], out_grad.get_logical_shape()[-1]}));
+            out_grad, core::create_shape({1, 1, tensor_shape[0] * tensor_shape[-1], out_grad.logical_shape()[-1]}));
         auto weight_grad = ttnn::embedding_bw(tensor->get_value(), weight->get_value(), out_grad);
         weight->add_grad(weight_grad);
     };

--- a/tt-train/sources/ttml/ops/layernorm_op.cpp
+++ b/tt-train/sources/ttml/ops/layernorm_op.cpp
@@ -22,7 +22,7 @@ namespace ttml::ops {
 // it works only for 4D tensors and for the last dimension
 autograd::TensorPtr layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
-    auto tensor_shape = tensor->get_value().get_logical_shape();
+    auto tensor_shape = tensor->get_value().logical_shape();
     auto mean = core::empty(
         core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1}),
         &autograd::ctx().get_device(),
@@ -78,10 +78,10 @@ autograd::TensorPtr layernorm(
 
 autograd::TensorPtr composite_layernorm(
     const autograd::TensorPtr& tensor, const autograd::TensorPtr& gamma, const autograd::TensorPtr& beta) {
-    auto tensor_shape = tensor->get_value().get_logical_shape();
+    auto tensor_shape = tensor->get_value().logical_shape();
 
     auto shape = core::create_shape({tensor_shape[0], tensor_shape[1], tensor_shape[2], 1});
-    auto mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().get_dtype());
+    auto mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
     ttnn::moreh_mean(
         tensor->get_value(),
         3,  // last dimension
@@ -137,9 +137,9 @@ autograd::TensorPtr composite_layernorm(
         // dtensor = (dnorm - dnorm.mean(-1, keepdim=True) - norm * (dnorm * norm).mean(-1, keepdim=True)) * rstd
 
         // dnorm.mean(-1, keepdim=True)
-        auto dnorm_shape = dtensor_normalized.get_logical_shape();
+        auto dnorm_shape = dtensor_normalized.logical_shape();
         auto shape = core::create_shape({dnorm_shape[0], dnorm_shape[1], dnorm_shape[2], 1});
-        auto dnorm_mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().get_dtype());
+        auto dnorm_mean = core::zeros(shape, &autograd::ctx().get_device(), tensor->get_value().dtype());
         ttnn::moreh_mean(
             dtensor_normalized,
             /* dim */ 3,

--- a/tt-train/sources/ttml/ops/losses.cpp
+++ b/tt-train/sources/ttml/ops/losses.cpp
@@ -70,7 +70,7 @@ autograd::TensorPtr nll_loss(
     auto* device = &autograd::ctx().get_device();
     auto divisor = core::empty(ttnn::Shape({1, 1}), device, prediction->get_value().memory_config());
 
-    auto tensor_shape = prediction->get_value().get_logical_shape();
+    auto tensor_shape = prediction->get_value().logical_shape();
     uint32_t Ndim = tensor_shape[0] * tensor_shape[1] * tensor_shape[2];
     uint32_t Cdim = tensor_shape[3];
     auto reshaped_tensor = ttnn::reshape(prediction->get_value(), ttnn::Shape({Ndim, Cdim}));
@@ -98,7 +98,7 @@ autograd::TensorPtr nll_loss(
             /* ignore_index */ -100,
             /* memory_config */ std::nullopt,
             /* compute_kernel_config */ core::ComputeKernelConfig::precise());
-        grad = ttnn::reshape(grad, prediction->get_value().get_logical_shape());
+        grad = ttnn::reshape(grad, prediction->get_value().logical_shape());
         prediction->add_grad(grad);
     };
     auto links = autograd::get_links(prediction);

--- a/tt-train/sources/ttml/ops/multi_head_utils.cpp
+++ b/tt-train/sources/ttml/ops/multi_head_utils.cpp
@@ -53,7 +53,7 @@ std::tuple<autograd::TensorPtr, autograd::TensorPtr, autograd::TensorPtr> heads_
 }
 
 autograd::TensorPtr heads_fusion(const autograd::TensorPtr& x) {
-    auto x_shape = x->get_value().get_logical_shape();
+    auto x_shape = x->get_value().logical_shape();
 
     uint32_t batch_size = x_shape[0];
     uint32_t num_heads = x_shape[1];

--- a/tt-train/sources/ttml/ops/rope_op.cpp
+++ b/tt-train/sources/ttml/ops/rope_op.cpp
@@ -44,12 +44,12 @@ void validate_rope_input_and_params(const autograd::TensorPtr& input, const Rota
             params.sequence_length));
     }
 
-    auto trans_mat_shape = params.trans_mat.get_logical_shape();
+    auto trans_mat_shape = params.trans_mat.logical_shape();
     auto trig_param_shapes = std::array{
-        params.cos_cache.get_logical_shape(),
-        params.sin_cache.get_logical_shape(),
-        params.neg_cos_cache.get_logical_shape(),
-        params.neg_sin_cache.get_logical_shape()};
+        params.cos_cache.logical_shape(),
+        params.sin_cache.logical_shape(),
+        params.neg_cos_cache.logical_shape(),
+        params.neg_sin_cache.logical_shape()};
 
     auto expected_trig_shape = ttnn::Shape{1U, 1U, input_seq_len, input_head_dim};
     if (!std::ranges::all_of(
@@ -59,10 +59,10 @@ void validate_rope_input_and_params(const autograd::TensorPtr& input, const Rota
             "cos_cache: {}, sin_cache: {}, neg_cos_cache: {}, neg_sin_cache: {}",
             input_seq_len,
             input_head_dim,
-            params.cos_cache.get_logical_shape(),
-            params.sin_cache.get_logical_shape(),
-            params.neg_cos_cache.get_logical_shape(),
-            params.neg_sin_cache.get_logical_shape()));
+            params.cos_cache.logical_shape(),
+            params.sin_cache.logical_shape(),
+            params.neg_cos_cache.logical_shape(),
+            params.neg_sin_cache.logical_shape()));
     }
 
     auto expected_trans_mat_shape = ttnn::Shape{1U, 1U, ttnn::TILE_SIZE, ttnn::TILE_SIZE};
@@ -76,14 +76,14 @@ void validate_rope_input_and_params(const autograd::TensorPtr& input, const Rota
 // the module hierarchy and passed to the operation.
 autograd::TensorPtr rope(const autograd::TensorPtr& input, const RotaryEmbeddingParams& params) {
     validate_rope_input_and_params(input, params);
-    auto input_logical_shape = input->get_value().get_logical_shape();
+    auto input_logical_shape = input->get_value().logical_shape();
     auto num_batch = input_logical_shape[0];
     auto num_heads = input_logical_shape[1];
     auto seq_len = input_logical_shape[2];
     auto head_dim = input_logical_shape[3];
 
     auto squish_batch = [num_batch, num_heads, seq_len, head_dim](const ttnn::Tensor& input) {
-        auto shape = input.get_logical_shape();
+        auto shape = input.logical_shape();
         auto seq_len = shape[2];
         auto head_dim = shape[3];
         auto unbatched_input = ttnn::reshape(input, ttnn::Shape{1U, num_batch * num_heads, seq_len, head_dim});

--- a/tt-train/sources/ttml/ops/unary_ops.cpp
+++ b/tt-train/sources/ttml/ops/unary_ops.cpp
@@ -118,7 +118,7 @@ autograd::TensorPtr mean(const autograd::TensorPtr& tensor) {
         std::nullopt,
         /* device_compute_kernel_config */ core::ComputeKernelConfig::precise());
     autograd::GradFunction grad = [tensor, out]() {
-        auto resulting_shape = tensor->get_value().get_logical_shape();
+        auto resulting_shape = tensor->get_value().logical_shape();
         auto res = ttnn::moreh_mean_backward(
             out->get_grad(),
             std::nullopt,
@@ -136,7 +136,7 @@ autograd::TensorPtr mean(const autograd::TensorPtr& tensor) {
 }
 
 autograd::TensorPtr broadcast_batch(const autograd::TensorPtr& tensor, uint32_t new_batch_dim) {
-    if (new_batch_dim == 1 || tensor->get_value().get_logical_shape()[0] == new_batch_dim) {
+    if (new_batch_dim == 1 || tensor->get_value().logical_shape()[0] == new_batch_dim) {
         return tensor;
     }
     auto out = ttml::autograd::create_tensor();

--- a/tt-train/sources/ttml/serialization/serialization.cpp
+++ b/tt-train/sources/ttml/serialization/serialization.cpp
@@ -68,9 +68,9 @@ void get_enum(MsgPackFile& file, std::string_view name, T& value) {
 }
 
 void write_ttnn_tensor(MsgPackFile& file, std::string_view name, const tt::tt_metal::Tensor& tensor) {
-    auto shape = tensor.get_logical_shape();
-    auto data_type = tensor.get_dtype();
-    auto layout = tensor.get_layout();
+    auto shape = tensor.logical_shape();
+    auto data_type = tensor.dtype();
+    auto layout = tensor.layout();
     auto storage_type = tensor.storage_type();
 
     file.put(std::string(name) + "/shape", to_bytes(shape));

--- a/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/distributed/ttnn_ops.cpp
@@ -23,7 +23,7 @@ tt::tt_metal::Tensor all_reduce(const tt::tt_metal::Tensor& tensor) {
         throw std::logic_error("All reduce should not be called for a single device case");
     }
 
-    auto shape = tensor.get_logical_shape();
+    auto shape = tensor.logical_shape();
     if (shape.rank() != 4U) {
         throw std::logic_error("All reduce supports only 4D tensors");
     }
@@ -50,7 +50,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
     }
 
     auto device_grid_shape = current_device->shape();
-    const auto& storage = std::get<tt::tt_metal::DeviceStorage>(tensor.get_storage());
+    const auto& storage = std::get<tt::tt_metal::DeviceStorage>(tensor.storage());
     const auto num_tensor_buffers = storage.specs.size();
 
     if (num_devices != num_tensor_buffers) {
@@ -61,7 +61,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
             num_tensor_buffers));
     }
 
-    auto tensor_shape = tensor.get_logical_shape();
+    auto tensor_shape = tensor.logical_shape();
     auto tensor_rank = tensor_shape.rank();
     if (tensor_rank != 4U) {
         throw std::logic_error(
@@ -88,7 +88,7 @@ tt::tt_metal::Tensor scatter(const tt::tt_metal::Tensor& tensor, int dim) {
     ttnn::Tensor scattered_tensor = tt::tt_metal::allocate_tensor_on_mesh(
         ttnn::TensorSpec(
             ttnn::Shape(scattered_shape),
-            tt::tt_metal::TensorLayout(tensor.get_dtype(), tensor.get_layout(), tensor.memory_config())),
+            tt::tt_metal::TensorLayout(tensor.dtype(), tensor.layout(), tensor.memory_config())),
         current_device);
     auto scattered_tensors = ttnn::distributed::get_device_tensors(scattered_tensor);
     if (scattered_tensors.size() != num_devices) {

--- a/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
+++ b/tt-train/sources/ttml/ttnn_fixed/matmuls.cpp
@@ -30,15 +30,16 @@ std::pair<tt::tt_metal::Tensor, tt::tt_metal::Tensor> matmul_backward(
     const tt::tt_metal::Tensor& out_grad,
     bool transpose_a,
     bool transpose_b) {
-    auto a_shape = a.get_logical_shape();
-    auto b_shape = b.get_logical_shape();
-    auto grad_shape = out_grad.get_logical_shape();
+    auto a_shape = a.logical_shape();
+    auto b_shape = b.logical_shape();
+    auto grad_shape = out_grad.logical_shape();
 
-    auto volume_without_features_a = a.get_logical_volume() / a.get_logical_shape()[-1];
-    auto reshaped_a = ttnn::reshape(a, ttnn::Shape({volume_without_features_a, a.get_logical_shape()[-1]}));
-    auto volume_without_features_grad = out_grad.get_logical_volume() / out_grad.get_logical_shape()[-1];
-    auto reshaped_grad =
-        ttnn::reshape(out_grad, ttnn::Shape({volume_without_features_grad, out_grad.get_logical_shape()[-1]}));
+    auto volume_without_features_a = a.logical_volume() / static_cast<uint64_t>(a.logical_shape()[-1]);
+    auto reshaped_a =
+        ttnn::reshape(a, ttnn::Shape({static_cast<uint32_t>(volume_without_features_a), a.logical_shape()[-1]}));
+    auto volume_without_features_grad = out_grad.logical_volume() / out_grad.logical_shape()[-1];
+    auto reshaped_grad = ttnn::reshape(
+        out_grad, ttnn::Shape({static_cast<uint32_t>(volume_without_features_a), out_grad.logical_shape()[-1]}));
 
     ttnn::Tensor reshaped_a_grad;
     ttnn::Tensor reshaped_b_grad;

--- a/tt-train/tests/autograd/autograd_test.cpp
+++ b/tt-train/tests/autograd/autograd_test.cpp
@@ -95,8 +95,8 @@ TEST_F(AutogradTest, BroadCastBatchTest) {
     res->backward();
     auto t1_back = ttml::core::to_vector(t1->get_grad());
     auto batch_shape = ttml::core::create_shape({4, 1, 1, 4});
-    auto new_shape = res->get_value().get_logical_shape();
-    auto back_shape = t1->get_grad().get_logical_shape();
+    auto new_shape = res->get_value().logical_shape();
+    auto back_shape = t1->get_grad().logical_shape();
 
     for (size_t i = 0; i < 4; i++) {
         EXPECT_EQ(new_shape[i], batch_shape[i]);

--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -197,7 +197,7 @@ TEST_F(N300UtilsTest, TestXTensorShardAxis3Matmul) {
 
     auto gathered_ta =
         ttnn::all_gather(tensor_a, 3 /*, {0, 4}, 1 ,std::nullopt, std::nullopt, std::nullopt, std::nullopt*/);
-    fmt::print("gathered_ta shape: {}\n", gathered_ta.get_logical_shape());
+    fmt::print("gathered_ta shape: {}\n", gathered_ta.logical_shape());
     auto mul_tensor = ttnn::matmul(
         gathered_ta,
         tensor_b,

--- a/tt-train/tests/core/tensor_utils_test.cpp
+++ b/tt-train/tests/core/tensor_utils_test.cpp
@@ -187,7 +187,7 @@ TEST_F(TensorUtilsTest, TestOnes_1) {
     auto* device = &ttml::autograd::ctx().get_device();
     auto shape = ttml::core::create_shape({1, 2, 3, 4});
     auto tensor_zeros = ttml::core::zeros(shape, device);
-    auto tensor_ones = ttml::core::ones(tensor_zeros.get_logical_shape(), device);
+    auto tensor_ones = ttml::core::ones(tensor_zeros.logical_shape(), device);
     auto tensor_vec = ttml::core::to_vector(tensor_ones);
     for (auto& val : tensor_vec) {
         EXPECT_EQ(val, 1.F);

--- a/tt-train/tests/model/gpt2s_test.cpp
+++ b/tt-train/tests/model/gpt2s_test.cpp
@@ -71,8 +71,8 @@ TEST_F(GPT2SBatch64Test, Matmul) {
     auto run_matmul = [](auto& a, auto& b, bool transpose_a, bool transpose_b) {
         fmt::println(
             "Running matmul with shapes {} and {}, tranpose_a {} transpose_b {}",
-            a.get_logical_shape(),
-            b.get_logical_shape(),
+            a.logical_shape(),
+            b.logical_shape(),
             transpose_a,
             transpose_b);
         [[maybe_unused]] auto c = ttnn::matmul(

--- a/tt-train/tests/ops/linear_op_test.cpp
+++ b/tt-train/tests/ops/linear_op_test.cpp
@@ -23,7 +23,7 @@ protected:
 };
 
 void compare_tensors(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) {
-    ASSERT_EQ(t1.get_logical_shape(), t2.get_logical_shape());
+    ASSERT_EQ(t1.logical_shape(), t2.logical_shape());
     auto t1_vec = ttml::core::to_vector(t1);
     auto t2_vec = ttml::core::to_vector(t2);
     ASSERT_EQ(t1_vec.size(), t2_vec.size());
@@ -38,7 +38,7 @@ void compare_tensors(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) 
 }
 
 bool compare_tensors_for_broken(const ttnn::Tensor& t1, const ttnn::Tensor& t2, float eps) {
-    if (t1.get_logical_shape() != t2.get_logical_shape()) {
+    if (t1.logical_shape() != t2.logical_shape()) {
         return false;
     }
 

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -151,14 +151,14 @@ TEST_F(TrivialTnnFixedTest, TestSumOverBatch_0) {
 
     auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
-    auto tensor_shape = tensor.get_logical_shape();
+    auto tensor_shape = tensor.logical_shape();
     EXPECT_EQ(tensor_shape[0], batch_size);
     EXPECT_EQ(tensor_shape[1], 1U);
     EXPECT_EQ(tensor_shape[2], 1U);
     EXPECT_EQ(tensor_shape[3], features);
 
     auto result = ttml::ttnn_fixed::sum_over_batch(tensor);
-    const auto& result_shape = result.get_logical_shape();
+    const auto& result_shape = result.logical_shape();
     ASSERT_EQ(result_shape.rank(), 4U);
     EXPECT_EQ(result_shape[0], 1U);
     EXPECT_EQ(result_shape[1], 1U);
@@ -183,7 +183,7 @@ TEST_F(TrivialTnnFixedTest, TestDivide) {
     auto rhs_tensor = ttml::core::from_vector(rhs, shape, device);
 
     auto result = ttml::ttnn_fixed::divide(lhs_tensor, rhs_tensor);
-    const auto& result_shape = result.get_logical_shape();
+    const auto& result_shape = result.logical_shape();
     ASSERT_EQ(result_shape.rank(), 4U);
     EXPECT_EQ(result_shape[0], batch_size);
     EXPECT_EQ(result_shape[1], 1U);
@@ -212,14 +212,14 @@ TEST_F(TrivialTnnFixedTest, TestSumOverBatch_1) {
 
     auto shape = ttml::core::create_shape({batch_size, 1, 1, features});
     auto tensor = ttml::core::from_vector(data, shape, device);
-    auto tensor_shape = tensor.get_logical_shape();
+    auto tensor_shape = tensor.logical_shape();
     EXPECT_EQ(tensor_shape[0], batch_size);
     EXPECT_EQ(tensor_shape[1], 1U);
     EXPECT_EQ(tensor_shape[2], 1U);
     EXPECT_EQ(tensor_shape[3], features);
 
     auto result = ttml::ttnn_fixed::sum_over_batch(tensor);
-    const auto& result_shape = result.get_logical_shape();
+    const auto& result_shape = result.logical_shape();
     ASSERT_EQ(result_shape.rank(), 4U);
     EXPECT_EQ(result_shape[0], 1U);
     EXPECT_EQ(result_shape[1], 1U);


### PR DESCRIPTION
### Problem description
TT-train our build is broken in main. 
* `ttnn/decorators.hpp` not found
* type narrowing warning as an error
* a lot of warnings related to shape changes

### What's changed
* Modified CMake 
* Add static cast for explicit type narrowing 
* Avoid using deprecated methods in shape

### Checklist
- [x] New/Existing tests provide coverage for changes