### PR TITLE
Add fallback openmpi when specific ulfm not found.

### DIFF
--- a/tt_metal/distributed/CMakeLists.txt
+++ b/tt_metal/distributed/CMakeLists.txt
@@ -24,7 +24,6 @@ set(ULFM_PREFIX /opt/openmpi-v5.0.7-ulfm)
 set(ULFM_LIB ${ULFM_PREFIX}/lib/libmpi.so.40)
 
 add_library(OpenMPI::MPI SHARED IMPORTED GLOBAL)
-
 set_target_properties(
     OpenMPI::MPI
     PROPERTIES
@@ -32,14 +31,31 @@ set_target_properties(
             TRUE
 )
 
-set_target_properties(
-    OpenMPI::MPI
-    PROPERTIES
-        IMPORTED_LOCATION
-            ${ULFM_LIB}
-        INTERFACE_INCLUDE_DIRECTORIES
-            ${ULFM_PREFIX}/include
-)
+if(EXISTS "${ULFM_LIB}")
+    message(STATUS "Using openmpi-ulfm ${ULFM_PREFIX}")
+
+    set_target_properties(
+        OpenMPI::MPI
+        PROPERTIES
+            IMPORTED_LOCATION
+                ${ULFM_LIB}
+            INTERFACE_INCLUDE_DIRECTORIES
+                ${ULFM_PREFIX}/include
+    )
+else()
+    message(STATUS "${ULFM_LIB} not found. Using fallback find_package(MPI).")
+
+    find_package(MPI REQUIRED)
+
+    set_target_properties(
+        OpenMPI::MPI
+        PROPERTIES
+            IMPORTED_LOCATION
+                ${MPI_CXX_LIBRARIES}
+            INTERFACE_INCLUDE_DIRECTORIES
+                ${MPI_CXX_INCLUDE_DIRS}
+    )
+endif()
 
 target_link_libraries(
     distributed


### PR DESCRIPTION
### Ticket
Closes https://github.com/tenstorrent/tt-metal/issues/22430

### Problem description
Recent commit in main put in a hard coded target for an openmpi library instance. Not having that particular install meant you couldn't build.

### What's changed
* cmake now checks if the specific openmpi-ulfm target exists.
* If that target doesn't exist, fallback to find_package
* The new library alias used for openmpi-ulfm is populated with the results of find_package, so the fallback should be transparent.

### Checklist
- [ ] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes