### PR TITLE
[skip ci] Run Smoke on Ubuntu 24.04 in Merge Gate

### DIFF
--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -90,7 +90,7 @@ jobs:
     secrets: inherit
     with:
       build-type: TSan
-      version: 22.04
+      version: 24.04
       skip-tt-train: false
       publish-artifact: false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
-# Plz run tests
-
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.24...3.30)
 
+# Plz run tests
+
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tt_metal/third_party/umd/CMakeLists.txt")
     message(FATAL_ERROR "Missing submodules.  Run: git submodule update --init --recursive")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We should start supporting Ubuntu 24.04.  Right now we only test a compile.  We should test some form of _running_, too.

### What's changed
Run the Smoke test (with TSan) on Ubuntu 24.04 in the Merge Gate.