### PR TITLE
Create TT_METAL_ENABLE_GATHERING env var

### DIFF
--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/hw/inc/firmware_common.h
+++ b/tt_metal/hw/inc/firmware_common.h
@@ -131,8 +131,8 @@ bool is_message_go() {
 #define EARLY_RETURN_FOR_DEBUG
 #endif
 
-inline __attribute__((always_inline)) void disable_gathering() {
-#if defined(ARCH_BLACKHOLE)
+inline __attribute__((always_inline)) void configure_gathering() {
+#if defined(ARCH_BLACKHOLE) && !defined(ENABLE_GATHERING)
     // Workaround for tt-metal#16439, making sure gathering multiple instructions issued to Tensix is disabled
     // Brisc does not issue Tensix instructions but to be consistent for all riscs around Tensix we disable it
     // Disable gathering: set bit 18
@@ -190,7 +190,7 @@ inline __attribute__((always_inline)) void disable_relaxed_memory_ordering() {
 }
 
 inline __attribute__((always_inline)) void configure_csr() {
-    disable_gathering();
+    configure_gathering();
     configure_l1_data_cache();
     disable_relaxed_memory_ordering();
 }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -242,6 +242,10 @@ void JitBuildEnv::init(
         this->defines_ += "-DDISABLE_RELAXED_MEMORY_ORDERING ";
     }
 
+    if (rtoptions.get_gathering_enabled()) {
+        this->defines_ += "-DENABLE_GATHERING ";
+    }
+
     if (tt::tt_metal::MetalContext::instance().get_cluster().is_base_routing_fw_enabled()) {
         this->defines_ += "-DROUTING_FW_ENABLED ";
     }

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <cstdlib>
 #include <cstring>
-#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -190,6 +189,10 @@ RunTimeOptions::RunTimeOptions() {
 
     if (getenv("TT_METAL_DISABLE_RELAXED_MEM_ORDERING")) {
         this->disable_relaxed_memory_ordering = true;
+    }
+
+    if (getenv("TT_METAL_ENABLE_GATHERING")) {
+        this->enable_gathering = true;
     }
 
     const char *arc_debug_enabled_str = std::getenv("TT_METAL_ARC_DEBUG_BUFFER_SIZE");

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+// SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -15,7 +15,6 @@
 #include <map>
 #include <set>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "core_coord.hpp"
@@ -157,6 +156,9 @@ class RunTimeOptions {
     // e.g. Store A followed by Load A will be unchanges but Store A followed by Load B may return B before A is written
     // This option will disable the relaxed ordering
     bool disable_relaxed_memory_ordering = false;
+
+    // Enable instruction gathering in Tensix core.
+    bool enable_gathering = false;
 
     // Buffer in DRAM to store various ARC processor samples. Feature not ready yet
     uint32_t arc_debug_buffer_size = 0;
@@ -358,6 +360,7 @@ public:
     inline bool get_hw_cache_invalidation_enabled() const { return this->enable_hw_cache_invalidation; }
 
     inline bool get_relaxed_memory_ordering_disabled() const { return this->disable_relaxed_memory_ordering; }
+    inline bool get_gathering_enabled() const { return this->enable_gathering; }
 
     tt_metal::DispatchCoreConfig get_dispatch_core_config() const;
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/22240

### Problem description
Gathering is currently globally disabled, and it requires source code modification in both tt_metal and tt_llk to re-enable it.

### What's changed
Create `TT_METAL_ENABLE_GATHERING` env var that controls a JIT build time option `ENABLE_GATHERING`.  Device code will call disable_gathering / enabled_gathering based on this flag.

There are two places that needs to be aware of this flag:
- `configure_csr` should not call `disable_gathering` if `ENABLE_GATHERING` is defined.
- (In tt_llk), `load_replay_buf` should call `disable_gathering` and `enable_gathering` around the TTI_REPLAY load instruction.  This will be an external change tracked at https://github.com/tenstorrent/tt-llk/pull/227.

TODO:
- [x] double check the commit of `tt_llk` submodule in this commit after the tt_llk PR is merged.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15174160623) CI passes
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15173205901) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes