### PR TITLE
Make `assert_equal` call assert

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -158,6 +158,8 @@ def run_identity_test(device, h, w, data_type, pcc=0.9999):
 @pytest.mark.parametrize("w", [128])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.uint8, ttnn.uint32, ttnn.int32, ttnn.float32])
 def test_fp32_uint32(device, h, w, dtype):
+    if dtype == ttnn.uint8 or dtype == ttnn.int32:
+        pytest.skip("Test case failing assert_equal() - see #22482")
     run_identity_test(device, h, w, dtype, pcc=0.9998)
 
 

--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/pool/test_downsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_downsample.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Â© 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +12,7 @@ import torch
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 
+@pytest.mark.skip("Test case failing assert_equal() - see #22482")
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 8192}], indirect=True)
 @pytest.mark.parametrize(
     "batch_size, output_channels, input_channels, input_height, input_width, stride_h, stride_w, num_cores, grid_size, height_sharded",

--- a/tests/ttnn/unit_tests/operations/pool/test_downsample.py
+++ b/tests/ttnn/unit_tests/operations/pool/test_downsample.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: Â© 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_index_fill.py
+++ b/tests/ttnn/unit_tests/operations/test_index_fill.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_index_fill.py
+++ b/tests/ttnn/unit_tests/operations/test_index_fill.py
@@ -29,6 +29,7 @@ def run_index_fill_test(shape, dim, value, dtype, device):
     assert assert_equal(ttnn_output, torch_output)
 
 
+@pytest.mark.skip("Test case failing assert_equal() - see #22482")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/tests/ttnn/unit_tests/operations/test_index_fill.py
+++ b/tests/ttnn/unit_tests/operations/test_index_fill.py
@@ -104,6 +104,7 @@ def test_index_fill_int(shape, dim, value, device):
     run_index_fill_test(shape, dim, value, torch.int32, device)
 
 
+@pytest.mark.skip("Test case failing assert_equal() - see #22482")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/tests/ttnn/unit_tests/operations/test_index_fill.py
+++ b/tests/ttnn/unit_tests/operations/test_index_fill.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/test_index_fill.py
+++ b/tests/ttnn/unit_tests/operations/test_index_fill.py
@@ -70,6 +70,7 @@ def test_index_fill_float(shape, dim, value, dtype, device):
     run_index_fill_test(shape, dim, value, dtype, device)
 
 
+@pytest.mark.skip("Test case failing assert_equal() - see #22482")
 @pytest.mark.parametrize(
     "shape",
     [

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2023 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -63,6 +63,7 @@ def assert_equal(expected_pytorch_result, actual_pytorch_result):
         actual_pytorch_result.shape
     ), f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}"
     equal_passed, equal_message = comp_equal(expected_pytorch_result, actual_pytorch_result)
+    assert equal_passed, equal_message
     return equal_passed, equal_message
 
 

--- a/tests/ttnn/utils_for_testing.py
+++ b/tests/ttnn/utils_for_testing.py
@@ -50,6 +50,27 @@ def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorc
 
 
 def assert_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
+    """
+    Assert that two PyTorch tensors are similar within a specified Pearson Correlation Coefficient (PCC) threshold.
+
+    This function compares two tensors using PCC, which measures the linear correlation between them.
+    It's particularly useful for floating-point comparisons where exact equality is not expected due to
+    numerical precision differences.
+
+    Args:
+        expected_pytorch_result (torch.Tensor): The expected reference tensor
+        actual_pytorch_result (torch.Tensor): The actual tensor to compare against the reference
+        pcc (float, optional): The minimum PCC threshold for the comparison to pass. Defaults to 0.9999.
+                              Values closer to 1.0 indicate stronger correlation.
+
+    Returns:
+        tuple: A tuple containing:
+            - pcc_passed (bool): True if the PCC check passed, False otherwise
+            - pcc_message (str): A message describing the PCC comparison result
+
+    Raises:
+        AssertionError: If the tensor shapes don't match or if the PCC is below the specified threshold
+    """
     assert list(expected_pytorch_result.shape) == list(
         actual_pytorch_result.shape
     ), f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}"
@@ -59,6 +80,24 @@ def assert_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
 
 
 def assert_equal(expected_pytorch_result, actual_pytorch_result):
+    """
+    Assert that two PyTorch tensors are exactly equal.
+
+    This function performs an exact equality comparison between two tensors, checking that
+    all corresponding elements are identical. Both tensor shapes and values must match exactly.
+
+    Args:
+        expected_pytorch_result (torch.Tensor): The expected reference tensor
+        actual_pytorch_result (torch.Tensor): The actual tensor to compare against the reference
+
+    Returns:
+        tuple: A tuple containing:
+            - equal_passed (bool): True if the tensors are exactly equal, False otherwise
+            - equal_message (str): A message describing the equality comparison result
+
+    Raises:
+        AssertionError: If the tensor shapes don't match or if the tensors are not exactly equal
+    """
     assert list(expected_pytorch_result.shape) == list(
         actual_pytorch_result.shape
     ), f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}"


### PR DESCRIPTION
### Summary

I noticed that `assert_equal` does not actually call `assert` internally. This is confusing because `assert_with_pcc` does call `assert` internally (as its name suggests).

Unfortunately, many people have been using `assert_equal` with the assumption that it does assert internally. 

This change adds the assert to the definition of `assert_equal` and adds skips for the failures that were uncovered. I have opened a follow-on issue to track the skipped tests:

- https://github.com/tenstorrent/tt-metal/issues/22482

Failure:

- `FAILED tests/ttnn/unit_tests/operations/test_index_fill.py` (150 failing test cases)
- `FAILED tests/ttnn/unit_tests/operations/eltwise/test_unary.py::test_fp32_uint32[dtype=DataType.UINT8-w=128-h=64] - AssertionError: Max ATOL Delta: 254, Max RTOL Delta: inf`
- `FAILED tests/ttnn/unit_tests/operations/eltwise/test_unary.py::test_fp32_uint32[dtype=DataType.INT32-w=128-h=64] - AssertionError: Max ATOL Delta: 8073922, Max RTOL Delta: inf`
- `FAILED tests/ttnn/unit_tests/operations/pool/test_downsample.py` (2 failing test cases)

I've also added some docstrings to clarify what these helper functions do.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/all-post-commit-workflows.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/15201570380
- [x] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml): https://github.com/tenstorrent/tt-metal/actions/runs/15209747627
