### PR TITLE
Multi-device mat_mul stress test

### DIFF
--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
       - "in-service"
       - "${{ inputs.runner-label }}"
-      - "${{ (inputs.runner == 'config-tg' || inputs.runner == 'config-6u') && 'bare-metal' || 'cloud-virtual-machine' }}"
+      - "${{ (inputs.runner-label == 'config-tg' || inputs.runner == 'config-6u') && 'bare-metal' || 'cloud-virtual-machine' }}"
 
 
     container:

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   ttnn:
     name: ttnn stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on: ["in-service", "${{ inputs.runner-label }}"]
+    runs-on: ["in-service", "${{ inputs.runner-label }}", "${{ 'bare-metal' && inputs.runner == 'tg' || 'cloud-virtual-machine' }}"]
 
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on:
       - "in-service"
       - "${{ inputs.runner-label }}"
-      - "${{ (inputs.runner-label == 'config-tg' || inputs.runner == 'config-6u') && 'bare-metal' || 'cloud-virtual-machine' }}"
+      - "${{ (inputs.runner-label == 'config-tg' || inputs.runner-label == 'topology-6u') && 'bare-metal' || 'cloud-virtual-machine' }}"
 
 
     container:

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   ttnn:
     name: ttnn stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on: ["in-service", "cloud-virtual-machine", "${{ inputs.runner-label }}"]
+    runs-on: ["in-service", "${{ inputs.runner-label }}"]
 
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/ttnn-stress-tests-impl.yaml
+++ b/.github/workflows/ttnn-stress-tests-impl.yaml
@@ -26,7 +26,11 @@ on:
 jobs:
   ttnn:
     name: ttnn stress tests ${{ inputs.arch }} ${{ inputs.runner-label }}
-    runs-on: ["in-service", "${{ inputs.runner-label }}", "${{ 'bare-metal' && inputs.runner == 'tg' || 'cloud-virtual-machine' }}"]
+    runs-on:
+      - "in-service"
+      - "${{ inputs.runner-label }}"
+      - "${{ (inputs.runner == 'config-tg' || inputs.runner == 'config-6u') && 'bare-metal' || 'cloud-virtual-machine' }}"
+
 
     container:
       image: ${{ inputs.docker-image }}

--- a/.github/workflows/ttnn-stress-tests.yaml
+++ b/.github/workflows/ttnn-stress-tests.yaml
@@ -19,6 +19,7 @@ on:
           - P150
           - config-tg
           - config-t3000
+          - topology-6u
       timeout:
         required: false
         type: number

--- a/tests/ttnn/stress_tests/test_matmul.py
+++ b/tests/ttnn/stress_tests/test_matmul.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+
 import os
 
 import pytest

--- a/tests/ttnn/stress_tests/test_matmul.py
+++ b/tests/ttnn/stress_tests/test_matmul.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import os
 
 import pytest
 
@@ -12,9 +13,17 @@ TEST_CASES = [
     "tests/ttnn/unit_tests/operations/matmul/test_matmul.py::test_padded_1d_matmul",
 ]
 
-NUM_REPEATS = 5
+NUM_REPEATS = 10
+NUM_DEVICES_ENV_KEY = "USE_NUM_DEVICES"
 
 
-def test_matmul():
+@pytest.fixture
+def use_num_devices_env():
+    os.environ[NUM_DEVICES_ENV_KEY] = "1"
+    yield
+    os.environ.pop(NUM_DEVICES_ENV_KEY)
+
+
+def test_matmul(use_num_devices_env):
     for _ in range(NUM_REPEATS):
-        pytest.main(TEST_CASES)
+        assert pytest.main(TEST_CASES) == pytest.ExitCode.OK

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -10,9 +10,9 @@ import torch
 import math
 import ttnn
 
-from models.utility_functions import comp_pcc
+from models.utility_functions import comp_pcc, is_blackhole, skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
-from models.utility_functions import skip_for_grayskull, is_wormhole_b0, is_grayskull, is_blackhole, run_for_wormhole_b0
+
 
 # for setting up multi-device stress tests
 NUM_DEVICES_ENV_KEY = "USE_NUM_DEVICES"
@@ -99,7 +99,6 @@ def test_pytorch_2_0_failed_cases(device, m, k, n):
     assert_with_pcc(z_t, z)
 
 
-@run_for_wormhole_b0()
 @pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 @pytest.mark.parametrize("m", [256])
 @pytest.mark.parametrize("k", [256])
@@ -201,7 +200,7 @@ def test_matmul_reuse_config_sharded_fd_column(
     assert_with_pcc(pt_out, output_tensor, expected_pcc)
 
 
-@run_for_wormhole_b0()
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
 @pytest.mark.parametrize("b", [2])
 @pytest.mark.parametrize("h", [3])
 @pytest.mark.parametrize("m", [256])
@@ -309,7 +308,7 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
     return padded_number
 
 
-@run_for_wormhole_b0()
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1280])
 @pytest.mark.parametrize("has_bias", [False, True])
@@ -324,12 +323,11 @@ def test_matmul_in1_dram_sharded_tiny_tile(
 ):
     # PCC issue when height not equal to tile height
     m = tile_h
-    if is_grayskull():
-        n_padded = n
-        num_banks = 8
+    if is_blackhole():
+        num_banks = mesh_device.dram_grid_size().x  # need to match harvesting of dram
     else:
         num_banks = 12
-        n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_banks)
+    n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_banks)
 
     in0_shape = [1, 1, m, k]
     in1_shape = [1, 1, k, n]
@@ -403,18 +401,12 @@ def test_matmul_in1_dram_sharded_tiny_tile(
         fused_activation=None,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=True,
-            packer_l1_acc=True,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
 
     if has_bias:
         output_t = ttnn.linear(
@@ -538,18 +530,12 @@ def run_matmul_2d_multiple_output_blocks_per_core(
         fuse_batch=fuse_batch,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
     if out_sharded:
         out_mem_config = ttnn.MemoryConfig(
             memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
@@ -586,7 +572,6 @@ def run_matmul_2d_multiple_output_blocks_per_core(
         assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@run_for_wormhole_b0()
 @pytest.mark.parametrize("b", [1, 2])
 @pytest.mark.parametrize("m", [512])
 @pytest.mark.parametrize("k", [512])
@@ -615,8 +600,9 @@ def test_matmul_2d_multiple_output_blocks_per_core(
     use_program_cache,
 ):
     compute_grid_size = mesh_device.compute_with_storage_grid_size()
-    grid_size = [compute_grid_size.x, compute_grid_size.y]
-    if grid_size[1] < 8:
+    required_size = 8  # input tensor sizes are too small to be subdivided on larger grids
+    grid_size = [min(required_size, compute_grid_size.x), min(required_size, compute_grid_size.y)]
+    if grid_size[1] < required_size:
         pytest.skip("device does not have 8x8 grid")
 
     for _ in range(2):
@@ -712,18 +698,12 @@ def run_matmul_2d_tiny_tile(
         fused_activation=None,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
     if out_sharded:
         out_mem_config = ttnn.MemoryConfig(
             memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
@@ -764,7 +744,7 @@ def run_matmul_2d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@run_for_wormhole_b0()
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
 @pytest.mark.parametrize("m", [512])
 @pytest.mark.parametrize("k", [512])
 @pytest.mark.parametrize("n", [768])
@@ -876,18 +856,12 @@ def run_matmul_1d_tiny_tile(
         mcast_in0=True,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
     if out_sharded:
         out_mem_config = ttnn.MemoryConfig(
             memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
@@ -928,7 +902,7 @@ def run_matmul_1d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@run_for_wormhole_b0()
+@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
 @pytest.mark.parametrize("m", [128])
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1024])
@@ -1090,18 +1064,12 @@ def run_matmul_1d_multiple_output_blocks_per_core(
         mcast_in0=mcast_in0,
     )
 
-    if is_grayskull():
-        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-        )
-    else:
-        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-            math_fidelity=ttnn.MathFidelity.LoFi,
-            math_approx_mode=True,
-            fp32_dest_acc_en=False,
-            packer_l1_acc=True,
-        )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
     if out_sharded:
         if mcast_in0:
             out_mem_config = ttnn.MemoryConfig(
@@ -1143,7 +1111,6 @@ def run_matmul_1d_multiple_output_blocks_per_core(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@run_for_wormhole_b0()
 @pytest.mark.parametrize("m", [256])
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [2048])
@@ -1364,7 +1331,6 @@ def test_padded_1d_matmul(mesh_device, side, has_program_config):
 
 
 # fmt: off
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("m_size,k_size,n_size", [
     (1, 2, 2),
     (1, 2, 4),
@@ -1394,7 +1360,6 @@ def test_matmul_with_matched_width_height(device, m_size, k_size, n_size):
 
 
 # fmt: off
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("k_size, n_size", [
     (2, 4),
     (4, 2),
@@ -1422,8 +1387,6 @@ def test_matmul_with_matched_width_height_from_1D(device, k_size, n_size):
     assert_with_pcc(torch_output_tensor, output, 0.9999)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
-@pytest.mark.skip(reason="ttnn.reshape doesn't support reshaping the input tensors used in this test")
 @pytest.mark.parametrize("w", [(4), (2)])
 def test_matmul_does_dot_product(device, w):
     torch.manual_seed(0)
@@ -1432,22 +1395,19 @@ def test_matmul_does_dot_product(device, w):
     torch_input_tensor_b = torch.zeros((w,), dtype=torch.bfloat16).uniform_(-0.1, 0.1)
     torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
 
-    input_tensor_a = ttnn.from_torch(torch_input_tensor_a)
-    input_tensor_b = ttnn.from_torch(torch_input_tensor_b)
-    input_tensor_a = ttnn.to_device(input_tensor_a, device)
-    input_tensor_b = ttnn.to_device(input_tensor_b, device)
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
     output = ttnn.matmul(input_tensor_a, input_tensor_b)
     output = ttnn.from_device(output)
 
     output = ttnn.to_torch(output)
 
     assert torch_output_tensor.shape == ()
-    assert output.shape == (32,)
-    assert torch.allclose(torch_output_tensor, output[0], atol=1e-2)
+    assert output.shape == ()
+    assert torch.allclose(torch_output_tensor, output, atol=1e-2)
 
 
 # fmt: off
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("n_size,c,h,w", [
     (1, 1, 2, 4),
     (1, 1, 4, 2),
@@ -1473,7 +1433,6 @@ def test_matmul_with_matched_width_height_4D(device, n_size, c, h, w):
 
 
 # fmt: off
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("n_size,c,h,w", [
     (1, 1, 2, 2),
     (1, 1, 4, 4),
@@ -1498,7 +1457,6 @@ def test_matmul_same_shape_and_valid(device, n_size, c, h, w):
 
 
 # fmt: off
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("input_a,input_b", [
         ([1.0,2.0,3.0],[3.0,4.0,5.0])
     ])
@@ -1525,7 +1483,6 @@ def test_matmul_same_shape_but_invalid(device, input_a, input_b):
     assert "The width of the first tensor must be equal to the height of the second tensor" in str(exception.value)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul(device):
     torch.manual_seed(0)
 
@@ -1546,7 +1503,6 @@ def test_tutorial_matmul(device):
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
     torch.manual_seed(0)
 
@@ -1571,7 +1527,6 @@ def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_core_grid(device):
     torch.manual_seed(0)
 
@@ -1599,7 +1554,6 @@ def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "batch_size_0, batch_size_1, m_size, k_size, n_size, bcast_batch, input_a_sharded_memory_config_args, input_b_sharded_memory_config_args",
     [
@@ -1735,7 +1689,6 @@ def test_sharded_matmul(
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 7])
 def test_matmul_with_core_grid(device, batch_size):
     torch.manual_seed(0)
@@ -1761,7 +1714,6 @@ def test_matmul_with_core_grid(device, batch_size):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [30, 61])
 @pytest.mark.parametrize("k_size", [1023, 2048])
@@ -1786,7 +1738,6 @@ def test_wide_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [1024, 2048])
 @pytest.mark.parametrize("k_size", [1023, 2048])
@@ -1811,7 +1762,6 @@ def test_tall_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.997)
 
 
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [31, 63])
 @pytest.mark.parametrize("k_size", [1024, 2048])
@@ -1870,7 +1820,6 @@ def test_matmul_with_transpose_a_or_b(device, n_size, c, m, k, n, transpose_a, t
 ##########################
 # MODEL SPECIFIC MATMULS #
 ##########################
-@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("m_size", [128])
 @pytest.mark.parametrize("k_size", [4544])
@@ -1896,7 +1845,6 @@ def test_falcon_query_key_value_matmul(device, batch_size, m_size, k_size, n_siz
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.996)
 
 
-@run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "in0_dtype, in1_dtype, num_activation_cores, num_compute_cores, has_bias, config, M, K, N",
     [

--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul.py
@@ -2,14 +2,21 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 from loguru import logger
 import pytest
 import torch
 import math
 import ttnn
 
-from models.utility_functions import comp_pcc, is_blackhole, skip_for_blackhole
+from models.utility_functions import comp_pcc
 from tests.ttnn.utils_for_testing import assert_with_pcc
+from models.utility_functions import skip_for_grayskull, is_wormhole_b0, is_grayskull, is_blackhole, run_for_wormhole_b0
+
+# for setting up multi-device stress tests
+NUM_DEVICES_ENV_KEY = "USE_NUM_DEVICES"
+NUM_DEVICES = ttnn.distributed.get_num_pcie_devices() if os.environ.get(NUM_DEVICES_ENV_KEY, None) is not None else 1
 
 
 def find_max_subblock(out_block_h, out_block_w):
@@ -92,6 +99,7 @@ def test_pytorch_2_0_failed_cases(device, m, k, n):
     assert_with_pcc(z_t, z)
 
 
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("device_params", [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL}], indirect=True)
 @pytest.mark.parametrize("m", [256])
 @pytest.mark.parametrize("k", [256])
@@ -193,7 +201,7 @@ def test_matmul_reuse_config_sharded_fd_column(
     assert_with_pcc(pt_out, output_tensor, expected_pcc)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("b", [2])
 @pytest.mark.parametrize("h", [3])
 @pytest.mark.parametrize("m", [256])
@@ -301,7 +309,7 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
     return padded_number
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1280])
 @pytest.mark.parametrize("has_bias", [False, True])
@@ -310,16 +318,18 @@ def pad_to_dram_banks(num, tile_w, lcm=32 * 12):
 @pytest.mark.parametrize("tile_w", [16, 32])
 @pytest.mark.parametrize("in1_dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
 @pytest.mark.parametrize("transpose_tile", [True, False])
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
 def test_matmul_in1_dram_sharded_tiny_tile(
-    device, k, n, has_bias, grid_size, tile_h, tile_w, in1_dtype, transpose_tile
+    mesh_device, k, n, has_bias, grid_size, tile_h, tile_w, in1_dtype, transpose_tile
 ):
     # PCC issue when height not equal to tile height
     m = tile_h
-    if is_blackhole():
-        num_banks = device.dram_grid_size().x  # need to match harvesting of dram
+    if is_grayskull():
+        n_padded = n
+        num_banks = 8
     else:
         num_banks = 12
-    n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_banks)
+        n_padded = pad_to_dram_banks(n, tile_w, tile_w * num_banks)
 
     in0_shape = [1, 1, m, k]
     in1_shape = [1, 1, k, n]
@@ -351,10 +361,10 @@ def test_matmul_in1_dram_sharded_tiny_tile(
         tile=ttnn.Tile((tile_h, 32)),
         dtype=ttnn.bfloat16,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
+        device=mesh_device,
         memory_config=in0_memory_config,
     )
-    in1_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
+    in1_shard_grid = ttnn.CoreCoord(mesh_device.dram_grid_size().x - 1, mesh_device.dram_grid_size().y - 1)
     in1_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), in1_shard_grid)})
     in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     in1_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec)
@@ -363,7 +373,7 @@ def test_matmul_in1_dram_sharded_tiny_tile(
         tile=ttnn.Tile((32, tile_w), transpose_tile=transpose_tile),
         dtype=in1_dtype,
         layout=ttnn.TILE_LAYOUT,
-        device=device,
+        device=mesh_device,
         memory_config=in1_memory_config,
     )
 
@@ -371,7 +381,7 @@ def test_matmul_in1_dram_sharded_tiny_tile(
         bias = torch.randn(bias_shape).bfloat16().float()
         bias_padded = bias.unsqueeze(2)
         bias_padded = torch.nn.functional.pad(bias_padded, (0, 0, 0, tile_h - bias_padded.size(2)), "constant", 0)
-        bias_shard_grid = ttnn.CoreCoord(device.dram_grid_size().x - 1, device.dram_grid_size().y - 1)
+        bias_shard_grid = ttnn.CoreCoord(mesh_device.dram_grid_size().x - 1, mesh_device.dram_grid_size().y - 1)
         bias_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), bias_shard_grid)})
         bias_shard_spec = ttnn.ShardSpec(bias_shard_grid, bias_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
         bias_mem_config = ttnn.MemoryConfig(
@@ -382,7 +392,7 @@ def test_matmul_in1_dram_sharded_tiny_tile(
             tile=ttnn.Tile((tile_h, tile_w)),
             dtype=ttnn.bfloat16,
             layout=ttnn.TILE_LAYOUT,
-            device=device,
+            device=mesh_device,
             memory_config=bias_mem_config,
         )
 
@@ -393,12 +403,18 @@ def test_matmul_in1_dram_sharded_tiny_tile(
         fused_activation=None,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=True,
-    )
+    if is_grayskull():
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+        )
+    else:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
 
     if has_bias:
         output_t = ttnn.linear(
@@ -421,7 +437,6 @@ def test_matmul_in1_dram_sharded_tiny_tile(
             compute_kernel_config=compute_kernel_config,
             output_tile=ttnn.Tile([tile_h, 32]) if tile_h <= 16 else ttnn.Tile([tile_h, tile_w]),
         )
-    output_tensor = ttnn.to_torch(output_t)
     pt_out = in0 @ in1
     if has_bias:
         pt_out += bias
@@ -429,7 +444,11 @@ def test_matmul_in1_dram_sharded_tiny_tile(
         expected_pcc = 0.993
     else:
         expected_pcc = 0.999
-    assert_with_pcc(pt_out, output_tensor, expected_pcc)
+
+    # required for multi-device stress tests
+    for o in ttnn.get_device_tensors(output_t):
+        output_tensor = ttnn.to_torch(o)
+        assert_with_pcc(pt_out, output_tensor, expected_pcc)
 
 
 def run_matmul_2d_multiple_output_blocks_per_core(
@@ -519,12 +538,18 @@ def run_matmul_2d_multiple_output_blocks_per_core(
         fuse_batch=fuse_batch,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=True,
-    )
+    if is_grayskull():
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+        )
+    else:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
     if out_sharded:
         out_mem_config = ttnn.MemoryConfig(
             memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
@@ -551,14 +576,17 @@ def run_matmul_2d_multiple_output_blocks_per_core(
             dtype=ttnn.bfloat16,
             compute_kernel_config=compute_kernel_config,
         )
-    output_tensor = ttnn.to_torch(output_t)
     pt_out = in0 @ in1
     if has_bias:
         pt_out += bias
 
-    assert_with_pcc(pt_out, output_tensor, 0.999)
+    # required for multi-device stress tests
+    for o in ttnn.get_device_tensors(output_t):
+        output_tensor = ttnn.to_torch(o)
+        assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("b", [1, 2])
 @pytest.mark.parametrize("m", [512])
 @pytest.mark.parametrize("k", [512])
@@ -570,8 +598,9 @@ def run_matmul_2d_multiple_output_blocks_per_core(
 @pytest.mark.parametrize("num_out_block_h", [1, 2])
 @pytest.mark.parametrize("num_out_block_w", [1, 2])
 @pytest.mark.parametrize("transpose_mcast", [True, False])
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
 def test_matmul_2d_multiple_output_blocks_per_core(
-    device,
+    mesh_device,
     b,
     m,
     k,
@@ -585,15 +614,14 @@ def test_matmul_2d_multiple_output_blocks_per_core(
     transpose_mcast,
     use_program_cache,
 ):
-    compute_grid_size = device.compute_with_storage_grid_size()
-    required_size = 8  # input tensor sizes are too small to be subdivided on larger grids
-    grid_size = [min(required_size, compute_grid_size.x), min(required_size, compute_grid_size.y)]
-    if grid_size[1] < required_size:
+    compute_grid_size = mesh_device.compute_with_storage_grid_size()
+    grid_size = [compute_grid_size.x, compute_grid_size.y]
+    if grid_size[1] < 8:
         pytest.skip("device does not have 8x8 grid")
 
     for _ in range(2):
         run_matmul_2d_multiple_output_blocks_per_core(
-            device,
+            mesh_device,
             b,
             m,
             k,
@@ -613,10 +641,10 @@ def test_matmul_2d_multiple_output_blocks_per_core(
             py_dummy_tensor,
             dtype=ttnn.DataType.BFLOAT16,
             layout=ttnn.TILE_LAYOUT,
-            device=device,
+            device=mesh_device,
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
-    assert device.num_program_cache_entries() == 1
+    assert mesh_device.num_program_cache_entries() == 1
 
 
 def run_matmul_2d_tiny_tile(
@@ -684,12 +712,18 @@ def run_matmul_2d_tiny_tile(
         fused_activation=None,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=True,
-    )
+    if is_grayskull():
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+        )
+    else:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
     if out_sharded:
         out_mem_config = ttnn.MemoryConfig(
             memory_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
@@ -730,7 +764,7 @@ def run_matmul_2d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("m", [512])
 @pytest.mark.parametrize("k", [512])
 @pytest.mark.parametrize("n", [768])
@@ -842,12 +876,18 @@ def run_matmul_1d_tiny_tile(
         mcast_in0=True,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=True,
-    )
+    if is_grayskull():
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+        )
+    else:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
     if out_sharded:
         out_mem_config = ttnn.MemoryConfig(
             memory_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
@@ -888,7 +928,7 @@ def run_matmul_1d_tiny_tile(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
-@skip_for_blackhole("TinyTile Matmul needs to be fixed on BH. Issue #22103")
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("m", [128])
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [1024])
@@ -1050,12 +1090,18 @@ def run_matmul_1d_multiple_output_blocks_per_core(
         mcast_in0=mcast_in0,
     )
 
-    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.LoFi,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=True,
-    )
+    if is_grayskull():
+        compute_kernel_config = ttnn.GrayskullComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+        )
+    else:
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            math_approx_mode=True,
+            fp32_dest_acc_en=False,
+            packer_l1_acc=True,
+        )
     if out_sharded:
         if mcast_in0:
             out_mem_config = ttnn.MemoryConfig(
@@ -1097,6 +1143,7 @@ def run_matmul_1d_multiple_output_blocks_per_core(
     assert_with_pcc(pt_out, output_tensor, 0.999)
 
 
+@run_for_wormhole_b0()
 @pytest.mark.parametrize("m", [256])
 @pytest.mark.parametrize("k", [1024])
 @pytest.mark.parametrize("n", [2048])
@@ -1234,7 +1281,8 @@ def test_padded_2d_matmul(device, side, tile_count):
     "has_program_config",
     [True, False],
 )
-def test_padded_1d_matmul(device, side, has_program_config):
+@pytest.mark.parametrize("mesh_device", [(1, NUM_DEVICES)], indirect=True)
+def test_padded_1d_matmul(mesh_device, side, has_program_config):
     if side == "height":
         M = 10069
         K = 96
@@ -1284,11 +1332,11 @@ def test_padded_1d_matmul(device, side, has_program_config):
     dummy_out = torch.zeros([1, 1, M, N])
     dummy_upper = torch.full([1, 1, X, X], 4)
 
-    act = ttnn.from_torch(torch_act, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
-    weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
-    lower_tt = ttnn.from_torch(dummy_lower, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
-    out_tt = ttnn.from_torch(dummy_out, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
-    upper_tt = ttnn.from_torch(dummy_upper, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+    act = ttnn.from_torch(torch_act, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16)
+    weight = ttnn.from_torch(torch_weight, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16)
+    lower_tt = ttnn.from_torch(dummy_lower, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16)
+    out_tt = ttnn.from_torch(dummy_out, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16)
+    upper_tt = ttnn.from_torch(dummy_upper, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16)
     # Free up dummy output tensor so linear will allocate output there
     ttnn.deallocate(out_tt)
     output_tensor = ttnn.matmul(
@@ -1300,17 +1348,23 @@ def test_padded_1d_matmul(device, side, has_program_config):
             math_fidelity=ttnn.MathFidelity.HiFi2, math_approx_mode=False, fp32_dest_acc_en=True, packer_l1_acc=False
         ),
     )
-    lower = ttnn.to_torch(lower_tt).float()
-    upper = ttnn.to_torch(upper_tt).float()
-    # Check that the tensors above and below the output are unchanged
+
+    # required for multi-device stress tests
     torch_output_tensor = torch.matmul(torch_act, torch_weight)
-    output_tensor = ttnn.to_torch(output_tensor)
-    assert_with_pcc(torch_output_tensor, output_tensor, pcc)
-    assert torch.all(lower == 2)
-    assert torch.all(upper == 4)
+    for l, u, o in zip(
+        ttnn.get_device_tensors(lower_tt), ttnn.get_device_tensors(upper_tt), ttnn.get_device_tensors(output_tensor)
+    ):
+        lower = ttnn.to_torch(l).float()
+        upper = ttnn.to_torch(u).float()
+        # Check that the tensors above and below the output are unchanged
+        output_tensor_i = ttnn.to_torch(o)
+        assert_with_pcc(torch_output_tensor, output_tensor_i, pcc)
+        assert torch.all(lower == 2)
+        assert torch.all(upper == 4)
 
 
 # fmt: off
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("m_size,k_size,n_size", [
     (1, 2, 2),
     (1, 2, 4),
@@ -1340,6 +1394,7 @@ def test_matmul_with_matched_width_height(device, m_size, k_size, n_size):
 
 
 # fmt: off
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("k_size, n_size", [
     (2, 4),
     (4, 2),
@@ -1367,6 +1422,8 @@ def test_matmul_with_matched_width_height_from_1D(device, k_size, n_size):
     assert_with_pcc(torch_output_tensor, output, 0.9999)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
+@pytest.mark.skip(reason="ttnn.reshape doesn't support reshaping the input tensors used in this test")
 @pytest.mark.parametrize("w", [(4), (2)])
 def test_matmul_does_dot_product(device, w):
     torch.manual_seed(0)
@@ -1375,19 +1432,22 @@ def test_matmul_does_dot_product(device, w):
     torch_input_tensor_b = torch.zeros((w,), dtype=torch.bfloat16).uniform_(-0.1, 0.1)
     torch_output_tensor = torch.matmul(torch_input_tensor_a, torch_input_tensor_b)
 
-    input_tensor_a = ttnn.from_torch(torch_input_tensor_a, layout=ttnn.TILE_LAYOUT, device=device)
-    input_tensor_b = ttnn.from_torch(torch_input_tensor_b, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor_a = ttnn.from_torch(torch_input_tensor_a)
+    input_tensor_b = ttnn.from_torch(torch_input_tensor_b)
+    input_tensor_a = ttnn.to_device(input_tensor_a, device)
+    input_tensor_b = ttnn.to_device(input_tensor_b, device)
     output = ttnn.matmul(input_tensor_a, input_tensor_b)
     output = ttnn.from_device(output)
 
     output = ttnn.to_torch(output)
 
     assert torch_output_tensor.shape == ()
-    assert output.shape == ()
-    assert torch.allclose(torch_output_tensor, output, atol=1e-2)
+    assert output.shape == (32,)
+    assert torch.allclose(torch_output_tensor, output[0], atol=1e-2)
 
 
 # fmt: off
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("n_size,c,h,w", [
     (1, 1, 2, 4),
     (1, 1, 4, 2),
@@ -1413,6 +1473,7 @@ def test_matmul_with_matched_width_height_4D(device, n_size, c, h, w):
 
 
 # fmt: off
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("n_size,c,h,w", [
     (1, 1, 2, 2),
     (1, 1, 4, 4),
@@ -1437,6 +1498,7 @@ def test_matmul_same_shape_and_valid(device, n_size, c, h, w):
 
 
 # fmt: off
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("input_a,input_b", [
         ([1.0,2.0,3.0],[3.0,4.0,5.0])
     ])
@@ -1463,6 +1525,7 @@ def test_matmul_same_shape_but_invalid(device, input_a, input_b):
     assert "The width of the first tensor must be equal to the height of the second tensor" in str(exception.value)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul(device):
     torch.manual_seed(0)
 
@@ -1483,6 +1546,7 @@ def test_tutorial_matmul(device):
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
     torch.manual_seed(0)
 
@@ -1507,6 +1571,7 @@ def test_tutorial_matmul_inputs_and_output_in_l1_memory(device):
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_core_grid(device):
     torch.manual_seed(0)
 
@@ -1534,6 +1599,7 @@ def test_tutorial_matmul_with_inputs_and_output_in_l1_memory_and_user_specified_
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize(
     "batch_size_0, batch_size_1, m_size, k_size, n_size, bcast_batch, input_a_sharded_memory_config_args, input_b_sharded_memory_config_args",
     [
@@ -1669,6 +1735,7 @@ def test_sharded_matmul(
     assert_with_pcc(torch_output_tensor, output, pcc=0.999)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 7])
 def test_matmul_with_core_grid(device, batch_size):
     torch.manual_seed(0)
@@ -1694,6 +1761,7 @@ def test_matmul_with_core_grid(device, batch_size):
     assert_with_pcc(torch_output_tensor, output_tensor, 0.999)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [30, 61])
 @pytest.mark.parametrize("k_size", [1023, 2048])
@@ -1718,6 +1786,7 @@ def test_wide_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     assert_with_pcc(torch_output_tensor, output_tensor, 0.997)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [1024, 2048])
 @pytest.mark.parametrize("k_size", [1023, 2048])
@@ -1742,6 +1811,7 @@ def test_tall_matmul_with_argument_for_core_grid_set_to_device_grid(device, batc
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.997)
 
 
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1, 8])
 @pytest.mark.parametrize("m_size", [31, 63])
 @pytest.mark.parametrize("k_size", [1024, 2048])
@@ -1800,6 +1870,7 @@ def test_matmul_with_transpose_a_or_b(device, n_size, c, m, k, n, transpose_a, t
 ##########################
 # MODEL SPECIFIC MATMULS #
 ##########################
+@pytest.mark.skipif(is_wormhole_b0() or is_blackhole(), reason="Unsupported on WH and BH")
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("m_size", [128])
 @pytest.mark.parametrize("k_size", [4544])
@@ -1825,6 +1896,7 @@ def test_falcon_query_key_value_matmul(device, batch_size, m_size, k_size, n_siz
     assert_with_pcc(torch_output_tensor, output_tensor, pcc=0.996)
 
 
+@run_for_wormhole_b0()
 @pytest.mark.parametrize(
     "in0_dtype, in1_dtype, num_activation_cores, num_compute_cores, has_bias, config, M, K, N",
     [


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/21531

### Problem description
- Stress tests are desired to check system integrity
- **Time sensitive**, needed for 5/21 customer installation

### What's changed
- Tweak the existing matmul stress test and the unit tests it calls to run on multiple devices. (Implementation is a bit awkward since this is needed right away).

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15117593535

- [x] stress test on TG https://github.com/tenstorrent/tt-metal/actions/runs/15122067119/job/42506929869 