### PR TITLE
Add CoreType param to append_fabric_connection_rt_args

### DIFF
--- a/tt_metal/api/tt-metalium/fabric.hpp
+++ b/tt_metal/api/tt-metalium/fabric.hpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <umd/device/types/cluster_descriptor_types.h>  // chip_id_t
 #include <vector>
+#include <umd/device/tt_core_coordinates.h>
 
 namespace tt {
 namespace tt_metal {
@@ -36,6 +37,7 @@ size_t get_tt_fabric_channel_buffer_size_bytes();
 // worker_program: program handle
 // worker_core: worker core logical coordinates
 // worker_args: list of existing run-time args to which the connection args will be appended
+// core_type: core type which the worker will be running on
 //
 // Constraints:
 // 1. Currently the sender and reciever chip should be physically adjacent
@@ -49,6 +51,7 @@ void append_fabric_connection_rt_args(
     uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
-    std::vector<uint32_t>& worker_args);
+    std::vector<uint32_t>& worker_args,
+    CoreType core_type = CoreType::WORKER);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -42,7 +42,8 @@ void append_fabric_connection_rt_args(
     uint32_t link_idx,
     tt::tt_metal::Program& worker_program,
     const CoreCoord& worker_core,
-    std::vector<uint32_t>& worker_args) {
+    std::vector<uint32_t>& worker_args,
+    CoreType core_type) {
     TT_FATAL(
         src_chip_id != dst_chip_id,
         "Expected different src and dst chip ids but got same, src: {}, dst: {}",
@@ -112,9 +113,9 @@ void append_fabric_connection_rt_args(
         .persistent_fabric = true,
         .edm_direction = router_direction};
 
-    auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0);
-    auto worker_teardown_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0);
-    auto worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0);
+    auto worker_flow_control_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0, core_type);
+    auto worker_teardown_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0, core_type);
+    auto worker_buffer_index_semaphore_id = tt_metal::CreateSemaphore(worker_program, {worker_core}, 0, core_type);
     append_worker_to_fabric_edm_sender_rt_args(
         edm_connection,
         worker_flow_control_semaphore_id,


### PR DESCRIPTION
### Ticket
#18726

### Problem description
- Currently `append_fabric_connection_rt_args` only supports Worker (TENSIX) cores 
- Other users like Dispatch need to create worker cores which will run on Idle Ethernet cores

### What's changed
- Add CoreType parameter so it can create semaphores properly on other core types

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes