### PR TITLE
Minor typo: fix the figure description to match the figure

### DIFF
--- a/tech_reports/SubDevices/SubDevices.md
+++ b/tech_reports/SubDevices/SubDevices.md
@@ -35,7 +35,7 @@ Each Sub-Device can be any combination of cores and core types. It could be only
 <!-- ![example_sub_device_grouping](images/example_sub_device_grouping.png){width=15 height=15} -->
 <img src="images/example_sub_device_grouping.png" style="width:400px;"/>
 
-Figure 1. Example sub-devices where the red sub-device is a contiguous grid of worker cores, purple is a discontiguous set of worker cores, yellow is a sub-device of only ethernet cores, and blue is a sub-device of worker and ethernet cores.
+Figure 1. Example sub-devices where the red sub-device is a contiguous grid of worker cores, purple is a discontiguous set of worker cores, blue is a sub-device of only ethernet cores, and yellow is a sub-device of worker and ethernet cores.
 
 To create a sub-device, we need to provide a list of cores by HalProgrammableCoreType, where the first index of the list are Tensix cores, the second index are Active Eth cores, etc. The order is based on the HalProgrammableCoreType enum. This api is expected to change as the device core coords are expected to be augmented to contain the core type in addition to the coords. With this change, then it would not matter what order the cores are passed in since they'd contain their core type.
 

--- a/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
+++ b/tech_reports/prog_examples/add_2_integers_in_compute/add_2_integers_in_compute.md
@@ -68,7 +68,7 @@ CircularBufferConfig cb_output_config = CircularBufferConfig(num_output_tiles * 
 CBHandle cb_output = tt_metal::CreateCircularBuffer(program, core, cb_output_config);
 ```
 
-L1 circular buffers will be used communicate data to and from the compute engine. We create circular buffers for the source vectors and destination vector. The source data will be sent from the DRAM buffers to the circular buffer of each specified core, then the results for a given core will be stored at another circular buffer index before being sent to DRAM.
+L1 circular buffers will be used to communicate data to and from the compute engine. We create circular buffers for the source vectors and destination vector. The source data will be sent from the DRAM buffers to the circular buffer of each specified core, then the results for a given core will be stored at another circular buffer index before being sent to DRAM.
 
 ## Kernel setup
 

--- a/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
+++ b/tech_reports/prog_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.md
@@ -69,7 +69,7 @@ CircularBufferConfig cb_src1_config = CircularBufferConfig(single_tile_size, {{s
 CBHandle cb_src1 = tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 ```
 
-L1 circular buffers will be used communicate data to and from the compute engine. We create a circular buffer for each of the source vectors. Each core will have its own segment of the source data stored in its corresponding circular buffer.
+L1 circular buffers will be used to communicate data to and from the compute engine. We create a circular buffer for each of the source vectors. Each core will have its own segment of the source data stored in its corresponding circular buffer.
 
 ## Kernel setup
 
@@ -128,7 +128,7 @@ uint32_t* dat1 = (uint32_t*) l1_write_addr_in1;
 
 dat0[0] = dat0[0] + dat1[0];
 
-// Write data from L1 circulr buffer (in0) -> DRAM
+// Write data from L1 circular buffer (in0) -> DRAM
 noc_async_write(l1_write_addr_in0, dst_dram_noc_addr, ublock_size_bytes_0);
 noc_async_write_barrier();
 ```

--- a/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
+++ b/tech_reports/prog_examples/hello_world_compute/hello_world_compute.md
@@ -27,7 +27,7 @@ CommandQueue& cq = device->command_queue();
 Program program = CreateProgram();
 ```
 
-We first obtain the global `CommandQueue` associated with the device in order to use the fast dispatch capabilities of the software. Thism mechanism enables commands to be run asynchronously between the host and device.
+We first obtain the global `CommandQueue` associated with the device in order to use the fast dispatch capabilities of the software. This mechanism enables commands to be run asynchronously between the host and device.
 
 Next, we create a `Program` to be run on our Grayskull accelerator. This object will encapsulate our data and kernels, and be dispatched through the `CommandQueue` to execute on the device.
 

--- a/tech_reports/tensor_layouts/tensor_layouts.md
+++ b/tech_reports/tensor_layouts/tensor_layouts.md
@@ -89,7 +89,7 @@ Unlike interleaved tensors, where pages are distributed across all available L1 
 
 This can be illustrated with an example. Consider a tensor with 16 pages, denoted P0 to P15. The left side of the figure shows how the tiled tensor appears in host memory. When the tensor is sharded, each shard is written into the L1 memory of a core.
 
-In the example illustrated in *Figure 4*, Core (0,0) holds pages 0, 1, 4, and 5, while Core (0,1) holds pages 2, 3, 7, and 8. This distribution is defined by a shard specification that includes the shard shape (in this case, 2x2 pages) and the core grid where the shards are placed (a 2x2 core grid).
+In the example illustrated in *Figure 4*, Core (0,0) holds pages 0, 1, 4, and 5, while Core (0,1) holds pages 2, 3, 6, and 7. This distribution is defined by a shard specification that includes the shard shape (in this case, 2x2 pages) and the core grid where the shards are placed (a 2x2 core grid).
 
 <img src="images/sharded_page_mapping_2.svg" style="width:1000px;"/>
 


### PR DESCRIPTION
Fix minor typo in the docs.