### PR TITLE
Create a microbenchmark with 100 ttnop to experiment with gathering

### DIFF
--- a/tests/tt_metal/microbenchmarks/tensix/test_gathering.py
+++ b/tests/tt_metal/microbenchmarks/tensix/test_gathering.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from tt_metal.tools.profiler.process_device_log import import_log_run_stats
+import tt_metal.tools.profiler.device_post_proc_config as device_post_proc_config
+
+
+def test_ttnop_time():
+    os.system(
+        f"TT_METAL_DEVICE_PROFILER=1 {os.environ['TT_METAL_HOME']}/build/test/tt_metal/perf_microbenchmark/tensix/test_gathering"
+    )
+    setup = device_post_proc_config.default_setup()
+    setup.timerAnalysis = {
+        "latency_trisc_0": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "TRISC_0", "zone_name": "TEST-FULL"},
+            "end": {"risc": "TRISC_0", "zone_name": "TEST-FULL"},
+        },
+        "latency_trisc_1": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "TRISC_1", "zone_name": "TEST-FULL"},
+            "end": {"risc": "TRISC_1", "zone_name": "TEST-FULL"},
+        },
+        "latency_trisc_2": {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "TRISC_2", "zone_name": "TEST-FULL"},
+            "end": {"risc": "TRISC_2", "zone_name": "TEST-FULL"},
+        },
+    }
+    stats = import_log_run_stats(setup)
+    analysis = stats["devices"][0]["cores"]["DEVICE"]["analysis"]
+    for stat_name in setup.timerAnalysis:
+        device_stats = analysis[stat_name]["stats"]
+        print(stat_name, device_stats)

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PERF_MICROBENCH_TESTS_SRCS
     routing/test_tt_fabric_multi_hop_sanity.cpp
     routing/test_tt_fabric_socket_sanity.cpp
     noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+    tensix/test_gathering.cpp
     old/matmul/matmul_global_l1.cpp
     old/matmul/matmul_local_l1.cpp
     old/noc/test_noc_read_global_l1.cpp

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/kernels/compute.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/kernels/compute.cpp
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "compute_kernel_api.h"
+#include "tools/profiler/kernel_profiler.hpp"
+
+namespace NAMESPACE {
+void MAIN {
+    for (int i = 0; i < LOOP_COUNT; i++) {
+        DeviceZoneScopedN("TEST-FULL");
+// Max unroll size
+#pragma GCC unroll 65534
+        for (int j = 0; j < LOOP_SIZE; j++) {
+            TTI_NOP;
+        }
+    }
+}
+}  // namespace NAMESPACE

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <map>
+#include <string>
+
+#include <tt-metalium/assert.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/data_types.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/utils.hpp>
+
+namespace tt_metal = tt::tt_metal;
+
+int main(int argc, char** argv) {
+    int device_id = 0;
+    auto device = tt_metal::CreateDevice(device_id);
+    CoreCoord compute_with_storage_size = device->compute_with_storage_grid_size();
+    CoreCoord start_core = {0, 0};
+    CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
+    CoreRange all_cores(start_core, end_core);
+
+    std::map<std::string, std::string> kernel_defines = {
+        {"LOOP_COUNT", "100"},
+        {"LOOP_SIZE", "100"},
+    };
+    auto program = tt_metal::CreateProgram();
+    tt_metal::CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/tensix/kernels/compute.cpp",
+        all_cores,
+        tt_metal::ComputeConfig{
+            .defines = kernel_defines,
+        });
+
+    tt_metal::EnqueueProgram(device->command_queue(), program, true);
+    tt_metal::detail::DumpDeviceProfileResults(device);
+    tt_metal::CloseDevice(device);
+}


### PR DESCRIPTION
### Ticket
#22240 

### Problem description
Need a microbenchmark to test the performance impact of gathering.

### What's changed
Added a microbenchmark that measures the run time of 100 ttnop instructions using profiler.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15310168733) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15217994276) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes