### PR TITLE
[EXTERNAL PR]: enable aarch_64 build and use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "loguru>=0.6.0",
   "networkx>=3.1",
   "graphviz>=0.20.3",
-  "torch==2.2.1+cpu",
+  "torch==2.2.1+cpu ; platform_machine == 'x86_64'",
+  "torch==2.2.1 ; platform_machine == 'aarch64'",
 ]
 requires-python = ">=3.10"
 description = "General compute framework for Tenstorrent devices"

--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -42,9 +42,11 @@ pytest-xdist==3.6.1
 pytest-benchmark==4.0.0
 jsbeautifier==1.14.7
 datasets==2.9.0
-torch==2.2.1.0+cpu
+torch==2.2.1.0+cpu ; platform_machine == 'x86_64'
+torch==2.2.1.0 ; platform_machine == 'aarch64'
 networkx==3.1
-torchvision==0.17.1+cpu
+torchvision==0.17.1+cpu ; platform_machine == 'x86_64'
+torchvision==0.17.1 ; platform_machine == 'aarch64'
 torchmetrics==1.3.1
 torch-fidelity==0.3.0
 transformers==4.38.0


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-metal/pull/20980

### Problem description

The image changed again underneath @plecluse 's feet

### What's changed

Screw it - I'll just do this.

Sorry about the delays @plecluse - we will what you suggested and I will merge under my name because our CI is slightly different for forks.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes https://github.com/tenstorrent/tt-metal/actions/runs/15162663918
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes