### PR TITLE
#19685: Fix Conv2D Width Sharded Row Major output when nhw%32 != 0

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -771,10 +771,12 @@ def test_conv_dram(
     [ttnn.bfloat16],
 )
 @pytest.mark.parametrize(
-    "activations_dtype",
-    [ttnn.bfloat16],
+    "activations_dtype, output_layout",
+    [
+        [ttnn.bfloat16, ttnn.ROW_MAJOR_LAYOUT],
+        [ttnn.bfloat8_b, ttnn.TILE_LAYOUT],
+    ],
 )
-@pytest.mark.parametrize("auto_shard", [True, False], ids=["auto_shard", "no_auto_shard"])
 def test_conv_ws(
     device,
     torch_tensor_map,
@@ -789,11 +791,11 @@ def test_conv_ws(
     pad_h,
     pad_w,
     act_block_w_div,
+    output_layout,
     stride,
     has_bias,
     weights_dtype,
     activations_dtype,
-    auto_shard,
 ):
     run_conv(
         device,
@@ -814,10 +816,11 @@ def test_conv_ws(
         config_override={
             "act_block_h": 32,
         },
-        output_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_layout=output_layout,
+        output_layout=output_layout,
         has_bias=True,
         packer_l1_acc=False,
-        auto_shard=auto_shard,
+        auto_shard=False,
         shard_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
     )
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -63,7 +63,7 @@ uint32_t find_closest_largest_divisor_with_num_padding_and_mult(uint32_t num, ui
     uint32_t divisor = start_divisor;
     uint32_t big_divisor = divisor * mult;
     uint32_t padded_num = round_up(num, big_divisor);
-    while ((padded_num - num) >= (int)(padded_num / big_divisor)) {
+    while ((padded_num - num) >= (int)(padded_num / big_divisor) && divisor > 1) {
         divisor = divisor - 1;
         big_divisor = divisor * mult;
         padded_num = round_up(num, big_divisor);
@@ -947,7 +947,7 @@ std::tuple<OptimizedConvParallelizationConfig, OptimizedConvBlockConfig, MemoryC
             get_num_cores_channels_from_parallel_config(largest_parallel_config));
 
     uint32_t nhw_out_padded_ntile_per_core =
-        conv_out_memory_config.shard_spec().value().shape[0] / tt::constants::TILE_HEIGHT;
+        tt::div_up(conv_out_memory_config.shard_spec().value().shape[0], tt::constants::TILE_HEIGHT);
 
     OptimizedConvBlockConfig opt_conv_op_block_config = determine_per_core_conv_block_config(
         input_parallel_config,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -299,10 +299,7 @@ MemoryConfig create_sharded_memory_config_from_parallel_config(
     auto shard_orientation = parallel_config.shard_orientation;
 
     uint32_t nhw_shape = tensor_shape[0] * tensor_shape[1] * tensor_shape[2];
-    uint32_t nhw_padded = nhw_shape;
-    if (shard_scheme != TensorMemoryLayout::WIDTH_SHARDED) {
-        nhw_padded = round_up(nhw_shape, num_cores_nhw * tile_size);
-    }
+    uint32_t nhw_padded = round_up(nhw_shape, num_cores_nhw * tile_size);
     uint32_t nhw_shard = nhw_padded / num_cores_nhw;
     TT_FATAL(channels % num_cores_channels == 0, "Channels: {}, num core channels: {}", channels, num_cores_channels);
     uint32_t channel_shard = channels / num_cores_channels;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op.cpp
@@ -201,9 +201,9 @@ std::vector<TensorSpec> OptimizedConvNew::compute_output_specs(const std::vector
             auto shard_spec = ShardSpec{shard_grid, shard_shape, this->memory_config.shard_spec().value().orientation};
             auto mem_config = this->memory_config.with_shard_spec(shard_spec);
             return {TensorSpec(
-                output_shape,
+                padded_output_shape,
                 TensorLayout::fromPaddedShape(
-                    dtype, PageConfig(output_layout), mem_config, output_shape, padded_output_shape))};
+                    dtype, PageConfig(output_layout), mem_config, padded_output_shape, padded_output_shape))};
         } else if (this->memory_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
             auto shard_grid = this->memory_config.shard_spec().value().grid;
             auto shard_spec = ShardSpec{


### PR DESCRIPTION
### Ticket
#19685 

### Problem description
Output Tensor creation fails due to mismatched physical height & physical shard height.

### What's changed
Use padded shape as the logical shape for width sharded Conv2D Outputs.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes