### PR TITLE
Change llama version from 3.1 to 3.3 for llama TG CI

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -31,7 +31,7 @@ jobs:
           {
             name: "Llama Galaxy Accuracy Test",
             arch: wormhole_b0,
-            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_llama_accuracy.py",
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ FAKE_DEVICE=TG pytest models/demos/llama3_subdevices/tests/test_llama_accuracy.py",
             timeout: 30,
             owner_id: U071CKL4AFK
           }, # Ammar Vora

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -39,7 +39,7 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
+        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
         TT_METAL_ENABLE_ERISC_IRAM: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/.github/workflows/tg-stress.yaml
+++ b/.github/workflows/tg-stress.yaml
@@ -40,7 +40,7 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
+        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
         TT_METAL_ENABLE_ERISC_IRAM: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
@@ -87,7 +87,7 @@ jobs:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
-        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/
+        LLAMA_DIR: /mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/
         TT_METAL_ENABLE_ERISC_IRAM: 1
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691


### PR DESCRIPTION
### Ticket
None

### Problem description
There's a mismatch in llama versions on CI tests. Currently, this is causing failures when new caches were generated for llama 3.3, but not for llama 3.1.

### What's changed
- changed LLAMA_DIR

### Checklist
- [x] [TG Pipelines](https://github.com/tenstorrent/tt-metal/actions/runs/15075704357) CI passes