### PR TITLE
Refactor transformer submesh creation

### DIFF
--- a/models/demos/llama3_subdevices/tt/generator_vllm.py
+++ b/models/demos/llama3_subdevices/tt/generator_vllm.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,17 +8,8 @@ from tqdm import tqdm
 from models.demos.llama3_subdevices.tt.generator import Generator
 from models.demos.llama3_subdevices.tt.llama_model import TtTransformer
 from models.demos.llama3_subdevices.tt.model_config import LlamaOptimizations, TtModelArgs
+from models.tt_transformers.tt.common import create_submeshes
 from vllm.inputs import INPUT_REGISTRY
-
-
-def generate_submeshes(mesh_device, data_parallel):
-    if not isinstance(mesh_device, ttnn.MeshDevice) or data_parallel == 1:
-        return [mesh_device]
-
-    num_devices = mesh_device.get_num_devices()
-    assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
-
-    return mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))
 
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: TtTransformer, tt_cache_path):
@@ -59,7 +50,7 @@ def initialize_vllm_text_transformer(
     dtype=ttnn.bfloat8_b,
     optimizations=LlamaOptimizations.performance,
 ):
-    submesh_devices = generate_submeshes(mesh_device, tt_data_parallel)
+    submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
     # Load model args, weights
     model_args = []
     for submesh in submesh_devices:

--- a/models/demos/llama3_subdevices/tt/generator_vllm.py
+++ b/models/demos/llama3_subdevices/tt/generator_vllm.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from models.demos.llama3_subdevices.tt.generator import Generator
 from models.demos.llama3_subdevices.tt.llama_model import TtTransformer
 from models.demos.llama3_subdevices.tt.model_config import LlamaOptimizations, TtModelArgs
-from models.tt_transformers.tt.common import create_submeshes
+from models.tt_transformers.tt.generator import create_submeshes
 from vllm.inputs import INPUT_REGISTRY
 
 

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -18,12 +18,11 @@ from models.demos.utils.llm_demo_utils import create_benchmark_data
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
-    create_submeshes,
     create_tt_model,
     preprocess_inputs_prefill,
     sample_host,
 )
-from models.tt_transformers.tt.generator import Generator, SamplingParams
+from models.tt_transformers.tt.generator import Generator, SamplingParams, create_submeshes
 from models.tt_transformers.tt.model_config import DecodersPrecision, parse_decoder_json
 
 

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib
@@ -17,6 +18,7 @@ from models.demos.utils.llm_demo_utils import create_benchmark_data
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
+    create_submeshes,
     create_tt_model,
     preprocess_inputs_prefill,
     sample_host,
@@ -117,12 +119,7 @@ def prepare_generator_args(
     page_params,
     paged_attention,
 ):
-    # Partition the mesh, singular model implemented for TP on 1xN mesh
-    submesh_devices = (
-        mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))
-        if isinstance(mesh_device, ttnn.MeshDevice) and data_parallel > 1
-        else [mesh_device]
-    )
+    submesh_devices = create_submeshes(mesh_device, data_parallel)
     state_dict = None
 
     # Hybrid requires a model per submesh

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
@@ -11,6 +12,8 @@ from llama_models.llama3.api.tokenizer import Tokenizer
 from loguru import logger
 from PIL import Image as PIL_Image
 from pkg_resources import resource_filename
+
+from models.tt_transformers.tt.common import create_submeshes
 
 IMG_PATH = Path(resource_filename("llama_models", "scripts/resources/"))
 
@@ -74,12 +77,7 @@ def create_multimodal_model(
 def prepare_generator_args(
     num_devices, data_parallel, mesh_device, max_batch_size, max_seq_len, dtype=ttnn.bfloat16, use_paged_kv_cache=False
 ):
-    # Partition the mesh, singular model implemented for TP on 1xN mesh
-    submesh_devices = (
-        mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))
-        if isinstance(mesh_device, ttnn.MeshDevice) and data_parallel > 1
-        else [mesh_device]
-    )
+    submesh_devices = create_submeshes(mesh_device, data_parallel)
     state_dict = None
 
     model_args = []

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -13,7 +13,7 @@ from loguru import logger
 from PIL import Image as PIL_Image
 from pkg_resources import resource_filename
 
-from models.tt_transformers.tt.common import create_submeshes
+from models.tt_transformers.tt.generator import create_submeshes
 
 IMG_PATH = Path(resource_filename("llama_models", "scripts/resources/"))
 

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -543,3 +544,21 @@ def create_tt_model(
     tt_kv_cache = [l.attention.layer_past for l in model.layers] if paged_attention_config else None
 
     return tt_model_args, model, tt_kv_cache, state_dict
+
+
+def create_submeshes(mesh_device, data_parallel):
+    if not isinstance(mesh_device, ttnn.MeshDevice) or data_parallel == 1:
+        return [mesh_device]
+
+    num_rows, num_cols = mesh_device.shape
+    num_devices = num_rows * num_cols
+    assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
+
+    # Check if the mesh is 8x4 (expected shape for TG) and perfer row split
+    if num_rows == 8 and num_cols == 4 and num_rows % data_parallel == 0:
+        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows // data_parallel, num_cols))
+        for submesh in submeshes:
+            submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))
+        return submeshes
+
+    return mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -555,6 +555,7 @@ def create_submeshes(mesh_device, data_parallel):
     assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
 
     # Check if the mesh is 8x4 (expected shape for TG) and perfer row split
+    # Submeshes with 8 devices are expected to be in ring topology hence the row split
     if num_rows == 8 and num_cols == 4 and num_rows % data_parallel == 0:
         submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows // data_parallel, num_cols))
         for submesh in submeshes:

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -1174,3 +1174,22 @@ class Generator:
 
         if hasattr(super(Generator, self), "__del__"):
             super().__del__()
+
+
+def create_submeshes(mesh_device, data_parallel):
+    if not isinstance(mesh_device, ttnn.MeshDevice) or data_parallel == 1:
+        return [mesh_device]
+
+    num_rows, num_cols = mesh_device.shape
+    num_devices = num_rows * num_cols
+    assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
+
+    # Check if the mesh is 8x4 (expected shape for TG) and perfer row split
+    # Submeshes with 8 devices are expected to be in ring topology hence the row split
+    if num_rows == 8 and num_cols == 4 and num_rows % data_parallel == 0:
+        submeshes = mesh_device.create_submeshes(ttnn.MeshShape(num_rows // data_parallel, num_cols))
+        for submesh in submeshes:
+            submesh.reshape(ttnn.MeshShape(1, num_devices // data_parallel))
+        return submeshes
+
+    return mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -15,8 +15,7 @@ from vllm.model_executor.models.mllama import MLLAMA_IMAGE_TOKEN, MLLAMA_IMAGE_T
 
 import ttnn
 from models.tt_transformers.demo.simple_vision_demo import create_multimodal_model
-from models.tt_transformers.tt.common import create_submeshes
-from models.tt_transformers.tt.generator import Generator
+from models.tt_transformers.tt.generator import Generator, create_submeshes
 from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs
 from models.utility_functions import nearest_32

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,20 +15,11 @@ from vllm.model_executor.models.mllama import MLLAMA_IMAGE_TOKEN, MLLAMA_IMAGE_T
 
 import ttnn
 from models.tt_transformers.demo.simple_vision_demo import create_multimodal_model
+from models.tt_transformers.tt.common import create_submeshes
 from models.tt_transformers.tt.generator import Generator
 from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs
 from models.utility_functions import nearest_32
-
-
-def generate_submeshes(mesh_device, data_parallel):
-    if not isinstance(mesh_device, ttnn.MeshDevice) or data_parallel == 1:
-        return [mesh_device]
-
-    num_devices = mesh_device.get_num_devices()
-    assert num_devices % data_parallel == 0, f"Unsupported device split: {num_devices} devices, {data_parallel} groups"
-
-    return mesh_device.create_submeshes(ttnn.MeshShape(1, num_devices // data_parallel))
 
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Transformer], tt_cache_path):
@@ -68,7 +59,7 @@ def initialize_vllm_text_transformer(
     dtype=ttnn.bfloat8_b,
     optimizations=DecodersPrecision.performance,
 ):
-    submesh_devices = generate_submeshes(mesh_device, tt_data_parallel)
+    submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
     # Load model args, weights
     model_args = []
     for submesh in submesh_devices:
@@ -176,7 +167,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     def initialize_vllm_model(cls, hf_config, mesh_device, max_batch_size, tt_data_parallel=1):
         max_seq_len = 131072
 
-        submesh_devices = generate_submeshes(mesh_device, tt_data_parallel)
+        submesh_devices = create_submeshes(mesh_device, tt_data_parallel)
 
         model_args = []
         model = []


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
We have duplicate code for submesh creation. Also, preferable way to open TG mesh devices is in `(8, 4)` shape which is not supported by the current submesh division implementation.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [x] [All post commit](https://github.com/tenstorrent/tt-metal/actions/runs/15192562385) CI passes
- [ ] [Blackhole Post commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml) CI with demo tests passes (if applicable)
- [ ] [Model regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml) CI passes (if applicable)
- [ ] [Device performance regression](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml) CI passes (if applicable)
- [ ] (For models and ops writers) [Single-card demo tests](https://github.com/tenstorrent/tt-metal/actions/workflows/single-card-demo-tests.yaml) CI passes (if applicable) See [recommended dev flow](https://github.com/tenstorrent/tt-metal/blob/main/models/MODEL_ADD.md#a-recommended-dev-flow-on-github-for-adding-new-models).
- [ ] New/Existing tests provide coverage for changes