### PR TITLE
TG Llama70B - Add Long Stress Test to TG Nightly [200K iterations]

### DIFF
--- a/.github/workflows/tg-nightly-tests-impl.yaml
+++ b/.github/workflows/tg-nightly-tests-impl.yaml
@@ -35,13 +35,13 @@ jobs:
             timeout: 30,
             owner_id: U053W15B6JF
           }, # Djordje Ivanovic
-          # { See GH Issue #22164
-          #   name: "Llama Galaxy Demo Long Generation Test",
-          #   arch: wormhole_b0,
-          #   cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k mini-stress-test",
-          #   timeout: 40,
-          #   owner_id: U044T8U8DEF
-          # }, # Johanna Rock
+          {
+            name: "Llama Galaxy Long Stress Test",
+            arch: wormhole_b0,
+            cmd: "LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.1-70B-Instruct/ FAKE_DEVICE=TG TT_METAL_ENABLE_ERISC_IRAM=1 pytest models/demos/llama3_subdevices/demo/demo_decode.py  -k 'stress-test and not mini-stress-test'",
+            timeout: 240,
+            owner_id: U053W15B6JF
+          }, # Djordje Ivanovic
         ]
     name: ${{ matrix.test-group.name }}
     runs-on:

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -190,9 +190,11 @@ def run_llama3_demo(
             * paged_attention_config.max_num_blocks
             / model_args.batch_size_per_device_group
         )
-        assert (
+        is_valid_token_position = (stress_test and start_pos <= paged_cache_max_seq_len) or (
             max_generated_tokens + start_pos <= paged_cache_max_seq_len
-        ), f"max_generated_tokens ({max_generated_tokens}) + start_pos ({start_pos}) needs to be <= than paged_cache_max_seq_len ({paged_cache_max_seq_len})"
+        )
+        assert_msg = f"Either stress test with start_pos ({start_pos}) <= paged_cache_max_seq_len ({paged_cache_max_seq_len}) or max_generated_tokens ({max_generated_tokens}) + start_pos ({start_pos}) <= paged_cache_max_seq_len ({paged_cache_max_seq_len})"
+        assert is_valid_token_position, assert_msg
 
         # Implied shuffling of blocks
         permutation = torch.randperm(paged_attention_config.max_num_blocks)

--- a/models/demos/llama3_subdevices/demo/demo_decode.py
+++ b/models/demos/llama3_subdevices/demo/demo_decode.py
@@ -600,7 +600,7 @@ def run_llama3_demo(
             1,  # repeat_batches
             128 * 1024,  # max_seq_len
             32,  # batch_size
-            4 * 128 * 1024,  # max_generated_tokens (same index for stress test)
+            500000,  # max_generated_tokens (same index for stress test)
             True,  # paged_attention
             {"page_block_size": 64, "page_max_num_blocks": 4096},  # page_params  # TODO This will be serviced by vLLM
             {"top_k": 32, "top_p": 0.08, "seed": 42},  # sampling_params (argmax)


### PR DESCRIPTION
### Problem description
Running 5x20K iterations might not be enough for long stress testing whole Llama model.

### What's changed
Long Stress test of 500K iterations is introduced in nightly which should take around 2.5-3hrs. 
### Checklist
- [x] [Long Stress Test](https://github.com/tenstorrent/tt-metal/actions/runs/15136131294/job/42548562553)