### PR TITLE
Move galaxy quick 4U tests to APC

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -216,6 +216,17 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+  # Galaxy Quick Tests (4U only for now)
+  tg-quick-test:
+    needs: build-artifact
+    secrets: inherit
+    uses: ./.github/workflows/tg-quick.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      topology-4u: true # 4U tests are moved to APC. Eventually we want to move all of Galaxy Quick to APC once 6Us are stable
+      topology-6u: false
   build-docs:
     needs: build-artifact
     uses: ./.github/workflows/docs-latest-public.yaml

--- a/.github/workflows/tg-quick-trigger.yaml
+++ b/.github/workflows/tg-quick-trigger.yaml
@@ -21,3 +21,5 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      topology-4u: false # 4U tests are moved to APC. Eventually we want to move all of Galaxy Quick to APC once 6Us are stable
+      topology-6u: true

--- a/.github/workflows/tg-quick.yaml
+++ b/.github/workflows/tg-quick.yaml
@@ -19,11 +19,11 @@ on:
       topology-4u:
         required: false
         type: boolean
-        default: true
+        default: false
       topology-6u:
         required: false
         type: boolean
-        default: true
+        default: false
 
 jobs:
   quick-4u:


### PR DESCRIPTION
### Ticket
Request from @djordje-tt 
https://tenstorrent.slack.com/archives/C05GRJC4J4A/p1747837608365799

### Problem description
We want to move some TG tests to APC
CI team would prefer to move all of Galaxy Quick to APC and get rid of galaxy quick itself triggering on push to main. But 6U tests are not ready to be moved.


### What's changed
As a stopgap, we only invoke galaxy quick 4U tests from APC, and only 6U tests from galaxy quick itself.

### Checklist
APC https://github.com/tenstorrent/tt-metal/actions/runs/15192785979
Galaxy Quick https://github.com/tenstorrent/tt-metal/actions/runs/15192805261 confirmed skipping 4U 