### PR TITLE
#0: Correctly rename to subordinate on profiler post proc

### DIFF
--- a/tt_metal/tools/profiler/process_device_log.py
+++ b/tt_metal/tools/profiler/process_device_log.py
@@ -362,9 +362,10 @@ def get_dispatch_core_ops(timeseries):
     for masterOpID, subordinateOpID in zip(
         riscData[masterRisc]["orderedOpIDs"], riscData[subordinateRisc]["orderedOpIDs"]
     ):
-        opsDict[masterOpID] = {
+        opsDict[masterOpID] = (
             riscData[masterRisc]["ops"][masterOpID] + riscData[subordinateRisc]["ops"][subordinateOpID]
-        }
+        )
+
         opsDict[masterOpID].sort(key=lambda x: x[1])
 
     ops = []


### PR DESCRIPTION
### Problem description
Renaming to subordinate broke device profiler post proc

### What's changed
Correctly rename dispatch op detection logic

### Checklist
- Just a change to post proc scripts and basically a revert to previously working code so no CI