### PR TITLE
Remove pull router from runtime TT-Fabric launch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -222,6 +222,7 @@ class CMakeBuild(build_ext):
             "api/tt-metalium/fabric_host_interface.h",
             "api/tt-metalium/fabric_edm_types.hpp",
             "api/tt-metalium/fabric_edm_packet_header.hpp",
+            "api/tt-metalium/edm_fabric_counters.hpp",
             "core_descriptors/*.yaml",
             "fabric/hw/**/*",
             "fabric/mesh_graph_descriptors/*.yaml",

--- a/tests/scripts/run_cpp_fabric_tests.sh
+++ b/tests/scripts/run_cpp_fabric_tests.sh
@@ -36,30 +36,25 @@ TESTS=(
     # Async Write
     "1 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
     "2 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 8 --num_dest_endpoints 8 --num_links 16 --benchmark"
-    "3 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --metal_fabric_init_level 1"
-    "4 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 8 --num_dest_endpoints 8 --num_links 16 --benchmark --metal_fabric_init_level 1"
      # Async Write Mcast
-    "5 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 1"
-    "6 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 1"
-    "7 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 1 --metal_fabric_init_level 1"
+    "3 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 1"
+    "4 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 1"
      # TODO: Enable benchmark functionality for mcast
      # Atomic Inc
-    "8 --fabric_command 64 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
-    "9 --fabric_command 64 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --metal_fabric_init_level 1"
+    "5 --fabric_command 64 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
      # Async Write Atomic Inc
-    "10 --fabric_command 65 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
-    "11 --fabric_command 65 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --metal_fabric_init_level 1"
+    "6 --fabric_command 65 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
 
      # Async Write with Push Router
-    "12 --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --push_router"
-    "13 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 8 --num_dest_endpoints 8 --num_links 16 --benchmark --push_router"
+    "7 --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --push_router"
+    "8 --fabric_command 1 --board_type n300 --data_kb_per_tx 10 --num_src_endpoints 8 --num_dest_endpoints 8 --num_links 16 --benchmark --push_router"
      # Async Write Mcast with Push Router
-    "14 --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --num_links 16 --e_depth 1 --push_router"
-    "15 --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --num_links 16 --w_depth 1 --push_router"
+    "9 --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --num_links 16 --e_depth 1 --push_router"
+    "10 --fabric_command 1 --board_type n300 --data_kb_per_tx 600 --num_links 16 --w_depth 1 --push_router"
      # Atomic Inc with Push Router
-    "16 --fabric_command 64 --board_type n300 --data_kb_per_tx 600 --push_router"
+    "11 --fabric_command 64 --board_type n300 --data_kb_per_tx 600 --push_router"
      # Async Write Atomic Inc with Push Router
-    "17 --fabric_command 65 --board_type n300 --data_kb_per_tx 600 --push_router"
+    "12 --fabric_command 65 --board_type n300 --data_kb_per_tx 600 --push_router"
 )
 
 for TEST in "${TESTS[@]}"; do

--- a/tests/scripts/t3000/run_t3000_unit_tests.sh
+++ b/tests/scripts/t3000/run_t3000_unit_tests.sh
@@ -51,7 +51,6 @@ run_t3000_ttfabric_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 65 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --metal_fabric_init_level 1
   # Unicast tests for push router
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --push_router
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 64 --board_type t3k --data_kb_per_tx 10 --push_router
@@ -61,7 +60,6 @@ run_t3000_ttfabric_tests() {
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 3
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 1
   TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --s_depth 1
-  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric_sanity_wormhole_b0 --fabric_command 1 --board_type t3k --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 3 --metal_fabric_init_level 1
 
   # Record the end time
   end_time=$(date +%s)

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -72,39 +72,37 @@ run_tg_tests() {
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     # TODO: Fix bug and enable Push mode https://github.com/tenstorrent/tt-metal/issues/19999
     #       TG + push mode + fast dispatch has bug at tt::tt_metal::detail::CreateDevices(ids)
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DPullFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DPushFixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMuxFixture.*"
     TESTS=(
         # Unicast tests
         "1 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
         "2 --fabric_command 64 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
         "3 --fabric_command 65 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16"
-        "4 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --metal_fabric_init_level 1"
         # Unicast tests for push router
-        "5 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --push_router"
-        "6 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --push_router"
-        "7 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --push_router"
+        "4 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --push_router"
+        "5 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --push_router"
+        "6 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --push_router"
         # Line Mcast tests
-        "8 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 7"
-        "9 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 7"
-        "10 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3"
-        "11 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --s_depth 3"
-        "12 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3 --metal_fabric_init_level 1"
+        "7 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --e_depth 7"
+        "8 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --w_depth 7"
+        "9 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --n_depth 3"
+        "10 --fabric_command 1 --board_type glx32 --data_kb_per_tx 10 --num_src_endpoints 20 --num_dest_endpoints 8 --num_links 16 --s_depth 3"
         # Line Mcast tests for push router - Async Write
-        "13 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --e_depth 7 --push_router"
-        "14 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --w_depth 7 --push_router"
-        "15 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --n_depth 3 --push_router"
-        "16 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --s_depth 3 --push_router"
+        "11 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --e_depth 7 --push_router"
+        "12 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --w_depth 7 --push_router"
+        "13 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --n_depth 3 --push_router"
+        "14 --fabric_command 1 --board_type glx32 --data_kb_per_tx 100 --s_depth 3 --push_router"
         # Line Mcast tests for push router Atomic Increment
-        "17 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --e_depth 7 --push_router"
-        "18 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --w_depth 7 --push_router"
-        "19 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --n_depth 3 --push_router"
-        "20 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --s_depth 3 --push_router"
+        "15 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --e_depth 7 --push_router"
+        "16 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --w_depth 7 --push_router"
+        "17 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --n_depth 3 --push_router"
+        "18 --fabric_command 64 --board_type glx32 --data_kb_per_tx 100 --s_depth 3 --push_router"
         # Line Mcast tests for push router Async Write + Atomic Increment
-        "21 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --e_depth 7 --push_router"
-        "22 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --w_depth 7 --push_router"
-        "23 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --n_depth 3 --push_router"
-        "24 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --s_depth 3 --push_router"
+        "19 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --e_depth 7 --push_router"
+        "20 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --w_depth 7 --push_router"
+        "21 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --n_depth 3 --push_router"
+        "22 --fabric_command 65 --board_type glx32 --data_kb_per_tx 100 --s_depth 3 --push_router"
 
     )
     for TEST in "${TESTS[@]}"; do

--- a/tests/scripts/tg/run_tg_unit_tests.sh
+++ b/tests/scripts/tg/run_tg_unit_tests.sh
@@ -72,7 +72,7 @@ run_tg_tests() {
     TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     # TODO: Fix bug and enable Push mode https://github.com/tenstorrent/tt-metal/issues/19999
     #       TG + push mode + fast dispatch has bug at tt::tt_metal::detail::CreateDevices(ids)
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DPushFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricMuxFixture.*"
     TESTS=(
         # Unicast tests

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -88,12 +88,8 @@ class Fabric1DFixture : public BaseFabricFixture {
     void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_1D); }
 };
 
-class Fabric2DPullFixture : public BaseFabricFixture {
-    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D); }
-};
-
 class Fabric2DPushFixture : public BaseFabricFixture {
-    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D_PUSH); }
+    void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D); }
 };
 
 class Fabric2DDynamicFixture : public BaseFabricFixture {

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -88,7 +88,7 @@ class Fabric1DFixture : public BaseFabricFixture {
     void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_1D); }
 };
 
-class Fabric2DPushFixture : public BaseFabricFixture {
+class Fabric2DFixture : public BaseFabricFixture {
     void SetUp() override { this->SetUpDevices(tt::tt_metal::FabricConfig::FABRIC_2D); }
 };
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -692,11 +692,7 @@ void RunAsyncWriteMulticastTest(
     }
 }
 
-TEST_F(Fabric2DPullFixture, TestAsyncWrite) { RunAsyncWriteTest(this, fabric_mode::PULL, false); }
-
 TEST_F(Fabric2DPushFixture, DISABLED_TestAsyncWrite) { RunAsyncWriteTest(this, fabric_mode::PUSH, false); }
-
-TEST_F(Fabric2DPullFixture, TestAsyncRawWrite) { RunAsyncWriteTest(this, fabric_mode::PULL, true); }
 
 TEST_F(Fabric2DPushFixture, TestUnicastRaw) {
     for (uint32_t i = 0; i < 10; i++) {
@@ -742,36 +738,14 @@ TEST_F(Fabric2DPushFixture, TestMCastConnAPI_2N1S) {
     RunTestMCastConnAPI(this, RoutingDirection::N, 2, RoutingDirection::S, 1);
 }
 
-TEST_F(Fabric2DPullFixture, TestAtomicInc) { RunAtomicIncTest(this, fabric_mode::PULL); }
-
 TEST_F(Fabric2DPushFixture, DISABLED_TestAtomicInc) { RunAtomicIncTest(this, fabric_mode::PUSH); }
-
-TEST_F(Fabric2DPullFixture, TestAsyncWriteAtomicInc) { RunAsyncWriteAtomicIncTest(this, fabric_mode::PULL, false); }
 
 TEST_F(Fabric2DPushFixture, DISABLED_TestAsyncWriteAtomicInc) {
     RunAsyncWriteAtomicIncTest(this, fabric_mode::PUSH, false);
 }
 
-TEST_F(Fabric2DPullFixture, TestAsyncRawWriteAtomicInc) { RunAsyncWriteAtomicIncTest(this, fabric_mode::PULL, true); }
-
 TEST_F(Fabric2DPushFixture, DISABLED_TestAsyncRawWriteAtomicInc) {
     RunAsyncWriteAtomicIncTest(this, fabric_mode::PUSH, true);
-}
-
-TEST_F(Fabric2DPullFixture, TestAsyncWriteMulticast) {
-    RunAsyncWriteMulticastTest(this, fabric_mode::PULL, false, false);
-}
-
-TEST_F(Fabric2DPullFixture, TestAsyncRawWriteMulticast) {
-    RunAsyncWriteMulticastTest(this, fabric_mode::PULL, true, false);
-}
-
-TEST_F(Fabric2DPullFixture, TestAsyncWriteMulticastMultidirectional) {
-    RunAsyncWriteMulticastTest(this, fabric_mode::PULL, false, true);
-}
-
-TEST_F(Fabric2DPullFixture, TestAsyncRawWriteMulticastMultidirectional) {
-    RunAsyncWriteMulticastTest(this, fabric_mode::PULL, true, true);
 }
 
 // 2D Dynamic Routing Unicast Tests

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -692,59 +692,59 @@ void RunAsyncWriteMulticastTest(
     }
 }
 
-TEST_F(Fabric2DPushFixture, DISABLED_TestAsyncWrite) { RunAsyncWriteTest(this, fabric_mode::PUSH, false); }
+TEST_F(Fabric2DFixture, DISABLED_TestAsyncWrite) { RunAsyncWriteTest(this, fabric_mode::PUSH, false); }
 
-TEST_F(Fabric2DPushFixture, TestUnicastRaw) {
+TEST_F(Fabric2DFixture, TestUnicastRaw) {
     for (uint32_t i = 0; i < 10; i++) {
         RunTestUnicastRaw(this);
     }
 }
 
-TEST_F(Fabric2DPushFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
+TEST_F(Fabric2DFixture, TestUnicastConnAPI) { RunTestUnicastConnAPI(this, 1); }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_1W1E) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_1W1E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 1, RoutingDirection::E, 1);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_1W2E) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_1W2E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 1, RoutingDirection::E, 2);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_2W1E) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_2W1E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 2, RoutingDirection::E, 1);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_2W2E) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_2W2E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 2, RoutingDirection::E, 2);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_3W3E) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_3W3E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 3, RoutingDirection::E, 3);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_4W3E) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_4W3E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 4, RoutingDirection::E, 3);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_3W4E) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_3W4E) {
     RunTestMCastConnAPI(this, RoutingDirection::W, 3, RoutingDirection::E, 4);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_1N2S) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_1N2S) {
     RunTestMCastConnAPI(this, RoutingDirection::N, 1, RoutingDirection::S, 2);
 }
 
-TEST_F(Fabric2DPushFixture, TestMCastConnAPI_2N1S) {
+TEST_F(Fabric2DFixture, TestMCastConnAPI_2N1S) {
     RunTestMCastConnAPI(this, RoutingDirection::N, 2, RoutingDirection::S, 1);
 }
 
-TEST_F(Fabric2DPushFixture, DISABLED_TestAtomicInc) { RunAtomicIncTest(this, fabric_mode::PUSH); }
+TEST_F(Fabric2DFixture, DISABLED_TestAtomicInc) { RunAtomicIncTest(this, fabric_mode::PUSH); }
 
-TEST_F(Fabric2DPushFixture, DISABLED_TestAsyncWriteAtomicInc) {
+TEST_F(Fabric2DFixture, DISABLED_TestAsyncWriteAtomicInc) {
     RunAsyncWriteAtomicIncTest(this, fabric_mode::PUSH, false);
 }
 
-TEST_F(Fabric2DPushFixture, DISABLED_TestAsyncRawWriteAtomicInc) {
+TEST_F(Fabric2DFixture, DISABLED_TestAsyncRawWriteAtomicInc) {
     RunAsyncWriteAtomicIncTest(this, fabric_mode::PUSH, true);
 }
 

--- a/tt_metal/api/tt-metalium/fabric_edm_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_edm_types.hpp
@@ -8,7 +8,7 @@
 
 namespace tt::tt_fabric {
 
-enum class Topology { Ring = 0, Linear = 1, Mesh = 2 };
+enum class Topology { Ring = 0, Linear = 1, Mesh = 2, Torus = 3 };
 
 struct WorkerXY {
     uint16_t x;

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -10,7 +10,7 @@ enum class FabricConfig : uint32_t {
     FABRIC_1D = 1,          // Instatiates fabric with 1D routing and no deadlock avoidance
     FABRIC_1D_RING = 2,     // Instatiates fabric with 1D routing and with deadlock avoidance using datelines
     FABRIC_2D = 3,          // Instatiates fabric with 2D routing in pull mode
-    FABRIC_2D_PUSH = 4,     // Instatiates fabric with 2D routing in push mode
+    FABRIC_2D_TORUS = 4,     // Instatiates fabric with 2D routing in push mode
     FABRIC_2D_DYNAMIC = 5,  // Instatiates fabric with 2D routing in push mode with dynamic routing
     CUSTOM = 6
 };

--- a/tt_metal/api/tt-metalium/fabric_types.hpp
+++ b/tt_metal/api/tt-metalium/fabric_types.hpp
@@ -9,9 +9,9 @@ enum class FabricConfig : uint32_t {
     DISABLED = 0,
     FABRIC_1D = 1,          // Instatiates fabric with 1D routing and no deadlock avoidance
     FABRIC_1D_RING = 2,     // Instatiates fabric with 1D routing and with deadlock avoidance using datelines
-    FABRIC_2D = 3,          // Instatiates fabric with 2D routing in pull mode
-    FABRIC_2D_TORUS = 4,     // Instatiates fabric with 2D routing in push mode
-    FABRIC_2D_DYNAMIC = 5,  // Instatiates fabric with 2D routing in push mode with dynamic routing
+    FABRIC_2D = 3,          // Instatiates fabric with 2D routing
+    FABRIC_2D_TORUS = 4,    // Instatiates fabric with 2D routing and with deadlock avoidance using datelines
+    FABRIC_2D_DYNAMIC = 5,  // Instatiates fabric with 2D routing with dynamic routing
     CUSTOM = 6
 };
 

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -88,15 +88,11 @@ FabricContext::FabricContext(tt::tt_metal::FabricConfig fabric_config) {
     this->max_payload_size_bytes_ = this->get_max_payload_size_bytes();
     this->channel_buffer_size_bytes_ = this->packet_header_size_bytes_ + this->max_payload_size_bytes_;
 
-    if (is_tt_fabric_config(this->fabric_config_)) {
-        this->router_config_ = std::make_unique<tt::tt_fabric::FabricEriscDatamoverConfig>(
-            this->channel_buffer_size_bytes_, this->topology_);
-        this->dateline_router_config_ = std::make_unique<tt::tt_fabric::FabricEriscDatamoverConfig>(
-            this->channel_buffer_size_bytes_, this->topology_, true);
-        set_routing_mode(this->topology_, this->fabric_config_);
-    } else {
-        this->router_config_ = nullptr;
-    }
+    this->router_config_ =
+        std::make_unique<tt::tt_fabric::FabricEriscDatamoverConfig>(this->channel_buffer_size_bytes_, this->topology_);
+    this->dateline_router_config_ = std::make_unique<tt::tt_fabric::FabricEriscDatamoverConfig>(
+        this->channel_buffer_size_bytes_, this->topology_, true);
+    set_routing_mode(this->topology_, this->fabric_config_);
 }
 
 bool FabricContext::is_wrap_around_mesh(mesh_id_t mesh_id) const {
@@ -152,39 +148,21 @@ chan_id_t FabricContext::get_fabric_master_router_chan(chip_id_t chip_id) const 
 }
 
 std::vector<size_t> FabricContext::get_fabric_router_addresses_to_clear() const {
-    if (is_tt_fabric_config(this->fabric_config_)) {
-        return {this->router_config_->edm_local_sync_address};
-    } else {
-        return {tt::tt_metal::hal::get_erisc_l1_unreserved_base()};
-    }
+    return {this->router_config_->edm_local_sync_address};
 }
 
-std::pair<uint32_t, uint32_t> FabricContext::get_fabric_router_sync_address_and_status(chip_id_t chip_id) const {
-    if (is_tt_fabric_config(this->fabric_config_)) {
-        return std::make_pair(
-            this->router_config_->edm_status_address, tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE);
-    } else {
-        return std::make_pair(
-            tt::tt_metal::hal::get_erisc_l1_unreserved_base(), get_num_fabric_initialized_routers(chip_id));
-    }
+std::pair<uint32_t, uint32_t> FabricContext::get_fabric_router_sync_address_and_status() const {
+    return std::make_pair(this->router_config_->edm_status_address, tt::tt_fabric::EDMStatus::LOCAL_HANDSHAKE_COMPLETE);
 }
 
 std::optional<std::pair<uint32_t, tt::tt_fabric::EDMStatus>> FabricContext::get_fabric_router_ready_address_and_signal()
     const {
-    if (is_tt_fabric_config(this->fabric_config_)) {
-        return std::make_pair(this->router_config_->edm_status_address, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
-    } else {
-        return std::nullopt;
-    }
+    return std::make_pair(this->router_config_->edm_status_address, tt::tt_fabric::EDMStatus::READY_FOR_TRAFFIC);
 }
 
 std::pair<uint32_t, uint32_t> FabricContext::get_fabric_router_termination_address_and_signal() const {
-    if (is_tt_fabric_config(this->fabric_config_)) {
-        return std::make_pair(
-            this->router_config_->termination_signal_address, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
-    } else {
-        return std::make_pair(tt::tt_metal::hal::get_erisc_l1_unreserved_base(), 0);
-    }
+    return std::make_pair(
+        this->router_config_->termination_signal_address, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
 }
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -46,8 +46,8 @@ tt::tt_fabric::Topology FabricContext::get_topology() const {
     switch (this->fabric_config_) {
         case tt::tt_metal::FabricConfig::FABRIC_1D: return tt::tt_fabric::Topology::Linear;
         case tt::tt_metal::FabricConfig::FABRIC_1D_RING: return tt::tt_fabric::Topology::Ring;
-        case tt::tt_metal::FabricConfig::FABRIC_2D_PUSH: return tt::tt_fabric::Topology::Mesh;
         case tt::tt_metal::FabricConfig::FABRIC_2D: return tt::tt_fabric::Topology::Mesh;
+        case tt::tt_metal::FabricConfig::FABRIC_2D_TORUS: return tt::tt_fabric::Topology::Torus;
         case tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC: return tt::tt_fabric::Topology::Mesh;
         case tt::tt_metal::FabricConfig::DISABLED:
         case tt::tt_metal::FabricConfig::CUSTOM:

--- a/tt_metal/fabric/fabric_context.hpp
+++ b/tt_metal/fabric/fabric_context.hpp
@@ -40,7 +40,7 @@ public:
 
     std::vector<size_t> get_fabric_router_addresses_to_clear() const;
 
-    std::pair<uint32_t, uint32_t> get_fabric_router_sync_address_and_status(chip_id_t chip_id) const;
+    std::pair<uint32_t, uint32_t> get_fabric_router_sync_address_and_status() const;
 
     std::optional<std::pair<uint32_t, tt::tt_fabric::EDMStatus>> get_fabric_router_ready_address_and_signal() const;
 

--- a/tt_metal/fabric/fabric_host_utils.cpp
+++ b/tt_metal/fabric/fabric_host_utils.cpp
@@ -24,13 +24,14 @@ namespace tt::tt_fabric {
 bool is_tt_fabric_config(tt::tt_metal::FabricConfig fabric_config) {
     return fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D ||
            fabric_config == tt::tt_metal::FabricConfig::FABRIC_1D_RING ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_PUSH ||
+           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D ||
+           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_TORUS ||
            fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
 }
 
 bool is_2d_fabric_config(tt::tt_metal::FabricConfig fabric_config) {
     return fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D ||
-           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_PUSH ||
+           fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_TORUS ||
            fabric_config == tt::tt_metal::FabricConfig::FABRIC_2D_DYNAMIC;
 }
 

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -315,7 +315,7 @@ void DevicePool::initialize_active_devices() const {
 
     // Activate fabric (must be before FD)
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
-    if (tt_fabric::is_tt_fabric_config(fabric_config) || tt_fabric::is_2d_fabric_config(fabric_config)) {
+    if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         log_info(tt::LogMetal, "Initializing Fabric");
         if (tt_fabric::is_2d_fabric_config(fabric_config)) {
             // TODO: need to write routing tables for unified 2d fabric.
@@ -472,7 +472,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     // Only can launch Fabric if all devices are active
-    if (tt_fabric::is_tt_fabric_config(fabric_config) || tt_fabric::is_2d_fabric_config(fabric_config)) {
+    if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         for (int i = 0; i < tt::tt_metal::MetalContext::instance().get_cluster().number_of_devices(); i++) {
             if (not _inst->is_device_active(i)) {
                 // Fabric currently requires all devices to be active
@@ -489,7 +489,7 @@ void DevicePool::add_devices_to_pool(const std::vector<chip_id_t>& device_ids) {
 
 void DevicePool::wait_for_fabric_router_sync() const {
     FabricConfig fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
-    if (!tt::tt_fabric::is_tt_fabric_config(fabric_config) && !tt::tt_fabric::is_2d_fabric_config(fabric_config)) {
+    if (!tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
         return;
     }
 
@@ -728,7 +728,7 @@ bool DevicePool::close_devices(const std::vector<IDevice*>& devices, bool skip_s
 
     // Terminate fabric routers
     const auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
-    if (tt::tt_fabric::is_tt_fabric_config(fabric_config) || tt::tt_fabric::is_2d_fabric_config(fabric_config)) {
+    if (tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
         const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
         const auto& fabric_context = control_plane->get_fabric_context();
         auto [termination_signal_address, signal] = fabric_context.get_fabric_router_termination_address_and_signal();

--- a/tt_metal/impl/device/device_pool.cpp
+++ b/tt_metal/impl/device/device_pool.cpp
@@ -506,8 +506,7 @@ void DevicePool::wait_for_fabric_router_sync() const {
             tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(dev->id()).get_eth_core_for_channel(
                 master_router_chan, CoordSystem::LOGICAL);
 
-        const auto [router_sync_address, expected_status] =
-            fabric_context.get_fabric_router_sync_address_and_status(dev->id());
+        const auto [router_sync_address, expected_status] = fabric_context.get_fabric_router_sync_address_and_status();
         std::vector<std::uint32_t> master_router_status{0};
         while (master_router_status[0] != expected_status) {
             tt_metal::detail::ReadFromDeviceL1(

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -142,7 +142,7 @@ void FDKernel::configure_kernel_variant(
     if (rt_options.watcher_dispatch_disabled()) {
         defines["FORCE_WATCHER_OFF"] = "1";
     }
-    if (tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config() != FabricConfig::FABRIC_2D_PUSH) {
+    if (tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config() != FabricConfig::FABRIC_2D) {
         defines["FVC_MODE_PULL"] = "1";
     }
     if (!DPrintServerReadsDispatchCores(device_->id())) {

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -974,79 +974,6 @@ void configure_dispatch_cores(IDevice* device) {
     }
 }
 
-std::unique_ptr<Program> create_and_compile_2d_fabric_program(IDevice* device, FabricConfig fabric_config) {
-    std::unique_ptr<Program> fabric_program_ptr;
-    std::uint32_t router_mask = 0;
-    const auto* control_plane = tt::tt_metal::MetalContext::instance().get_cluster().get_control_plane();
-    auto [mesh_id, chip_id] = control_plane->get_mesh_chip_id_from_physical_chip_id(device->id());
-    auto& fabric_context = control_plane->get_fabric_context();
-
-    auto router_chans_and_direction = control_plane->get_active_fabric_eth_channels(mesh_id, chip_id);
-    fabric_context.set_num_fabric_initialized_routers(device->id(), router_chans_and_direction.size());
-    if (router_chans_and_direction.empty()) {
-        return nullptr;
-    }
-
-    fabric_program_ptr = std::make_unique<Program>();
-
-    for (const auto& router_chan : router_chans_and_direction) {
-        router_mask += 0x1 << (uint32_t)router_chan.first;
-    }
-
-    auto master_router_chan = (uint32_t)(router_chans_and_direction.begin()->first);
-    fabric_context.set_fabric_master_router_chan(device->id(), master_router_chan);
-
-    // setup runtime args
-    std::vector<uint32_t> router_runtime_args = {
-        router_chans_and_direction.size(),  // 0: number of active fabric routers
-        router_mask,                        // 1: active fabric router mask
-        master_router_chan,                 // 2: master router channel
-    };
-
-    std::vector<uint32_t> router_compile_args = {
-        (tt::tt_fabric::DEFAULT_ROUTER_RX_QUEUE_SIZE_BYTES >> 4),  // 0: rx_queue_size_words
-        0,                                                         // 1: test_results_addr
-        0,                                                         // 2: test_results_size
-        0,  // 3: timeout_mcycles * 1000 * 1000 * 4, // 3: timeout_cycles
-        0,  // 4: is_master_router
-        0,  // 5: router direction
-    };
-
-    std::map<string, string> router_defines = {};
-    if (fabric_config == FabricConfig::FABRIC_2D) {
-        router_defines["FVC_MODE_PULL"] = "";
-        tt::tt_fabric::set_routing_mode(ROUTING_MODE_MESH | ROUTING_MODE_2D | ROUTING_MODE_PULL);
-    } else {
-        // TODO: delete or selectively set
-        //       https://github.com/tenstorrent/tt-metal/issues/20000
-        if (isFabricUnitTest()) {
-            tt::tt_fabric::set_routing_mode(ROUTING_MODE_MESH | ROUTING_MODE_2D | ROUTING_MODE_PUSH);
-            router_defines["DISABLE_LOW_LATENCY_ROUTING"] = "";
-        } else {
-            tt::tt_fabric::set_routing_mode(
-                ROUTING_MODE_MESH | ROUTING_MODE_2D | ROUTING_MODE_PUSH | ROUTING_MODE_LOW_LATENCY);
-        }
-    }
-
-    auto soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-    for (const auto& [router_chan, direction] : router_chans_and_direction) {
-        router_compile_args[4] = (master_router_chan == router_chan);
-        router_compile_args[5] = direction;
-        auto router_logical_core = soc_desc.get_eth_core_for_channel(router_chan, CoordSystem::LOGICAL);
-        auto kernel = tt_metal::CreateKernel(
-            *fabric_program_ptr,
-            "tt_metal/fabric/impl/kernels/tt_fabric_router.cpp",
-            router_logical_core,
-            tt_metal::EthernetConfig{
-                .noc = tt_metal::NOC::NOC_0, .compile_args = router_compile_args, .defines = router_defines});
-
-        tt_metal::SetRuntimeArgs(*fabric_program_ptr, kernel, router_logical_core, router_runtime_args);
-    }
-
-    detail::CompileProgram(device, *fabric_program_ptr, /*force_slow_dispatch=*/device->using_fast_dispatch());
-    return fabric_program_ptr;
-}
-
 bool check_dateline(
     const tt_fabric::ControlPlane& control_plane,
     tt_fabric::Topology topology,
@@ -1324,8 +1251,6 @@ std::unique_ptr<Program> create_and_compile_fabric_program(IDevice* device) {
     auto fabric_config = tt::tt_metal::MetalContext::instance().get_cluster().get_fabric_config();
     if (tt_fabric::is_tt_fabric_config(fabric_config)) {
         return create_and_compile_tt_fabric_program(device);
-    } else if (tt_fabric::is_2d_fabric_config(fabric_config)) {
-        return create_and_compile_2d_fabric_program(device, fabric_config);
     }
     return nullptr;
 }

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1117,7 +1117,7 @@ void Cluster::initialize_fabric_config(tt_metal::FabricConfig fabric_config) {
     this->fabric_config_ = fabric_config;
     if (fabric_config != tt_metal::FabricConfig::DISABLED) {
         this->reserve_ethernet_cores_for_fabric_routers();
-        if (tt::tt_fabric::is_tt_fabric_config(fabric_config) || tt::tt_fabric::is_2d_fabric_config(fabric_config)) {
+        if (tt::tt_fabric::is_tt_fabric_config(fabric_config)) {
             this->get_control_plane()->initialize_fabric_context(fabric_config);
         }
     } else {


### PR DESCRIPTION
Now that we have a single tt-fabric router kernel that is launched with 1D or 2D routing topology, pull mode tt-fabric router is being deprecated.
This PR cleans up the runtime fabric launch code paths to remove support for launching legacy 2D fabric routers.
Remove pull mode tests as well when fabric is launched on device init.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes