### PR TITLE
[skip ci] No smoke in APC

### DIFF
--- a/.github/workflows/all-post-commit-workflows.yaml
+++ b/.github/workflows/all-post-commit-workflows.yaml
@@ -54,21 +54,6 @@ jobs:
       tracy: true
       version: 22.04
 
-  smoke-tests:
-    needs: build-artifact
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [
-          "N150",
-          "N300",
-        ]
-    uses: ./.github/workflows/smoke.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
-      runner: ${{ matrix.platform }}
-
   # Slow Dispatch Unit Tests
   sd-unit-tests:
     needs: build-artifact


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We run Smoke tests in PR Gate (with ASan) and again in Merge Gate (with TSan).  A release run in APC doesn't add value.

### What's changed
rm -rf