### PR TITLE
#22271: skip test_ttnn_matmul_dram_sharded on BH

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_experimental.py
+++ b/tests/ttnn/unit_tests/operations/test_experimental.py
@@ -7,7 +7,14 @@ import pytest
 import torch
 
 import ttnn
-from models.utility_functions import is_wormhole_b0, torch_random, is_wormhole_b0, is_grayskull, is_blackhole
+from models.utility_functions import (
+    is_wormhole_b0,
+    torch_random,
+    is_wormhole_b0,
+    is_grayskull,
+    is_blackhole,
+    skip_for_blackhole,
+)
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
@@ -142,7 +149,7 @@ def test_ttnn_linear(
     assert_with_pcc(torch_output_tensor, output_tensor, 0.9996)
 
 
-@pytest.mark.skipif(is_grayskull(), reason="parallelization not supported for GS")
+@skip_for_blackhole("Does not work on BH P100a. Issue #22271")
 @pytest.mark.parametrize("m_size", [32])
 @pytest.mark.parametrize("k_size", [8192])
 @pytest.mark.parametrize("n_size", [1024])

--- a/tests/ttnn/unit_tests/operations/test_full.py
+++ b/tests/ttnn/unit_tests/operations/test_full.py
@@ -7,9 +7,8 @@ import pytest
 import torch
 import torch.nn as nn
 import ttnn
-from models.utility_functions import comp_allclose
+from models.utility_functions import comp_allclose, skip_for_blackhole
 from loguru import logger
-
 from tests.ttnn.utils_for_testing import assert_equal, tt_dtype_to_torch_dtype
 
 
@@ -36,6 +35,7 @@ def test_full_int(device, input_shape, fill_value):
     assert torch.equal(torch_output, tt_output_cpu)
 
 
+@skip_for_blackhole("Does not work on BH P150. Issue #22274")
 @pytest.mark.parametrize(
     "input_shape",
     [

--- a/tests/ttnn/unit_tests/operations/test_moreh_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_cumsum.py
@@ -8,8 +8,7 @@ import ttnn
 
 from loguru import logger
 
-from models.utility_functions import comp_allclose_and_pcc
-
+from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
 from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH
 
 
@@ -96,6 +95,7 @@ def test_moreh_cumsum_dim(input_shape, dim, device):
     assert passing
 
 
+@skip_for_blackhole("Does not work on BH P150. Issue #22273")
 @pytest.mark.parametrize(
     "input_shape",
     (


### PR DESCRIPTION
### Ticket
Link to Github Issue #22271
https://github.com/tenstorrent/tt-metal/issues/22274
https://github.com/tenstorrent/tt-metal/issues/22273

### Problem description
test fails on P150a

### What's changed
Skip until the issue can be figure out

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes N/A
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) N/A
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable) N/A
- [ ] New/Existing tests provide coverage for changes N/A