### PR TITLE
#22375:: Ensure that MeshDevice::num_virtual_eth_cores() matches value seen by cq_dispatch* for submeshes on TG

### DIFF
--- a/tt_metal/api/tt-metalium/device_pool.hpp
+++ b/tt_metal/api/tt-metalium/device_pool.hpp
@@ -62,6 +62,8 @@ public:
     bool is_dispatch_firmware_active() const;
     void init_profiler() const;
     void initialize_fabric_and_dispatch_fw() const;
+    // API needed due to Issue #19729
+    std::size_t get_max_num_eth_cores_across_all_devices() const;
 
 private:
     ~DevicePool();

--- a/tt_metal/api/tt-metalium/mesh_device.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device.hpp
@@ -114,7 +114,8 @@ private:
     uint32_t max_num_eth_cores_ = 0;
     std::shared_ptr<ThreadPool> dispatch_thread_pool_;
     std::shared_ptr<ThreadPool> reader_thread_pool_;
-
+    // Num Virtual Eth Cores == Max Number of Eth Cores across all opened devices (Issue #19729)
+    std::size_t num_virtual_eth_cores_ = 0;
     std::unique_ptr<program_cache::detail::ProgramCache> program_cache_;
     // This is a reference device used to query properties that are the same for all devices in the mesh.
     IDevice* reference_device() const;

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -639,16 +639,8 @@ std::vector<CoreCoord> MeshDevice::get_ethernet_sockets(chip_id_t /*connected_ch
 
 uint32_t MeshDevice::num_virtual_eth_cores(SubDeviceId sub_device_id) {
     // Issue #19729: Return the maximum number of active ethernet cores across physical devices in the Mesh.
-    TT_FATAL(
-        *(sub_device_manager_tracker_->get_active_sub_device_manager()->id()) ==
-            *(this->get_default_sub_device_manager_id()),
-        "Virtualizing Ethernet Cores across a MeshDevice is not supported when a custom SubDeviceManager is loaded.");
-    if (not max_num_eth_cores_) {
-        for (auto device : this->get_devices()) {
-            max_num_eth_cores_ = std::max(device->num_virtual_eth_cores(SubDeviceId{0}), max_num_eth_cores_);
-        }
-    }
-    return max_num_eth_cores_;
+    TT_FATAL(*sub_device_id == 0, "Cannot query virtual ethernet cores per sub-device when using MeshDevice");
+    return num_virtual_eth_cores_;
 }
 
 // Core and worker management methods (These are OK)
@@ -789,6 +781,9 @@ bool MeshDevice::initialize(
     const auto& allocator = reference_device()->allocator();
     sub_device_manager_tracker_ = std::make_unique<SubDeviceManagerTracker>(
         this, std::make_unique<L1BankingAllocator>(allocator->get_config()), sub_devices);
+    // Issue #19729: Store the maximum number of active ethernet cores across opened physical devices in the Mesh
+    // as the number of virtual ethernet cores seen by the MeshDevice
+    num_virtual_eth_cores_ = DevicePool::instance().get_max_num_eth_cores_across_all_devices();
     mesh_command_queues_.reserve(this->num_hw_cqs());
     if (this->using_fast_dispatch()) {
         for (std::size_t cq_id = 0; cq_id < this->num_hw_cqs(); cq_id++) {

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -1646,12 +1646,6 @@ HalMemType Device::get_mem_type_of_core(CoreCoord virtual_core) const {
 
 std::shared_ptr<distributed::MeshDevice> Device::get_mesh_device() { return mesh_device.lock(); }
 
-void Device::set_ethernet_core_count_on_dispatcher(uint32_t num_ethernet_cores) {
-    ethernet_core_count_on_dispatcher_ = num_ethernet_cores;
-}
-
-uint32_t Device::get_ethernet_core_count_on_dispatcher() const { return ethernet_core_count_on_dispatcher_; }
-
 }  // namespace tt_metal
 
 }  // namespace tt

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -153,8 +153,6 @@ public:
     void init_command_queue_device() override;
 
     void init_fabric() override;
-    void set_ethernet_core_count_on_dispatcher(uint32_t num_ethernet_cores);
-    uint32_t get_ethernet_core_count_on_dispatcher() const;
     // Puts device into reset
     bool close() override;
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -30,6 +30,8 @@
 #include "dispatch/system_memory_manager.hpp"
 #include "utils.hpp"
 
+#include "tt_metal/api/tt-metalium/device_pool.hpp"
+
 using namespace tt::tt_metal;
 
 void DispatchKernel::GenerateStaticConfigs() {
@@ -354,7 +356,7 @@ void DispatchKernel::CreateKernel() {
     // num_physical_ethernet_cores is the number of actual available ethernet cores on the current device.
     // virtualize_num_eth_cores is set if the number of virtual cores is greater than the number of actual
     // ethernet cores in the chip.
-    uint32_t num_virtual_active_eth_cores = dynamic_cast<Device*>(device_)->get_ethernet_core_count_on_dispatcher();
+    uint32_t num_virtual_active_eth_cores = tt::DevicePool::instance().get_max_num_eth_cores_across_all_devices();
     uint32_t num_physical_active_eth_cores =
         MetalContext::instance()
             .get_cluster()

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -26,6 +26,8 @@
 #include <umd/device/types/xy_pair.h>
 #include "utils.hpp"
 
+#include "tt_metal/api/tt-metalium/device_pool.hpp"
+
 using namespace tt::tt_metal;
 
 void DispatchSKernel::GenerateStaticConfigs() {
@@ -86,13 +88,13 @@ void DispatchSKernel::GenerateDependentConfigs() {
 
 void DispatchSKernel::CreateKernel() {
     // Issue #19729: Workaround to allow TT-Mesh Workload dispatch to target active ethernet cores.
-    // Num num_virtual_active_eth_cores is set if the user application requested virtualizing the
+    // num_virtual_active_eth_cores is set if the user application requested virtualizing the
     // number of ethernet cores across devices (to essentially fake uniformity). This value is the
-    // max number of ethernet cores acorss all chip in the cluster.
+    // max number of ethernet cores across all chips in the opened cluster.
     // num_physical_ethernet_cores is the number of actual available ethernet cores on the current device.
     // virtualize_num_eth_cores is set if the number of virtual cores is greater than the number of actual
     // ethernet cores in the chip.
-    uint32_t num_virtual_active_eth_cores = dynamic_cast<Device*>(device_)->get_ethernet_core_count_on_dispatcher();
+    uint32_t num_virtual_active_eth_cores = tt::DevicePool::instance().get_max_num_eth_cores_across_all_devices();
     uint32_t num_physical_active_eth_cores =
         MetalContext::instance()
             .get_cluster()


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-metal/issues/22375)

### Problem description
- Use of legacy CCLs requires us to "virtualize" the number of ethernet cores seen across physical devices encapsulated by the `MeshDevice`.
- This is done by providing the dispatch kernels the number of virtual ethernet cores (uniform: max across all physical devices) and the number of physical ethernet cores (per chip).
- Given a value for `num_unicast_txns` in the `go_signal_mcast` command (corresponding to the max number of ethernet cores across the mesh), the dispatcher can then issue unicasts to the actual physical cores and fake acks up to the number of virtual eth cores, to ensure lock step state across all physical devices.
- When submeshes are spawned on TG, it is currently possible for the number of virtual eth cores seen by the `MeshDevice`  to mismatch with those seen by the `cq_dispatch*`kernels. This is because on TG, the max number of eth cores seen by the kernel are computed based on the open devices, which can be a superset of the `MeshDevice` (since for TG we always open all non-MMIO devices tied to a single MMIO device, not the minimal number of devices).
- This mismatch was causing LLAMA 8B on TG submeshes to hang.

### What's changed
- Modify `MeshDevice::num_virtual_eth_cores` to return the number of ethernet cores queried from the `DevicePool`. This matches what the dispatch kernels see in all cases.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15178144705) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [x] [Model regression](https://github.com/tenstorrent/tt-metal/actions/runs/15183397984) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes