### PR TITLE
SDXL: fixed failing CI tests

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tests/pcc/test_module_tt_upblock2d.py
@@ -25,7 +25,7 @@ from models.utility_functions import torch_random
 )
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 3 * 16384}], indirect=True)
 @pytest.mark.parametrize("conv_weights_dtype", [ttnn.bfloat16])
-def test_crossattnup(
+def test_upblock(
     device,
     input_shape,
     temb_shape,

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/tt_decoder.py
@@ -56,7 +56,7 @@ class TtDecoder(nn.Module):
         self.conv_out_bias = state_dict[f"decoder.conv_out.bias"]
 
         core_y, self.norm_blocks = get_DRAM_GN_config(None, 1)
-        self.norm_core_grid = ttnn.CoreGrid(y=core_y, x=8)
+        self.norm_core_grid = ttnn.CoreGrid(y=core_y, x=4)
 
         self.gamma_t, self.beta_t = prepare_gn_beta_gamma(
             device, norm_out_weights, norm_out_bias, self.norm_core_grid.y

--- a/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
+++ b/models/experimental/stable_diffusion_xl_base/vae/tt/vae_utility.py
@@ -8,7 +8,7 @@ import ttnn
 def get_DRAM_GN_config(module_path, idx):
     if module_path is None:
         core_y = 4
-        num_out_blocks = 64
+        num_out_blocks = 128
     elif "mid_block" in module_path:
         core_y = 4
         num_out_blocks = 4


### PR DESCRIPTION
### What's changed
Fixed grid sizes that caused asserts for group norm. Significant reduction of core grids impacts UNet and VAE perf(device time):

- UNet: 0.998s
- VAE (with host fallback): 2.177s

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15109406598) CI passes
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15109296905) CI passes