### PR TITLE
#21926: Do some cleanup and docstrings for the large model caching stuff in CIv2

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -233,7 +233,7 @@ def model_location_generator(is_ci_v2_env):
 
     :return: The path to the model files (internal MLPerf path, CI v2 cache
              path, or just model_version which uses HF_HOME)
-    :rtype: str
+    :rtype: os.PathLike (str, pathlib.Path etc.)
 
     :raises AssertionError: If trying to run in CIv2 environment with MLPerf
     files which is impossible, or if model_subdir contains unsupported

--- a/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
+++ b/models/demos/ttnn_falcon7b/tests/multi_chip/test_falcon_causallm.py
@@ -74,7 +74,7 @@ def test_falcon_causal_lm(
     else:
         shard_dim = 0
 
-    model_location_or_version = model_location_generator(model_version, download_if_ci_v2=True)
+    model_location_or_version = model_location_generator(model_version, download_if_ci_v2=True, ci_v2_timeout_in_s=900)
 
     configuration = transformers.FalconConfig.from_pretrained(model_location_or_version)
     configuration.num_hidden_layers = num_layers


### PR DESCRIPTION
### Ticket

#21926

### Problem description

Follow up to #22018 

### What's changed
Add initial docstring for model_location_generator + add some initial error wrapping around wget because it's an external + brittle call

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15172432944
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] **(For models and ops writers)** Full [new models tests](https://github.com/tenstorrent/tt-metal/actions/workflows/full-new-models-suite.yaml) CI passes (if applicable)
- [ ] New/Existing tests provide coverage for changes