### PR TITLE
Fix issue #22423: missing standard include

### DIFF
--- a/tt_metal/api/tt-metalium/distributed_context.hpp
+++ b/tt_metal/api/tt-metalium/distributed_context.hpp
@@ -9,6 +9,7 @@
 #include <tt_stl/span.hpp>
 #include <optional>
 #include <cstddef>
+#include <cstdint>
 #include <complex>
 
 namespace tt::tt_metal::distributed::multihost {


### PR DESCRIPTION
### Ticket
#22423 

### Problem description
I'm not sure why I see this issue and you don't see it on your end, we both use clang-17 and libstdc++. Possibly because we have a slightly more recent version of stdlibc++ (we have gcc-13 installed on the machines).

But the right fix is to include the header that according to C++ standard has definition of `uint8_t`.

CC @dmakoviichuk-tt 

### What's changed
Added necessary standard include.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes