### PR TITLE
Added Scheduler to SDXL demo

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/models/experimental/stable_diffusion_xl_base/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo.py
@@ -12,6 +12,7 @@ from loguru import logger
 import ttnn
 from models.experimental.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
 from models.experimental.stable_diffusion_xl_base.vae.tt.tt_autoencoder_kl import TtAutoencoderKL
+from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
 
 
 # Copied from sdxl pipeline
@@ -74,33 +75,37 @@ def retrieve_timesteps(
     return timesteps, num_inference_steps
 
 
-def run_tt_unet(
-    ttnn_device, tt_unet, torch_latent_model_input, ttnn_prompt_embeds, ttnn_added_cond_kwargs, ttnn_timestep
+def run_tt_iteration(
+    ttnn_device,
+    tt_unet,
+    tt_scheduler,
+    input_tensor,
+    input_shape,
+    ttnn_prompt_embeds,
+    ttnn_added_cond_kwargs,
+    ttnn_timestep,
+    i,
 ):
-    B, C, H, W = torch_latent_model_input.shape
-    ttnn_latent_model_input = ttnn.from_torch(
-        torch_latent_model_input,
-        dtype=ttnn.bfloat16,
-        device=ttnn_device,
-        layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
+    B, C, H, W = input_shape
+    if isinstance(input_tensor, torch.Tensor):
+        input_tensor = ttnn.from_torch(
+            input_tensor,
+            dtype=ttnn.bfloat16,
+            device=ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
 
-    ttnn_latent_model_input = ttnn.permute(ttnn_latent_model_input, (0, 2, 3, 1))
-    ttnn_latent_model_input = ttnn.reshape(ttnn_latent_model_input, (1, 1, B * H * W, C))
-
+    input_tensor = tt_scheduler.scale_model_input(input_tensor, tt_scheduler.tt_timesteps[i])
     ttnn_noise_pred, output_shape = tt_unet.forward(
-        ttnn_latent_model_input,
+        input_tensor,
         [B, C, H, W],
         timestep=ttnn_timestep,
         encoder_hidden_states=ttnn_prompt_embeds,
         added_cond_kwargs=ttnn_added_cond_kwargs,
     )
 
-    noise_pred = ttnn.to_torch(ttnn_noise_pred)
-    noise_pred = noise_pred.reshape(B, output_shape[1], output_shape[2], output_shape[0])
-    noise_pred = torch.permute(noise_pred, (0, 3, 1, 2))
-    return noise_pred
+    return ttnn_noise_pred, output_shape
 
 
 @torch.no_grad()
@@ -135,7 +140,7 @@ def run_demo_inference(
         use_safetensors=True,
     )
 
-    # 2. Load tt_unet
+    # 2. Load tt_unet, tt_vae and tt_scheduler
     tt_unet = TtUNet2DConditionModel(
         ttnn_device,
         pipeline.unet.state_dict(),
@@ -144,6 +149,26 @@ def run_demo_inference(
         transformer_weights_dtype=ttnn.bfloat16,
     )
     tt_vae = TtAutoencoderKL(ttnn_device, pipeline.vae.state_dict()) if vae_on_device else None
+    tt_scheduler = TtEulerDiscreteScheduler(
+        ttnn_device,
+        pipeline.scheduler.config.num_train_timesteps,
+        pipeline.scheduler.config.beta_start,
+        pipeline.scheduler.config.beta_end,
+        pipeline.scheduler.config.beta_schedule,
+        pipeline.scheduler.config.trained_betas,
+        pipeline.scheduler.config.prediction_type,
+        pipeline.scheduler.config.interpolation_type,
+        pipeline.scheduler.config.use_karras_sigmas,
+        pipeline.scheduler.config.use_exponential_sigmas,
+        pipeline.scheduler.config.use_beta_sigmas,
+        pipeline.scheduler.config.sigma_min,
+        pipeline.scheduler.config.sigma_max,
+        pipeline.scheduler.config.timestep_spacing,
+        pipeline.scheduler.config.timestep_type,
+        pipeline.scheduler.config.steps_offset,
+        pipeline.scheduler.config.rescale_betas_zero_snr,
+        pipeline.scheduler.config.final_sigmas_type,
+    )
 
     cpu_device = "cpu"
 
@@ -170,7 +195,10 @@ def run_demo_inference(
     )
 
     # Prepare timesteps
-    timesteps, num_inference_steps = retrieve_timesteps(pipeline.scheduler, num_inference_steps, cpu_device, None, None)
+    _, _ = retrieve_timesteps(
+        pipeline.scheduler, num_inference_steps, cpu_device, None, None
+    )  # Bad output if this is removed, implicit dependency exists
+    timesteps, num_inference_steps = retrieve_timesteps(tt_scheduler, num_inference_steps, cpu_device, None, None)
 
     # Convert timesteps to ttnn
     ttnn_timesteps = []
@@ -314,15 +342,34 @@ def run_demo_inference(
         ]
 
     logger.info("Performing warmup run, to make use of program caching in actual inference...")
-    latent_model_input = latents
-    latent_model_input = pipeline.scheduler.scale_model_input(latent_model_input, timesteps[0])
-    run_tt_unet(
+    B, C, H, W = latents.shape
+
+    # All device code will work with channel last tensors
+    latents = torch.permute(latents, (0, 2, 3, 1))
+    latents = latents.reshape(1, 1, B * H * W, C)
+
+    latents = ttnn.from_torch(
+        latents,
+        dtype=ttnn.bfloat16,
+        device=ttnn_device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # UNet will deallocate the input tensor
+    latent_model_input = ttnn.clone(latents)
+
+    # Compile run of Scheduler and UNet
+    run_tt_iteration(
         ttnn_device,
         tt_unet,
+        tt_scheduler,
         latent_model_input,
+        [B, C, H, W],
         ttnn_prompt_embeds[0],
         ttnn_added_cond_kwargs[0],
         ttnn_timesteps[0],
+        0,
     )
 
     logger.info("Starting ttnn inference...")
@@ -330,52 +377,63 @@ def run_demo_inference(
         unet_outputs = []
         for unet_slice in range(len(ttnn_prompt_embeds)):
             latent_model_input = latents
-            latent_model_input = pipeline.scheduler.scale_model_input(latent_model_input, timesteps[i])
-
-            noise_pred = run_tt_unet(
+            noise_pred, noise_shape = run_tt_iteration(
                 ttnn_device,
                 tt_unet,
+                tt_scheduler,
                 latent_model_input,
+                [B, C, H, W],
                 ttnn_prompt_embeds[unet_slice],
                 ttnn_added_cond_kwargs[unet_slice],
                 t,
+                i,
             )
+            C, H, W = noise_shape
 
             unet_outputs.append(noise_pred)
 
-        if len(unet_outputs) > 1:
-            noise_pred = torch.cat(unet_outputs, dim=0)
-        else:
-            noise_pred = unet_outputs[0]
         # perform guidance
         if classifier_free_guidance:
-            noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+            noise_pred_uncond, noise_pred_text = unet_outputs
             noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_text - noise_pred_uncond)
-        # guidance rescale is 0, skip next step
-        latents = pipeline.scheduler.step(noise_pred, timesteps[i], latents, **extra_step_kwargs, return_dict=False)[0]
 
-    latents = latents.to(pipeline.vae.dtype)
-    # VAE upcasting to float32 is happening in the reference SDXL demo if VAE dtype is float16. If it's bfloat16, it will not be upcasted.
-    latents = latents / pipeline.vae.config.scaling_factor
+            ttnn.deallocate(noise_pred_uncond)
+            ttnn.deallocate(noise_pred_text)
+        else:
+            noise_pred = unet_outputs[0]
+
+        latents = tt_scheduler.step(
+            noise_pred, tt_scheduler.timesteps[i], latents, **extra_step_kwargs, return_dict=False
+        )[0]
+
+        ttnn.deallocate(noise_pred)
+        latents = ttnn.move(latents)
 
     if vae_on_device:
+        scaling_factor = ttnn.from_torch(
+            torch.Tensor([pipeline.vae.config.scaling_factor]),
+            dtype=ttnn.bfloat16,
+            device=ttnn_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
+        )
+        latents = ttnn.div(latents, scaling_factor)
+
         # Workaround for #22017
         ttnn_device.disable_and_clear_program_cache()
 
-        B, C, H, W = list(latents.shape)
-        latents = torch.permute(latents, (0, 2, 3, 1))
-        latents = latents.reshape(1, 1, B * H * W, C)
-        ttnn_latents = ttnn.from_torch(
-            latents,
-            dtype=ttnn.bfloat16,
-            device=ttnn_device,
-            layout=ttnn.ROW_MAJOR_LAYOUT,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
-        )
-
         logger.info("Running TT VAE")
-        image = tt_vae.forward(ttnn_latents, [B, C, H, W])
+        image = tt_vae.forward(latents, [B, C, H, W])
     else:
+        latents = ttnn.from_device(latents).to_torch()
+        latents = latents.reshape(B, H, W, C)
+        latents = torch.permute(latents, (0, 3, 1, 2))
+
+        latents = latents.to(pipeline.vae.dtype)
+
+        # VAE upcasting to float32 is happening in the reference SDXL demo if VAE dtype is float16. If it's bfloat16, it will not be upcasted.
+        latents = latents / pipeline.vae.config.scaling_factor
+
         image = pipeline.vae.decode(latents, return_dict=False)[0]
     image = pipeline.image_processor.postprocess(image, output_type="pil")[0]
 

--- a/models/experimental/stable_diffusion_xl_base/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo.py
@@ -103,6 +103,7 @@ def run_tt_iteration(
 @torch.no_grad()
 def run_demo_inference(
     ttnn_device,
+    is_ci_env,
     prompt,
     num_inference_steps,
     classifier_free_guidance,
@@ -427,8 +428,11 @@ def run_demo_inference(
         image = pipeline.vae.decode(latents, return_dict=False)[0]
     image = pipeline.image_processor.postprocess(image, output_type="pil")[0]
 
-    image.save("output.png")
-    logger.info(f"Image saved to output.png")
+    if is_ci_env:
+        logger.info(f"Image generated successfully")
+    else:
+        image.save("output.png")
+        logger.info(f"Image saved to output.png")
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 6 * 16384}], indirect=True)
@@ -459,6 +463,7 @@ def run_demo_inference(
 def test_demo(
     device,
     use_program_cache,
+    is_ci_env,
     prompt,
     num_inference_steps,
     classifier_free_guidance,
@@ -466,6 +471,7 @@ def test_demo(
 ):
     return run_demo_inference(
         device,
+        is_ci_env,
         prompt,
         num_inference_steps,
         classifier_free_guidance,

--- a/models/experimental/stable_diffusion_xl_base/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo.py
@@ -161,6 +161,7 @@ def run_demo_inference(
         pipeline.scheduler.config.rescale_betas_zero_snr,
         pipeline.scheduler.config.final_sigmas_type,
     )
+    pipeline.scheduler = tt_scheduler
 
     cpu_device = "cpu"
 
@@ -187,10 +188,7 @@ def run_demo_inference(
     )
 
     # Prepare timesteps
-    _, _ = retrieve_timesteps(
-        pipeline.scheduler, num_inference_steps, cpu_device, None, None
-    )  # Bad output if this is removed, implicit dependency exists
-    timesteps, num_inference_steps = retrieve_timesteps(tt_scheduler, num_inference_steps, cpu_device, None, None)
+    timesteps, num_inference_steps = retrieve_timesteps(pipeline.scheduler, num_inference_steps, cpu_device, None, None)
 
     # Convert timesteps to ttnn
     ttnn_timesteps = []

--- a/models/experimental/stable_diffusion_xl_base/demo.py
+++ b/models/experimental/stable_diffusion_xl_base/demo.py
@@ -87,14 +87,6 @@ def run_tt_iteration(
     i,
 ):
     B, C, H, W = input_shape
-    if isinstance(input_tensor, torch.Tensor):
-        input_tensor = ttnn.from_torch(
-            input_tensor,
-            dtype=ttnn.bfloat16,
-            device=ttnn_device,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
 
     input_tensor = tt_scheduler.scale_model_input(input_tensor, tt_scheduler.tt_timesteps[i])
     ttnn_noise_pred, output_shape = tt_unet.forward(

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 from loguru import logger

--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
@@ -11,9 +11,15 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.experimental.stable_diffusion_xl_base.tt.tt_euler_discrete_scheduler import TtEulerDiscreteScheduler
 
 
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (1, 1, 128 * 128, 4),
+    ],
+)
 @pytest.mark.parametrize("num_inference_steps", [5])
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
-def test_euler_discrete_scheduler(device, num_inference_steps):
+def test_euler_discrete_scheduler(device, input_shape, num_inference_steps):
     try:
         from tracy import signpost
     except ImportError:
@@ -66,7 +72,7 @@ def test_euler_discrete_scheduler(device, num_inference_steps):
         tt_sigma = tt_scheduler.init_noise_sigma
         assert_with_pcc(ref_sigma, tt_sigma, 0.999)
 
-        ref_latent = torch.randn((1, 4, 128, 128), dtype=torch.float32)
+        ref_latent = torch.randn(input_shape, dtype=torch.float32)
         tt_latent = ttnn.from_torch(ref_latent, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT).to(device=device)
         tt_latent = ttnn.to_memory_config(tt_latent, ttnn.L1_MEMORY_CONFIG)
 
@@ -79,7 +85,7 @@ def test_euler_discrete_scheduler(device, num_inference_steps):
             passed, msg = assert_with_pcc(ref_scaled_latent, torch_scaled_latent, 0.999)
             logger.debug(f"{i}: scaled_model_input pcc passed: {msg}")
 
-            noise_pred = torch.randn((1, 4, 128, 128), dtype=torch.float32)  # this comes from unet
+            noise_pred = torch.randn(input_shape, dtype=torch.float32)  # this comes from unet
             tt_noise_pred = ttnn.from_torch(noise_pred, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT).to(device=device)
 
             ref_prev_sample, ref_pred_original_sample = scheduler.step(


### PR DESCRIPTION
### What's changed
Added device implementation for scheduler to SDXL demo. Additionally, changed the scheduler test to use channel last format, since neither reference or ttnn implementation assume a specific dimension order.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15070033927) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15070038212) CI passes