### PR TITLE
Fix TTT demo prefill profiling

### DIFF
--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -561,7 +561,7 @@ def test_demo_text(
         logger.info("Starting prefill warmup...")
         profiler.start(f"compile_prefill", iteration=batch_idx)
         logits = generator.prefill_forward_text(
-            input_tokens_prefill_pt[::batch_size, :],  # Warmup prefill for each device
+            input_tokens_prefill_pt,  # Prefill warmup for all users, in case some users have different seqlens than others
             page_table=page_table,
             kv_cache=tt_kv_cache,
             prompt_lens=decoding_pos,


### PR DESCRIPTION
In TT-Transformers, `simple_text_demo.py` was just running prefill warmup for a single user, to measure compile time.
This works fine if all users have the same sequence length.

However, when running the batch-32 demo, user 5 has a shorter seqlen than all other users (pads to 128 instead of 256). This would lead to a compile prefill inside the metrics for prefill-performance, skewing the TTFT up by a large margin sometimes (especially when HF weights were used for some reason).

This fix makes sure that we always run prefill compile for all users, so it will have a small compile-time impact to the demo (negligible if all users are the same size), but will avoid capturing wrong prefill times.

Thanks to @yieldthought for the debug help!