### PR TITLE
[Reproduction] Problem when doing mixed arithmetic with bfloat16 and uint8

### DIFF
--- a/tt_metal/api/tt-metalium/uint8.hpp
+++ b/tt_metal/api/tt-metalium/uint8.hpp
@@ -4,5 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <vector>
+
 // Number of elements needs to be divisible by 4 for the time being
 std::vector<std::uint32_t> create_constant_vector_of_uint8(uint32_t num_bytes, uint8_t value);

--- a/tt_metal/api/tt-metalium/uint8.hpp
+++ b/tt_metal/api/tt-metalium/uint8.hpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Number of elements needs to be divisible by 4 for the time being
+std::vector<std::uint32_t> create_constant_vector_of_uint8(uint32_t num_bytes, uint8_t value);

--- a/tt_metal/impl/CMakeLists.txt
+++ b/tt_metal/impl/CMakeLists.txt
@@ -21,6 +21,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/bfloat16.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/data_format/uint8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocator/algorithms/free_list.cpp

--- a/tt_metal/impl/data_format/uint8.cpp
+++ b/tt_metal/impl/data_format/uint8.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/uint8.hpp>
+
+uint32_t pack_uint8_into_uint32(uint8_t value) {
+    uint32_t v = (uint32_t) value;
+    return v | v << 8 | v << 16 | v << 24;
+}
+
+std::vector<std::uint32_t> create_constant_vector_of_uint8(uint32_t num_bytes, uint8_t value) {
+    const uint32_t num_elements_vec = static_cast<uint32_t>(num_bytes / sizeof(std::uint32_t));
+    std::vector<std::uint32_t> vec(num_elements_vec, 0);
+    for (int i = 0; i < vec.size(); i++) {
+        vec.at(i) = pack_uint8_into_uint32(value);
+    }
+
+    return vec;
+}

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -4,6 +4,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/uint8.hpp>
 #include <tt-metalium/bfloat16.hpp>
 
 using namespace tt;
@@ -19,14 +20,20 @@ int main() {
     constexpr CoreCoord core = {0, 0};
 
     constexpr uint32_t single_tile_size = 2 * 1024;
+    constexpr uint32_t single_tile_size_u8 = 1024;
     tt_metal::InterleavedBufferConfig dram_config{
         .device = device,
         .size = single_tile_size,
         .page_size = single_tile_size,
         .buffer_type = tt_metal::BufferType::DRAM};
+    tt_metal::InterleavedBufferConfig dram_config_u8{
+        .device = device,
+        .size = single_tile_size_u8,
+        .page_size = single_tile_size_u8,
+        .buffer_type = tt_metal::BufferType::DRAM};
 
     std::shared_ptr<tt::tt_metal::Buffer> src0_dram_buffer = CreateBuffer(dram_config);
-    std::shared_ptr<tt::tt_metal::Buffer> src1_dram_buffer = CreateBuffer(dram_config);
+    std::shared_ptr<tt::tt_metal::Buffer> src1_dram_buffer = CreateBuffer(dram_config_u8);
     std::shared_ptr<tt::tt_metal::Buffer> dst_dram_buffer = CreateBuffer(dram_config);
 
     // Since all interleaved buffers have size == page_size, they are entirely contained in the first DRAM bank
@@ -44,8 +51,8 @@ int main() {
 
     constexpr uint32_t src1_cb_index = CBIndex::c_1;
     CircularBufferConfig cb_src1_config =
-        CircularBufferConfig(num_input_tiles * single_tile_size, {{src1_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src1_cb_index, single_tile_size);
+        CircularBufferConfig(num_input_tiles * single_tile_size_u8, {{src1_cb_index, tt::DataFormat::UInt8}})
+            .set_page_size(src1_cb_index, single_tile_size_u8);
     CBHandle cb_src1 = tt_metal::CreateCircularBuffer(program, core, cb_src1_config);
 
     constexpr uint32_t output_cb_index = CBIndex::c_16;
@@ -78,7 +85,7 @@ int main() {
         core,
         ComputeConfig{
             .math_fidelity = MathFidelity::HiFi4,
-            .fp32_dest_acc_en = false,
+            .fp32_dest_acc_en = true,
             .math_approx_mode = false,
             .compile_args = compute_kernel_args,
         });
@@ -87,7 +94,7 @@ int main() {
     std::vector<uint32_t> src0_vec;
     std::vector<uint32_t> src1_vec;
     src0_vec = create_constant_vector_of_bfloat16(single_tile_size, 14.0f);
-    src1_vec = create_constant_vector_of_bfloat16(single_tile_size, 8.0f);
+    src1_vec = create_constant_vector_of_uint8(single_tile_size_u8, 1);
 
     EnqueueWriteBuffer(cq, src0_dram_buffer, src0_vec, false);
     EnqueueWriteBuffer(cq, src1_dram_buffer, src1_vec, false);
@@ -111,6 +118,6 @@ int main() {
     printf("Result = %d\n", result_vec[0]);  // 22 = 1102070192
     printf(
         "Expected = %d\n",
-        pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfloat16(22.0f), bfloat16(22.0f))));
+        pack_two_bfloat16_into_uint32(std::pair<bfloat16, bfloat16>(bfloat16(15.0f), bfloat16(15.0f))));
     CloseDevice(device);
 }

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -6,7 +6,26 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
-#include "debug/dprint_pages.h"
+inline void print_full_tile(uint32_t cb_id, uint32_t tile_id = 0, bool untilize = false) {
+    DPRINT << "======" << ENDL();
+    for (uint16_t r = 0; r < 32; ++r) {
+        DPRINT << (uint)r << " : "
+               << TileSlice(
+                      cb_id,
+                      tile_id,
+                      SliceRange{
+                          .h0 = (uint8_t)r,
+                          .h1 = (uint8_t)(r + 1),
+                          .hs = (uint8_t)1,
+                          .w0 = (uint8_t)0,
+                          .w1 = (uint8_t)32,
+                          .ws = (uint8_t)1},
+                      true,
+                      untilize)
+               << ENDL();
+    }
+    DPRINT << "++++++" << ENDL();
+}
 
 namespace NAMESPACE {
 void MAIN {
@@ -23,7 +42,7 @@ void MAIN {
 
     tile_regs_acquire();  // acquire 8 tile registers
 
-    tt::compute::common::print_full_tile(cb_in0);
+    print_full_tile(cb_in0);
     add_tiles(cb_in0, cb_in1, 0, 0, 0);
 
     tile_regs_commit();  // signal the packer

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -23,7 +23,7 @@ void MAIN {
 
     tile_regs_acquire();  // acquire 8 tile registers
 
-    print_full_tile(cb_in0);
+    tt::compute::common::print_full_tile(cb_in0);
     add_tiles(cb_in0, cb_in1, 0, 0, 0);
 
     tile_regs_commit();  // signal the packer

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -6,6 +6,8 @@
 #include "compute_kernel_api/eltwise_binary.h"
 #include "compute_kernel_api/tile_move_copy.h"
 
+#include "debug/dprint_pages.h"
+
 namespace NAMESPACE {
 void MAIN {
     constexpr auto cb_in0 = tt::CBIndex::c_0;
@@ -21,6 +23,7 @@ void MAIN {
 
     tile_regs_acquire();  // acquire 8 tile registers
 
+    print_full_tile(cb_in0);
     add_tiles(cb_in0, cb_in1, 0, 0, 0);
 
     tile_regs_commit();  // signal the packer

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -42,6 +42,7 @@ void MAIN {
 
     tile_regs_acquire();  // acquire 8 tile registers
 
+    reconfig_data_format_srcb<true>(cb_in1);
     add_tiles(cb_in0, cb_in1, 0, 0, 0);
 
     tile_regs_commit();  // signal the packer

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -42,7 +42,7 @@ void MAIN {
 
     tile_regs_acquire();  // acquire 8 tile registers
 
-    print_full_tile(cb_in0);
+    print_full_tile(cb_in1);
     add_tiles(cb_in0, cb_in1, 0, 0, 0);
 
     tile_regs_commit();  // signal the packer

--- a/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/kernels/compute/add_2_tiles.cpp
@@ -42,7 +42,6 @@ void MAIN {
 
     tile_regs_acquire();  // acquire 8 tile registers
 
-    print_full_tile(cb_in1);
     add_tiles(cb_in0, cb_in1, 0, 0, 0);
 
     tile_regs_commit();  // signal the packer
@@ -54,6 +53,7 @@ void MAIN {
     cb_pop_front(cb_in0, 1);
     cb_pop_front(cb_in1, 1);
 
+    print_full_tile(cb_out0);
     cb_push_back(cb_out0, 1);
 }
 }  // namespace NAMESPACE


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22284

### Problem description
Trying to do mixed arithmetic with uint8 / bfloat16

### What's changed
This is a reproduction of the issue, I'm expecting for "Result" and "Expected" to be the same in the modified example, but Result is always 0.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes