### PR TITLE
[skip ci] update blackhole post commit and blackhole nightly

### DIFF
--- a/.github/workflows/blackhole-nightly-tests-impl.yaml
+++ b/.github/workflows/blackhole-nightly-tests-impl.yaml
@@ -12,6 +12,16 @@ on:
       docker-image:
         required: true
         type: string
+      runner-label:
+        required: true
+        type: string
+        default: ''
+        description: '["P100"] (P100 only), ["P150"] (P150 only)'
+      arch_name:
+        required: false
+        type: string
+        default: 'blackhole'
+        description: 'Architecture name to use'
 
 jobs:
   nightly-bh-models:
@@ -21,16 +31,16 @@ jobs:
       fail-fast: false
       matrix:
         test-group: [
-            { model: whisper, card: BH, owner_id: U05RWH3QUPM, arch: blackhole },  #Salar Hosseini
+            { model: whisper, owner_id: U05RWH3QUPM },  #Salar Hosseini
           ]
-    name: Nightly ${{ matrix.test-group.card }} ${{ matrix.test-group.model }}
-    runs-on: ["cloud-virtual-machine", "in-service", "${{ matrix.test-group.card }}"]
+    name: Nightly ${{ inputs.runner-label }} ${{ matrix.test-group.model }} #Salar Hosseini
+    runs-on: ["cloud-virtual-machine", "in-service", "${{ inputs.runner-label }}"]
     container:
       image: ${{ inputs.docker-image }}
       env:
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: ${{ inputs.arch_name }}
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -4,19 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       runner-label:
-          description: 'Optional: BH'
-          required: true
-          type: string
-          default: 'BH'
+        description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only)'
+        required: false
+        type: string
+        default: '["P100", "P150"]'
   workflow_call:
     inputs:
       runner-label:
-          description: 'Optional: BH'
-          required: false
-          type: string
-          default: 'BH'
+        description: 'Valid inputs: ["P100", "P150"] (both cards), ["P100"] (P100 only), ["P150"] (P150 only)'
+        required: false
+        type: string
+        default: '["P100", "P150"]'
   schedule:
-    - cron: "0 */12 * * *"  # Every day at 0:00 and 12:00 UTC
+    - cron: "0 */8 * * *"  # Every 8 hours at 0:00, 8:00, and 16:00 UTC
 
 jobs:
   build-artifact:
@@ -28,8 +28,12 @@ jobs:
   bh-nightly:
     needs: build-artifact
     uses: ./.github/workflows/blackhole-nightly-tests-impl.yaml
+    strategy:
+      matrix:
+        card_type: ${{ fromJSON(inputs.runner-label) }}
     secrets: inherit
     with:
+      runner-label: ${{ matrix.card_type }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -37,9 +41,12 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml
+    strategy:
+      matrix:
+        card_type: ${{ fromJSON(inputs.runner-label) }}
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.card_type }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -47,9 +54,12 @@ jobs:
     needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/tt-metal-l2-nightly-impl.yaml
+    strategy:
+      matrix:
+        card_type: ${{ fromJSON(inputs.runner-label) }}
     with:
       arch: blackhole
-      runner-label: ${{ inputs.runner-label || 'BH' }}
+      runner-label: ${{ matrix.card_type }}
       timeout: 120
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}

--- a/.github/workflows/blackhole-nightly-tests.yaml
+++ b/.github/workflows/blackhole-nightly-tests.yaml
@@ -54,21 +54,3 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-  ttnn-stress-tests:
-    needs: build-artifact
-    secrets: inherit
-    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
-    strategy:
-      fail-fast: false
-      matrix:
-        test-group: [
-          { runner-label: P100 },
-          { runner-label: P150 },
-        ]
-    with:
-      arch: blackhole
-      runner-label: ${{ matrix.test-group.runner-label }}
-      timeout: 45
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -12,6 +12,10 @@ on:
           description: 'Enable watcher in BH Post commit'
           default: false
           type: boolean
+      enable-ttnn-unit-tests:
+          description: 'Enable ttnn unit tests'
+          default: false
+          type: boolean
   workflow_dispatch:
     inputs:
       runner-label:
@@ -20,6 +24,7 @@ on:
           type: string
           default: 'BH'
       build-type:
+        description: 'Build type for the workflow'
         required: false
         default: Release
         type: choice
@@ -31,6 +36,10 @@ on:
           - TSan
       enable-watcher:
         description: 'Enable watcher in BH Post commit'
+        default: false
+        type: boolean
+      enable-ttnn-unit-tests:
+        description: 'Enable ttnn unit tests'
         default: false
         type: boolean
   schedule:
@@ -48,6 +57,7 @@ permissions:
   pages: write
   id-token: write
   packages: write
+  checks: write
 
 jobs:
   build-artifact:
@@ -150,17 +160,55 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-#   profiler-regression:
-#     needs: build-artifact-profiler
-#     uses: ./.github/workflows/run-profiler-regression.yaml
-#     secrets: inherit
+
+  ttnn-unit-tests:
+    needs: build-artifact
+    if: ${{ inputs.enable-ttnn-unit-tests }}
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-post-commit.yaml
+    with:
+      arch: blackhole
+      runner-label: ${{ inputs.runner-label || 'BH' }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+
+  ttnn-stress-tests:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/ttnn-stress-tests-impl.yaml
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: [
+          { runner-label: P100 },
+          { runner-label: P150 },
+        ]
+    with:
+      arch: blackhole
+      runner-label: ${{ matrix.test-group.runner-label }}
+      timeout: 45
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  smoke-tests:
+    needs: build-artifact
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          "P100",
+          "P150",
+        ]
+    uses: ./.github/workflows/smoke.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      runner: ${{ matrix.platform }}
 #   build-and-test-wheels:
 #     uses: Check all-post-commit yaml for directions
 #     secrets: inherit
-#   build-docs:
-#     needs: build-artifact
-#     uses: ./.github/workflows/docs-latest-public.yaml
-#     secrets: inherit
+
   # We used to use this for post-commit, but we didn't have enough runners
   # to support the number of developers running this workflow
   # build-and-test-measure-perf:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22126)

### Problem description
New BH runners, test coverage can be updated

### What's changed
BH PC now runs smoke tests, ttnn stress tests. Adds option to run ttnn-unit tests for QoL for Devs.
Scheduled runs will run without ttnn-unit tests

BH nightly: removed running ttnn stress tests since moved to BH PC.
Added ability to run nightly for either p100/p150/or both p100 & p150
Upped frequency to every 6 hours.

Will monitor new usage and decide if we can enable running BH PC at higher freq or enable splitting runs into p100 and p150 split jobs

### Checklist
BH PC with ttnn enabled: https://github.com/tenstorrent/tt-metal/actions/runs/15082354840
BH PC with ttnn disabled: https://github.com/tenstorrent/tt-metal/actions/runs/15082353153

BH Nightly running both P150/P100 https://github.com/tenstorrent/tt-metal/actions/runs/15083097526
