### PR TITLE
#22146: BH ttnn unit failure in test for sort fix

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -5,7 +5,6 @@
 import pytest
 import torch
 import ttnn
-from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sort.py
@@ -9,7 +9,6 @@ from models.utility_functions import skip_for_blackhole
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 
-@skip_for_blackhole("Sort needs to be tested and is failing on BH. Issue #22146")
 @pytest.mark.parametrize(
     "shape, dim, descending",
     [
@@ -49,7 +48,6 @@ def test_sort_standard(shape, dim, descending, device):
         assert_with_pcc(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
 
-@skip_for_blackhole("Sort needs to be tested and is failing on BH. Issue #22146")
 @pytest.mark.parametrize(
     "shape, dim, descending",
     [

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -133,7 +133,35 @@ void MAIN {
                         // Get indexes of tiles to compare
                         const uint32_t left_tile_id = i;
                         const uint32_t right_tile_id = j;
-
+                        /**
+                         * Compute kernel for performing bitonic sort on tiles with synchronization caveats.
+                         *
+                         * Potential Bug: Unpacker and Packer Threads Synchronization Issue
+                         *
+                         * After migrating to the wormhole architecture, undefined behavior was observed, resulting in
+                         * incorrect results. The core of the issue lies in the synchronization between the unpacker
+                         * (reading tiles from CB to registers) and packer (writing tiles from registers back to CB)
+                         * threads.
+                         *
+                         * In the this loop, two tiles are read from a circular buffer (CB) into LLK registers, an LLK
+                         * operation is performed, and then the results are written back to the same CB. If there is
+                         * insufficient synchronization between the packer and unpacker threads, it is possible that the
+                         * packer thread does not have enough time to fully pack the tiles from the registers back to
+                         * the CB before the next loop iteration begins. As a result, the unpacker thread in the next
+                         * iteration may read tiles into registers before the previous packing operation is complete,
+                         * leading to data hazards and undefined behavior.
+                         *
+                         * Debugging revealed that inserting a delay between loop iterations resolved the issue,
+                         * suggesting a race condition between packing and unpacking. However, since there is no
+                         * semaphore or similar synchronization primitive available in the compute kernel, it is not
+                         * possible to enforce proper synchronization programmatically.
+                         *
+                         * As a temporary workaround, swapping the order of read and write operations helped mitigate
+                         * the issue, but this is not a robust or permanent solution. Proper synchronization between
+                         * packer and unpacker threads is required to ensure data integrity and correct results.
+                         *
+                         * See also: https://github.com/tenstorrent/tt-metal/pull/22340
+                         */
                         tile_regs_acquire();
                         copy_tile_to_dst_init_short_with_dt(
                             input_tensor_transposed_cb_index, index_tensor_transposed_cb_index);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -134,24 +134,16 @@ void MAIN {
                         const uint32_t left_tile_id = i;
                         const uint32_t right_tile_id = j;
 
-                        // Temporary solution - wait
-                        for (uint32_t i = 0; i < 100000; i++) {
-                            asm volatile("nop");
-                        }
-
                         tile_regs_acquire();
-
-                        // copy_tile_to_dst_init_short(index_tensor_transposed_cb_index);
-                        copy_tile_to_dst_init_short_with_dt(
-                            index_tensor_transposed_cb_index, input_tensor_transposed_cb_index);
-                        copy_tile(input_tensor_transposed_cb_index, left_tile_id, input_dest_start);
-                        copy_tile(input_tensor_transposed_cb_index, right_tile_id, input_dest_end);
-
-                        // copy_tile_to_dst_init_short(input_tensor_transposed_cb_index);
                         copy_tile_to_dst_init_short_with_dt(
                             input_tensor_transposed_cb_index, index_tensor_transposed_cb_index);
                         copy_tile(index_tensor_transposed_cb_index, left_tile_id, index_dest_start);
                         copy_tile(index_tensor_transposed_cb_index, right_tile_id, index_dest_end);
+
+                        copy_tile_to_dst_init_short_with_dt(
+                            index_tensor_transposed_cb_index, input_tensor_transposed_cb_index);
+                        copy_tile(input_tensor_transposed_cb_index, left_tile_id, input_dest_start);
+                        copy_tile(input_tensor_transposed_cb_index, right_tile_id, input_dest_end);
 
                         ckernel::topk_local_sort(0, (int)dir, 5);
 

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -134,19 +134,29 @@ void MAIN {
                         const uint32_t left_tile_id = i;
                         const uint32_t right_tile_id = j;
 
-                        acquire_dst();
+                        // Temporary solution - wait
+                        for (uint32_t i = 0; i < 100000; i++) {
+                            asm volatile("nop");
+                        }
 
+                        tile_regs_acquire();
+
+                        // copy_tile_to_dst_init_short(index_tensor_transposed_cb_index);
                         copy_tile_to_dst_init_short_with_dt(
                             index_tensor_transposed_cb_index, input_tensor_transposed_cb_index);
                         copy_tile(input_tensor_transposed_cb_index, left_tile_id, input_dest_start);
                         copy_tile(input_tensor_transposed_cb_index, right_tile_id, input_dest_end);
 
+                        // copy_tile_to_dst_init_short(input_tensor_transposed_cb_index);
                         copy_tile_to_dst_init_short_with_dt(
                             input_tensor_transposed_cb_index, index_tensor_transposed_cb_index);
                         copy_tile(index_tensor_transposed_cb_index, left_tile_id, index_dest_start);
                         copy_tile(index_tensor_transposed_cb_index, right_tile_id, index_dest_end);
 
                         ckernel::topk_local_sort(0, (int)dir, 5);
+
+                        tile_regs_commit();
+                        tile_regs_wait();
 
                         pack_reconfig_data_format(input_tensor_transposed_cb_index);
                         pack_tile<true>(input_dest_start, input_tensor_transposed_cb_index, left_tile_id);
@@ -156,7 +166,7 @@ void MAIN {
                         pack_tile<true>(index_dest_start, index_tensor_transposed_cb_index, left_tile_id);
                         pack_tile<true>(index_dest_end, index_tensor_transposed_cb_index, right_tile_id);
 
-                        release_dst();
+                        tile_regs_release();
                     }
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort.cpp
@@ -138,7 +138,7 @@ void MAIN {
                          *
                          * Potential Bug: Unpacker and Packer Threads Synchronization Issue
                          *
-                         * After migrating to the wormhole architecture, undefined behavior was observed, resulting in
+                         * After migrating to the blackhole architecture, undefined behavior was observed, resulting in
                          * incorrect results. The core of the issue lies in the synchronization between the unpacker
                          * (reading tiles from CB to registers) and packer (writing tiles from registers back to CB)
                          * threads.

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/compute/sort_common.hpp
@@ -18,7 +18,7 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
 
     bool ascending_local = ascending;
     for (uint32_t wt = 0; wt < Wt; wt += 2) {
-        acquire_dst();
+        tile_regs_acquire();
 
         cb_wait_front(input_cb_index, 2);
         cb_wait_front(index_cb_index, 2);
@@ -37,6 +37,9 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
         // llk_topk_sort -> inplace
         ckernel::topk_local_sort(0, (int)ascending_local, end_phase);
 
+        tile_regs_commit();
+        tile_regs_wait();
+
         // pack value tiles into transposed buffer
         pack_reconfig_data_format(input_transposed_cb_index);
         pack_tile(0, input_transposed_cb_index);
@@ -46,11 +49,10 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
         pack_reconfig_data_format(index_transposed_cb_index);
         pack_tile(2, index_transposed_cb_index);
         pack_tile(3, index_transposed_cb_index);
-
         cb_pop_front(input_cb_index, 2);
         cb_pop_front(index_cb_index, 2);
 
-        release_dst();
+        tile_regs_release();
 
         // Switch sorting direction for bitonic merge sort
         ascending_local = switch_dir ? !ascending_local : ascending_local;
@@ -71,14 +73,18 @@ void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, ui
     cb_wait_front(transposed_cb_index, Wt);
 
     for (uint32_t i = 0; i < Wt; ++i) {
-        acquire_dst();
+        tile_regs_acquire();
 
         cb_reserve_back(dest_cb_index, one_tile);
         transpose_wh_tile(transposed_cb_index, i, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
         pack_tile(0, dest_cb_index);
         cb_push_back(dest_cb_index, one_tile);
 
-        release_dst();
+        tile_regs_release();
     }
 
     cb_wait_front(transposed_cb_index, Wt);

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/sort/device/kernels/dataflow/writer.cpp
@@ -7,8 +7,9 @@
 #include "debug/dprint.h"
 
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
+    constexpr uint32_t one_tile = 1;
     // Reserve space
-    cb_reserve_back(cb_id, 1);
+    cb_reserve_back(cb_id, one_tile);
 
     // Writer config
     const uint32_t writer_addr = get_write_ptr(cb_id);
@@ -37,7 +38,7 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     }  // i loop
 
     // Push the tile
-    cb_push_back(cb_id, 1);
+    cb_push_back(cb_id, one_tile);
 }
 
 /*


### PR DESCRIPTION
### Ticket
[BH TTNN Unit failure in test for sort](https://github.com/tenstorrent/tt-metal/issues/22146)

### Problem description
After moving tests to BH, it was discovered that one of the tests of the `ttnn.sort` operation stopped working. Test spec: `"shape, dim, descending" : ([32, 128], -1, False)`, error: `AssertionError: 0.8550714185387979`.

### What's changed
- `*_dst()` was replaced with new constructs `tile_regs_()*`,
- Changed order of loading data to LLK,
- Removed skip test from test sort tests. 

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes