### PR TITLE
[skip ci] bring back titles in post commit for clarity when looking at runs

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -35,7 +35,14 @@ permissions:
   packages: write
   checks: write
 
-run-name: All post-commit tests${{ (github.event_name == 'workflow_dispatch' && inputs.with-retries) && ' (with retries)' || ''}}
+run-name: >-
+  ${{
+    github.event_name == 'push'
+      && format('All post-commit tests - {0}', github.event.head_commit.message)
+      || (github.event_name == 'workflow_dispatch' && inputs.with-retries
+          && 'All post-commit tests (with retries)')
+      || 'All post-commit tests'
+  }}
 jobs:
   build-artifact:
     uses: ./.github/workflows/build-artifact.yaml


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22267)

### Problem description
Runs all look the same.

Hard to differentiate between runs because commit-ids are also hidden behind links.


### What's changed
Quality of life improvement

on push: have title
on manual trigger
outcome
![image](https://github.com/user-attachments/assets/823bb21a-491d-43be-8e17-5a8c9efd96b6)

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes