### PR TITLE
Decrease log verbosity in graph processor

### DIFF
--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -181,7 +181,7 @@ void GraphProcessor::track_program(tt::tt_metal::Program* program, const tt::tt_
 
 void GraphProcessor::track_function_start(std::string_view function_name, std::span<std::any> input_parameters) {
     const std::lock_guard<std::mutex> lock(mutex);
-    tt::log_info("Begin op: {}", function_name);
+    tt::log_debug("Begin op: {}", function_name);
     std::unordered_map<std::string, std::string> params = {
         {kInputs, std::to_string(input_parameters.size())},
         {kName, std::string(function_name)},
@@ -213,14 +213,14 @@ void GraphProcessor::track_function_start(std::string_view function_name, std::s
         if (it != begin_function_any_map.end()) {
             it->second(any);
         } else {
-            tt::log_info("input any type name ignored: {}", graph_demangle(any.type().name()));
+            tt::log_debug("input any type name ignored: {}", graph_demangle(any.type().name()));
         }
     }
 }
 
 void GraphProcessor::track_function_end_impl() {
     auto name = graph[current_op_id.top()].params[kName];
-    tt::log_info("End op: {}", name);
+    tt::log_debug("End op: {}", name);
 
     auto counter = graph.size();
     {
@@ -248,7 +248,7 @@ void GraphProcessor::track_function_end(const std::any& output_tensors) {
     if (it != end_function_any_map.end()) {
         it->second(output_tensors);
     } else {
-        tt::log_info("output any type name ignored: {}", graph_demangle(output_tensors.type().name()));
+        tt::log_debug("output any type name ignored: {}", graph_demangle(output_tensors.type().name()));
     }
     TT_ASSERT(current_op_id.size() > 0);  // we should always have capture_start on top
     current_op_id.pop();
@@ -296,7 +296,7 @@ int GraphProcessor::add_tensor(const Tensor& t) {
     }
 
     if (buffer == nullptr) {
-        tt::log_info(
+        tt::log_debug(
             "Tensor doesn't have buffer, but storage is {}", graph_demangle(get_type_in_var(t.get_storage()).name()));
     } else {
         auto buffer_id = add_buffer(buffer);


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-mlir/issues/3440

### Problem description
Graph processor logs pollute stdout too much. This affects CI in Forge and general user experience.

### What's changed
Change info to debug verbosity.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes