### PR TITLE
[DM]: Move get_noc_addr calls outside of transaction loop

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/reader_unary.cpp
@@ -27,6 +27,10 @@ void kernel_main() {
         DeviceZoneScopedN("RISCV1");
         uint64_t src_base_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
+            /* The 64-bit NOC addresses consists of a 32-bit local address and a NOC XY coordinate. The local address
+             * occupies the lower 32 bits and the NOC XY coordinate occupies the next 12 (unicast) to 24 (multicast)
+             * bits. In the get_noc_addr call, we set the local address to 0 to get the base address. Then, we OR it
+             * with the local address (src_addr) in each iteration to get the full NOC address. */
             uint64_t src_noc_addr = src_base_noc_addr | src_addr;
 
             noc_async_read(src_noc_addr, l1_write_addr, transaction_size_bytes);

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/reader_unary.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/reader_unary.cpp
@@ -25,8 +25,9 @@ void kernel_main() {
     uint32_t l1_write_addr = get_write_ptr(cb_id_in0);
     {
         DeviceZoneScopedN("RISCV1");
+        uint64_t src_base_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            uint64_t src_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, src_addr);
+            uint64_t src_noc_addr = src_base_noc_addr | src_addr;
 
             noc_async_read(src_noc_addr, l1_write_addr, transaction_size_bytes);
 

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary.cpp
@@ -27,6 +27,10 @@ void kernel_main() {
         DeviceZoneScopedN("RISCV0");
         uint64_t dst_base_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
+            /* The 64-bit NOC addresses consists of a 32-bit local address and a NOC XY coordinate. The local address
+             * occupies the lower 32 bits and the NOC XY coordinate occupies the next 12 (unicast) to 24 (multicast)
+             * bits. In the get_noc_addr call, we set the local address to 0 to get the base address. Then, we OR it
+             * with the local address (dst_addr) in each iteration to get the full NOC address. */
             uint64_t dst_noc_addr = dst_base_noc_addr | dst_addr;
 
             noc_async_write(l1_read_addr, dst_noc_addr, transaction_size_bytes);

--- a/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_unary/kernels/writer_unary.cpp
@@ -25,8 +25,9 @@ void kernel_main() {
     uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
     {
         DeviceZoneScopedN("RISCV0");
+        uint64_t dst_base_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            uint64_t dst_noc_addr = get_noc_addr_from_bank_id<true>(bank_id, dst_addr);
+            uint64_t dst_noc_addr = dst_base_noc_addr | dst_addr;
 
             noc_async_write(l1_read_addr, dst_noc_addr, transaction_size_bytes);
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_all/kernels/gatherer.cpp
@@ -36,6 +36,10 @@ void kernel_main() {
         for (uint32_t sub_core = 0; sub_core < total_subordinate_cores; sub_core++) {
             uint64_t src_base_noc_addr = get_noc_addr(responder_coords[sub_core][0], responder_coords[sub_core][1], 0);
             for (uint32_t i = 0; i < num_of_transactions; i++) {
+                /* The 64-bit NOC addresses consists of a 32-bit local address and a NOC XY coordinate. The local
+                 * address occupies the lower 32 bits and the NOC XY coordinate occupies the next 12 (unicast) to 24
+                 * (multicast) bits. In the get_noc_addr call, we set the local address to 0 to get the base address.
+                 * Then, we OR it with the local address in each iteration to get the full NOC address. */
                 uint64_t src_noc_addr = src_base_noc_addr | subordinate_l1_byte_addresses[sub_core];
 
                 noc_async_read(src_noc_addr, dst_addr, transaction_size_bytes);

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor.cpp
@@ -25,8 +25,9 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV1");
+        uint64_t src_base_noc_addr = get_noc_addr(responder_x_coord, responder_y_coord, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            uint64_t src_noc_addr = get_noc_addr(responder_x_coord, responder_y_coord, src_addr);
+            uint64_t src_noc_addr = src_base_noc_addr | src_addr;
 
             noc_async_read(src_noc_addr, dst_addr, transaction_size_bytes);
 

--- a/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_from_one/kernels/requestor.cpp
@@ -27,6 +27,10 @@ void kernel_main() {
         DeviceZoneScopedN("RISCV1");
         uint64_t src_base_noc_addr = get_noc_addr(responder_x_coord, responder_y_coord, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
+            /* The 64-bit NOC addresses consists of a 32-bit local address and a NOC XY coordinate. The local address
+             * occupies the lower 32 bits and the NOC XY coordinate occupies the next 12 (unicast) to 24 (multicast)
+             * bits. In the get_noc_addr call, we set the local address to 0 to get the base address. Then, we OR it
+             * with the local address (src_addr) in each iteration to get the full NOC address. */
             uint64_t src_noc_addr = src_base_noc_addr | src_addr;
 
             noc_async_read(src_noc_addr, dst_addr, transaction_size_bytes);

--- a/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_all/kernels/sender.cpp
@@ -23,11 +23,11 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
-        for (uint32_t i = 0; i < num_of_transactions; i++) {
-            for (uint32_t subordinate = 0; subordinate < num_subordinates; subordinate++) {
-                uint32_t dest_x = get_arg_val<uint32_t>(subordinate_coords_offset + 2 * subordinate);
-                uint32_t dest_y = get_arg_val<uint32_t>(subordinate_coords_offset + 2 * subordinate + 1);
-                uint64_t dst_noc_addr = get_noc_addr(dest_x, dest_y, dst_addr);
+        for (uint32_t subordinate = 0; subordinate < num_subordinates; subordinate++) {
+            uint32_t dest_x = get_arg_val<uint32_t>(subordinate_coords_offset + 2 * subordinate);
+            uint32_t dest_y = get_arg_val<uint32_t>(subordinate_coords_offset + 2 * subordinate + 1);
+            uint64_t dst_noc_addr = get_noc_addr(dest_x, dest_y, dst_addr);
+            for (uint32_t i = 0; i < num_of_transactions; i++) {
                 noc_async_write(src_addr, dst_noc_addr, transaction_size_bytes);
             }
         }

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
@@ -28,8 +28,9 @@ void kernel_main() {
 
     {
         DeviceZoneScopedN("RISCV0");
+        uint64_t dst_base_noc_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
-            uint64_t dst_noc_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, dst_addr);
+            uint64_t dst_noc_addr = dst_base_noc_addr | dst_addr;
 
             noc_async_write(src_addr, dst_noc_addr, transaction_size_bytes);
 

--- a/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/one_to_one/kernels/sender.cpp
@@ -30,6 +30,10 @@ void kernel_main() {
         DeviceZoneScopedN("RISCV0");
         uint64_t dst_base_noc_addr = get_noc_addr(receiver_x_coord, receiver_y_coord, 0);
         for (uint32_t i = 0; i < num_of_transactions; i++) {
+            /* The 64-bit NOC addresses consists of a 32-bit local address and a NOC XY coordinate. The local address
+             * occupies the lower 32 bits and the NOC XY coordinate occupies the next 12 (unicast) to 24 (multicast)
+             * bits. In the get_noc_addr call, we set the local address to 0 to get the base address. Then, we OR it
+             * with the local address (dst_addr) in each iteration to get the full NOC address. */
             uint64_t dst_noc_addr = dst_base_noc_addr | dst_addr;
 
             noc_async_write(src_addr, dst_noc_addr, transaction_size_bytes);

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -167,7 +167,7 @@ test_bounds = {
     },
     "blackhole": {
         0: {
-            "riscv_1": {"latency": {"lower": 400, "upper": 17000}, "bandwidth": 0.12},
+            "riscv_1": {"latency": {"lower": 400, "upper": 17000}, "bandwidth": 0.1},
             "riscv_0": {"latency": {"lower": 300, "upper": 16000}, "bandwidth": 0.15},
         },
         1: {
@@ -189,34 +189,34 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 300, "upper": 9200}, "bandwidth": 0.17},
         },
         6: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 70000}, "bandwidth": 0.4},
+            "riscv_0": {"latency": {"lower": 400, "upper": 70000}, "bandwidth": 0.5},
         },
         7: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 300000}, "bandwidth": 1.0},
+            "riscv_0": {"latency": {"lower": 900, "upper": 275000}, "bandwidth": 1.12},
         },
         8: {
-            "riscv_0": {"latency": {"lower": 2000, "upper": 2000000}, "bandwidth": 1.0},
+            "riscv_0": {"latency": {"lower": 3800, "upper": 1700000}, "bandwidth": 1.65},
         },
         9: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 30000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 300, "upper": 30000}, "bandwidth": 0.16},
         },
         10: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 70000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 500, "upper": 70000}, "bandwidth": 0.12},
         },
         11: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 200000}, "bandwidth": 0.04},
+            "riscv_0": {"latency": {"lower": 700, "upper": 115000}, "bandwidth": 0.08},
         },
         12: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 30000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 300, "upper": 20000}, "bandwidth": 0.16},
         },
         13: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 30000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 500, "upper": 24000}, "bandwidth": 0.12},
         },
         14: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 100000}, "bandwidth": 0.04},
+            "riscv_0": {"latency": {"lower": 700, "upper": 46000}, "bandwidth": 0.08},
         },
         15: {
-            "riscv_1": {"latency": {"lower": 800, "upper": 135000}, "bandwidth": 1.19},
+            "riscv_1": {"latency": {"lower": 800, "upper": 87000}, "bandwidth": 1.19},
         },
         16: {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},

--- a/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/test_data_movement.py
@@ -108,8 +108,8 @@ test_bounds = {
             "riscv_0": {"latency": {"lower": 24000, "upper": 25000}, "bandwidth": 21},
         },
         2: {
-            "riscv_1": {"latency": {"lower": 500, "upper": 600}, "bandwidth": 0.24},
-            "riscv_0": {"latency": {"lower": 400, "upper": 500}, "bandwidth": 0.30},
+            "riscv_1": {"latency": {"lower": 300, "upper": 600}, "bandwidth": 0.08},
+            "riscv_0": {"latency": {"lower": 300, "upper": 500}, "bandwidth": 0.08},
         },
         3: {
             "riscv_1": {"latency": {"lower": 33000, "upper": 35000}, "bandwidth": 22},
@@ -122,34 +122,34 @@ test_bounds = {
             "riscv_1": {"latency": {"lower": 200, "upper": 19000}, "bandwidth": 0.1},
         },
         6: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 70000}, "bandwidth": 0.4},
+            "riscv_0": {"latency": {"lower": 400, "upper": 70000}, "bandwidth": 0.3},
         },
         7: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 30000}, "bandwidth": 1.0},
+            "riscv_0": {"latency": {"lower": 800, "upper": 300000}, "bandwidth": 0.6},
         },
         8: {
-            "riscv_0": {"latency": {"lower": 2000, "upper": 2000000}, "bandwidth": 1.0},
+            "riscv_0": {"latency": {"lower": 1900, "upper": 900000}, "bandwidth": 0.8},
         },
         9: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 300000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 300, "upper": 30000}, "bandwidth": 0.09},
         },
         10: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 70000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 400, "upper": 60000}, "bandwidth": 0.07},
         },
         11: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 200000}, "bandwidth": 0.04},
+            "riscv_0": {"latency": {"lower": 500, "upper": 90000}, "bandwidth": 0.04},
         },
         12: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 30000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 200, "upper": 20000}, "bandwidth": 0.09},
         },
         13: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 30000}, "bandwidth": 0.1},
+            "riscv_0": {"latency": {"lower": 400, "upper": 30000}, "bandwidth": 0.07},
         },
         14: {
-            "riscv_0": {"latency": {"lower": 200, "upper": 100000}, "bandwidth": 0.04},
+            "riscv_0": {"latency": {"lower": 500, "upper": 40000}, "bandwidth": 0.04},
         },
         15: {
-            "riscv_1": {"latency": {"lower": 700, "upper": 120000}, "bandwidth": 0.7},
+            "riscv_1": {"latency": {"lower": 700, "upper": 85000}, "bandwidth": 0.71},
         },
         16: {
             "riscv_0": {"latency": {"lower": 50, "upper": 30000}, "bandwidth": 0.4},

--- a/tt_metal/hw/inc/dataflow_api.h
+++ b/tt_metal/hw/inc/dataflow_api.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/21640)

### Problem description
Every data movement kernel has a loop that iterates over the transaction count. In each of these iterations, the `get_noc_addr` API, or the like, is called to obtain a noc address for the target address. Calling this each iteration may cause overhead and add latency to our performance measurements.

### What's changed
Moved the `get_noc_addr` calls outside of the transaction loop in all kernels. This change doesn’t have much performance impact on single core tests such as `dram_unary` or `one_to_one`, but the performance impact is more pronounced in multicore tests such as `one_to_all` and `one_from_all`.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15220067329) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15220069580) CI with demo tests passes (if applicable)
- [x] [metal - Run microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/runs/15220071376)
- [x] New/Existing tests provide coverage for changes