### PR TITLE
Remove ARCH_NAME dependence for perf microbenchmark tests

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/CMakeLists.txt
@@ -52,54 +52,45 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
     list(APPEND PERF_MICROBENCH_TESTS_SRCS ${X86_64_ONLY_TESTS})
 endif()
 
-set(ARCHITECTURES
-    "wormhole"
-    "blackhole"
-)
+foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
+    get_filename_component(TEST_TARGET ${TEST_SRC} NAME_WE)
+    get_filename_component(TEST_DIR ${TEST_SRC} DIRECTORY)
+    # test_rw_buffer have two versions >:/ can we remove one?
+    if(${TEST_SRC} STREQUAL "old/pcie/test_rw_buffer.cpp")
+        set(TEST_TARGET "test_rw_buffer_old")
+    endif()
+    string(REPLACE "wormhole" "wormhole_b0" TEST_TARGET ${TEST_TARGET})
 
-foreach(arch ${ARCHITECTURES})
-    foreach(TEST_SRC ${PERF_MICROBENCH_TESTS_SRCS})
-        get_filename_component(TEST_TARGET ${TEST_SRC} NAME_WE)
-        get_filename_component(TEST_DIR ${TEST_SRC} DIRECTORY)
-        # test_rw_buffer have two versions >:/ can we remove one?
-        if(${TEST_SRC} STREQUAL "old/pcie/test_rw_buffer.cpp")
-            set(TEST_TARGET "test_rw_buffer_old")
-        endif()
-        set(TEST_TARGET "${TEST_TARGET}_${arch}")
-        string(REPLACE "wormhole" "wormhole_b0" TEST_TARGET ${TEST_TARGET})
-
-        add_executable(${TEST_TARGET} ${TEST_SRC})
-        target_link_libraries(
-            ${TEST_TARGET}
-            PUBLIC
-                test_metal_common_libs
-            PRIVATE
-                yaml-cpp::yaml-cpp
-                fabric
-        )
-        if(${TEST_SRC} STREQUAL "dispatch/test_pgm_dispatch.cpp")
-            target_link_libraries(${TEST_TARGET} PRIVATE benchmark::benchmark)
-        endif()
-        target_include_directories(
-            ${TEST_TARGET}
-            BEFORE
-            PRIVATE
-                ${PROJECT_SOURCE_DIR}/tt_metal/hw/inc/${arch}
-                "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
-                ${PROJECT_SOURCE_DIR}/ttnn/cpp/ttnn/deprecated # this all should go away and be replaced with link to ttnn
-                ${PROJECT_SOURCE_DIR}/tests
-                ${PROJECT_SOURCE_DIR}/tests/tt_metal/test_utils
-                ${CMAKE_CURRENT_SOURCE_DIR}
-        )
-        set_target_properties(
-            ${TEST_TARGET}
-            PROPERTIES
-                RUNTIME_OUTPUT_DIRECTORY
-                    ${PROJECT_BINARY_DIR}/test/tt_metal/perf_microbenchmark/${TEST_DIR}
-        )
-        target_compile_options(${TEST_TARGET} PUBLIC ${COMPILE_OPTIONS})
-        list(APPEND PERF_MICROBENCH_TEST_TARGETS ${TEST_TARGET})
-    endforeach()
+    add_executable(${TEST_TARGET} ${TEST_SRC})
+    target_link_libraries(
+        ${TEST_TARGET}
+        PUBLIC
+            test_metal_common_libs
+        PRIVATE
+            yaml-cpp::yaml-cpp
+            fabric
+    )
+    if(${TEST_SRC} STREQUAL "dispatch/test_pgm_dispatch.cpp")
+        target_link_libraries(${TEST_TARGET} PRIVATE benchmark::benchmark)
+    endif()
+    target_include_directories(
+        ${TEST_TARGET}
+        BEFORE
+        PRIVATE
+            "$<TARGET_PROPERTY:Metalium::Metal,INCLUDE_DIRECTORIES>"
+            ${PROJECT_SOURCE_DIR}/ttnn/cpp/ttnn/deprecated # this all should go away and be replaced with link to ttnn
+            ${PROJECT_SOURCE_DIR}/tests
+            ${PROJECT_SOURCE_DIR}/tests/tt_metal/test_utils
+            ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    set_target_properties(
+        ${TEST_TARGET}
+        PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY
+                ${PROJECT_BINARY_DIR}/test/tt_metal/perf_microbenchmark/${TEST_DIR}
+    )
+    target_compile_options(${TEST_TARGET} PUBLIC ${COMPILE_OPTIONS})
+    list(APPEND PERF_MICROBENCH_TEST_TARGETS ${TEST_TARGET})
 endforeach()
 
 add_custom_target(metal_perf_microbenchmark_tests DEPENDS ${PERF_MICROBENCH_TEST_TARGETS})

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -12,13 +12,14 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/allocator.hpp>
 
-#include "noc/noc_parameters.h"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 
-#include <tt-metalium/hal.hpp>
 #include "llrt.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include <magic_enum/magic_enum.hpp>
+
+#include "llrt/hal.hpp"
+#include "tt_metal/impl/context/metal_context.hpp"
 
 using namespace tt::tt_metal;  // test only
 
@@ -852,7 +853,8 @@ inline void add_dispatcher_packed_cmd(
     add_bare_dispatcher_cmd(cmds, cmd);
     for (CoreCoord core : worker_cores) {
         CoreCoord phys_worker_core = device->worker_core_from_logical_core(core);
-        cmds.push_back(NOC_XY_ENCODING(phys_worker_core.x, phys_worker_core.y));
+        cmds.push_back(
+            tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y));
     }
     cmds.resize(
         padded_size(cmds.size(), MetalContext::instance().hal().get_alignment(HalMemType::L1) / sizeof(uint32_t)));
@@ -872,7 +874,8 @@ inline void gen_bare_dispatcher_unicast_write_cmd(
     const uint32_t bank_id = 0;  // No interleaved pages here.
 
     cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
-    cmd.write_linear.noc_xy_addr = NOC_XY_ENCODING(phys_worker_core.x, phys_worker_core.y);
+    cmd.write_linear.noc_xy_addr =
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y);
     cmd.write_linear.addr = device_data.get_result_data_addr(worker_core, bank_id);
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = 0;
@@ -892,7 +895,8 @@ inline void gen_dispatcher_unicast_write_cmd(
     const uint32_t bank_id = 0;  // No interleaved pages here.
 
     cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
-    cmd.write_linear.noc_xy_addr = NOC_XY_ENCODING(phys_worker_core.x, phys_worker_core.y);
+    cmd.write_linear.noc_xy_addr =
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y);
     cmd.write_linear.addr = device_data.get_result_data_addr(worker_core, bank_id);
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = 0;
@@ -918,8 +922,8 @@ inline void gen_dispatcher_multicast_write_cmd(
     const uint32_t bank_id = 0;  // No interleaved pages here.
 
     cmd.base.cmd_id = CQ_DISPATCH_CMD_WRITE_LINEAR;
-    cmd.write_linear.noc_xy_addr =
-        NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
+    cmd.write_linear.noc_xy_addr = tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
+        physical_start.x, physical_start.y, physical_end.x, physical_end.y);
     cmd.write_linear.addr = device_data.get_result_data_addr(worker_core_range.start_coord);
     cmd.write_linear.length = length;
     cmd.write_linear.num_mcast_dests = worker_core_range.size();
@@ -1124,8 +1128,8 @@ inline bool gen_rnd_dispatcher_packed_write_large_cmd(
         CQDispatchWritePackedLargeSubCmd sub_cmd;
         CoreCoord physical_start = device->worker_core_from_logical_core(range.start_coord);
         CoreCoord physical_end = device->worker_core_from_logical_core(range.end_coord);
-        sub_cmd.noc_xy_addr =
-            NOC_MULTICAST_ENCODING(physical_start.x, physical_start.y, physical_end.x, physical_end.y);
+        sub_cmd.noc_xy_addr = tt::tt_metal::MetalContext::instance().hal().noc_multicast_encoding(
+            physical_start.x, physical_start.y, physical_end.x, physical_end.y);
         sub_cmd.addr = device_data.get_result_data_addr(range.start_coord);
         sub_cmd.length = xfer_size_bytes;
         sub_cmd.num_mcast_dests =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -40,7 +40,6 @@
 #include <tt-metalium/kernel_types.hpp>
 #include "llrt.hpp"
 #include <tt-metalium/logger.hpp>
-#include "noc/noc_parameters.h"
 #include <tt-metalium/program.hpp>
 #include "impl/dispatch/command_queue_common.hpp"
 #include "impl/dispatch/dispatch_settings.hpp"
@@ -359,7 +358,8 @@ void add_prefetcher_linear_read_cmd(IDevice* device,
 
     cmd.relay_linear.pad1 = 0;
     cmd.relay_linear.pad2 = 0;
-    cmd.relay_linear.noc_xy_addr = NOC_XY_ENCODING(phys_worker_core.x, phys_worker_core.y);
+    cmd.relay_linear.noc_xy_addr =
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_worker_core.x, phys_worker_core.y);
     cmd.relay_linear.addr = addr;
     cmd.relay_linear.length = length;
 
@@ -2339,7 +2339,7 @@ void configure_for_single_chip(
         0,  // unused on hd, filled in below for h and d
         0,  // unused unless tunneler is between h and d
         split_prefetcher_g,
-        NOC_XY_ENCODING(phys_prefetch_core_g.x, phys_prefetch_core_g.y),
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_prefetch_core_g.x, phys_prefetch_core_g.y),
         prefetch_downstream_cb_sem,
         prefetch_downstream_buffer_pages,
         num_compute_cores,  // max_write_packed_cores
@@ -3224,7 +3224,7 @@ void configure_for_multi_chip(
         0,  // unused on hd, filled in below for h and d
         0,  // unused unless tunneler is between h and d
         split_prefetcher_g,
-        NOC_XY_ENCODING(phys_prefetch_core_g.x, phys_prefetch_core_g.y),
+        tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(phys_prefetch_core_g.x, phys_prefetch_core_g.y),
         prefetch_downstream_cb_sem,
         prefetch_downstream_buffer_pages,
         num_compute_cores,


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes