### PR TITLE
SDXL: reuse all conv weights

### DIFF
--- a/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
+++ b/models/experimental/stable_diffusion_xl_base/tt/tt_downsample2d.py
@@ -54,12 +54,11 @@ class TtDownsample2D(nn.Module):
         )
         C = self.conv_params["output_channels"]
 
-        # reuse of weights produces pcc issues
-        # self.tt_weights = d_w
-        # self.tt_bias = d_b
+        self.tt_weights = d_w
+        self.tt_bias = d_b
 
-        # self.conv_config.preprocess_weights_on_device = False
-        # self.conv_config.always_preprocess_weights = False
+        self.conv_config.preprocess_weights_on_device = False
+        self.conv_config.always_preprocess_weights = False
 
         hidden_states = ttnn.sharded_to_interleaved(hidden_states, ttnn.L1_MEMORY_CONFIG)
         return hidden_states, [C, H, W]


### PR DESCRIPTION
### What's changed
Enabled reuse of conv2d weights in `TtDownsample2D`. This caused memory corruption of another convs weights, but problem was resolved in the meantime.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15162585113) CI passes
- [x] [Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15162580070) CI passes