### PR TITLE
Fix Mobilenetv2 trace low pcc issue

### DIFF
--- a/models/demos/mobilenetv2/tests/mobilenetv2_performant.py
+++ b/models/demos/mobilenetv2/tests/mobilenetv2_performant.py
@@ -71,10 +71,11 @@ def run_mobilenetv2_trace_inference(
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
     test_infra.run()
     test_infra.validate()
-    test_infra.dealloc_output()
 
     # Capture
     test_infra.input_tensor = tt_inputs_host.to(device, input_mem_config)
+
+    test_infra.dealloc_output()
     trace_input_addr = test_infra.input_tensor.buffer_address()
     tid = ttnn.begin_trace_capture(device, cq_id=0)
     test_infra.run()

--- a/models/demos/mobilenetv2/tests/test_e2e_performant.py
+++ b/models/demos/mobilenetv2/tests/test_e2e_performant.py
@@ -14,6 +14,8 @@ from models.utility_functions import run_for_wormhole_b0
 
 
 @run_for_wormhole_b0()
+@pytest.mark.models_performance_bare_metal
+@pytest.mark.models_performance_virtual_machine
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 24576, "trace_region_size": 6434816, "num_command_queues": 2}], indirect=True
 )

--- a/models/demos/mobilenetv2/tt/common.py
+++ b/models/demos/mobilenetv2/tt/common.py
@@ -24,7 +24,7 @@ class TtMobileNetV2Conv2D:
         act_blocks=32,
         enable_act_double_buffer=False,
         enable_split_reader=False,
-        reshard_if_not_optimal=False,
+        reshard_if_not_optimal=True,
         activation_dtype=ttnn.bfloat8_b,
         shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
     ):
@@ -68,7 +68,7 @@ class TtMobileNetV2Conv2D:
             enable_subblock_padding=False,
             output_layout=self.output_layout,
             reallocate_halo_output=False,
-            reshard_if_not_optimal=True,
+            reshard_if_not_optimal=self.reshard_if_not_optimal,
         )
 
         if self.act_block_h:

--- a/models/demos/mobilenetv2/tt/ttnn_mobilenetv2.py
+++ b/models/demos/mobilenetv2/tt/ttnn_mobilenetv2.py
@@ -18,6 +18,8 @@ class TtMobileNetV2:
             device,
             batchsize,
             deallocate_activation=True,
+            # enable_split_reader = True
+            reshard_if_not_optimal=False,
         )
         self.conv2 = TtMobileNetV2Conv2D(
             [3, 1, 1, 32],


### PR DESCRIPTION
### Ticket
[Link to the GitHub Issue](https://github.com/tenstorrent/tt-metal/issues/13798)

### Problem description.
Pcc dropped in the model when input is sharded in trace implementation.

### What's changed
Add fix for the low pcc drop .

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15162489410/job/42632225675#step:8:3249)  Pass
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15162600738)  Pass