### PR TITLE
Reimplement debug tools utils

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_test_utils.hpp
@@ -7,19 +7,16 @@
 #include <tt-metalium/host_api.hpp>
 #include "llrt.hpp"
 
+#include <string_view>
+
 // Helper function to open a file as an fstream, and check that it was opened properly.
 inline bool OpenFile(string &file_name, std::fstream &file_stream, std::ios_base::openmode mode) {
     file_stream.open(file_name, mode);
     if (file_stream.is_open()) {
         return true;
-    } else {
-        tt::log_info(
-            tt::LogTest,
-            "Test Error: Couldn't open file {}.",
-            file_name
-        );
-        return false;
     }
+    tt::log_info(tt::LogTest, "Test Error: Couldn't open file {}.", file_name);
+    return false;
 }
 
 // Helper function to dump a file
@@ -32,40 +29,50 @@ inline void DumpFile(string file_name) {
 
     tt::log_info(tt::LogTest, "File \'{}\' contains:", file_name);
     string line;
-    while (getline(log_file, line))
+    while (getline(log_file, line)) {
         tt::log_info(tt::LogTest, "{}", line);
+    }
 }
 
-// Compare two strings with a (single-character) wildcard
-inline bool StringCompareWithWildcard(const string& s1, const string& s2, char wildcard) {
-    if (s1.size() != s2.size())
+// Wildcard is '?', just like a glob.
+inline bool StringCompareWithWildcard(const std::string_view str, const std::string_view pattern) {
+    size_t pattern_size = pattern.size();
+    if (pattern_size != str.size())
         return false;
-
-    for (int idx = 0; idx < s1.size(); idx++) {
-        if (s1[idx] != s2[idx] && s1[idx] != wildcard && s2[idx] != wildcard)
+    for (int idx = 0; idx < pattern_size; idx++) {
+        if (str[idx] != pattern[idx] && pattern[idx] != '?') {
             return false;
+        }
     }
-
     return true;
 }
 
-// Check if s1 is in s2, with wildcard character support
-inline bool StringContainsWithWildcard(const string& s1, const string& s2, char wildcard) {
-    int substr_len = s1.size();
-    int superstr_len = s2.size();
-    if (substr_len > superstr_len)
+// Check if haystack contains needle, return true. needle may contain
+// '?' to match any character (just like glob).
+inline bool StringContainsWithWildcard(std::string_view haystack, std::string_view needle) {
+    size_t needle_size = needle.size();
+    if (needle_size == 0 || needle.front() == '?') {
+        // The needle is empty, or begins with '?', fail in order to
+        // force test to be fixed.
         return false;
+    }
+    if (needle_size > haystack.size()) {
+        return false;
+    }
+    char first = needle.front();
 
-    for (int idx = 0; idx <= superstr_len - substr_len; idx++) {
-        string substr = s2.substr(idx, substr_len);
-        if (StringCompareWithWildcard(s1, substr, wildcard))
+    for (size_t idx = 0, limit = haystack.size() - needle_size;
+         (idx = haystack.find(first, idx)) <= limit; idx++) {
+        std::string_view substr(&haystack[idx], needle_size);
+        if (StringCompareWithWildcard(substr, needle)) {
             return true;
+        }
     }
 
     return false;
 }
 
-// Check whether the given file contains a list of strings. Doesn't check for
+// Check whether the given file contains a list of strings in any order. Doesn't check for
 // strings between lines in the file.
 inline bool FileContainsAllStrings(string file_name, const std::vector<string> &must_contain) {
     std::fstream log_file;
@@ -73,33 +80,40 @@ inline bool FileContainsAllStrings(string file_name, const std::vector<string> &
         return false;
 
     // Construct a set of required strings, we'll remove each one when it's found.
-    std::set<string> must_contain_set(must_contain.begin(), must_contain.end());
-
-    if (log_file.is_open()) {
-        string line;
-        while (getline(log_file, line)) {
-            // Check for all target strings in the current line
-            std::vector<string> found_on_current_line;
-            for (const string &s : must_contain_set) {
-                if (StringContainsWithWildcard(s, line, '*'))
-                    found_on_current_line.push_back(s);
-            }
-
-            // Remove all strings found on this line from the set to continue searching for
-            for (const string &s : found_on_current_line)
-                must_contain_set.erase(s);
-
-            // If all strings have been found, return true
-            if (must_contain_set.empty())
-                return true;
-        }
+    std::set<std::string_view> must_contain_set;
+    for (auto const &str : must_contain) {
+        must_contain_set.insert(str);
     }
-    log_file.close();
 
-    // If the log file doesn't exist, is empty, or doesn't contain all strings, return false.
+    for (;;) {
+        if (must_contain_set.empty()) {
+            // Found them all.
+            return true;
+        }
+
+        string line;
+        if (!getline(log_file, line)) {
+            break;
+        }
+
+        // Check for all target strings in the current line
+        std::vector<std::string_view> found_on_current_line;
+        for (const auto &s : must_contain_set) {
+            if (StringContainsWithWildcard(line, s)) {
+                found_on_current_line.push_back(s);
+            }
+        }
+
+        // Remove all strings found on this line from the set to continue searching for
+        for (const auto &s : found_on_current_line)
+            must_contain_set.erase(s);
+    }
+
+    // Reached EOF with strings yet to find.
     string missing_strings = "";
-    for (const string &s : must_contain_set)
-        missing_strings += s + ",";
+    for (const auto &s : must_contain_set) {
+        missing_strings.append(&", \""[missing_strings.empty() ? 2 : 0]).append(s).push_back('"');
+    }
     tt::log_info(
         tt::LogTest,
         "Test Error: Expected file {} to contain the following strings: {}",
@@ -116,31 +130,36 @@ inline bool FileContainsAllStringsInOrder(string file_name, const std::vector<st
     if (!OpenFile(file_name, log_file, std::fstream::in))
         return false;
 
-    // Construct a queue of required strings, we'll remove each one when it's found.
-    std::deque<string> must_contain_queue(must_contain.begin(), must_contain.end());
+    // Construct a deque of required strings, we'll remove each one when it's found.
+    std::deque<std::string_view> must_contain_queue;
+    for (auto const &str : must_contain) {
+        must_contain_queue.push_back(str);
+    }
 
-    if (log_file.is_open()) {
+    for (;;) {
+        if (must_contain_queue.empty()) {
+            // Found them all
+            return true;
+        }
+
         string line;
-        while (getline(log_file, line)) {
-            // Check for all target strings in the current line
-            while (
-                !must_contain_queue.empty() &&
-                StringContainsWithWildcard(must_contain_queue.front(), line, '*')
-            ) {
-                must_contain_queue.pop_front();
-            }
+        if (!getline(log_file, line)) {
+            break;
+        }
 
-            // If all strings have been found, return true
-            if (must_contain_queue.empty())
-                return true;
+        // Check for all target strings in the current line
+        for (; !must_contain_queue.empty(); must_contain_queue.pop_front()) {
+            if (!StringContainsWithWildcard(line, must_contain_queue.front())) {
+                break;
+            }
         }
     }
-    log_file.close();
 
-    // If the log file doesn't exist, is empty, or doesn't contain all strings, return false.
+    // Reached EOF with strings yet to find.
     string missing_strings = "";
-    for (const string &s : must_contain_queue)
-        missing_strings += s + ",";
+    for (const auto &s : must_contain_queue) {
+        missing_strings.append(&", \""[missing_strings.empty() ? 2 : 0]).append(s).push_back('"');
+    }
     tt::log_info(
         tt::LogTest,
         "Test Error: Expected file {} to contain the following strings: {}",
@@ -171,7 +190,7 @@ inline bool FilesMatchesString(string file_name, const string& expected) {
     int line_num = 0;
     while (getline(file, line_a) && getline(expect_stream, line_b)) {
         line_num++;
-        if (!StringCompareWithWildcard(line_a, line_b, '*')) {
+        if (!StringCompareWithWildcard(line_a, line_b)) {
             tt::log_info(
                 tt::LogTest,
                 "Test Error: Line {} of {} did not match expected:\n\t{}\n\t{}",

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_hanging.cpp
@@ -37,7 +37,7 @@ namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 // Some machines will run this test on different virtual cores, so wildcard the exact coordinates.
 const std::string golden_output =
-    R"(DPRINT server timed out on Device *, worker core (x=*,y=*), riscv 4, waiting on a RAISE signal: 1
+    R"(DPRINT server timed out on Device ?, worker core (x=?,y=?), riscv 4, waiting on a RAISE signal: 1
 )";
 
 void RunTest(DPrintFixture* fixture, IDevice* device) {

--- a/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/dprint/test_print_prepend_device_core_risc.cpp
@@ -37,7 +37,7 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 void UpdateGoldenOutput(std::vector<string>& golden_output, const IDevice* device, const string& risc) {
     // Using wildcard characters in lieu of actual values for the virtual coordinates as virtual coordinates can vary
     // by machine
-    const string& device_core_risc = std::to_string(device->id()) + ":(x=*,y=*):" + risc + ": ";
+    const string& device_core_risc = std::to_string(device->id()) + ":(x=?,y=?):" + risc + ": ";
 
     const string& output_line_all_riscs = device_core_risc + "Printing on a RISC.";
     golden_output.push_back(output_line_all_riscs);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_waypoint.cpp
@@ -195,9 +195,9 @@ void RunTest(WatcherFixture* fixture, IDevice* device) {
                     // Active eth core only has one available erisc to test on.
                     (device->arch() == ARCH::BLACKHOLE and not is_active) ? waypoint : "   X");
                 if (device->arch() == ARCH::BLACKHOLE) {
-                    expected += fmt::format("rmsg:***|** h_id:  0 smsg:* k_id:{}", k_id_s);
+                    expected += fmt::format("rmsg:???|?? h_id:  0 smsg:? k_id:{}", k_id_s);
                 } else {
-                    expected += fmt::format("rmsg:***|* h_id:  0 k_id:{}", k_id_s);
+                    expected += fmt::format("rmsg:???|? h_id:  0 k_id:{}", k_id_s);
                 }
             } else {
                 // Each different config has a different calculation for k_id, let's just do one. Fast Dispatch, one device.
@@ -210,9 +210,9 @@ void RunTest(WatcherFixture* fixture, IDevice* device) {
                     k_id_s = "";
                 }
                 expected = fmt::format(
-                    "Device {} worker core(x={:2},y={:2}) virtual(x={:2},y={:2}): {},{},{},{},{}  rmsg:***|*** h_id:  "
+                    "Device {} worker core(x={:2},y={:2}) virtual(x={:2},y={:2}): {},{},{},{},{}  rmsg:???|??? h_id:  "
                     "0 "
-                    "smsg:**** k_ids:{}",
+                    "smsg:???? k_ids:{}",
                     device->id(),
                     logical_core.x,
                     logical_core.y,


### PR DESCRIPTION
### Ticket
NA
### Problem description
In working on a stack usage test, I noticed that the debug tool utils used rather poor string handling 
* We're copying strings.
* Making too many comparisons
* Confusingly using '*' as a single-character wildcard
* Allowing other wildcard characters, but only using `*`

### What's changed
* Fix a bunch of formatting
* Use std::string_view
* Reimplement what is essentially strstr (with a wildcard)
* Change wildcard from `*` to `?`, like glob
* Hard wire it into the string comparisons

### Checklist
- [YES] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [YES] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes