### PR TITLE
#22273: remove BH skip for moreh cumsum test

### DIFF
--- a/tests/ttnn/unit_tests/operations/test_moreh_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/test_moreh_cumsum.py
@@ -8,7 +8,7 @@ import ttnn
 
 from loguru import logger
 
-from models.utility_functions import comp_allclose_and_pcc, skip_for_blackhole
+from models.utility_functions import comp_allclose_and_pcc
 from tests.ttnn.unit_tests.operations.test_utils import TILE_HEIGHT, TILE_WIDTH
 
 
@@ -95,7 +95,6 @@ def test_moreh_cumsum_dim(input_shape, dim, device):
     assert passing
 
 
-@skip_for_blackhole("Does not work on BH P150. Issue #22273")
 @pytest.mark.parametrize(
     "input_shape",
     (


### PR DESCRIPTION
### Ticket
Link to Github Issue #22273

### Problem description
- test failed before on BH

### What's changed
- test passes now on BH, remove the skip

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes N/A
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable) https://github.com/tenstorrent/tt-metal/actions/runs/15169288837
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable) N/A
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable) N/A
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models). N/A
- [x] New/Existing tests provide coverage for changes

BH Nightly: P100 and P150 passes https://github.com/tenstorrent/tt-metal/actions/runs/15169295631