### PR TITLE
Integrate MeshSockets with 2D Dynamic Routing Fabric

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -558,11 +558,10 @@ void test_single_connection_multi_device_socket(
     auto recv_virtual_coord = md1->worker_core_from_logical_core(recv_logical_coord);
 
     auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    auto fabric_max_packet_size = tt::tt_metal::MetalContext::instance()
-                                      .get_cluster()
-                                      .get_control_plane()
-                                      ->get_fabric_context()
-                                      .get_fabric_max_payload_size_bytes();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto& fabric_context = control_plane->get_fabric_context();
+    auto fabric_max_packet_size = fabric_context.get_fabric_max_payload_size_bytes();
+    auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
 
     // Create Socket between Sender and Receiver
     SocketConnection socket_connection = {
@@ -610,7 +609,6 @@ void test_single_connection_multi_device_socket(
     std::iota(src_vec.begin(), src_vec.end(), 0);
     WriteShard(md0->mesh_command_queue(), sender_data_buffer, src_vec, MeshCoordinate(0, 0));
 
-    static constexpr auto packet_header_size_bytes = sizeof(tt::tt_fabric::PacketHeader);
     const auto reserved_packet_header_CB_index = tt::CB::c_in0;
 
     tt::tt_metal::CircularBufferConfig sender_cb_reserved_packet_header_config =
@@ -760,11 +758,12 @@ void test_single_connection_multi_device_socket_with_workers(
     auto output_virtual_coord = md1->worker_core_from_logical_core(output_logical_coord);
 
     auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
-    auto fabric_max_packet_size = tt::tt_metal::MetalContext::instance()
-                                      .get_cluster()
-                                      .get_control_plane()
-                                      ->get_fabric_context()
-                                      .get_fabric_max_payload_size_bytes();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto& fabric_context = control_plane->get_fabric_context();
+
+    auto fabric_max_packet_size = fabric_context.get_fabric_max_payload_size_bytes();
+    auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
+
     // Create Socket between Sender and Receiver
     SocketConnection socket_connection = {
         .sender_core = {MeshCoordinate(0, 0), sender_logical_coord},
@@ -813,7 +812,6 @@ void test_single_connection_multi_device_socket_with_workers(
 
     WriteShard(md0->mesh_command_queue(), sender_data_buffer, src_vec, MeshCoordinate(0, 0));
 
-    static constexpr auto packet_header_size_bytes = sizeof(tt::tt_fabric::PacketHeader);
     const auto reserved_packet_header_CB_index = tt::CB::c_in0;
 
     tt::tt_metal::CircularBufferConfig sender_cb_reserved_packet_header_config =
@@ -948,12 +946,12 @@ std::shared_ptr<Program> create_sender_program(
     const CoreCoord& sender_logical_coord,
     chip_id_t sender_physical_device_id,
     chip_id_t recv_physical_device_id) {
-    static constexpr auto packet_header_size_bytes = sizeof(tt::tt_fabric::PacketHeader);
-    auto fabric_max_packet_size = tt::tt_metal::MetalContext::instance()
-                                      .get_cluster()
-                                      .get_control_plane()
-                                      ->get_fabric_context()
-                                      .get_fabric_max_payload_size_bytes();
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto& fabric_context = control_plane->get_fabric_context();
+
+    auto fabric_max_packet_size = fabric_context.get_fabric_max_payload_size_bytes();
+    auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
+
     const auto reserved_packet_header_CB_index = tt::CB::c_in0;
     auto sender_program = std::make_shared<Program>();
     auto sender_kernel = CreateKernel(
@@ -996,7 +994,10 @@ std::shared_ptr<Program> create_split_reduce_program(
     chip_id_t sender0_physical_device_id,
     chip_id_t sender1_physical_device_id,
     chip_id_t recv_physical_device_id) {
-    static constexpr auto packet_header_size_bytes = sizeof(tt::tt_fabric::PacketHeader);
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto& fabric_context = control_plane->get_fabric_context();
+
+    auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
 
     auto reserved_packet_header_CB_index = tt::CB::c_in0;
     auto config0_cb_index = tt::CBIndex::c_1;
@@ -1130,7 +1131,10 @@ std::shared_ptr<Program> create_reduce_program(
     chip_id_t sender1_physical_device_id,
     chip_id_t reducer_physical_device_id,
     chip_id_t recv_physical_device_id) {
-    static constexpr auto packet_header_size_bytes = sizeof(tt::tt_fabric::PacketHeader);
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto& fabric_context = control_plane->get_fabric_context();
+
+    auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
 
     auto reserved_receiver_packet_header_CB_index = tt::CBIndex::c_0;
     auto reserved_sender_packet_header_CB_index = tt::CBIndex::c_1;
@@ -1213,7 +1217,10 @@ std::shared_ptr<Program> create_recv_program(
     const CoreCoord& output_logical_coord,
     chip_id_t sender_physical_device_id,
     chip_id_t recv_physical_device_id) {
-    static constexpr auto packet_header_size_bytes = sizeof(tt::tt_fabric::PacketHeader);
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto& fabric_context = control_plane->get_fabric_context();
+
+    auto packet_header_size_bytes = fabric_context.get_fabric_packet_header_size_bytes();
 
     auto reserved_packet_header_CB_index = tt::CB::c_in0;
 
@@ -1579,12 +1586,82 @@ void test_multi_connection_multi_device_data_copy(
     }
 }
 
+template <typename FixtureT>
+void run_single_connection_multi_device_socket_with_workers(FixtureT* fixture) {
+    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+    test_single_connection_multi_device_socket_with_workers(md0, md1, 1024, 64, 1024);
+}
+
+template <typename FixtureT>
+void run_single_connection_multi_device_socket(FixtureT* fixture) {
+    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+    test_single_connection_multi_device_socket(md0, md1, 1024, 64, 1024, false);
+    test_single_connection_multi_device_socket(md0, md1, 1024, 64, 2048, false);
+    test_single_connection_multi_device_socket(md0, md1, 4096, 1088, 9792, false);
+}
+
+template <typename FixtureT>
+void run_single_connection_multi_device_socket_with_cbs(FixtureT* fixture) {
+    auto tile_size_bytes = tile_size(tt::DataFormat::UInt32);
+
+    auto md0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    auto md1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
+
+    test_single_connection_multi_device_socket(
+        md0, md1, 2 * tile_size_bytes, tile_size_bytes, 4 * tile_size_bytes, true);
+    test_single_connection_multi_device_socket(
+        md0, md1, 6 * tile_size_bytes, 3 * tile_size_bytes, 15 * tile_size_bytes, true);
+    test_single_connection_multi_device_socket(
+        md0, md1, 5 * tile_size_bytes, 3 * tile_size_bytes, 27 * tile_size_bytes, true);
+    test_single_connection_multi_device_socket(
+        md0, md1, 9 * tile_size_bytes, 4 * tile_size_bytes, 28 * tile_size_bytes, true);
+    test_single_connection_multi_device_socket(
+        md0, md1, 6 * tile_size_bytes, 5 * tile_size_bytes, 25 * tile_size_bytes, true);
+}
+
+template <typename FixtureT>
+void run_multi_sender_single_recv(FixtureT* fixture, bool split_reducer) {
+    auto sender_0 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
+    auto sender_1 = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 2));
+    auto reducer = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 1));
+    auto receiver = fixture->get_mesh_device()->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 1));
+
+    log_info(LogTest, "Sender 0 ID: {}", sender_0->get_device(MeshCoordinate(0, 0))->id());
+    log_info(LogTest, "Sender 1 ID: {}", sender_1->get_device(MeshCoordinate(0, 0))->id());
+    log_info(LogTest, "Reduce ID: {}", reducer->get_device(MeshCoordinate(0, 0))->id());
+    log_info(LogTest, "Receiver ID: {}", receiver->get_device(MeshCoordinate(0, 0))->id());
+
+    uint32_t num_interations = 10;
+    test_multi_sender_single_recv(
+        sender_0, sender_1, reducer, receiver, 1024, 64, 1024, num_interations, split_reducer);
+    test_multi_sender_single_recv(
+        sender_0, sender_1, reducer, receiver, 2048, 64, 5120, num_interations, split_reducer);
+    test_multi_sender_single_recv(
+        sender_0, sender_1, reducer, receiver, 4096, 1088, 9792, num_interations, split_reducer);
+}
+
+template <typename FixtureT>
+void run_multi_connection_multi_device_data_copy(FixtureT* fixture) {
+    fixture->get_mesh_device()->reshape(MeshShape(1, 8));
+
+    auto sender_mesh = fixture->get_mesh_device()->create_submesh(MeshShape(1, 4), MeshCoordinate(0, 0));
+    auto recv_mesh = fixture->get_mesh_device()->create_submesh(MeshShape(1, 4), MeshCoordinate(0, 4));
+
+    test_multi_connection_multi_device_data_copy(sender_mesh, recv_mesh, 1024, 64, 1024);
+    test_multi_connection_multi_device_data_copy(sender_mesh, recv_mesh, 1024, 64, 2048);
+    test_multi_connection_multi_device_data_copy(sender_mesh, recv_mesh, 4096, 1088, 9792);
+}
+
 // ========= Config Validation Tests =========
 
 // Sanity test with a single connection
 TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
     auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
+    auto current_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(current_device_id);
     auto sender_logical_coord = CoreCoord(0, 0);
     auto recv_logical_coord = CoreCoord(0, 1);
     auto sender_virtual_coord = md0->worker_core_from_logical_core(sender_logical_coord);
@@ -1624,8 +1701,8 @@ TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
         recv_config,
         send_socket,
         recv_socket,
-        current_device_id,
-        current_device_id,
+        current_mesh_chip_id.second,
+        current_mesh_chip_id.second,
         sender_virtual_coord,
         recv_virtual_coord,
         socket_fifo_size);
@@ -1633,8 +1710,10 @@ TEST_F(MeshSocketTest, SingleConnectionSingleDeviceConfig) {
 
 // Test multiple connections
 TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
     auto current_device_id = md0->get_device(MeshCoordinate(0, 0))->id();
+    auto current_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(current_device_id);
     std::size_t socket_fifo_size = 1024;
     const auto& worker_grid = md0->compute_with_storage_grid_size();
     std::vector<CoreCoord> sender_logical_coords;
@@ -1701,8 +1780,8 @@ TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
             recv_config,
             send_socket,
             recv_socket,
-            current_device_id,
-            current_device_id,
+            current_mesh_chip_id.second,
+            current_mesh_chip_id.second,
             sender_virtual_coord,
             recv_virtual_coord,
             socket_fifo_size);
@@ -1711,6 +1790,7 @@ TEST_F(MeshSocketTest, MultiConnectionSingleDeviceConfig) {
 
 // Test random connections across multiple devices
 TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceTest) {
+    auto control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     auto md0 = mesh_device_->create_submesh(MeshShape(1, 4), MeshCoordinate(0, 0));
     auto md1 = mesh_device_->create_submesh(MeshShape(1, 4), MeshCoordinate(1, 0));
     std::unordered_map<MeshCoordinate, chip_id_t> sender_device_coord_to_id;
@@ -1817,13 +1897,15 @@ TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceTest) {
         const auto& sender_config = sender_configs_per_dev_coord[sender_device_coord][sender_idx];
         const auto& recv_config = recv_configs_per_dev_coord[recv_device_coord][recv_idx];
 
+        auto sender_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(sender_device_id);
+        auto receiver_mesh_chip_id = control_plane->get_mesh_chip_id_from_physical_chip_id(receiver_device_id);
         verify_socket_configs(
             sender_config,
             recv_config,
             send_socket_l1,
             recv_socket_l1,
-            receiver_device_id,
-            sender_device_id,
+            receiver_mesh_chip_id.second,
+            sender_mesh_chip_id.second,
             sender_virtual_coord,
             recv_virtual_coord,
             socket_fifo_size);
@@ -2069,89 +2151,44 @@ TEST_F(MeshSocketTest, MultiConnectionSingleDeviceSocketWithWorkersLoopAck) {
     test_single_device_socket_with_workers(md0, 4096, 1088, 9792, socket_core_mappings, false);
 }
 
-// ========= Multi Device Data Movement Tests =========
+// ========= Multi Device Data Movement Tests (1D Fabric) =========
 
 TEST_F(MeshSocketTest1DFabric, SingleConnectionMultiDeviceSocketWithWorkers) {
-    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
-    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    test_single_connection_multi_device_socket_with_workers(md0, md1, 1024, 64, 1024);
+    run_single_connection_multi_device_socket_with_workers(this);
 }
 
-TEST_F(MeshSocketTest1DFabric, SingleConnectionMultiDeviceSocket) {
-    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
-    test_single_connection_multi_device_socket(md0, md1, 1024, 64, 1024, false);
-    test_single_connection_multi_device_socket(md0, md1, 1024, 64, 2048, false);
-    test_single_connection_multi_device_socket(md0, md1, 4096, 1088, 9792, false);
-}
+TEST_F(MeshSocketTest1DFabric, SingleConnectionMultiDeviceSocket) { run_single_connection_multi_device_socket(this); }
 
 TEST_F(MeshSocketTest1DFabric, SingleConnectionMultiDeviceSocketWithCBs) {
-    auto tile_size_bytes = tile_size(tt::DataFormat::UInt32);
-
-    auto md0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto md1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 0));
-    test_single_connection_multi_device_socket(
-        md0, md1, 2 * tile_size_bytes, tile_size_bytes, 4 * tile_size_bytes, true);
-    test_single_connection_multi_device_socket(
-        md0, md1, 6 * tile_size_bytes, 3 * tile_size_bytes, 15 * tile_size_bytes, true);
-    test_single_connection_multi_device_socket(
-        md0, md1, 5 * tile_size_bytes, 3 * tile_size_bytes, 27 * tile_size_bytes, true);
-    test_single_connection_multi_device_socket(
-        md0, md1, 9 * tile_size_bytes, 4 * tile_size_bytes, 28 * tile_size_bytes, true);
-    test_single_connection_multi_device_socket(
-        md0, md1, 6 * tile_size_bytes, 5 * tile_size_bytes, 25 * tile_size_bytes, true);
+    run_single_connection_multi_device_socket_with_cbs(this);
 }
 
-TEST_F(MeshSocketTest1DFabric, MultiSenderSingleRecv) {
-    auto sender_0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto sender_1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 2));
-    auto reducer = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 1));
-    auto receiver = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 1));
+TEST_F(MeshSocketTest1DFabric, MultiSenderSingleRecv) { run_multi_sender_single_recv(this, false); }
 
-    log_info(LogTest, "Sender 0 ID: {}", sender_0->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Sender 1 ID: {}", sender_1->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Reduce ID: {}", reducer->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Receiver ID: {}", receiver->get_device(MeshCoordinate(0, 0))->id());
-
-    uint32_t num_interations = 10;
-    bool split_reducer = false;
-    test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 1024, 64, 1024, num_interations, split_reducer);
-    test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 2048, 64, 5120, num_interations, split_reducer);
-    test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 4096, 1088, 9792, num_interations, split_reducer);
-}
-
-TEST_F(MeshSocketTest1DFabric, MultiSenderSingleRecvSplitReducer) {
-    auto sender_0 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 0));
-    auto sender_1 = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 2));
-    auto reducer = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(0, 1));
-    auto receiver = mesh_device_->create_submesh(MeshShape(1, 1), MeshCoordinate(1, 1));
-
-    log_info(LogTest, "Sender 0 ID: {}", sender_0->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Sender 1 ID: {}", sender_1->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Reduce ID: {}", reducer->get_device(MeshCoordinate(0, 0))->id());
-    log_info(LogTest, "Receiver ID: {}", receiver->get_device(MeshCoordinate(0, 0))->id());
-
-    uint32_t num_interations = 10;
-    bool split_reducer = true;
-    test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 1024, 64, 1024, num_interations, split_reducer);
-    test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 2048, 64, 5120, num_interations, split_reducer);
-    test_multi_sender_single_recv(
-        sender_0, sender_1, reducer, receiver, 4096, 1088, 9792, num_interations, split_reducer);
-}
+TEST_F(MeshSocketTest1DFabric, MultiSenderSingleRecvSplitReducer) { run_multi_sender_single_recv(this, true); }
 
 TEST_F(MeshSocketTest1DFabric, MultiConnectionMultiDeviceDataCopy) {
-    mesh_device_->reshape(MeshShape(1, 8));
+    run_multi_connection_multi_device_data_copy(this);
+}
 
-    auto sender_mesh = mesh_device_->create_submesh(MeshShape(1, 4), MeshCoordinate(0, 0));
-    auto recv_mesh = mesh_device_->create_submesh(MeshShape(1, 4), MeshCoordinate(0, 4));
-    test_multi_connection_multi_device_data_copy(sender_mesh, recv_mesh, 1024, 64, 1024);
-    test_multi_connection_multi_device_data_copy(sender_mesh, recv_mesh, 1024, 64, 2048);
-    test_multi_connection_multi_device_data_copy(sender_mesh, recv_mesh, 4096, 1088, 9792);
+// ========= Multi Device Data Movement Tests (2D Fabric with Dynamic Routing) =========
+
+TEST_F(MeshSocketTest2DFabric, SingleConnectionMultiDeviceSocketWithWorkers) {
+    run_single_connection_multi_device_socket_with_workers(this);
+}
+
+TEST_F(MeshSocketTest2DFabric, SingleConnectionMultiDeviceSocket) { run_single_connection_multi_device_socket(this); }
+
+TEST_F(MeshSocketTest2DFabric, SingleConnectionMultiDeviceSocketWithCBs) {
+    run_single_connection_multi_device_socket_with_cbs(this);
+}
+
+TEST_F(MeshSocketTest2DFabric, MultiSenderSingleRecv) { run_multi_sender_single_recv(this, false); }
+
+TEST_F(MeshSocketTest2DFabric, MultiSenderSingleRecvSplitReducer) { run_multi_sender_single_recv(this, true); }
+
+TEST_F(MeshSocketTest2DFabric, MultiConnectionMultiDeviceDataCopy) {
+    run_multi_connection_multi_device_data_copy(this);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/multi_device_fixture.hpp
@@ -88,6 +88,12 @@ protected:
 };
 
 class MeshDeviceFixtureBase : public ::testing::Test {
+public:
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> get_mesh_device() {
+        TT_FATAL(mesh_device_, "MeshDevice not initialized in {}", __FUNCTION__);
+        return mesh_device_;
+    }
+
 protected:
     using MeshDevice = ::tt::tt_metal::distributed::MeshDevice;
     using MeshDeviceConfig = ::tt::tt_metal::distributed::MeshDeviceConfig;
@@ -276,7 +282,9 @@ class T3000MeshDevice2DFabricFixture : public MeshDeviceFixtureBase {
 protected:
     T3000MeshDevice2DFabricFixture() :
         MeshDeviceFixtureBase(Config{
-            .mesh_device_types = {MeshDeviceType::T3000}, .num_cqs = 1, .fabric_config = FabricConfig::FABRIC_2D}) {}
+            .mesh_device_types = {MeshDeviceType::T3000},
+            .num_cqs = 1,
+            .fabric_config = FabricConfig::FABRIC_2D_DYNAMIC}) {}
 };
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_reduce_sender.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
         socket_reserve_pages(sender_socket, 1);
         // Write Data over Fabric
         uint32_t data_addr = get_read_ptr(out_cb_id);
-        data_packet_header_addr->to_chip_unicast(static_cast<uint8_t>(1));
+        fabric_set_unicast_route(data_packet_header_addr, sender_socket);
         data_packet_header_addr->to_noc_unicast_write(
             NocUnicastCommandHeader{receiver_noc_coord_addr | sender_socket.write_ptr}, page_size);
         sender_fabric_connection.wait_for_empty_write_slot();

--- a/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/socket/fabric_sender.cpp
@@ -11,8 +11,8 @@ void fabric_write_any_len(
     uint32_t src_addr,
     uint64_t dst_addr,
     uint32_t xfer_size,
-    uint32_t downstream_encoding) {
-    data_packet_header_addr->to_chip_unicast(static_cast<uint8_t>(downstream_encoding));
+    SocketSenderInterface& sender_socket) {
+    fabric_set_unicast_route(data_packet_header_addr, sender_socket);
     while (xfer_size > FABRIC_MAX_PACKET_SIZE) {
         data_packet_header_addr->to_noc_unicast_write(NocUnicastCommandHeader{dst_addr}, FABRIC_MAX_PACKET_SIZE);
         fabric_connection.wait_for_empty_write_slot();
@@ -71,7 +71,7 @@ void kernel_main() {
             data_addr,
             receiver_noc_coord_addr | sender_socket.write_ptr,
             page_size,
-            sender_socket.downstream_chip_id);
+            sender_socket);
         data_addr += page_size;
         outstanding_data_size -= page_size;
         socket_push_pages(sender_socket, 1);

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -58,7 +58,9 @@ tt::tt_fabric::Topology FabricContext::get_topology() const {
 
 size_t FabricContext::get_packet_header_size_bytes() const {
     if (this->topology_ == Topology::Mesh) {
-        return sizeof(tt::tt_fabric::LowLatencyMeshPacketHeader);
+        return (this->fabric_config_ == tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC)
+                   ? sizeof(tt::tt_fabric::MeshPacketHeader)
+                   : sizeof(tt::tt_fabric::LowLatencyMeshPacketHeader);
     } else {
         return sizeof(tt::tt_fabric::PacketHeader);
     }


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22256

### Problem description
- Routing Table based 2D Fabric is enabled on main
- This is the main mechanism that will be used for multi-mesh workloads
- `MeshSocket` is currently only enabled + tested for 1D Line/Ring Fabric

### What's changed
- Add support and tests to use sockets on 2D Fabric. This is the first step to test sockets with multi-mesh workloads
- Add `fabric_set_unicast_route(volatile tt_l1_ptr PACKET_HEADER_TYPE* fabric_header_addr, const SocketT& socket)` API to `tt_metal/hw/inc/socket_api.h` to set fabric headers based on socket config, agnostic of the socket type or fabric config
- Add packet header query for `FABRIC_2D_DYNAMIC` to `FabricContext::get_packet_header_size_bytes()` (this was meant to be in the PR mainlining Dynamic Routing but was missed)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes