### PR TITLE
Increase generic pool kernel capacity to 32 sticks per tile

### DIFF
--- a/models/demos/yolov8x/tests/test_perf_yolov8x.py
+++ b/models/demos/yolov8x/tests/test_perf_yolov8x.py
@@ -100,7 +100,7 @@ def test_yolov8x(device, input_tensor, use_weights_from_ultralytics):
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 45],
+        [1, 48],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/demos/yolov9c/tests/perf/test_perf.py
+++ b/models/demos/yolov9c/tests/perf/test_perf.py
@@ -91,7 +91,7 @@ def test_perf(device, use_weights_from_ultralytics):
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 76.27],
+        [1, 79.6],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/yolov10/tests/perf/test_perf_yolov10.py
+++ b/models/experimental/yolov10/tests/perf/test_perf_yolov10.py
@@ -97,7 +97,7 @@ def test_perf(device, use_weights_from_ultralytics):
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 37.28],
+        [1, 38.5],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/models/experimental/yolov8s_world/tests/test_perf_yolov8s_world.py
+++ b/models/experimental/yolov8s_world/tests/test_perf_yolov8s_world.py
@@ -132,7 +132,7 @@ def test_perf(device, use_pretrained_weight, use_program_cache):
 @pytest.mark.parametrize(
     "batch_size, expected_perf",
     [
-        [1, 69.27],
+        [1, 71.2],
     ],
 )
 @pytest.mark.models_device_performance_bare_metal

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
@@ -84,6 +84,11 @@ void MAIN {
     constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
     constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::SUM) ? true : false;
 
+    // In case we have <=16 sticks we will use only upper two faces of the tile.
+    // In this case we can configure reduce to only process as many rows as needed.
+    // In case #sticks > 16 we need bottom two faces as well, and we need to configure reduce to
+    // process all rows per face. In the case we rely on reader kernel to put "clear value"
+    // in datums which are not used.
     constexpr uint32_t face_r_dim = window_size_hw > 16 ? 16 : window_size_hw;
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
         in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, face_r_dim);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/pool_2d_multi_core.cpp
@@ -16,35 +16,33 @@
 #include "debug/dprint_tensix.h"
 #endif
 
-template <uint32_t num_output_tiles, bool is_partial_tile, uint32_t split_reader, uint32_t unpA_face_r_dim>
+template <
+    uint32_t num_output_tiles,
+    bool is_partial_tile,
+    uint32_t split_reader,
+    uint32_t unpA_face_r_dim,
+    uint32_t num_faces_in_tile>
 inline void reduce_h_fused(
     const uint32_t in_cb_id_0,
     const uint32_t in_cb_id_1,
     const uint32_t in_scalar_cb_id,
     const uint32_t in_stick_index,
     const uint32_t out_cb_id) {
-    constexpr uint32_t num_faces_in_tile = is_partial_tile ? 1 : 2;
     constexpr uint32_t num_out_rows = 1;
-
+    constexpr uint32_t num_output_faces = (is_partial_tile ? 1 : 2);
     cb_reserve_back(out_cb_id, num_output_tiles);
     const uint32_t curr_in_cb_id = (split_reader && (in_stick_index & 0x1)) ? in_cb_id_1 : in_cb_id_0;
     cb_wait_front(curr_in_cb_id, 1);
     tile_regs_acquire();
-    unpack_tilizeA_B_block(
-        curr_in_cb_id,
-        in_scalar_cb_id,
-        num_output_tiles,
-        0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/,
-        num_faces_in_tile /* unpack 1 or 2 faces ) */,
-        unpA_face_r_dim);
+    unpack_tilizeA_B_block(curr_in_cb_id, in_scalar_cb_id, num_output_tiles, 0, num_faces_in_tile, unpA_face_r_dim);
     for (uint32_t c_i = 0; c_i < num_output_tiles; ++c_i) {
-        reduce_tile_math(c_i, num_faces_in_tile /* reduce 1 or 2 faces */);
+        reduce_tile_math(c_i, num_faces_in_tile);
     }
     cb_pop_front(curr_in_cb_id, 1);
     tile_regs_wait();
     tile_regs_commit();
     pack_untilize_dst<num_output_tiles>(
-        out_cb_id, 1 /*out_subblock_h*/, 0, num_out_rows, num_faces_in_tile); /* pack 1 row (1x16 or 1x32) */
+        out_cb_id, 1 /*out_subblock_h*/, 0, num_out_rows, num_output_faces); /* pack 1 row (1x16 or 1x32) */
     tile_regs_release();
     cb_push_back(out_cb_id, num_output_tiles);
 }
@@ -72,7 +70,7 @@ void MAIN {
 
     constexpr bool is_partial_tile = in_c < 32;
     static_assert((!is_partial_tile || (in_c == 16)), "Partial tile must have c_dim 16");
-    constexpr uint32_t num_faces_in_tile = is_partial_tile ? 1 : 2;
+    constexpr uint32_t num_faces_in_tile = window_size_hw > 16 ? 4 : (is_partial_tile ? 1 : 2);
     constexpr uint32_t num_out_rows = 1;
 
     constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
@@ -86,19 +84,32 @@ void MAIN {
     constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
     constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::SUM) ? true : false;
 
+    constexpr uint32_t face_r_dim = window_size_hw > 16 ? 16 : window_size_hw;
     tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
-        in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, window_size_hw);
+        in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, out_cb_id, num_faces_in_tile, face_r_dim);
     pack_untilize_dst_init_short<max_tiles_per_iter>(out_cb_id, num_out_rows, num_faces_in_tile);
 
+    // tilize reconfiguration is needed if we have more than one block and the number of tiles
+    // is not a multiple of MAX_TILES_PER_REDUCTION
+    constexpr bool tilize_reconfig_needed = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0;
     cb_wait_front(in_scalar_cb_id, 1);
     for (uint32_t i = 0; i < nsticks_per_core; ++i) {
         // perform the reduction over the first N - 1 whole chunks
+        if constexpr (tilize_reconfig_needed) {
+            UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                in_cb_id_0, in_scalar_cb_id, max_tiles_per_iter, num_faces_in_tile, face_r_dim, 1)));
+        }
         for (uint32_t b_i = 0; b_i < in_nblocks_c - 1; ++b_i) {
-            reduce_h_fused<max_tiles_per_iter, is_partial_tile, split_reader, window_size_hw>(
+            reduce_h_fused<max_tiles_per_iter, is_partial_tile, split_reader, face_r_dim, num_faces_in_tile>(
                 in_cb_id_0, in_cb_id_1, in_scalar_cb_id, i, out_cb_id);
         }
+
+        if constexpr (tilize_reconfig_needed) {
+            UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                in_cb_id_0, in_scalar_cb_id, partial_iter_output_tiles, num_faces_in_tile, face_r_dim, 1)));
+        }
         // perform the reduction over the either whole or partial chunk N
-        reduce_h_fused<partial_iter_output_tiles, is_partial_tile, split_reader, window_size_hw>(
+        reduce_h_fused<partial_iter_output_tiles, is_partial_tile, split_reader, face_r_dim, num_faces_in_tile>(
             in_cb_id_0, in_cb_id_1, in_scalar_cb_id, i, out_cb_id);
     }
     cb_pop_front(in_scalar_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_v2.cpp
@@ -25,6 +25,21 @@ ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
     return true;
 }
 
+template <uint32_t cb_id, uint32_t clear_value_cb_id>
+FORCE_INLINE void clear_out_tiles() {
+    constexpr uint32_t tile_size = get_tile_size(cb_id);
+    const uint32_t num_pages = get_local_cb_interface(cb_id).fifo_num_pages;
+    const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_page_size / tile_size;
+    const uint64_t clear_value_addr = get_noc_addr(get_read_ptr(clear_value_cb_id));
+    uint64_t write_addr = get_noc_addr(get_write_ptr(cb_id));
+
+    for (uint32_t i = 0; i < num_tiles * num_pages; ++i) {
+        noc_async_read(clear_value_addr, write_addr, tile_size);
+        write_addr += tile_size;
+    }
+    noc_async_write_barrier();
+}
+
 /**
  * Pool 2D (Max pool 2D and Avg pool 2D)
  */
@@ -49,20 +64,28 @@ void kernel_main() {
     // compile time args
     // BF16 value packed in UINT32. For maxpool, value is 1, for avg pool value is 1/kernel_size.
     constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
-
+    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(11);
     constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(15);
 
+    constexpr uint32_t TILE_HEIGHT = 32;
     constexpr uint32_t TILE_WIDTH = 32;
 
     constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(17) : get_compile_time_arg_val(16);
     constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(18);
     constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
     constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(23);
 
     if (reader_id == 0) {
         cb_reserve_back(in_scalar_cb_id, 1);
         fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, bf16_scalar >> 16);
         cb_push_back(in_scalar_cb_id, 1);
+    }
+
+    constexpr uint32_t window_hw = window_h * window_w;
+    if constexpr (window_hw > 16) {
+        fill_with_val(get_read_ptr(clear_value_cb_id), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+        clear_out_tiles<in_cb_id, clear_value_cb_id>();
     }
 
     const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
@@ -85,7 +108,7 @@ void kernel_main() {
             noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, in_nbytes_c * window_w);
             out_l1_write_addr += in_nbytes_c * window_w;
         }
-        if (split_reader) {
+        if constexpr (split_reader) {
             counter++;  // interleave the indices
         }
         noc_async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_wide.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d_multi_core_sharded_with_halo_wide.cpp
@@ -25,6 +25,32 @@ ALWI bool fill_with_val(uint32_t begin_addr, uint32_t n, uint16_t val) {
     return true;
 }
 
+template <uint32_t cb_id, uint32_t clear_value_cb_id>
+FORCE_INLINE void clear_out_tiles() {
+    constexpr uint32_t tile_size = get_tile_size(cb_id);
+    const uint32_t num_pages = get_local_cb_interface(cb_id).fifo_num_pages;
+    const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_page_size / tile_size;
+    const uint64_t clear_value_addr = get_noc_addr(get_read_ptr(clear_value_cb_id));
+    uint64_t write_addr = get_noc_addr(get_write_ptr(cb_id));
+
+    for (uint32_t i = 0; i < num_tiles * num_pages; ++i) {
+        noc_async_read(clear_value_addr, write_addr, tile_size);
+        write_addr += tile_size;
+    }
+    noc_async_write_barrier();
+}
+
+template <uint32_t clear_value_cb_id, uint32_t num_tiles>
+FORCE_INLINE void clear_out_tiles(uint64_t write_addr, uint64_t clear_value_addr) {
+    constexpr uint32_t tile_size = get_tile_size(clear_value_cb_id);
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        noc_async_read(clear_value_addr, write_addr, tile_size);
+        write_addr += tile_size;
+    }
+    noc_async_write_barrier();
+}
+
 /**
  * Pool 2D (Max pool 2D and Avg pool 2D)
  */
@@ -42,6 +68,7 @@ void kernel_main() {
     constexpr int32_t in_w = get_compile_time_arg_val(5);
 
     constexpr uint32_t in_c = get_compile_time_arg_val(6);
+    constexpr uint32_t in_nbytes_leftover = (in_c % (32 * 8)) * 2;
 
     constexpr uint32_t split_reader = get_compile_time_arg_val(7);
     constexpr uint32_t reader_id = get_compile_time_arg_val(8);
@@ -49,24 +76,38 @@ void kernel_main() {
     // compile time args
     // BF16 value packed in UINT32. For maxpool, value is 1, for avgpool value is 1/kernel_size.
     constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
+    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(11);
 
     constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(12);
 
     constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(15);
 
+    constexpr uint32_t TILE_HEIGHT = 32;
     constexpr uint32_t TILE_WIDTH = 32;
-    constexpr uint32_t MAX_ELE_PER_REDUCTION = 512;  // TILE_WIDTH * 8 * numbytes
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+    constexpr uint32_t BYTES_PER_DATUM = 2;
+    constexpr uint32_t MAX_BYTES_PER_REDUCTION = TILE_WIDTH * MAX_TILES_PER_REDUCTION * BYTES_PER_DATUM;
 
     constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(17) : get_compile_time_arg_val(16);
     constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(18);
     constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(19);
     constexpr uint32_t in_scalar_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(23);
 
     if (reader_id == 0) {
         cb_reserve_back(in_scalar_cb_id, 1);
         fill_with_val(get_write_ptr(in_scalar_cb_id), TILE_WIDTH, bf16_scalar >> 16);
         cb_push_back(in_scalar_cb_id, 1);
     }
+
+    constexpr uint32_t window_hw = window_h * window_w;
+    constexpr bool full_dest_width = in_c % (TILE_WIDTH * MAX_TILES_PER_REDUCTION) == 0;
+    constexpr uint32_t leftover_num_tiles = (in_c % (TILE_WIDTH * MAX_TILES_PER_REDUCTION)) / TILE_WIDTH;
+    if constexpr (window_hw > 16) {
+        fill_with_val(get_read_ptr(clear_value_cb_id), TILE_HEIGHT * TILE_WIDTH, bf16_init_value);
+        clear_out_tiles<in_cb_id, clear_value_cb_id>();
+    }
+    const uint64_t clear_value_addr = get_noc_addr(get_read_ptr(clear_value_cb_id));
 
     const uint32_t in_l1_read_base_addr = get_read_ptr(in_shard_cb_id);
     uint32_t reader_indices_l1_addr = get_read_ptr(in_reader_indices_cb_id);
@@ -77,27 +118,34 @@ void kernel_main() {
 
     constexpr uint32_t npages_to_reserve = 1;
     uint32_t counter = reader_id;
-    constexpr uint32_t read_bytes = MAX_ELE_PER_REDUCTION;
     while (counter < reader_nindices) {
         const uint16_t top_left_local_index = reader_indices_ptr[counter++];
         for (uint32_t c_i = 0; c_i < in_nblocks_c; ++c_i) {
             cb_reserve_back(in_cb_id, npages_to_reserve);
             uint32_t out_l1_write_addr = get_write_ptr(in_cb_id);
+
+            uint32_t read_bytes = MAX_BYTES_PER_REDUCTION;
+            if constexpr (!full_dest_width) {
+                if (c_i == in_nblocks_c - 1) {
+                    read_bytes = in_nbytes_leftover;
+                    clear_out_tiles<clear_value_cb_id, leftover_num_tiles>(out_l1_write_addr, clear_value_addr);
+                }
+            }
+
             for (uint32_t h = 0; h < window_h; ++h) {
                 for (uint32_t w = 0; w < window_w; ++w) {
                     const uint32_t stick_offset = top_left_local_index + w + h * in_w_padded;
                     const uint32_t read_offset =
-                        in_l1_read_base_addr +
-                        (stick_offset * in_nbytes_c + c_i * MAX_ELE_PER_REDUCTION);  // 2 bytes, max 8 tiles
+                        in_l1_read_base_addr + (stick_offset * in_nbytes_c + c_i * MAX_BYTES_PER_REDUCTION);
                     noc_async_read_one_packet(get_noc_addr(read_offset), out_l1_write_addr, read_bytes);
-                    out_l1_write_addr += MAX_ELE_PER_REDUCTION;
+                    out_l1_write_addr += read_bytes;
                 }
             }
             noc_async_read_barrier();  // At this line, read is complete.
 
             cb_push_back(in_cb_id, npages_to_reserve);
         }
-        if (split_reader) {
+        if constexpr (split_reader) {
             counter++;  // interleave the indices
         }
     }

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -62,20 +62,18 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
     uint32_t in_ntiles_hw = (uint32_t)std::ceil((float)kernel_size_hw_padded / tt::constants::TILE_HEIGHT);
     uint32_t in_ntiles_c = (uint32_t)std::ceil((float)input_shape[3] / num_shards_c / tt::constants::TILE_WIDTH);
     uint32_t out_ntiles_c = (uint32_t)std::ceil((float)output_shape[3] / num_shards_c / tt::constants::TILE_WIDTH);
+    const bool is_partial_tile = (input_shape[3] / num_shards_c) == 16;
 
-    uint32_t max_rows_for_reduction = 16;
-    // TODO #14588: temporarily disabling 32 row reductions due to issues in large kernels
-    /* uint32_t max_rows_for_reduction = tt::constants::TILE_HEIGHT;
-    // For GRAYSKULL, make reduction for 16 rows at a time.
-    if (device->arch() == tt::ARCH::GRAYSKULL)
-        max_rows_for_reduction /= 2; */
-
+    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
+    const bool is_wide_reduction = in_ntiles_c > MAX_TILES_PER_REDUCTION;
     // Hardware can do reduction of 8 tiles at a time.
     // CB sizes can be restricted to this in case input channels are more than 256 to perform reduction iteratively.
-    constexpr uint32_t MAX_TILES_PER_REDUCTION = 8;
-    const bool is_large_kernel = kernel_size_hw > max_rows_for_reduction;
-    const bool is_wide_reduction = in_ntiles_c > MAX_TILES_PER_REDUCTION;
+    const bool is_large_kernel =
+        is_partial_tile ? kernel_size_hw > tt::constants::TILE_HEIGHT / 2 : kernel_size_hw > tt::constants::TILE_HEIGHT;
 
+    // ToDo: enable 32 sticks per tile for reduction for all cases.
+    const uint32_t max_rows_for_reduction =
+        (!is_partial_tile && !is_large_kernel) ? tt::constants::TILE_HEIGHT : tt::constants::TILE_HEIGHT / 2;
     TT_FATAL(nblocks == 1, "Multiple blocks not yet supported");
 
     if (input_shape[3] < tt::constants::TILE_WIDTH) {
@@ -127,6 +125,15 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         uint32_t in_one_cb_npages = 1;
         tt::tt_metal::create_cb(in_one_cb_id, program, all_cores, in_one_cb_pagesize, in_one_cb_npages, in_df);
         log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_one_cb_id, in_one_cb_pagesize, in_one_cb_npages);
+    }
+
+    uint32_t clear_value_cb_id = 32;
+    if (max_rows_for_reduction == tt::constants::TILE_HEIGHT) {
+        // CB storing just "clear value" (-inf for maxpool, 0 for avgpool)
+        // is needed only if we use more then 16 sticks per tile for reduction.
+        clear_value_cb_id = next_cb_index++;
+        tt::tt_metal::create_cb(clear_value_cb_id, program, all_cores, tile_size(in_df), 1, in_df);
+        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", clear_value_cb_id, tile_size(in_df), 1);
     }
 
     // incoming data is the input cb instead of raw l1/dram addr
@@ -297,7 +304,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_reader_indices_cb_id,
         in_scalar_cb_id,
         max_pool_partials_cb_id,
-        in_one_cb_id};
+        in_one_cb_id,
+        clear_value_cb_id};
 
     std::vector<uint32_t> reader1_ct_args = {
         out_nhw_per_core,
@@ -322,7 +330,8 @@ Pool2D::MultiCore::cached_program_t pool2d_multi_core_sharded_with_halo_v2_impl_
         in_reader_indices_cb_id,
         in_scalar_cb_id,
         max_pool_partials_cb_id,
-        in_one_cb_id};
+        in_one_cb_id,
+        clear_value_cb_id};
 
     std::string reader_kernel_fname;
     if (is_large_kernel) {


### PR DESCRIPTION
Previously, max pool kernels were limited to 16 sticks per tile, forcing the use of the slower "large kernel" implementation when kernel height × width exceeded 16.

This change doubles capacity to 32 sticks per tile, which:
- Avoids using the inefficient large kernel implementation for moderate kernel sizes
- Significantly improves performance for kernels like the 5×5 used in YOLOv8 models
- Measured ~23x speedup for YOLOv8's pooling operations

Fixes #14588

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/14588)

### Checklist
- [x] [Nightly tt-metal L2 tests BH](https://github.com/tenstorrent/tt-metal/actions/runs/15173003074) CI passes
- [x] [Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/runs/15172999214) CI with demo tests passes (if applicable)
- [x] [All post-commit tests](https://github.com/tenstorrent/tt-metal/actions/runs/15163052702) CI passes (if applicable)
- [x] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/runs/15219396487) CI passes (if applicable)
- [x] [(Single-card) Frequent model and ttnn tests](https://github.com/tenstorrent/tt-metal/actions/runs/15148821919) CI passes