### PR TITLE
Revert "#20354: Enable binary_ng for supported configurations (#22243)"

### DIFF
--- a/tt-train/tests/core/n300_utils_test.cpp
+++ b/tt-train/tests/core/n300_utils_test.cpp
@@ -264,5 +264,5 @@ TEST_F(N300UtilsTest, MorehClipGradNorm) {
 
     ttml::core::MeshToXTensorVariant<float> identity_composer = ttml::core::VectorMeshToXTensor<float>(mesh_shape);
     auto res_back = ttml::core::to_xtensor(tensor, identity_composer)[0];
-    EXPECT_TRUE(xt::allclose(expected_res, res_back, 2.2e-2F));
+    EXPECT_TRUE(xt::allclose(expected_res, res_back, 2e-2F));
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.cpp
@@ -176,151 +176,6 @@ inline auto preprocess_inputs(BinaryOpType binary_op_type, Tensor a, Tensor b) {
     return std::make_tuple(a, b);
 }
 
-inline auto any_row_broadcasted(const Tensor& a, const auto& b) {
-    if constexpr (requires { b.get_logical_shape(); }) {
-        const auto& a_shape = a.get_logical_shape();
-        const auto& b_shape = b.get_logical_shape();
-
-        return (a_shape[-2] == 1 and b_shape[-2] > 1) or (b_shape[-2] == 1 and a_shape[-2] > 1);
-    }
-
-    return false;
-}
-
-inline auto any_sharded_block_format(const Tensor& a, const auto& b) {
-    if (a.is_sharded() and is_block_format(a.get_dtype())) {
-        return true;
-    }
-
-    if constexpr (requires { b.is_sharded(); }) {
-        if (b.is_sharded() and is_block_format(b.get_dtype())) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-inline auto any_subtile_broadcasted_block_format(const Tensor& a, const auto& b) {
-    if constexpr (requires { b.get_logical_shape(); }) {
-        const auto& a_shape = a.get_logical_shape();
-        const auto& b_shape = b.get_logical_shape();
-
-        if (is_block_format(a.get_dtype()) and
-            (a_shape[-2] == 1 and b_shape[-2] > 1 or a_shape[-1] == 1 and b_shape[-1] > 1)) {
-            return true;
-        }
-
-        if (is_block_format(b.get_dtype()) and
-            (b_shape[-2] == 1 and a_shape[-2] > 1 or b_shape[-1] == 1 and a_shape[-1] > 1)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-inline auto any_non_height_sharded(const Tensor& a, const auto& b, const MemoryConfig& c) {
-    if (a.is_sharded()) {
-        return a.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED;
-    }
-
-    if constexpr (requires { b.is_sharded(); }) {
-        if (b.is_sharded()) {
-            return b.memory_config().memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED;
-        }
-    }
-
-    if (c.is_sharded()) {
-        return c.memory_layout() != TensorMemoryLayout::HEIGHT_SHARDED;
-    }
-
-    return false;
-}
-
-inline auto is_uneven(const Tensor& t) {
-    if (not t.is_sharded()) {
-        return false;
-    }
-
-    const auto& shape = t.get_padded_shape();
-    const auto& shard = t.shard_spec()->shape;
-
-    return (shape[-4] * shape[-3] * shape[-2] % shard[0]) != 0 or (shape[-1] % shard[1]) != 0;
-}
-
-inline auto any_uneven(const Tensor& a, const auto& b, const std::optional<Tensor>& c) {
-    if (is_uneven(a)) {
-        return true;
-    }
-
-    if constexpr (requires { is_uneven(b); }) {
-        if (is_uneven(b)) {
-            return true;
-        }
-    }
-
-    if (c.has_value() and is_uneven(*c)) {
-        return true;
-    }
-
-    return false;
-}
-
-}  // namespace detail
-
-bool is_legacy_only(
-    const Tensor& lhs,
-    const auto& rhs,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations) {
-    const auto& output_mem_cfg = memory_config.value_or(output ? output->memory_config() : MemoryConfig{});
-
-    if (detail::any_row_broadcasted(lhs, rhs) or detail::any_sharded_block_format(lhs, rhs) or
-        detail::any_subtile_broadcasted_block_format(lhs, rhs) or
-        detail::any_non_height_sharded(lhs, rhs, output_mem_cfg) or detail::any_uneven(lhs, rhs, output)) {
-        TT_FATAL(
-            lhs_activations.size() <= 1,
-            "lhs_activations support maximum of 1 for legacy-only configuration; Override with use_legacy=False "
-            "but note there may be issues");
-        TT_FATAL(
-            rhs_activations.empty(),
-            "rhs_activations not supported for legacy-only configuration; Override with use_legacy=False but note "
-            "there may be issues");
-        return true;
-    }
-
-    return false;
-}
-
-template bool is_legacy_only<Tensor>(
-    const Tensor& lhs,
-    const Tensor& rhs,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
-
-template bool is_legacy_only<float>(
-    const Tensor& lhs,
-    const float& rhs,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
-
-template bool is_legacy_only<int32_t>(
-    const Tensor& lhs,
-    const int32_t& rhs,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
-
-namespace detail {
-
 inline auto invoke_binary_ng(
     QueueId queue_id,
     const Tensor& lhs,
@@ -333,8 +188,9 @@ inline auto invoke_binary_ng(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
-    if (use_legacy ? *use_legacy
-                   : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations)) {
+    const auto& output_mem_cfg = memory_config ? *memory_config : output ? output->memory_config() : MemoryConfig{};
+
+    if (use_legacy.value_or(true)) {
         const std::vector activations(post_activations.begin(), post_activations.end());
         const std::optional lhs_activation =
             lhs_activations.empty() ? std::nullopt : std::optional{lhs_activations.front()};
@@ -512,8 +368,7 @@ Tensor RelationalBinary<binary_op_type>::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
-    if (use_legacy ? *use_legacy
-                   : binary::is_legacy_only(lhs, rhs, memory_config, output, lhs_activations, rhs_activations)) {
+    if (use_legacy.value_or(true)) {
         return detail::binary_impl(DefaultQueueId, binary_op_type, lhs, rhs, dtype, memory_config, output);
     }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/binary.hpp
@@ -17,14 +17,6 @@ struct UnaryWithParam;
 }
 namespace binary {
 
-bool is_legacy_only(
-    const Tensor& lhs,
-    const auto& rhs,
-    const std::optional<MemoryConfig>& memory_config,
-    const std::optional<Tensor>& output,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
-    tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations);
-
 template <BinaryOpType binary_op_type>
 struct BinaryOperation {
     static Tensor invoke(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -241,14 +241,7 @@ Tensor ExecuteDiv::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
-    const auto has_legacy_only_args = round_mode.has_value() or accurate_mode;
-    if (not(use_legacy ? *use_legacy
-                       : has_legacy_only_args or
-                             binary::is_legacy_only(
-                                 input, value, output_mem_config, output_tensor, lhs_activations, rhs_activations))) {
-        TT_FATAL(
-            not has_legacy_only_args,
-            "round_mode, accurate_mode are not valid when passing use_legacy parameter in div");
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<BinaryOpType::DIV>::invoke(
             queue_id,
             input,
@@ -288,14 +281,9 @@ Tensor ExecuteDiv::invoke(
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const ttnn::operations::unary::UnaryWithParam> rhs_activations,
     const std::optional<bool>& use_legacy) {
-    const auto has_legacy_only_args = round_mode.has_value() or accurate_mode;
-    if (not(use_legacy
-                ? *use_legacy
-                : has_legacy_only_args or
-                      binary::is_legacy_only(
-                          input_a, input_b, output_mem_config, output_tensor, lhs_activations, rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         TT_FATAL(
-            not has_legacy_only_args,
+            (!round_mode.has_value() && !accurate_mode),
             "round_mode, accurate_mode are not valid when passing use_legacy parameter in div");
         return BinaryOperation<BinaryOpType::DIV>::invoke(
             queue_id,
@@ -336,37 +324,37 @@ Tensor ExecuteDiv::invoke(
             output_tensor);
     }
 
-    if (round_mode == "trunc") {
-        result = ttnn::trunc(queue_id, result, output_mem_config, output_tensor);
-    } else if (round_mode == "floor") {
-        result = ttnn::floor(queue_id, result, output_mem_config, output_tensor);
-    }
+        if (round_mode == "trunc") {
+            result = ttnn::trunc(queue_id, result, output_mem_config, output_tensor);
+        } else if (round_mode == "floor") {
+            result = ttnn::floor(queue_id, result, output_mem_config, output_tensor);
+        }
 
-    if (is_fp32) {
-        return result;
-    }
+        if (is_fp32) {
+            return result;
+        }
 
-    // Accurate mode: handle division by zero (inf/nan cases)
-    if (accurate_mode) {
-        float t_nan = std::nanf("");
-        float t_inf = std::numeric_limits<float>::infinity();
-        result = where(
-            queue_id,
-            ttnn::eqz(queue_id, input_b, output_mem_config),
-            ttnn::where(
+        // Accurate mode: handle division by zero (inf/nan cases)
+        if (accurate_mode) {
+            float t_nan = std::nanf("");
+            float t_inf = std::numeric_limits<float>::infinity();
+            result = where(
                 queue_id,
-                ttnn::eqz(queue_id, input_a, output_mem_config),
-                t_nan,
-                ttnn::multiply(
+                ttnn::eqz(queue_id, input_b, output_mem_config),
+                ttnn::where(
                     queue_id,
-                    ttnn::sign(queue_id, input_a, output_mem_config),
-                    t_inf,
-                    std::nullopt,
-                    output_mem_config)),
-            result);
-    }
+                    ttnn::eqz(queue_id, input_a, output_mem_config),
+                    t_nan,
+                    ttnn::multiply(
+                        queue_id,
+                        ttnn::sign(queue_id, input_a, output_mem_config),
+                        t_inf,
+                        std::nullopt,
+                        output_mem_config)),
+                result);
+        }
 
-    return typecast(queue_id, result, input_dtype, std::nullopt, output_tensor);
+        return typecast(queue_id, result, input_dtype, std::nullopt, output_tensor);
 }
 
 Tensor _div_no_nan_overload(const Tensor& input_a, float value, const std::optional<MemoryConfig>& output_mem_config) {
@@ -767,14 +755,7 @@ Tensor ExecuteRsub::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::RSUB>::invoke(
             queue_id,
             input_tensor_a,
@@ -803,14 +784,7 @@ Tensor ExecuteBitwiseAnd::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_tensor_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::BITWISE_AND>::invoke(
             queue_id,
             input_tensor_a,
@@ -847,14 +821,7 @@ Tensor ExecuteBitwiseAnd::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::BITWISE_AND>::invoke(
             queue_id,
             input_tensor_a,
@@ -884,14 +851,7 @@ Tensor ExecuteBitwiseOr::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_tensor_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::BITWISE_OR>::invoke(
             queue_id,
             input_tensor_a,
@@ -919,14 +879,7 @@ Tensor ExecuteBitwiseOr::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::BITWISE_OR>::invoke(
             queue_id,
             input_tensor_a,
@@ -956,14 +909,7 @@ Tensor ExecuteBitwiseXor::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_tensor_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::BITWISE_XOR>::invoke(
             queue_id,
             input_tensor_a,
@@ -991,14 +937,7 @@ Tensor ExecuteBitwiseXor::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::BITWISE_XOR>::invoke(
             queue_id,
             input_tensor_a,
@@ -1028,14 +967,7 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_tensor_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::LEFT_SHIFT>::invoke(
             queue_id,
             input_tensor_a,
@@ -1063,14 +995,7 @@ Tensor ExecuteBitwiseLeftShift::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::LEFT_SHIFT>::invoke(
             queue_id,
             input_tensor_a,
@@ -1100,14 +1025,7 @@ Tensor ExecuteBitwiseRightShift::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_tensor_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::RIGHT_SHIFT>::invoke(
             queue_id,
             input_tensor_a,
@@ -1135,14 +1053,7 @@ Tensor ExecuteBitwiseRightShift::invoke(
     tt::stl::Span<const unary::UnaryWithParam> lhs_activations,
     tt::stl::Span<const unary::UnaryWithParam> rhs_activations,
     std::optional<bool> use_legacy) {
-    if (not(use_legacy ? *use_legacy
-                       : binary::is_legacy_only(
-                             input_tensor_a,
-                             input_b,
-                             memory_config,
-                             optional_output_tensor,
-                             lhs_activations,
-                             rhs_activations))) {
+    if (not use_legacy.value_or(true)) {
         return BinaryOperation<operations::binary::BinaryOpType::RIGHT_SHIFT>::invoke(
             queue_id,
             input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -285,9 +285,9 @@ void set_or_update_runtime_arguments(
         } else if (core_group_2.contains(core)) {
             c_num_tiles = num_tiles_per_core_group_2;
         } else {
-            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 18>{0});
+            handle_args(program, reader_kernel_id, core, std::array<uint32_t, 13>{0});
             handle_args(program, writer_kernel_id, core, std::array<uint32_t, 14>{0});
-            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 4>{0});
+            handle_args(program, compute_kernel_id, core, std::array<uint32_t, 3>{0});
             continue;
         }
 


### PR DESCRIPTION
This reverts commit c785901ae4b118316af3c2b9c7b0eb2190fba704.

This commit broke some models that likely need to use the legacy binary.

### Ticket

#22307

### Problem description

This broke some models in frequent ttnn, and maybe demos as well.

### What's changed

Revert `binary_ng` enablement.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes