### PR TITLE
#19609: Update pow backward op

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/backward/test_backward_pow.py
@@ -23,8 +23,8 @@ from tests.ttnn.unit_tests.operations.eltwise.backward.utility_funcs import (
     ],
 )
 def test_negative_exponent(input_shapes, exponent, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     with pytest.raises(RuntimeError) as _e:
         tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
@@ -42,8 +42,8 @@ def test_negative_exponent(input_shapes, exponent, device):
     ],
 )
 def test_fw_exponent(input_shapes, exponent, device):
-    in_data, input_tensor = data_gen_with_range(input_shapes, -90, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -90, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -20, 20, device, seed=1)
 
     golden_tensor = [
         torch.pow(grad_data, exponent),
@@ -64,28 +64,19 @@ def test_fw_exponent(input_shapes, exponent, device):
     ),
 )
 @pytest.mark.parametrize(
-    "exponent_and_pcc",
-    [
-        (0.0, 0.99),
-        (1.0, 0.99),
-        (2.0, 0.99),
-        (5.0, 0.99),
-        (0.5, 0.92),
-        (1.5, 0.84),
-        (2.5, 0.57),
-    ],
+    "exponent",
+    [(0.5), (0.0), (1.5), (4.5), (7.25), (10.0), (12.75), (16.0)],
 )
-def test_bw_unary_pow(input_shapes, exponent_and_pcc, device):
-    exponent, pcc = exponent_and_pcc
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+def test_bw_unary_pow(input_shapes, exponent, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
 
     golden_function = ttnn.get_golden_function(ttnn.pow_bw)
     golden_tensor = golden_function(grad_data, in_data, exponent)
 
-    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, pcc=pcc)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, pcc=0.99)
     assert status
 
 
@@ -95,8 +86,8 @@ def test_bw_unary_pow(input_shapes, exponent_and_pcc, device):
 )
 def test_bw_unary_pow_test_inf(input_shapes, device):
     exponent = 2
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 9, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, 1, 9, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
     golden_function = ttnn.get_golden_function(ttnn.pow_bw)
@@ -112,8 +103,8 @@ def test_bw_unary_pow_test_inf(input_shapes, device):
 )
 def test_bw_unary_pow_test_neg_inf(input_shapes, device):
     exponent = 2
-    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, -1, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, 1.74e38, 1.8e38, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -5, -1, device, seed=1)
 
     tt_output_tensor_on_device = ttnn.pow_bw(grad_tensor, input_tensor, exponent)
 
@@ -133,21 +124,12 @@ def test_bw_unary_pow_test_neg_inf(input_shapes, device):
     ),
 )
 @pytest.mark.parametrize(
-    "exponent_and_pcc",
-    [
-        (0.0, 0.99),
-        (1.0, 0.99),
-        (2.0, 0.99),
-        (5.0, 0.99),
-        (0.5, 0.92),
-        (1.5, 0.84),
-        (2.5, 0.57),
-    ],
+    "exponent",
+    [(0.5), (0.0), (1.5), (4.5), (7.25), (10.0), (12.75), (16.0)],
 )
-def test_bw_unary_pow_output(input_shapes, exponent_and_pcc, device):
-    exponent, pcc = exponent_and_pcc
-    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
-    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device)
+def test_bw_unary_pow_output(input_shapes, exponent, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, 0, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
     input_grad = None
 
     _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
@@ -166,5 +148,42 @@ def test_bw_unary_pow_output(input_shapes, exponent_and_pcc, device):
     golden_function = ttnn.get_golden_function(ttnn.pow_bw)
     golden_tensor = golden_function(grad_data, in_data, exponent)
 
-    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, pcc=pcc)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, pcc=0.99)
+    assert status
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize(
+    "exponent",
+    [(0.5), (0.0), (1.5), (4.5), (7.25), (10.0), (12.75), (16.0)],
+)
+def test_bw_unary_pow_negative_inputs(input_shapes, exponent, device):
+    in_data, input_tensor = data_gen_with_range(input_shapes, -100, 100, device, True, seed=0)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -10, 10, device, seed=1)
+    input_grad = None
+
+    _, input_grad = data_gen_with_range(input_shapes, -1, 1, device)
+
+    cq_id = 0
+    tt_output_tensor_on_device = ttnn.pow_bw(
+        grad_tensor,
+        input_tensor,
+        exponent=exponent,
+        input_grad=input_grad,
+        queue_id=cq_id,
+    )
+
+    in_data.retain_grad()
+
+    golden_function = ttnn.get_golden_function(ttnn.pow_bw)
+    golden_tensor = golden_function(grad_data, in_data, exponent)
+
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, pcc=0.99)
     assert status

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -261,7 +261,9 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardPow::invoke(
     }
 
     Tensor result = ttnn::multiply(queue_id, power_input, exponent, std::nullopt, output_mem_config);
+    power_input.deallocate();
     Tensor final_result = ttnn::multiply(queue_id, result, grad, std::nullopt, output_mem_config);
+    result.deallocate();
     // Handle negative inputs by returning infinity
     where(
         queue_id,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary_backward/unary_backward.cpp
@@ -255,26 +255,19 @@ std::vector<std::optional<Tensor>> ExecuteUnaryBackwardPow::invoke(
         return grad_tensor;
     }
 
-    Tensor power_input = ttnn::power(queue_id, input, std::fabs(exponent - 1.0f), output_mem_config);
+    Tensor power_input = ttnn::pow(queue_id, input, std::fabs(exponent - 1.0f), output_mem_config);
     if (exponent < 1.0f) {
         power_input = ttnn::reciprocal(queue_id, power_input, output_mem_config);
     }
 
     Tensor result = ttnn::multiply(queue_id, power_input, exponent, std::nullopt, output_mem_config);
-    power_input.deallocate();
     Tensor final_result = ttnn::multiply(queue_id, result, grad, std::nullopt, output_mem_config);
-    result.deallocate();
-    Tensor temp = where(
-        queue_id,
-        ttnn::le(queue_id, final_result, -3.4e+38, std::nullopt, output_mem_config),
-        -std::numeric_limits<float>::infinity(),
-        final_result,
-        output_mem_config);
+    // Handle negative inputs by returning infinity
     where(
         queue_id,
-        ttnn::ge(queue_id, final_result, 3.4e+38, std::nullopt, output_mem_config),
+        ttnn::lez(queue_id, input),
         std::numeric_limits<float>::infinity(),
-        temp,
+        final_result,
         output_mem_config,
         input_grad);
     grad_tensor.emplace_back(input_grad);

--- a/ttnn/ttnn/operations/unary_backward.py
+++ b/ttnn/ttnn/operations/unary_backward.py
@@ -822,6 +822,9 @@ def _golden_function(grad_tensor, input_tensor, exponent, *args, **kwargs):
     pyt_y = torch.pow(input_tensor, exponent)
     pyt_y.backward(gradient=grad_tensor)
 
+    if exponent != 0:
+        input_tensor.grad.masked_fill_(input_tensor < 0, float("inf"))
+
     return [input_tensor.grad]
 
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #19609 

### Problem description
Tests failing on backward pow.

### What's changed
**Backward pow** : The issue was with negative inputs—Torch returns NaN for negative inputs when computing power with fractional exponents, whereas TTNN does not. Since returning NaN is not supported in WHB0, I modified both the ttnn implementation and golden functions to return inf for input values less than 0. Also kept separate unit test for inputs with negative values.

### Checklist
- [ ] All post commit CI