### PR TITLE
Fabric MUX Stateful API

### DIFF
--- a/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
+++ b/tt_metal/fabric/hw/inc/edm_fabric/edm_fabric_utils.hpp
@@ -44,13 +44,17 @@ FORCE_INLINE void send_chunk_from_address_with_trid(
     }
 }
 
-template <EDM_IO_BLOCKING_MODE blocking_mode = EDM_IO_BLOCKING_MODE::BLOCKING>
+template <EDM_IO_BLOCKING_MODE blocking_mode = EDM_IO_BLOCKING_MODE::BLOCKING, bool stateful_api = false>
 FORCE_INLINE void send_chunk_from_address(
     const uint32_t& local_l1_address,
     const uint32_t& num_pages,
     const uint32_t& page_size,
     uint64_t remote_l1_write_addr) {
-    noc_async_write(local_l1_address, remote_l1_write_addr, page_size * num_pages);
+    if constexpr (stateful_api) {
+        noc_async_write_with_state(local_l1_address, remote_l1_write_addr, page_size * num_pages);
+    } else {
+        noc_async_write(local_l1_address, remote_l1_write_addr, page_size * num_pages);
+    }
     if constexpr (blocking_mode == EDM_IO_BLOCKING_MODE::FLUSH_BLOCKING) {
         noc_async_writes_flushed();
     } else if constexpr (blocking_mode == EDM_IO_BLOCKING_MODE::BLOCKING) {

--- a/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/blackhole/noc_nonblocking_api.h
@@ -236,6 +236,78 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write(
     }
 }
 
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write_set_state(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint32_t src_addr,
+    uint64_t dest_addr,
+    uint32_t len_bytes,
+    uint32_t vc,
+    bool mcast,
+    bool linked,
+    uint32_t num_dests,
+    bool multicast_path_reserve,
+    bool posted = false,
+    uint32_t trid = 0) {
+    uint32_t noc_cmd_field =
+        NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) | (linked ? NOC_CMD_VC_LINKED : 0x0) |
+        (mcast ? ((multicast_path_reserve ? NOC_CMD_PATH_RESERVE : 0) | NOC_CMD_BRCST_PACKET) : 0x0) |
+        (posted ? 0 : NOC_CMD_RESP_MARKED);
+
+    if constexpr (use_trid) {
+        NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_PACKET_TAG, NOC_PACKET_TAG_TRANSACTION_ID(trid));
+    }
+
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dest_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dest_addr >> 32) & 0x1000000F);
+    NOC_CMD_BUF_WRITE_REG(
+        noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dest_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_BRCST_EXCLUDE, 0);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+}
+
+// Assumes NOC Destination is already programmed
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false>
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write_with_state(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint32_t src_addr,
+    uint64_t dest_addr,
+    uint32_t len_bytes,
+    uint32_t vc,
+    bool mcast,
+    bool linked,
+    uint32_t num_dests,
+    bool multicast_path_reserve,
+    bool posted = false,
+    uint32_t trid = 0) {
+    if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+        if (posted) {
+            inc_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(noc, 1);
+        } else {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, num_dests);
+        }
+    }
+
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dest_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, len_bytes);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+
+    if constexpr (noc_mode == DM_DEDICATED_NOC) {
+        if (posted) {
+            noc_posted_writes_num_issued[noc] += 1;
+        } else {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += num_dests;
+        }
+    }
+}
+
 template <uint8_t noc_mode = DM_DEDICATED_NOC>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_loopback_src(
     uint32_t noc,
@@ -560,7 +632,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_read_any_len(
     ncrisc_noc_fast_read<noc_mode>(noc, cmd_buf, src_addr, dest_addr, len_bytes);
 }
 
-template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false, bool one_packet = false>
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false, bool one_packet = false, bool with_state = false>
 inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     uint32_t noc,
     uint32_t cmd_buf,
@@ -577,26 +649,116 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len(
     if constexpr (!one_packet) {
         while (len_bytes > NOC_MAX_BURST_SIZE) {
             while (!noc_cmd_buf_ready(noc, cmd_buf));
-            ncrisc_noc_fast_write<noc_mode, use_trid>(
-                noc,
-                cmd_buf,
-                src_addr,
-                dest_addr,
-                NOC_MAX_BURST_SIZE,
-                vc,
-                mcast,
-                linked,
-                num_dests,
-                multicast_path_reserve,
-                posted,
-                trid);
+            if constexpr (with_state) {
+                ncrisc_noc_fast_write_with_state<noc_mode, use_trid>(
+                    noc,
+                    cmd_buf,
+                    src_addr,
+                    dest_addr,
+                    NOC_MAX_BURST_SIZE,
+                    vc,
+                    mcast,
+                    linked,
+                    num_dests,
+                    multicast_path_reserve,
+                    posted,
+                    trid);
+            } else {
+                ncrisc_noc_fast_write<noc_mode, use_trid>(
+                    noc,
+                    cmd_buf,
+                    src_addr,
+                    dest_addr,
+                    NOC_MAX_BURST_SIZE,
+                    vc,
+                    mcast,
+                    linked,
+                    num_dests,
+                    multicast_path_reserve,
+                    posted,
+                    trid);
+            }
             src_addr += NOC_MAX_BURST_SIZE;
             dest_addr += NOC_MAX_BURST_SIZE;
             len_bytes -= NOC_MAX_BURST_SIZE;
         }
     }
     while (!noc_cmd_buf_ready(noc, cmd_buf));
-    ncrisc_noc_fast_write<noc_mode, use_trid>(
+    if constexpr (with_state) {
+        ncrisc_noc_fast_write_with_state<noc_mode, use_trid>(
+            noc,
+            cmd_buf,
+            src_addr,
+            dest_addr,
+            len_bytes,
+            vc,
+            mcast,
+            linked,
+            num_dests,
+            multicast_path_reserve,
+            posted,
+            trid);
+    } else {
+        ncrisc_noc_fast_write<noc_mode, use_trid>(
+            noc,
+            cmd_buf,
+            src_addr,
+            dest_addr,
+            len_bytes,
+            vc,
+            mcast,
+            linked,
+            num_dests,
+            multicast_path_reserve,
+            posted,
+            trid);
+    }
+}
+
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false, bool one_packet = false>
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_with_state(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint32_t src_addr,
+    uint64_t dest_addr,
+    uint32_t len_bytes,
+    uint32_t vc,
+    bool mcast,
+    bool linked,
+    uint32_t num_dests,
+    bool multicast_path_reserve,
+    bool posted = false,
+    uint32_t trid = 0) {
+    ncrisc_noc_fast_write_any_len<noc_mode, use_trid, one_packet, true>(
+        noc,
+        cmd_buf,
+        src_addr,
+        dest_addr,
+        len_bytes,
+        vc,
+        mcast,
+        linked,
+        num_dests,
+        multicast_path_reserve,
+        posted,
+        trid);
+}
+
+template <uint8_t noc_mode = DM_DEDICATED_NOC, bool use_trid = false, bool one_packet = false>
+inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_set_state(
+    uint32_t noc,
+    uint32_t cmd_buf,
+    uint32_t src_addr,
+    uint64_t dest_addr,
+    uint32_t len_bytes,
+    uint32_t vc,
+    bool mcast,
+    bool linked,
+    uint32_t num_dests,
+    bool multicast_path_reserve,
+    bool posted = false,
+    uint32_t trid = 0) {
+    ncrisc_noc_fast_write_set_state<noc_mode, use_trid>(
         noc,
         cmd_buf,
         src_addr,

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -726,7 +726,11 @@ void noc_async_read_inc_num_issued(std::uint32_t num_issued_reads_inc, uint8_t n
 // this issues only a single packet with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
 FORCE_INLINE
 void noc_async_write_one_packet(
-    std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    std::uint32_t src_local_l1_addr,
+    std::uint64_t dst_noc_addr,
+    std::uint32_t size,
+    uint8_t noc = noc_index,
+    uint8_t cmd_buf = write_cmd_buf) {
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_,dst_noc_addr,size,NOC_UNICAST_WRITE_VC);
 
     if constexpr (noc_mode == DM_DYNAMIC_NOC) {
@@ -735,7 +739,7 @@ void noc_async_write_one_packet(
     }
     WAYPOINT("NWPW");
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
-    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NWPD");
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(NOC_UNICAST_WRITE_VC) |
@@ -743,20 +747,17 @@ void noc_async_write_one_packet(
                              0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                              NOC_CMD_RESP_MARKED;
 
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, (uint32_t)dst_noc_addr);
 #ifdef ARCH_BLACKHOLE
     // Handles writing to PCIe
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
 #endif
     NOC_CMD_BUF_WRITE_REG(
-        noc,
-        write_cmd_buf,
-        NOC_RET_ADDR_COORDINATE,
-        (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, size);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+        noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
     if constexpr (noc_mode == DM_DEDICATED_NOC) {
         noc_nonposted_writes_num_issued[noc] += 1;
         noc_nonposted_writes_acked[noc] += 1;  // num_dests
@@ -814,11 +815,15 @@ void noc_async_write_multicast_one_packet(
 // this sets the state for issuing a single packet with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_set_state(
-    std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index, uint8_t vc = NOC_UNICAST_WRITE_VC) {
+    std::uint64_t dst_noc_addr,
+    std::uint32_t size,
+    uint8_t noc = noc_index,
+    uint8_t vc = NOC_UNICAST_WRITE_VC,
+    uint8_t cmd_buf = write_cmd_buf) {
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_SET_STATE, dst_noc_addr, size, vc);
 
     WAYPOINT("NWPW");
-    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NWPD");
 
     uint32_t noc_cmd_field = NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(vc) |
@@ -826,24 +831,24 @@ FORCE_INLINE void noc_async_write_one_packet_set_state(
                              0x0 |  // (mcast ? (NOC_CMD_PATH_RESERVE | NOC_CMD_BRCST_PACKET) : 0x0)
                              (non_posted ? NOC_CMD_RESP_MARKED : 0x0);
 
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CTRL, noc_cmd_field);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CTRL, noc_cmd_field);
 #ifdef ARCH_BLACKHOLE
     // Handles writing to PCIe
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_MID, (uint32_t)(dst_noc_addr >> 32) & 0x1000000F);
 #endif
     NOC_CMD_BUF_WRITE_REG(
-        noc,
-        write_cmd_buf,
-        NOC_RET_ADDR_COORDINATE,
-        (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_AT_LEN_BE, size);
+        noc, cmd_buf, NOC_RET_ADDR_COORDINATE, (uint32_t)(dst_noc_addr >> NOC_ADDR_COORD_SHIFT) & NOC_COORDINATE_MASK);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
 }
 
 // TODO: write docs
 // this issues only a single packet with cmd buf state with size <= NOC_MAX_BURST_SIZE (ie maximum packet size)
 template <bool non_posted = true>
 FORCE_INLINE void noc_async_write_one_packet_with_state(
-    std::uint32_t src_local_l1_addr, std::uint32_t dst_noc_addr, uint8_t noc = noc_index) {
+    std::uint32_t src_local_l1_addr,
+    std::uint32_t dst_noc_addr,
+    uint8_t noc = noc_index,
+    uint8_t cmd_buf = write_cmd_buf) {
     RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
 
     if constexpr (non_posted) {
@@ -853,15 +858,51 @@ FORCE_INLINE void noc_async_write_one_packet_with_state(
         }
     }
     WAYPOINT("NWPW");
-    while (!noc_cmd_buf_ready(noc, write_cmd_buf));
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
     WAYPOINT("NWPD");
 
     // In order to sanitize, need to grab full noc addr + xfer size from state.
     DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_noc_addr, src_local_l1_addr);
 
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_RET_ADDR_LO, dst_noc_addr);
-    NOC_CMD_BUF_WRITE_REG(noc, write_cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+
+    if constexpr (non_posted) {
+        if constexpr (noc_mode == DM_DEDICATED_NOC) {
+            noc_nonposted_writes_num_issued[noc] += 1;
+            noc_nonposted_writes_acked[noc] += 1;  // num_dests
+        }
+    }
+}
+
+// Assumes NOC destination is already programmed
+template <bool non_posted = true>
+FORCE_INLINE void noc_async_write_one_packet_with_state(
+    std::uint32_t src_local_l1_addr,
+    std::uint32_t dst_noc_addr,
+    std::uint32_t size,
+    uint8_t noc = noc_index,
+    uint8_t cmd_buf = write_cmd_buf) {
+    RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_WITH_STATE, 0ull, 0, -1);
+
+    if constexpr (non_posted) {
+        if constexpr (noc_mode == DM_DYNAMIC_NOC) {
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_NUM_ISSUED>(noc, 1);
+            inc_noc_counter_val<proc_type, NocBarrierType::NONPOSTED_WRITES_ACKED>(noc, 1);
+        }
+    }
+    WAYPOINT("NWPW");
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
+    WAYPOINT("NWPD");
+
+    // In order to sanitize, need to grab full noc addr + xfer size from state.
+    DEBUG_SANITIZE_NOC_WRITE_TRANSACTION_WITH_ADDR_AND_SIZE_STATE(noc, dst_noc_addr, src_local_l1_addr);
+
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_TARG_ADDR_LO, src_local_l1_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_RET_ADDR_LO, dst_noc_addr);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_CMD_CTRL, NOC_CTRL_SEND_REQ);
+    NOC_CMD_BUF_WRITE_REG(noc, cmd_buf, NOC_AT_LEN_BE, size);
 
     if constexpr (non_posted) {
         if constexpr (noc_mode == DM_DEDICATED_NOC) {
@@ -927,16 +968,60 @@ FORCE_INLINE void noc_async_read_tile(
 // clang-format on
 template <uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1>
 inline void noc_async_write(
-    std::uint32_t src_local_l1_addr, std::uint64_t dst_noc_addr, std::uint32_t size, uint8_t noc = noc_index) {
+    std::uint32_t src_local_l1_addr,
+    std::uint64_t dst_noc_addr,
+    std::uint32_t size,
+    uint8_t noc = noc_index,
+    uint8_t cmd_buf = write_cmd_buf) {
     if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size, noc);
+        noc_async_write_one_packet(src_local_l1_addr, dst_noc_addr, size, noc, cmd_buf);
     } else {
         RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, NOC_UNICAST_WRITE_VC);
 
         WAYPOINT("NAWW");
         DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
         ncrisc_noc_fast_write_any_len<noc_mode>(
-            noc, write_cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true);
+            noc, cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true);
+        WAYPOINT("NAWD");
+    }
+}
+
+template <uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1>
+inline void noc_async_write_with_state(
+    std::uint32_t src_local_l1_addr,
+    std::uint64_t dst_noc_addr,
+    std::uint32_t size,
+    uint8_t noc = noc_index,
+    uint8_t cmd_buf = write_cmd_buf) {
+    if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
+        noc_async_write_one_packet_with_state(src_local_l1_addr, dst_noc_addr, size, noc, cmd_buf);
+    } else {
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, NOC_UNICAST_WRITE_VC);
+
+        WAYPOINT("NAWW");
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
+        ncrisc_noc_fast_write_any_len_with_state<noc_mode>(
+            noc, cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true);
+        WAYPOINT("NAWD");
+    }
+}
+
+template <uint32_t max_page_size = NOC_MAX_BURST_SIZE + 1>
+inline void noc_async_write_set_state(
+    std::uint32_t src_local_l1_addr,
+    std::uint64_t dst_noc_addr,
+    std::uint32_t size,
+    uint8_t noc = noc_index,
+    uint8_t cmd_buf = write_cmd_buf) {
+    if constexpr (max_page_size <= NOC_MAX_BURST_SIZE) {
+        noc_async_write_one_packet_set_state(src_local_l1_addr, dst_noc_addr, size, noc, cmd_buf);
+    } else {
+        RECORD_NOC_EVENT_WITH_ADDR(NocEventType::WRITE_, dst_noc_addr, size, NOC_UNICAST_WRITE_VC);
+
+        WAYPOINT("NAWW");
+        DEBUG_SANITIZE_NOC_WRITE_TRANSACTION(noc, dst_noc_addr, src_local_l1_addr, size);
+        ncrisc_noc_fast_write_any_len_set_state<noc_mode>(
+            noc, cmd_buf, src_local_l1_addr, dst_noc_addr, size, NOC_UNICAST_WRITE_VC, false, false, 1, true);
         WAYPOINT("NAWD");
     }
 }

--- a/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/wormhole/noc_nonblocking_api.h
@@ -679,6 +679,7 @@ inline __attribute__((always_inline)) void ncrisc_noc_fast_write_any_len_set_sta
     bool multicast_path_reserve,
     bool posted = false,
     uint32_t trid = 0) {
+    while (!noc_cmd_buf_ready(noc, cmd_buf));
     ncrisc_noc_fast_write_set_state<noc_mode, use_trid>(
         noc,
         cmd_buf,


### PR DESCRIPTION
### Ticket
#18726

### Problem description
- Previously we got 6-7% test_pgm_dispatch improvement from using stateful APIs in the D2H and H2D relaying process with the packet queue
- The new Fabric Client <-> MUX interface does not use stateful APIs right now

### What's changed
- Add the option to use stateful APIs on the client - fabric mux interface. This will save several register writes for the client to mux path
- noc_async_write_with_state in dataflow_api.h
- noc_async_write_one_packet with size parameter in dataflow_api.h
- Parameterize cmd buffer in noc_async_write API. Prefetch H uses 2 command bufs for noc_async_write.


### Checklist
APC
https://github.com/tenstorrent/tt-metal/actions/runs/15149583095