### PR TITLE
[Fabric] Updates to control plane and host side connection setup APIs

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -107,6 +107,8 @@ void RunTestUnicastRaw(
 void RunTestUnicastConnAPI(
     BaseFabricFixture* fixture, uint32_t num_hops = 1, RoutingDirection direction = RoutingDirection::E);
 
+void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture);
+
 void RunTestMCastConnAPI(
     BaseFabricFixture* fixture,
     RoutingDirection fwd_dir = RoutingDirection::W,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -609,29 +609,16 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     EXPECT_EQ(sender_bytes, receiver_bytes);
 }
 
-void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDirection direction) {
+void run_unicast_test_bw_chips(
+    BaseFabricFixture* fixture, chip_id_t src_physical_device_id, chip_id_t dst_physical_device_id, uint32_t num_hops) {
     CoreCoord sender_logical_core = {0, 0};
     CoreCoord receiver_logical_core = {1, 0};
 
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-
-    std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
-    std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
-    chip_id_t not_used_1;
-    chip_id_t not_used_2;
-    // Find a device with a neighbour in the East direction
-    bool connection_found = find_device_with_neighbor_in_direction(
-        fixture, src_mesh_chip_id, dst_mesh_chip_id, not_used_1, not_used_2, direction);
-    if (!connection_found) {
-        GTEST_SKIP() << "No path found between sender and receivers";
-    }
-
-    tt::log_info(tt::LogTest, "Src MeshId {} ChipId {}", src_mesh_chip_id.first, src_mesh_chip_id.second);
-    tt::log_info(tt::LogTest, "Dst MeshId {} ChipId {}", dst_mesh_chip_id.first, dst_mesh_chip_id.second);
-    tt::log_info(tt::LogTest, "Dst Device is {} hops in direction: {}", num_hops, direction);
-
-    chip_id_t src_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(src_mesh_chip_id);
-    chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id =
+        control_plane->get_mesh_chip_id_from_physical_chip_id(src_physical_device_id);
+    std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id =
+        control_plane->get_mesh_chip_id_from_physical_chip_id(dst_physical_device_id);
 
     auto* sender_device = DevicePool::instance().get_active_device(src_physical_device_id);
     auto* receiver_device = DevicePool::instance().get_active_device(dst_physical_device_id);
@@ -695,8 +682,17 @@ void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, Routin
         num_hops};
 
     // append the EDM connection rt args
+    uint32_t link_idx = 0;
+    if (is_2d_fabric) {
+        link_idx = get_forwarding_link_indices(src_physical_device_id, dst_physical_device_id)[0];
+    }
     append_fabric_connection_rt_args(
-        src_physical_device_id, dst_physical_device_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
+        src_physical_device_id,
+        dst_physical_device_id,
+        link_idx,
+        sender_program,
+        {sender_logical_core},
+        sender_runtime_args);
 
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 
@@ -749,6 +745,56 @@ void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, Routin
     uint64_t receiver_bytes =
         ((uint64_t)receiver_status[TT_FABRIC_WORD_CNT_INDEX + 1] << 32) | receiver_status[TT_FABRIC_WORD_CNT_INDEX];
     EXPECT_EQ(sender_bytes, receiver_bytes);
+}
+
+void RunTestUnicastConnAPI(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDirection direction) {
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+
+    std::pair<mesh_id_t, chip_id_t> src_mesh_chip_id;
+    std::pair<mesh_id_t, chip_id_t> dst_mesh_chip_id;
+    chip_id_t not_used_1;
+    chip_id_t not_used_2;
+    // Find a device with a neighbour in the East direction
+    bool connection_found = find_device_with_neighbor_in_direction(
+        fixture, src_mesh_chip_id, dst_mesh_chip_id, not_used_1, not_used_2, direction);
+    if (!connection_found) {
+        GTEST_SKIP() << "No path found between sender and receivers";
+    }
+
+    tt::log_info(tt::LogTest, "Src MeshId {} ChipId {}", src_mesh_chip_id.first, src_mesh_chip_id.second);
+    tt::log_info(tt::LogTest, "Dst MeshId {} ChipId {}", dst_mesh_chip_id.first, dst_mesh_chip_id.second);
+    tt::log_info(tt::LogTest, "Dst Device is {} hops in direction: {}", num_hops, direction);
+
+    chip_id_t src_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(src_mesh_chip_id);
+    chip_id_t dst_physical_device_id = control_plane->get_physical_chip_id_from_mesh_chip_id(dst_mesh_chip_id);
+
+    run_unicast_test_bw_chips(fixture, src_physical_device_id, dst_physical_device_id, num_hops);
+}
+
+void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture) {
+    const auto topology = tt::tt_metal::MetalContext::instance()
+                              .get_cluster()
+                              .get_control_plane()
+                              ->get_fabric_context()
+                              .get_fabric_topology();
+    uint32_t is_2d_fabric = topology == Topology::Mesh;
+    if (!is_2d_fabric) {
+        GTEST_SKIP() << "This test is only supported for 2D fabric currently";
+    }
+
+    auto devices = fixture->get_devices();
+    // create a list of available deive ids in a random order
+    // In 2D routing the source and desitnation devices can be anywhere on the mesh.
+    auto random_dev_list = get_random_numbers_from_range(0, devices.size() - 1, 2);
+
+    const auto src_physical_device_id = devices[random_dev_list[0]]->id();
+    const auto dst_physical_device_id = devices[random_dev_list[1]]->id();
+
+    tt::log_info(tt::LogTest, "Src Phys ChipId {}", src_physical_device_id);
+    tt::log_info(tt::LogTest, "Dst Phys ChipId {}", dst_physical_device_id);
+
+    run_unicast_test_bw_chips(
+        fixture, src_physical_device_id, dst_physical_device_id, 0 /* num_hops, not needed for 2d */);
 }
 
 void RunTestMCastConnAPI(
@@ -885,12 +931,28 @@ void RunTestMCastConnAPI(
     };
 
     // append the EDM connection rt args for fwd connection
+    chip_id_t dst_chip_id;
+    uint32_t link_idx;
+
+    if (is_2d_fabric) {
+        dst_chip_id = left_recv_phys_chip_id;
+    } else {
+        dst_chip_id = left_first_hop_phys_chip_id;
+    }
+    link_idx = get_forwarding_link_indices(src_phys_chip_id, dst_chip_id)[0];
     append_fabric_connection_rt_args(
-        src_phys_chip_id, left_first_hop_phys_chip_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
+        src_phys_chip_id, dst_chip_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
     sender_runtime_args.push_back(right_mesh_chip_id.second);
     sender_runtime_args.push_back(bwd_hops); /* mcast_bwd_hops */
+
+    if (is_2d_fabric) {
+        dst_chip_id = right_recv_phys_chip_id;
+    } else {
+        dst_chip_id = right_first_hop_phys_chip_id;
+    }
+    link_idx = get_forwarding_link_indices(src_phys_chip_id, dst_chip_id)[0];
     append_fabric_connection_rt_args(
-        src_phys_chip_id, right_first_hop_phys_chip_id, 0, sender_program, {sender_logical_core}, sender_runtime_args);
+        src_phys_chip_id, dst_chip_id, link_idx, sender_program, {sender_logical_core}, sender_runtime_args);
 
     tt_metal::SetRuntimeArgs(sender_program, sender_kernel, sender_logical_core, sender_runtime_args);
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -162,8 +162,8 @@ void RunAsyncWriteTest(
     std::string test_type = is_raw_write ? "Raw Async Write" : "Async Write";
     tt::log_info(tt::LogTest, "{} from {} to {}", test_type, start_mesh_chip_id.second, end_mesh_chip_id.second);
 
-    // Get the optimal routers (no internal hops) on the start chip that will forward in the direction of the end chip
-    auto routers = control_plane->get_routers_to_chip(
+    // Get the optimal channels (no internal hops) on the start chip that will forward in the direction of the end chip
+    auto router_chans = control_plane->get_forwarding_eth_chans_to_chip(
         start_mesh_chip_id.first, start_mesh_chip_id.second, end_mesh_chip_id.first, end_mesh_chip_id.second);
 
     auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
@@ -212,6 +212,8 @@ void RunAsyncWriteTest(
         (uint32_t)mode, (uint32_t)test_mode::TEST_ASYNC_WRITE, (uint32_t)is_raw_write};
     auto outbound_eth_channels =
         control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
+    auto router_virtual_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+        physical_start_device_id, *router_chans.begin());
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -219,7 +221,7 @@ void RunAsyncWriteTest(
         data_size,
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
-        tt_metal::MetalContext::instance().hal().noc_xy_encoding(routers[0].second.x, routers[0].second.y),
+        tt_metal::MetalContext::instance().hal().noc_xy_encoding(router_virtual_core.x, router_virtual_core.y),
         outbound_eth_channels.begin()->first};
     std::map<string, string> defines = {};
     if (mode == fabric_mode::PULL) {
@@ -276,8 +278,8 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
         GTEST_SKIP() << "No path found between sender and receivers";
     }
 
-    // Get the optimal routers (no internal hops) on the start chip that will forward in the direction of the end chip
-    auto routers = control_plane->get_routers_to_chip(
+    // Get the optimal channels (no internal hops) on the start chip that will forward in the direction of the end chip
+    auto router_chans = control_plane->get_forwarding_eth_chans_to_chip(
         start_mesh_chip_id.first, start_mesh_chip_id.second, end_mesh_chip_id.first, end_mesh_chip_id.second);
 
     auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
@@ -320,6 +322,8 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
     std::vector<uint32_t> sender_compile_time_args = {(uint32_t)mode, (uint32_t)TEST_ATOMIC_INC, 0};
     auto outbound_eth_channels =
         control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
+    auto router_virtual_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+        physical_start_device_id, *router_chans.begin());
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -328,7 +332,7 @@ void RunAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode) {
         wrap_boundary,
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
-        tt_metal::MetalContext::instance().hal().noc_xy_encoding(routers[0].second.x, routers[0].second.y),
+        tt_metal::MetalContext::instance().hal().noc_xy_encoding(router_virtual_core.x, router_virtual_core.y),
         outbound_eth_channels.begin()->first};
 
     CreateSenderKernel(
@@ -376,8 +380,8 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
         GTEST_SKIP() << "No path found between sender and receivers";
     }
 
-    // Get the optimal routers (no internal hops) on the start chip that will forward in the direction of the end chip
-    auto routers = control_plane->get_routers_to_chip(
+    // Get the optimal channels (no internal hops) on the start chip that will forward in the direction of the end chip
+    auto router_chans = control_plane->get_forwarding_eth_chans_to_chip(
         start_mesh_chip_id.first, start_mesh_chip_id.second, end_mesh_chip_id.first, end_mesh_chip_id.second);
 
     auto* sender_device = DevicePool::instance().get_active_device(physical_start_device_id);
@@ -439,6 +443,8 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
         (uint32_t)mode, (uint32_t)TEST_ASYNC_WRITE_ATOMIC_INC, (uint32_t)is_raw_write};
     auto outbound_eth_channels =
         control_plane->get_active_fabric_eth_channels(start_mesh_chip_id.first, start_mesh_chip_id.second);
+    auto router_virtual_core = tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+        physical_start_device_id, *router_chans.begin());
     std::vector<uint32_t> sender_runtime_args = {
         sender_buffer->address(),
         receiver_noc_encoding,
@@ -448,7 +454,7 @@ void RunAsyncWriteAtomicIncTest(BaseFabricFixture* fixture, fabric_mode mode, bo
         atomic_inc,
         end_mesh_chip_id.first,
         end_mesh_chip_id.second,
-        tt_metal::MetalContext::instance().hal().noc_xy_encoding(routers[0].second.x, routers[0].second.y),
+        tt_metal::MetalContext::instance().hal().noc_xy_encoding(router_virtual_core.x, router_virtual_core.y),
         outbound_eth_channels.begin()->first};
 
     CreateSenderKernel(
@@ -603,12 +609,14 @@ void RunAsyncWriteMulticastTest(
     // Get router encodings for each direction
     std::unordered_map<RoutingDirection, uint32_t> sender_router_noc_xys;
     for (auto& [routing_direction, end_mesh_chip_ids] : end_mesh_chip_ids_by_dir) {
-        auto routers = control_plane->get_routers_to_chip(
+        auto router_chans = control_plane->get_forwarding_eth_chans_to_chip(
             start_mesh_chip_id.first,
             start_mesh_chip_id.second,
             end_mesh_chip_ids[0].first,
             end_mesh_chip_ids[0].second);
-        auto& sender_virtual_router_coord = routers[0].second;
+        const auto& sender_virtual_router_coord =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                physical_start_device_id, *router_chans.begin());
         sender_router_noc_xys.try_emplace(
             routing_direction,
             tt_metal::MetalContext::instance().hal().noc_xy_encoding(

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -710,6 +710,12 @@ TEST_F(Fabric2DFixture, TestUnicastRaw) {
 
 TEST_F(Fabric2DFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
 
+TEST_F(Fabric2DFixture, TestUnicastConnAPIRandom) {
+    for (uint32_t i = 0; i < 10; i++) {
+        RunTestUnicastConnAPIRandom(this);
+    }
+}
+
 TEST_F(Fabric2DFixture, TestMCastConnAPI_1W1E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 1, RoutingDirection::E, 1);
 }

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -54,6 +54,7 @@ TEST_F(ControlPlaneFixture, TestTGFabricRoutes) {
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 3);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 0, 4, 31, chan);
+        EXPECT_EQ(path.size() > 0, true);
     }
 }
 
@@ -81,10 +82,12 @@ TEST_F(ControlPlaneFixture, TestT3kFabricRoutes) {
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 0, 0, 7, chan);
+        EXPECT_EQ(path.size() > 0, true);
     }
     valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 1);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 0, 0, 7, chan);
+        EXPECT_EQ(path.size() > 0, true);
     }
 }
 
@@ -112,18 +115,22 @@ TEST_F(ControlPlaneFixture, TestT3kSplitMeshFabricRoutes) {
     auto valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 0, 0, 3, chan);
+        EXPECT_EQ(path.size() > 0, true);
     }
     valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 1, 1);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 1, 1, 2, chan);
+        EXPECT_EQ(path.size() > 0, true);
     }
     valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(0, 0, 0);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(0, 0, 1, 3, chan);
+        EXPECT_EQ(path.size() > 0, true);
     }
     valid_chans = control_plane->get_valid_eth_chans_on_routing_plane(1, 2, 1);
     for (auto chan : valid_chans) {
         auto path = control_plane->get_fabric_route(1, 2, 0, 2, chan);
+        EXPECT_EQ(path.size() > 0, true);
     }
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -92,9 +92,6 @@ const std::string rx_kernel_src =
     "tests/tt_metal/tt_metal/perf_microbenchmark/routing/kernels/tt_fabric_traffic_gen_rx.cpp";
 std::string tx_kernel_src;
 
-static constexpr auto routing_directions = {
-    RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
-
 uint32_t get_noc_distance(uint32_t noc_idx, CoreCoord src, CoreCoord dest, uint32_t grid_size_x, uint32_t grid_size_y) {
     uint32_t x_dist = 0;
     uint32_t y_dist = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity.cpp
@@ -487,18 +487,7 @@ struct test_board_t {
 
     inline routing_plane_id_t get_routing_plane_from_chan(chip_id_t physical_chip_id, chan_id_t eth_chan) {
         const auto mesh_chip_id = this->get_mesh_chip_id(physical_chip_id);
-        std::vector<chan_id_t> eth_chans_in_dir;
-        for (const auto& direction : routing_directions) {
-            eth_chans_in_dir = control_plane->get_active_fabric_eth_channels_in_direction(
-                mesh_chip_id.first, mesh_chip_id.second, direction);
-            if (std::find(eth_chans_in_dir.begin(), eth_chans_in_dir.end(), eth_chan) != eth_chans_in_dir.end()) {
-                break;
-            }
-        }
-        if (eth_chans_in_dir.empty()) {
-            TT_THROW("Cannot find ethernet channel direction");
-        }
-        return control_plane->get_routing_plane_id(eth_chan, eth_chans_in_dir);
+        return control_plane->get_routing_plane_id(mesh_chip_id.first, mesh_chip_id.second, eth_chan);
     }
 
     inline eth_chan_directions get_eth_chan_direction(mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t eth_chan) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -353,8 +353,8 @@ int main(int argc, char** argv) {
                                             .get_cluster()
                                             .get_soc_desc(test_device_id_l)
                                             .logical_eth_core_to_chan_map.at(router_logical_core);
-                        routing_plane = control_plane->get_routing_plane_id(eth_chan);
-
+                        // routing_plane = control_plane->get_routing_plane_id(eth_chan);
+                        routing_plane = 0;
                         router_core_found = true;
                     }
                     auto connected_logical_cores = device.second->get_ethernet_sockets(neighbor);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_tt_fabric_socket_sanity.cpp
@@ -353,8 +353,7 @@ int main(int argc, char** argv) {
                                             .get_cluster()
                                             .get_soc_desc(test_device_id_l)
                                             .logical_eth_core_to_chan_map.at(router_logical_core);
-                        // routing_plane = control_plane->get_routing_plane_id(eth_chan);
-                        routing_plane = 0;
+                        routing_plane = control_plane->get_routing_plane_id(dev_l_mesh_id, dev_l_chip_id, eth_chan);
                         router_core_found = true;
                     }
                     auto connected_logical_cores = device.second->get_ethernet_sockets(neighbor);

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/control_plane.hpp
@@ -65,8 +65,7 @@ public:
     std::unordered_map<mesh_id_t, std::vector<chip_id_t>> get_chip_neighbors(
         mesh_id_t src_mesh_id, chip_id_t src_chip_id, RoutingDirection routing_direction) const;
 
-    routing_plane_id_t get_routing_plane_id(
-        chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction) const;
+    routing_plane_id_t get_routing_plane_id(mesh_id_t mesh_id, chip_id_t chip_id, chan_id_t eth_chan_id) const;
 
     size_t get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t chip_id) const;
 
@@ -103,6 +102,9 @@ private:
 
     // custom logic to order eth channels
     void order_ethernet_channels();
+
+    routing_plane_id_t get_routing_plane_id(
+        chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction) const;
 
     // Tries to get a valid downstream channel from the candidate_target_chans
     // First along same routing plane, but if not available, take round robin from candidates

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -40,7 +40,7 @@ size_t get_tt_fabric_channel_buffer_size_bytes();
 // core_type: core type which the worker will be running on
 //
 // Constraints:
-// 1. Currently the sender and reciever chip should be physically adjacent
+// 1. Currently the sender and reciever chip should be physically adjacent (for 1D)
 // 2. Currently the sender and reciever chip should be on the same mesh (for 1D)
 // 3. When connecting with 1D fabric routers, users are responsible for setting up the
 // connection appropriately. The API will not perform any checks to ensure that the

--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -46,9 +46,9 @@ size_t get_tt_fabric_channel_buffer_size_bytes();
 // connection appropriately. The API will not perform any checks to ensure that the
 // connection is indeed a 1D connection b/w all the workers.
 void append_fabric_connection_rt_args(
-    chip_id_t src_chip_id,
-    chip_id_t dst_chip_id,
-    uint32_t link_idx,
+    const chip_id_t src_chip_id,
+    const chip_id_t dst_chip_id,
+    const uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -440,7 +440,7 @@ routing_plane_id_t ControlPlane::get_routing_plane_id(
 chan_id_t ControlPlane::get_downstream_eth_chan_id(
     routing_plane_id_t src_routing_plane_id, const std::vector<chan_id_t>& candidate_target_chans) const {
     if (candidate_target_chans.empty()) {
-        return eth_chan_magic_values::INVALID_ROUTING_TABLE_ENTRY;
+        return eth_chan_magic_values::INVALID_DIRECTION;
     }
 
     for (const auto& target_chan_id : candidate_target_chans) {
@@ -458,7 +458,7 @@ chan_id_t ControlPlane::get_downstream_eth_chan_id(
     return candidate_target_chans[src_routing_plane_id];
     */
 
-    return eth_chan_magic_values::INVALID_ROUTING_TABLE_ENTRY;
+    return eth_chan_magic_values::INVALID_DIRECTION;
 };
 
 void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
@@ -894,7 +894,7 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
             // Intra-mesh routing
             next_chan_id = this->intra_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_chip_id];
         }
-        if (next_chan_id == eth_chan_magic_values::INVALID_ROUTING_TABLE_ENTRY) {
+        if (next_chan_id == eth_chan_magic_values::INVALID_DIRECTION) {
             // The complete route b/w src and dst not found, probably some eth cores are reserved along the path
             return {};
         }

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -420,7 +420,7 @@ routing_plane_id_t ControlPlane::get_routing_plane_id(
         mesh_id);
 
     std::optional<std::vector<chan_id_t>> eth_chans_in_direction;
-    const auto chip_eth_chans_map = this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id];
+    const auto& chip_eth_chans_map = this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id];
     for (const auto& [_, eth_chans] : chip_eth_chans_map) {
         if (std::find(eth_chans.begin(), eth_chans.end(), eth_chan_id) != eth_chans.end()) {
             eth_chans_in_direction = eth_chans;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -402,34 +402,41 @@ void ControlPlane::initialize_from_mesh_graph_desc_file(const std::string& mesh_
     }
 }
 
-routing_plane_id_t ControlPlane::get_routing_plane_id(chan_id_t eth_chan_id) const {
-    // Assumes that ethernet channels are incrementing by one in the same direction
-    // Same mapping for all variants of active eth cores
-    std::uint32_t num_eth_ports_per_direction = routing_table_generator_->get_chip_spec().num_eth_ports_per_direction;
-    return eth_chan_id % num_eth_ports_per_direction;
+routing_plane_id_t ControlPlane::get_routing_plane_id(
+    chan_id_t eth_chan_id, const std::vector<chan_id_t>& eth_chans_in_direction) const {
+    const auto num_eth_ports_per_direction = routing_table_generator_->get_chip_spec().num_eth_ports_per_direction;
+    TT_FATAL(
+        eth_chans_in_direction.size() <= num_eth_ports_per_direction,
+        "Number of eth channels: {} in a direction are more than expected: {}",
+        eth_chans_in_direction.size(),
+        num_eth_ports_per_direction);
+
+    auto it = std::find(eth_chans_in_direction.begin(), eth_chans_in_direction.end(), eth_chan_id);
+    return std::distance(eth_chans_in_direction.begin(), it);
 }
 
 chan_id_t ControlPlane::get_downstream_eth_chan_id(
-    chan_id_t src_chan_id, const std::vector<chan_id_t>& candidate_target_chans) const {
+    routing_plane_id_t src_routing_plane_id, const std::vector<chan_id_t>& candidate_target_chans) const {
     if (candidate_target_chans.empty()) {
         return eth_chan_magic_values::INVALID_ROUTING_TABLE_ENTRY;
     }
-    // Explicitly map router plane channels based on mod
-    //   - chan 0,4,8,12 talk to each other
-    //   - chan 1,5,9,13 talk to each other
-    //   - chan 2,6,10,14 talk to each other
-    //   - chan 3,7,11,15 talk to each other
-    std::uint32_t src_routing_plane_id = this->get_routing_plane_id(src_chan_id);
+
     for (const auto& target_chan_id : candidate_target_chans) {
-        if (src_routing_plane_id == this->get_routing_plane_id(target_chan_id)) {
+        if (src_routing_plane_id == this->get_routing_plane_id(target_chan_id, candidate_target_chans)) {
             return target_chan_id;
         }
     }
+
+    /* TODO: for now disable collapsing routing planes until we add the corresponding logic for
+        connecting the routers on these planes
     // If no match found, return a channel from candidate_target_chans
     while (src_routing_plane_id >= candidate_target_chans.size()) {
         src_routing_plane_id = src_routing_plane_id % candidate_target_chans.size();
     }
     return candidate_target_chans[src_routing_plane_id];
+    */
+
+    return eth_chan_magic_values::INVALID_ROUTING_TABLE_ENTRY;
 };
 
 void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
@@ -480,8 +487,10 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
                             const auto& eth_chans_in_target_direction =
                                 this->router_port_directions_to_physical_eth_chan_map_[mesh_id][src_chip_id]
                                                                                       [target_direction];
+                            const auto src_routing_plane_id =
+                                this->get_routing_plane_id(src_chan_id, eth_chans_on_side);
                             this->intra_mesh_routing_tables_[mesh_id][src_chip_id][src_chan_id][dst_chip_id] =
-                                this->get_downstream_eth_chan_id(src_chan_id, eth_chans_in_target_direction);
+                                this->get_downstream_eth_chan_id(src_routing_plane_id, eth_chans_in_target_direction);
                         }
                     }
                 }
@@ -536,8 +545,10 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
                             const auto& eth_chans_in_target_direction =
                                 this->router_port_directions_to_physical_eth_chan_map_[src_mesh_id][src_chip_id]
                                                                                       [target_direction];
+                            const auto src_routing_plane_id =
+                                this->get_routing_plane_id(src_chan_id, eth_chans_on_side);
                             this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id] =
-                                this->get_downstream_eth_chan_id(src_chan_id, eth_chans_in_target_direction);
+                                this->get_downstream_eth_chan_id(src_routing_plane_id, eth_chans_in_target_direction);
                         }
                     }
                 }
@@ -546,6 +557,24 @@ void ControlPlane::convert_fabric_routing_table_to_chip_routing_table() {
     }
     // Printing, only enabled with log_debug
     this->print_routing_tables();
+}
+
+// order ethernet channels using virtual coordinates
+void ControlPlane::order_ethernet_channels() {
+    for (mesh_id_t mesh_id = 0; mesh_id < this->router_port_directions_to_physical_eth_chan_map_.size(); mesh_id++) {
+        for (chip_id_t chip_id = 0; chip_id < this->router_port_directions_to_physical_eth_chan_map_[mesh_id].size();
+             chip_id++) {
+            for (auto& [_, eth_chans] : this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
+                auto phys_chip_id = this->get_physical_chip_id_from_mesh_chip_id({mesh_id, chip_id});
+                const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(phys_chip_id);
+                std::sort(eth_chans.begin(), eth_chans.end(), [&soc_desc](const auto& a, const auto& b) {
+                    auto virt_coords_a = soc_desc.get_eth_core_for_channel(a, CoordSystem::VIRTUAL);
+                    auto virt_coords_b = soc_desc.get_eth_core_for_channel(b, CoordSystem::VIRTUAL);
+                    return virt_coords_a.x < virt_coords_b.x;
+                });
+            }
+        }
+    }
 }
 
 void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
@@ -632,6 +661,9 @@ void ControlPlane::configure_routing_tables_for_fabric_ethernet_channels() {
             }
         }
     }
+
+    this->order_ethernet_channels();
+
     this->convert_fabric_routing_table_to_chip_routing_table();
 }
 
@@ -664,30 +696,31 @@ void ControlPlane::write_routing_tables_to_chip(mesh_id_t mesh_id, chip_id_t chi
                 fabric_router_config.inter_mesh_table.dest_entry[i] = eth_chan_inter_mesh_routing_table[i];
             }
 
+            const auto src_routing_plane_id = this->get_routing_plane_id(eth_chan, eth_chans);
             if (chip_eth_chans_map.find(RoutingDirection::N) != chip_eth_chans_map.end()) {
                 fabric_router_config.port_direction.directions[eth_chan_directions::NORTH] =
-                    this->get_downstream_eth_chan_id(eth_chan, chip_eth_chans_map.at(RoutingDirection::N));
+                    this->get_downstream_eth_chan_id(src_routing_plane_id, chip_eth_chans_map.at(RoutingDirection::N));
             } else {
                 fabric_router_config.port_direction.directions[eth_chan_directions::NORTH] =
                     eth_chan_magic_values::INVALID_DIRECTION;
             }
             if (chip_eth_chans_map.find(RoutingDirection::S) != chip_eth_chans_map.end()) {
                 fabric_router_config.port_direction.directions[eth_chan_directions::SOUTH] =
-                    this->get_downstream_eth_chan_id(eth_chan, chip_eth_chans_map.at(RoutingDirection::S));
+                    this->get_downstream_eth_chan_id(src_routing_plane_id, chip_eth_chans_map.at(RoutingDirection::S));
             } else {
                 fabric_router_config.port_direction.directions[eth_chan_directions::SOUTH] =
                     eth_chan_magic_values::INVALID_DIRECTION;
             }
             if (chip_eth_chans_map.find(RoutingDirection::E) != chip_eth_chans_map.end()) {
                 fabric_router_config.port_direction.directions[eth_chan_directions::EAST] =
-                    this->get_downstream_eth_chan_id(eth_chan, chip_eth_chans_map.at(RoutingDirection::E));
+                    this->get_downstream_eth_chan_id(src_routing_plane_id, chip_eth_chans_map.at(RoutingDirection::E));
             } else {
                 fabric_router_config.port_direction.directions[eth_chan_directions::EAST] =
                     eth_chan_magic_values::INVALID_DIRECTION;
             }
             if (chip_eth_chans_map.find(RoutingDirection::W) != chip_eth_chans_map.end()) {
                 fabric_router_config.port_direction.directions[eth_chan_directions::WEST] =
-                    this->get_downstream_eth_chan_id(eth_chan, chip_eth_chans_map.at(RoutingDirection::W));
+                    this->get_downstream_eth_chan_id(src_routing_plane_id, chip_eth_chans_map.at(RoutingDirection::W));
             } else {
                 fabric_router_config.port_direction.directions[eth_chan_directions::WEST] =
                     eth_chan_magic_values::INVALID_DIRECTION;
@@ -772,7 +805,7 @@ std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
         for (const auto& eth_chan : eth_chans) {
-            if (this->get_routing_plane_id(eth_chan) == routing_plane_id) {
+            if (this->get_routing_plane_id(eth_chan, eth_chans) == routing_plane_id) {
                 valid_eth_chans.push_back(eth_chan);
             }
         }
@@ -828,12 +861,7 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
     while (src_mesh_id != dst_mesh_id or src_chip_id != dst_chip_id) {
         i++;
         if (i >= tt::tt_fabric::MAX_MESH_SIZE * tt::tt_fabric::MAX_NUM_MESHES) {
-            TT_THROW(
-                "Control Plane could not find route from M{}D{} to M{}D{}",
-                src_mesh_id,
-                src_chip_id,
-                dst_mesh_id,
-                dst_chip_id);
+            return {};
         }
         auto physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
         chan_id_t next_chan_id = 0;
@@ -844,10 +872,15 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
             // Intra-mesh routing
             next_chan_id = this->intra_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_chip_id];
         }
+        if (next_chan_id == eth_chan_magic_values::INVALID_ROUTING_TABLE_ENTRY) {
+            // The complete route b/w src and dst not found, probably some eth cores are reserved along the path
+            return {};
+        }
         if (src_chan_id != next_chan_id) {
             // Chan to chan within chip
             route.push_back({physical_chip_id, next_chan_id});
         }
+
         std::tie(src_mesh_id, src_chip_id, src_chan_id) =
             this->get_connected_mesh_chip_chan_ids(src_mesh_id, src_chip_id, next_chan_id);
         auto connected_physical_chip_id = logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
@@ -857,18 +890,16 @@ std::vector<std::pair<chip_id_t, chan_id_t>> ControlPlane::get_fabric_route(
     return route;
 }
 
-std::vector<std::pair<routing_plane_id_t, CoreCoord>> ControlPlane::get_routers_to_chip(
+std::optional<RoutingDirection> ControlPlane::get_forwarding_direction(
     mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id) const {
-    std::vector<std::pair<routing_plane_id_t, CoreCoord>> routers;
     const auto& router_direction_eth_channels =
-        router_port_directions_to_physical_eth_chan_map_[src_mesh_id][src_chip_id];
+        this->router_port_directions_to_physical_eth_chan_map_[src_mesh_id][src_chip_id];
     for (const auto& [direction, eth_chans] : router_direction_eth_channels) {
         for (const auto& src_chan_id : eth_chans) {
             chan_id_t next_chan_id = 0;
             if (src_mesh_id != dst_mesh_id) {
                 // Inter-mesh routing
                 next_chan_id = this->inter_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_mesh_id];
-
             } else if (src_chip_id != dst_chip_id) {
                 // Intra-mesh routing
                 next_chan_id = this->intra_mesh_routing_tables_[src_mesh_id][src_chip_id][src_chan_id][dst_chip_id];
@@ -876,15 +907,34 @@ std::vector<std::pair<routing_plane_id_t, CoreCoord>> ControlPlane::get_routers_
             if (src_chan_id != next_chan_id) {
                 continue;
             }
-            const auto& physical_chip_id =
-                this->logical_mesh_chip_id_to_physical_chip_id_mapping_[src_mesh_id][src_chip_id];
-            routers.emplace_back(
-                this->get_routing_plane_id(src_chan_id),
-                tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
-                    physical_chip_id, src_chan_id));
+
+            // dimension-order routing: only 1 direction should give the desired shortest path from src to dst
+            return direction;
         }
     }
-    return routers;
+
+    return std::nullopt;
+}
+
+std::vector<chan_id_t> ControlPlane::get_forwarding_eth_chans_to_chip(
+    mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id) const {
+    const auto& forwarding_direction = get_forwarding_direction(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
+    if (!forwarding_direction.has_value()) {
+        return {};
+    }
+
+    std::vector<chan_id_t> forwarding_channels;
+    const auto& active_channels =
+        this->get_active_fabric_eth_channels_in_direction(src_mesh_id, src_chip_id, forwarding_direction.value());
+    for (const auto& src_chan_id : active_channels) {
+        // check for end-to-end route before accepting this channel
+        if (get_fabric_route(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id, src_chan_id).empty()) {
+            continue;
+        }
+        forwarding_channels.push_back(src_chan_id);
+    }
+
+    return forwarding_channels;
 }
 
 stl::Span<const chip_id_t> ControlPlane::get_intra_chip_neighbors(
@@ -925,12 +975,12 @@ size_t ControlPlane::get_num_active_fabric_routers(mesh_id_t mesh_id, chip_id_t 
     return num_routers;
 }
 
-std::set<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction(
+std::vector<chan_id_t> ControlPlane::get_active_fabric_eth_channels_in_direction(
     mesh_id_t mesh_id, chip_id_t chip_id, RoutingDirection routing_direction) const {
     for (const auto& [direction, eth_chans] :
          this->router_port_directions_to_physical_eth_chan_map_[mesh_id][chip_id]) {
         if (routing_direction == direction) {
-            return std::set<chan_id_t>(eth_chans.begin(), eth_chans.end());
+            return eth_chans;
         }
     }
     return {};

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -103,6 +103,15 @@ void append_fabric_connection_rt_args(
         link_idx,
         candidate_eth_chans.size());
 
+    const auto forwarding_links =
+        get_forwarding_link_indices_in_direction(src_chip_id, dst_chip_id, forwarding_direction.value());
+    TT_FATAL(
+        std::find(forwarding_links.begin(), forwarding_links.end(), link_idx) != forwarding_links.end(),
+        "requested link idx {}, cannot be used for forwarding b/w src {} and dst {}",
+        link_idx,
+        src_chip_id,
+        dst_chip_id);
+
     const auto fabric_router_channel = candidate_eth_chans[link_idx];
     const auto router_direction = control_plane->routing_direction_to_eth_direction(forwarding_direction.value());
 

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -32,14 +32,14 @@ class Program;
 namespace tt::tt_fabric {
 
 size_t get_tt_fabric_channel_buffer_size_bytes() {
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
     return control_plane->get_fabric_context().get_fabric_channel_buffer_size_bytes();
 }
 
 void append_fabric_connection_rt_args(
-    chip_id_t src_chip_id,
-    chip_id_t dst_chip_id,
-    uint32_t link_idx,
+    const chip_id_t src_chip_id,
+    const chip_id_t dst_chip_id,
+    const uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
@@ -50,14 +50,15 @@ void append_fabric_connection_rt_args(
         src_chip_id,
         dst_chip_id);
 
-    auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
 
-    auto [src_mesh_id, src_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(src_chip_id);
-    auto [dst_mesh_id, dst_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dst_chip_id);
+    const auto [src_mesh_id, src_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(src_chip_id);
+    const auto [dst_mesh_id, dst_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dst_chip_id);
 
     const auto& fabric_context = control_plane->get_fabric_context();
-    auto topology = fabric_context.get_fabric_topology();
-    bool is_2d_fabric = topology == Topology::Mesh;
+    const auto topology = fabric_context.get_fabric_topology();
+    const bool is_2d_fabric = topology == Topology::Mesh;
+
     if (!is_2d_fabric) {
         TT_FATAL(
             src_mesh_id == dst_mesh_id,
@@ -66,33 +67,44 @@ void append_fabric_connection_rt_args(
             dst_mesh_id);
     }
 
-    auto routing_directions = {RoutingDirection::N, RoutingDirection::S, RoutingDirection::E, RoutingDirection::W};
-    std::optional<std::set<chan_id_t>> candidate_ethernet_cores;
-    // mimic the 1d fabric connection setup steps to correctly find the candidate links
-    for (const auto& direction : routing_directions) {
-        // This assumes all neighbor chips to the dst mesh are the same
-        auto neighbors = control_plane->get_chip_neighbors(src_mesh_id, src_logical_chip_id, direction);
-        auto neighbor_mesh_chips = neighbors.find(dst_mesh_id);
-        if (neighbor_mesh_chips == neighbors.end() || neighbor_mesh_chips->second[0] != dst_logical_chip_id) {
-            continue;
-        }
+    // get the direction in which the data will be forwarded from the src_chip_id
+    std::optional<RoutingDirection> forwarding_direction;
+    if (is_2d_fabric) {
+        forwarding_direction =
+            control_plane->get_forwarding_direction(src_mesh_id, src_logical_chip_id, dst_mesh_id, dst_logical_chip_id);
+    } else {
+        // for 1D fabric, we loop to match the dst chip since we need to ensure src and dst are on the same line
+        // remove this once control plane has row/col info/view
+        for (const auto& direction : FabricContext::routing_directions) {
+            // This assumes all neighbor chips to the dst mesh are the same
+            auto neighbors = control_plane->get_chip_neighbors(src_mesh_id, src_logical_chip_id, direction);
+            auto neighbor_mesh_chips = neighbors.find(dst_mesh_id);
+            if (neighbor_mesh_chips == neighbors.end() || neighbor_mesh_chips->second[0] != dst_logical_chip_id) {
+                continue;
+            }
 
-        candidate_ethernet_cores =
-            control_plane->get_active_fabric_eth_channels_in_direction(src_mesh_id, src_logical_chip_id, direction);
-        break;
+            forwarding_direction = direction;
+            break;
+        }
     }
 
     TT_FATAL(
-        candidate_ethernet_cores.has_value(),
-        "Could not find any fabric ethernet cores between src {} and dst {} chips",
+        forwarding_direction.has_value(),
+        "Could not find any forwarding direction from src {} to dst {}",
         src_chip_id,
         dst_chip_id);
 
-    TT_FATAL(link_idx < candidate_ethernet_cores.value().size(), "link idx out of bounds");
+    const auto candidate_eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
+        src_mesh_id, src_logical_chip_id, forwarding_direction.value());
 
-    auto fabric_router_channel = get_ordered_fabric_eth_chans(src_chip_id, candidate_ethernet_cores.value())[link_idx];
-    auto router_direction =
-        control_plane->get_eth_chan_direction(src_mesh_id, src_logical_chip_id, fabric_router_channel);
+    TT_FATAL(
+        link_idx < candidate_eth_chans.size(),
+        "requested link idx {}, out of bounds, max available {}",
+        link_idx,
+        candidate_eth_chans.size());
+
+    const auto fabric_router_channel = candidate_eth_chans[link_idx];
+    const auto router_direction = control_plane->routing_direction_to_eth_direction(forwarding_direction.value());
 
     CoreCoord fabric_router_virtual_core =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -55,7 +55,7 @@ private:
     bool initialized_ = false;
     tt::tt_metal::FabricConfig fabric_config_{};
 
-    std::unordered_map<mesh_id_t, bool> wrap_around_mesh_;
+    std::unordered_map<mesh_id_t, bool> wrap_around_mesh_{};
     tt::tt_fabric::Topology topology_{};
     size_t packet_header_size_bytes_ = 0;
     size_t max_payload_size_bytes_ = 0;

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -58,23 +58,34 @@ FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::Cluster
     return FabricType::MESH;
 }
 
-std::vector<chan_id_t> get_ordered_fabric_eth_chans(chip_id_t chip_id, const std::set<chan_id_t>& eth_chans) {
-    std::vector<std::pair<chan_id_t, CoreCoord>> ordered_eth_chans_cores;
-    auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(chip_id);
-    for (const auto& chan : eth_chans) {
-        ordered_eth_chans_cores.push_back(
-            std::make_pair(chan, soc_desc.get_eth_core_for_channel(chan, CoordSystem::VIRTUAL)));
+std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id) {
+    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
+    const auto [src_mesh_id, src_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(src_chip_id);
+    const auto [dst_mesh_id, dst_logical_chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(dst_chip_id);
+
+    // find the forwarding direction b/w src and dest chip
+    const auto& forwarding_direction =
+        control_plane->get_forwarding_direction(src_mesh_id, src_logical_chip_id, dst_mesh_id, dst_logical_chip_id);
+    if (!forwarding_direction.has_value()) {
+        return {};
     }
 
-    std::sort(ordered_eth_chans_cores.begin(), ordered_eth_chans_cores.end(), [](const auto& a, const auto& b) {
-        return a.second.x < b.second.x;
-    });
+    // the subset of routers that support forwarding b/w those chips
+    const std::vector<chan_id_t>& forwarding_channels = control_plane->get_forwarding_eth_chans_to_chip(
+        src_mesh_id, src_logical_chip_id, dst_mesh_id, dst_logical_chip_id);
 
-    std::vector<chan_id_t> ordered_eth_chans;
-    for (const auto& [chan, _] : ordered_eth_chans_cores) {
-        ordered_eth_chans.push_back(chan);
+    const std::vector<chan_id_t>& fabric_channels = control_plane->get_active_fabric_eth_channels_in_direction(
+        src_mesh_id, src_logical_chip_id, forwarding_direction.value());
+
+    std::vector<uint32_t> link_indices;
+    for (uint32_t i = 0; i < fabric_channels.size(); i++) {
+        if (std::find(forwarding_channels.begin(), forwarding_channels.end(), fabric_channels[i]) !=
+            forwarding_channels.end()) {
+            link_indices.push_back(i);
+        }
     }
-    return ordered_eth_chans;
+
+    return link_indices;
 }
 
 void set_routing_mode(uint16_t routing_mode) {

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -27,6 +27,9 @@ void set_routing_mode(Topology topology, tt::tt_metal::FabricConfig fabric_confi
 
 FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type);
 
+std::vector<uint32_t> get_forwarding_link_indices_in_direction(
+    chip_id_t src_chip_id, chip_id_t dst_chip_id, RoutingDirection direction);
+
 // returns which links on a given src chip are avaialable for forwarding the data to a dst chip
 // these link indices can then be used to establish connection with the fabric routers
 std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id);

--- a/tt_metal/fabric/fabric_host_utils.hpp
+++ b/tt_metal/fabric/fabric_host_utils.hpp
@@ -27,7 +27,9 @@ void set_routing_mode(Topology topology, tt::tt_metal::FabricConfig fabric_confi
 
 FabricType get_fabric_type(tt::tt_metal::FabricConfig fabric_config, tt::ClusterType cluster_type);
 
-std::vector<chan_id_t> get_ordered_fabric_eth_chans(chip_id_t chip_id, const std::set<chan_id_t>& eth_chans);
+// returns which links on a given src chip are avaialable for forwarding the data to a dst chip
+// these link indices can then be used to establish connection with the fabric routers
+std::vector<uint32_t> get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id);
 
 void get_optimal_noc_for_edm(
     FabricEriscDatamoverBuilder& edm_builder1,

--- a/tt_metal/fabric/hw/inc/tt_fabric.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/hw/inc/tt_fabric.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric.h
@@ -527,11 +527,13 @@ struct fvc_inbound_push_state_t {
         uint32_t dst_mesh_id = packet_header->routing.dst_mesh_id;
         if (dst_mesh_id != routing_table->my_mesh_id) {
             uint32_t next_port = routing_table->inter_mesh_table.dest_entry[dst_mesh_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             remote_wrptr_direction = port_direction_table[next_port];
             return eth_chan_to_noc_xy[noc_index][next_port];
         } else {
             uint32_t dst_device_id = packet_header->routing.dst_dev_id;
             uint32_t next_port = routing_table->intra_mesh_table.dest_entry[dst_device_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             remote_wrptr_direction = port_direction_table[next_port];
             return eth_chan_to_noc_xy[noc_index][next_port];
         }
@@ -541,9 +543,11 @@ struct fvc_inbound_push_state_t {
     uint32_t get_next_hop_router_noc_xy(uint32_t dst_mesh_id, uint32_t dst_dev_id) {
         if (dst_mesh_id != routing_table->my_mesh_id) {
             uint32_t next_port = routing_table->inter_mesh_table.dest_entry[dst_mesh_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             return eth_chan_to_noc_xy[noc_index][next_port];
         } else {
             uint32_t next_port = routing_table->intra_mesh_table.dest_entry[dst_dev_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             return eth_chan_to_noc_xy[noc_index][next_port];
         }
     }
@@ -553,8 +557,10 @@ struct fvc_inbound_push_state_t {
         uint32_t direction = 0;
         if (dst_mesh_id != routing_table->my_mesh_id) {
             next_port = routing_table->inter_mesh_table.dest_entry[dst_mesh_id];
+            ASSERT(next_port != INVALID_DIRECTION);
         } else {
             next_port = routing_table->intra_mesh_table.dest_entry[dst_dev_id];
+            ASSERT(next_port != INVALID_DIRECTION);
         }
 
         if (routing_table->port_direction.directions[eth_chan_directions::EAST] == next_port) {
@@ -1367,10 +1373,12 @@ struct fvc_inbound_pull_state_t {
         uint32_t dst_mesh_id = current_packet_header.routing.dst_mesh_id;
         if (dst_mesh_id != routing_table->my_mesh_id) {
             uint32_t next_port = routing_table->inter_mesh_table.dest_entry[dst_mesh_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             return eth_chan_to_noc_xy[noc_index][next_port];
         } else {
             uint32_t dst_device_id = current_packet_header.routing.dst_dev_id;
             uint32_t next_port = routing_table->intra_mesh_table.dest_entry[dst_device_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             return eth_chan_to_noc_xy[noc_index][next_port];
         }
     }
@@ -1978,10 +1986,12 @@ struct fvcc_inbound_state_t {
         uint32_t dst_mesh_id = current_packet_header->routing.dst_mesh_id;
         if (dst_mesh_id != routing_table->my_mesh_id) {
             uint32_t next_port = routing_table->inter_mesh_table.dest_entry[dst_mesh_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             return eth_chan_to_noc_xy[noc_index][next_port];
         } else {
             uint32_t dst_device_id = current_packet_header->routing.dst_dev_id;
             uint32_t next_port = routing_table->intra_mesh_table.dest_entry[dst_device_id];
+            ASSERT(next_port != INVALID_DIRECTION);
             return eth_chan_to_noc_xy[noc_index][next_port];
         }
     }

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/hw/inc/tt_fabric_api.h
+++ b/tt_metal/fabric/hw/inc/tt_fabric_api.h
@@ -42,9 +42,11 @@ inline uint32_t get_next_hop_router_noc_xy(
     fabric_router_l1_config_t* routing_table = (fabric_router_l1_config_t*)client_interface->routing_tables_l1_offset;
     if (dst_mesh_id != routing_table[routing_plane].my_mesh_id) {
         uint32_t next_port = routing_table[routing_plane].inter_mesh_table.dest_entry[dst_mesh_id];
+        ASSERT(next_port != INVALID_DIRECTION);
         return eth_chan_to_noc_xy[noc_index][next_port];
     } else {
         uint32_t next_port = routing_table[routing_plane].intra_mesh_table.dest_entry[dst_dev_id];
+        ASSERT(next_port != INVALID_DIRECTION);
         return eth_chan_to_noc_xy[noc_index][next_port];
     }
 }
@@ -60,8 +62,10 @@ inline uint32_t get_next_hop_router_direction(
     uint32_t direction = 0;
     if (dst_mesh_id != routing_table[routing_plane].my_mesh_id) {
         next_port = routing_table[routing_plane].inter_mesh_table.dest_entry[dst_mesh_id];
+        ASSERT(next_port != INVALID_DIRECTION);
     } else {
         next_port = routing_table[routing_plane].intra_mesh_table.dest_entry[dst_dev_id];
+        ASSERT(next_port != INVALID_DIRECTION);
     }
 
     if (routing_table[routing_plane].port_direction.directions[eth_chan_directions::EAST] == next_port) {

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
+++ b/tt_metal/fabric/impl/kernels/edm_fabric/fabric_erisc_datamover.cpp
@@ -473,6 +473,7 @@ FORCE_INLINE bool can_forward_packet_completely(
 
         if (dest_mesh_id != routing_table->my_mesh_id) {
             uint32_t downstream_channel = routing_table->inter_mesh_table.dest_entry[dest_mesh_id];
+            ASSERT(downstream_channel != INVALID_DIRECTION);
             auto downstream_direction = port_direction_table[downstream_channel];
             return downstream_edm_interface[downstream_direction].edm_has_space_for_packet();
         } else {
@@ -493,6 +494,7 @@ FORCE_INLINE bool can_forward_packet_completely(
             } else {
                 // Unicast packet needs to be forwarded
                 auto downstream_channel = routing_table->intra_mesh_table.dest_entry[(uint8_t)dest_chip_id];
+                ASSERT(downstream_channel != INVALID_DIRECTION);
                 auto downstream_direction = port_direction_table[downstream_channel];
                 return downstream_edm_interface[downstream_direction].edm_has_space_for_packet();
             }
@@ -621,6 +623,7 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_pack
 
     if (dest_mesh_id != routing_table->my_mesh_id) {
         uint32_t downstream_channel = routing_table->inter_mesh_table.dest_entry[dest_mesh_id];
+        ASSERT(downstream_channel != INVALID_DIRECTION);
         auto downstream_direction = port_direction_table[downstream_channel];
         forward_payload_to_downstream_edm<SENDER_NUM_BUFFERS, enable_ring_support, false>(
             packet_start,
@@ -648,6 +651,7 @@ FORCE_INLINE __attribute__((optimize("jump-tables"))) void receiver_forward_pack
         } else {
             // Unicast forward packet to downstream
             auto downstream_channel = routing_table->intra_mesh_table.dest_entry[dest_chip_id];
+            ASSERT(downstream_channel != INVALID_DIRECTION);
             auto downstream_direction = port_direction_table[downstream_channel];
             forward_payload_to_downstream_edm<SENDER_NUM_BUFFERS, enable_ring_support, false>(
                 packet_start,
@@ -1904,7 +1908,7 @@ void kernel_main() {
 
     for (uint32_t i = eth_chan_directions::EAST; i < eth_chan_directions::COUNT; i++) {
         auto forwarding_channel = routing_table->port_direction.directions[i];
-        if (forwarding_channel <= num_eth_ports - 1) {
+        if (forwarding_channel != INVALID_DIRECTION) {
             // A valid port/eth channel was found for this direction. Specify the port to direction lookup
             port_direction_table[forwarding_channel] = i;
         }

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -42,7 +42,7 @@ void FabricRouterVC::GenerateDependentConfigs() {
         const auto& router_chans =
             control_plane->get_forwarding_eth_chans_to_chip(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
         TT_ASSERT(
-            !routers.empty(),
+            !router_chans.empty(),
             "No routers for (mesh {}, chip {}) to (mesh {}, chip{})",
             src_mesh_id,
             src_chip_id,
@@ -55,7 +55,7 @@ void FabricRouterVC::GenerateDependentConfigs() {
         const auto& router_chans_rev =
             control_plane->get_forwarding_eth_chans_to_chip(dst_mesh_id, dst_chip_id, src_mesh_id, src_chip_id);
         TT_ASSERT(
-            !routers_rev.empty(),
+            !router_chans_rev.empty(),
             "No routers for return path (mesh {}, chip {}) to (mesh {}, chip{})",
             dst_mesh_id,
             dst_chip_id,

--- a/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fabric_router_vc.cpp
@@ -39,7 +39,8 @@ void FabricRouterVC::GenerateDependentConfigs() {
             control_plane->get_mesh_chip_id_from_physical_chip_id(us_kernel->GetDeviceId());
         const auto& [dst_mesh_id, dst_chip_id] =
             control_plane->get_mesh_chip_id_from_physical_chip_id(ds_kernel->GetDeviceId());
-        const auto& routers = control_plane->get_routers_to_chip(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
+        const auto& router_chans =
+            control_plane->get_forwarding_eth_chans_to_chip(src_mesh_id, src_chip_id, dst_mesh_id, dst_chip_id);
         TT_ASSERT(
             !routers.empty(),
             "No routers for (mesh {}, chip {}) to (mesh {}, chip{})",
@@ -47,10 +48,12 @@ void FabricRouterVC::GenerateDependentConfigs() {
             src_chip_id,
             dst_mesh_id,
             dst_chip_id);
-        const auto& [routing_plane, fabric_router] = routers.front();
+        const auto& fabric_router =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                us_kernel->GetDeviceId(), *router_chans.begin());
 
-        const auto& routers_rev =
-            control_plane->get_routers_to_chip(dst_mesh_id, dst_chip_id, src_mesh_id, src_chip_id);
+        const auto& router_chans_rev =
+            control_plane->get_forwarding_eth_chans_to_chip(dst_mesh_id, dst_chip_id, src_mesh_id, src_chip_id);
         TT_ASSERT(
             !routers_rev.empty(),
             "No routers for return path (mesh {}, chip {}) to (mesh {}, chip{})",
@@ -58,7 +61,9 @@ void FabricRouterVC::GenerateDependentConfigs() {
             dst_chip_id,
             src_mesh_id,
             src_chip_id);
-        const auto& [routing_plane_rev, fabric_router_rev] = routers_rev.front();
+        const auto& fabric_router_rev =
+            tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
+                ds_kernel->GetDeviceId(), *router_chans_rev.begin());
 
         bool valid_path{false};
         if (auto prefetch_us = dynamic_cast<PrefetchKernel*>(us_kernel);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -1045,11 +1045,11 @@ void build_tt_fabric_program(
         return;
     }
 
-    std::unordered_map<RoutingDirection, std::set<chan_id_t>> active_fabric_eth_channels;
+    std::unordered_map<RoutingDirection, std::vector<chan_id_t>> active_fabric_eth_channels;
     std::unordered_map<RoutingDirection, chip_id_t> chip_neighbors;
     uint32_t num_intra_chip_neighbors = 0;
     const auto topology = fabric_context.get_fabric_topology();
-    bool is_2D_routing = topology == Topology::Mesh;
+    const bool is_2D_routing = topology == Topology::Mesh;
 
     for (const auto& direction : tt::tt_fabric::FabricContext::routing_directions) {
         auto active_eth_chans = control_plane->get_active_fabric_eth_channels_in_direction(
@@ -1131,8 +1131,8 @@ void build_tt_fabric_program(
         bool can_connect =
             (chip_neighbors.find(dir1) != chip_neighbors.end()) && (chip_neighbors.find(dir2) != chip_neighbors.end());
         if (can_connect) {
-            auto eth_chans_dir1 = get_ordered_fabric_eth_chans(device->id(), active_fabric_eth_channels.at(dir1));
-            auto eth_chans_dir2 = get_ordered_fabric_eth_chans(device->id(), active_fabric_eth_channels.at(dir2));
+            auto eth_chans_dir1 = active_fabric_eth_channels.at(dir1);
+            auto eth_chans_dir2 = active_fabric_eth_channels.at(dir2);
 
             auto eth_chans_dir1_it = eth_chans_dir1.begin();
             auto eth_chans_dir2_it = eth_chans_dir2.begin();


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/22705)

### Problem description
1. Currently there is a disparity b/w how the control plane sees the routing plane and how the fabric is actually set up on those routing planes. While setting up fabric, we order the eth channels based on their virtual coords and then connect the intra-chip routers/edms based on that ordering. Because of this ordering, the routes queried from control plane (and hence the routing tables) will not always match the actual routing since we may have already 'cross-wired' the routing planes.
2. The current host side connection setup API for workers expects the src and dst chip to be physically adjacent. So if a worker wants to send data multiple hops away, it should know the 'next hop chip' in the route so that it can connect to the correct router. This constraints comes from 1D fabric since we didnt have the capability to check if the src and dst are on the same row/column

### What's changed
1. Move the eth channel ordering logic to the control plane itself. This requires:
  a. Updates to the routing plane id method to not be mod based. The routing plane ids will now be chip and direction dependent.
  b. Stop collapsing routing planes until we have the logic to connect the routers correctly
2. Add a couple of APIs in control plane to query the forwarding direction and the channels for a given src and dest
  a. `get_forwarding_direction(mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id)`
  b. `get_forwarding_eth_chans_to_chip(mesh_id_t src_mesh_id, chip_id_t src_chip_id, mesh_id_t dst_mesh_id, chip_id_t dst_chip_id)`
3. The host side connection API now handles non-adjacent src and dst (only for 2D routing currently)
4. Added a host-side helper to query the link indices/routing planes that can support the routing b/w the given src and dst. This is needed since not all the links will be able to forward because of missing links due to tunneling.
  a. `get_forwarding_link_indices(chip_id_t src_chip_id, chip_id_t dst_chip_id)`


### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes (https://github.com/tenstorrent/tt-metal/actions/runs/15193766380)
- [x]  [T3K nightly] (https://github.com/tenstorrent/tt-metal/actions/runs/15172852800)
- [ ]  [T3K unit] (https://github.com/tenstorrent/tt-metal/actions/runs/15172785840)
- [x]  [T3K model perf] (https://github.com/tenstorrent/tt-metal/actions/runs/15172807369)
- [ ]  [TG model perf] (https://github.com/tenstorrent/tt-metal/actions/runs/15172835602)
- [x]  [TG Demo] (https://github.com/tenstorrent/tt-metal/actions/runs/15175625704)
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes